### PR TITLE
fix: client 中心の6ファイル、as を18箇所とも外す (#1231)

### DIFF
--- a/scripts/model-trials.ts
+++ b/scripts/model-trials.ts
@@ -24,6 +24,7 @@ import { claudeAdapter } from "../server/agents/claude.js";
 import { loadAppConfig } from "../server/config/app-config.js";
 import { cleanupSessionSettings, settingsArgument } from "../server/session/session-settings.js";
 import { requireResolution, resolveProvider, withoutUnset } from "../server/session/provider-env.js";
+import { isRecord } from "../common/isRecord.js";
 
 const TRIAL_TIMEOUT_MS = 240_000;
 const ANSI = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
@@ -66,7 +67,7 @@ function attempt(provider: string, model: string): { ok: boolean; seconds: numbe
   try {
     execFileSync(claudeAdapter.bin(), ["-p", PROBE_TASK, "--settings", settings, "--model", model, "--dangerously-skip-permissions"], {
       cwd,
-      env: withoutUnset(process.env, resolved.unset) as NodeJS.ProcessEnv,
+      env: withoutUnset(process.env, resolved.unset),
       encoding: "utf8",
       timeout: TRIAL_TIMEOUT_MS,
     });
@@ -75,11 +76,14 @@ function attempt(provider: string, model: string): { ok: boolean; seconds: numbe
     const ok = wrote.toUpperCase().includes(PROBE_WORD.toUpperCase());
     return { ok, seconds: Math.round((Date.now() - started) / 1000), detail: ok ? "" : `no tool write (wrote ${JSON.stringify(wrote)})` };
   } catch (err) {
-    const e = err as { stderr?: string; stdout?: string; message?: string; signal?: string };
+    // execFileSync attaches stderr/stdout/signal to what it throws, but a thrown value is
+    // `unknown` — read each field only if it is really a string.
+    const text = (value: unknown): string => (typeof value === "string" ? value : "");
+    const e = isRecord(err) ? err : {};
     // Keep the WHOLE message: the interesting part is rarely at the end — the tail is
     // usually Claude Code's benign "connectors are disabled" warning, which hid the real
     // 404 through the first sweep of this script.
-    const detail = ((e.stderr ?? "") + (e.stdout ?? "") + (e.message ?? "")).replace(ANSI, "").replace(/\s+/g, " ");
+    const detail = (text(e.stderr) + text(e.stdout) + text(e.message)).replace(ANSI, "").replace(/\s+/g, " ");
     return { ok: false, seconds: Math.round((Date.now() - started) / 1000), detail: e.signal === "SIGTERM" ? "timeout" : detail };
   } finally {
     cleanupSessionSettings(sessionId);

--- a/server/agents/antigravity-mcp.ts
+++ b/server/agents/antigravity-mcp.ts
@@ -22,6 +22,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { TOOL_GROUPS, toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
+import { isRecord } from "../../common/isRecord.js";
 
 /** agy's workspace customization dir. `.agent`/`_agents`/`_agent` are also accepted by agy; we write one. */
 const CUSTOMIZATION_DIR = ".agents";
@@ -67,9 +68,9 @@ function readMcpServers(file: string): Record<string, unknown> | null {
   if (!existsSync(file)) return {};
   try {
     const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    const servers = Object.prototype.hasOwnProperty.call(parsed, "mcpServers") ? (parsed as Record<string, unknown>).mcpServers : {};
-    return servers && typeof servers === "object" && !Array.isArray(servers) ? { ...(servers as Record<string, unknown>) } : {};
+    if (!isRecord(parsed)) return null;
+    const servers = Object.prototype.hasOwnProperty.call(parsed, "mcpServers") ? parsed.mcpServers : {};
+    return isRecord(servers) ? { ...servers } : {};
   } catch {
     return null; // present but not JSON — someone else's file, and rewriting it would lose it
   }

--- a/server/git/pr-for-branch.ts
+++ b/server/git/pr-for-branch.ts
@@ -3,6 +3,7 @@
 // doesn't shell out to gh each time. Pure parse + injectable deps keep it unit-testable without gh.
 import { createTtlCache } from "./ttl-cache.js";
 import { branchQuery, type BranchQueryDeps } from "./branch-query.js";
+import { isRecord } from "../../common/isRecord.js";
 
 const cache = createTtlCache<string | null>();
 
@@ -12,8 +13,8 @@ export function parsePrUrl(stdout: string): string | null {
     const arr: unknown = JSON.parse(stdout);
     if (Array.isArray(arr) && arr.length > 0) {
       const first: unknown = arr[0];
-      if (typeof first === "object" && first !== null && typeof (first as { url?: unknown }).url === "string") {
-        return (first as { url: string }).url;
+      if (isRecord(first) && typeof first.url === "string") {
+        return first.url;
       }
     }
   } catch {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -66,6 +66,7 @@ import { router } from "../router";
 import { usePubSub } from "../composables/usePubSub";
 import type { LaunchAgent } from "../../common/launchAgent";
 import type { LaunchPick } from "./launchers";
+import { isRecord } from "../../common/isRecord";
 
 // The multi-terminal grid view, shown at /terminals. Leaving the grid is just a
 // route push from the shared toolbar (Chat / Collections / a favorite), so there's
@@ -164,9 +165,9 @@ async function seedMeta(id: string, cwd: string | null) {
     const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok || latestMetaSeed.get(id) !== seed) return;
-    const d = (await res.json()) as Partial<SessionMetaView>;
+    const d: unknown = await res.json();
     if (latestMetaSeed.get(id) !== seed) return;
-    sessionMeta.set(id, mergeSessionMeta(sessionMeta.get(id) ?? EMPTY_SESSION_META, d));
+    sessionMeta.set(id, mergeSessionMeta(sessionMeta.get(id) ?? EMPTY_SESSION_META, isRecord(d) ? d : {}));
   } catch {
     // best-effort — the next poll retries
   }
@@ -183,12 +184,13 @@ async function seedPhase(cwd: string) {
   try {
     const res = await fetch(`/api/pr-phase?cwd=${encodeURIComponent(cwd)}`);
     if (!res.ok || latestPhaseSeed.get(cwd) !== seed) return;
-    const d = (await res.json()) as { phase?: unknown };
+    const d: unknown = await res.json();
     if (latestPhaseSeed.get(cwd) !== seed) return;
-    if (isPrPhase(d.phase)) {
+    const phase = isRecord(d) ? d.phase : undefined;
+    if (isPrPhase(phase)) {
       // Before the set, so the previous value is still the one to compare against.
-      if (becameCiFailing(phaseByCwd.get(cwd), d.phase)) notifySound("pr-ci-failed", cwd);
-      phaseByCwd.set(cwd, d.phase);
+      if (becameCiFailing(phaseByCwd.get(cwd), phase)) notifySound("pr-ci-failed", cwd);
+      phaseByCwd.set(cwd, phase);
     }
   } catch {
     // best-effort — the next poll retries
@@ -219,8 +221,11 @@ const refreshAllChrome = () => {
 // A user editing .mulmoterminal.json is announced on the dir-config channel; re-fetch that
 // directory's chrome so an open roster recolours without a reload. The unsubscribe is kept
 // and called on unmount so a remounted grid doesn't stack duplicate handlers.
-const cwdOf = (data: unknown): string | null =>
-  typeof data === "object" && data !== null && typeof (data as { cwd?: unknown }).cwd === "string" ? (data as { cwd: string }).cwd : null;
+// A cell with no PR yet. A named constant rather than a literal assertion at the call site:
+// the annotation is checked, `"none" as PrPhase` was not.
+const NO_PR_PHASE: PrPhase = "none";
+
+const cwdOf = (data: unknown): string | null => (isRecord(data) && typeof data.cwd === "string" ? data.cwd : null);
 const unsubscribeDirConfig = usePubSub().subscribe("dir-config", (data) => {
   const cwd = cwdOf(data);
   if (cwd) {
@@ -324,7 +329,7 @@ const rosterRow = (c: Cell): CockpitRow => {
     prompt: meta.lastPrompt,
     response: meta.lastResponse,
     fallback: fallbackLabel(c),
-    phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? ("none" as PrPhase),
+    phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? NO_PR_PHASE,
     workPhase: meta.workPhase,
     headerColor: chrome.headerColor,
     headerTextColor: chrome.headerTextColor,
@@ -589,9 +594,10 @@ async function adoptUnplacedSessions(): Promise<void> {
   try {
     const res = await fetch("/api/sessions/unplaced");
     if (!res.ok) return;
-    const body = (await res.json()) as { sessions?: { id?: unknown; agent?: unknown; cwd?: unknown }[] };
-    for (const row of body.sessions ?? []) {
-      if (typeof row?.id !== "string" || !row.id) continue;
+    const body: unknown = await res.json();
+    const rows = isRecord(body) && Array.isArray(body.sessions) ? body.sessions : [];
+    for (const row of rows) {
+      if (!isRecord(row) || typeof row.id !== "string" || !row.id) continue;
       // Already here: the server clears the mark when a cell attaches, but this tab may still be
       // holding a cell whose attach has not landed yet — and adopting twice would give one session
       // two cells fighting over the same socket.
@@ -639,7 +645,7 @@ watch(
 // of them would refetch many times a turn to learn nothing; the spawn is the one moment a session
 // can become unplaced. A create that arrives while the user is elsewhere in the app needs nothing
 // extra — the watcher adopts it on the way back.
-const isSessionCreated = (data: unknown): boolean => typeof data === "object" && data !== null && (data as { event?: unknown }).event === "created";
+const isSessionCreated = (data: unknown): boolean => isRecord(data) && data.event === "created";
 const { subscribe: subscribeSessions, onReconnect } = usePubSub();
 const unsubscribeSessions = subscribeSessions("sessions", (data) => {
   if (isSessionCreated(data) && onTerminalsRoute()) void adoptUnplacedSessions();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -53,6 +53,7 @@ import { handoffTargets, pullLastTurn, type HandoffTarget } from "../composables
 import { runOneExchange, liveCrossTalkDeps } from "../composables/useCrossTalk";
 import { outcomeMessage } from "../composables/exchangeRules";
 import { worktreeFailureMessage } from "./cellChromeRules";
+import { isRecord } from "../../common/isRecord";
 
 // How long a handoff failure stays on the cell before it clears itself.
 const ASK_MSG_MS = 4000;
@@ -499,7 +500,7 @@ function openGithub(suffix: string) {
 }
 
 function onGhOutside(e: MouseEvent) {
-  if (ghWrap.value && !ghWrap.value.contains(e.target as Node)) ghMenuOpen.value = false;
+  if (ghWrap.value && !(e.target instanceof Node && ghWrap.value.contains(e.target))) ghMenuOpen.value = false;
 }
 watch(ghMenuOpen, (open) => {
   if (open) document.addEventListener("mousedown", onGhOutside);
@@ -562,7 +563,7 @@ async function exchangeWith(target: HandoffTarget) {
 }
 
 function onAskOutside(e: MouseEvent) {
-  if (askWrap.value && !askWrap.value.contains(e.target as Node)) askMenuOpen.value = false;
+  if (askWrap.value && !(e.target instanceof Node && askWrap.value.contains(e.target))) askMenuOpen.value = false;
 }
 watch(askMenuOpen, (open) => {
   if (open) document.addEventListener("mousedown", onAskOutside);
@@ -795,7 +796,7 @@ async function saveMemo() {
     });
     if (!res.ok) throw new Error(`memo save failed: ${res.status}`);
     const data: unknown = await res.json();
-    const saved = typeof data === "object" && data !== null && "memo" in data ? (data as { memo: unknown }).memo : null;
+    const saved = isRecord(data) ? data.memo : null;
     if (sessionId.value === id && typeof saved === "string") memo.value = saved || null;
   } catch {
     // Put back what the server still has, rather than leaving a note on screen that no other
@@ -871,6 +872,10 @@ function commitViaClaude() {
   prMsg.value = delivered ? "Asked Claude to commit…" : "Couldn't reach the session";
 }
 
+// The refusal reason as the message table can use it. The response is untrusted JSON, so a
+// non-string `reason` reads as absent and the caller shows the generic "Failed".
+const reasonOf = (data: Record<string, unknown>): string | null => (typeof data.reason === "string" ? data.reason : null);
+
 async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, unknown> | null> {
   if (!cwd.value || prBusy.value) return null;
   prBusy.value = true;
@@ -896,7 +901,7 @@ async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, u
 
 async function pushBranch() {
   const data = await worktreeAction("push");
-  if (data) prMsg.value = data.ok ? `Pushed ${data.branch}` : worktreeFailureMessage(data.reason as string);
+  if (data) prMsg.value = data.ok ? `Pushed ${data.branch}` : worktreeFailureMessage(reasonOf(data));
 }
 
 async function openPR() {
@@ -906,7 +911,7 @@ async function openPR() {
     window.open(data.url, "_blank", "noopener,noreferrer");
     prMsg.value = data.via === "gh" ? "PR created" : "Opened PR page";
   } else {
-    prMsg.value = worktreeFailureMessage(data.reason as string);
+    prMsg.value = worktreeFailureMessage(reasonOf(data));
   }
 }
 

--- a/src/components/rosterPhase.ts
+++ b/src/components/rosterPhase.ts
@@ -68,14 +68,21 @@ export interface SessionMetaView {
 
 export const EMPTY_SESSION_META: SessionMetaView = { lastPrompt: null, aiTitle: null, lastResponse: null, memo: null, workPhase: null };
 
-// `workPhase` is typed unknown because it arrives as untrusted JSON — isWorkPhase is the
-// only thing that may decide it is a phase.
-export function mergeSessionMeta(previous: SessionMetaView, fetched: Omit<Partial<SessionMetaView>, "workPhase"> & { workPhase?: unknown }): SessionMetaView {
+// `string | null` as it arrives in untrusted JSON. Anything else reads as ABSENT, so a field the
+// server sent as a number leaves the previous value standing rather than replacing it with junk.
+const stringOrNull = (value: unknown): string | null | undefined => (typeof value === "string" || value === null ? value : undefined);
+
+// EVERY field arrives as untrusted JSON, so every one is decided by a check here. `workPhase` was
+// already typed `unknown` for exactly that reason (isWorkPhase is the only thing that may call it
+// a phase); the other four said `string | null` and were taken on trust from the same response.
+export function mergeSessionMeta(previous: SessionMetaView, fetched: Record<string, unknown>): SessionMetaView {
+  const aiTitle = stringOrNull(fetched.aiTitle);
+  const memo = stringOrNull(fetched.memo);
   return {
-    lastPrompt: fetched.lastPrompt ?? previous.lastPrompt,
-    aiTitle: fetched.aiTitle !== undefined ? fetched.aiTitle : previous.aiTitle,
-    lastResponse: fetched.lastResponse ?? previous.lastResponse,
-    memo: fetched.memo !== undefined ? fetched.memo : previous.memo,
+    lastPrompt: stringOrNull(fetched.lastPrompt) ?? previous.lastPrompt,
+    aiTitle: aiTitle !== undefined ? aiTitle : previous.aiTitle,
+    lastResponse: stringOrNull(fetched.lastResponse) ?? previous.lastResponse,
+    memo: memo !== undefined ? memo : previous.memo,
     workPhase: isWorkPhase(fetched.workPhase) ? fetched.workPhase : null,
   };
 }


### PR DESCRIPTION
## Summary

#1231。client 中心の 6 ファイル・**18 箇所**。**96 → 78**。allowlist は 1 件も足していません。

## Items to Confirm / Review

### 1. 同じ JSON で、1 フィールドだけ検査していた（`rosterPhase.ts`）

`mergeSessionMeta` は `workPhase` を `unknown` として扱い、コメントにもこう書いてありました。

> `workPhase` is typed unknown because it arrives as untrusted JSON

**ところが同じ応答の他 4 フィールド（`lastPrompt` / `aiTitle` / `lastResponse` / `memo`）は `string | null` と宣言され、無検査で受けていました。** 呼び出し側の `(await res.json()) as Partial<SessionMetaView>` がそれを支えていた形です。

全フィールドを検査する形に揃えました。文字列でも null でもない値（サーバが数値を返した等）は**「不在」として扱い、前の値を残します** — 前は junk がそのまま画面に載り得ました。

```ts
const stringOrNull = (value: unknown): string | null | undefined => (typeof value === "string" || value === null ? value : undefined);
```

`null` を明示的に上書きとして扱う `aiTitle` / `memo` の意味論はそのままです。既存の `rosterPhase.spec.ts`（35 tests）は変更なしで通ります。

### 2. `e.target as Node` は `instanceof` で本物の検査になる（`TerminalCell.vue`）

issue が「DOM の型付けの限界。allowlist に理由付きで」と想定していた類型ですが、**`instanceof` があります**。

```diff
-if (ghWrap.value && !ghWrap.value.contains(e.target as Node)) ghMenuOpen.value = false;
+if (ghWrap.value && !(e.target instanceof Node && ghWrap.value.contains(e.target))) ghMenuOpen.value = false;
```

**否定の位置に注意して書いています。** 単純に `&&` を足すと「Node でないとき閉じない」に変わってしまうので、`!(instanceof && contains)` として**元の挙動（Node でなければ閉じる）を保存**しました。

### 3. `as NodeJS.ProcessEnv` は完全に不要だった（`model-trials.ts`）

`withoutUnset` の戻り型が既に `NodeJS.ProcessEnv` でした。外すだけです。**不要キャストはこれで通算 6 件目**です。

### 4. `(await res.json()) as T`（`GridView.vue` 3 箇所）

サーバ応答を無検査で信じていた箇所。`unknown` で受けて `isRecord` で読みます。`/api/pr-phase` は narrow した値を以降でも使うよう直しました（型エラーが 2 件出て気づいた箇所です）。

### 5. `"none" as PrPhase` → 名前付き定数の注釈

```diff
-phase: (...) ?? ("none" as PrPhase),
+phase: (...) ?? NO_PR_PHASE,   // const NO_PR_PHASE: PrPhase = "none";
```

## User Prompt

- #1231 を進めてほしい。修正中にバグを見つけたら issue に詳細と原因を残す。
- PR は並列で。CodeRabbit は無視で良い。CI に時間がかかるので 5 つくらいまとめて。
- 基本は 0 にできると思うよ、普通の方法で。

→ **allowlist に逃げず 0 を目指す**方針で進めています。この PR でも allowlist は 0 件です。

## 検証

`yarn lint`（0 error、78 warnings ← 96）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7392 passed**。

`GridView.vue` は単一ビュー廃止後の**アプリ本体のシェル**なので、型とテストだけでは足りないと判断し実ブラウザでも確認しました。

- 画面描画（body テキスト 739 文字）、ランチャーのエージェント切替が存在
- 今回書き換えた **click-outside 経路**（`e.target` 判定）をクリックで実際に踏む
- uncaught console error **0**

> `yarn typecheck:test` の 4 件エラーは main 時点で同じ（calendar 関連）で無関係です。

refs #1231

work in mulmoterminal3
