### PR TITLE
feat: GitLab の issue から着手できるようにする（#981 段階4c-1）

### DIFF
--- a/common/issueStartPlan.ts
+++ b/common/issueStartPlan.ts
@@ -7,7 +7,11 @@
 // not one encoded here. It cannot offer the menu (the phone never picks a directory, see
 // docs/remote-host-protocol.md), so it refuses `choose` where the desktop opens it.
 import type { RepoDirs } from "./repoDirs";
-import { GITHUB_HOST, parseRepoEntry } from "./repoEntry";
+import { GITHUB_HOST, GITLAB_HOST, parseRepoEntry } from "./repoEntry";
+
+// Where work can be STARTED — the issue is read and a worktree cut. A host that is merely listable
+// still refuses, and says which host it is rather than blaming a missing clone (#981).
+const STARTABLE_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, GITLAB_HOST]);
 
 export type IssueStartPlan =
   /** No clone of this repo on this machine, so there is nowhere for the work to happen. */
@@ -31,7 +35,7 @@ export function issueStartPlan(entry: RepoDirs | undefined, repo: string): Issue
   // Checked before the clone list, because a GitLab repo has no entry there and would otherwise
   // read as "no clone" — a reason that is not true and points at the wrong fix.
   const parsed = parseRepoEntry(repo);
-  if (parsed && parsed.host !== GITHUB_HOST) return { kind: "unsupported-forge", host: parsed.host };
+  if (parsed && !STARTABLE_HOSTS.has(parsed.host)) return { kind: "unsupported-forge", host: parsed.host };
   const dirs = entry?.dirs ?? [];
   if (dirs.length === 0) return { kind: "no-clone" };
   // A recording wins even when the repo has one clone: it is still the same answer, and treating

--- a/common/issueStartPlan.ts
+++ b/common/issueStartPlan.ts
@@ -13,6 +13,11 @@ import { GITHUB_HOST, GITLAB_HOST, parseRepoEntry } from "./repoEntry";
 // still refuses, and says which host it is rather than blaming a missing clone (#981).
 const STARTABLE_HOSTS: ReadonlySet<string> = new Set([GITHUB_HOST, GITLAB_HOST]);
 
+/** The hosts named in a refusal, read off the set rather than written out beside it — a hardcoded
+ *  "github.com only" survived GitLab becoming startable and told users the opposite of the truth
+ *  (Codex review). Exported so the phone's refusal says the same thing. */
+export const startableHosts = (): string => [...STARTABLE_HOSTS].join(" and ");
+
 export type IssueStartPlan =
   /** No clone of this repo on this machine, so there is nowhere for the work to happen. */
   | { kind: "no-clone" }
@@ -48,6 +53,6 @@ export function issueStartPlan(entry: RepoDirs | undefined, repo: string): Issue
 
 /** Why the control is disabled, for the row's title text. Null when it is not disabled. */
 export function issueStartBlockedReason(plan: IssueStartPlan, repo: string): string | null {
-  if (plan.kind === "unsupported-forge") return `Starting work is github.com only — ${plan.host} issues are listed here, not started from`;
+  if (plan.kind === "unsupported-forge") return `Starting work supports ${startableHosts()} — ${plan.host} issues are listed here, not started from`;
   return plan.kind === "no-clone" ? `No local clone of ${repo} — add one to your directory presets to start work here` : null;
 }

--- a/common/repoEntry.ts
+++ b/common/repoEntry.ts
@@ -7,6 +7,7 @@
 // is undoing.
 
 export const GITHUB_HOST = "github.com";
+export const GITLAB_HOST = "gitlab.com";
 
 // A leading segment containing a DOT is the host. GitHub user and organisation names may hold only
 // alphanumerics and hyphens, so `owner/repo` and `host/owner/repo` cannot be confused.
@@ -42,6 +43,17 @@ export function parseRepoEntry(entry: string): RepoEntry | null {
  *  and reports "no local clone" for a repo that has one (Codex review).
  */
 export const canonicalRepo = (entry: string): string => parseRepoEntry(entry)?.path.join("/") ?? entry.trim();
+
+/** The identity used to MATCH a configured entry against a resolved clone: always host-qualified.
+ *
+ *  Distinct from `canonicalRepo`, which strips the host because that is what a CLI's `--repo`
+ *  wants. Matching needs the opposite: without the host, `github.com/a/b` and `gitlab.com/a/b`
+ *  collapse to the same key, and a clone of one would answer for the other (#981).
+ */
+export const repoIdentity = (entry: string): string => {
+  const parsed = parseRepoEntry(entry);
+  return parsed ? `${parsed.host}/${parsed.path.join("/")}`.toLowerCase() : entry.trim().toLowerCase();
+};
 
 // The value reaches a CLI's `--repo`, so no spaces and nothing readable as a flag.
 const REPO_CHARS_RE = /^[A-Za-z0-9._/-]+$/;

--- a/plans/feat-981-4c1-gitlab-issue-start.md
+++ b/plans/feat-981-4c1-gitlab-issue-start.md
@@ -1,0 +1,49 @@
+# feat(#1257 / #981 段階4c-1): GitLab の issue から着手できるようにする
+
+段階4a で一覧は読めるようになったが、行の ▶ は「github.com only」のままだった。その入口
+（issue 本文の読み取り）を GitLab 対応にする。**GitHub の挙動は変えない。**
+
+## 実物で確認したこと
+
+glab 1.111.0 をテストプロジェクトに対して実行して分かったもの。**記憶で書くと踏む。**
+
+| コマンド | 出力形式のフラグ |
+| --- | --- |
+| `mr list` | `-F` |
+| `issue list` | **`-O`**（`-F` は details/ids/urls） |
+| `issue view` | **`-F`**（`-O` は「Unknown shorthand flag」で即エラー） |
+
+フィールド: `number` → **`iid`**、`body` → **`description`**。
+
+## 途中で見つかった穴（実機で通して初めて出た）
+
+**1. GitLab のクローンが `/api/repo-dirs` に載らない。** `repoForDir` は GitHub 以外に
+`repo: null` を返していた（段階2b の時点では GitHub しか着手できなかったので正しかった）。
+これを直さないと、ゲートを広げてもボタンは無効のまま。
+
+**2. ホストを剥がすと forge が分からなくなる。** ルートが `canonicalRepo` してから
+`startIssueWork` に渡していたので、`isamu1/node-test` が「ホスト無し＝GitHub」と解釈され、
+存在しない GitHub リポを見に行っていた。
+
+## 2つの識別子を分ける
+
+1 と 2 の根っこは同じで、**1つの文字列に2つの役割を持たせていた**こと。分けた。
+
+| | 何に使うか | ホスト |
+| --- | --- | --- |
+| `repoIdentity` | 設定エントリと解決済みクローンの**照合** | **付ける**（`github.com/a/b` と `gitlab.com/a/b` を潰さないため） |
+| `canonicalRepo` | CLI の `--repo` に渡す | **剥がす**（ホストはそのホスト自身が知っている） |
+
+ホスト付きのまま持ち回り、**CLI の直前でだけ剥がす**。
+
+## 検証
+
+- `fetchIssueDetail` を実 GitLab issue と実 GitHub issue の両方で実行し、正しく読めることを確認
+- `repoForDir` が GitLab クローンを `gitlab.com/isamu1/node-test` として返すことを確認
+- `/api/repo-dirs` がそれを載せることを確認
+- `POST /api/issues/start` が検証を通り、クローンと照合し、issue 読み取りまで到達することを確認
+
+**worktree 作成と spawn まではサンドボックスで未確認。** demo 用の `HOME` に差し替えると glab が
+認証情報を見つけられず（keychain のトークンは glab が内部でリフレッシュしていて取り出せない）、
+`MULMOTERMINAL_HOME` は `os.homedir()` 由来で上書きできないため。その先のコードは forge 非依存で、
+GitHub 経路で実証済み。

--- a/server/backends/remoteHost/handlers/issueWork.ts
+++ b/server/backends/remoteHost/handlers/issueWork.ts
@@ -15,7 +15,7 @@ import { listIssuesAcrossRepos } from "../../../git/issues.js";
 import { startIssueWork } from "../../../git/issue-work.js";
 import { repoDirsFromPresets } from "../../../git/repo-dirs.js";
 import { issueStartPlan, type BlockedIssueStartPlan } from "../../../../common/issueStartPlan.js";
-import { canonicalRepo, isRepoEntry } from "../../../../common/repoEntry.js";
+import { isRepoEntry, repoIdentity } from "../../../../common/repoEntry.js";
 import { isIssueNumber } from "../../../../common/prPhase.js";
 import type { RepoDirs } from "../../../../common/repoDirs.js";
 import type { RemoteHostHandlerDeps } from "./deps.js";
@@ -27,8 +27,8 @@ import type { RemoteHostHandlerDeps } from "./deps.js";
 // different places: `prRepos` is typed by hand, an entry's own name comes from the remote URL —
 // which is also why the host a hand-typed entry may declare is stripped before comparing (#981).
 const entryFor = (repos: RepoDirs[], repo: string): RepoDirs | undefined => {
-  const wanted = canonicalRepo(repo).toLowerCase();
-  return repos.find((r) => canonicalRepo(r.repo).toLowerCase() === wanted);
+  const wanted = repoIdentity(repo);
+  return repos.find((r) => repoIdentity(r.repo) === wanted);
 };
 
 /** Why the phone cannot start work on this repo. Written for a person, and it names the DESKTOP
@@ -70,9 +70,9 @@ const startIssueWorkHandler =
     const plan = issueStartPlan(entryFor(await repoDirsNow(), repo), repo);
     if (plan.kind !== "ready") throw new Error(issueStartRefusal(plan, repo));
 
-    // Named the way its own host does, like the desktop route — an entry may declare a host that
-    // the repo's own identity does not carry.
-    const result = await startIssueWork(canonicalRepo(repo), issue, plan.dir, { spawnDraft: spawnIssueDraft });
+    // Carried on as configured, host and all: the layer below reads the host to decide which forge
+    // to ask, and strips it only when building the CLI argument.
+    const result = await startIssueWork(repo, issue, plan.dir, { spawnDraft: spawnIssueDraft });
     // A failed step stops here with the reason it failed — the same detail the desktop route turns
     // into a status code, which on this channel is simply the sentence the phone shows.
     if (!result.ok || !result.sessionId) throw new Error(result.detail ?? `could not start work on ${repo}#${issue}`);

--- a/server/backends/remoteHost/handlers/issueWork.ts
+++ b/server/backends/remoteHost/handlers/issueWork.ts
@@ -14,7 +14,7 @@ import { getCwdPresets, getPrRepos, getRepoDirs } from "../../../config/config-r
 import { listIssuesAcrossRepos } from "../../../git/issues.js";
 import { startIssueWork } from "../../../git/issue-work.js";
 import { repoDirsFromPresets } from "../../../git/repo-dirs.js";
-import { issueStartPlan, type BlockedIssueStartPlan } from "../../../../common/issueStartPlan.js";
+import { issueStartPlan, startableHosts, type BlockedIssueStartPlan } from "../../../../common/issueStartPlan.js";
 import { isRepoEntry, repoIdentity } from "../../../../common/repoEntry.js";
 import { isIssueNumber } from "../../../../common/prPhase.js";
 import type { RepoDirs } from "../../../../common/repoDirs.js";
@@ -37,7 +37,8 @@ const entryFor = (repos: RepoDirs[], repo: string): RepoDirs | undefined => {
 export function issueStartRefusal(plan: BlockedIssueStartPlan, repo: string): string {
   // Named separately from "no clone" on purpose: adding a clone would not help, so a reader told
   // the wrong reason would go and do something useless (#981).
-  if (plan.kind === "unsupported-forge") return `${repo} is on ${plan.host}. Its issues are listed here, but starting work on them is github.com only for now.`;
+  if (plan.kind === "unsupported-forge")
+    return `${repo} is on ${plan.host}. Its issues are listed here, but work can only be started on ${startableHosts()} for now.`;
   return plan.kind === "no-clone"
     ? `No local clone of ${repo} on this machine. Add one to your directory presets on the desktop to start work here.`
     : `${repo} has several clones on this machine and none is chosen yet. Start one issue from the desktop to choose which clone the work happens in, and this will use it from then on.`;

--- a/server/git/forge-support.ts
+++ b/server/git/forge-support.ts
@@ -41,7 +41,16 @@ export interface DirRepo {
   repo: string | null;
 }
 
-const dirRepo = (forge: RemoteForge | null): DirRepo | null => (forge ? { forge, repo: forge.kind === "github" ? projectPath(forge) : null } : null);
+// `repo` is set for every forge this app can ACT on, and carries the host unless it is GitHub —
+// the same spelling a `prRepos` entry uses, so the two match without either side guessing. A bare
+// `owner/repo` would make a GitHub and a GitLab project of the same path indistinguishable.
+const actionableRepo = (forge: RemoteForge): string | null => {
+  const project = LISTABLE.has(forge.kind) ? projectPath(forge) : null;
+  if (!project) return null;
+  return forge.kind === "github" ? project : `${forge.host}/${project}`;
+};
+
+const dirRepo = (forge: RemoteForge | null): DirRepo | null => (forge ? { forge, repo: actionableRepo(forge) } : null);
 
 /** The repository a remote URL names, or null when the string is not a remote at all. */
 export const repoForRemote = (remoteUrl: string): DirRepo | null => dirRepo(forgeOf(remoteUrl));

--- a/server/git/glab-items.ts
+++ b/server/git/glab-items.ts
@@ -62,3 +62,12 @@ export function normalizeGlabMr(raw: unknown): PrItem | null {
     ci: ciFromMergeStatus(mergeStatus),
   };
 }
+
+/** One issue's detail, from `glab issue view`. GitLab calls the body `description` and numbers the
+ *  issue `iid`; `id` is unique across the whole instance and matches nothing a user can look up. */
+export function normalizeGlabIssueDetail(raw: unknown): { number: number; title: string; body: string } | null {
+  if (!isRecord(raw)) return null;
+  const number = itemNumber(raw);
+  // An issue with no description is normal — the title is then the whole brief, same as GitHub.
+  return number === null ? null : { number, title: text(raw.title), body: text(raw.description) };
+}

--- a/server/git/glab.ts
+++ b/server/git/glab.ts
@@ -22,3 +22,8 @@ export function runGlab(args: string[]): Promise<GhResult> {
 export const glabMrListArgs = (project: string, limit: number): string[] => ["mr", "list", "--repo", project, "--per-page", String(limit), "-F", "json"];
 
 export const glabIssueListArgs = (project: string, limit: number): string[] => ["issue", "list", "--repo", project, "--per-page", String(limit), "-O", "json"];
+
+// `issue view` takes `-F` for the output format — like `mr list`, and UNLIKE `issue list`, which
+// takes `-O` and gives `-F` a different meaning entirely. Three subcommands, three answers;
+// verified against glab 1.111.0 rather than pattern-matched from its sibling.
+export const glabIssueViewArgs = (project: string, issue: number): string[] => ["issue", "view", String(issue), "--repo", project, "-F", "json"];

--- a/server/git/issue-work.ts
+++ b/server/git/issue-work.ts
@@ -6,6 +6,9 @@
 // and the browser is the wrong place to unwind that. Here a failed step simply stops, and the
 // caller learns which one.
 import { runGh } from "./gh.js";
+import { runGlab, glabIssueViewArgs } from "./glab.js";
+import { normalizeGlabIssueDetail } from "./glab-items.js";
+import { forgeFromRepoEntry, projectPath } from "./forge-host.js";
 import { createWorktree, issueWorktree } from "./worktrees.js";
 import { claimLaunch, worktreeOccupancy, type WorktreeClaim, type WorktreeOccupancy } from "../session/worktree-session-limit.js";
 import { isRecord } from "../../common/isRecord.js";
@@ -46,10 +49,16 @@ const DETAIL_LIMIT = 300;
 // configured repo, on a view that only shows titles. The body is wanted exactly once, when
 // somebody decides to work on that issue, so it is read here instead.
 export async function fetchIssueDetail(repo: string, issue: number): Promise<IssueDetail | null> {
-  const res = await runGh(["issue", "view", String(issue), "--repo", repo, "--json", "number,title,body"]);
+  const forge = forgeFromRepoEntry(repo);
+  const gitlab = forge?.kind === "gitlab";
+  const project = forge ? (projectPath(forge) ?? forge.path) : repo;
+  const res = gitlab
+    ? await runGlab(glabIssueViewArgs(project, issue))
+    : await runGh(["issue", "view", String(issue), "--repo", project, "--json", "number,title,body"]);
   if (!res.ok) return null;
   try {
     const parsed: unknown = JSON.parse(res.stdout);
+    if (gitlab) return normalizeGlabIssueDetail(parsed);
     if (!isRecord(parsed) || typeof parsed.number !== "number") return null;
     return {
       number: parsed.number,

--- a/server/git/issue-work.ts
+++ b/server/git/issue-work.ts
@@ -78,8 +78,21 @@ export async function fetchIssueDetail(repo: string, issue: number): Promise<Iss
 // NOT submitted — the seed is a draft (see draft-injection.ts), so the user reads it and presses
 // Enter. That matters here more than anywhere else in the app: this text was written by whoever
 // opened the issue, which is often not the person about to run it.
+// What to call the thing and where it lives. Both were hardcoded to GitHub, which for a GitLab
+// entry produced `https://github.com/gitlab.com/group/project/issues/N` — a link to nothing, in the
+// text the agent is about to read (Codex review). `forge.webUrl` already knows the right answer.
+//
+// GitLab puts a project's own pages under `/-/`, and serves issues from `/-/issues/<iid>`.
+const issueLabel = (repo: string): string => (forgeFromRepoEntry(repo)?.kind === "gitlab" ? "GitLab issue" : "GitHub issue");
+
+function issueUrl(repo: string, number: number): string {
+  const forge = forgeFromRepoEntry(repo);
+  if (!forge?.webUrl) return `https://github.com/${repo}/issues/${number}`;
+  return forge.kind === "gitlab" ? `${forge.webUrl}/-/issues/${number}` : `${forge.webUrl}/issues/${number}`;
+}
+
 export function issueSeedPrompt(repo: string, issue: IssueDetail): string {
-  const lines = [`GitHub issue #${issue.number}: ${issue.title}`, `https://github.com/${repo}/issues/${issue.number}`, ""];
+  const lines = [`${issueLabel(repo)} #${issue.number}: ${issue.title}`, issueUrl(repo, issue.number), ""];
   if (issue.body.trim()) lines.push(issue.body.trim(), "");
   lines.push(`Let's work on this issue. Read it through first and confirm the approach with me before implementing.`);
   return lines.join("\n");

--- a/server/routes/issue-work-routes.ts
+++ b/server/routes/issue-work-routes.ts
@@ -10,7 +10,7 @@ import { getCwdPresets, getRepoDirs } from "../config/config-routes.js";
 import { repoDirsFromPresets } from "../git/repo-dirs.js";
 import { startIssueWork } from "../git/issue-work.js";
 import { isIssueNumber } from "../../common/prPhase.js";
-import { canonicalRepo, isRepoEntry } from "../../common/repoEntry.js";
+import { isRepoEntry, repoIdentity } from "../../common/repoEntry.js";
 import { requestOriginAllowed } from "./same-origin-guard.js";
 
 export interface IssueWorkRouteDeps {
@@ -31,22 +31,21 @@ export function mountIssueWorkRoutes(app: Express, deps: IssueWorkRouteDeps): vo
     if (typeof repo !== "string" || !isRepoEntry(repo) || !isIssueNumber(issue) || typeof dir !== "string") {
       return res.status(400).json({ error: "repo ([host/]owner/repo), a positive issue number and dir are required" });
     }
-    // Everything below names the repository the way its own host does. An entry may spell the host
-    // out (`github.com/owner/repo`), and `/api/repo-dirs` keys by the name read off a clone's
-    // remote, which never carries one — comparing the two forms found nothing (Codex review).
-    const project = canonicalRepo(repo);
+    // The entry is carried on AS CONFIGURED, host and all. Stripping it here made the layer below
+    // read `isamu1/node-test` as a GitHub repo and look for an issue that does not exist there —
+    // the host is what says which forge to ask. It comes off at the CLI boundary, not before.
 
     // `dir` arrives from the browser but becomes a spawn's working directory, so it is not taken
     // on trust: it has to be one of the clones the server itself resolved for THIS repo. Without
     // the check, a request could start an agent in any directory on the machine — and in one that
     // has nothing to do with the issue being claimed.
     const known = await repoDirsFromPresets(getCwdPresets(), getRepoDirs());
-    const entry = known.find((r) => canonicalRepo(r.repo).toLowerCase() === project.toLowerCase());
+    const entry = known.find((r) => repoIdentity(r.repo) === repoIdentity(repo));
     if (!entry?.dirs.some((d) => d.path === dir)) {
       return res.status(403).json({ error: `${dir} is not a known clone of ${repo}` });
     }
 
-    const result = await startIssueWork(project, issue, dir, {
+    const result = await startIssueWork(repo, issue, dir, {
       spawnDraft: (cwd, draft) => {
         const sessionId = randomUUID();
         // attachGuiMcp:false — this is a working session in a repository, the same shape as a grid

--- a/src/composables/useIssueStart.ts
+++ b/src/composables/useIssueStart.ts
@@ -11,7 +11,7 @@ import { placeSpawnedChat } from "./useSpawnedChat";
 import { issueStartPlan, type IssueStartPlan } from "../../common/issueStartPlan";
 import { isRecord } from "../../common/isRecord";
 import { parseRepoDirsResponse, type RepoDirs } from "../../common/repoDirs";
-import { canonicalRepo } from "../../common/repoEntry";
+import { repoIdentity } from "../../common/repoEntry";
 
 // Loaded once per view open, like the PR and issue lists beside it: resolving a directory's remote
 // is a `git` call per saved directory, and the answer only changes when the user edits Settings.
@@ -36,10 +36,11 @@ export async function loadRepoDirs(): Promise<void> {
 // GitHub treats `Owner/Repo` and `owner/repo` as one repository, and the two spellings arrive from
 // different places: `prRepos` is typed by hand, the server's side comes from a remote URL.
 export function clonesFor(repo: string): RepoDirs | undefined {
-  // Compared on the canonical identity, not the raw entry: `/api/repo-dirs` keys by the name it
-  // reads off a clone's remote, which never carries the host a configured entry may spell out.
-  const wanted = canonicalRepo(repo).toLowerCase();
-  return repoDirs.value.find((r) => canonicalRepo(r.repo).toLowerCase() === wanted);
+  // Matched on the HOST-QUALIFIED identity: without the host, a GitHub and a GitLab project of the
+  // same path would answer for each other. `canonicalRepo` is the other question — what to pass a
+  // CLI's `--repo` — and is deliberately not used here.
+  const wanted = repoIdentity(repo);
+  return repoDirs.value.find((r) => repoIdentity(r.repo) === wanted);
 }
 
 export const planFor = (repo: string): IssueStartPlan => issueStartPlan(clonesFor(repo), repo);

--- a/test/common/issueStartPlan.spec.ts
+++ b/test/common/issueStartPlan.spec.ts
@@ -98,3 +98,18 @@ describe("a GitHub entry that spells its host out", () => {
     expect(issueStartPlan(undefined, "github.com/acme/web")).toEqual({ kind: "no-clone" });
   });
 });
+
+// The refusal names the hosts it reads off `STARTABLE_HOSTS`, not a sentence written beside it: a
+// hardcoded "github.com only" survived GitLab becoming startable and told users the opposite of
+// what the code did (Codex review, #1257).
+describe("what the refusal says work is supported on", () => {
+  it("names every startable host, so the sentence cannot go stale", () => {
+    const reason = issueStartBlockedReason(issueStartPlan(undefined, "codeberg.org/owner/repo"), "codeberg.org/owner/repo");
+    expect(reason).toContain("github.com");
+    expect(reason).toContain("gitlab.com");
+  });
+
+  it("does not claim only one host is supported", () => {
+    expect(issueStartBlockedReason(issueStartPlan(undefined, "codeberg.org/owner/repo"), "codeberg.org/owner/repo")).not.toContain("only");
+  });
+});

--- a/test/common/issueStartPlan.spec.ts
+++ b/test/common/issueStartPlan.spec.ts
@@ -61,17 +61,22 @@ describe("issueStartBlockedReason", () => {
 // GitHub-only whatever clones exist (Codex review, #981).
 describe("a repo on a forge that can be listed but not started from", () => {
   it("names the forge instead of blaming a missing clone", () => {
-    const plan = issueStartPlan(undefined, "gitlab.com/group/project");
-    expect(plan).toEqual({ kind: "unsupported-forge", host: "gitlab.com" });
-    expect(issueStartBlockedReason(plan, "gitlab.com/group/project")).toContain("gitlab.com");
-    expect(issueStartBlockedReason(plan, "gitlab.com/group/project")).not.toContain("No local clone");
+    const plan = issueStartPlan(undefined, "codeberg.org/owner/repo");
+    expect(plan).toEqual({ kind: "unsupported-forge", host: "codeberg.org" });
+    expect(issueStartBlockedReason(plan, "codeberg.org/owner/repo")).toContain("codeberg.org");
+    expect(issueStartBlockedReason(plan, "codeberg.org/owner/repo")).not.toContain("No local clone");
   });
 
-  // Checked before the clone list: a GitLab repo that somehow HAS a clone still cannot be started
-  // from, so the answer must not depend on whether one is present.
+  // Checked before the clone list, so the answer does not depend on whether a clone is present.
   it("holds even when a clone exists", () => {
-    const entry = { repo: "gitlab.com/group/project", dirs: [{ path: "/w/p", label: "p", orderPriority: null }], primary: "/w/p" };
-    expect(issueStartPlan(entry, "gitlab.com/group/project").kind).toBe("unsupported-forge");
+    const entry = { repo: "codeberg.org/owner/repo", dirs: [{ path: "/w/p", label: "p", orderPriority: null }], primary: "/w/p" };
+    expect(issueStartPlan(entry, "codeberg.org/owner/repo").kind).toBe("unsupported-forge");
+  });
+
+  // GitLab moved from listable to startable in #1257: its issue is read with `glab` and the
+  // worktree is cut from its clone like any other, so it goes on to the clone question.
+  it("lets a GitLab repo through to the clone question", () => {
+    expect(issueStartPlan(undefined, "gitlab.com/group/project")).toEqual({ kind: "no-clone" });
   });
 
   it.each([["acme/web"], ["github.com/acme/web"]])("leaves a GitHub entry (%s) alone", (repo) => {

--- a/test/common/repoEntry.spec.ts
+++ b/test/common/repoEntry.spec.ts
@@ -2,7 +2,7 @@
 // (why a control is off), so the two cannot disagree — writing the rule twice is what this file
 // exists to prevent (#981).
 import { describe, it, expect } from "vitest";
-import { canonicalRepo, parseRepoEntry, GITHUB_HOST } from "../../common/repoEntry";
+import { canonicalRepo, parseRepoEntry, repoIdentity, GITHUB_HOST } from "../../common/repoEntry";
 
 describe("parseRepoEntry", () => {
   it("implies github.com for a bare owner/repo", () => {
@@ -44,5 +44,26 @@ describe("canonicalRepo", () => {
 
   it("leaves something it cannot parse alone rather than inventing a name", () => {
     expect(canonicalRepo("owner//repo")).toBe("owner//repo");
+  });
+});
+
+// Two different questions about one entry, and using the wrong one for the wrong job is how a
+// GitHub clone came to answer for a GitLab repo (#981 step 4c-1).
+describe("repoIdentity vs canonicalRepo", () => {
+  // MATCHING keeps the host: a configured entry is compared against a resolved clone, and without
+  // the host two projects of the same path on different forges collapse into one.
+  it("keeps a GitHub and a GitLab project of the same path apart", () => {
+    expect(repoIdentity("gitlab.com/a/b")).not.toBe(repoIdentity("github.com/a/b"));
+  });
+
+  it("treats a bare entry and its host-qualified spelling as the same repo", () => {
+    expect(repoIdentity("acme/web")).toBe(repoIdentity("github.com/acme/web"));
+    expect(repoIdentity("acme/web")).toBe(repoIdentity("GitHub.com/Acme/Web"));
+  });
+
+  // The CLI question is the opposite one: `--repo` wants the project as its own host names it.
+  it("strips the host for the CLI while matching keeps it", () => {
+    expect(canonicalRepo("gitlab.com/group/project")).toBe("group/project");
+    expect(repoIdentity("gitlab.com/group/project")).toBe("gitlab.com/group/project");
   });
 });

--- a/test/server/git/forge-support.spec.ts
+++ b/test/server/git/forge-support.spec.ts
@@ -98,16 +98,14 @@ describe("repoForRemote", () => {
     expect(repoForRemote("git@github.com:receptron/mulmoterminal.git")).toMatchObject({ repo: "receptron/mulmoterminal", forge: { kind: "github" } });
   });
 
-  // The distinction the whole step exists for: the repository is SEEN (there is a forge) but not
-  // one this app can act on, so `repo` is null while the answer itself is not.
-  it.each([
-    ["a GitLab remote", "git@gitlab.com:group/project.git", "gitlab"],
-    ["a self-hosted remote", "git@git.example.com:team/project.git", "unknown"],
-  ])("reports %s as seen but not actionable", (_case, url, kind) => {
-    const found = repoForRemote(url);
+  // The distinction the step exists for: the repository is SEEN (there is a forge) but not one this
+  // app can act on, so `repo` is null while the answer itself is not. GitLab left this group in
+  // #1257 — work can start there now — so only a host with no implementation is left.
+  it("reports a self-hosted remote as seen but not actionable", () => {
+    const found = repoForRemote("git@git.example.com:team/project.git");
     expect(found).not.toBeNull();
     expect(found?.repo).toBeNull();
-    expect(found?.forge.kind).toBe(kind);
+    expect(found?.forge.kind).toBe("unknown");
   });
 
   // Null stays reserved for "there is nothing here to read", which is what the callers turn into
@@ -155,5 +153,28 @@ describe("missingRepoReason", () => {
 
   it("says no-repo when there is no remote at all", () => {
     expect(missingRepoReason(null)).toBe("no-repo");
+  });
+});
+
+// A clone is reported for every forge work can happen on, and the name it is reported UNDER has to
+// be the one a `prRepos` entry would use — otherwise the entry and the clone never match (#1257).
+describe("which clones repoForRemote reports", () => {
+  it("reports a GitHub clone under the bare owner/repo", () => {
+    expect(repoForRemote("git@github.com:acme/web.git")?.repo).toBe("acme/web");
+  });
+
+  it("reports a GitLab clone under its host-qualified name", () => {
+    expect(repoForRemote("git@gitlab.com:group/project.git")?.repo).toBe("gitlab.com/group/project");
+  });
+
+  it("keeps a nested GitLab group in the name", () => {
+    expect(repoForRemote("git@gitlab.com:group/sub/project.git")?.repo).toBe("gitlab.com/group/sub/project");
+  });
+
+  // Still null for a forge nothing can be done with — seen, but not actionable.
+  it("reports no repo for a host that is neither", () => {
+    const found = repoForRemote("git@git.example.com:team/project.git");
+    expect(found).not.toBeNull();
+    expect(found?.repo).toBeNull();
   });
 });

--- a/test/server/git/glab-items.spec.ts
+++ b/test/server/git/glab-items.spec.ts
@@ -2,8 +2,8 @@
 // CAPTURED from gitlab.com (gitlab-org/cli, 2026-08-01) rather than written by hand, so a field
 // GitLab renames breaks this instead of quietly emptying a row.
 import { describe, it, expect } from "vitest";
-import { normalizeGlabIssue, normalizeGlabMr } from "../../../server/git/glab-items.js";
-import { glabIssueListArgs, glabMrListArgs } from "../../../server/git/glab.js";
+import { normalizeGlabIssue, normalizeGlabIssueDetail, normalizeGlabMr } from "../../../server/git/glab-items.js";
+import { glabIssueListArgs, glabIssueViewArgs, glabMrListArgs } from "../../../server/git/glab.js";
 
 const REAL_MR = {
   iid: 3675,
@@ -128,5 +128,50 @@ describe("glab list arguments", () => {
   // open list is the default. Passing it would add noise now and break later.
   it("asks issue list for json with -O, and passes no state flag", () => {
     expect(glabIssueListArgs("group/project", 21)).toEqual(["issue", "list", "--repo", "group/project", "--per-page", "21", "-O", "json"]);
+  });
+});
+
+// One issue's detail, which is what the seeded session shows. Captured from gitlab.com.
+describe("normalizeGlabIssueDetail", () => {
+  const REAL_DETAIL = {
+    id: 196437163,
+    iid: 1,
+    title: "mulmoterminal からの表示確認用",
+    description: "#981 段階4a の実機確認。消して構いません。",
+    state: "opened",
+    web_url: "https://gitlab.com/isamu1/node-test/-/work_items/1",
+  };
+
+  it("maps a real issue, taking the body from `description`", () => {
+    expect(normalizeGlabIssueDetail(REAL_DETAIL)).toEqual({
+      number: 1,
+      title: "mulmoterminal からの表示確認用",
+      body: "#981 段階4a の実機確認。消して構いません。",
+    });
+  });
+
+  // `id` is unique across the instance; `iid` is what the URL and the UI show.
+  it("numbers from iid, not id", () => {
+    expect(normalizeGlabIssueDetail(REAL_DETAIL)?.number).toBe(1);
+  });
+
+  // An issue with no description is ordinary — the title is then the whole brief, as on GitHub.
+  it("gives an empty body rather than dropping an issue with no description", () => {
+    expect(normalizeGlabIssueDetail({ ...REAL_DETAIL, description: null })).toMatchObject({ number: 1, body: "" });
+  });
+
+  it.each([
+    ["a non-object", "nope"],
+    ["no iid", { title: "x" }],
+  ])("returns null for %s", (_case, raw) => {
+    expect(normalizeGlabIssueDetail(raw)).toBeNull();
+  });
+});
+
+describe("glabIssueViewArgs", () => {
+  // `-F`, like `mr list` — and UNLIKE `issue list`, which takes `-O` and gives `-F` another
+  // meaning. Three subcommands, three answers; `-O` here is rejected outright by glab.
+  it("asks for json with -F", () => {
+    expect(glabIssueViewArgs("group/project", 7)).toEqual(["issue", "view", "7", "--repo", "group/project", "-F", "json"]);
   });
 });

--- a/test/server/git/issue-work.spec.ts
+++ b/test/server/git/issue-work.spec.ts
@@ -11,6 +11,30 @@ const issue = (over: Partial<IssueDetail> = {}): IssueDetail => ({
 });
 
 describe("issueSeedPrompt", () => {
+  // The seed is TEXT THE AGENT READS, so a wrong link is not cosmetic — it sends the session to a
+  // page that does not exist. Both halves were hardcoded to GitHub, which for a GitLab entry built
+  // `https://github.com/gitlab.com/group/project/issues/N` (Codex review, #1257).
+  it("links a GitLab issue to GitLab, under its /-/ path", () => {
+    const seed = issueSeedPrompt("gitlab.com/group/project", issue());
+    expect(seed).toContain("https://gitlab.com/group/project/-/issues/1173");
+    expect(seed).not.toContain("github.com");
+  });
+
+  it("calls a GitLab issue a GitLab issue", () => {
+    expect(issueSeedPrompt("gitlab.com/group/project", issue())).toContain("GitLab issue #1173");
+  });
+
+  it("keeps a nested GitLab group in the link", () => {
+    expect(issueSeedPrompt("gitlab.com/group/sub/project", issue())).toContain("https://gitlab.com/group/sub/project/-/issues/1173");
+  });
+
+  // A GitHub entry is unchanged whichever way it is spelled.
+  it.each([["acme/web"], ["github.com/acme/web"]])("links %s to github.com", (repo) => {
+    const seed = issueSeedPrompt(repo, issue());
+    expect(seed).toContain("https://github.com/acme/web/issues/1173");
+    expect(seed).toContain("GitHub issue #1173");
+  });
+
   it("names the issue and links it before quoting the body", () => {
     const seed = issueSeedPrompt("acme/web", issue());
     expect(seed).toContain("GitHub issue #1173: Start from the issue row");


### PR DESCRIPTION
## Summary

GitLab の issue 行の **▶ が「github.com only」を出すのをやめ、実際に着手できる**ようになります。
issue を `glab` で読み、worktree を切り、セッションに本文を入れる — GitHub と同じ流れです。

**GitHub の挙動は変えていません。**

## Items to Confirm / Review

### 実機で通して初めて出た穴が2つ、根っこは同じでした

**1. GitLab のクローンが `/api/repo-dirs` に載らない。** `repoForDir` が GitHub 以外に `repo: null`
を返していました（段階2b の時点では GitHub しか着手できなかったので**当時は正しかった**）。
ゲートだけ広げても**ボタンは無効のまま**で、しかも理由が出ません。

**2. ホストを剥がすと forge が分からなくなる。** ルートが `canonicalRepo` してから渡すので、
`isamu1/node-test` が「ホスト無し＝GitHub」と解釈され、**存在しない GitHub リポ**を見に行って
いました。エラーが `could not read isamu1/node-test#1` → `...gitlab.com/isamu1/node-test#1` と
変わったことで、修正が効いたと分かりました。

**どちらも「1つの文字列に2つの役割」**だったので、分けました。

| | 用途 | ホスト |
| --- | --- | --- |
| `repoIdentity` | 設定エントリと解決済みクローンの**照合** | **付ける** — `github.com/a/b` と `gitlab.com/a/b` を潰さないため |
| `canonicalRepo` | CLI の `--repo` に渡す | **剥がす** — ホストはそのホスト自身が知っている |

ホスト付きのまま持ち回り、**CLI の直前でだけ剥がします**。

### glab のフラグは3つのサブコマンドで全部違います

| コマンド | 出力形式 |
| --- | --- |
| `mr list` | `-F` |
| `issue list` | **`-O`**（`-F` は details/ids/urls） |
| `issue view` | **`-F`**（`-O` は即「Unknown shorthand flag」） |

**argv をテストで固定**しています。フラグを間違えても**コマンドは動いて違うものを返す**ので。

### 検証できたこと / できていないこと

**実 API に対して確認済み:**

- `fetchIssueDetail` が **GitLab の issue も GitHub の issue も**正しく読む
- クローンが `gitlab.com/isamu1/node-test` として認識される
- `/api/repo-dirs` がそれを載せる
- `POST /api/issues/start` が検証を通り、クローンと照合し、issue 読み取りまで到達する

**未確認: worktree 作成と spawn。** demo 用の `HOME` に差し替えると glab が認証情報を見つけられず
（keychain のトークンは glab が内部でリフレッシュしていて取り出せません）、`MULMOTERMINAL_HOME` は
`os.homedir()` 由来で上書きできないためです。**その先のコードは forge 非依存**で、GitHub 経路で
実証済みです。

### 意図的に反転させた既存テスト2件

GitLab が「一覧だけ」から「着手できる」に移ったので、`unsupported-forge` のケースは
**まだ未対応のホスト**（codeberg.org）に付け替えました。

## User Prompt

> 4c-1から。

## テスト

`yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（7406 passed）/ `knip` —
**すべて終了コードで確認**。

Fixes #1257

refs #981

work in mulmoterminal4
