### PR TITLE
refactor: デスクトップの issue 起動も issueSpawnOptions を通す

### DIFF
--- a/plans/refactor-1259-issue-spawn-options-desktop.md
+++ b/plans/refactor-1259-issue-spawn-options-desktop.md
@@ -1,0 +1,54 @@
+# refactor(#1259): デスクトップの issue 起動も issueSpawnOptions を通す
+
+## いま二重になっているもの
+
+#1253 で「種を draft として置くか、送信まで行うか」の決定を純関数 `issueSpawnOptions` に出した。
+スマホ経路はそこを通るが、デスクトップ経路 `server/routes/issue-work-routes.ts` はオプションを
+直書きしたままで、`attachGuiMcp: false` の**理由コメントごと**重複している。
+
+出力は同じ。危ないのは出力ではなく、**同じ判断が2箇所にあること**。
+
+## この重複が壊れるときの壊れ方
+
+`planDraftInjection` は `draft ?? initialPrompt` を解決する。つまり:
+
+- 両方立てば **draft が勝つ** — auto-run は静かに効かなくなる
+- どちらも立たなければ **何もタイプされない**
+
+いずれも例外を投げず、ログにも出ない。`typecheck` もテストも CI も通る。
+だからこの決定は 1 箇所に閉じ、テストで固定する価値がある。
+
+## テストの穴（この refactor で塞ぐ）
+
+`test/server/routes/issue-work-route.spec.ts` は `startIssueWork` の引数は検証しているが、
+**`spawnClaudePty` に渡ったオプションを一度も assert していない**。
+「デスクトップは draft のまま」という #1253 の決定が、今は何にも守られていない。
+
+refactor の前後で挙動が変わらないことを保証するのは、まさにこの assert なので、
+コードを差し替える前に**先にテストを足す**。
+
+## 変更するファイル
+
+| ファイル | 変更 |
+|---|---|
+| `server/routes/issue-work-routes.ts` | `issueSpawnOptions(cwd, draft, false)` を使う。`IssueWorkRouteDeps.spawnClaudePty` の `options` 型を `SpawnClaudeOptions` に広げる |
+| `test/server/routes/issue-work-route.spec.ts` | スタブの型を合わせ、デスクトップの spawn が `draft` を持ち `initialPrompt` を持たないことを固定 |
+
+`options` 型を広げる件: 現在の narrow な型に付いている「わざと狭くしている」という注記は、
+**返り値を `PtyEntry` にしないため**の話（テストを含む全呼び出し元に `PtyEntry` を作らせない）。
+オプション側が狭いのは付随的なもので、実際の配線 `app-routes.ts` は
+`ReturnType<typeof createClaudeSpawner>["spawnClaudePty"]`（= `SpawnClaudeOptions` を取る）を渡している。
+広げても呼び出し元は影響を受けない。注記は返り値の話であることが分かるよう書き直す。
+
+## テストで固定すること
+
+- デスクトップの spawn オプションが `{ cwd, draft, attachGuiMcp: false }` であること
+- **`initialPrompt` を持たないこと**（持つと draft が勝って auto-run しない、という静かな壊れ方の入口）
+- `cwd` が worktree であって、切り出し元のクローンではないこと
+
+## やらないこと
+
+- 挙動の変更。デスクトップは今までどおり「入力欄に入れて送信しない」
+- スマホ経路 (`server/index.ts` / `handlers/issueWork.ts`) の変更
+- `randomUUID` によるセッション ID 生成の共通化 — スマホ側は `markUnplacedSession` も呼ぶので
+  同じ関数にはならない。共通なのは**オプションの決定**だけで、そこはもう共通化されている

--- a/server/routes/issue-work-routes.ts
+++ b/server/routes/issue-work-routes.ts
@@ -9,14 +9,17 @@ import { randomUUID } from "node:crypto";
 import { getCwdPresets, getRepoDirs } from "../config/config-routes.js";
 import { repoDirsFromPresets } from "../git/repo-dirs.js";
 import { startIssueWork } from "../git/issue-work.js";
+import { issueSpawnOptions } from "../session/issue-spawn-options.js";
+import type { SpawnClaudeOptions } from "../session/spawn-claude.js";
 import { isIssueNumber } from "../../common/prPhase.js";
 import { canonicalRepo, isRepoEntry } from "../../common/repoEntry.js";
 import { requestOriginAllowed } from "./same-origin-guard.js";
 
 export interface IssueWorkRouteDeps {
-  /** Narrower than the spawner's own type on purpose: this route ignores the PtyEntry it returns,
-   *  and asking for the whole shape would make every caller — including a test — construct one. */
-  spawnClaudePty: (sessionId: string, resume: null, ws: null, options: { cwd: string; draft: string; attachGuiMcp: boolean }) => unknown;
+  /** Returns `unknown` on purpose: this route ignores the PtyEntry the spawner hands back, and
+   *  asking for the whole shape would make every caller — including a test — construct one. The
+   *  options are the spawner's own type, because they are built by issueSpawnOptions. */
+  spawnClaudePty: (sessionId: string, resume: null, ws: null, options: SpawnClaudeOptions) => unknown;
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
 }
 
@@ -49,10 +52,10 @@ export function mountIssueWorkRoutes(app: Express, deps: IssueWorkRouteDeps): vo
     const result = await startIssueWork(project, issue, dir, {
       spawnDraft: (cwd, draft) => {
         const sessionId = randomUUID();
-        // attachGuiMcp:false — this is a working session in a repository, the same shape as a grid
-        // dev terminal, so the project's own MCP servers load instead of being replaced by the GUI
-        // one under --strict-mcp-config.
-        deps.spawnClaudePty(sessionId, null, null, { cwd, draft, attachGuiMcp: false });
+        // run:false — the desktop leaves the seed in the input box. The issue text was written by
+        // whoever opened it, who is often not the person about to run it, so the Enter is theirs.
+        // The phone passes true (#1253): it has no Enter key.
+        deps.spawnClaudePty(sessionId, null, null, issueSpawnOptions(cwd, draft, false));
         return sessionId;
       },
     });

--- a/test/server/routes/issue-work-route.spec.ts
+++ b/test/server/routes/issue-work-route.spec.ts
@@ -9,6 +9,7 @@ import type { Express } from "express";
 import { makeTempDir } from "../../support/tempDir.js";
 import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "../git/wtTestUtil.js";
 import type { CwdPreset } from "../../../server/config/config-schema.js";
+import type { SpawnClaudeOptions } from "../../../server/session/spawn-claude.js";
 
 const configState: { presets: CwdPreset[]; recorded: Record<string, string> } = { presets: [], recorded: {} };
 
@@ -50,7 +51,7 @@ const makeRes = (): FakeRes => ({
 
 type Handler = (req: { headers: { origin?: string }; body?: unknown; method: string; path: string }, res: FakeRes) => unknown;
 
-const spawnClaudePty = vi.fn<(sessionId: string, resume: null, ws: null, options: { cwd: string; draft: string; attachGuiMcp: boolean }) => unknown>();
+const spawnClaudePty = vi.fn<(sessionId: string, resume: null, ws: null, options: SpawnClaudeOptions) => unknown>();
 
 function startHandler(allowOrigin = true): Handler {
   const map: Record<string, Handler> = {};
@@ -163,6 +164,30 @@ describe("POST /api/issues/start", () => {
       expect(res.statusCode).toBe(200);
       expect(res.payload).toMatchObject({ ok: true, sessionId: "s-1", branch: "issue/7-x" });
       expect(issueWork.start).toHaveBeenCalledWith("acme/web", 7, clone, expect.anything());
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
+  // The desktop leaves the seed for review — the issue text was written by whoever opened it, and
+  // the Enter is the reader's (#1253 gave the PHONE a `run`, and deliberately not this route).
+  //
+  // Asserted on the spawn options rather than on the reply, because that is where it would go
+  // wrong silently: planDraftInjection resolves `draft ?? initialPrompt`, so a route that grew an
+  // initialPrompt would still type the draft and still answer 200 — the auto-run simply would not
+  // happen, with nothing raised anywhere.
+  it.skipIf(!hasGit)(
+    "spawns with the seed as a draft, never as an initialPrompt",
+    async () => {
+      issueWork.start.mockImplementation(async (_repo: string, _issue: number, _dir: string, deps: { spawnDraft: (cwd: string, seed: string) => string }) => ({
+        ok: true,
+        sessionId: deps.spawnDraft("/wt/7-x", "GitHub issue #7"),
+      }));
+      await post({ repo: "acme/web", issue: 7, dir: clone });
+      expect(spawnClaudePty).toHaveBeenCalledTimes(1);
+      // The seed goes into the WORKTREE, not the clone it was cut from.
+      const options = spawnClaudePty.mock.calls[0][3];
+      expect(options).toEqual({ cwd: "/wt/7-x", draft: "GitHub issue #7", attachGuiMcp: false });
+      expect(options.initialPrompt).toBeUndefined();
     },
     GIT_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

`POST /api/issues/start`（デスクトップ）も、#1253 で切り出した純関数
`issueSpawnOptions(cwd, seed, run)` を通すようにしました。デスクトップは `run: false` を渡します。

**挙動は一切変わりません。** `issueSpawnOptions(cwd, draft, false)` の出力は、これまで手で書いていた
`{ cwd, draft, attachGuiMcp: false }` とバイト単位で同一です。

あわせて、**これまでテストが無かった「デスクトップは draft のまま」**を spec で固定しました。

## Items to Confirm / Review

1. **テストを先に足し、リファクタ前のコードで通ることを確認してからコードを差し替えました。**
   これが「挙動が変わっていない」ことの外部証拠です（リライトを後追いで記述したテストではない）。
   - リファクタ前: 新テスト含む 12 件 pass
   - リファクタ後: 同じ 12 件 pass
2. **assert の対象を返り値ではなく spawn オプションにしています。** `planDraftInjection` は
   `draft ?? initialPrompt` を解決するので、このルートが誤って `initialPrompt` を持つようになっても
   **draft が勝ち、200 を返し、auto-run だけが静かに起きない**。レスポンスを見ていては捕まりません。
   そのため `initialPrompt` が **undefined であること**まで明示的に assert しています。
3. **`IssueWorkRouteDeps.spawnClaudePty` の `options` 型を `SpawnClaudeOptions` に広げました。**
   元のコメント「わざと狭くしている」は**返り値**の話（呼び出し元に `PtyEntry` を作らせない）で、
   オプション側が狭いのは付随的なものでした。コメントをその趣旨に書き直しています。
   実配線 `app-routes.ts` は元々 `ReturnType<typeof createClaudeSpawner>["spawnClaudePty"]` を
   渡しており、影響はありません。

## User Prompt

> デスクトップ経路 issue-work-routes.ts の共通化

（#1253 / PR #1255 のレビュー時に「issue に『変更なし』とあるので触っていない」と保留し、
そのうえで改めて依頼されたものです。）

## なぜ直す価値があるか

出力が同じなので、危ないのは出力ではなく **同じ判断が 2 箇所にあること**でした。

1. `attachGuiMcp: false` の理由（「リポジトリ内の作業セッションなので、GUI MCP に置き換えず
   プロジェクト自身の MCP を読ませる」）が**両方にコメントごと重複**していました。
   方針が変わったとき片方だけ直しても、`typecheck` もテストも CI も通ります。
2. 「デスクトップは draft のまま」という #1253 の決定が、**何にも守られていませんでした**。
   `issue-work-route.spec.ts` は `startIssueWork` の引数は見ていましたが、
   `spawnClaudePty` に渡ったオプションは一度も assert していませんでした。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `server/routes/issue-work-routes.ts` | `issueSpawnOptions(cwd, draft, false)` を使用。dep の `options` 型を `SpawnClaudeOptions` に |
| `test/server/routes/issue-work-route.spec.ts` | スタブ型を合わせ、`draft` があり `initialPrompt` が無いことを固定 |
| `plans/refactor-1259-issue-spawn-options-desktop.md` | 設計メモ |

## やらないこと

- 挙動の変更。デスクトップは今までどおり「入力欄に入れて送信しない」
- スマホ経路（`server/index.ts` / `handlers/issueWork.ts`）の変更
- `randomUUID` によるセッション ID 生成の共通化 — スマホ側は `markUnplacedSession` も呼ぶので
  同じ関数にはなりません。共通なのは**オプションの決定**だけで、そこはもう共通化されています

## 検証

`yarn format` / `lint`（新規エラー 0）/ `typecheck` / `typecheck:server` / `typecheck:test` /
`build` / `knip`（新規指摘 0）/ `test` — **512 files・7409 tests 全 pass**。

Closes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
