### PR TITLE
fix: 11ファイルの as を13箇所外す (#1231)

### DIFF
--- a/server/backends/collectionNotifierAdapter.ts
+++ b/server/backends/collectionNotifierAdapter.ts
@@ -7,6 +7,7 @@
 // here rather than imported.
 import type { CompletionPriority } from "@mulmoclaude/core/collection-watchers";
 import type { NotifierSeverity } from "@mulmoclaude/core/notifier";
+import { isRecord } from "../../common/isRecord.js";
 
 // `legacy: true` + a string `legacyId` + a string `kind` is the marker both apps'
 // readEntry recognise; the navigate `action` preserves the bell's icon/routing.
@@ -19,8 +20,8 @@ export interface LegacyNotifierPluginData {
 }
 
 export function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
-  if (value === null || typeof value !== "object") return false;
-  const rec = value as Record<string, unknown>;
+  if (!isRecord(value)) return false;
+  const rec = value;
   return rec.legacy === true && typeof rec.legacyId === "string" && typeof rec.kind === "string";
 }
 

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -25,6 +25,7 @@ import { publishFileChange } from "./fileChange.js";
 import { statFileOr404 } from "./statFileOr404.js";
 import { streamFileToResponse } from "./streamFile.js";
 import { isWithin } from "../infra/path-within.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Curated CDN allowlist for an LLM-authored page that may pull a charting/util lib or font
 // from a CDN. Core owns the list so this policy and the remote-view CSP can't drift — widen
@@ -73,7 +74,7 @@ function sendHtmlDocument(res: Response, abs: string): void {
  *  registered BEFORE mountAllRoutes. */
 export function mountHtmlDispatchRoute(app: Express): void {
   app.post("/api/plugin/presentHtml", async (req: Request, res: Response, next: NextFunction) => {
-    const args = (req.body ?? {}) as { kind?: unknown; path?: unknown };
+    const args: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     // A tool-call (no `kind`) is left to the package execute via the catch-all.
     if (args.kind !== "loadHtml" && args.kind !== "saveHtml") return next();
     try {

--- a/server/backends/mulmoscript.ts
+++ b/server/backends/mulmoscript.ts
@@ -28,6 +28,7 @@ import {
 } from "@mulmoclaude/mulmoscript-plugin/server";
 import type { SaveMulmoScriptArgs } from "@mulmoclaude/mulmoscript-plugin";
 import { artifactsFileOps } from "./artifacts.js";
+import { isRecord } from "../../common/isRecord.js";
 
 /** Pubsub channel the extracted View subscribes to for generation progress —
  *  `plugin:<scope>:<event>`, matching the client runtime's channel formula
@@ -162,7 +163,7 @@ export function mountMulmoScriptDispatchRoute(app: Express): void {
       res.status(503).json({ error: "mulmoScript backend not initialised" });
       return;
     }
-    const body = (req.body ?? {}) as Record<string, unknown>;
+    const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     try {
       if (typeof body.kind === "string") {
         res.json(await dispatchHandler(body));

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -207,14 +207,14 @@ async function updateViaView(
   // Shape the returned item like a getItems item — same host-computed fields
   // (derived, toggle, embed) — then inline the view's declared image fields.
   const [enriched] = await deps.enrichItems(collection, [result.item]);
-  const item = enriched as RemoteViewItem;
+  const item = enriched;
   const baseBytes = Buffer.byteLength(JSON.stringify(item), "utf8");
   if (baseBytes > REMOTE_VIEW_ITEMS_MAX_BYTES) return { kind: "too-large", bytes: baseBytes };
   const imageFields = inlineFields(view, collection.schema, undefined);
   if (imageFields.length > 0) {
     await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, REMOTE_VIEW_ITEMS_MAX_BYTES - baseBytes);
   }
-  return { kind: "ok", op: "update", item: item as CollectionItem };
+  return { kind: "ok", op: "update", item };
 }
 
 export const mutateRemoteView = createMutateRemoteView({ storeFor, enrichItems, resolveThumbnail });
@@ -287,7 +287,7 @@ export const createRemoteViewItems =
     // loaded, derived formulas evaluated, toggles/embeds resolved — the phone
     // gets plain resolved scalars so mobile numbers match desktop exactly.
     const items = await deps.listRecords(collection);
-    const derived = (await deps.enrichItems(collection, items)) as RemoteViewItem[];
+    const derived = await deps.enrichItems(collection, items);
     const page = pageFromItems(derived, request, collection.schema.primaryKey);
     const baseBytes = Buffer.byteLength(JSON.stringify(page), "utf8");
     if (baseBytes > REMOTE_VIEW_ITEMS_MAX_BYTES) return { kind: "too-large", bytes: baseBytes };

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -398,7 +398,7 @@ export function sanitizeProviders(input: unknown): Provider[] {
 // Sanitize a parsed config object into an AppConfig. Pure; `raw` is whatever JSON.parse
 // produced (any shape), so every field is defended by its own sanitizer.
 function sanitizeAppConfig(raw: unknown): AppConfig {
-  const o = (raw ?? {}) as Record<string, unknown>;
+  const o: Record<string, unknown> = isRecord(raw) ? raw : {};
   return {
     cwdPresets: sanitizePresets(o.cwdPresets),
     soundFile: sanitizeSoundFile(o.soundFile),

--- a/server/git/prs.ts
+++ b/server/git/prs.ts
@@ -25,8 +25,8 @@ export function rollupCiState(checks: unknown): CiState {
   if (!Array.isArray(checks) || checks.length === 0) return "none";
   let anyPending = false;
   for (const c of checks) {
-    if (!c || typeof c !== "object") continue;
-    const o = c as Record<string, unknown>;
+    if (!isRecord(c)) continue;
+    const o = c;
     const conclusion = String(o.conclusion ?? "").toUpperCase();
     const state = String(o.state ?? "").toUpperCase();
     if (FAIL.has(conclusion) || state === "FAILURE" || state === "ERROR") return "failing";

--- a/server/session/background-chat.ts
+++ b/server/session/background-chat.ts
@@ -5,6 +5,7 @@
 // The agent tool calls this, so the body is whatever a model produced — every field is
 // treated as absent unless it is exactly what we accept.
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface BackgroundChatRequest {
   agent: TerminalAgent;
@@ -17,7 +18,7 @@ export interface BackgroundChatRequest {
 
 /** The request, or the message to answer with when it cannot be served. */
 export function parseBackgroundChat(body: unknown): { ok: true; request: BackgroundChatRequest } | { ok: false; message: string } {
-  const record = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  const record: Record<string, unknown> = isRecord(body) ? body : {};
   const message = typeof record.message === "string" ? record.message.trim() : "";
   if (!message) return { ok: false, message: "spawnBackgroundChat: `message` is required (non-empty string)." };
   return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ import { useUnloadGuard } from "./composables/useUnloadGuard";
 import { usePubSub } from "./composables/usePubSub";
 import { openTerminalAt } from "./composables/useNewTerminal";
 import { LAUNCH_TERMINAL_CHANNEL, isLaunchAgent, type LaunchAgent } from "../common/launchAgent";
+import { isRecord } from "../common/isRecord";
 
 // The phone asked for a new terminal in a session's directory (#831). The grid is browser state —
 // the host can only ask — so SOMETHING has to be listening for this to be servable, and the host
@@ -33,8 +34,8 @@ import { LAUNCH_TERMINAL_CHANNEL, isLaunchAgent, type LaunchAgent } from "../com
 // component is the one that certainly exists: the grid is mounted for the life of the page now,
 // but openTerminalAt already queues and brings it on screen, so the seam costs nothing to keep.
 const launchRequestOf = (data: unknown): { cwd: string; agent: LaunchAgent } | null => {
-  if (typeof data !== "object" || data === null) return null;
-  const { cwd, agent } = data as { cwd?: unknown; agent?: unknown };
+  if (!isRecord(data)) return null;
+  const { cwd, agent } = data;
   return typeof cwd === "string" && cwd && isLaunchAgent(agent) ? { cwd, agent } : null;
 };
 // Appended at the end of the grid: the phone has no notion of which desktop cell is

--- a/src/components/cellPayload.ts
+++ b/src/components/cellPayload.ts
@@ -1,4 +1,5 @@
 // The two payload shapes a cell believes without asking anyone: the token usage and the
+import { isRecord } from "../../common/isRecord";
 // running model/context that back its header badges.
 //
 // They arrive from /api/session/:id and the cost route, and the guards only asked whether a
@@ -25,7 +26,7 @@ export interface CellContext {
 // a string would.
 const isRenderableCount = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
 
-const asRecord = (value: unknown): Record<string, unknown> | null => (typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null);
+const asRecord = (value: unknown): Record<string, unknown> | null => (isRecord(value) ? value : null);
 
 export function isCellUsage(value: unknown): value is CellUsage {
   const usage = asRecord(value);

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -49,6 +49,7 @@ import {
 import PinToggle from "../components/PinToggle.vue";
 import { startCollectionChat } from "./useChatLauncher";
 import { browserLocale } from "../utils/browserLocale";
+import { isRecord } from "../../common/isRecord";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -103,7 +104,11 @@ async function postTranslation(req: TranslateRequest): Promise<TranslateResponse
       body: JSON.stringify(req),
     });
     if (!res.ok) return null;
-    return (await res.json()) as TranslateResponse;
+    const body: unknown = await res.json();
+    // `null` is the transport's documented miss — the caller falls back to the English source —
+    // so a malformed body takes that path rather than handing the cache a bad shape.
+    if (!isRecord(body) || !Array.isArray(body.translations) || !body.translations.every((line) => typeof line === "string")) return null;
+    return { translations: body.translations };
   } catch {
     return null;
   }

--- a/src/composables/pluginRuntime.ts
+++ b/src/composables/pluginRuntime.ts
@@ -12,7 +12,7 @@
 //   - locale    → a fixed "en" ref (MulmoTerminal has no locale picker; the
 //                 package's bundled i18n falls back to English).
 //   - openUrl   → scheme-allowlisted window.open.
-import { computed, defineComponent, h, markRaw, provide, ref, type Component, type Ref } from "vue";
+import { defineComponent, h, markRaw, provide, ref, type Component, type Ref } from "vue";
 import { PLUGIN_RUNTIME_KEY, type BrowserPluginRuntime } from "gui-chat-protocol/vue";
 import { usePubSub } from "./usePubSub";
 import { isOpenablePluginUrl } from "./pluginUrlPolicy";
@@ -68,7 +68,7 @@ export function makeBrowserPluginRuntime(deps: MakeRuntimeDeps): BrowserPluginRu
         return subscribe(pluginChannelName(scope, eventName), handler as (data: unknown) => void);
       },
     },
-    locale: computed(() => sharedLocale.value) as Ref<string>,
+    locale: sharedLocale,
     log: {
       debug: (msg, data) => console.debug(tag, msg, data),
       info: (msg, data) => console.info(tag, msg, data),


### PR DESCRIPTION
## Summary

#1231。11 ファイル・**13 箇所**。**73 → 60**。allowlist は引き続き **0 件**。

## Items to Confirm / Review

### 1. `remoteView.ts` の 3 箇所は **すべて no-op** だった

```ts
export type RemoteViewItem = Record<string, unknown>;   // @mulmoclaude/core
export type CollectionItem = Record<string, unknown>;   // @mulmoclaude/core
```

**同じ型どうしの cast** でした。3 箇所とも外すだけで型エラーが出ません。

不要キャストはこれで通算 **9 件**です。「まず外してみる」を各ファイルの最初の手順にしているのは、これが理由です。

### 2. `pluginRuntime.ts` の `locale` は、ラップごと不要だった

```diff
-locale: computed(() => sharedLocale.value) as Ref<string>,
+locale: sharedLocale,
```

`ComputedRef` は `Ref` に代入できないため cast が要る、という構図に見えますが、**`sharedLocale` 自体が既に `Ref<string>`** です（`const sharedLocale: Ref<string> = ref("en")`）。`computed` のラップが目的を持っていませんでした。外したら `computed` の import も未使用になり、それが裏付けになっています。

### 3. `TranslateResponse` は検証できる形だった

```diff
-return (await res.json()) as TranslateResponse;
+const body: unknown = await res.json();
+if (!isRecord(body) || !Array.isArray(body.translations) || !body.translations.every((line) => typeof line === "string")) return null;
+return { translations: body.translations };
```

`TranslateResponse` は `{ translations: string[] }` だけなので確かめられます。**不正なら `null`** を返しますが、これは transport が定義する「ミス」の経路そのもの（`@mulmoclaude/core/translation/client` のコメント: *`null` on any network / HTTP failure — the cache treats `null` as a miss and the caller falls back to the English source*）なので、挙動として自然です。

### 4. 残りは `isRecord` への置換（8 ファイル）

`req.body` の無検査使用（html / mulmoscript）と、手書きの object 判定（app-config / background-chat / prs / collectionNotifierAdapter / cellPayload / App.vue）。

## User Prompt

- #1231 を進めてほしい。修正中にバグを見つけたら issue に詳細と原因を残す。
- PR は並列で。CodeRabbit は無視で良い。CI に時間がかかるので 5 つくらいまとめて。
- 基本は 0 にできると思うよ、普通の方法で。
- あれ。全部レビューしてマージずみ？であればのこり 73 個を！

## 「0 にできない可能性がある」ものが見えてきました（この PR では触っていません）

残り 60 のうち、**7 箇所**はホスト側の型付けでは消せない可能性があります。調べた結果を先に共有します。

| 箇所 | 状況 |
|---|---|
| `mcp-routes.ts:121` | **upstream SDK の宣言バグ**。`@modelcontextprotocol/sdk` が `implements Transport` と書きながら `exactOptionalPropertyTypes` 下で不一致。[upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083) が既に開いていて、コードにもその旨と「ランドしたら外す」と書いてあります |
| `collectionUi.ts` の teleport（2 hits） | パッケージが `() => string \| HTMLElement` と宣言。**Vue 自身の `TeleportProps.to` は `string \| RendererElement` で ShadowRoot を受ける**ので、パッケージの型が Vue より狭い。module augmentation も試しましたが、既存プロパティの型は広げられませんでした（TS の仕様） |
| `pluginRuntime.ts` の `dispatch<T>` / `subscribe<T>` | プロトコルがジェネリックを宣言しており、ホストは検証できない `T` を作る側に立たされます |
| `early-frames.ts`（2 hits） | 同上（`bufferEarlyFrames<T>` が untyped socket から `T` を約束する） |

**いずれも「upstream の型を直すのが正しい」類**です。`subscribe` は一度 `handler(data as T)` に書き換えてみましたが、**cast を移動しただけで消えていない**ので戻しました。

残り 53 はまだ普通の方法で消せる見込みです。上記 7 箇所をどうするか（upstream PR / allowlist）は、53 を片付けてから改めて相談させてください。

## 検証

`yarn lint`（0 error、65 problems ← 78。うち 5 件は既存の別ルール）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7409 passed**。

`App.vue` はアプリのシェルなので実ブラウザでも確認（描画・console error 0）。

refs #1231

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or unexpected request data to prevent processing errors.
  * Added safer validation for application configuration and translation responses.
  * Malformed translation results are now rejected instead of being used incorrectly.
  * Improved validation of background chat, dispatch, tool-call, and launch request data.

* **Refactor**
  * Standardized record validation across server and client workflows.
  * Simplified locale handling without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->