### PR TITLE
fix: client 8ファイルの as を11箇所外す (#1231)

### DIFF
--- a/src/components/WikiProse.vue
+++ b/src/components/WikiProse.vue
@@ -32,17 +32,23 @@ function activateLink(el: HTMLElement | null): void {
   if (slug) wikiGotoPage(slug);
 }
 
+// The .wiki-link an event landed on, or null. `e.target` is `EventTarget | null`, so this asks
+// whether it is an Element instead of declaring it one.
+function wikiLinkAt(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element ? target.closest<HTMLElement>(".wiki-link") : null;
+}
+
 // Mouse + keyboard activation, both event-delegated over the rendered body. The spans
 // carry role="link" + tabindex="0" (added in renderWikiHtml) so they're focusable.
 function onBodyClick(e: MouseEvent): void {
-  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+  const el = wikiLinkAt(e.target);
   if (!el) return;
   e.preventDefault();
   activateLink(el);
 }
 function onBodyKeydown(e: KeyboardEvent): void {
   if (e.key !== "Enter" && e.key !== " ") return;
-  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+  const el = wikiLinkAt(e.target);
   if (!el) return;
   e.preventDefault();
   activateLink(el);

--- a/src/components/filesPaneStore.ts
+++ b/src/components/filesPaneStore.ts
@@ -10,6 +10,7 @@
 // Pure: no localStorage here. The host reads and writes the string through its own best-effort
 // storage helpers, which is also what makes this testable without a DOM.
 import type { FilesPaneState } from "./FilesPane.vue";
+import { isRecord } from "../../common/isRecord";
 
 export interface RememberedPane {
   cwd: string;
@@ -25,8 +26,8 @@ export const MAX_REMEMBERED_DIRS = 20;
 export const MAX_EXPANDED_PATHS = 200;
 
 const isPaneState = (value: unknown): value is FilesPaneState => {
-  if (typeof value !== "object" || value === null) return false;
-  const { openPath, expanded } = value as Partial<FilesPaneState>;
+  if (!isRecord(value)) return false;
+  const { openPath, expanded } = value;
   const openPathOk = openPath === null || typeof openPath === "string";
   return openPathOk && Array.isArray(expanded) && expanded.every((p) => typeof p === "string");
 };
@@ -37,8 +38,8 @@ const isPaneState = (value: unknown): value is FilesPaneState => {
 const capped = (state: FilesPaneState): FilesPaneState => ({ openPath: state.openPath, expanded: state.expanded.slice(0, MAX_EXPANDED_PATHS) });
 
 const isRemembered = (value: unknown): value is RememberedPane => {
-  if (typeof value !== "object" || value === null) return false;
-  const { cwd, state } = value as Partial<RememberedPane>;
+  if (!isRecord(value)) return false;
+  const { cwd, state } = value;
   return typeof cwd === "string" && cwd !== "" && isPaneState(state);
 };
 

--- a/src/components/gridLayout.ts
+++ b/src/components/gridLayout.ts
@@ -17,7 +17,7 @@ const DIMS: Record<Layout, { cols: number; rows: number }> = {
 export const MAX_CELLS = 9;
 
 export function isLayout(v: unknown): v is Layout {
-  return typeof v === "string" && (LAYOUTS as readonly string[]).includes(v);
+  return typeof v === "string" && LAYOUTS.some((layout) => layout === v);
 }
 
 export function dims(layout: Layout) {

--- a/src/composables/customThemes.ts
+++ b/src/composables/customThemes.ts
@@ -8,6 +8,7 @@
 import { ref, computed } from "vue";
 import { THEME_VAR_KEYS, resolveThemeVars, isLightTheme, termThemeFromVars, type CustomThemeInput, type ThemeVars } from "../../common/themeVars";
 import type { ThemeId } from "../../common/themeIds";
+import { isRecord } from "../../common/isRecord";
 
 // The built-in palettes, read from the stylesheet rather than restated here — style.css is the
 // source of truth for what Midnight is, and a second copy would drift the moment one is edited.
@@ -43,8 +44,11 @@ function ruleVars(id: ThemeId, sheets: readonly CSSStyleSheet[]): ThemeVars | nu
       });
     }
   }
-  return THEME_VAR_KEYS.every((key) => found[key]) ? (found as ThemeVars) : null;
+  return isCompleteVars(found) ? found : null;
 }
+
+// Every variable present — a guard so the check narrows instead of being restated as a cast.
+const isCompleteVars = (vars: Partial<ThemeVars>): vars is ThemeVars => THEME_VAR_KEYS.every((key) => !!vars[key]);
 
 export function readBuiltinVars(id: ThemeId, doc: Document = document): ThemeVars | null {
   return ruleVars(
@@ -61,8 +65,8 @@ export function setCustomThemes(input: unknown): void {
 }
 
 function isCustomThemeInput(value: unknown): value is CustomThemeInput {
-  if (typeof value !== "object" || value === null) return false;
-  const theme = value as Record<string, unknown>;
+  if (!isRecord(value)) return false;
+  const theme = value;
   return typeof theme.id === "string" && typeof theme.label === "string" && typeof theme.colors === "object" && theme.colors !== null;
 }
 

--- a/src/composables/sessionActivity.ts
+++ b/src/composables/sessionActivity.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../common/isRecord";
 // Pure parse of a "sessions" pub/sub payload into an attention-state update, so the
 // grid can track a cell's blocked/done even while the cell is OFF-PAGE (unmounted).
 // The payload carries dev-terminal (grid) activity that the /api/sessions list drops,
@@ -12,8 +13,8 @@ export interface CellActivity {
 export type SessionActivityUpdate = { id: string; closed: true } | { id: string; activity: CellActivity };
 
 export function parseSessionActivityPayload(data: unknown): SessionActivityUpdate | null {
-  if (!data || typeof data !== "object") return null;
-  const d = data as Record<string, unknown>;
+  if (!isRecord(data)) return null;
+  const d = data;
   if (typeof d.id !== "string") return null;
   // A "closed" push means the session's PTY was reaped — drop it (no attention).
   if (d.event === "closed") return { id: d.id, closed: true };

--- a/src/composables/useFileDropGuard.ts
+++ b/src/composables/useFileDropGuard.ts
@@ -10,10 +10,20 @@ import { dragCarriesFiles } from "../components/dropPaths";
 // never an in-app element drag.
 type DragTarget = Pick<Window, "addEventListener" | "removeEventListener">;
 
+// The drag's `dataTransfer.types`, or none. Read off the Event structurally rather than declaring
+// it a DragEvent: `addEventListener` types its listener with the base `Event`, and `instanceof
+// DragEvent` is not an option — jsdom (and any non-browser host) does not define the constructor,
+// so the check would throw where the old assertion merely lied.
+const dragTypesOf = (event: Event): readonly string[] => {
+  const dataTransfer: unknown = Reflect.get(event, "dataTransfer");
+  if (!dataTransfer || typeof dataTransfer !== "object") return [];
+  const types: unknown = Reflect.get(dataTransfer, "types");
+  return Array.isArray(types) ? types.filter((type): type is string => typeof type === "string") : [];
+};
+
 export function installFileDropGuard(target: DragTarget = window): () => void {
   const guard = (event: Event) => {
-    const dt = (event as DragEvent).dataTransfer;
-    if (dt && dragCarriesFiles(dt.types)) event.preventDefault();
+    if (dragCarriesFiles(dragTypesOf(event))) event.preventDefault();
   };
   target.addEventListener("dragover", guard);
   target.addEventListener("drop", guard);

--- a/src/composables/useRateLimits.ts
+++ b/src/composables/useRateLimits.ts
@@ -27,7 +27,7 @@ let timer: ReturnType<typeof setTimeout> | null = null;
 let watchers = 0;
 
 const PROBE_STATES: readonly ClaudeProbeState[] = ["ok", "no-claude", "no-windows", "no-report"];
-const isProbeState = (v: unknown): v is ClaudeProbeState => typeof v === "string" && (PROBE_STATES as readonly string[]).includes(v);
+const isProbeState = (v: unknown): v is ClaudeProbeState => typeof v === "string" && PROBE_STATES.some((state) => state === v);
 
 // A failure leaves the last known windows in place. Blanking them would read as "0% used", which
 // is the opposite of the truth we just failed to fetch.

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -58,7 +58,12 @@ export function mergeStable(prev: Session[], incoming: Session[], resort: boolea
   if (resort || prev.length === 0) return incoming;
   const incomingById = new Map(incoming.map((s) => [s.id, s]));
   const prevIds = new Set(prev.map((s) => s.id));
-  const kept = prev.filter((s) => incomingById.has(s.id)).map((s) => incomingById.get(s.id) as Session);
+  // flatMap over the lookup: `filter` then `get` made the compiler re-derive that the key is
+  // present, which is what the assertion was papering over.
+  const kept = prev.flatMap((s) => {
+    const fresh = incomingById.get(s.id);
+    return fresh ? [fresh] : [];
+  });
   const added = incoming.filter((s) => !prevIds.has(s.id));
   return [...added, ...kept];
 }


### PR DESCRIPTION
## Summary

#1231。client 8 ファイル・**11 箇所**。**52 → 41**。allowlist は **0 件**。

## Items to Confirm / Review

### 1. `instanceof DragEvent` は**投げる** — テストが捕まえました

`useFileDropGuard.ts` の `(event as DragEvent).dataTransfer` を、#1258 で `e.target as Node` を直したのと同じ要領で `event instanceof DragEvent` に書き換えたところ、**テストが 4 件落ちました**。

```
ReferenceError: DragEvent is not defined
```

**jsdom は `DragEvent` コンストラクタを定義しません。** 元のアサーションは嘘をつくだけでしたが、`instanceof` は**例外を投げます** — 直したつもりで悪化させる書き換えでした。ブラウザ以外のホスト（テスト環境、SSR）で同じことが起きます。

`dataTransfer.types` を構造的に読む形に直しました。

```ts
const dragTypesOf = (event: Event): readonly string[] => {
  const dataTransfer: unknown = Reflect.get(event, "dataTransfer");
  if (!dataTransfer || typeof dataTransfer !== "object") return [];
  const types: unknown = Reflect.get(dataTransfer, "types");
  return Array.isArray(types) ? types.filter((type): type is string => typeof type === "string") : [];
};
```

**`instanceof` が常に正解ではない**という反例なので、残りの DOM 系を直すときの注意点として記録します（`Element` / `Node` は jsdom にあるので #1258 と本 PR の `WikiProse.vue` は問題なし）。

### 2. `useSessions.ts` — 二度引きが assertion を必要にしていた

```diff
-const kept = prev.filter((s) => incomingById.has(s.id)).map((s) => incomingById.get(s.id) as Session);
+const kept = prev.flatMap((s) => {
+  const fresh = incomingById.get(s.id);
+  return fresh ? [fresh] : [];
+});
```

`has` で確かめてから `get` で引き直すので、コンパイラは「キーがある」ことを覚えていられません。1 回引きにすれば assertion が要らなくなります。挙動は同じ（`mergeStable` の spec が通ります）。

### 3. `customThemes.ts` — 検査済みの事実が伝わっていなかった

`found as ThemeVars` は `THEME_VAR_KEYS.every(...)` で全キーの存在を**既に確かめた後**の cast でした。型述語 `isCompleteVars` にすれば結果がコンパイラに渡ります（#1244 の `themeVars.ts` と同じ形）。

### 4. 残り — `.some()` と `isRecord` と `instanceof Element`

`gridLayout` / `useRateLimits` は `.includes` の型 widening、`sessionActivity` / `filesPaneStore`(2) は `isRecord`、`WikiProse.vue`(2) は `wikiLinkAt()` に集約して `instanceof Element` にしました。

## 検証

`yarn lint`（0 error、46 problems ← 57）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7409 passed**。

refs #1231

work in mulmoterminal3
