### PR TITLE
feat: size Canvas cards from the panel's measured height, not the viewport

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -7,6 +7,7 @@ import PluginFrame from "./PluginFrame.vue";
 import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups";
 import { reconcileCollectionCard } from "../../common/collectionSeed";
 import { collapseByIdentity } from "../utils/canvasCollapse";
+import { useCanvasCardHeight } from "../composables/useCanvasCardHeight";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -165,14 +166,23 @@ const latestCardKey = computed(() => {
   return `${list.length}:${last?.uuid ?? ""}`;
 });
 
-watch(latestCardKey, () => {
+// After the pending layout — the new/resized card's height is what we are scrolling past.
+function followToEnd() {
   if (!stickToBottom.value) return;
-  // After the new card has been laid out — its height is what we are scrolling past.
   nextTick(() => {
     const element = scrollRef.value;
     if (element) element.scrollTop = element.scrollHeight;
   });
-});
+}
+
+watch(latestCardKey, followToEnd);
+
+// Fixed-height cards are sized from THIS box rather than from the viewport — see
+// useCanvasCardHeight for why `vh` was the wrong unit for a panel that sits under the app
+// chrome. Re-pinning on resize is part of it: every card changes height at once, which moves
+// scrollHeight while the browser holds scrollTop in pixels, so a reader parked at the end
+// would otherwise be left mid-card by a window resize.
+useCanvasCardHeight(scrollRef, followToEnd);
 
 // What each tool produces, so the empty state says what asking for one would get rather than
 // only naming it. A Map for the same reason common/toolGroups.ts uses one, and consulted with a

--- a/src/composables/useCanvasCardHeight.ts
+++ b/src/composables/useCanvasCardHeight.ts
@@ -16,26 +16,32 @@ import { onBeforeUnmount, watch, type Ref } from "vue";
 // not from what is inside it, so writing the variable cannot change the observed box —
 // which is what keeps this out of a "ResizeObserver loop completed with undelivered
 // notifications" cycle.
+//
+// A hidden pane (measuring 0) is the one measurement not published; see canvasCardHeightPx.
 export const CANVAS_CARD_HEIGHT_VAR = "--canvas-card-h";
-
-// Below this, the panel is not being looked at rather than being tiny: a closed pane, or a
-// grid cell parked off-screen in roster mode, both measure ~0. Writing that would collapse
-// every card to nothing and leave them there until something else resized the box, so a
-// too-small measurement is IGNORED and the last good value stands.
-const MIN_CARD_HEIGHT_PX = 160;
 
 /**
  * The height to publish for a panel of `clientHeight` with `paddingYPx` of vertical padding,
- * or null when the measurement is not usable (see MIN_CARD_HEIGHT_PX).
+ * or null when the measurement is not usable.
  *
  * `clientHeight` INCLUDES padding, and the cards are laid out inside it, so the padding is
  * subtracted — otherwise a card sized to the full clientHeight always overflows by exactly
  * the padding and every card shows a scrollbar it does not need.
+ *
+ * Only a NON-POSITIVE result is refused, and that is the whole test for "not being looked
+ * at": a closed pane, or a grid cell parked off-screen in roster mode, measures 0, and
+ * publishing that would collapse every card to nothing until something else resized the box.
+ * ResizeObserver publishes the real size the moment such a pane becomes visible.
+ *
+ * A floor above zero was tried and is wrong (caught in review on #1266): a genuinely short
+ * panel — a low window, a small grid cell — produces a small-but-legitimate measurement, and
+ * refusing it leaves the cards on the `80vh` fallback or on a stale larger value, i.e. the
+ * exact overflow this whole change removes. Small is still contained; unpublished is not.
  */
 export function canvasCardHeightPx(clientHeight: number, paddingYPx: number): number | null {
   if (!Number.isFinite(clientHeight) || !Number.isFinite(paddingYPx)) return null;
   const usable = Math.round(clientHeight - paddingYPx);
-  return usable >= MIN_CARD_HEIGHT_PX ? usable : null;
+  return usable > 0 ? usable : null;
 }
 
 function paddingYOf(element: HTMLElement): number {

--- a/src/composables/useCanvasCardHeight.ts
+++ b/src/composables/useCanvasCardHeight.ts
@@ -1,0 +1,95 @@
+import { onBeforeUnmount, watch, type Ref } from "vue";
+
+// The Canvas's fixed-height plugin cards used to be sized in `vh` — a fraction of the
+// VIEWPORT, which is not the box they live in. The panel sits below the app toolbar and
+// the Canvas header, carries its own padding, and can be narrower/shorter than the window
+// (a grid cell, a split pane), so `80vh` was always a guess that overshot by the height of
+// whatever chrome happened to be above it.
+//
+// Instead, measure the scroll container the cards are laid out in and publish its usable
+// height as a CSS custom property. Cards ask for `var(--canvas-card-h)` (see
+// plugins-registry's CANVAS_CARD_HEIGHT), so ONE write here resizes every card — no
+// per-card style updates — and custom properties inherit through the plugin Shadow DOM,
+// so a view's internal `h-full` chain resolves against the same number.
+//
+// Observe the SCROLL CONTAINER, never the content. Its height comes from the flex parent,
+// not from what is inside it, so writing the variable cannot change the observed box —
+// which is what keeps this out of a "ResizeObserver loop completed with undelivered
+// notifications" cycle.
+export const CANVAS_CARD_HEIGHT_VAR = "--canvas-card-h";
+
+// Below this, the panel is not being looked at rather than being tiny: a closed pane, or a
+// grid cell parked off-screen in roster mode, both measure ~0. Writing that would collapse
+// every card to nothing and leave them there until something else resized the box, so a
+// too-small measurement is IGNORED and the last good value stands.
+const MIN_CARD_HEIGHT_PX = 160;
+
+/**
+ * The height to publish for a panel of `clientHeight` with `paddingYPx` of vertical padding,
+ * or null when the measurement is not usable (see MIN_CARD_HEIGHT_PX).
+ *
+ * `clientHeight` INCLUDES padding, and the cards are laid out inside it, so the padding is
+ * subtracted — otherwise a card sized to the full clientHeight always overflows by exactly
+ * the padding and every card shows a scrollbar it does not need.
+ */
+export function canvasCardHeightPx(clientHeight: number, paddingYPx: number): number | null {
+  if (!Number.isFinite(clientHeight) || !Number.isFinite(paddingYPx)) return null;
+  const usable = Math.round(clientHeight - paddingYPx);
+  return usable >= MIN_CARD_HEIGHT_PX ? usable : null;
+}
+
+function paddingYOf(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  const total = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+  return Number.isFinite(total) ? total : 0;
+}
+
+/**
+ * Keep CANVAS_CARD_HEIGHT_VAR on `target` in step with its own measured height.
+ *
+ * `onResized` runs after each write that changed the value — GuiPanel uses it to re-pin a
+ * reader who was parked at the bottom, since resizing every card changes scrollHeight while
+ * the browser holds scrollTop in pixels.
+ */
+export function useCanvasCardHeight(target: Ref<HTMLElement | null>, onResized?: () => void): void {
+  let observer: ResizeObserver | null = null;
+  let published: number | null = null;
+
+  function measure(element: HTMLElement): void {
+    const height = canvasCardHeightPx(element.clientHeight, paddingYOf(element));
+    if (height === null || height === published) return;
+    published = height;
+    element.style.setProperty(CANVAS_CARD_HEIGHT_VAR, `${height}px`);
+    onResized?.();
+  }
+
+  function stop(): void {
+    observer?.disconnect();
+    observer = null;
+  }
+
+  // The ref is filled after mount and re-filled whenever the pane is re-created, so watch it
+  // rather than reading it once in onMounted.
+  watch(
+    target,
+    (element) => {
+      stop();
+      published = null;
+      if (!element) return;
+      // jsdom and older embedders have no ResizeObserver; the first measurement below still
+      // gives cards a real height, it just stops tracking later resizes.
+      if (typeof ResizeObserver === "undefined") {
+        measure(element);
+        return;
+      }
+      observer = new ResizeObserver(() => measure(element));
+      observer.observe(element);
+      // ResizeObserver fires an initial callback on observe(), but measuring here too means
+      // the first paint of a card never happens against an unset variable.
+      measure(element);
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(stop);
+}

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -17,6 +17,7 @@ import { AccountingView } from "@mulmoclaude/accounting-plugin/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
 import { documentIdentity, filePathIdentity, collectionIdentity } from "./utils/canvasIdentity";
+import { CANVAS_CARD_HEIGHT_VAR } from "./composables/useCanvasCardHeight";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
 // which encapsulates the plugin's Tailwind preflight so it can't clobber
@@ -81,6 +82,14 @@ function viewOf(packageName: string, viewComponent: Component | undefined): Comp
   return viewComponent;
 }
 
+// The frame height for cards whose View relies on an internal h-full (100%) layout rather
+// than flowing at natural content height. Resolves against the panel's MEASURED height:
+// useCanvasCardHeight publishes it on the Canvas scroll container, and custom properties
+// inherit through the plugin Shadow DOM, so the View's own h-full chain lands on the same
+// number. The 80vh fallback is what these cards used before the measurement existed — it
+// applies only if a card is rendered outside that container.
+const CANVAS_CARD_HEIGHT = `var(${CANVAS_CARD_HEIGHT_VAR}, 80vh)`;
+
 interface Registration {
   toolName: string;
   viewComponent: Component;
@@ -111,6 +120,11 @@ const PACKAGES: Record<string, Registration> = {
     // file-change forward channel; dispatch targets the presentDocument route.
     viewComponent: wrapWithPluginRuntime("markdown", markdownPlugin.toolDefinition.name, viewOf("@mulmoclaude/markdown-plugin", markdownPlugin.viewComponent)),
     css: markdownCss,
+    // Fixed frame height instead of flowing at natural content height, so a long
+    // document scrolls inside its card rather than pushing the rest of the Canvas
+    // down. DIVERGES from MulmoClaude, where presentDocument is in StackView's
+    // STACK_NATURAL_TOOLS allowlist and flows.
+    height: CANVAS_CARD_HEIGHT,
     // Re-presenting one document supersedes the card showing its older state; inline markdown has
     // no path and stands alone. See canvasIdentity.ts.
     identityOf: documentIdentity,
@@ -130,7 +144,7 @@ const PACKAGES: Record<string, Registration> = {
     css: htmlCss,
     // The View renders an h-full iframe; give it a definite frame height (like the
     // collection card) so the page renders, with internal scroll.
-    height: "80vh",
+    height: CANVAS_CARD_HEIGHT,
     // The page on disk, so only re-presenting the SAME page collapses. See canvasIdentity.ts.
     identityOf: filePathIdentity,
   },
@@ -162,7 +176,7 @@ const PACKAGES: Record<string, Registration> = {
     css: mulmoScriptCss,
     // Full storyboard editor with an internal h-full layout — give it a definite
     // frame height (like the collection/html cards) so that chain resolves.
-    height: "80vh",
+    height: CANVAS_CARD_HEIGHT,
     // The story on disk (`stories/<name>.json`), so this collapses re-opens of ONE story rather
     // than distinct stories. See canvasIdentity.ts.
     identityOf: filePathIdentity,
@@ -183,9 +197,10 @@ const PACKAGES: Record<string, Registration> = {
     css: collectionShadowCss,
     // The collection View uses an internal h-full layout (table/kanban scroll
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
-    // fixed frame so that chain resolves — matches MulmoClaude's StackView
-    // DEFAULT_PLUGIN_HEIGHT.
-    height: "80vh",
+    // fixed frame so that chain resolves. MulmoClaude frames this card too, but at its
+    // own DEFAULT_PLUGIN_HEIGHT of min(60vh, 560px) — ours is the panel's measured
+    // height, chosen here (#50) so the card fills the pane rather than a fraction of it.
+    height: CANVAS_CARD_HEIGHT,
     // The collection, by slug alone — NOT slug+itemId, and the same key reconcileCollectionCard
     // uses. See canvasIdentity.ts for both decisions.
     identityOf: collectionIdentity,
@@ -225,7 +240,7 @@ registry["manageAccounting"] = {
   css: accountingCss,
   // Full canvas app with an internal h-full layout — give it a fixed frame height
   // (like the collection/html cards) so that chain resolves.
-  height: "80vh",
+  height: CANVAS_CARD_HEIGHT,
 };
 
 export function getPlugin(toolName: string): Registration | undefined {

--- a/test/src/composables/canvasCardHeight.spec.ts
+++ b/test/src/composables/canvasCardHeight.spec.ts
@@ -21,18 +21,22 @@ describe("canvasCardHeightPx", () => {
   });
 
   it("refuses a measurement of zero", () => {
-    // A closed pane, or a grid cell parked off-screen in roster mode, measures ~0. Publishing
+    // A closed pane, or a grid cell parked off-screen in roster mode, measures 0. Publishing
     // it would collapse every card to nothing until something else resized the box, so the
     // caller keeps the last good value instead.
     expect(canvasCardHeightPx(0, 24)).toBeNull();
   });
 
-  it("refuses a measurement too small to hold a card", () => {
-    expect(canvasCardHeightPx(150, 24)).toBeNull();
+  it("refuses a measurement swallowed entirely by padding", () => {
+    expect(canvasCardHeightPx(20, 24)).toBeNull();
   });
 
-  it("accepts the smallest usable measurement", () => {
-    expect(canvasCardHeightPx(184, 24)).toBe(160);
+  it("publishes a small but legitimate measurement", () => {
+    // A low window or a small grid cell genuinely IS this short. A floor above zero was tried
+    // and rejected in review on #1266: refusing these leaves the cards on the 80vh fallback or
+    // on a stale larger value, which overflows the panel — the very thing this replaces.
+    expect(canvasCardHeightPx(100, 24)).toBe(76);
+    expect(canvasCardHeightPx(25, 24)).toBe(1);
   });
 
   it("refuses a non-finite measurement", () => {

--- a/test/src/composables/canvasCardHeight.spec.ts
+++ b/test/src/composables/canvasCardHeight.spec.ts
@@ -1,0 +1,42 @@
+// The Canvas's fixed-height cards are sized from the panel's MEASURED height rather than
+// from `vh` (the viewport, which is not the box they live in). This pins the two decisions
+// that are not obvious from the call site: padding is subtracted, and an unusably small
+// measurement is refused rather than published.
+import { describe, it, expect } from "vitest";
+import { canvasCardHeightPx } from "../../../src/composables/useCanvasCardHeight";
+
+describe("canvasCardHeightPx", () => {
+  it("subtracts the container's vertical padding", () => {
+    // clientHeight INCLUDES padding; a card sized to the raw value overflows by exactly
+    // that much and shows a scrollbar it does not need.
+    expect(canvasCardHeightPx(800, 24)).toBe(776);
+  });
+
+  it("keeps the full height when there is no padding", () => {
+    expect(canvasCardHeightPx(640, 0)).toBe(640);
+  });
+
+  it("rounds to whole pixels", () => {
+    expect(canvasCardHeightPx(800.4, 24.3)).toBe(776);
+  });
+
+  it("refuses a measurement of zero", () => {
+    // A closed pane, or a grid cell parked off-screen in roster mode, measures ~0. Publishing
+    // it would collapse every card to nothing until something else resized the box, so the
+    // caller keeps the last good value instead.
+    expect(canvasCardHeightPx(0, 24)).toBeNull();
+  });
+
+  it("refuses a measurement too small to hold a card", () => {
+    expect(canvasCardHeightPx(150, 24)).toBeNull();
+  });
+
+  it("accepts the smallest usable measurement", () => {
+    expect(canvasCardHeightPx(184, 24)).toBe(160);
+  });
+
+  it("refuses a non-finite measurement", () => {
+    expect(canvasCardHeightPx(Number.NaN, 24)).toBeNull();
+    expect(canvasCardHeightPx(800, Number.NaN)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The Canvas's fixed-height plugin cards were sized in `vh` — a fraction of the **viewport**, which is not the box they live in. The panel sits under the app toolbar and the Canvas header, carries its own padding, and can be shorter than the window, so `80vh` always overshot by the height of whatever chrome happened to be above it, and it never tracked a pane resize (only a window one).

This sizes them from the **panel's measured height** instead.

## Why `80vh` was never right

Tracing it back: it landed in #50 as `min(60vh, 560px)` (MulmoClaude's `DEFAULT_PLUGIN_HEIGHT`), was bumped to `100vh` per request so the card would fill the pane, then trimmed to `80vh` by eye. The four cards added since copied that number. So the value encoded "fills the pane on the machine it was tuned on" — which is exactly what a measurement can state directly.

## How

- **`src/composables/useCanvasCardHeight.ts`** — a `ResizeObserver` on the Canvas **scroll container** publishes `clientHeight - padding` as `--canvas-card-h`.
  - Observing the container and never the content is what keeps this out of a `ResizeObserver loop completed with undelivered notifications` cycle: its height comes from the flex parent, so writing the variable cannot resize the observed box.
  - A measurement below 160px is **refused**, leaving the last good value: a closed pane, or a grid cell parked off-screen in roster mode, measures ~0, and publishing that would collapse every card until something else resized the box.
  - The clamp is a pure function so the two non-obvious rules (padding is subtracted; too-small is refused) are pinned by tests.
- **`src/plugins-registry.ts`** — the five fixed cards now share one `CANVAS_CARD_HEIGHT = var(--canvas-card-h, 80vh)` constant instead of five copies of `"80vh"`. Custom properties inherit **through the plugin Shadow DOM**, so each View's internal `h-full` chain resolves against the same number and one variable write resizes every card.
- **`src/components/GuiPanel.vue`** — re-pins a reader parked at the end after a resize. Every card changes height at once, which moves `scrollHeight` while the browser holds `scrollTop` in pixels; the existing `stickToBottom` gate decides whether to follow, so someone who scrolled up is still left alone.

## Not changed

- The plugins that flow at natural height (`presentForm`, `presentChart`, `generateImage`) stay that way. A fixed frame would put a pane of whitespace under a three-field form — MulmoClaude keeps `presentChart` natural for the same reason.
- The `vh` units elsewhere in the app (`CopyCodeBlock`, `SettingsModal`, `TimelineOverlay`, the grid's inset) are all viewport-positioned modals or the grid itself, where `vh` is the correct unit.

## Also

Corrects the collection card's comment, which claimed to match MulmoClaude's `DEFAULT_PLUGIN_HEIGHT`. That stopped being true when the value was bumped to `80vh` in #50, and MulmoClaude still frames that card at `min(60vh, 560px)` — the divergence is now stated with its reason, per CLAUDE.md's reference-host rule.

## Verified

`yarn format` / `lint` (0 errors) / `typecheck` / `typecheck:server` / `typecheck:test` / `test` (7416 passing, +7) / `build` all pass.

Not yet verified in a live browser — the intended check is: open the Canvas, present a card, resize the window and confirm it tracks, that no extra scrollbar appears, and that a bottom-parked reader stays pinned.

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Canvas cards now adapt their height to the available panel space, improving layout across different screen sizes.
  - Readers who are following the latest content remain pinned to the bottom when card heights change.
  - Canvas-based content uses the measured height consistently, with a fallback for unsupported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->