### PR TITLE
fix: API 応答の as を検証に置き換える（6ファイル） (#1231)

### DIFF
--- a/common/voiceInputStatus.ts
+++ b/common/voiceInputStatus.ts
@@ -6,6 +6,8 @@
 // package implements transcription behind it is not the UI's business. The server's
 // `getVoiceInputStatus(): VoiceInputStatus` annotation is what keeps the two in step.
 
+import { isRecord } from "./isRecord.js";
+
 export type VoiceModelState = "idle" | "downloading" | "ready" | "error";
 
 export interface VoiceInputStatus {
@@ -18,4 +20,16 @@ export interface VoiceInputStatus {
     progress?: number;
     error?: string;
   };
+}
+
+export const VOICE_MODEL_STATES: readonly VoiceModelState[] = ["idle", "downloading", "ready", "error"];
+
+/** The wire response as it arrives from `GET /api/transcribe/model`. Lives beside the type so the
+ *  guard and the shape it checks cannot drift; the UI treats anything else as "no status". */
+export function isVoiceInputStatus(value: unknown): value is VoiceInputStatus {
+  if (!isRecord(value) || typeof value.capable !== "boolean" || !isRecord(value.model)) return false;
+  const { name, state, progress, error } = value.model;
+  if (typeof name !== "string" || !VOICE_MODEL_STATES.some((known) => known === state)) return false;
+  if (progress !== undefined && typeof progress !== "number") return false;
+  return error === undefined || typeof error === "string";
 }

--- a/src/composables/seedCollectionCanvas.ts
+++ b/src/composables/seedCollectionCanvas.ts
@@ -9,10 +9,7 @@
 // the open record on any path change — so route-derived state is already gone by the time a spawn
 // resolves. The prompt travels with the chat.
 import { parseCollectionSlashSeed, makeSyntheticCollectionResult } from "../../common/collectionSeed";
-
-interface CollectionsListResponse {
-  collections?: { slug?: unknown }[];
-}
+import { isRecord } from "../../common/isRecord";
 
 /** Does `slug` name a real collection? Asked before seeding so a NON-collection slash command
  *  (`/deep-research`, a typo) does not flash a "collection not found" card. A failed request
@@ -22,8 +19,9 @@ async function isKnownCollection(slug: string): Promise<boolean> {
   try {
     const res = await fetch("/api/collections/list");
     if (!res.ok) return false;
-    const body = (await res.json()) as CollectionsListResponse;
-    return Array.isArray(body.collections) && body.collections.some((entry) => entry?.slug === slug);
+    const body: unknown = await res.json();
+    const collections = isRecord(body) && Array.isArray(body.collections) ? body.collections : [];
+    return collections.some((entry) => isRecord(entry) && entry.slug === slug);
   } catch {
     return false;
   }

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -22,6 +22,7 @@ import { ref, watch } from "vue";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { placeSpawnedChat } from "./useSpawnedChat";
 import { seedCollectionCanvas } from "./seedCollectionCanvas";
+import { isRecord } from "../../common/isRecord";
 
 export type Agent = TerminalAgent;
 
@@ -62,8 +63,10 @@ export async function startCollectionChat(prompt: string, opts: { hidden?: boole
       console.error(`[startChat] spawn failed: HTTP ${res.status}`);
       return null;
     }
-    const data = (await res.json()) as { jsonData?: { chatId?: unknown } };
-    chatId = typeof data?.jsonData?.chatId === "string" ? data.jsonData.chatId : undefined;
+    const data: unknown = await res.json();
+    const jsonData = isRecord(data) ? data.jsonData : undefined;
+    const id = isRecord(jsonData) ? jsonData.chatId : undefined;
+    chatId = typeof id === "string" ? id : undefined;
   } catch (err) {
     console.error("[startChat] spawn failed", err);
     return null;

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -15,6 +15,7 @@ import { browserLocale } from "../utils/browserLocale";
 import { modelReadiness, voiceAction } from "./voiceAction";
 import { browserVoiceLanguage, resolveVoiceLanguage, voiceLanguage } from "./voiceLanguage";
 import { fetchVoiceInputStatus } from "./voiceModelStatus";
+import { isRecord } from "../../common/isRecord";
 
 export interface UseVoiceInput {
   /** Platform + binaries present — gate the mic button's visibility on this. */
@@ -48,7 +49,11 @@ function createVoiceTransport(capable: Ref<boolean>, downloading: Ref<boolean>):
         body: JSON.stringify({ dataUrl, language }),
       });
       if (!res.ok) throw new Error(`transcription failed (HTTP ${res.status})`);
-      return (await res.json()) as { text: string };
+      const body: unknown = await res.json();
+      // The one field the caller inserts into the terminal — checked, so a malformed reply is a
+      // thrown error here rather than `undefined` typed into someone's prompt.
+      if (!isRecord(body) || typeof body.text !== "string") throw new Error("transcription returned no text");
+      return { text: body.text };
     },
     // `status` is null on a transient fetch/non-OK; `model` may be absent on a partial
     // response. Optional-chain throughout so a status blip degrades to "not ready" instead

--- a/src/composables/voiceModelStatus.ts
+++ b/src/composables/voiceModelStatus.ts
@@ -1,4 +1,4 @@
-import type { VoiceInputStatus } from "../../common/voiceInputStatus";
+import { isVoiceInputStatus, type VoiceInputStatus } from "../../common/voiceInputStatus";
 
 // One reader for `GET /api/transcribe/model`. Two callers want it for different reasons —
 // the mic polls it for readiness, the settings modal asks once whether to show the voice
@@ -19,7 +19,8 @@ export async function fetchVoiceInputStatus(): Promise<VoiceInputStatus | null> 
   try {
     const res = await fetch("/api/transcribe/model", { signal: controller.signal });
     if (!res.ok) return null;
-    return (await res.json()) as VoiceInputStatus;
+    const body: unknown = await res.json();
+    return isVoiceInputStatus(body) ? body : null;
   } catch {
     return null;
   } finally {

--- a/src/utils/translateUi.ts
+++ b/src/utils/translateUi.ts
@@ -1,4 +1,5 @@
 import { browserLocale } from "./browserLocale";
+import { isRecord } from "../../common/isRecord";
 
 const REQUEST_TIMEOUT_MS = 8000;
 
@@ -20,8 +21,9 @@ export async function translateUiSentence(english: string, namespace: string): P
       signal: controller.signal,
     });
     if (!res.ok) return english;
-    const data = (await res.json()) as { translations?: string[] };
-    return typeof data.translations?.[0] === "string" ? data.translations[0] : english;
+    const data: unknown = await res.json();
+    const first = isRecord(data) && Array.isArray(data.translations) ? data.translations[0] : undefined;
+    return typeof first === "string" ? first : english;
   } catch {
     return english;
   } finally {


### PR DESCRIPTION
## Summary

#1231。6 ファイル・**5 箇所**（`(await res.json()) as T` = サーバ応答の無検査）。allowlist は **0 件**。

#1265 とファイルが重ならないので独立にマージできます。

## Items to Confirm / Review

### 1. `isVoiceInputStatus` は型と同じファイルに置きました

`VoiceInputStatus` は `common/voiceInputStatus.ts` にあり、**サーバが作って UI が読む API 契約**です。guard を `src/` 側に書くと型と guard が離れて片方だけ育つので、**型の隣**に置きました（`common/` なのでサーバ側からも使えます）。

ネストした `model.state` の enum まで確かめています。

```ts
export function isVoiceInputStatus(value: unknown): value is VoiceInputStatus {
  if (!isRecord(value) || typeof value.capable !== "boolean" || !isRecord(value.model)) return false;
  const { name, state, progress, error } = value.model;
  if (typeof name !== "string" || !VOICE_MODEL_STATES.some((known) => known === state)) return false;
  ...
```

### 2. `useVoiceInput` は**投げる**ようにしました（挙動が変わる唯一の箇所）

```diff
-return (await res.json()) as { text: string };
+if (!isRecord(body) || typeof body.text !== "string") throw new Error("transcription returned no text");
+return { text: body.text };
```

`text` の無い応答を通すと、**`undefined` がユーザーのプロンプトに入力されます**。呼び出し側は既に HTTP エラーを throw で扱っているので、同じ経路に乗せました。

### 3. 残り 3 箇所は挙動不変

`translateUi` / `useChatLauncher` / `seedCollectionCanvas` は、いずれも cast の後で**既にオプショナルチェーンや `Array.isArray` で防御していました**。`isRecord` に置き換えても結果は同じで、「主張」が「検査」になっただけです。

### 4. `CollectionsListResponse` は cast に名前を与えるためだけの型でした

検証に置き換えたら未使用になり、lint が捕まえました。削除しています。**cast を消すと、それを支えるためだけの型も消える**という例です。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7429 passed**。

refs #1231

work in mulmoterminal3
