### PR TITLE
fix(windows): spell the present-path spec's session cwd the way the platform does

### DIFF
--- a/plans/fix-1267-windows-present-path-spec.md
+++ b/plans/fix-1267-windows-present-path-spec.md
@@ -1,0 +1,51 @@
+# fix #1267 — the present-path spec must spell a session cwd the way the platform does
+
+## The failure
+
+`Windows (daily)` has been red on every run since #1226 landed (2026-08-01 16:58 UTC); the first is
+[run 30709308166](https://github.com/receptron/mulmoterminal/actions/runs/30709308166) and the most
+recent is [run 30724035812](https://github.com/receptron/mulmoterminal/actions/runs/30724035812).
+Last green: [30702245163](https://github.com/receptron/mulmoterminal/actions/runs/30702245163).
+
+One assertion, on both 22.x and 24.x, in `test/server/backends/presentPathRoot.spec.ts`:
+
+```
+FAIL  absolutizePresentPath > resolves a relative path against the session cwd
+-   "path": "/repos/mulmoterminal/README.md",
++   "path": "D:\\repos\\mulmoterminal\\README.md",
+```
+
+Linux and macOS are green, which is why #1226 merged clean.
+
+## Root cause
+
+The spec's fixture is `const CWD = "/repos/mulmoterminal"` and the expectation is the template
+`` `${CWD}/README.md` `` — a hardcoded POSIX join. `absolutizePresentPath` resolves with
+`path.resolve(cwd, value)`, which on Windows both picks up the current drive and joins with `\`.
+
+The product code is right: a session cwd is whatever the platform spells, and the two hops
+downstream (the View's dispatch, the `/htmlfile` mount) receive that same native path. Every other
+expectation in the file already goes through `path.resolve` — which is why only this one test
+failed while the middleware tests covering the same rewrite passed.
+
+## Fix
+
+1. Resolve the fixtures (`CWD`, `WORKSPACE`, `DOT_CWD`) with `path.resolve`, the idiom already used
+   for absolute fixtures in `test/server/config/cwd-presets.spec.ts` and
+   `test/server/files/pathContainment.spec.ts`. A session cwd that is drive-relative on Windows is
+   not a session cwd any server would report.
+2. Build the expected value with `path.join(CWD, "docs", "design.md")` rather than string
+   concatenation.
+
+Deliberately **not** `path.resolve(CWD, value)` in the expectation: that is the exact call the
+implementation makes, so it would assert nothing beyond "the function is itself". With `CWD` already
+absolute, `path.join` is a separate function that reaches the same answer.
+
+Scope is the spec alone. The Windows job runs the whole suite, and this was the only failure, so
+there is no second site with the same POSIX-only spelling to sweep.
+
+## Verification
+
+macOS passing proves only that this is not a regression — the bug is invisible there by
+construction. The ground truth is a `workflow_dispatch` of `Windows (daily)` at the fix branch,
+which is the job that actually failed. Required before the PR is called done.

--- a/test/server/backends/presentPathRoot.spec.ts
+++ b/test/server/backends/presentPathRoot.spec.ts
@@ -12,14 +12,16 @@ import { absolutizePresentPath, mountPresentPathRoot, SESSION_HEADER } from "../
 
 const MD = [".md"] as const;
 const HTML = [".html", ".htm"] as const;
-const CWD = "/repos/mulmoterminal";
-const WORKSPACE = "/home/u/mulmoclaude";
+// A session cwd is a native absolute path, so the fixtures are resolved rather than spelled
+// POSIX-only: on Windows `/repos/…` is drive-relative and the separator is `\`.
+const CWD = path.resolve("/repos/mulmoterminal");
+const WORKSPACE = path.resolve("/home/u/mulmoclaude");
 
 describe("absolutizePresentPath", () => {
   it("resolves a relative path against the session cwd", () => {
-    expect(absolutizePresentPath({ title: "T", path: "README.md" }, CWD, MD)).toEqual({ title: "T", path: `${CWD}/README.md` });
-    expect(absolutizePresentPath({ path: "docs/design.md" }, CWD, MD)).toEqual({ path: `${CWD}/docs/design.md` });
-    expect(absolutizePresentPath({ path: "docs/report.html" }, CWD, HTML)).toEqual({ path: `${CWD}/docs/report.html` });
+    expect(absolutizePresentPath({ title: "T", path: "README.md" }, CWD, MD)).toEqual({ title: "T", path: path.join(CWD, "README.md") });
+    expect(absolutizePresentPath({ path: "docs/design.md" }, CWD, MD)).toEqual({ path: path.join(CWD, "docs", "design.md") });
+    expect(absolutizePresentPath({ path: "docs/report.html" }, CWD, HTML)).toEqual({ path: path.join(CWD, "docs", "report.html") });
   });
 
   it("leaves an absolute path alone", () => {
@@ -62,7 +64,7 @@ describe("the /api/plugin middleware", () => {
   const SESSION = "11111111-2222-3333-4444-555555555555";
 
   const DOT_SESSION = "99999999-8888-7777-6666-555555555555";
-  const DOT_CWD = "/home/u/.mulmoterminal/worktrees/repo-ab12/task";
+  const DOT_CWD = path.resolve("/home/u/.mulmoterminal/worktrees/repo-ab12/task");
 
   beforeAll(async () => {
     const app = express();


### PR DESCRIPTION
## Summary

`Windows (daily)` has been red on **every** run since #1226 landed. One assertion, on both 22.x and
24.x, in `test/server/backends/presentPathRoot.spec.ts`:

```
FAIL  absolutizePresentPath > resolves a relative path against the session cwd
-   "path": "/repos/mulmoterminal/README.md",
+   "path": "D:\\repos\\mulmoterminal\\README.md",
```

The spec's fixture is `const CWD = "/repos/mulmoterminal"` and its expectation is the template
`` `${CWD}/README.md` `` — a hardcoded POSIX join. `absolutizePresentPath` resolves with
`path.resolve(cwd, value)`, which on Windows picks up the current drive and joins with `\`.

The product code is correct; only this expectation is POSIX-only. Every other expectation in the
same file already goes through `path.resolve`, which is why the middleware tests covering the same
rewrite passed and only the unit one failed.

Fix: resolve the absolute fixtures (`CWD`, `WORKSPACE`, `DOT_CWD`) and build the expected value with
`path.join`. Test-only change — no product code touched.

refs #1267

## Items to Confirm / Review

- **`path.join`, not `path.resolve`, in the expectation.** `path.resolve(CWD, value)` is the exact
  call the implementation makes, so it would assert nothing beyond "the function is itself". With
  `CWD` already absolute the two agree, and `join` is a separate function reaching the same answer.
- **Resolving `WORKSPACE` / `DOT_CWD` too** is not needed to make the job green — both already pass
  because their expectations run through `path.resolve`. They are resolved for coherence: a session
  cwd that is drive-relative on Windows is not one any server would report. Say so if you would
  rather keep that diff to the one failing constant.
- **Scope.** The Windows job runs the whole suite and this was its only failure, so there is no
  second site with the same POSIX-only spelling to sweep.

## User Prompt

> fix https://github.com/receptron/mulmoterminal/actions/runs/30724035812

## Root cause and history

| run | commit | result |
| --- | --- | --- |
| [30702245163](https://github.com/receptron/mulmoterminal/actions/runs/30702245163) | before #1226 | green (last) |
| [30709308166](https://github.com/receptron/mulmoterminal/actions/runs/30709308166) | #1226 | **red** (first) |
| [30724035812](https://github.com/receptron/mulmoterminal/actions/runs/30724035812) | #1260 merge | red (the reported run) |

Linux and macOS are green throughout, which is why #1226 merged clean — `Windows (daily)` is kept
out of `pull_request` on purpose.

Plan: [`plans/fix-1267-windows-present-path-spec.md`](plans/fix-1267-windows-present-path-spec.md).

## Verification

- `yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build`: clean.
- `yarn test` on macOS: 512 files, 7429 passed — which proves only that this is not a regression;
  the bug is invisible on macOS by construction.
- Ground truth: a `workflow_dispatch` of `Windows (daily)` at this branch. Linked below once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows-specific failures when resolving and displaying present-path information.
  * Updated path handling to use platform-compatible resolution, including session working directories.

* **Documentation**
  * Added a plan documenting the cause, proposed solution, and Windows verification steps for the path-related issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->