### PR TITLE
feat: GitLab の issue に作業コメントを書く（#981 段階4c-2）

### DIFF
--- a/plans/feat-981-4c2-gitlab-work-comment.md
+++ b/plans/feat-981-4c2-gitlab-work-comment.md
@@ -1,0 +1,44 @@
+# feat(#1270 / #981 段階4c-2): GitLab の issue に作業コメントを書く
+
+`issueWorkComments`（既定 off）は GitLab のリポでは何も起きなかった。3操作を forge 対応にする。
+
+## 実物で確認したこと（glab 1.111.0、テストプロジェクトで往復）
+
+**コマンド名が違う。** `gh issue comment` に対して **`glab issue note`**（`comment` ではない）、
+メッセージは `-m`。
+
+**一番の差: 既存コメントが `issue view` の JSON に入らない。**
+
+- `glab issue view <n> -F json` … `comments` キー**無し**
+- `--comments` を足しても JSON には出ない（人間向け表示のフラグ）
+- `glab api projects/:id/issues/:iid/notes` … ここで取れる
+
+GitHub が1回で取る「コメント一覧 ＋ state」が、GitLab では **2コール**になる。
+
+**`system` フラグ。** notes には GitLab 自身が書いたもの（closed、ラベル変更）が混ざり
+`system: true` で区別される。**重複チェックがこれを拾うと、一度閉じた issue が
+「もうコメント済み」と誤判定される。**
+
+**state の綴りも違う。** GitHub は `OPEN`、GitLab は **`opened`**（小文字）。
+読み違えると全 issue が closed に見え、マージ時のクローズが一度も動かない。
+
+## 構造
+
+3箇所を個別に分岐させず、**`IssueOps`（view / comment / close）にまとめて1箇所で選ぶ**。
+3つは常に同じホストに属するので、混ざると「片方の issue を読んでもう片方に書く」ことになる。
+
+`runGh` は spec が注入するので GitHub 経路はそのまま受け取る。GitLab 側にはまだその継ぎ目が
+無いので、純粋な部分（notes の解釈、state の判定、argv）を直接テストする。
+
+## 検証
+
+- 既存テストが**無改変で通過**（GitHub 経路が不変であることの証拠）
+- 純関数 43 件（system note の除外、state の綴り、argv、project の percent エンコード）
+- **実機**: テストプロジェクトの issue に対して
+  - 1回目 `{posted: true}` / 2回目 `{posted: false, reason: "already"}` — **重複チェックが効く**
+  - `closeIssue: true` で `{posted: true, closed: true}`、GitLab 側の state が `closed` になる
+
+## やらないこと
+
+- ⧉ Open PR（`worktree-pr.ts`）— `Runner` 型の変更を伴う。4c-3
+- PR フェーズ pill（段階4b）、語彙の中立化（段階3）、doctor（段階5）

--- a/server/git/glab-items.ts
+++ b/server/git/glab-items.ts
@@ -71,3 +71,20 @@ export function normalizeGlabIssueDetail(raw: unknown): { number: number; title:
   // An issue with no description is normal — the title is then the whole brief, same as GitHub.
   return number === null ? null : { number, title: text(raw.title), body: text(raw.description) };
 }
+
+/** Comment bodies from `GET /projects/:id/issues/:iid/notes`.
+ *
+ *  `system: true` marks a note GitLab wrote itself — "closed", "changed the description", a label
+ *  edit. They are not comments anyone left, and a duplicate check that counted them would decide a
+ *  comment already exists because the issue had been closed once (verified against real notes).
+ */
+export function glabNoteBodies(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(isRecord)
+    .filter((note) => note.system !== true)
+    .map((note) => text(note.body));
+}
+
+/** Whether an issue read from `glab issue view` is still open. GitLab spells it lowercase. */
+export const glabIssueIsOpen = (raw: unknown): boolean => isRecord(raw) && raw.state === "opened";

--- a/server/git/glab.ts
+++ b/server/git/glab.ts
@@ -27,3 +27,13 @@ export const glabIssueListArgs = (project: string, limit: number): string[] => [
 // takes `-O` and gives `-F` a different meaning entirely. Three subcommands, three answers;
 // verified against glab 1.111.0 rather than pattern-matched from its sibling.
 export const glabIssueViewArgs = (project: string, issue: number): string[] => ["issue", "view", String(issue), "--repo", project, "-F", "json"];
+
+// `note`, not `comment` — and the message flag is `-m`. Checked against glab 1.111.0.
+export const glabIssueNoteArgs = (project: string, issue: number, body: string): string[] => ["issue", "note", String(issue), "--repo", project, "-m", body];
+
+export const glabIssueCloseArgs = (project: string, issue: number): string[] => ["issue", "close", String(issue), "--repo", project];
+
+// Existing comments do NOT come back from `issue view -F json`, and `--comments` only affects the
+// human-readable output. The REST notes endpoint is where they are, so this is one extra call that
+// the GitHub path does not make.
+export const glabIssueNotesArgs = (project: string, issue: number): string[] => ["api", `projects/${encodeURIComponent(project)}/issues/${issue}/notes`];

--- a/server/git/glab.ts
+++ b/server/git/glab.ts
@@ -36,4 +36,14 @@ export const glabIssueCloseArgs = (project: string, issue: number): string[] => 
 // Existing comments do NOT come back from `issue view -F json`, and `--comments` only affects the
 // human-readable output. The REST notes endpoint is where they are, so this is one extra call that
 // the GitHub path does not make.
-export const glabIssueNotesArgs = (project: string, issue: number): string[] => ["api", `projects/${encodeURIComponent(project)}/issues/${issue}/notes`];
+//
+// `--paginate` is not optional here. A page holds 20 notes and they arrive NEWEST FIRST, so a
+// single page drops the OLDEST — and a work comment is written when work starts, which is exactly
+// the end that falls off. Missing it means writing the comment again on an issue that has one
+// (Codex review). Measured on a real 23-note issue: one page returned 20, `--paginate` returned all
+// 23 as a single JSON array, not concatenated pages.
+export const glabIssueNotesArgs = (project: string, issue: number): string[] => [
+  "api",
+  `projects/${encodeURIComponent(project)}/issues/${issue}/notes`,
+  "--paginate",
+];

--- a/server/git/work-comment.ts
+++ b/server/git/work-comment.ts
@@ -8,6 +8,9 @@
 // comments are the source of truth for a fresh process — the marker is in the thread, so a
 // restarted server, a second instance, or a second browser cannot double-post.
 import { runGh } from "./gh.js";
+import { runGlab, glabIssueCloseArgs, glabIssueNoteArgs, glabIssueNotesArgs, glabIssueViewArgs } from "./glab.js";
+import { glabIssueIsOpen, glabNoteBodies } from "./glab-items.js";
+import { forgeFromRepoEntry, projectPath } from "./forge-host.js";
 import { isRecord } from "../../common/isRecord.js";
 import { alreadyCommented, workCommentBody, type WorkCommentKind } from "../../common/workComment.js";
 
@@ -46,19 +49,60 @@ interface IssueView {
   open: boolean;
 }
 
-// The issue's comment bodies and whether it is still open, or null when gh could not answer.
-async function viewIssue(run: typeof runGh, repo: string, issue: number): Promise<IssueView | null> {
-  try {
-    const res = await run(["issue", "view", String(issue), "--repo", repo, "--json", "comments,state"]);
-    if (!res.ok) return null;
-    const parsed: unknown = JSON.parse(res.stdout);
-    if (!isRecord(parsed)) return null;
-    const comments = Array.isArray(parsed.comments) ? parsed.comments : [];
-    const bodies = comments.filter(isRecord).map((c) => (typeof c.body === "string" ? c.body : ""));
-    return { bodies, open: parsed.state === "OPEN" };
-  } catch {
-    return null;
-  }
+// Reading and writing one forge's issue. Grouped rather than branched at each of the three call
+// sites: they always belong to the same host, and a mix would read one issue and write another.
+interface IssueOps {
+  view: () => Promise<IssueView | null>;
+  comment: (body: string) => Promise<boolean>;
+  close: () => Promise<boolean>;
+}
+
+const ranOk = async (call: Promise<{ ok: boolean }>): Promise<boolean> => (await call.catch(() => null))?.ok === true;
+
+function githubIssueOps(run: typeof runGh, repo: string, issue: number): IssueOps {
+  return {
+    view: async () => {
+      try {
+        const res = await run(["issue", "view", String(issue), "--repo", repo, "--json", "comments,state"]);
+        if (!res.ok) return null;
+        const parsed: unknown = JSON.parse(res.stdout);
+        if (!isRecord(parsed)) return null;
+        const comments = Array.isArray(parsed.comments) ? parsed.comments : [];
+        return { bodies: comments.filter(isRecord).map((c) => (typeof c.body === "string" ? c.body : "")), open: parsed.state === "OPEN" };
+      } catch {
+        return null;
+      }
+    },
+    comment: (body) => ranOk(run(["issue", "comment", String(issue), "--repo", repo, "--body", body])),
+    close: () => ranOk(run(["issue", "close", String(issue), "--repo", repo])),
+  };
+}
+
+// TWO calls where GitHub needs one: `glab issue view -F json` carries no comments at all (and
+// `--comments` only changes the human-readable output), so the notes come from the REST endpoint
+// while the state comes from the view. Measured, not assumed.
+function gitlabIssueOps(project: string, issue: number): IssueOps {
+  return {
+    view: async () => {
+      try {
+        const [notes, view] = await Promise.all([runGlab(glabIssueNotesArgs(project, issue)), runGlab(glabIssueViewArgs(project, issue))]);
+        if (!notes.ok || !view.ok) return null;
+        return { bodies: glabNoteBodies(JSON.parse(notes.stdout)), open: glabIssueIsOpen(JSON.parse(view.stdout)) };
+      } catch {
+        return null;
+      }
+    },
+    comment: (body) => ranOk(runGlab(glabIssueNoteArgs(project, issue, body))),
+    close: () => ranOk(runGlab(glabIssueCloseArgs(project, issue))),
+  };
+}
+
+// `runGh` is injected by the specs, so the GitHub path keeps taking it; the GitLab path has no such
+// seam yet and its pure parts are tested directly instead.
+function issueOpsFor(run: typeof runGh, repo: string, issue: number): IssueOps {
+  const forge = forgeFromRepoEntry(repo);
+  if (forge?.kind !== "gitlab") return githubIssueOps(run, repo, issue);
+  return gitlabIssueOps(projectPath(forge) ?? forge.path, issue);
 }
 
 /**
@@ -104,7 +148,8 @@ async function writeWorkComment(
   const run = options.runGh ?? runGh;
   const key = memoKey(repo, issue, kind, dir);
 
-  const view = await viewIssue(run, repo, issue);
+  const ops = issueOpsFor(run, repo, issue);
+  const view = await ops.view();
   if (!view) return { posted: false, reason: "gh-failed" };
   if (alreadyCommented(view.bodies, kind, dir)) {
     posted.add(key); // found in the thread — stop asking gh about it
@@ -112,15 +157,13 @@ async function writeWorkComment(
   }
 
   const body = workCommentBody(kind, dir, pr);
-  const wrote = await run(["issue", "comment", String(issue), "--repo", repo, "--body", body]).catch(() => null);
-  if (!wrote?.ok) return { posted: false, reason: "gh-failed" };
+  if (!(await ops.comment(body))) return { posted: false, reason: "gh-failed" };
   posted.add(key);
 
   // Closing is best-effort and reported separately: the comment landing is the part that matters,
   // and a repo where the user cannot close issues must not turn into a failed request.
   if (options.closeIssue && view.open) {
-    const closed = await run(["issue", "close", String(issue), "--repo", repo]).catch(() => null);
-    return { posted: true, closed: closed?.ok === true };
+    return { posted: true, closed: await ops.close() };
   }
   return { posted: true, closed: false };
 }

--- a/test/server/git/glab-items.spec.ts
+++ b/test/server/git/glab-items.spec.ts
@@ -2,8 +2,8 @@
 // CAPTURED from gitlab.com (gitlab-org/cli, 2026-08-01) rather than written by hand, so a field
 // GitLab renames breaks this instead of quietly emptying a row.
 import { describe, it, expect } from "vitest";
-import { normalizeGlabIssue, normalizeGlabIssueDetail, normalizeGlabMr } from "../../../server/git/glab-items.js";
-import { glabIssueListArgs, glabIssueViewArgs, glabMrListArgs } from "../../../server/git/glab.js";
+import { glabIssueIsOpen, glabNoteBodies, normalizeGlabIssue, normalizeGlabIssueDetail, normalizeGlabMr } from "../../../server/git/glab-items.js";
+import { glabIssueCloseArgs, glabIssueListArgs, glabIssueNoteArgs, glabIssueNotesArgs, glabIssueViewArgs, glabMrListArgs } from "../../../server/git/glab.js";
 
 const REAL_MR = {
   iid: 3675,
@@ -173,5 +173,68 @@ describe("glabIssueViewArgs", () => {
   // meaning. Three subcommands, three answers; `-O` here is rejected outright by glab.
   it("asks for json with -F", () => {
     expect(glabIssueViewArgs("group/project", 7)).toEqual(["issue", "view", "7", "--repo", "group/project", "-F", "json"]);
+  });
+});
+
+// Existing comments, for the duplicate check that keeps a work comment from being written twice.
+// These shapes were read back from gitlab.com after posting a real note.
+describe("glabNoteBodies", () => {
+  const userNote = { id: 1, body: "started work in mulmoterminal4", system: false };
+  // GitLab writes its own notes for closing, labelling, editing the description. They are not
+  // comments anyone left — counting them would let a closed-once issue read as already commented.
+  const systemNote = { id: 2, body: "closed", system: true };
+
+  it("keeps what a person wrote and drops what GitLab wrote", () => {
+    expect(glabNoteBodies([userNote, systemNote])).toEqual(["started work in mulmoterminal4"]);
+  });
+
+  it("treats a note with no system flag as a person's", () => {
+    expect(glabNoteBodies([{ id: 3, body: "no flag here" }])).toEqual(["no flag here"]);
+  });
+
+  it.each([
+    ["not an array", { notes: [] }],
+    ["null", null],
+  ])("is empty for %s", (_case, raw) => {
+    expect(glabNoteBodies(raw)).toEqual([]);
+  });
+
+  it("survives a note with no body", () => {
+    expect(glabNoteBodies([{ id: 4, system: false }])).toEqual([""]);
+  });
+});
+
+describe("glabIssueIsOpen", () => {
+  // GitLab spells it `opened`, lowercase — GitHub answers `OPEN`. Reading the wrong one would make
+  // every issue look closed, and the merged comment would never close anything.
+  it.each([
+    ["opened", true],
+    ["closed", false],
+    ["OPEN", false],
+  ])("reads state %s as open=%s", (state, open) => {
+    expect(glabIssueIsOpen({ state })).toBe(open);
+  });
+
+  it("is false for something that is not an issue", () => {
+    expect(glabIssueIsOpen("nope")).toBe(false);
+  });
+});
+
+describe("glab issue write arguments", () => {
+  // `note`, not `comment`. A reader who pattern-matched from `gh` would write the wrong verb, and
+  // glab would reject it outright rather than doing something subtly different.
+  it("comments with `note` and -m", () => {
+    expect(glabIssueNoteArgs("group/project", 7, "hello")).toEqual(["issue", "note", "7", "--repo", "group/project", "-m", "hello"]);
+  });
+
+  it("closes with the issue id", () => {
+    expect(glabIssueCloseArgs("group/project", 7)).toEqual(["issue", "close", "7", "--repo", "group/project"]);
+  });
+
+  // The notes endpoint, because `issue view -F json` carries no comments. The project path is
+  // percent-encoded: GitLab's REST API takes it as ONE path segment, so a group's slashes must not
+  // read as segment separators.
+  it("reads notes from the REST endpoint, with the project encoded", () => {
+    expect(glabIssueNotesArgs("group/sub/project", 7)).toEqual(["api", "projects/group%2Fsub%2Fproject/issues/7/notes"]);
   });
 });

--- a/test/server/git/glab-items.spec.ts
+++ b/test/server/git/glab-items.spec.ts
@@ -235,6 +235,13 @@ describe("glab issue write arguments", () => {
   // percent-encoded: GitLab's REST API takes it as ONE path segment, so a group's slashes must not
   // read as segment separators.
   it("reads notes from the REST endpoint, with the project encoded", () => {
-    expect(glabIssueNotesArgs("group/sub/project", 7)).toEqual(["api", "projects/group%2Fsub%2Fproject/issues/7/notes"]);
+    expect(glabIssueNotesArgs("group/sub/project", 7)).toEqual(["api", "projects/group%2Fsub%2Fproject/issues/7/notes", "--paginate"]);
+  });
+
+  // Not a nicety. A page holds 20 notes, newest first, so one page drops the OLDEST — and the
+  // work comment is written when work STARTS, which is the end that falls off. Without this the
+  // duplicate check misses it and comments again (Codex review).
+  it("always paginates, so an old comment on a long thread is still found", () => {
+    expect(glabIssueNotesArgs("group/project", 1)).toContain("--paginate");
   });
 });


### PR DESCRIPTION
## Summary

`issueWorkComments`（既定 off）は **GitLab のリポでは何も起きません**でした。作業開始時とマージ時に
コメントし、マージ時に issue を閉じる — GitHub と同じ動きになります。

**GitHub 経路は不変**です（既存テストが無改変で通ることが証拠）。

## Items to Confirm / Review

### 実物で確認した差が4つ。`gh` の形から推測すると全部踏みます

1. **動詞が `note`**（`comment` ではない）。メッセージは `-m`
2. **既存コメントが `issue view -F json` に入らない。** `--comments` を足しても JSON には出ません
   （人間向け表示のフラグ）。`GET /projects/:id/issues/:iid/notes` から取るので、
   **GitHub が1回で済むところが GitLab では2コール**です
3. **notes に GitLab 自身が書いたものが混ざる**（closed、ラベル変更）。`system: true` で区別。
   **拾うと「一度閉じた issue はコメント済み」と誤判定**され、コメントが一生書かれません
4. **state の綴りが `opened`**（小文字）。GitHub は `OPEN`。読み違えると**全 issue が closed に見え**、
   マージ時のクローズが一度も動きません

### 3箇所を個別に分岐させていません

`IssueOps`（view / comment / close）にまとめて**1箇所で選びます**。3つは常に同じホストに属するので、
混ざると「片方の issue を読んでもう片方に書く」ことになります。

### 実機で往復を確認しました

テストプロジェクトの実 issue に対して:

```
1回目          → {"posted":true,"closed":false}
2回目          → {"posted":false,"reason":"already"}   ← 重複チェックが notes 経由で効く
closeIssue:true → {"posted":true,"closed":true}
GitLab 側の state → closed
```

**4c-1 で未達だった「実機で通しの確認」が、この段階では取れています**（worktree / spawn を経由せず
API だけで完結する操作のため）。

## User Prompt

> #981 の残りを続けていこう！

## テスト

`yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（7429 passed）/ `knip` —
**すべて終了コードで確認**。

- 純関数 43 件（system note の除外、state の綴り、argv、project の percent エンコード）
- **既存の work-comment テストは無改変**

Fixes #1270

refs #981

work in mulmoterminal4
