### PR TITLE
fix: early-frames のジェネリックをやめて as を2箇所外す (#1231)

### DIFF
--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -434,7 +434,7 @@ export function startAndWire(
   session: {
     id: string;
     tag: string;
-    early: EarlyFrames<{ toString(): string }>;
+    early: EarlyFrames;
     startFailureMessage: (err: unknown) => string;
     /** The browser's own geometry, off the connect URL. */
     size?: TerminalSize | null;
@@ -459,15 +459,15 @@ export function startAndWire(
 // Tell the browser which session this is, and from that moment collect what it sends: its first
 // frame is the terminal's real geometry, and it arrives while the caller is still reading config
 // files, so without this it lands on the floor (see early-frames.ts).
-function announceSession(ws: WebSocket, sessionId: string, cwd: string): EarlyFrames<{ toString(): string }> {
+function announceSession(ws: WebSocket, sessionId: string, cwd: string): EarlyFrames {
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd }));
-  return bufferEarlyFrames<{ toString(): string }>(ws);
+  return bufferEarlyFrames(ws);
 }
 
 // False when the client left during those reads — the caller must return WITHOUT spawning. A spawn
 // for a socket that has already closed leaks a pty nobody reaps, because the close handlers are not
 // installed until startAndWire.
-function clientStillConnected(ws: WebSocket, tag: string, sessionId: string, early: EarlyFrames<{ toString(): string }>): boolean {
+function clientStillConnected(ws: WebSocket, tag: string, sessionId: string, early: EarlyFrames): boolean {
   if (ws.readyState === ws.OPEN) return true;
   console.log(`[ws/${tag}] client left before spawn — abandoning ${sessionId}`);
   early.discard();

--- a/server/session/early-frames.ts
+++ b/server/session/early-frames.ts
@@ -9,20 +9,24 @@
 //
 // So the socket is listened to from the start, into a buffer, and the buffer is replayed in
 // arrival order once there is a pty to give it to.
-import type { WebSocket } from "ws";
+import type { RawData, WebSocket } from "ws";
 
-export interface EarlyFrames<T> {
+export interface EarlyFrames {
   /** Replay what arrived, in order, and stop buffering. Safe to call when nothing arrived. */
-  release: (deliver: (raw: T) => void) => void;
+  release: (deliver: (raw: RawData) => void) => void;
   /** Drop what arrived and stop buffering — for a connection that never gets its session. */
   discard: () => void;
 }
 
-export function bufferEarlyFrames<T>(ws: Pick<WebSocket, "on" | "off">): EarlyFrames<T> {
-  const pending: T[] = [];
-  const collect = (raw: T) => pending.push(raw);
-  ws.on("message", collect as (...args: unknown[]) => void);
-  const stop = () => ws.off("message", collect as (...args: unknown[]) => void);
+// `RawData` rather than a generic: it is what the socket actually hands the listener, and an
+// unconstrained `T` could not receive it — which is what the two assertions here were undoing.
+// A caller wanting something narrower still passes its own handler to `release` (a function
+// accepting the wider type is usable where the narrower one is expected).
+export function bufferEarlyFrames(ws: Pick<WebSocket, "on" | "off">): EarlyFrames {
+  const pending: RawData[] = [];
+  const collect = (raw: RawData) => pending.push(raw);
+  ws.on("message", collect);
+  const stop = () => ws.off("message", collect);
   return {
     release(deliver) {
       // Detached BEFORE the replay: a frame arriving mid-replay must reach the real listener the

--- a/test/server/routes/start-and-wire.spec.ts
+++ b/test/server/routes/start-and-wire.spec.ts
@@ -65,7 +65,7 @@ function harness() {
     },
     handleClientClose,
   };
-  const early = bufferEarlyFrames<{ toString(): string }>(asWebSocket(socket));
+  const early = bufferEarlyFrames(asWebSocket(socket));
   return { socket, delivered, handleClientClose, deps, early };
 }
 

--- a/test/server/session/early-frames.spec.ts
+++ b/test/server/session/early-frames.spec.ts
@@ -28,12 +28,12 @@ const socket = () => new FakeSocket() as unknown as FakeSocket & Parameters<type
 describe("bufferEarlyFrames", () => {
   it("replays what arrived before the session existed, in order", () => {
     const ws = socket();
-    const early = bufferEarlyFrames<string>(ws);
-    ws.emit("resize-80x24");
-    ws.emit("input-a");
+    const early = bufferEarlyFrames(ws);
+    ws.emit(Buffer.from("resize-80x24"));
+    ws.emit(Buffer.from("input-a"));
 
     const delivered: string[] = [];
-    early.release((raw) => delivered.push(raw));
+    early.release((raw) => delivered.push(raw.toString()));
     expect(delivered).toEqual(["resize-80x24", "input-a"]);
   });
 
@@ -41,29 +41,29 @@ describe("bufferEarlyFrames", () => {
   // drains again — the terminal would go dead after its first keystroke.
   it("stops collecting once released", () => {
     const ws = socket();
-    const early = bufferEarlyFrames<string>(ws);
+    const early = bufferEarlyFrames(ws);
     early.release(() => {});
     expect(ws.listenerCount).toBe(0);
   });
 
   it("delivers nothing when nothing arrived", () => {
     const ws = socket();
-    const early = bufferEarlyFrames<string>(ws);
+    const early = bufferEarlyFrames(ws);
     const delivered: string[] = [];
-    early.release((raw) => delivered.push(raw));
+    early.release((raw) => delivered.push(raw.toString()));
     expect(delivered).toEqual([]);
   });
 
   // A connection whose spawn failed has no pty to replay into.
   it("drops what it holds when discarded", () => {
     const ws = socket();
-    const early = bufferEarlyFrames<string>(ws);
-    ws.emit("input-a");
+    const early = bufferEarlyFrames(ws);
+    ws.emit(Buffer.from("input-a"));
     early.discard();
     expect(ws.listenerCount).toBe(0);
 
     const delivered: string[] = [];
-    early.release((raw) => delivered.push(raw));
+    early.release((raw) => delivered.push(raw.toString()));
     expect(delivered).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

#1231。`early-frames.ts` の `as` 2 箇所。**36 → 34**。

**前回「upstream 起因で消せない可能性がある」と報告した 7 箇所のうち 2 箇所は、私の誤診でした。** 原因は upstream ではなく、このモジュール自身のジェネリックです。

## Items to Confirm / Review

### 誤診の内訳

`bufferEarlyFrames<T>` は **untyped な socket から `T` のフレームを約束していた**ので、リスナを `ws.on("message", ...)` に渡すのに 2 つのアサーションが要りました。私はこれを「プロトコルのジェネリックだから消せない」と分類しましたが、このジェネリックは**外から要求されたものではなく、このファイルが自分で導入したもの**です。

**手がかりは同じ流れの中にありました。** `ws-routes.ts:453-454` の `deliver` は、**キャスト無しで** `ws.on("message", deliver)` に渡せています。

```ts
const deliver = (raw: { toString(): string }) => deps.handleClientFrame(...);
ws.on("message", deliver);        // ← キャスト不要
```

`RawData` が `{ toString(): string }` に代入可能なので overload が一致するためです。**制約の無い `T` だけが一致しませんでした。**

### 直し方

実際に届くのは ws の `RawData` なので、それを直接受けます。

```diff
-export function bufferEarlyFrames<T>(ws: ...): EarlyFrames<T> {
-  const pending: T[] = [];
-  const collect = (raw: T) => pending.push(raw);
-  ws.on("message", collect as (...args: unknown[]) => void);
+export function bufferEarlyFrames(ws: ...): EarlyFrames {
+  const pending: RawData[] = [];
+  const collect = (raw: RawData) => pending.push(raw);
+  ws.on("message", collect);
```

`release` は `(raw: RawData) => void` を取ります。より狭い型を取るハンドラを渡す既存の呼び出しは**そのまま通ります**（広い型を受ける関数は、狭い型が期待される場所で使えます）。呼び出し側は型引数を落とすだけで、実装は変えていません。

### 残る「upstream 起因」は 5 箇所に減りました

| 箇所 | 状況 |
|---|---|
| `collectionUi.ts` teleport (2) | **upstream PR を出しました** → receptron/mulmoclaude#2721 |
| `pluginRuntime.ts` `dispatch<T>` / `subscribe<T>` (2) | `gui-chat-protocol` のジェネリック。early-frames と違い**プロトコルが宣言している**ので、ホストの都合では変えられません |
| `mcp-routes.ts` (1) | `@modelcontextprotocol/sdk` の宣言バグ。[upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083) |

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7429 passed**。

refs #1231

work in mulmoterminal3
