### PR TITLE
feat: スマホのターミナル画面をスクロールバック300行まで広げる

### DIFF
--- a/plans/feat-1272-screen-scrollback.md
+++ b/plans/feat-1272-screen-scrollback.md
@@ -1,0 +1,86 @@
+# feat: スマホのターミナル画面をスクロールバック300行まで広げる（#1272）
+
+## いま
+
+`getTerminalScreen` が返す `screen` は「見えているペイン1画面分」だけ。
+
+- tmux 経路: `tmuxCaptureStyledPane` が `capture-pane -p -e`（`-S` なし = 可視ペインのみ）
+- フォールバック経路: `renderScreen` が `active.getLine(active.baseY + row)` を `rows` 本だけ読む
+
+スマホの狭い画面ではこれだと足りず、直前の出力を追えない。
+
+## 変更
+
+`SCREEN_HISTORY_ROWS = 300` を `server/backends/remoteHost/terminalScreen.ts` に置き、3箇所で使う。
+
+1. **tmux 経路** — `tmuxCaptureStyledPane(id, historyLines)` にして `-S -<historyLines>` を渡す。
+   tmux の `history-limit` は既に 20000（`server/infra/tmux.ts:88`）なので履歴は溜まっている。
+   実機で確認済み: `capture-pane -p -e` は10行（= pane rows）、`-S -300` は121行を返した。
+
+2. **フォールバック経路** — `renderScreen` に `historyLines` を足し、`baseY - historyLines` から
+   `baseY + rows` までを読む。emulator の `scrollback` も同じ値で明示する（xterm の既定 1000 に
+   暗黙に依存させない）。入力 `buffer` は既に 1 MiB の bounded tail（`OUTPUT_BUFFER_LIMIT`）。
+
+3. **切り揃え** — `captureSessionScreen` で末尾 `SCREEN_HISTORY_ROWS` 行に揃える。
+   2経路が別々に窓を決めると tmux の有無で見え方が変わるので、窓の規則は1箇所に置く。
+
+## 窓の規則（`screenWindow`）
+
+1. 末尾の空行を落とす — 可視ペインの余白であって内容ではない。先に落とさないと
+   「300行 − ペインの空き」しか残らない。`rowsToScreen(...).trimEnd()` が最終的に消すので
+   表示上の差はない。
+2. 末尾300行を取る。
+3. バイト上限（256 KiB）まで、**新しい行から**詰める。溢れたらそこで打ち切り（間を飛ばして
+   古い小さい行を拾うと窓が不連続になる）。
+
+バイト上限を入れる理由: `terminalScreen.ts` 冒頭の「screen は rows×cols で有界だから 1MiB の
+command-doc 上限に対して paging 不要」という前提が、履歴を含めた時点で崩れるため。
+300行 × 200桁の日本語 ≒ 180 KB なので、通常の使い方では上限に触れない。触るのは
+4K モニタ級の極端に広いペインだけ。
+
+## 計測: どのセッションに効くのか（実測）
+
+**Claude セッションには効かない。** このマシンの実セッション41本を調べた結果:
+
+```
+15本  alt=1 hist=0  cmd=2.1.220 (Claude Code)
+ 3本  alt=0 hist=0  cmd=2.1.220
+13本  alt=0 hist=0  cmd=zsh
+ 数本  alt=0 hist=3〜82  cmd=zsh
+```
+
+Claude Code は alternate screen で動く。tmux の alt screen にはスクロールバックが無く
+（`history_size=0`）、`capture-pane -a -S -` で退避された通常画面を取っても空行しか返らない。
+
+さらに、PTY のバイト列を再生しても出てこない。自分のセッションを 0.4 秒間隔で40フレーム
+キャプチャし、フレーム N+1 が N を上へずらしたものかを判定した結果:
+
+```
+framesChanged: 39 / scrollTransitions: 0 / repaintTransitions: 39 / rowsScrolledOffTotal: 0
+```
+
+39回の変化すべてがその場の描き直しで、スクロールはゼロ行。見えなくなった行は
+「ビューポートより上の行」としてどこにも存在したことがない。
+`useTerminalConnections.ts` の #782 の注記（"tmux owning the scrollback — the outer xterm
+only ever receives the visible screen"）とも一致する。
+
+したがって、この変更が効くのは**スクロールバックが実際に溜まるペイン**だけ
+（実測でシェルセッションの 3〜82 行）。Claude セッションの過去ログは transcript
+（`sessionLastTurn` / `sessionTimeline`）にしか無い — 別 issue。
+
+## 影響しない（確認済み）
+
+- `suggestionFromRows` は `findLastIndex(offersSuggestion)`（`screen-rows.ts:119`）。
+  スクロールバック中の古いゴーストは拾わない。
+- スマホ側の `parseChoices` も最後の連続 1..N ブロックだけを取る。
+
+## テスト
+
+- `terminalScreen.spec.ts` — `screenWindow`: 末尾空行の除去、300行への切り揃え、
+  バイト上限での打ち切り、上限以下ならそのまま。
+- `headlessScreen.spec.ts` — `historyLines` 分のスクロールバックが返ること、
+  履歴が足りないセッションでも落ちないこと。
+
+## スマホ側
+
+`<pre>` の高さ制限と下端追従は mulmoserver#139。

--- a/plans/feat-1272-screen-scrollback.md
+++ b/plans/feat-1272-screen-scrollback.md
@@ -42,7 +42,7 @@ command-doc 上限に対して paging 不要」という前提が、履歴を含
 
 **Claude セッションには効かない。** このマシンの実セッション41本を調べた結果:
 
-```
+```text
 15本  alt=1 hist=0  cmd=2.1.220 (Claude Code)
  3本  alt=0 hist=0  cmd=2.1.220
 13本  alt=0 hist=0  cmd=zsh
@@ -55,7 +55,7 @@ Claude Code は alternate screen で動く。tmux の alt screen にはスクロ
 さらに、PTY のバイト列を再生しても出てこない。自分のセッションを 0.4 秒間隔で40フレーム
 キャプチャし、フレーム N+1 が N を上へずらしたものかを判定した結果:
 
-```
+```text
 framesChanged: 39 / scrollTransitions: 0 / repaintTransitions: 39 / rowsScrolledOffTotal: 0
 ```
 

--- a/server/backends/remoteHost/handlers/terminalSession.ts
+++ b/server/backends/remoteHost/handlers/terminalSession.ts
@@ -1,6 +1,7 @@
 // The phone's remote terminal view (#435): pick a session, read its screen, and — since #445 —
-// type into it. Screens are bounded by the terminal's own geometry (rows x cols), so unlike
-// collections they need no paging to stay under the 1 MiB command-doc ceiling.
+// type into it. A screen is a fixed-size WINDOW ending at the live prompt — a bounded number of
+// rows and bytes, see SCREEN_HISTORY_ROWS — so unlike collections it needs no paging to stay
+// under the 1 MiB command-doc ceiling.
 //
 // No MulmoClaude counterpart: that host has no PTY table to look at.
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -130,6 +130,21 @@ export function buildSessionList({ liveIds, tmuxIds, isResumable, isGridSession,
   );
 }
 
+// How much scrollback the phone is shown above the visible pane. One pane's worth is too
+// little to read on a phone — the output that explains what just happened has already
+// scrolled off (mulmoserver#139).
+export const SCREEN_HISTORY_ROWS = 300;
+
+// The second bound, and the reason it exists: the reply is written to a Firestore command
+// doc, which rejects anything over 1 MiB. Before the history the row count alone kept the
+// screen small (see the note at the top of handlers/terminalSession.ts); it no longer does.
+// 300 rows of a 200-column pane in Japanese is ~180 KB, so this only bites on a pane far
+// wider than any phone will ever read comfortably — it is a ceiling, not a budget.
+const SCREEN_MAX_BYTES = 256 * 1024;
+
+// Newline, counted alongside each row so the cap measures the string the phone receives.
+const ROW_SEPARATOR_BYTES = 1;
+
 export interface ScreenSource {
   buffer: string;
   cols: number;
@@ -259,13 +274,42 @@ const quickCommandsOf = (id: string, read: CaptureScreenDeps["quickCommandsOf"])
   }
 };
 
+// The blank rows below the last line are the unused part of the visible pane, not content.
+// Dropped BEFORE the row cap, or a session using two lines of a 40-row pane would be sent a
+// window of 262 real lines instead of 300. rowsToScreen already trimEnd()s them out of the
+// string, so nothing about the screen the phone draws changes.
+const withoutTrailingBlanks = (rows: readonly ScreenRow[]): readonly ScreenRow[] => rows.slice(0, rows.findLastIndex((row) => row.text.trim() !== "") + 1);
+
+// The newest rows that fit in SCREEN_MAX_BYTES. Scanned from the bottom and stopped at the
+// first row that doesn't fit: skipping an oversized row to keep smaller ones above it would
+// hand the phone a window with a hole in it.
+const withinByteCap = (rows: readonly ScreenRow[]): ScreenRow[] =>
+  rows.reduceRight<{ kept: ScreenRow[]; bytes: number; full: boolean }>(
+    (state, row) => {
+      if (state.full) return state;
+      const bytes = state.bytes + Buffer.byteLength(row.text, "utf8") + ROW_SEPARATOR_BYTES;
+      if (bytes > SCREEN_MAX_BYTES) return { ...state, full: true };
+      return { kept: [row, ...state.kept], bytes, full: false };
+    },
+    { kept: [], bytes: 0, full: false },
+  ).kept;
+
+// What the phone is shown, from whichever capture path produced the rows. Both paths are
+// asked for the same history, but only this decides the window — otherwise a host with tmux
+// and one without would answer the same session differently.
+//
+// Oldest-first is the only direction to drop in: the live prompt, the agent's ghost text and
+// any menu the phone offers as chips are all at the bottom.
+export const screenWindow = (rows: readonly ScreenRow[]): ScreenRow[] => withinByteCap(withoutTrailingBlanks(rows).slice(-SCREEN_HISTORY_ROWS));
+
 export async function captureSessionScreen(id: string, deps: CaptureScreenDeps): Promise<SessionScreen> {
   // Concurrently: the meta read shells out to git, which is otherwise pure latency added to
   // every screen the phone pulls.
   const [rows, meta] = await Promise.all([screenRowsOf(id, deps), screenMetaOf(id, deps.metaOf)]);
+  const windowRows = screenWindow(rows);
   return {
-    screen: rowsToScreen(rows).trimEnd(),
-    suggestion: suggestionFromRows(rows),
+    screen: rowsToScreen(windowRows).trimEnd(),
+    suggestion: suggestionFromRows(windowRows),
     quickCommands: quickCommandsOf(id, deps.quickCommandsOf),
     ...meta,
   };

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,6 +85,7 @@ import { createAntigravitySpawner } from "./session/spawn-antigravity.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import {
   agentFromPaneCommand,
+  SCREEN_HISTORY_ROWS,
   buildScreenMeta,
   buildSessionList,
   captureSessionScreen,
@@ -699,12 +700,14 @@ const remoteHostSessionScreenMeta = (sessionId: string): Promise<SessionScreenMe
 
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {
-    captureStyledPane: tmuxCaptureStyledPane,
+    // Both capture paths are asked for the same history; how much of it the phone actually
+    // gets is captureSessionScreen's call, so the two agree (mulmoserver#139).
+    captureStyledPane: (id) => tmuxCaptureStyledPane(id, SCREEN_HISTORY_ROWS),
     sourceOf: (id) => {
       const entry = ptys.get(id);
       return entry ? { buffer: entry.buffer, cols: entry.term.cols, rows: entry.term.rows } : undefined;
     },
-    render: renderScreen,
+    render: (source) => renderScreen({ ...source, historyLines: SCREEN_HISTORY_ROWS }),
     metaOf: remoteHostSessionScreenMeta,
     // Read from config on every screen so an edit in Settings reaches the phone without a
     // restart; scoped here rather than on the phone, which then needs no notion of session

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -269,16 +269,20 @@ export function tmuxKillSession(id: string): void {
   tmux(["kill-session", "-t", tmuxSessionName(id)]);
 }
 
-// The rendered contents of a session's visible pane — what the user would see right now,
-// available even while the session is DETACHED and across a server restart (tmux outlives
-// the node process). Null when tmux has no such session, which is also how a tmux-less
-// host reports "ask someone else".
+// The rendered contents of a session's pane — the visible screen plus `historyLines` of
+// scrollback above it — available even while the session is DETACHED and across a server
+// restart (tmux outlives the node process). Null when tmux has no such session, which is
+// also how a tmux-less host reports "ask someone else".
 //
 // `-e` keeps the escape sequences, which the caller strips back out (session/screen-rows).
 // Only one attribute is actually wanted — dim, the thing that marks an agent's ghost
 // suggestion apart from text the user typed — but tmux has no way to emit that alone.
-export function tmuxCaptureStyledPane(id: string): string | null {
-  const r = tmux(["capture-pane", "-p", "-e", "-t", tmuxSessionName(id)]);
+//
+// `-S -n` starts n lines into the history, clamped to whatever the session actually has,
+// so a young session simply yields less. How much is worth asking for is the caller's
+// call — this only knows how to ask.
+export function tmuxCaptureStyledPane(id: string, historyLines: number): string | null {
+  const r = tmux(["capture-pane", "-p", "-e", "-S", `-${historyLines}`, "-t", tmuxSessionName(id)]);
   return r.status === 0 ? r.stdout : null;
 }
 

--- a/server/session/headlessScreen.ts
+++ b/server/session/headlessScreen.ts
@@ -19,6 +19,9 @@ export interface HeadlessScreenInput {
   buffer: string;
   cols: number;
   rows: number;
+  // How much scrollback to read above the visible pane, so this path yields the same
+  // window as the tmux one (`capture-pane -S -n`).
+  historyLines: number;
 }
 
 // Dim is read off the cells rather than re-parsed out of the buffer, so this path yields
@@ -34,16 +37,19 @@ const rowOf = (line: IBufferLine | undefined, cols: number): ScreenRow => {
 
 // `term.write` is ASYNC — the callback fires once the parser has consumed the chunk, and
 // reading `buffer.active` before that yields an EMPTY screen. The await is load-bearing.
-export async function renderScreen({ buffer, cols, rows }: HeadlessScreenInput): Promise<ScreenRow[]> {
+export async function renderScreen({ buffer, cols, rows, historyLines }: HeadlessScreenInput): Promise<ScreenRow[]> {
   // `buffer` is still proposed API in xterm 6; reading it (and the cells below) throws
-  // without this opt-in.
-  const term = new Terminal({ cols, rows, allowProposedApi: true });
+  // without this opt-in. `scrollback` is stated rather than left at xterm's default, so
+  // asking for more history than the emulator keeps can't silently return less.
+  const term = new Terminal({ cols, rows, scrollback: historyLines, allowProposedApi: true });
   try {
     await new Promise<void>((resolve) => term.write(buffer, resolve));
     const active = term.buffer.active;
-    // baseY is the top of the viewport, so this reads the CURRENT screen rather than the
-    // emulator's whole scrollback — matching what `tmux capture-pane` returns.
-    return Array.from({ length: rows }, (_, row) => rowOf(active.getLine(active.baseY + row), cols));
+    // baseY is the top of the viewport, so reading from above it is what picks up the
+    // scrollback — matching what `tmux capture-pane -S -n` returns. Clamped at 0: a
+    // session with less history than asked for simply yields less.
+    const top = Math.max(0, active.baseY - historyLines);
+    return Array.from({ length: active.baseY - top + rows }, (_, row) => rowOf(active.getLine(top + row), cols));
   } finally {
     term.dispose();
   }

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -2,15 +2,18 @@
 import { describe, it, expect, vi } from "vitest";
 
 import {
+  SCREEN_HISTORY_ROWS,
   agentFromPaneCommand,
   buildScreenMeta,
   buildSessionList,
   captureSessionScreen,
   definedScreenMeta,
+  screenWindow,
   type CaptureScreenDeps,
   type ScreenMetaSources,
   type SessionListInput,
 } from "../../../../server/backends/remoteHost/terminalScreen.js";
+import type { ScreenRow } from "../../../../server/session/screen-rows.js";
 import { undefinedPaths } from "@mulmoclaude/core/remote-host/server";
 
 const ESC = String.fromCharCode(0x1b);
@@ -156,6 +159,56 @@ describe("buildSessionList", () => {
   it("carries the per-session title and cwd through", () => {
     const sessions = buildSessionList(listInput({ liveIds: ["a"], detailOf: () => ({ title: "Fix the parser", cwd: "/repo", agent: "shell" }) }));
     expect(sessions[0]).toMatchObject({ title: "Fix the parser", cwd: "/repo" });
+  });
+});
+
+const plainRows = (texts: readonly string[]): ScreenRow[] => texts.map((text) => ({ text, dim: "" }));
+
+// The window the phone is shown: the newest SCREEN_HISTORY_ROWS rows, under a byte ceiling.
+// Both capture paths hand their rows through this, so tmux and the fallback renderer answer
+// the same session identically (mulmoserver#139).
+describe("screenWindow", () => {
+  it("keeps a short screen whole", () => {
+    expect(screenWindow(plainRows(["one", "two", "three"])).map((row) => row.text)).toEqual(["one", "two", "three"]);
+  });
+
+  // Oldest-first, because the live prompt, the ghost text and any menu are all at the bottom.
+  it("drops the oldest rows once the history is longer than the window", () => {
+    const rows = screenWindow(plainRows(Array.from({ length: SCREEN_HISTORY_ROWS + 50 }, (_, index) => `line-${index}`)));
+    expect(rows).toHaveLength(SCREEN_HISTORY_ROWS);
+    expect(rows[0].text).toBe("line-50");
+    expect(rows.at(-1)?.text).toBe(`line-${SCREEN_HISTORY_ROWS + 49}`);
+  });
+
+  // The blanks below the last line are the unused part of the pane. Counting them would spend
+  // the window on emptiness — a session using two rows of a 40-row pane would lose 38 real ones.
+  it("spends the window on content rather than on the pane's empty rows", () => {
+    const rows = screenWindow(plainRows([...Array.from({ length: SCREEN_HISTORY_ROWS + 10 }, (_, index) => `line-${index}`), ...Array(38).fill("")]));
+    expect(rows).toHaveLength(SCREEN_HISTORY_ROWS);
+    expect(rows.at(-1)?.text).toBe(`line-${SCREEN_HISTORY_ROWS + 9}`);
+  });
+
+  // The reply is written to a Firestore command doc, which rejects anything over 1 MiB. Only
+  // an unusually wide pane can reach this — 300 rows of a 200-column pane is well under it.
+  it("stops at the byte ceiling even when the row count would allow more", () => {
+    const wide = "あ".repeat(2000); // 6 KB per row: 300 of them would be 1.8 MB
+    const rows = screenWindow(plainRows(Array.from({ length: SCREEN_HISTORY_ROWS }, (_, index) => `${index}:${wide}`)));
+    expect(rows.length).toBeLessThan(SCREEN_HISTORY_ROWS);
+    expect(rows.reduce((bytes, row) => bytes + Buffer.byteLength(row.text, "utf8") + 1, 0)).toBeLessThanOrEqual(256 * 1024);
+    // Truncated from the top: the newest row is the one that must survive.
+    expect(rows.at(-1)?.text.startsWith(`${SCREEN_HISTORY_ROWS - 1}:`)).toBe(true);
+  });
+
+  // A row too big for the ceiling on its own must END the window, not be skipped over — the
+  // rows above it would leave the phone a window with a hole in the middle of it.
+  it("stops at an oversized row instead of stepping over it", () => {
+    const rows = screenWindow(plainRows(["ancient", "あ".repeat(256 * 1024), "newest"]));
+    expect(rows.map((row) => row.text)).toEqual(["newest"]);
+  });
+
+  it("survives a session with nothing on screen at all", () => {
+    expect(screenWindow(plainRows(["", "", ""]))).toEqual([]);
+    expect(screenWindow([])).toEqual([]);
   });
 });
 

--- a/test/server/session/headlessScreen.spec.ts
+++ b/test/server/session/headlessScreen.spec.ts
@@ -4,14 +4,16 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { renderScreen } from "../../../server/session/headlessScreen.js";
+import { renderScreen, type HeadlessScreenInput } from "../../../server/session/headlessScreen.js";
 import { rowsToScreen } from "../../../server/session/screen-rows.js";
 
 const ESC = String.fromCharCode(0x1b);
 
 // renderScreen returns rows carrying each line's dim run alongside its text (#563);
-// everything below this helper is about the text.
-const screenOf = async (input: Parameters<typeof renderScreen>[0]): Promise<string> => rowsToScreen(await renderScreen(input)).trimEnd();
+// everything below this helper is about the text. historyLines defaults to none, so each
+// case says whether it is about the visible pane or about the scrollback above it.
+const screenOf = async (input: Omit<HeadlessScreenInput, "historyLines"> & { historyLines?: number }): Promise<string> =>
+  rowsToScreen(await renderScreen({ historyLines: 0, ...input })).trimEnd();
 
 // @xterm/headless ships a UMD/CJS bundle whose `module` field points at a path that does
 // not exist, so Node's ESM loader falls back to CJS and cannot see the named export. A
@@ -56,6 +58,23 @@ describe("renderScreen", () => {
     expect(await screenOf({ buffer, cols: 20, rows: 4 })).toBe("line8\nline9\nline10\nline11");
   });
 
+  // What the phone actually reads: one pane's worth is too little on a small screen, so the
+  // window reaches above the viewport — the same history `capture-pane -S -n` returns
+  // (mulmoserver#139).
+  it("reaches above the viewport for the scrollback the phone is shown", async () => {
+    const buffer = Array.from({ length: 12 }, (_, i) => `line${i}`).join("\r\n");
+    expect(await screenOf({ buffer, cols: 20, rows: 4, historyLines: 5 })).toBe(
+      ["line3", "line4", "line5", "line6", "line7", "line8", "line9", "line10", "line11"].join("\n"),
+    );
+  });
+
+  // A session younger than the window has less history, not an error — and asking for more
+  // than the emulator ever held must not shift the window off the live rows.
+  it("yields what history there is when the session is younger than the window", async () => {
+    const buffer = Array.from({ length: 6 }, (_, i) => `line${i}`).join("\r\n");
+    expect(await screenOf({ buffer, cols: 20, rows: 4, historyLines: 300 })).toBe(["line0", "line1", "line2", "line3", "line4", "line5"].join("\n"));
+  });
+
   it("wraps at the configured width", async () => {
     expect(await screenOf({ buffer: "abcdef", cols: 3, rows: 4 })).toBe("abc\ndef");
   });
@@ -73,12 +92,12 @@ describe("renderScreen", () => {
   // Dim is what tells an agent's ghost suggestion apart from text the user typed, so a
   // tmux-less host has to carry it out of the emulator too.
   it("reads the dim run off the cells", async () => {
-    const rows = await renderScreen({ buffer: `❯ ${ESC}[2mwrite the tests${ESC}[0m`, cols: 40, rows: 2 });
+    const rows = await renderScreen({ buffer: `❯ ${ESC}[2mwrite the tests${ESC}[0m`, cols: 40, rows: 2, historyLines: 0 });
     expect(rows[0]).toEqual({ text: "❯ write the tests", dim: "write the tests" });
   });
 
   it("leaves dim empty on a plain row", async () => {
-    const rows = await renderScreen({ buffer: "❯ write the tests", cols: 40, rows: 2 });
+    const rows = await renderScreen({ buffer: "❯ write the tests", cols: 40, rows: 2, historyLines: 0 });
     expect(rows[0]).toEqual({ text: "❯ write the tests", dim: "" });
   });
 });


### PR DESCRIPTION
## Summary

`getTerminalScreen` が返す `screen` を「見えているペイン1画面分」から **現在の画面＋スクロールバックで最大300行** に広げる。tmux 経路と headless フォールバック経路の両方に同じ履歴を要求し、窓の決定は `screenWindow` 1箇所に集約したので、tmux のあるホストと無いホストが同じセッションに同じ答えを返す。

行数に加えてバイト上限（256 KiB）も入れた。返信は Firestore の command doc（1 MiB 上限）に書かれるが、履歴を含めた時点で「rows × cols で有界」という従来の前提が崩れるため。

refs #1272

## Items to Confirm / Review

**1. 効果の範囲を計測済み — Claude セッションには効きません（no-op）。**

このマシンの実セッション41本:

```
15本  alt=1 hist=0  cmd=2.1.220 (Claude Code)
 3本  alt=0 hist=0  cmd=2.1.220
13本  alt=0 hist=0  cmd=zsh
 数本  alt=0 hist=3〜82  cmd=zsh
```

Claude Code は alternate screen で動き、tmux の alt screen にはスクロールバックが無い（`history_size=0`）。`capture-pane -a -S -` で退避された通常画面を取っても空行のみ。

さらに PTY のバイト列を再生しても出てこない。実セッションを 0.4 秒間隔で40フレーム撮り、フレーム N+1 が N を上へずらしたものかを判定した結果:

```
framesChanged: 39 / scrollTransitions: 0 / repaintTransitions: 39 / rowsScrolledOffTotal: 0
```

39回の変化すべてがその場の描き直しで、スクロールはゼロ行。見えなくなった行は「ビューポートより上の行」としてどこにも存在したことがない。`useTerminalConnections.ts` の #782 の注記（"tmux owning the scrollback — the outer xterm only ever receives the visible screen"）とも一致する。

**この PR が効くのは、スクロールバックが実際に溜まるペイン（シェルセッション、実測 3〜82 行）だけ**です。それでも入れる価値はあると判断しましたが、no-op のために複雑さを足す判断が妥当かはレビューをお願いします。

**2. バイト上限 256 KiB の値。** 300行 × 200桁の日本語 ≒ 180 KB なので、通常は触りません。触るのは 4K モニタ級の極端に広いペインだけの想定です。

**3. `withoutTrailingBlanks` を切り揃えの前に入れている点。** 先に落とさないと「300行 − ペインの空き」しか残りません。`rowsToScreen(...).trimEnd()` が最終的に消すので表示上の差はありません。

**4. `renderScreen` の `historyLines` を必須にした点。** optional + 既定0 にすると「渡し忘れると黙って1画面になる」ため必須にしました。spec 側の呼び出しは全て更新済みです。

## User Prompt

> terminalが１画面分しかおくられてこないので狭いんだけど、mulmoterminal側でバッファーたどってもっと５００行くらいおくればサーバ改造しなくても多く見える？
>
> じゃあ300行で、pre の高さ制限と下端スクロールも入れて
>
> tmux の中のバッファーをよんで送ったりすることは出来ない？データはあるはずなんだよね。

（3つめの問いへの答えが「Items to Confirm」1番の計測です。スマホ側の高さ制限・下端スクロールは receptron/mulmoserver#140。）

## 実装

- `SCREEN_HISTORY_ROWS = 300` を `terminalScreen.ts` に置き、3箇所で使う
- **tmux 経路** — `tmuxCaptureStyledPane(id, historyLines)` にして `-S -<n>` を渡す。`history-limit` は既に 20000（`tmux.ts:88`）。実機確認: `capture-pane -p -e` は10行（= pane rows）、`-S -300` は121行
- **フォールバック経路** — `renderScreen` が `baseY - historyLines` から `baseY + rows` を読む。emulator の `scrollback` も同じ値で明示（xterm の既定1000に暗黙に依存させない）
- **切り揃え** — `screenWindow`: ①末尾の空行を落とす ②末尾300行 ③バイト上限まで新しい行から詰め、溢れたらそこで打ち切り（間を飛ばすと窓が不連続になる）

## 影響しない（確認済み）

- `suggestionFromRows` は `findLastIndex`（`screen-rows.ts:119`）— スクロールバック中の古いゴーストは拾わない
- スマホ側の `parseChoices` も最後の連続 1..N ブロックだけを取る

## 検証

- `yarn lint` 0 errors（既存の warning のみ）
- `yarn typecheck:server` pass
- `yarn test` 7437 passed / 45 skipped
- 実 tmux セッションに対して実際の capture 経路を実行し、行数・バイト数を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal screen capture now includes up to 300 lines of recent scrollback.
  * Output is consistently limited to 256 KiB for reliable responses.
  * Scrollback is supported across terminal capture paths, including emulator-rendered screens.

* **Bug Fixes**
  * Removed trailing blank rows from captured terminal output.
  * Prevented oversized output rows from exceeding response limits.

* **Tests**
  * Added coverage for scrollback, truncation, blank rows, and output-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->