### PR TITLE
fix: wikiMarkdown と PrsOverlay の as を3箇所外す (#1231)

### DIFF
--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -10,6 +10,7 @@ import { useEscapeToClose } from "../composables/useEscapeToClose";
 import { useIssueStart } from "../composables/useIssueStart";
 import { relativeTimeFromIso } from "./cellDisplay";
 import IssueStartButton from "./IssueStartButton.vue";
+import { isRecord } from "../../common/isRecord";
 
 const { isOpen, close } = usePrsView();
 const { loadRepoDirs, startError } = useIssueStart();
@@ -23,6 +24,11 @@ let reqId = 0;
 
 // Each section loads independently so one endpoint failing (e.g. a transient
 // /api/issues error) never blanks the other — the PR dashboard keeps rendering.
+// The two row shapes as they arrive from /api/prs and /api/issues. Only `repo` is required to
+// place a row; everything else the templates read is optional there too.
+const isRepoPrs = (row: unknown): row is RepoPrs => isRecord(row) && typeof row.repo === "string";
+const isRepoIssues = (row: unknown): row is RepoIssues => isRecord(row) && typeof row.repo === "string";
+
 async function loadSection(path: string): Promise<{ rows: unknown[]; error: string | null }> {
   try {
     const res = await fetch(path);
@@ -43,9 +49,9 @@ async function load(): Promise<void> {
   // their start control can say anything, and it is the same one-shot read on view open.
   const [prs, issues] = await Promise.all([loadSection("/api/prs"), loadSection("/api/issues"), loadRepoDirs()]);
   if (id !== reqId) return;
-  repos.value = prs.rows as RepoPrs[];
+  repos.value = prs.rows.filter(isRepoPrs);
   prsError.value = prs.error;
-  issueRepos.value = issues.rows as RepoIssues[];
+  issueRepos.value = issues.rows.filter(isRepoIssues);
   issuesError.value = issues.error;
   loading.value = false;
 }

--- a/src/wikiMarkdown.ts
+++ b/src/wikiMarkdown.ts
@@ -30,7 +30,11 @@ export function stripFrontmatter(content: string): string {
 export function renderWikiHtml(content: string): string {
   // renderWikiLinks first (it escapes the text), then marked — see the file header.
   const linked = renderWikiLinks(stripFrontmatter(content));
-  const html = marked.parse(linked, { async: false }) as string;
+  // `{ async: false }` makes marked return synchronously, but its declared return type is still
+  // `string | Promise<string>`; check rather than assert so a future default flip cannot hand
+  // DOMPurify a Promise (which sanitizes to the string "[object Promise]").
+  const parsed = marked.parse(linked, { async: false });
+  const html = typeof parsed === "string" ? parsed : "";
   // DOMPurify keeps class + data-* by default (so the data-page hook survives).
   const clean = DOMPurify.sanitize(html, { ADD_ATTR: ["target"] });
   const doc = new DOMParser().parseFromString(clean, "text/html");


### PR DESCRIPTION
## Summary

#1231。2 ファイル・**3 箇所**。allowlist は **0 件**。

## Items to Confirm / Review

### 1. `marked.parse(...) as string` は、失敗しても例外が出ない類でした

`{ async: false }` を渡しても marked の**宣言上の戻り型は `string | Promise<string>` のまま**です。アサーションで潰すと、もし Promise が返った場合に **DOMPurify が文字列 `"[object Promise]"` をサニタイズして通します** — 例外は出ず、記事本文がその 1 語に化けるだけなので、原因から遠い場所で気づくことになります。

```diff
-const html = marked.parse(linked, { async: false }) as string;
+const parsed = marked.parse(linked, { async: false });
+const html = typeof parsed === "string" ? parsed : "";
```

### 2. `PrsOverlay.vue` — 自分で `unknown[]` と書いておいて、受け側で信じていました

```ts
async function loadSection(path: string): Promise<{ rows: unknown[]; error: string | null }> { ... }
```

**`unknown[]` と宣言しているのは同じファイル**です。それを `as RepoPrs[]` で丸ごと信じ直していました。行ごとの述語 filter に変えています。`RepoPrs` / `RepoIssues` の必須フィールドは `repo` だけなので、述語もそこだけ見ます（他は全て optional）。

## 着手して、この PR には含めなかったもの

`useTheme.ts` の `Object.fromEntries(entries) as Record<ThemeId, ThemeVars>` です。

`readBuiltinVars` は null を返し得るので**キーが欠ける場合があり**、アサーションはそれでも完全な Record だと主張していました。戻り型を正直に `Partial<Record<...>>` にしたところ、`applyCustomTheme` / `customTermTheme` / `resolveThemeVars` の **3 箇所が完全な Record を要求**していて連鎖します。

「欠けたテーマをどう扱うか」は設計判断なので、機械的な置換とは分けます。次で扱います。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / **`yarn typecheck:test`** / `yarn build` / `yarn test` **7442 passed**。

> `typecheck:test` は #1273 で CI を落とした反省から毎回回しています。実際この PR でも、`useTheme` の変更が `typecheck` は通るのに `typecheck:test` で落ちることを検出しました。

refs #1231

work in mulmoterminal3
