### PR TITLE
fix: collection-plugin 1.2.3 へ上げて teleport の二段キャストを外す (#1231)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^1.1.0",
     "@mulmoclaude/chart-plugin": "^1.0.3",
-    "@mulmoclaude/collection-plugin": "^1.2.1",
+    "@mulmoclaude/collection-plugin": "^1.2.3",
     "@mulmoclaude/core": "^1.12.0",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.1",

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -249,7 +249,8 @@ configureCollectionUi({
   //    new-collection starter modal's localized cards; omitted ⇒ English fallback. ──
   translate: postTranslation,
 
-  // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime
-  //    though the declared type is string | HTMLElement.
-  modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
+  // ── Shadow-DOM modal target ── the innermost open Shadow root, or the body when none is open.
+  //    The package types this `string | HTMLElement | ShadowRoot` as of 1.2.3, so the value this
+  //    host has always passed no longer needs a cast to be expressible (mulmoclaude#2721).
+  modalTeleportTarget: () => teleportStack[teleportStack.length - 1] ?? "body",
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,10 +1959,10 @@
   dependencies:
     "@mulmoclaude/core" "^1.5.0"
 
-"@mulmoclaude/collection-plugin@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-1.2.1.tgz#b9ec1b19d9dfb42eeee67d69679affe3eb2d4618"
-  integrity sha512-tx8sBOoA3Eznn27P9s7sIu7a5Os4PnDJAZFPD/cltNHvvd/H55htbN702CJ9xaGQhLQh+aIQVU9piqpyRm94IQ==
+"@mulmoclaude/collection-plugin@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-1.2.3.tgz#3ae937b1c28bf6c053d333ca0a8051fc714b6bd5"
+  integrity sha512-eYOPOVer2snvLChw0xSnu/r0Iz8xlcTKEY25O4Dvkeow9q5d2+g3H/OseViPBYLw/kYMJoJ2JDr1QxRHShCvfg==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"


### PR DESCRIPTION
## Summary

upstream 修正（[receptron/mulmoclaude#2721](https://github.com/receptron/mulmoclaude/pull/2721)）が **1.2.3 で publish された**ので取り込み、#1231 の残りから **2 箇所**消します。**34 → 32**。

## Items to Confirm / Review

### 1. 「消せない」と分類していた 5 箇所のうち 2 箇所が消えました

`modalTeleportTarget` の型が `() => string | HTMLElement | ShadowRoot` になったので、**この host が元から渡していた値**がキャスト無しで書けます。

```diff
-  // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime
-  //    though the declared type is string | HTMLElement.
-  modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
+  // ── Shadow-DOM modal target ── the innermost open Shadow root, or the body when none is open.
+  modalTeleportTarget: () => teleportStack[teleportStack.length - 1] ?? "body",
```

**runtime の挙動は変わりません。** Vue の Teleport は元から ShadowRoot を受けており、狭すぎたのは型だけでした。

### 2. 依存の差分は 1.2.1 → 1.2.3 です

`^1.2.1` のままでも解決は 1.2.3 になりますが、**この修正に依存するコードが入る**ので下限を上げました。1.2.2 は無関係の変更です。

### 3. lockfile が変わるので、クリーン install で検証しました

`yarn add` は lockfile を書き換えるため、既に展開済みの `node_modules` の上でテストしても意味がありません（CLAUDE.md にある「warm な node_modules は嘘をつく」）。

```
rm -rf node_modules && yarn install --frozen-lockfile
```

からやり直して、`typecheck` / `typecheck:test` / `test` **7442 passed** を確認しています。

## 検証

- `yarn lint`（0 error、34 problems ← 36）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7442 passed**
- **クリーン install からの再検証**（上記）
- **実ブラウザ**: `presentCollection` の View が登録され `viewComponent` が nullish でないこと、画面描画、console error **0** を確認

## 残り

| 箇所 | 状況 |
|---|---|
| `pluginRuntime.ts` (2) | `gui-chat-protocol` のプロトコル側ジェネリック。未調査 |
| `mcp-routes.ts` (1) | MCP SDK の宣言バグ（[upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083)） |
| その他 | 29 箇所。うち `useTheme.ts` は設計判断が要ります |

refs #1231

work in mulmoterminal3
