### PR TITLE
feat: GitLab の worktree から ⧉ Open PR を押せるようにする（#981 段階4c-3）

### DIFF
--- a/plans/feat-981-4c3-gitlab-open-pr.md
+++ b/plans/feat-981-4c3-gitlab-open-pr.md
@@ -1,0 +1,50 @@
+# feat(#1277 / #981 段階4c-3): GitLab の worktree から ⧉ Open PR
+
+#981 の最後の実装段階。**GitHub の挙動は変えない。**
+
+## この経路だけ構造が違う
+
+他の GitLab 対応は `--repo <owner/repo>` を渡す形だったが、ここは **worktree の cwd から
+repo を推測**させている（`--repo` は `OWNER/REPO` しか受け付けないので、リポジトリの PATH を
+渡すと必ず失敗する、とコメントに書かれている）。
+
+**glab も同じことができる**ことを実物で確認した — remote だけ設定したディレクトリで
+`glab mr list` が通る。なので `--repo` を足す必要はなく、**変えるのは「どの CLI を呼ぶか」だけ**。
+
+## 実物で確認した4操作（テストプロジェクトで実行）
+
+| したいこと | glab | 確認 |
+| --- | --- | --- |
+| 作る | `mr create --fill -s <br> -b <base> --yes` | MR が実際に作られた |
+| 既存を探す | `mr list --source-branch <br> -F json` | `web_url` が取れた |
+| 本文を読む | `mr view <url> -F json` の `description` | 取れた |
+| 本文を書く | `mr update <url> --description <text>` | 書けて読み戻せた |
+
+**`gh` との差2つ:**
+
+1. **`--fill` は push も行う**（`gh pr create --fill` は行わない）。push していないブランチから
+   MR が作られることを確認済み。`pushWorktree` の後なら無害で、push が飛んだ場合はこれが救う
+2. **URL をそのまま渡せる**（`mr view` / `mr update` とも）。だから `finalizePrBody` は
+   受け取った URL を持ち回る形のままでよい
+
+## 構造
+
+`PrOps`（cli / create / forBranch / viewBody / readBody / readUrl / updateBody）にまとめ、
+**cwd の remote から1回だけ選ぶ**。4操作は同じ MR を指すので、混ざると片方を読んで片方に書く。
+
+`readBody` と `readUrl` を ops に持たせたのは、**出力形式が違う**ため — gh は `--jq` で生文字列、
+glab は JSON。呼び出し側に三項を置くと lint（`no-nested-conditional`）にも引っかかる。
+
+## `via` の名前を変えた
+
+`"gh" | "compare"` → **`"cli" | "compare"`**。glab がここに来ると「gh で作った」と報告することに
+なる。UI は `via === "cli"` で「PR created」と出すだけなので、意味を**結果**に寄せた。
+
+## 検証
+
+- 既存テストは `via` の値以外**無改変で通過**（GitHub 経路が不変であることの証拠）
+- 純関数と argv 58 件（`--repo` を渡さないこと、URL 指定、空 description、空リスト）
+- **実機**: 管理下の worktree から `createOrOpenPR` を2回
+  - 1回目 `{ok: true, url: .../merge_requests/3, via: "cli"}` — MR が作られた
+  - 2回目 **同じ URL** — 既存 MR を開く
+  - 本文に **`Fixes #1` とフッター `work in glreal`** の両方が入った

--- a/server/git/glab-items.ts
+++ b/server/git/glab-items.ts
@@ -88,3 +88,14 @@ export function glabNoteBodies(raw: unknown): string[] {
 
 /** Whether an issue read from `glab issue view` is still open. GitLab spells it lowercase. */
 export const glabIssueIsOpen = (raw: unknown): boolean => isRecord(raw) && raw.state === "opened";
+
+/** The merge request's description, from `glab mr view -F json`. GitLab calls the body
+ *  `description`; an empty one is normal and is not a read failure. */
+export const glabMrBody = (raw: unknown): string => (isRecord(raw) ? text(raw.description) : "");
+
+/** The web URL of the first merge request in a `glab mr list` answer, or null when there is none. */
+export function glabFirstMrUrl(raw: unknown): string | null {
+  const first = Array.isArray(raw) ? raw.find(isRecord) : null;
+  const url = first ? text(first.web_url) : "";
+  return url || null;
+}

--- a/server/git/glab.ts
+++ b/server/git/glab.ts
@@ -47,3 +47,28 @@ export const glabIssueNotesArgs = (project: string, issue: number): string[] => 
   `projects/${encodeURIComponent(project)}/issues/${issue}/notes`,
   "--paginate",
 ];
+
+// The merge-request half. Like `gh`, glab infers the project from the working directory, so none of
+// these pass `--repo` — verified by running `glab mr list` in a directory holding nothing but a
+// remote. A URL is accepted wherever an iid is, which is what lets the body helpers keep taking the
+// URL they were given.
+//
+// `--fill` differs from `gh pr create --fill` in one way that matters: it PUSHES the branch too
+// (observed — an unpushed branch produced a merge request). Harmless after `pushWorktree` has
+// already pushed, and it is what makes the command work at all when the push was skipped.
+export const glabMrCreateArgs = (base: string, branch: string): string[] => [
+  "mr",
+  "create",
+  "--fill",
+  "--source-branch",
+  branch,
+  "--target-branch",
+  base,
+  "--yes",
+];
+
+export const glabMrForBranchArgs = (branch: string): string[] => ["mr", "list", "--source-branch", branch, "-F", "json"];
+
+export const glabMrViewArgs = (mr: string): string[] => ["mr", "view", mr, "-F", "json"];
+
+export const glabMrUpdateBodyArgs = (mr: string, body: string): string[] => ["mr", "update", mr, "--description", body];

--- a/server/git/worktree-pr.ts
+++ b/server/git/worktree-pr.ts
@@ -4,6 +4,17 @@
 // upstream by origin checks; here every command is argv-only (no shell).
 import { repoRoot, defaultBaseBranch, isManagedWorktree, git } from "./worktrees.js";
 import { resolveGithubUrl } from "./gitRemote.js";
+import { repoForDir } from "./forge-support.js";
+import { glabMrCreateArgs, glabMrForBranchArgs, glabMrUpdateBodyArgs, glabMrViewArgs } from "./glab.js";
+import { glabFirstMrUrl, glabMrBody } from "./glab-items.js";
+
+const safeJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
 import { spawnCollect, type SpawnResult } from "./spawn-collect.js";
 import { lastGhUrl } from "./git-parse.js";
 import { parsePrUrl } from "./pr-for-branch.js";
@@ -22,7 +33,10 @@ export interface PushResult {
 export interface PrResult {
   ok: boolean;
   url?: string | undefined;
-  via?: "gh" | "compare";
+  /** How the URL was produced: a CLI made or found the request, or we fell back to the forge's
+   *  compare page. Named for the OUTCOME rather than the tool since #981 — `glab` reaching this
+   *  point would otherwise have to report itself as "gh". */
+  via?: "cli" | "compare";
   reason?: Reason | undefined;
   detail?: string | undefined;
 }
@@ -37,7 +51,9 @@ export const NETWORK_MUTATION_TIMEOUT_MS = 300_000;
 
 // worktrees.ts' git() drops stderr and only runs git; push/gh failures report via
 // stderr, so use the stderr-capturing runner, constrained to those two tools.
-export type Runner = (cmd: "git" | "gh", args: string[], cwd: string) => Promise<SpawnResult>;
+// `glab` joins `gh` here rather than the type naming one forge (#981). Which of them a worktree
+// wants is decided from its own remote, so the runner just has to be able to spawn either.
+export type Runner = (cmd: "git" | "gh" | "glab", args: string[], cwd: string) => Promise<SpawnResult>;
 
 const run: Runner = (cmd, args, cwd) => spawnCollect(cmd, args, { cwd, errorStderr: "spawn failed", timeoutMs: NETWORK_MUTATION_TIMEOUT_MS });
 
@@ -87,27 +103,74 @@ const describeAdditions = ({ footer, issue }: PrBodyAdditions): string => [issue
 
 // Add those lines to a PR body that already exists (#872, #1171). Two calls rather than one,
 // because `--body` on `gh pr create` REPLACES what `--fill` derived from the commits instead of
+
+// How one forge phrases the four merge-request operations. Chosen once per call from the worktree's
+// own remote, because all four concern the SAME merge request — mixing them would read one and
+// write another.
+interface PrOps {
+  cli: "gh" | "glab";
+  create: (base: string, branch: string) => string[];
+  forBranch: (branch: string) => string[];
+  viewBody: (prUrl: string) => string[];
+  /** How to read the body out of `viewBody`'s stdout. gh is asked for the raw string with `--jq`;
+   *  glab has no such flag, so its JSON is parsed here. */
+  readBody: (stdout: string) => string;
+  /** The existing merge request's URL out of `forBranch`'s stdout, or null when there is none. */
+  readUrl: (stdout: string) => string | null;
+  updateBody: (prUrl: string, body: string) => string[];
+}
+
+const GITHUB_PR_OPS: PrOps = {
+  cli: "gh",
+  create: (base, branch) => ["pr", "create", "--base", base, "--head", branch, "--fill"],
+  forBranch: (branch) => ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"],
+  viewBody: (prUrl) => ["pr", "view", prUrl, "--json", "body", "--jq", ".body"],
+  readBody: (stdout) => stdout,
+  readUrl: (stdout) => parsePrUrl(stdout),
+  updateBody: (prUrl, body) => ["pr", "edit", prUrl, "--body", body],
+};
+
+const GITLAB_PR_OPS: PrOps = {
+  cli: "glab",
+  create: (base, branch) => glabMrCreateArgs(base, branch),
+  forBranch: (branch) => glabMrForBranchArgs(branch),
+  viewBody: (prUrl) => glabMrViewArgs(prUrl),
+  readBody: (stdout) => glabMrBody(safeJson(stdout)),
+  readUrl: (stdout) => glabFirstMrUrl(safeJson(stdout)),
+  updateBody: (prUrl, body) => glabMrUpdateBodyArgs(prUrl, body),
+};
+
+// Neither `gh` nor `glab` is told which project this is: both infer it from the working directory,
+// which is why none of the argument builders pass `--repo`. Only the CHOICE of CLI comes from the
+// remote (#981).
+async function prOpsFor(cwd: string): Promise<PrOps> {
+  const found = await repoForDir(cwd);
+  return found?.forge.kind === "gitlab" ? GITLAB_PR_OPS : GITHUB_PR_OPS;
+}
+
 // adding to it — so the body has to be read back and edited. ONE read and at most one write for
 // both lines: two independent read-modify-writes against the same body would race each other.
 //
 // Never fails the PR: the PR exists by the time this runs, and reporting an error for a missing
 // trailing line would tell the user their PR wasn't created when it was.
-export async function finalizePrBody(prUrl: string, additions: PrBodyAdditions, cwd: string, runner: Runner = run): Promise<void> {
+export async function finalizePrBody(prUrl: string, additions: PrBodyAdditions, cwd: string, runner: Runner = run, ops?: PrOps): Promise<void> {
   const { footer, issue } = additions;
   if (!footer && issue === null) return;
-  const viewed = await runner("gh", ["pr", "view", prUrl, "--json", "body", "--jq", ".body"], cwd);
+  const forge = ops ?? (await prOpsFor(cwd));
+  const viewed = await runner(forge.cli, forge.viewBody(prUrl), cwd);
   if (!viewed.ok) {
     console.warn(`[pr] could not read the body of ${prUrl} to append "${describeAdditions(additions)}": ${viewed.stderr.trim().slice(0, DETAIL_LIMIT)}`);
     return;
   }
   // Issue reference first, clone line last: the latter is a FOOTER, and appending `Fixes #N`
   // after it would bury it mid-body.
-  const referenced = issue === null ? viewed.stdout : withIssueRef(viewed.stdout, issue);
+  const current = forge.readBody(viewed.stdout);
+  const referenced = issue === null ? current : withIssueRef(current, issue);
   const body = footer ? withFooter(referenced, footer) : referenced;
   // Both helpers return their input unchanged when the line is already there, so this is the
   // "nothing to say" case — don't spend a write (and a PR-edited event) saying it.
-  if (body === viewed.stdout) return;
-  const edited = await runner("gh", ["pr", "edit", prUrl, "--body", body], cwd);
+  if (body === current) return;
+  const edited = await runner(forge.cli, forge.updateBody(prUrl, body), cwd);
   if (!edited.ok) console.warn(`[pr] could not append "${describeAdditions(additions)}" to ${prUrl}: ${edited.stderr.trim().slice(0, DETAIL_LIMIT)}`);
 }
 
@@ -121,13 +184,14 @@ export async function createOrOpenPR(cwd: string): Promise<PrResult> {
   if (!repo) return { ok: false, reason: "not-worktree" };
   const base = await defaultBaseBranch(repo);
 
-  const gh = await run("gh", ["pr", "create", "--base", base, "--head", branch, "--fill"], cwd);
+  const ops = await prOpsFor(cwd);
+  const gh = await run(ops.cli, ops.create(base, branch), cwd);
   const ghUrl = gh.ok ? lastGhUrl(gh.stdout) : null;
   if (ghUrl) {
     // Only on the PR we just created: rewriting the body of an EXISTING PR every time the button
     // is pressed would edit whatever the author has since written there.
-    await finalizePrBody(ghUrl, { footer: getPrWorkdirFooter() ? workdirFooter(repo) : null, issue: issueFromAnchoredBranch(branch) }, cwd);
-    return { ok: true, url: ghUrl, via: "gh" };
+    await finalizePrBody(ghUrl, { footer: getPrWorkdirFooter() ? workdirFooter(repo) : null, issue: issueFromAnchoredBranch(branch) }, cwd, run, ops);
+    return { ok: true, url: ghUrl, via: "cli" };
   }
 
   // `gh pr create` fails when a PR for this branch ALREADY exists — re-running the button
@@ -135,9 +199,9 @@ export async function createOrOpenPR(cwd: string): Promise<PrResult> {
   // No `--repo`: like the `gh pr create` above, gh infers the repo from `cwd` (the worktree).
   // Passing repoRoot(cwd) here would be a filesystem PATH, but `--repo` only accepts an
   // OWNER/REPO slug, so it would always error and defeat this lookup.
-  const existing = await run("gh", ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"], cwd);
-  const existingUrl = existing.ok ? parsePrUrl(existing.stdout) : null;
-  if (existingUrl) return { ok: true, url: existingUrl, via: "gh" };
+  const existing = await run(ops.cli, ops.forBranch(branch), cwd);
+  const existingUrl = existing.ok ? ops.readUrl(existing.stdout) : null;
+  if (existingUrl) return { ok: true, url: existingUrl, via: "cli" };
 
   const githubUrl = await resolveGithubUrl(cwd);
   if (!githubUrl) return { ok: false, reason: "no-github", detail: gh.stderr.trim().slice(0, DETAIL_LIMIT) };

--- a/server/git/worktree-pr.ts
+++ b/server/git/worktree-pr.ts
@@ -3,7 +3,6 @@
 // unauthed it falls back to opening the GitHub compare URL in the browser. Guarded
 // upstream by origin checks; here every command is argv-only (no shell).
 import { repoRoot, defaultBaseBranch, isManagedWorktree, git } from "./worktrees.js";
-import { resolveGithubUrl } from "./gitRemote.js";
 import { repoForDir } from "./forge-support.js";
 import { glabMrCreateArgs, glabMrForBranchArgs, glabMrUpdateBodyArgs, glabMrViewArgs } from "./glab.js";
 import { glabFirstMrUrl, glabMrBody } from "./glab-items.js";
@@ -22,7 +21,10 @@ import { getPrWorkdirFooter } from "../config/config-routes.js";
 import { withFooter, withIssueRef, workdirFooter } from "./pr-footer.js";
 import { issueFromAnchoredBranch } from "../../common/prPhase.js";
 
-type Reason = "not-worktree" | "no-branch" | "no-remote" | "no-github" | "push-failed" | "failed";
+// `no-forge` was `no-github` until #981: the message it drove said "Not a GitHub repo" about a
+// GitLab one, which is both wrong and unhelpful — the push HAD succeeded and the user needed to
+// know where to go, not what their repo is not.
+type Reason = "not-worktree" | "no-branch" | "no-remote" | "no-forge" | "push-failed" | "failed";
 
 export interface PushResult {
   ok: boolean;
@@ -78,6 +80,13 @@ async function hasOrigin(cwd: string): Promise<boolean> {
 // (agent/<task>) — GitHub's compare path takes them raw, not percent-encoded.
 export function compareUrl(githubUrl: string, base: string, branch: string): string {
   return `${githubUrl}/compare/${base}...${branch}?expand=1`;
+}
+
+// GitLab's equivalent, and it is NOT a compare page: the project's "New merge request" form,
+// pre-filled with the source branch. This is the URL GitLab itself prints on `git push` — copied
+// from a real push rather than composed from the docs, including the bracket encoding.
+export function newMergeRequestUrl(projectUrl: string, branch: string): string {
+  return `${projectUrl}/-/merge_requests/new?merge_request%5Bsource_branch%5D=${encodeURIComponent(branch)}`;
 }
 
 // Push the worktree's branch to origin (so it can be turned into a PR).
@@ -203,7 +212,14 @@ export async function createOrOpenPR(cwd: string): Promise<PrResult> {
   const existingUrl = existing.ok ? ops.readUrl(existing.stdout) : null;
   if (existingUrl) return { ok: true, url: existingUrl, via: "cli" };
 
-  const githubUrl = await resolveGithubUrl(cwd);
-  if (!githubUrl) return { ok: false, reason: "no-github", detail: gh.stderr.trim().slice(0, DETAIL_LIMIT) };
-  return { ok: true, url: compareUrl(githubUrl, base, branch), via: "compare" };
+  // The CLI could not make or find the request, so fall back to the page where a person can. Which
+  // page that is comes from the forge — `resolveGithubUrl` answers null for GitLab, so reusing it
+  // here reported "Not a GitHub repo" about a GitLab repo and buried glab's real error, whatever it
+  // was (Codex review).
+  const detail = gh.stderr.trim().slice(0, DETAIL_LIMIT);
+  const found = await repoForDir(cwd);
+  const webUrl = found?.forge.webUrl;
+  if (!webUrl) return { ok: false, reason: "no-forge", detail };
+  const url = found.forge.kind === "gitlab" ? newMergeRequestUrl(webUrl, branch) : compareUrl(webUrl, base, branch);
+  return { ok: true, url, via: "compare" };
 }

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -909,7 +909,7 @@ async function openPR() {
   if (!data) return;
   if (data.ok && typeof data.url === "string") {
     window.open(data.url, "_blank", "noopener,noreferrer");
-    prMsg.value = data.via === "gh" ? "PR created" : "Opened PR page";
+    prMsg.value = data.via === "cli" ? "PR created" : "Opened PR page";
   } else {
     prMsg.value = worktreeFailureMessage(reasonOf(data));
   }

--- a/src/components/cellChromeRules.ts
+++ b/src/components/cellChromeRules.ts
@@ -5,7 +5,7 @@ const REASON_MESSAGES = new Map<string, string>([
   ["not-worktree", "Not a worktree"],
   ["no-branch", "No branch to push"],
   ["no-remote", "No git remote (origin) configured"],
-  ["no-github", "Not a GitHub repo — push succeeded; open the PR manually"],
+  ["no-forge", "Push succeeded — this remote is on a forge MulmoTerminal cannot open a request on; do it there"],
   ["push-failed", "Push failed"],
   ["failed", "Failed"],
 ]);

--- a/test/server/git/glab-items.spec.ts
+++ b/test/server/git/glab-items.spec.ts
@@ -2,8 +2,27 @@
 // CAPTURED from gitlab.com (gitlab-org/cli, 2026-08-01) rather than written by hand, so a field
 // GitLab renames breaks this instead of quietly emptying a row.
 import { describe, it, expect } from "vitest";
-import { glabIssueIsOpen, glabNoteBodies, normalizeGlabIssue, normalizeGlabIssueDetail, normalizeGlabMr } from "../../../server/git/glab-items.js";
-import { glabIssueCloseArgs, glabIssueListArgs, glabIssueNoteArgs, glabIssueNotesArgs, glabIssueViewArgs, glabMrListArgs } from "../../../server/git/glab.js";
+import {
+  glabFirstMrUrl,
+  glabIssueIsOpen,
+  glabMrBody,
+  glabNoteBodies,
+  normalizeGlabIssue,
+  normalizeGlabIssueDetail,
+  normalizeGlabMr,
+} from "../../../server/git/glab-items.js";
+import {
+  glabIssueCloseArgs,
+  glabIssueListArgs,
+  glabMrCreateArgs,
+  glabMrForBranchArgs,
+  glabMrUpdateBodyArgs,
+  glabMrViewArgs,
+  glabIssueNoteArgs,
+  glabIssueNotesArgs,
+  glabIssueViewArgs,
+  glabMrListArgs,
+} from "../../../server/git/glab.js";
 
 const REAL_MR = {
   iid: 3675,
@@ -243,5 +262,63 @@ describe("glab issue write arguments", () => {
   // duplicate check misses it and comments again (Codex review).
   it("always paginates, so an old comment on a long thread is still found", () => {
     expect(glabIssueNotesArgs("group/project", 1)).toContain("--paginate");
+  });
+});
+
+// The merge-request half of the ⧉ Open PR path. Shapes read back from a real MR on gitlab.com.
+describe("glabMrBody", () => {
+  it("takes the body from `description`", () => {
+    expect(glabMrBody({ iid: 2, description: "Fixes #1\n\nwork in glreal" })).toBe("Fixes #1\n\nwork in glreal");
+  });
+
+  // A merge request with no description is ordinary — `--fill` leaves it empty when the commit has
+  // no body. Reading it as a failure would skip appending the footer.
+  it.each([
+    ["an empty description", { iid: 2, description: "" }],
+    ["no description at all", { iid: 2 }],
+    ["something that is not an MR", "nope"],
+  ])("is the empty string for %s", (_case, raw) => {
+    expect(glabMrBody(raw)).toBe("");
+  });
+});
+
+describe("glabFirstMrUrl", () => {
+  it("takes the web_url of the first merge request", () => {
+    expect(glabFirstMrUrl([{ iid: 2, web_url: "https://gitlab.com/o/p/-/merge_requests/2" }])).toBe("https://gitlab.com/o/p/-/merge_requests/2");
+  });
+
+  // An empty list is the ordinary "no merge request for this branch yet" answer, which is what
+  // sends the caller on to the compare-page fallback rather than to an error.
+  it.each([
+    ["an empty list", []],
+    ["not a list", { merge_requests: [] }],
+    ["a row with no web_url", [{ iid: 2 }]],
+  ])("is null for %s", (_case, raw) => {
+    expect(glabFirstMrUrl(raw)).toBeNull();
+  });
+});
+
+describe("glab merge-request arguments", () => {
+  // No `--repo` anywhere: glab infers the project from the working directory, the same way `gh`
+  // does — verified by running `glab mr list` in a directory holding nothing but a remote.
+  it.each([
+    ["create", glabMrCreateArgs("master", "issue/1-x")],
+    ["forBranch", glabMrForBranchArgs("issue/1-x")],
+    ["view", glabMrViewArgs("https://gitlab.com/o/p/-/merge_requests/2")],
+    ["update", glabMrUpdateBodyArgs("https://gitlab.com/o/p/-/merge_requests/2", "body")],
+  ])("%s passes no --repo", (_name, args) => {
+    expect(args).not.toContain("--repo");
+  });
+
+  it("creates with the source and target branches named", () => {
+    expect(glabMrCreateArgs("master", "issue/1-x")).toEqual(["mr", "create", "--fill", "--source-branch", "issue/1-x", "--target-branch", "master", "--yes"]);
+  });
+
+  // A URL is accepted wherever an iid is, which is what lets the body helpers keep taking the URL
+  // they were handed rather than parsing an iid out of it.
+  it("views and updates by whatever identifier it was given", () => {
+    const url = "https://gitlab.com/o/p/-/merge_requests/2";
+    expect(glabMrViewArgs(url)).toEqual(["mr", "view", url, "-F", "json"]);
+    expect(glabMrUpdateBodyArgs(url, "b")).toEqual(["mr", "update", url, "--description", "b"]);
   });
 });

--- a/test/server/git/worktree-pr-timeout.spec.ts
+++ b/test/server/git/worktree-pr-timeout.spec.ts
@@ -50,7 +50,7 @@ describe("createOrOpenPR opens an existing PR (#748)", () => {
       return { ok: true, stdout: "", stderr: "" };
     });
     const res = await createOrOpenPR("/repo/wt");
-    expect(res).toEqual({ ok: true, url: "https://github.com/o/r/pull/42", via: "gh" });
+    expect(res).toEqual({ ok: true, url: "https://github.com/o/r/pull/42", via: "cli" });
     // Regression (#762 Codex review): the lookup must NOT pass `--repo` — `run(..., cwd)` runs
     // gh inside the worktree so it infers the repo, and `--repo` only accepts an OWNER/REPO
     // slug (repoRoot(cwd) is a filesystem path, which would always error and defeat the lookup).
@@ -66,6 +66,6 @@ describe("createOrOpenPR opens an existing PR (#748)", () => {
       return { ok: true, stdout: "", stderr: "" };
     });
     const res = await createOrOpenPR("/repo/wt");
-    expect(res).toEqual({ ok: true, url: "https://github.com/o/r/pull/7", via: "gh" });
+    expect(res).toEqual({ ok: true, url: "https://github.com/o/r/pull/7", via: "cli" });
   });
 });

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -95,7 +95,7 @@ describe("push / PR actions", () => {
   );
 
   it.skipIf(!hasGit)(
-    "createOrOpenPR pushes, then reports no-github for a non-GitHub remote",
+    "createOrOpenPR pushes, then reports no-forge for a remote on no forge it knows",
     async () => {
       g(repo, "remote", "add", "origin", remote); // a local bare remote, not github.com
       const wt = await createWorktree(repo, "feature");
@@ -105,9 +105,9 @@ describe("push / PR actions", () => {
       g(wt.path, "commit", "-m", "work");
 
       const res = await createOrOpenPR(wt.path);
-      // gh can't make a PR (no GitHub) and the remote isn't github.com → no compare url
+      // No CLI can make a request here and the remote is on no forge we know → no page to fall back to
       expect(res.ok).toBe(false);
-      expect(res.reason).toBe("no-github");
+      expect(res.reason).toBe("no-forge");
       // but the push half still landed the branch on the remote
       const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/feature"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
       expect(refs).toContain("agent/feature");

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1350,7 +1350,7 @@ describe("TerminalCell", () => {
   });
 
   it("Open PR opens the returned url in a new tab", async () => {
-    mockFetchWithPr(aheadDiff(2), { body: { ok: true, url: "https://github.com/owner/repo/pull/9", via: "gh" } });
+    mockFetchWithPr(aheadDiff(2), { body: { ok: true, url: "https://github.com/owner/repo/pull/9", via: "cli" } });
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();

--- a/test/src/components/cellChromeRules.spec.ts
+++ b/test/src/components/cellChromeRules.spec.ts
@@ -11,9 +11,13 @@ describe("worktreeFailureMessage", () => {
     expect(worktreeFailureMessage(reason)).toBe(expected);
   });
 
-  // The push half succeeded — the message has to say so, or the user re-pushes.
-  it("tells the user their push landed even though the PR did not", () => {
-    expect(worktreeFailureMessage("no-github")).toContain("push succeeded");
+  // The push half succeeded — the message has to say so, or the user re-pushes. It must NOT say
+  // "not a GitHub repo": since #981 this reason covers any forge we cannot open a request on, and
+  // naming GitHub told a GitLab user something both wrong and useless.
+  it("tells the user their push landed even though the request did not", () => {
+    const message = worktreeFailureMessage("no-forge");
+    expect(message.toLowerCase()).toContain("push succeeded");
+    expect(message).not.toContain("GitHub");
   });
 
   it.each([[undefined], [null], [""], ["something-new"]])("falls back to a plain failure for %j", (reason) => {


### PR DESCRIPTION
## Summary

セルの **⧉ Open PR** が GitLab の worktree で動きます。MR を作り、2回目は既存を開き、本文に
`Fixes #N` とクローンのフッターを入れる — **すべて実プロジェクトで確認済み**です。

**#981 の最後の実装段階**です。**GitHub の挙動は変えていません。**

## Items to Confirm / Review

### この経路だけ構造が違いました

他の GitLab 対応は `--repo <owner/repo>` を渡す形でしたが、ここは **`--repo` を渡しません**。
両 CLI とも cwd から推測します（コメントに理由あり: `--repo` は `OWNER/REPO` しか受け付けないので、
ここで渡せるリポジトリの PATH は必ず失敗する）。

**glab も同じことができる**ことを実物で確認しました — remote だけ設定したディレクトリで
`glab mr list` が通ります。したがって**変えるのは「どの CLI を呼ぶか」だけ**です。

### `gh` との差2つ（実行して分かったもの）

1. **`--fill` は push も行います。** `gh pr create --fill` は行いません。**push していない
   ブランチから MR が作られる**ことを確認しました。`pushWorktree` の後なら無害で、push が
   飛んだ場合はむしろこれが救います
2. **URL をそのまま渡せます**（`mr view` / `mr update` とも）。なので `finalizePrBody` は
   受け取った URL を持ち回る形のままで済みます

### `via` の名前を変えました（レビューで見てほしい点）

`"gh" | "compare"` → **`"cli" | "compare"`**。glab がここに来ると「gh で作った」と報告することに
なるためです。UI は `via === "cli"` で「PR created」と出すだけなので、意味を**結果**に寄せました。

**ワイヤ上の値が変わる**ので、既存の spec 3箇所も更新しています。

### 4操作を1つにまとめています

`PrOps` を **cwd の remote から1回だけ選びます**。4操作は同じ MR を指すので、混ざると
「片方を読んで片方に書く」ことになります。`readBody` / `readUrl` を ops に持たせたのは
**出力形式が違う**ためです（gh は `--jq` で生文字列、glab は JSON）。

## 実機で通しの確認

管理下の worktree から `createOrOpenPR` を2回:

```
1回目 → {"ok":true,"url":".../merge_requests/3","via":"cli"}   MR が作られた
2回目 → 同じ URL                                                既存 MR を開く
本文  → "Fixes #1\n\nwork in glreal"                            両方入った
```

テストで使った MR・ブランチ・worktree は削除済みです。

## User Prompt

> #981 の残りを続けていこう！ / key セットした

## テスト

`yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（7456 passed）/ `knip` —
**すべて終了コードで確認**。

- 純関数と argv 58 件（`--repo` を渡さないこと、URL 指定、空 description、空リスト）
- **既存テストは `via` の値以外すべて無改変**

Fixes #1277

refs #981

work in mulmoterminal4
