### PR TITLE
fix: 6ファイルの as を6箇所外す (#1231)

### DIFF
--- a/server/config/keymap-check.ts
+++ b/server/config/keymap-check.ts
@@ -9,6 +9,7 @@
 // An UNKNOWN ACTION only warns: that is what a config written for a newer MulmoTerminal
 // looks like, and downgrading must not brick the app.
 import { validateKeymap } from "../../common/keymap.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface KeymapCheck {
   warnings: string[];
@@ -21,7 +22,7 @@ const describe = (binding: unknown): string =>
 // Pure: the raw parsed config object in, human-readable lines out. The caller decides
 // what to print and whether to exit.
 export function checkKeymap(rawConfig: unknown): KeymapCheck {
-  const keymap = typeof rawConfig === "object" && rawConfig !== null && !Array.isArray(rawConfig) ? (rawConfig as Record<string, unknown>).keymap : undefined;
+  const keymap = isRecord(rawConfig) ? rawConfig.keymap : undefined;
   const problems = validateKeymap(keymap);
   const line = (p: (typeof problems)[number]) => `  keymap.${p.action}: ${describe(p.binding)} — ${p.reason}`;
   return {

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -1,5 +1,6 @@
 import { spawnSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { isRecord } from "../../common/isRecord.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -41,11 +42,14 @@ export async function spawnCaptureAsync(bin: string, args: string[], options: { 
   } catch (e) {
     // A non-zero exit and a timeout both land here; both carry whatever the child managed to
     // print, which is what the caller reports to the user.
-    const err = e as { code?: unknown; stdout?: string; stderr?: string; message?: string };
+    // execFileSync attaches code/stdout/stderr to what it throws, but a thrown value is
+    // `unknown` — read each field only when it really is the type this reports.
+    const err = isRecord(e) ? e : {};
+    const text = (value: unknown): string => (typeof value === "string" ? value : "");
     return {
       status: typeof err.code === "number" ? err.code : 1,
-      stdout: err.stdout ?? "",
-      stderr: err.stderr || err.message || "",
+      stdout: text(err.stdout),
+      stderr: text(err.stderr) || text(err.message),
     };
   }
 }

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -247,7 +247,10 @@ export interface SessionUsage {
   cacheCreationTokens: number;
 }
 
-const usageNum = (u: Record<string, unknown>, key: string): number => (typeof u[key] === "number" ? (u[key] as number) : 0);
+const usageNum = (u: Record<string, unknown>, key: string): number => {
+  const value = u[key];
+  return typeof value === "number" ? value : 0;
+};
 
 export function sessionUsageFromParsed(records: Record<string, unknown>[]): SessionUsage {
   const total: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -15,11 +15,20 @@ import ToolbarPopover from "./ToolbarPopover.vue";
 import { auth } from "../config/firebase";
 // Session parking (localStorage) + reconnect-outcome decision live in a plain module
 // so they're unit-testable without mounting this Firebase-importing component.
-import { healthOrFallback, loadStoredSession, persistSession, reconnectAction, type FetchResult, type RemoteHostStatus } from "./remoteHostSession";
+import {
+  healthOrFallback,
+  loadStoredSession,
+  persistSession,
+  reconnectAction,
+  type FetchResult,
+  type RemoteHostStatus,
+  isRemoteHostStatus,
+} from "./remoteHostSession";
 import { registerRemoteHostSelfHeal } from "./remoteHostSelfHeal";
 import { remoteHostAlarm, remoteHostView } from "./remoteHostView";
 import { usePubSub } from "../composables/usePubSub";
 import type { RunnerHealth } from "../../common/remoteHostHealth";
+import { isRecord } from "../../common/isRecord";
 
 // Mobile companion PWA — shown in the dropdown as help text (not fetched here).
 const MOBILE_URL = "https://mulmoserver.web.app";
@@ -70,8 +79,12 @@ async function fetchStatus(url: string, method: "GET" | "POST", body?: unknown):
       const detail = await res.json().catch(() => null);
       return { ok: false, error: (detail && typeof detail.error === "string" && detail.error) || `HTTP ${res.status}`, httpStatus: res.status };
     }
-    const data = (await res.json()) as { status: RemoteHostStatus; session: string | null; health?: unknown };
-    return { ok: true, status: data.status, session: data.session ?? null, health: healthOrFallback(data.health, data.status.connected) };
+    const data: unknown = await res.json();
+    const status = isRecord(data) ? data.status : undefined;
+    if (!isRemoteHostStatus(status)) return { ok: false, error: "malformed remote-host status", httpStatus: res.status };
+    const session = isRecord(data) ? data.session : null;
+    const health = isRecord(data) ? data.health : undefined;
+    return { ok: true, status, session: typeof session === "string" ? session : null, health: healthOrFallback(health, status.connected) };
   } catch (err) {
     return { ok: false, error: errorText(err), httpStatus: 0 };
   }

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -465,8 +465,9 @@ const asLauncher = (v: unknown): CellLauncher | null => {
 // A cell entry is kept if its session/cwd are well-formed; uid is validated only to
 // match the persisted `expanded` (it is renumbered below regardless).
 const isCell = (c: unknown): c is Cell => {
-  const o = c as Cell | null;
-  return !!o && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
+  if (!isRecord(c)) return false;
+  const sessionOk = c.session === null || (typeof c.session === "string" && isUuid(c.session));
+  return sessionOk && (c.cwd === null || typeof c.cwd === "string");
 };
 
 export function parseGridState(raw: string | null): GridState | null {

--- a/src/components/remoteHostSession.ts
+++ b/src/components/remoteHostSession.ts
@@ -3,11 +3,16 @@
 // unit-testable without mounting the Firebase-importing component.
 
 import { isRunnerHealth, type RunnerHealth } from "../../common/remoteHostHealth";
+import { isRecord } from "../../common/isRecord";
 
 export interface RemoteHostStatus {
   connected: boolean;
   uid: string | null;
 }
+
+/** The status as it arrives over the wire. Beside the type so the two cannot drift. */
+export const isRemoteHostStatus = (value: unknown): value is RemoteHostStatus =>
+  isRecord(value) && typeof value.connected === "boolean" && (value.uid === null || typeof value.uid === "string");
 
 // The result of a /api/remote-host/* call: the status + parked blob + runner health on
 // success, or an error with the HTTP status (0 for a network failure) so the caller can


### PR DESCRIPTION
## Summary

#1231。6 ファイル・**6 箇所**。**29 → 23**。allowlist は **0 件**。

## Items to Confirm / Review

### 1. `gridTabs.ts` — `isUuid()` に非文字列が渡り得ました

```ts
const isCell = (c: unknown): c is Cell => {
  const o = c as Cell | null;
  return !!o && (o.session === null || isUuid(o.session)) && ...
```

`o.session` は cast 越しに `string | null` を**名乗っていただけ**で、実体は `unknown` です。これは **localStorage から読んだ永続グリッド状態**のパース経路なので、手で編集された / 別ビルドが書いた JSON に数値が入っていれば `isUuid(number)` が走ります。

`isRecord` + `typeof` で実際に確かめる形にしました。

### 2. `RemoteHostControl.vue` — 壊れた応答で `undefined.connected` に至る経路

```ts
const data = (await res.json()) as { status: RemoteHostStatus; ... };
return { ok: true, status: data.status, ..., health: healthOrFallback(data.health, data.status.connected) };
```

`status` が無い応答だと `data.status.connected` で throw します（同じ関数の `catch` に落ちるので「ネットワークエラー」として表示され、原因が分かりません）。

`isRemoteHostStatus` を **型の隣**（`remoteHostSession.ts`）に置いて検証し、壊れていれば `ok: false` で理由を返します。#1268 の `isVoiceInputStatus` と同じ方針です。

### 3. `transcript.ts` — 同じキーを 2 回引いていただけ

```diff
-const usageNum = (u, key) => (typeof u[key] === "number" ? (u[key] as number) : 0);
+const value = u[key];
+return typeof value === "number" ? value : 0;
```

`typeof u[key] === "number"` で narrow しても、**次に `u[key]` と書き直すと別の式**なので型が戻ります。1 回引けば narrow が効きます。#1265 の `useSessions` と同じ形です。

### 4. `spawnCapture.ts` — throw された値を無検査で文字列扱い

`err.stdout ?? ""` は `stdout` が数値でもそのまま通ります。`isRecord` + `typeof` に。

### 5. `keymap-check.ts` — 手書きの object 判定 → `isRecord`

## 検証

`yarn lint`（0 error、29 problems ← 35）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7442 passed**。UI も実ブラウザで描画・console error 0 を確認。

refs #1231

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of configuration, remote-host responses, persisted session data, and keymap values.
  * Remote-host status handling now rejects malformed responses and accepts only valid session identifiers.
  * Improved error handling for asynchronous process failures, preserving available exit codes and output.
  * Added safer handling for unexpected usage and persisted data values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->