### PR TITLE
fix: useNotifications と wikiApi の as を4箇所外す (#1231)

### DIFF
--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -10,6 +10,7 @@ import { ref, computed } from "vue";
 import { usePubSub } from "./usePubSub";
 import { applyLiveChanges, type LiveChange } from "./liveMerge";
 import { browseNavigateToRecord } from "./useCollectionBrowse";
+import { isRecord } from "../../common/isRecord";
 
 // Must match server/backends/notifier.ts NOTIFIER_CHANNEL.
 const NOTIFIER_CHANNEL = "notifications";
@@ -32,6 +33,26 @@ export interface NotifierEntry {
 // Discriminated union mirroring the server's NotifierEvent.
 type NotifierEvent =
   { type: "published"; entry: NotifierEntry } | { type: "updated"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };
+
+const SEVERITIES: readonly NotifierSeverity[] = ["info", "nudge", "urgent"];
+const LIFECYCLES: readonly NotifierLifecycle[] = ["fyi", "action"];
+
+/** One notification as it arrives from `/api/notifications` or the pub/sub channel. Both carry
+ *  the same shape from the same server, so one guard answers for both. */
+export function isNotifierEntry(value: unknown): value is NotifierEntry {
+  if (!isRecord(value)) return false;
+  const { id, pluginPkg, severity, lifecycle, title, body } = value;
+  if (typeof id !== "string" || typeof pluginPkg !== "string" || typeof title !== "string") return false;
+  if (!SEVERITIES.some((known) => known === severity)) return false;
+  if (lifecycle !== undefined && !LIFECYCLES.some((known) => known === lifecycle)) return false;
+  return body === undefined || typeof body === "string";
+}
+
+const isNotifierEvent = (value: unknown): value is NotifierEvent => {
+  if (!isRecord(value)) return false;
+  if (value.type === "published" || value.type === "updated") return isNotifierEntry(value.entry);
+  return (value.type === "cleared" || value.type === "cancelled") && typeof value.id === "string";
+};
 
 const SEVERITY_RANK: Record<NotifierSeverity, number> = { info: 0, nudge: 1, urgent: 2 };
 
@@ -112,9 +133,10 @@ async function fetchActive(): Promise<void> {
       console.error(`[notifications] list failed: HTTP ${res.status}`);
       return;
     }
-    const data = (await res.json()) as { active?: NotifierEntry[] };
+    const data: unknown = await res.json();
     if (fetchId !== latestFetch) return;
-    const snapshot = Array.isArray(data.active) ? data.active : [];
+    const rows = isRecord(data) && Array.isArray(data.active) ? data.active : [];
+    const snapshot = rows.filter(isNotifierEntry);
     active.value = applyLiveChanges(snapshot, changes, (entry) => entry.id);
   } catch (err) {
     console.error("[notifications] list failed", err);
@@ -128,7 +150,11 @@ function ensureInit(): void {
   if (initialized) return;
   initialized = true;
   const pubsub = usePubSub();
-  pubsub.subscribe(NOTIFIER_CHANNEL, (data) => applyEvent(data as NotifierEvent));
+  // A malformed push is dropped rather than switched on: `applyEvent` reads `event.entry`
+  // straight into the list, so an unrecognised shape used to land in the bell as a blank row.
+  pubsub.subscribe(NOTIFIER_CHANNEL, (data) => {
+    if (isNotifierEvent(data)) applyEvent(data);
+  });
   // pubsub only replays room membership on reconnect, not the events missed while
   // disconnected — re-fetch the authoritative list so the bell can't go stale.
   pubsub.onReconnect(() => void fetchActive());

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -41,10 +41,14 @@ const LIFECYCLES: readonly NotifierLifecycle[] = ["fyi", "action"];
  *  the same shape from the same server, so one guard answers for both. */
 export function isNotifierEntry(value: unknown): value is NotifierEntry {
   if (!isRecord(value)) return false;
-  const { id, pluginPkg, severity, lifecycle, title, body } = value;
+  const { id, pluginPkg, severity, lifecycle, title, body, navigateTarget, createdAt } = value;
   if (typeof id !== "string" || typeof pluginPkg !== "string" || typeof title !== "string") return false;
+  // Required, and not merely cosmetic: the list sorts on `createdAt.localeCompare`, which throws
+  // when it is absent (Codex review on #1282).
+  if (typeof createdAt !== "string") return false;
   if (!SEVERITIES.some((known) => known === severity)) return false;
   if (lifecycle !== undefined && !LIFECYCLES.some((known) => known === lifecycle)) return false;
+  if (navigateTarget !== undefined && typeof navigateTarget !== "string") return false;
   return body === undefined || typeof body === "string";
 }
 

--- a/src/wikiApi.ts
+++ b/src/wikiApi.ts
@@ -4,6 +4,7 @@
 // shapes it returns. Types mirror @mulmoclaude/core/wiki(/server) so the views stay
 // in lockstep with the engine.
 import type { WikiPageEntry, WikiGraph } from "@mulmoclaude/core/wiki";
+import { isRecord } from "../common/isRecord";
 
 /** index.md raw content + its parsed page entries (GET /api/wiki). */
 export interface WikiIndex {
@@ -26,14 +27,59 @@ export interface WikiLint {
   report: string;
 }
 
-async function getJson<T>(url: string): Promise<T> {
+// Each endpoint hands `getJson` the reader for its own shape, so the response is CHECKED rather
+// than named: the generic used to be satisfied by an assertion, which made `getJson<WikiIndex>`
+// a claim about the server rather than a question asked of it.
+async function getJson<T>(url: string, read: (raw: unknown) => T): Promise<T> {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`${url} → ${res.status}`);
-  return (await res.json()) as T;
+  return read(await res.json());
 }
 
+const str = (value: unknown): string => (typeof value === "string" ? value : "");
+const rows = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+// Missing/!string fields read as "" rather than throwing: every one of these renders as text, so a
+// partial response should show what arrived, not blank the page.
+const readEntry = (raw: unknown): WikiPageEntry => {
+  const o = isRecord(raw) ? raw : {};
+  return {
+    title: str(o.title),
+    slug: str(o.slug),
+    description: str(o.description),
+    tags: rows(o.tags).filter((tag): tag is string => typeof tag === "string"),
+  };
+};
+
+const readIndex = (raw: unknown): WikiIndex => {
+  const o = isRecord(raw) ? raw : {};
+  return { content: str(o.content), entries: rows(o.entries).map(readEntry) };
+};
+
+const readGraph = (raw: unknown): WikiGraph => {
+  const o = isRecord(raw) ? raw : {};
+  const node = (n: unknown) => ({ slug: str(isRecord(n) ? n.slug : undefined), title: str(isRecord(n) ? n.title : undefined) });
+  const edge = (e: unknown) => ({ from: str(isRecord(e) ? e.from : undefined), to: str(isRecord(e) ? e.to : undefined) });
+  return { nodes: rows(o.nodes).map(node), edges: rows(o.edges).map(edge) };
+};
+
+const readLint = (raw: unknown): WikiLint => {
+  const o = isRecord(raw) ? raw : {};
+  return { issues: rows(o.issues).filter((issue): issue is string => typeof issue === "string"), report: str(o.report) };
+};
+
+const readPage = (raw: unknown, slug: string): WikiPage => {
+  const o = isRecord(raw) ? raw : {};
+  return {
+    filePath: typeof o.filePath === "string" ? o.filePath : null,
+    content: str(o.content),
+    exists: o.exists === true,
+    resolvedTitle: typeof o.resolvedTitle === "string" ? o.resolvedTitle : slug,
+  };
+};
+
 export function fetchWikiIndex(): Promise<WikiIndex> {
-  return getJson<WikiIndex>("/api/wiki");
+  return getJson("/api/wiki", readIndex);
 }
 
 /** Fetch one page. A 404 resolves to an `exists: false` page rather than throwing,
@@ -42,13 +88,13 @@ export async function fetchWikiPage(slug: string): Promise<WikiPage> {
   const res = await fetch(`/api/wiki?slug=${encodeURIComponent(slug)}`);
   if (res.status === 404) return { filePath: null, content: "", exists: false, resolvedTitle: slug };
   if (!res.ok) throw new Error(`/api/wiki?slug=${slug} → ${res.status}`);
-  return (await res.json()) as WikiPage;
+  return readPage(await res.json(), slug);
 }
 
 export function fetchWikiGraph(): Promise<WikiGraph> {
-  return getJson<WikiGraph>("/api/wiki/graph");
+  return getJson("/api/wiki/graph", readGraph);
 }
 
 export function fetchWikiLint(): Promise<WikiLint> {
-  return getJson<WikiLint>("/api/wiki/lint");
+  return getJson("/api/wiki/lint", readLint);
 }

--- a/src/wikiApi.ts
+++ b/src/wikiApi.ts
@@ -39,28 +39,44 @@ async function getJson<T>(url: string, read: (raw: unknown) => T): Promise<T> {
 const str = (value: unknown): string => (typeof value === "string" ? value : "");
 const rows = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
 
-// Missing/!string fields read as "" rather than throwing: every one of these renders as text, so a
-// partial response should show what arrived, not blank the page.
-const readEntry = (raw: unknown): WikiPageEntry => {
+// An identifier the UI keys and navigates by, or null. Deliberately NOT defaulted to "": a slug is
+// not display text — several rows missing one would collide on the same key, and a link built from
+// it goes nowhere. Rows without a usable id are dropped instead (Codex review on #1282).
+const id = (value: unknown): string | null => (typeof value === "string" && value !== "" ? value : null);
+
+// DISPLAY fields do default to "": they only ever render as text, so a partial response should
+// show what arrived rather than blank the page.
+const readEntry = (raw: unknown): WikiPageEntry[] => {
   const o = isRecord(raw) ? raw : {};
-  return {
-    title: str(o.title),
-    slug: str(o.slug),
-    description: str(o.description),
-    tags: rows(o.tags).filter((tag): tag is string => typeof tag === "string"),
-  };
+  const slug = id(o.slug);
+  if (!slug) return [];
+  return [
+    {
+      title: str(o.title),
+      slug,
+      description: str(o.description),
+      tags: rows(o.tags).filter((tag): tag is string => typeof tag === "string"),
+    },
+  ];
 };
 
 const readIndex = (raw: unknown): WikiIndex => {
   const o = isRecord(raw) ? raw : {};
-  return { content: str(o.content), entries: rows(o.entries).map(readEntry) };
+  return { content: str(o.content), entries: rows(o.entries).flatMap(readEntry) };
 };
 
 const readGraph = (raw: unknown): WikiGraph => {
   const o = isRecord(raw) ? raw : {};
-  const node = (n: unknown) => ({ slug: str(isRecord(n) ? n.slug : undefined), title: str(isRecord(n) ? n.title : undefined) });
-  const edge = (e: unknown) => ({ from: str(isRecord(e) ? e.from : undefined), to: str(isRecord(e) ? e.to : undefined) });
-  return { nodes: rows(o.nodes).map(node), edges: rows(o.edges).map(edge) };
+  const nodes = rows(o.nodes).flatMap((n) => {
+    const slug = id(isRecord(n) ? n.slug : undefined);
+    return slug ? [{ slug, title: str(isRecord(n) ? n.title : undefined) }] : [];
+  });
+  const edges = rows(o.edges).flatMap((e) => {
+    const from = id(isRecord(e) ? e.from : undefined);
+    const to = id(isRecord(e) ? e.to : undefined);
+    return from && to ? [{ from, to }] : [];
+  });
+  return { nodes, edges };
 };
 
 const readLint = (raw: unknown): WikiLint => {

--- a/test/src/composables/useNotifications.spec.ts
+++ b/test/src/composables/useNotifications.spec.ts
@@ -110,6 +110,23 @@ describe("useNotifications — the list fetched while the channel is live", () =
     vi.restoreAllMocks();
   });
 
+  // A push whose entry is missing fields the list LATER reads must not be admitted: `sorted`
+  // calls `createdAt.localeCompare`, so an entry without it throws while rendering the bell —
+  // far from the malformed push that caused it (Codex review on #1282).
+  it("drops a pushed entry that is missing createdAt, and keeps rendering the rest", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active, sorted } = useNotifications();
+
+    deliver({ type: "published", entry: { id: "bad", pluginPkg: "test", severity: "info", title: "No timestamp" } });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n1"]);
+    // The read the missing field would have thrown on.
+    expect(() => sorted.value).not.toThrow();
+  });
+
   it("does not bring back a notification cleared while the list was loading", async () => {
     const { answer } = deferredList([BELL, OTHER]);
     const { useNotifications } = await freshModule();


### PR DESCRIPTION
## Summary

#1231。2 ファイル・**4 箇所**。**29 → 25 problems**（as は 24 → 20）。allowlist は **0 件**。

## Items to Confirm / Review

### 1. 通知は 2 経路とも無検査でした

通知は **リスト API（`/api/notifications`）と pub/sub の push** の両方から届きます。**どちらも無検査**で、特に push 側が問題でした。

```ts
pubsub.subscribe(NOTIFIER_CHANNEL, (data) => applyEvent(data as NotifierEvent));
```

`applyEvent` は `event.entry` を**そのままベルの一覧に入れます**。壊れた push が来ると、`title` も `severity` も無いエントリが空行として並び、しかも例外は出ません。

同じサーバの同じ形なので guard は 1 つ（`isNotifierEntry`）にし、イベント側（`isNotifierEvent`）から呼んでいます。`severity` / `lifecycle` の enum も確かめます。

### 2. `getJson<T>` は自前のジェネリックでした

gui-chat-protocol の `dispatch<T>` と形は同じですが、**こちらはプロトコルではなくこのファイルが定義したもの**なので、検証関数を受け取る形に変えられます。

```diff
-async function getJson<T>(url: string): Promise<T> {
-  return (await res.json()) as T;
+async function getJson<T>(url: string, read: (raw: unknown) => T): Promise<T> {
+  return read(await res.json());
```

`getJson<WikiIndex>(url)` は「サーバはこの形だ」という**主張**でしたが、`getJson(url, readIndex)` は**問い**になります。

**欠けた文字列フィールドは `""` として読みます。** いずれも画面に文字として出るだけなので、部分的な応答は「届いたぶんを表示」が妥当で、throw して真っ白にするより良いと判断しました（`resolvedTitle` だけは要求された slug にフォールバック）。

## 検証

`yarn lint`（0 error）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7449 passed**。

> 途中 1 回 `unusable-cwd-routes.spec.ts` が落ちましたが、単独実行では 6/6 通り、全体を 2 回再実行しても再現しません（触っていないファイルです）。flaky と判断しました。

refs #1231

work in mulmoterminal3
