### PR TITLE
fix(title): 要約が「返事」を返したときヘッダー見出しに載せない + 使い捨てセッション記録の抑制

### DIFF
--- a/server/config/header-title.ts
+++ b/server/config/header-title.ts
@@ -31,6 +31,12 @@ export const MAX_TITLE_CHARS = 80;
 
 const clip = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max)}…` : s);
 
+// Clipping a turn lands mid-sentence, and a bare "…" reads like the human's own message
+// broke off — the summarizer then replies about it ("your message seems cut off …") instead
+// of titling. An explicit marker says the cut is ours.
+const CLIP_MARK = "…[clipped by mulmoterminal]";
+const clipTurn = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max)}${CLIP_MARK}` : s);
+
 // Regenerate the title when there's none yet, when the newest prompt was a
 // trivial/context-dependent ack (the raw last-prompt would be stale or meaningless), or
 // every `maxTurns` turns to keep a long session's title fresh.
@@ -64,7 +70,7 @@ export function titleWindow(turns: ConversationTurn[]): ConversationTurn[] {
 // A labelled transcript the model reads on stdin, assistant turns clipped shorter.
 export function renderTurns(turns: ConversationTurn[]): string {
   return turns
-    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${clip(t.text, t.role === "user" ? USER_TURN_CHARS : ASSISTANT_TURN_CHARS)}`)
+    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${clipTurn(t.text, t.role === "user" ? USER_TURN_CHARS : ASSISTANT_TURN_CHARS)}`)
     .join("\n");
 }
 
@@ -74,6 +80,8 @@ export function buildTitlePrompt(): string {
     "Summarize what the USER is trying to accomplish as a short, concise title: a phrase, NOT a full",
     "sentence — no trailing punctuation. Base it on the User's intent, not the Assistant's wording.",
     "Match the User's language.",
+    `Turns are machine-clipped and can stop mid-sentence (marked "${CLIP_MARK}"). That is normal —`,
+    "never remark on it and never ask for the missing part; title what is there.",
     "Output ONLY the title: no quotes, no labels, no explanation.",
   ].join("\n");
 }
@@ -91,14 +99,27 @@ function stripQuotes(text: string): string {
   return chars.slice(start, end).join("").trim();
 }
 
-// Take the first non-empty line, strip surrounding quotes, and cap the length.
+// Sentence punctuation and a line far past the cap are prose, not a title. A title long
+// enough to need clipping is still a title, so the reject line sits well above MAX.
+const PROSE_MARKS = ["。", "．", "！", "？", ". ", "! ", "? "];
+const MAX_TITLE_LINE_CHARS = MAX_TITLE_CHARS * 2;
+
+// Does this look like a title rather than a reply? The summarizer occasionally answers the
+// transcript instead of titling it (asking about a clipped turn, narrating its reasoning),
+// and a title is always a single short clause: one line, no sentence punctuation.
+export function looksLikeTitle(lines: string[]): boolean {
+  return lines.length === 1 && lines[0].length <= MAX_TITLE_LINE_CHARS && !PROSE_MARKS.some((m) => lines[0].includes(m));
+}
+
+// Take the single non-empty line, strip surrounding quotes, and cap the length. Prose (a
+// reply, not a title) is rejected as "" so generateHeaderTitle returns null and the header
+// keeps falling back to the last prompt — a stale header beats a paragraph in the header.
 export function parseTitleOutput(stdout: string): string {
-  const firstLine =
-    stdout
-      .split("\n")
-      .map((l) => l.trim())
-      .find(Boolean) ?? "";
-  return clip(stripQuotes(firstLine), MAX_TITLE_CHARS);
+  const lines = stdout
+    .split("\n")
+    .map((l) => stripQuotes(l.trim()))
+    .filter(Boolean);
+  return looksLikeTitle(lines) ? clip(lines[0], MAX_TITLE_CHARS) : "";
 }
 
 export interface GenerateTitleDeps {

--- a/server/session/command-summary.ts
+++ b/server/session/command-summary.ts
@@ -84,9 +84,8 @@ export type RunClaude = (params: { bin: string; prompt: string; input: string; t
 // timeout kills a hung CLI so the request can't wait forever. Injected into
 // summarizeLog so tests mock it — no `claude` binary needed. `model` (when given) picks
 // a cheaper/faster model via `--model` — used by the header-title generator.
-export const runClaudeHeadless: RunClaude = ({ bin, prompt, input, timeoutMs, model }) =>
+const spawnClaude = (bin: string, args: string[], input: string, timeoutMs: number): Promise<ClaudeRunResult> =>
   new Promise((resolve, reject) => {
-    const args = model ? ["-p", prompt, "--model", model] : ["-p", prompt];
     const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
     const out: Buffer[] = [];
     const err: Buffer[] = [];
@@ -106,6 +105,20 @@ export const runClaudeHeadless: RunClaude = ({ bin, prompt, input, timeoutMs, mo
     });
     child.stdin.end(input);
   });
+
+// These one-shot runs are throwaway: the title generator fires every few user turns, and
+// each persisted transcript buries the user's real sessions in the resume list (measured:
+// 1738 of 1739 recorded sessions for this repo were title runs). `--no-session-persistence`
+// (print mode only) stops the recording. A CLI too old to know the flag rejects it before
+// doing any work, so that one case retries plainly rather than losing the summary.
+const NO_PERSIST = "--no-session-persistence";
+const rejectedNoPersist = (r: ClaudeRunResult): boolean => r.code !== 0 && r.stderr.includes(NO_PERSIST) && /unknown|unrecognized|unsupported/i.test(r.stderr);
+
+export const runClaudeHeadless: RunClaude = async ({ bin, prompt, input, timeoutMs, model }) => {
+  const args = model ? ["-p", prompt, "--model", model] : ["-p", prompt];
+  const run = await spawnClaude(bin, [...args, NO_PERSIST], input, timeoutMs);
+  return rejectedNoPersist(run) ? spawnClaude(bin, args, input, timeoutMs) : run;
+};
 
 export interface SummaryResult {
   summary: string;

--- a/test/server/config/header-title.spec.ts
+++ b/test/server/config/header-title.spec.ts
@@ -86,6 +86,21 @@ describe("parseTitleOutput", () => {
   it("returns an empty string for blank output", () => {
     expect(parseTitleOutput("   \n  ")).toBe("");
   });
+
+  // Observed in the wild: a clipped turn read like an unfinished message, so the summarizer
+  // answered it and its first line was pasted into the header instead of a title.
+  it("rejects a reply instead of putting prose in the header", () => {
+    expect(parseTitleOutput("ユーザーのメッセージが途中で切れているようです。次に何をすべきか教えてください。\n\nいまの状況:\n- S4a-2 完了")).toBe("");
+    expect(parseTitleOutput("The user's message appears to be cut off. Could you resend it?")).toBe("");
+  });
+
+  it("rejects multi-line output even when the first line is short", () => {
+    expect(parseTitleOutput("了解しました\n\nタイトル: パーサー修正")).toBe("");
+  });
+
+  it("still accepts a plain title", () => {
+    expect(parseTitleOutput("Prisma include の scalar 混入で 500 になる不具合を調査")).toBe("Prisma include の scalar 混入で 500 になる不具合を調査");
+  });
 });
 
 describe("renderTurns", () => {
@@ -95,6 +110,12 @@ describe("renderTurns", () => {
       { role: "assistant", text: "hello" },
     ];
     expect(renderTurns(turns)).toBe("User: hi\nAssistant: hello");
+  });
+
+  it("marks a clipped turn as clipped by us, not left dangling on an ellipsis", () => {
+    const rendered = renderTurns([{ role: "assistant", text: "x".repeat(400) }]);
+    expect(rendered).toContain("[clipped by mulmoterminal]");
+    expect(buildTitlePrompt()).toContain("[clipped by mulmoterminal]");
   });
 });
 


### PR DESCRIPTION
## 症状

ターミナルの見出しに、タイトルではなく**会話文**が出ることがある。実例（transcript で 7/24〜8/1 に約20件を確認）:

> ユーザーのメッセージが途中で切れているようです。S4b の前提ズレと…

ユーザーからは「コンテキストの引き継ぎが壊れているのでは」と見える。実際には本体の会話は無傷で、壊れているのは見出し生成だけだった。

## 原因（3段）

1. `renderTurns()` が発言を 600 / 160 文字で切り、末尾が bare `…`。**人間の発言が途切れたように見える**（teammate-message が絡む長文で顕著）。
2. プロンプトに「切り詰めは正常」と書いていないので、要約モデルが `Output ONLY the title` を無視して**普通に返信**する。
3. `parseTitleOutput()` が「1行目を取って80字で切る」だけで**タイトル形状の検査が無い** → 返信の1行目が見出しに昇格。

## 変更

- 切り詰めマーカーを `…[clipped by mulmoterminal]` に（切ったのは道具側だと明示）
- プロンプトに「切れていても指摘・聞き返しをせずタイトルを出せ」を追加
- `parseTitleOutput` に形状検査（**1行 / 160字以内 / 文末記号 `。．！？. ` を含まない**）。外れたら `""` → `generateHeaderTitle` が `null` → **既存のフォールバック（最後のプロンプト）に戻る**
- `runClaudeHeadless` に `--no-session-persistence`。タイトル生成は数ターンごとに走るため使い捨て transcript が resume 一覧を埋めていた（**実測: 手元では該当 1,988 件 / 111.6MB、うち 1,802 件がこのリポジトリ分**）。フラグ非対応の古い CLI は「unknown option」検出時のみフラグ無しで1回再試行するので要約機能は壊れない

## 検証

- **実物 E2E**: 途中で切れた teammate-message 入り transcript で `generateHeaderTitle` 実行 → 見出し `"S4bの前提ズレを報告"`（正常）、セッションファイル増加 **0 件**
- `--no-session-persistence` の因果を実測: フラグ無し → +1 ファイル / フラグ有り → +0
- **検査自体の検査**: 形状検査を元に戻すと新規テスト2本が赤になることを確認
- `tsc --noEmit` OK / eslint 0 / `vitest run test/server` **3953 passed, 45 skipped**（退行なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENMe3TRWuWxpBwvUve6yep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic title generation by rejecting responses that are overly long, multiline, or written as sentences.
  * Added clear handling for truncated transcript content so it is not mistaken for part of the title.
  * Improved one-time command execution reliability while supporting older command-line versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->