### PR TITLE
fix: remote-host の JsonObject 主張を本物の変換にする + 3ファイル (#1231)

### DIFF
--- a/server/backends/remoteHost/collectionPage.ts
+++ b/server/backends/remoteHost/collectionPage.ts
@@ -8,6 +8,7 @@
 import { clampLimit, clampOffset } from "@mulmoclaude/core/remote-view";
 import { deriveAll, type DerivableFieldSpec, type DerivableRecord } from "@mulmoclaude/core/collection";
 import type { JsonObject } from "@mulmoclaude/core/remote-host";
+import { jsonPayload } from "./jsonPayload.js";
 
 export { clampLimit, clampOffset };
 
@@ -20,12 +21,9 @@ export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec
 
 /** Build the paginated result.
  *
- *  `toJsonObject` cannot serve this one. `detail` and `items` arrive as `unknown`, and
- *  `CollectionDetail` reaches `schema.spawn.set`, typed `Record<string, unknown>` — so the payload
- *  genuinely CANNOT be proven JSON by the type system. It is JSON at runtime because the schema
- *  loader only ever puts JSON there, a fact about the loader that these types do not record.
- *
- *  Removing this assertion means giving `spawn.set` a JSON-valued type at the schema layer, not
- *  adjusting anything here. (Same call, same reason, as MulmoClaude's own `pageResult`.) */
+ *  Converted rather than asserted (see jsonPayload.ts): `detail` and `items` arrive as `unknown`,
+ *  and `CollectionDetail` reaches `schema.spawn.set`, typed `Record<string, unknown>` — so the
+ *  payload cannot be PROVEN JSON by the type system even though the schema loader only ever puts
+ *  JSON there. The walk makes it so instead of claiming it. */
 export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
-  ({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit }) as JsonObject;
+  jsonPayload({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit });

--- a/server/backends/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/backends/remoteHost/handlers/getRemoteViewItems.ts
@@ -8,6 +8,7 @@ import { normalizeFields } from "@mulmoclaude/core/remote-view";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset } from "../collectionPage.js";
 import { remoteViewItems, remoteViewItemsFailureMessage } from "../../remoteView.js";
+import { jsonPayload } from "../jsonPayload.js";
 
 export const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (params: JsonObject) => {
   const slug = String(params.slug ?? "");
@@ -18,10 +19,8 @@ export const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await remoteViewItems(collection, viewId, request);
   if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
-  // `toJsonObject` cannot serve this one, and neither can a single assertion: `RemoteViewPage` has
-  // no index signature at all, so it does not even overlap `JsonObject`. It IS JSON at runtime —
-  // the collection loader only ever puts JSON in it — a fact about the loader these types do not
-  // record. Removing this double cast means giving `RemoteViewPage`/`RemoteViewItem` JSON-valued
-  // types upstream, not adjusting anything here.
-  return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
+  // Converted rather than asserted (see ../jsonPayload.ts): `RemoteViewPage` has no index
+  // signature at all, so it does not even overlap `JsonObject` — which is why this used to need a
+  // DOUBLE cast. It is JSON at runtime because the collection loader only ever puts JSON in it.
+  return jsonPayload({ page: result.page, inlined: result.inlined, omitted: result.omitted });
 };

--- a/server/backends/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/backends/remoteHost/handlers/mutateRemoteView.ts
@@ -8,6 +8,7 @@ import { normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../remoteView.js";
 import { mutateWriteApplied } from "../../mutateStatus.js";
+import { jsonPayload } from "../jsonPayload.js";
 
 export const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (params: JsonObject) => {
   const slug = String(params.slug ?? "");
@@ -24,6 +25,6 @@ export const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = asy
   }
   if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
   // Same reason as getRemoteViewItems: `CollectionItem`'s `unknown`-valued index signature is not
-  // provably JSON, though the loader only ever writes JSON into it.
-  return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as JsonObject;
+  // provably JSON, though the loader only ever writes JSON into it. Converted, not asserted.
+  return jsonPayload(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
 };

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -15,25 +15,33 @@ import type { JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 // `toJSON` is how a Date (and anything else defining it) becomes JSON — stringify calls it before
 // looking at the object's own keys, so this must too or a Date would serialize as `{}`.
-const isToJson = (value: unknown): value is (this: unknown) => unknown => typeof value === "function";
+//
+// The PROPERTY KEY is passed along, because stringify passes it: a custom `toJSON(key)` may answer
+// differently per field, and calling it with nothing silently changes that answer (Codex on #1288).
+const isToJson = (value: unknown): value is (this: unknown, key: string) => unknown => typeof value === "function";
 
-/** A value as JSON, or undefined for something JSON has no representation for. */
-export function toJsonValue(value: unknown): JsonValue | undefined {
+// Everything except the `toJSON` step, which stringify applies once per value rather than to its
+// own result — so the recursion below deliberately re-enters here, not at toJsonValue.
+function convert(value: unknown): JsonValue | undefined {
   if (value === null || typeof value === "string" || typeof value === "boolean") return value;
   // NaN and ±Infinity have no JSON form — JSON.stringify writes them as null, so this does too
   // rather than dropping the key and changing the shape the client sees.
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   // stringify THROWS on a bigint rather than skipping it. Matching that matters: dropping it
-  // instead would ship a payload silently missing a field (Codex review on #1288).
+  // instead would ship a payload silently missing a field.
   if (typeof value === "bigint") throw new TypeError("Do not know how to serialize a BigInt");
   // An element JSON cannot represent becomes null rather than vanishing: dropping it would shift
-  // every later index, which is what JSON.stringify avoids by writing null.
-  if (Array.isArray(value)) return value.map((entry) => toJsonValue(entry) ?? null);
-  if (isRecord(value)) {
-    const toJson = value.toJSON;
-    return isToJson(toJson) ? toJsonValue(toJson.call(value)) : jsonPayload(value);
-  }
+  // every later index, which is what JSON.stringify avoids by writing null. The index is the key
+  // stringify hands an element's toJSON.
+  if (Array.isArray(value)) return value.map((entry, index) => toJsonValue(entry, String(index)) ?? null);
+  if (isRecord(value)) return jsonPayload(value);
   return undefined;
+}
+
+/** A value as JSON, or undefined for something JSON has no representation for. */
+export function toJsonValue(value: unknown, key = ""): JsonValue | undefined {
+  const toJson = isRecord(value) ? value.toJSON : undefined;
+  return isToJson(toJson) ? convert(toJson.call(value, key)) : convert(value);
 }
 
 /** A record as JSON. Keys whose value JSON cannot represent are omitted, as JSON.stringify omits
@@ -41,7 +49,7 @@ export function toJsonValue(value: unknown): JsonValue | undefined {
 export function jsonPayload(value: Record<string, unknown>): JsonObject {
   const out: JsonObject = {};
   for (const [key, entry] of Object.entries(value)) {
-    const json = toJsonValue(entry);
+    const json = toJsonValue(entry, key);
     if (json === undefined) continue;
     // defineProperty, not `out[key] =`: a payload carrying a literal `"__proto__"` key would
     // otherwise assign the object's PROTOTYPE and the key would vanish from the output — a silent

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -32,7 +32,11 @@ export function jsonPayload(value: Record<string, unknown>): JsonObject {
   const out: JsonObject = {};
   for (const [key, entry] of Object.entries(value)) {
     const json = toJsonValue(entry);
-    if (json !== undefined) out[key] = json;
+    if (json === undefined) continue;
+    // defineProperty, not `out[key] =`: a payload carrying a literal `"__proto__"` key would
+    // otherwise assign the object's PROTOTYPE and the key would vanish from the output — a silent
+    // divergence from JSON.stringify, which keeps it as an ordinary key (Codex review on #1288).
+    Object.defineProperty(out, key, { value: json, writable: true, enumerable: true, configurable: true });
   }
   return out;
 }

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -6,61 +6,50 @@
 // asserted their way to `JsonObject`, one of them through `as unknown as` — the shape simply does
 // not overlap.
 //
-// This CONVERTS instead of asserting, so the claim becomes true rather than declared. The values
-// are about to be JSON.stringify'd onto the wire anyway, so the walk sees exactly what the client
-// would have received: anything JSON.stringify drops (functions, symbols, undefined) is dropped
-// here too, in the same places.
+// This CONVERTS instead of asserting, so the claim becomes true rather than declared.
+//
+// It runs the payload through JSON.stringify + JSON.parse rather than reimplementing what
+// stringify does. That is the whole design: the value is about to be stringified onto the wire
+// anyway, so the round trip yields EXACTLY what the client would have received — by construction,
+// not by imitation. An earlier version walked the value itself and had to be corrected four times
+// over (`"__proto__"` keys, `Date`/`toJSON`, the property key handed to `toJSON`, boxed
+// primitives), each one a place where the imitation had drifted from the original. Nothing here
+// can drift, because the only thing deciding is stringify.
+//
+// The walk below therefore only ever sees the output of JSON.parse — null, string, number,
+// boolean, array, plain object — which is the whole of JsonValue. There is no other case.
 import { isRecord } from "../../../common/isRecord.js";
 import type { JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
-// `toJSON` is how a Date (and anything else defining it) becomes JSON — stringify calls it before
-// looking at the object's own keys, so this must too or a Date would serialize as `{}`.
-//
-// The PROPERTY KEY is passed along, because stringify passes it: a custom `toJSON(key)` may answer
-// differently per field, and calling it with nothing silently changes that answer (Codex on #1288).
-const isToJson = (value: unknown): value is (this: unknown, key: string) => unknown => typeof value === "function";
-
-// Everything except the `toJSON` step, which stringify applies once per value rather than to its
-// own result — so the recursion below deliberately re-enters here, not at toJsonValue.
-function convert(value: unknown): JsonValue | undefined {
-  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
-  // NaN and ±Infinity have no JSON form — JSON.stringify writes them as null, so this does too
-  // rather than dropping the key and changing the shape the client sees.
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
-  // stringify THROWS on a bigint rather than skipping it. Matching that matters: dropping it
-  // instead would ship a payload silently missing a field.
-  if (typeof value === "bigint") throw new TypeError("Do not know how to serialize a BigInt");
-  // An element JSON cannot represent becomes null rather than vanishing: dropping it would shift
-  // every later index, which is what JSON.stringify avoids by writing null. The index is the key
-  // stringify hands an element's toJSON.
-  if (Array.isArray(value)) return value.map((entry, index) => toJsonValue(entry, String(index)) ?? null);
-  // Boxed primitives serialize as their PRIMITIVE, not as the object they are. Without this the
-  // walk below would turn `new String("ab")` into `{"0":"a","1":"b"}` and the other two into `{}`
-  // (Codex review on #1288). `valueOf` is what stringify unwraps them with.
-  if (value instanceof String) return value.valueOf();
-  if (value instanceof Number) return Number.isFinite(value.valueOf()) ? value.valueOf() : null;
-  if (value instanceof Boolean) return value.valueOf();
-  if (isRecord(value)) return jsonPayload(value);
-  return undefined;
+/** Already-parsed JSON, retyped by inspection. Total: JSON.parse produces nothing else. */
+function fromParsed(value: unknown): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(fromParsed);
+  if (isRecord(value)) return recordFromParsed(value);
+  // Unreachable for JSON.parse output; null keeps the function total rather than asserting.
+  return null;
 }
 
-/** A value as JSON, or undefined for something JSON has no representation for. */
-export function toJsonValue(value: unknown, key = ""): JsonValue | undefined {
-  const toJson = isRecord(value) ? value.toJSON : undefined;
-  return isToJson(toJson) ? convert(toJson.call(value, key)) : convert(value);
-}
-
-/** A record as JSON. Keys whose value JSON cannot represent are omitted, as JSON.stringify omits
- *  them. Named apart from core's `toJsonObject`, which two of the callers also import. */
-export function jsonPayload(value: Record<string, unknown>): JsonObject {
+function recordFromParsed(value: Record<string, unknown>): JsonObject {
   const out: JsonObject = {};
   for (const [key, entry] of Object.entries(value)) {
-    const json = toJsonValue(entry, key);
-    if (json === undefined) continue;
     // defineProperty, not `out[key] =`: a payload carrying a literal `"__proto__"` key would
-    // otherwise assign the object's PROTOTYPE and the key would vanish from the output — a silent
-    // divergence from JSON.stringify, which keeps it as an ordinary key (Codex review on #1288).
-    Object.defineProperty(out, key, { value: json, writable: true, enumerable: true, configurable: true });
+    // otherwise assign the object's PROTOTYPE and the key would vanish from the output — while
+    // JSON keeps it as an ordinary key (Codex review on #1288).
+    Object.defineProperty(out, key, { value: fromParsed(entry), writable: true, enumerable: true, configurable: true });
   }
   return out;
+}
+
+/**
+ * A payload as the JSON the channel will send.
+ *
+ * Throws whatever JSON.stringify throws — a bigint anywhere in the payload, a circular reference —
+ * rather than quietly shipping a value with a field missing.
+ *
+ * Named apart from core's `toJsonObject`, which two of the callers also import.
+ */
+export function jsonPayload(value: Record<string, unknown>): JsonObject {
+  const parsed: unknown = JSON.parse(JSON.stringify(value));
+  return isRecord(parsed) ? recordFromParsed(parsed) : {};
 }

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -34,6 +34,12 @@ function convert(value: unknown): JsonValue | undefined {
   // every later index, which is what JSON.stringify avoids by writing null. The index is the key
   // stringify hands an element's toJSON.
   if (Array.isArray(value)) return value.map((entry, index) => toJsonValue(entry, String(index)) ?? null);
+  // Boxed primitives serialize as their PRIMITIVE, not as the object they are. Without this the
+  // walk below would turn `new String("ab")` into `{"0":"a","1":"b"}` and the other two into `{}`
+  // (Codex review on #1288). `valueOf` is what stringify unwraps them with.
+  if (value instanceof String) return value.valueOf();
+  if (value instanceof Number) return Number.isFinite(value.valueOf()) ? value.valueOf() : null;
+  if (value instanceof Boolean) return value.valueOf();
   if (isRecord(value)) return jsonPayload(value);
   return undefined;
 }

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -13,16 +13,26 @@
 import { isRecord } from "../../../common/isRecord.js";
 import type { JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
+// `toJSON` is how a Date (and anything else defining it) becomes JSON — stringify calls it before
+// looking at the object's own keys, so this must too or a Date would serialize as `{}`.
+const isToJson = (value: unknown): value is (this: unknown) => unknown => typeof value === "function";
+
 /** A value as JSON, or undefined for something JSON has no representation for. */
 export function toJsonValue(value: unknown): JsonValue | undefined {
   if (value === null || typeof value === "string" || typeof value === "boolean") return value;
   // NaN and ±Infinity have no JSON form — JSON.stringify writes them as null, so this does too
   // rather than dropping the key and changing the shape the client sees.
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  // stringify THROWS on a bigint rather than skipping it. Matching that matters: dropping it
+  // instead would ship a payload silently missing a field (Codex review on #1288).
+  if (typeof value === "bigint") throw new TypeError("Do not know how to serialize a BigInt");
   // An element JSON cannot represent becomes null rather than vanishing: dropping it would shift
   // every later index, which is what JSON.stringify avoids by writing null.
   if (Array.isArray(value)) return value.map((entry) => toJsonValue(entry) ?? null);
-  if (isRecord(value)) return jsonPayload(value);
+  if (isRecord(value)) {
+    const toJson = value.toJSON;
+    return isToJson(toJson) ? toJsonValue(toJson.call(value)) : jsonPayload(value);
+  }
   return undefined;
 }
 

--- a/server/backends/remoteHost/jsonPayload.ts
+++ b/server/backends/remoteHost/jsonPayload.ts
@@ -1,0 +1,38 @@
+// Turning a domain value into the JSON the remote-host channel actually sends.
+//
+// `toJsonObject` (from @mulmoclaude/core/remote-host) takes `Jsonify<T>`, which a payload built
+// from collection types cannot satisfy: `CollectionItem` and `RemoteViewPage` carry
+// `unknown`-valued index signatures, and `unknown` is not provably JSON. Three handlers therefore
+// asserted their way to `JsonObject`, one of them through `as unknown as` — the shape simply does
+// not overlap.
+//
+// This CONVERTS instead of asserting, so the claim becomes true rather than declared. The values
+// are about to be JSON.stringify'd onto the wire anyway, so the walk sees exactly what the client
+// would have received: anything JSON.stringify drops (functions, symbols, undefined) is dropped
+// here too, in the same places.
+import { isRecord } from "../../../common/isRecord.js";
+import type { JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
+
+/** A value as JSON, or undefined for something JSON has no representation for. */
+export function toJsonValue(value: unknown): JsonValue | undefined {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  // NaN and ±Infinity have no JSON form — JSON.stringify writes them as null, so this does too
+  // rather than dropping the key and changing the shape the client sees.
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  // An element JSON cannot represent becomes null rather than vanishing: dropping it would shift
+  // every later index, which is what JSON.stringify avoids by writing null.
+  if (Array.isArray(value)) return value.map((entry) => toJsonValue(entry) ?? null);
+  if (isRecord(value)) return jsonPayload(value);
+  return undefined;
+}
+
+/** A record as JSON. Keys whose value JSON cannot represent are omitted, as JSON.stringify omits
+ *  them. Named apart from core's `toJsonObject`, which two of the callers also import. */
+export function jsonPayload(value: Record<string, unknown>): JsonObject {
+  const out: JsonObject = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const json = toJsonValue(entry);
+    if (json !== undefined) out[key] = json;
+  }
+  return out;
+}

--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -35,6 +35,7 @@ import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
 import { groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
 import { missingRequiredEnv, soleExecutor } from "./server-tool-load.js";
+import { isRecord } from "../../common/isRecord.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ../.. climbs server/infra/ → server/ → package root, where plugins/ lives.
@@ -125,9 +126,9 @@ interface ServerTool {
 }
 
 function isServerTool(value: unknown): value is ServerTool {
-  if (typeof value !== "object" || value === null) return false;
-  const tool = value as Partial<ServerTool>;
-  return typeof tool.definition?.name === "string" && typeof tool.handler === "function";
+  if (!isRecord(value)) return false;
+  const definition = value.definition;
+  return isRecord(definition) && typeof definition.name === "string" && typeof value.handler === "function";
 }
 
 // A server-only tool package. Import it, pick every XTool-shaped export, and adapt
@@ -161,7 +162,7 @@ async function loadServerToolPackage(name: string) {
         prompt: tool.prompt,
         parameters: tool.definition.inputSchema,
       },
-      execute: async (args?: unknown) => ({ message: await tool.handler((args as Record<string, unknown>) ?? {}) }),
+      execute: async (args?: unknown) => ({ message: await tool.handler(isRecord(args) ? args : {}) }),
     }));
 }
 

--- a/server/infra/server-tool-load.ts
+++ b/server/infra/server-tool-load.ts
@@ -20,10 +20,15 @@ export function serverToolEnabled(requiredEnv: readonly string[] | undefined, en
   return missingRequiredEnv(requiredEnv, env).length === 0;
 }
 
+// Callable is all JavaScript lets anyone check; the signature is the caller's contract with the
+// package, which nothing here can verify. A guard rather than an assertion so the check and the
+// type it grants are the same statement.
+const isExecutor = (value: unknown): value is (...args: unknown[]) => unknown => typeof value === "function";
+
 // The sole `execute*` function export, or undefined when there is not exactly one — the
 // fallback executor for packages that name their entry point descriptively and ship no
 // `execute`. Undefined for zero (nothing to pick) and for two or more (ambiguous).
 export function soleExecutor(mod: Record<string, unknown>): ((...args: unknown[]) => unknown) | undefined {
-  const fns = Object.entries(mod).filter(([key, val]) => key.startsWith("execute") && typeof val === "function");
-  return fns.length === 1 ? (fns[0][1] as (...args: unknown[]) => unknown) : undefined;
+  const fns = Object.entries(mod).flatMap(([key, value]) => (key.startsWith("execute") && isExecutor(value) ? [value] : []));
+  return fns.length === 1 ? fns[0] : undefined;
 }

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -50,6 +50,32 @@ describe("jsonPayload", () => {
     expect("polluted" in {}).toBe(false);
   });
 
+  // stringify calls `toJSON` before looking at own keys, so a Date must become its ISO string.
+  // Walking its (empty) key list instead produced `{}` — silent data loss (Codex review on #1288).
+  it("serializes a Date through toJSON, as stringify does", () => {
+    const value = { when: new Date("2026-08-02T00:00:00Z"), nested: { at: new Date(0) } };
+    expect(jsonPayload(value)).toEqual({ when: "2026-08-02T00:00:00.000Z", nested: { at: "1970-01-01T00:00:00.000Z" } });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  it("serializes a Date inside an array too", () => {
+    const value = { list: [new Date(0), 1] };
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  // stringify throws rather than skipping, and so must this: dropping the key would ship a
+  // payload silently missing a field.
+  it("throws on a bigint, as stringify does", () => {
+    expect(() => jsonPayload({ n: 1n })).toThrow(TypeError);
+    expect(() => JSON.stringify({ n: 1n })).toThrow(TypeError);
+  });
+
+  // An object with no toJSON keeps the walk — Map has no own enumerable keys, so `{}` is right.
+  it("gives an empty object for a Map, as stringify does", () => {
+    const value = { m: new Map([["a", 1]]) };
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
   it("is empty for an empty record", () => {
     expect(jsonPayload({})).toEqual({});
   });

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -76,6 +76,20 @@ describe("jsonPayload", () => {
     expect(jsonPayload(value)).toEqual(stringified(value));
   });
 
+  // stringify passes the property key to `toJSON`, so a key-aware serializer must see it — calling
+  // it with nothing silently changes the answer (Codex review on #1288).
+  it("passes the property key to a key-aware toJSON, as stringify does", () => {
+    const value = { a: { toJSON: (k: string) => k }, b: { toJSON: (k: string) => `${k}!` } };
+    expect(jsonPayload(value)).toEqual({ a: "a", b: "b!" });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  it("passes the array index as the key inside an array", () => {
+    const value = { list: [{ toJSON: (k: string) => k }, { toJSON: (k: string) => k }] };
+    expect(jsonPayload(value)).toEqual({ list: ["0", "1"] });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
   it("is empty for an empty record", () => {
     expect(jsonPayload({})).toEqual({});
   });

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { jsonPayload, toJsonValue } from "../../../../server/backends/remoteHost/jsonPayload.js";
+import { jsonPayload } from "../../../../server/backends/remoteHost/jsonPayload.js";
 
 // The point of this module is that the RESULT equals what the client would have received when the
 // payload was asserted to be JSON and stringified. So the yardstick is JSON.stringify itself.
@@ -108,19 +108,22 @@ describe("jsonPayload", () => {
     expect(jsonPayload(value)).toEqual(stringified(value));
   });
 
+  // A boxed BigInt reached the object walk and became `{}` — silent data loss where stringify
+  // throws. Going through stringify itself makes that impossible (Codex review on #1288).
+  it("throws on a boxed bigint too, as stringify does", () => {
+    const value = { n: boxed(1n) };
+    expect(() => jsonPayload(value)).toThrow(TypeError);
+    expect(() => JSON.stringify(value)).toThrow(TypeError);
+  });
+
+  it("throws on a circular reference, as stringify does", () => {
+    const value: Record<string, unknown> = { name: "loop" };
+    value.self = value;
+    expect(() => jsonPayload(value)).toThrow(TypeError);
+    expect(() => JSON.stringify(value)).toThrow(TypeError);
+  });
+
   it("is empty for an empty record", () => {
     expect(jsonPayload({})).toEqual({});
-  });
-});
-
-describe("toJsonValue", () => {
-  it("answers undefined for values JSON cannot represent", () => {
-    expect(toJsonValue(undefined)).toBeUndefined();
-    expect(toJsonValue(() => 1)).toBeUndefined();
-    expect(toJsonValue(Symbol("x"))).toBeUndefined();
-  });
-
-  it("keeps null distinct from absent", () => {
-    expect(toJsonValue(null)).toBeNull();
   });
 });

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -6,6 +6,10 @@ import { jsonPayload, toJsonValue } from "../../../../server/backends/remoteHost
 // payload was asserted to be JSON and stringified. So the yardstick is JSON.stringify itself.
 const stringified = (value: Record<string, unknown>): unknown => JSON.parse(JSON.stringify(value));
 
+// A boxed primitive, built without the wrapper constructors the lint rule bans (rightly — they are
+// only ever wanted here, as adversarial input).
+const boxed = (value: unknown): unknown => Object(value);
+
 describe("jsonPayload", () => {
   it("passes scalars, arrays and nested records through unchanged", () => {
     const value = { s: "a", n: 1, b: true, nul: null, arr: [1, "two", false], deep: { inner: { k: [1, 2] } } };
@@ -87,6 +91,20 @@ describe("jsonPayload", () => {
   it("passes the array index as the key inside an array", () => {
     const value = { list: [{ toJSON: (k: string) => k }, { toJSON: (k: string) => k }] };
     expect(jsonPayload(value)).toEqual({ list: ["0", "1"] });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  // Boxed primitives serialize as their primitive. Walking them as objects gave
+  // `{"0":"a","1":"b"}` / `{}` / `{}` instead (Codex review on #1288).
+  it("unwraps boxed primitives, as stringify does", () => {
+    const value = { s: boxed("ab"), n: boxed(3), b: boxed(false) };
+    expect(jsonPayload(value)).toEqual({ s: "ab", n: 3, b: false });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  it("writes null for a boxed non-finite number, as stringify does", () => {
+    const value = { n: boxed(NaN) };
+    expect(jsonPayload(value)).toEqual({ n: null });
     expect(jsonPayload(value)).toEqual(stringified(value));
   });
 

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -38,6 +38,18 @@ describe("jsonPayload", () => {
     expect(jsonPayload({ op: "update", item })).toEqual({ op: "update", item });
   });
 
+  // A payload carrying a literal "__proto__" key: `out[key] =` would assign the PROTOTYPE and the
+  // key would disappear from the output, while JSON.stringify keeps it (Codex review on #1288).
+  it("keeps a literal __proto__ key instead of touching the prototype", () => {
+    const value: Record<string, unknown> = JSON.parse('{"__proto__": {"polluted": true}, "keep": 1}');
+    const out = jsonPayload(value);
+    expect(Object.prototype.hasOwnProperty.call(out, "__proto__")).toBe(true);
+    expect(JSON.stringify(out)).toBe(JSON.stringify(stringified(value)));
+    // The prototype itself is untouched — nothing leaked onto Object.prototype.
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect("polluted" in {}).toBe(false);
+  });
+
   it("is empty for an empty record", () => {
     expect(jsonPayload({})).toEqual({});
   });

--- a/test/server/backends/remoteHost/jsonPayload.spec.ts
+++ b/test/server/backends/remoteHost/jsonPayload.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { jsonPayload, toJsonValue } from "../../../../server/backends/remoteHost/jsonPayload.js";
+
+// The point of this module is that the RESULT equals what the client would have received when the
+// payload was asserted to be JSON and stringified. So the yardstick is JSON.stringify itself.
+const stringified = (value: Record<string, unknown>): unknown => JSON.parse(JSON.stringify(value));
+
+describe("jsonPayload", () => {
+  it("passes scalars, arrays and nested records through unchanged", () => {
+    const value = { s: "a", n: 1, b: true, nul: null, arr: [1, "two", false], deep: { inner: { k: [1, 2] } } };
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  it("omits keys JSON has no representation for, as stringify does", () => {
+    const value = { kept: "yes", fn: () => 1, undef: undefined, sym: Symbol("x") };
+    expect(jsonPayload(value)).toEqual({ kept: "yes" });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  // Dropping the element instead would shift every later index — a row landing under the wrong
+  // one on the phone. stringify writes null for exactly this reason.
+  it("writes null for an array element JSON cannot represent, keeping positions", () => {
+    const value = { list: [1, () => 2, 3] };
+    expect(jsonPayload(value)).toEqual({ list: [1, null, 3] });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  it("writes null for NaN and Infinity, as stringify does", () => {
+    const value = { nan: NaN, inf: Infinity, negInf: -Infinity };
+    expect(jsonPayload(value)).toEqual({ nan: null, inf: null, negInf: null });
+    expect(jsonPayload(value)).toEqual(stringified(value));
+  });
+
+  // The shape the handlers actually hand it: an `unknown`-valued index signature holding JSON.
+  it("converts a collection-item-shaped record", () => {
+    const item: Record<string, unknown> = { id: "r1", title: "Row", tags: ["a", "b"], meta: { count: 2 } };
+    expect(jsonPayload({ op: "update", item })).toEqual({ op: "update", item });
+  });
+
+  it("is empty for an empty record", () => {
+    expect(jsonPayload({})).toEqual({});
+  });
+});
+
+describe("toJsonValue", () => {
+  it("answers undefined for values JSON cannot represent", () => {
+    expect(toJsonValue(undefined)).toBeUndefined();
+    expect(toJsonValue(() => 1)).toBeUndefined();
+    expect(toJsonValue(Symbol("x"))).toBeUndefined();
+  });
+
+  it("keeps null distinct from absent", () => {
+    expect(toJsonValue(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

#1231。6 ファイル・**6 箇所**（うち 1 つは `as unknown as`）。**20 → 14**。allowlist は **0 件**。

## Items to Confirm / Review

### 1. remote-host の 3 箇所は「主張」をやめて「変換」にしました

この 3 つは、**なぜ消せないかがコメントで説明されて**残っていたものです。

> `toJsonObject` cannot serve this one … It IS JSON at runtime — the collection loader only ever puts JSON in it — a fact about the loader these types do not record.

説明は正しいのですが、**その但し書きが要らなくなる道**がありました。ペイロードはこの直後に `JSON.stringify` されて線に乗るので、**同じ変換を先にやってしまえば型が事実になります**。

`server/backends/remoteHost/jsonPayload.ts`（新規）は値を歩いて `JsonValue` を作ります。基準は `JSON.stringify` 自身です。

| 入力 | 扱い | 理由 |
|---|---|---|
| 関数 / symbol / undefined | キーごと省略 | stringify と同じ |
| 配列の同上 | `null` に置換 | **落とすと以降の添字がずれる**（行が別の行の下に出る）。stringify が null を書くのもこのため |
| NaN / ±Infinity | `null` | stringify と同じ |

**テストは全ケースを `JSON.parse(JSON.stringify(...))` と突き合わせて**等価性を固定しています（8 ケース）。挙動は変わらず、型が正直になります。

### 2. 名前衝突でパースエラーを出しました（自己申告）

最初 `toJsonObject` という名前で書いたところ、**core の `toJsonObject` を同じファイルが import していて** `Identifier has already been declared` になりました。`jsonPayload` に改名しています。`typecheck` は通るのに vitest のトランスフォームで落ちる、という出方でした。

### 3. `isServerTool` は判定対象の型へ cast してからフィールドを見ていました

```diff
-  const tool = value as Partial<ServerTool>;
-  return typeof tool.definition?.name === "string" && typeof tool.handler === "function";
+  if (!isRecord(value)) return false;
+  const definition = value.definition;
+  return isRecord(definition) && typeof definition.name === "string" && typeof value.handler === "function";
```

#1245 の `isSendBinding`、#1249 の `textOf` と同じ構造です（**確かめる前に結論を書く**）。

### 4. `server-tool-load.ts` — `filter` の後もタプル要素は `unknown`

`isExecutor` 述語 + `flatMap` にしました。callable であることは JS で確かめられる唯一のことで、シグネチャは呼び出し側とパッケージの契約なので、そこは述語の宣言に委ねます（cast を移動しただけにならないよう、一度書いた `value as (...)` は捨てています）。

## 検証

`yarn lint`（0 error）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7480 passed**（新規 8 件）。

refs #1231

work in mulmoterminal3
