### PR TITLE
refactor: jscpd の重複 4 件を共通化して 0 にする (#1289)

### DIFF
--- a/plans/refactor-1289-jscpd-clones.md
+++ b/plans/refactor-1289-jscpd-clones.md
@@ -1,0 +1,72 @@
+# refactor: code scanning の重複コード 4 件を潰す（#1289）
+
+jscpd が Code Scanning に上げている open alert 4 件（136 / 137 / 138 / 139）を 0 にする。
+挙動は変えない。抽出した先にはテストを足し、最後に CI と同じオプションの jscpd で 0 件を確認する。
+
+## 1. ws-routes: エージェント接続の前処理（alert 139）
+
+`handleCodexConnection` と `handleAntigravityConnection` が、セッション解決の直後に同じ 4 行を
+同じ順で書いている。claude / launch も同じ並びを持っており、実質 4 箇所の重複。
+
+```ts
+if (await refuseSecondWorktreeSession(ws, kind, cwd, { requested, sessionId })) return;
+if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+markAttachedSessionPlaced(sessionId, requested);
+const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
+```
+
+順序が壊れやすい部分（拒否は browser に id を伝える前でなければならない）なので、
+`admitAgentSession()` として 1 関数にまとめ、`EarlyFrames | null` を返す。null は
+「socket を閉じた、呼び出し元は return しろ」。
+
+- `devTerminal` は「サイドバーに出さないグリッドのセルか」。claude / codex / antigravity は
+  `!attachGuiMcp`、launch は常に true（launcher は常に dev terminal 扱い）。
+- `worktreeLimited` は launch のためのフラグ。launcher は「codex を起動する launcher だけ」
+  worktree の制限を受ける（`launcherRunsAgent`）。他は常に true。
+
+## 2. モーダルのキーボード処理（alert 136）
+
+Escape で閉じる / Tab をダイアログ内にトラップする、というハンドラが 4 コンポーネントにある
+（`SettingsModal` / `ModelSetupHelp` / `CopyCodeBlock` / `TimelineOverlay`）。
+listener の付け外しのタイミングだけが 4 者で違う（mount / 開いた瞬間 / watch）。
+
+`src/composables/useModalKeyboard.ts` に 2 段で置く。
+
+- `modalKeydown(modalEl, onClose, trapSelector?)` — ハンドラ本体だけ。付け外しは呼び出し元。
+  `CopyCodeBlock`（textarea をフォーカス＆選択する独自の開き方）と `TimelineOverlay`
+  （watch で open を見ている）はこちらを使う。
+- `useModalKeyboard({ modalEl, onClose, focusSelector, trapSelector })` — mount で登録 ＋
+  初期フォーカス、unmount で解除。`SettingsModal` と `ModelSetupHelp` はこちら。
+
+## 3. 通知音の emit 宣言（alert 137）
+
+`NotificationSoundsSection` が上げる 3 つの emit を、中継する `SettingsModal` が同じ形で
+書き直している。`GridCellEmits` と同じやり方で共有の型に出す
+（`src/components/settings/soundEmits.ts`）。props は片方が 13 個・片方が 3 個で形が違うので触らない。
+
+## 4. handler queue（alert 138）
+
+`useNewTerminal` と `useSpawnedChat` は「grid が mount していなければ queue し、register 時に
+全件 drain し、stale な unregister は新しいハンドラを消さない」という同じ実装を持つ。
+違いはハンドラの戻り値だけ（前者は void、後者は「grid が受け取ったか」の boolean）。
+
+`src/composables/handlerQueue.ts` に `createHandlerQueue<Req, Ret>()` を置く。
+
+- `register(h)` — 登録して queue を drain、unregister を返す
+- `deliver(req, queuedResult)` — ハンドラがいれば呼んでその戻り値、いなければ queue して
+  `queuedResult`（`useSpawnedChat` が「queue も grid 行きなので true」と決めている値）
+- `reset()` — テスト用
+
+各ファイルの「なぜ 1 枠ではなく全件持つのか」といった WHY コメントは、共有の仕組みの説明は
+`handlerQueue.ts` へ、その seam 固有の話は元のファイルに残す。
+
+## テスト
+
+- `test/src/composables/modalKeyboard.spec.ts`（新規）— Escape / Tab / それ以外のキー / modalEl 無し
+- `test/src/composables/handlerQueue.spec.ts`（新規）— drain 順、stale unregister、queue 後の空、戻り値
+- 既存の `useNewTerminal.spec.ts` / `spawnedChat.spec.ts` / `test/server/routes/*` はそのまま通ること
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` / `typecheck:server` / `typecheck:test` →
+`yarn build` → `yarn test`、最後に CI と同じ引数の jscpd で `0 clones` を確認する。

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -202,6 +202,41 @@ async function refuseSecondWorktreeSession(
   return true;
 }
 
+/**
+ * Everything an agent endpoint does between resolving its session and spawning it, in the order
+ * the four of them (claude, launch, codex, antigravity) already ran it in.
+ *
+ * The order is the fragile part: the worktree refusal has to happen BEFORE the browser is told a
+ * session id (#1207), and the dev-terminal mark has to be recorded on every attach — new, resumed
+ * or reattached — which is what makes this the single choke point for the chat sidebar's exclusion
+ * list (see devTerminalSessions).
+ *
+ * Returns null when the socket was refused and closed: the caller must return without spawning.
+ */
+async function admitAgentSession(
+  ws: WebSocket,
+  kind: TerminalWsKind,
+  session: {
+    requested: string | null;
+    sessionId: string;
+    live: PtyEntry | undefined;
+    cwd: string;
+    /** A grid cell rather than the single view: keep it out of the chat sidebar. */
+    devTerminal: boolean;
+    /** False only for a launcher that runs no agent — `yarn dev` is not an agent editing the tree
+     *  and stays free of the one-session-per-worktree rule (see launcherRunsAgent). */
+    worktreeLimited?: boolean;
+  },
+): Promise<EarlyFrames | null> {
+  const { requested, sessionId, live, cwd, devTerminal, worktreeLimited = true } = session;
+  if (worktreeLimited && (await refuseSecondWorktreeSession(ws, kind, cwd, { requested, sessionId }))) return null;
+  if (devTerminal) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+  markAttachedSessionPlaced(sessionId, requested);
+  // The EFFECTIVE cwd, not this request's: on a reattach the live PTY's own directory is where the
+  // agent really runs, and the request's `?cwd=` is ignored by everything downstream.
+  return announceSession(ws, sessionId, live?.cwd ?? cwd);
+}
+
 async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
   const buttonId = url.searchParams.get("buttonId");
   if (!buttonId) return null;
@@ -362,24 +397,11 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // re-persists, so the reload just reopens a working terminal seamlessly.
   const { reattachId, resume, sessionId } = resolveClaudeSession(requested, cwd);
   const live = reattachId ? ptys.get(reattachId) : undefined;
-  if (await refuseSecondWorktreeSession(ws, "claude", cwd, { requested, sessionId })) return;
-
-  // A dev terminal (gui=0) is a multi-terminal GRID cell: remember its session id so
-  // it's excluded from the chat sidebar (see devTerminalSessions). This is the single
-  // choke point for every grid attach — new, resumed, or reattached — so the mark is
-  // recorded (and re-recorded after a reboot when the cell reconnects) exactly once.
-  if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  markAttachedSessionPlaced(sessionId, requested);
-
-  // Tell the browser which session this is (it learns the id of new sessions) and
-  // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
-  // PTY's own cwd (NOT this request's ?cwd=, which it ignores); otherwise it's the
-  // resolved cwd the new PTY will spawn in.
-  const reportedCwd = live?.cwd ?? cwd;
-  // Buffered from here, like every other terminal endpoint: the browser's first frame is the
-  // terminal's geometry and it arrives while this handler may still be awaiting the Keychain — /ws
-  // was the one route that let it fall on the floor (#1178, see early-frames.ts).
-  const early = announceSession(ws, sessionId, reportedCwd);
+  // Buffered from the announcement on, like every other terminal endpoint: the browser's first
+  // frame is the terminal's geometry and it arrives while this handler may still be awaiting the
+  // Keychain — /ws was the one route that let it fall on the floor (#1178, see early-frames.ts).
+  const early = await admitAgentSession(ws, "claude", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+  if (!early) return;
 
   // A provider refusal already says exactly what is wrong with the directory's config (#579), and a
   // refused spawn already names the binary and the PATH it searched, or the directory that is gone
@@ -490,10 +512,15 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // A launcher is a command line, so the limit follows what it RUNS: a launcher configured as
   // `codex` is the agent toggle by another name and is held to the same rule, while `yarn dev` or
   // a shell is not an agent editing the tree and stays free (see launcherRunsAgent).
-  if (launcherRunsAgent(command) && (await refuseSecondWorktreeSession(ws, "launch", cwd, { requested, sessionId }))) return;
-  markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  markAttachedSessionPlaced(sessionId, requested);
-  const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
+  const early = await admitAgentSession(ws, "launch", {
+    requested,
+    sessionId,
+    live,
+    cwd,
+    devTerminal: true,
+    worktreeLimited: launcherRunsAgent(command),
+  });
+  if (!early) return;
 
   // A launcher that runs codex gets the directory's registered tool groups too. The chip and the
   // agent toggle land in the same cell and look the same, so a Canvas that lights up for one and
@@ -520,10 +547,8 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
-  if (await refuseSecondWorktreeSession(ws, "codex", cwd, { requested, sessionId })) return;
-  if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  markAttachedSessionPlaced(sessionId, requested);
-  const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
+  const early = await admitAgentSession(ws, "codex", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+  if (!early) return;
 
   // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
   // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
@@ -591,10 +616,8 @@ async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req
   // conversation that is right there — which is the restart case this exists for.
   await antigravityConversationsHydrated;
   const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
-  if (await refuseSecondWorktreeSession(ws, "antigravity", cwd, { requested, sessionId })) return;
-  if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  markAttachedSessionPlaced(sessionId, requested);
-  const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
+  const early = await admitAgentSession(ws, "antigravity", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+  if (!early) return;
 
   // The directory's registered groups, read here because the lookup reads Claude Code's config
   // files and the spawner is sync. Only for a SPAWN: a reattach keeps the tools its running

--- a/src/components/CopyCodeBlock.vue
+++ b/src/components/CopyCodeBlock.vue
@@ -10,7 +10,8 @@
 import { ref, onUnmounted } from "vue";
 import { fetchLastTurn } from "../composables/useHandoff";
 import { copyOutcomeFor, copyOutcomeMessage, clipboardAvailable } from "./codeBlockCopy";
-import { trapTabKey, MODAL_FOCUSABLE } from "../utils/focusTrap";
+import { MODAL_FOCUSABLE } from "../utils/focusTrap";
+import { modalKeydownHandler } from "../composables/useModalKeyboard";
 import type { TerminalAgent } from "../../common/sessionAgent";
 
 const props = defineProps<{ sessionId: string; cwd: string | null; agent: TerminalAgent }>();
@@ -22,6 +23,15 @@ const manual = ref<string | null>(null);
 const box = ref<HTMLTextAreaElement>();
 const modalEl = ref<HTMLElement | null>(null);
 let noteTimer: ReturnType<typeof setTimeout> | undefined;
+
+// The shared modal keyboard contract, but registered only while the dialog is open — this component
+// is always mounted (it is a cell button), so listening for its whole lifetime would swallow Escape
+// for everything else.
+//
+// MODAL_FOCUSABLE rather than the default selector: this dialog's first stop is the `textarea`
+// holding the code, and the default list is buttons only — the trap would then wrap Tab onto the
+// Close button and the text itself would be unreachable from the keyboard.
+const onKeydown = modalKeydownHandler({ modalEl, onClose: () => closeManual(), trapSelector: MODAL_FOCUSABLE });
 
 const flash = (message: string): void => {
   note.value = message;
@@ -66,23 +76,6 @@ async function showForManualCopy(text: string): Promise<void> {
   // one key, or one long-press on a phone.
   box.value?.focus();
   box.value?.select();
-}
-
-// Modal keyboard behavior, same as TimelineOverlay and SettingsModal: Escape closes, Tab stays
-// inside. On the document rather than the dialog element — bound to the element it would only
-// fire while focus is already inside, so one click on the backdrop would kill Escape. Registered
-// only while open so it cannot swallow either key for anything else.
-//
-// MODAL_FOCUSABLE rather than the default selector: this dialog's first stop is the `textarea`
-// holding the code, and the default list is buttons only — the trap would then wrap Tab onto the
-// Close button and the text itself would be unreachable from the keyboard.
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape") {
-    closeManual();
-    return;
-  }
-  if (e.key !== "Tab" || !modalEl.value) return;
-  trapTabKey(e, modalEl.value, MODAL_FOCUSABLE);
 }
 
 function closeManual(): void {

--- a/src/components/ModelSetupHelp.vue
+++ b/src/components/ModelSetupHelp.vue
@@ -6,8 +6,9 @@
 // already knows exactly what is missing — that sentence goes at the top, and the full
 // walkthrough moves below it. Setup instructions that bury the one broken line are how a
 // user ends up re-doing the parts that already worked.
-import { computed, onMounted, onUnmounted, nextTick, ref } from "vue";
-import { MODAL_FOCUSABLE, trapTabKey } from "../utils/focusTrap";
+import { computed, ref } from "vue";
+import { MODAL_FOCUSABLE } from "../utils/focusTrap";
+import { useModalKeyboard } from "../composables/useModalKeyboard";
 import type { LaunchProviderOption } from "../../common/launchOptions";
 
 const props = defineProps<{ providers: LaunchProviderOption[] }>();
@@ -36,18 +37,9 @@ const copy = (text: string) => navigator.clipboard?.writeText(text);
 
 const modalEl = ref<HTMLElement>();
 
-// Same modal keyboard contract as the settings dialog: Escape closes, Tab stays inside.
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === "Escape") return emit("close");
-  if (e.key !== "Tab" || !modalEl.value) return;
-  trapTabKey(e, modalEl.value, MODAL_FOCUSABLE);
-}
-
-onMounted(() => {
-  document.addEventListener("keydown", onKeydown);
-  nextTick(() => modalEl.value?.querySelector<HTMLElement>("button")?.focus());
-});
-onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+// Same modal keyboard contract as the settings dialog: Escape closes, Tab stays inside. This one
+// has nothing to type into — every stop is a button — so the first one is where focus lands.
+useModalKeyboard({ modalEl, onClose: () => emit("close"), trapSelector: MODAL_FOCUSABLE, focusSelector: "button" });
 </script>
 
 <template>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -6,8 +6,9 @@
 // is one file under ./settings, and what stays here is what belongs to the modal itself. The
 // props/emits below are pure plumbing: they exist because the shells (and the specs) address
 // this component, and each one is handed straight to the section that reads it.
-import { ref, onMounted, onUnmounted, nextTick } from "vue";
-import { MODAL_FOCUSABLE, trapTabKey } from "../utils/focusTrap";
+import { ref } from "vue";
+import { MODAL_FOCUSABLE } from "../utils/focusTrap";
+import { useModalKeyboard } from "../composables/useModalKeyboard";
 import SettingsButton from "./SettingsButton.vue";
 import ThemeSection from "./settings/ThemeSection.vue";
 import TerminalFontSizeSection from "./settings/TerminalFontSizeSection.vue";
@@ -32,6 +33,7 @@ import type { QuickCommand } from "../../common/quickCommands";
 import type { PushKind } from "../../common/pushKinds";
 import type { NotifyKind } from "../../common/notifyKinds";
 import type { SoundMap } from "../composables/soundSettings";
+import type { SoundEmits } from "./settings/soundEmits";
 import type { BundledSkillName } from "../../common/bundledSkills";
 
 defineProps<{
@@ -51,39 +53,29 @@ defineProps<{
   dirPaths?: string[];
 }>();
 
-const emit = defineEmits<{
-  (e: "update-sound", file: string | null): void;
-  (e: "update-sound-kinds", kinds: NotifyKind[]): void;
-  (e: "update-sounds", sounds: SoundMap): void;
-  (e: "update-push-enabled", on: boolean): void;
-  (e: "update-push-kinds", kinds: PushKind[]): void;
-  (e: "update-repos", repos: string[]): void;
-  (e: "update-launchers", launchers: Launcher[]): void;
-  (e: "update-quick-commands", commands: QuickCommand[]): void;
-  (e: "update-user-mcp", servers: UserMcpServer[]): void;
-  // Hand a section over to the skill that owns it. Named by skill rather than by section
-  // ("configure-appearance") so a new button costs nothing outside this file.
-  (e: "launch-skill", skill: BundledSkillName): void;
-  (e: "close"): void;
-}>();
+// The sound events come from NotificationSoundsSection's own contract — this modal only forwards
+// them, so it must not spell them out a second time.
+const emit = defineEmits<
+  SoundEmits & {
+    (e: "update-push-enabled", on: boolean): void;
+    (e: "update-push-kinds", kinds: PushKind[]): void;
+    (e: "update-repos", repos: string[]): void;
+    (e: "update-launchers", launchers: Launcher[]): void;
+    (e: "update-quick-commands", commands: QuickCommand[]): void;
+    (e: "update-user-mcp", servers: UserMcpServer[]): void;
+    // Hand a section over to the skill that owns it. Named by skill rather than by section
+    // ("configure-appearance") so a new button costs nothing outside this file.
+    (e: "launch-skill", skill: BundledSkillName): void;
+    (e: "close"): void;
+  }
+>();
 
 const modalEl = ref<HTMLElement>();
 
-// Modal keyboard behavior: Escape closes; Tab is trapped within the dialog.
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === "Escape") {
-    emit("close");
-    return;
-  }
-  if (e.key !== "Tab" || !modalEl.value) return;
-  trapTabKey(e, modalEl.value, MODAL_FOCUSABLE);
-}
-
-onMounted(() => {
-  document.addEventListener("keydown", onKeydown);
-  nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
-});
-onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+// Escape closes; Tab is trapped within the dialog. The first stop is an `input` where there is
+// one — the sections are mostly text fields, and landing on the Close button instead means
+// tabbing past the whole dialog to reach the setting you opened it for.
+useModalKeyboard({ modalEl, onClose: () => emit("close"), trapSelector: MODAL_FOCUSABLE, focusSelector: "input, button" });
 </script>
 
 <template>

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -3,7 +3,7 @@
 // first), fetched from GET /api/transcript/timeline. Opened from the cell header's
 // history button so you can see "what did it do?" without scrolling the raw transcript.
 import { ref, watch, onUnmounted, nextTick } from "vue";
-import { trapTabKey } from "../utils/focusTrap";
+import { modalKeydownHandler } from "../composables/useModalKeyboard";
 import { isRecord } from "../../common/isRecord";
 
 interface TimelineEvent {
@@ -59,17 +59,10 @@ const formatTime = (iso: string): string => {
 
 const modalEl = ref<HTMLElement | null>(null);
 
-// Modal keyboard behavior (mirrors SettingsModal): Escape closes; Tab is trapped in
-// the dialog so focus can't reach background controls. Document-level so it works
-// regardless of where focus lands. Attached only while open; removed on close/unmount.
-const onKeydown = (e: KeyboardEvent) => {
-  if (e.key === "Escape") {
-    emit("close");
-    return;
-  }
-  if (e.key !== "Tab" || !modalEl.value) return;
-  trapTabKey(e, modalEl.value);
-};
+// The shared modal keyboard contract, attached only while open (this overlay stays mounted while
+// closed) and removed on close/unmount. The default trap selector is right here: everything the
+// timeline offers is a button.
+const onKeydown = modalKeydownHandler({ modalEl, onClose: () => emit("close") });
 
 // One watch over open + identity: (re)load whenever the overlay is open — covering
 // both the open transition and a session/cwd change while it stays open (so it never

--- a/src/components/settings/NotificationSoundsSection.vue
+++ b/src/components/settings/NotificationSoundsSection.vue
@@ -10,15 +10,11 @@ import { SECTION_HEADING } from "./sectionClasses";
 import { NOTIFY_KINDS, type NotifyKind } from "../../../common/notifyKinds";
 import { presetRef, SOUND_PRESETS } from "../../../common/notifySounds";
 import type { BundledSkillName } from "../../../common/bundledSkills";
+import type { SoundEmits } from "./soundEmits";
 import { isRecord } from "../../../common/isRecord";
 
 const props = defineProps<{ soundFile?: string | null | undefined; soundKinds?: NotifyKind[] | undefined; sounds?: SoundMap | undefined }>();
-const emit = defineEmits<{
-  (e: "update-sound", file: string | null): void;
-  (e: "update-sound-kinds", kinds: NotifyKind[]): void;
-  (e: "update-sounds", sounds: SoundMap): void;
-  (e: "launch-skill", skill: BundledSkillName): void;
-}>();
+const emit = defineEmits<SoundEmits & { (e: "launch-skill", skill: BundledSkillName): void }>();
 
 // Which moments beep, and what each one plays (#873). The toolbar's speaker icon says whether to
 // beep at all, this says which moments qualify.

--- a/src/components/settings/soundEmits.ts
+++ b/src/components/settings/soundEmits.ts
@@ -1,0 +1,15 @@
+// What the notification-sounds section reports upward. Declared once because the Settings modal
+// that hosts it has to re-declare every one of them to forward it to App.vue, and a section's
+// events written out twice drift apart one payload type at a time (#1289 — same reason as
+// GridCellEmits).
+import type { NotifyKind } from "../../../common/notifyKinds";
+import type { SoundMap } from "../../composables/soundSettings";
+
+export interface SoundEmits {
+  /** The fallback file for every kind that has no sound of its own. Null = the built-in chime. */
+  (e: "update-sound", file: string | null): void;
+  /** Which moments beep at all. */
+  (e: "update-sound-kinds", kinds: NotifyKind[]): void;
+  /** The whole per-kind map, persisted as one value. */
+  (e: "update-sounds", sounds: SoundMap): void;
+}

--- a/src/composables/handlerQueue.ts
+++ b/src/composables/handlerQueue.ts
@@ -1,0 +1,50 @@
+// The seam GridView is reached through: a module-level handler the grid registers when it is there,
+// and a queue for the requests that arrive when it isn't. Two of these exist — useNewTerminal (spawn
+// a cell here) and useSpawnedChat (adopt an already-spawned session as a cell) — and they had the
+// same twenty lines each (#1289).
+//
+// The queue holds EVERY waiting request, not just the newest. One slot was enough while a person
+// pressing a button was the only caller — nobody can press twice before the route changes — but the
+// phone asks over pub/sub (#831) and a collection action can start several chats at once, and each
+// command is answered with success, so a dropped request is work reported as done that never happened.
+
+export interface HandlerQueue<Req, Ret> {
+  /** Register the live handler and drain everything queued before it, in arrival order. The
+   *  returned function unregisters it (from onBeforeUnmount / onDeactivated). */
+  register: (h: (req: Req) => Ret) => () => void;
+  /** Hand the request to the live handler and return its answer, or queue it and return
+   *  `queuedResult` — what the caller considers true of a request that is merely waiting. */
+  deliver: (req: Req, queuedResult: Ret) => Ret;
+  /** Test seam: drop anything a previous case left queued. Not used by the app. */
+  reset: () => void;
+}
+
+export function createHandlerQueue<Req, Ret>(): HandlerQueue<Req, Ret> {
+  let handler: ((req: Req) => Ret) | null = null;
+  let pending: Req[] = [];
+
+  return {
+    register(h) {
+      handler = h;
+      // Taken before dispatching: a handler that itself queues (it can reach the opener through the
+      // grid) would otherwise have its request dropped by the clear below.
+      const queued = pending;
+      pending = [];
+      // Not `queued.forEach(h)`: forEach would hand the handler the index and the array too.
+      queued.forEach((req) => h(req));
+      // Only if it is still the current one — a stale unregister must not detach its successor.
+      return () => {
+        if (handler === h) handler = null;
+      };
+    },
+    deliver(req, queuedResult) {
+      if (handler) return handler(req);
+      pending.push(req);
+      return queuedResult;
+    },
+    reset() {
+      handler = null;
+      pending = [];
+    },
+  };
+}

--- a/src/composables/useModalKeyboard.ts
+++ b/src/composables/useModalKeyboard.ts
@@ -1,0 +1,46 @@
+// The keyboard contract every modal in the app follows: Escape closes it, and Tab stays inside it
+// so focus can't reach the controls behind the backdrop. Written out once per dialog until #1289,
+// which is how one of them ended up trapping a different set of elements than the others.
+//
+// Two layers because the dialogs differ in WHEN they listen, not in what they do: SettingsModal and
+// ModelSetupHelp exist only while open, so they listen for their whole lifetime; CopyCodeBlock opens
+// on demand and TimelineOverlay is driven by a watch, so those two keep their own add/remove and
+// take the handler alone.
+import { onMounted, onUnmounted, nextTick } from "vue";
+import { trapTabKey } from "../utils/focusTrap";
+
+// Read-only, and structural rather than `Ref`: the dialogs declare their root as `ref<HTMLElement>()`
+// and as `ref<HTMLElement | null>(null)`, which are two Ref types a writable parameter can't take both of.
+type ModalElement = { readonly value: HTMLElement | null | undefined };
+
+interface ModalKeyboardOptions {
+  modalEl: ModalElement;
+  onClose: () => void;
+  /** What Tab may reach inside the dialog. Omitted leaves trapTabKey's own (buttons + tabindex). */
+  trapSelector?: string;
+}
+
+/** The handler itself, for a dialog that manages its own listener. Bind it to the DOCUMENT rather
+ *  than to the dialog element: bound to the element it only fires while focus is already inside,
+ *  so one click on the backdrop would kill Escape. */
+export function modalKeydownHandler({ modalEl, onClose, trapSelector }: ModalKeyboardOptions): (e: KeyboardEvent) => void {
+  return (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose();
+      return;
+    }
+    if (e.key !== "Tab" || !modalEl.value) return;
+    trapTabKey(e, modalEl.value, trapSelector);
+  };
+}
+
+/** The same handler, listening for as long as the component is mounted, plus the initial focus that
+ *  makes the trap reachable from the keyboard at all. */
+export function useModalKeyboard(options: ModalKeyboardOptions & { focusSelector: string }): void {
+  const onKeydown = modalKeydownHandler(options);
+  onMounted(() => {
+    document.addEventListener("keydown", onKeydown);
+    nextTick(() => options.modalEl.value?.querySelector<HTMLElement>(options.focusSelector)?.focus());
+  });
+  onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+}

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -6,13 +6,10 @@
 //
 // When the grid isn't mounted (the button pressed from the single view), the request is QUEUED and the
 // app switches to /terminals; GridView drains the queue when it registers on mount — mirroring
-// usePendingScript for the single view's Run menu.
-//
-// The queue holds EVERY waiting request, not just the newest. One slot was enough while the only
-// caller was a button — a person cannot press it twice before the route changes — but the phone
-// asks over pub/sub (#831) and the host answers each command with success, so a dropped request
-// would be a launch reported as done that never happened.
+// usePendingScript for the single view's Run menu. The queueing itself is createHandlerQueue, shared
+// with useSpawnedChat.
 import { router } from "../router";
+import { createHandlerQueue, type HandlerQueue } from "./handlerQueue";
 import type { LaunchAgent } from "../../common/launchAgent";
 
 export interface NewTerminalRequest {
@@ -24,30 +21,20 @@ export interface NewTerminalRequest {
 }
 type Handler = (req: NewTerminalRequest) => void;
 
-let handler: Handler | null = null;
-let pending: NewTerminalRequest[] = [];
+// Annotated rather than `createHandlerQueue<NewTerminalRequest, void>()`: `void` is only valid as a
+// type argument of a type reference, not of a call.
+const queue: HandlerQueue<NewTerminalRequest, void> = createHandlerQueue();
 
 // GridView registers its opener; every request queued before it mounted drains immediately, in
 // arrival order. The returned function unregisters it (call in onBeforeUnmount).
 export function registerNewTerminalHandler(h: Handler): () => void {
-  handler = h;
-  // Taken before dispatching: a handler that itself queues (it can reach openTerminalAt through
-  // the grid) would otherwise have its request dropped by the clear below.
-  const queued = pending;
-  pending = [];
-  // Not `queued.forEach(h)`: forEach would hand the handler the index and the array too.
-  queued.forEach((req) => h(req));
-  return () => {
-    if (handler === h) handler = null;
-  };
+  return queue.register(h);
 }
 
 // Open a new terminal cell in `cwd`, next to `afterSlotKey`'s cell — running `agent`, or the OS
 // default shell when it is omitted. If the grid isn't mounted yet, queue the request and switch to it.
 export function openTerminalAt(cwd: string, afterSlotKey: string | null, agent?: LaunchAgent): void {
-  const req: NewTerminalRequest = { cwd, afterSlotKey, agent };
-  if (handler) handler(req);
-  else pending.push(req);
+  queue.deliver({ cwd, afterSlotKey, agent }, undefined);
   // Then SHOW the grid. Mounted is not the same as on screen: it now stays alive underneath a
   // full-screen overlay, so the phone's launch (#831) would be reported as served while the new
   // terminal appeared behind the wiki or the collection browser, seen by nobody. Before the grid

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -12,10 +12,11 @@
 //
 // When the grid isn't mounted (the chat was started from a collection overlay, which renders in
 // the single-view shell), the request is QUEUED and the app switches to /terminals; GridView
-// drains the queue when it registers on activate. Same contract as useNewTerminal, including the
-// queue holding EVERY waiting request: a collection action can spawn more than one chat before
-// the route changes, and a dropped one is a live agent with nowhere to appear.
+// drains the queue when it registers on activate. Same contract as useNewTerminal, down to the
+// shared createHandlerQueue: a collection action can spawn more than one chat before the route
+// changes, and a dropped one is a live agent with nowhere to appear.
 import { router } from "../router";
+import { createHandlerQueue } from "./handlerQueue";
 import type { TerminalAgent } from "../../common/sessionAgent";
 
 export interface SpawnedChatRequest {
@@ -42,28 +43,19 @@ export interface SpawnedChatRequest {
  *  take the user away from where the session just appeared. */
 type Handler = (req: SpawnedChatRequest) => boolean;
 
-let handler: Handler | null = null;
-let pending: SpawnedChatRequest[] = [];
+const queue = createHandlerQueue<SpawnedChatRequest, boolean>();
 
 // GridView registers its placer; every request queued before it activated drains immediately, in
 // arrival order. The returned function unregisters it (call in onDeactivated / onBeforeUnmount).
 export function registerSpawnedChatHandler(h: Handler): () => void {
-  handler = h;
-  // Taken before dispatching, as in useNewTerminal: a handler that itself queues would otherwise
-  // have its request dropped by the clear below.
-  const queued = pending;
-  pending = [];
-  queued.forEach((req) => h(req));
-  return () => {
-    if (handler === h) handler = null;
-  };
+  return queue.register(h);
 }
 
 /** Show a spawned chat as a grid cell. If the grid isn't mounted yet, queue it and switch to it. */
 export function placeSpawnedChat(req: SpawnedChatRequest): void {
   // `true` for a queued request too: the grid will have it as soon as it registers, so the grid is
   // still where the user should be looking.
-  const goingToTheGrid = handler ? handler(req) : (pending.push(req), true);
+  const goingToTheGrid = queue.deliver(req, true);
   // Then SHOW the grid. Mounted is not the same as on screen: since #1190 the grid stays alive
   // UNDERNEATH a full-screen overlay, so a chat started from the collections browser is placed
   // into a grid the user cannot see. Navigating is also what closes that overlay — before the grid
@@ -78,6 +70,5 @@ export function placeSpawnedChat(req: SpawnedChatRequest): void {
 
 /** Test seam: drop anything queued by a previous case. Not used by the app. */
 export function resetSpawnedChatQueue(): void {
-  handler = null;
-  pending = [];
+  queue.reset();
 }

--- a/test/src/composables/handlerQueue.spec.ts
+++ b/test/src/composables/handlerQueue.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { createHandlerQueue, type HandlerQueue } from "../../../src/composables/handlerQueue";
+
+describe("createHandlerQueue", () => {
+  it("hands a request to the live handler and answers with what it returned", () => {
+    const queue = createHandlerQueue<string, boolean>();
+    const handler = vi.fn(() => false);
+    queue.register(handler);
+    expect(queue.deliver("a", true)).toBe(false);
+    expect(handler).toHaveBeenCalledWith("a");
+  });
+
+  it("queues while nothing is registered and answers with queuedResult", () => {
+    const queue = createHandlerQueue<string, boolean>();
+    expect(queue.deliver("a", true)).toBe(true);
+  });
+
+  // Every waiting request, in arrival order: the callers answer each one with success, so a
+  // dropped request is work reported as done that never happened (#831).
+  it("drains everything queued, in arrival order, on register", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    queue.deliver("first", undefined);
+    queue.deliver("second", undefined);
+    queue.deliver("third", undefined);
+    const handler = vi.fn();
+    queue.register(handler);
+    expect(handler.mock.calls).toEqual([["first"], ["second"], ["third"]]);
+  });
+
+  it("hands the handler the request alone — not forEach's index and array", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    queue.deliver("only", undefined);
+    const handler = vi.fn();
+    queue.register(handler);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("only");
+  });
+
+  it("empties the queue once drained, so a later register replays nothing", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    queue.deliver("once", undefined);
+    queue.register(vi.fn())();
+    const second = vi.fn();
+    queue.register(second);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  // A request made from inside the draining handler (it can reach the opener through the grid)
+  // must not be dropped by the clear that follows the drain — which is why the queue is taken
+  // and emptied before anything is dispatched.
+  it("does not lose a request made from inside the draining handler", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    queue.deliver("first", undefined);
+    const seen: string[] = [];
+    queue.register((req) => {
+      seen.push(req);
+      if (req === "first") queue.deliver("from-handler", undefined);
+    });
+    expect(seen).toEqual(["first", "from-handler"]);
+  });
+
+  it("a stale unregister does not detach a newer handler", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    const first = vi.fn();
+    const second = vi.fn();
+    const offFirst = queue.register(first);
+    queue.register(second);
+    offFirst();
+    queue.deliver("a", undefined);
+    expect(second).toHaveBeenCalledWith("a");
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("reset drops the handler and anything waiting", () => {
+    const queue: HandlerQueue<string, void> = createHandlerQueue();
+    queue.deliver("waiting", undefined);
+    queue.reset();
+    const handler = vi.fn();
+    queue.register(handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/test/src/composables/modalKeyboard.spec.ts
+++ b/test/src/composables/modalKeyboard.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { defineComponent, h, ref, nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import { MODAL_FOCUSABLE } from "../../../src/utils/focusTrap";
+import { modalKeydownHandler, useModalKeyboard } from "../../../src/composables/useModalKeyboard";
+
+// jsdom only tracks document.activeElement for attached elements, so every dialog is mounted
+// into document.body.
+function dialog(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+function key(name: string, shift = false): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: name, shiftKey: shift, cancelable: true });
+}
+
+describe("modalKeydownHandler", () => {
+  let el: HTMLElement | null = null;
+  afterEach(() => {
+    el?.remove();
+    el = null;
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    modalKeydownHandler({ modalEl: { value: null }, onClose })(key("Escape"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("traps Tab inside the dialog", () => {
+    el = dialog('<button id="a">a</button><button id="b">b</button>');
+    el.querySelector<HTMLElement>("#b")?.focus();
+    const e = key("Tab");
+    modalKeydownHandler({ modalEl: { value: el }, onClose: vi.fn() })(e);
+    expect(document.activeElement).toBe(el.querySelector("#a"));
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  // The dialogs that open on demand keep this handler bound while closed, so a Tab arriving with
+  // no dialog element must fall through to the page rather than be swallowed.
+  it("leaves Tab alone when there is no dialog element", () => {
+    const e = key("Tab");
+    modalKeydownHandler({ modalEl: { value: null }, onClose: vi.fn() })(e);
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("passes the trap selector through, so a text field is reachable", () => {
+    el = dialog('<textarea id="text"></textarea><button id="btn">b</button>');
+    el.querySelector<HTMLElement>("#text")?.focus();
+    const e = key("Tab", true);
+    modalKeydownHandler({ modalEl: { value: el }, onClose: vi.fn(), trapSelector: MODAL_FOCUSABLE })(e);
+    expect(document.activeElement).toBe(el.querySelector("#btn"));
+  });
+
+  it("ignores every other key", () => {
+    const onClose = vi.fn();
+    const e = key("Enter");
+    modalKeydownHandler({ modalEl: { value: el }, onClose })(e);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+});
+
+// A dialog that exists only while open: it listens for its whole lifetime, and must stop when it
+// goes away — a handler left on the document closes a modal that is no longer there.
+describe("useModalKeyboard", () => {
+  const modalWith = (onClose: () => void) =>
+    defineComponent({
+      setup() {
+        const modalEl = ref<HTMLElement>();
+        useModalKeyboard({ modalEl, onClose, trapSelector: MODAL_FOCUSABLE, focusSelector: "input, button" });
+        return () => h("div", { ref: modalEl }, [h("button", "close"), h("input")]);
+      },
+    });
+
+  it("closes on Escape while mounted, and stops listening once unmounted", () => {
+    const onClose = vi.fn();
+    const wrapper = mount(modalWith(onClose), { attachTo: document.body });
+    document.dispatchEvent(key("Escape"));
+    expect(onClose).toHaveBeenCalledOnce();
+
+    wrapper.unmount();
+    document.dispatchEvent(key("Escape"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("focuses the dialog's first control on mount, so the trap is reachable from the keyboard", async () => {
+    const wrapper = mount(modalWith(vi.fn()), { attachTo: document.body });
+    await nextTick();
+    expect(document.activeElement).toBe(wrapper.find("button").element);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Code scanning (jscpd) が open で報告していた重複コード 4 件（alert 136 / 137 / 138 / 139）を 0 にする。
挙動は変えていない。抽出先には単体テストを足し、CI と同じ引数の jscpd をローカルで回して `Found 0 clones.` を確認済み。

| alert | 重複していた場所 | 対応 |
|---|---|---|
| 139 | `server/routes/ws-routes.ts` codex ↔ antigravity ハンドラ | `admitAgentSession()` に集約（claude / launch も同じ 4 行だったので 4 ハンドラすべて） |
| 136 | `ModelSetupHelp.vue` ↔ `SettingsModal.vue` のモーダル keyboard 処理 | `src/composables/useModalKeyboard.ts`（`CopyCodeBlock` / `TimelineOverlay` も同じハンドラを使うよう統一） |
| 137 | `SettingsModal.vue` ↔ `NotificationSoundsSection.vue` の emit 宣言 | `src/components/settings/soundEmits.ts` の `SoundEmits`（`GridCellEmits` と同じやり方） |
| 138 | `useNewTerminal.ts` ↔ `useSpawnedChat.ts` の queue 実装 | `src/composables/handlerQueue.ts` の `createHandlerQueue<Req, Ret>()` |

## Items to Confirm / Review

- **`admitAgentSession` に claude と launch も通した**のは、報告されていた codex ↔ antigravity 以外にも同じ 4 行が
  あったため（重複は 2 箇所ではなく実質 4 箇所）。順序（拒否は browser に session id を伝える *前*）は保存している。
  launch だけ「codex を起動する launcher のときだけ worktree 制限を受ける」ので `worktreeLimited` フラグで表現した。
  ここは実サーバでの動作確認もしている（下記）。
- **`devTerminal` という名前**にした（元は `!attachGuiMcp`）。launch は GUI MCP の話ではなく常に dev terminal なので、
  4 ハンドラで意味が通る名前に寄せた。
- **`SoundEmits` を intersection で使っている**（`defineEmits<SoundEmits & { ... }>()`）。既存の `GridCellEmits` と同じ形。
- **`createHandlerQueue<Req, void>()` ではなく型注釈**（`const queue: HandlerQueue<Req, void> = createHandlerQueue()`）
  にしているのは、`@typescript-eslint/no-invalid-void-type` が call の型引数の `void` を通さないため。理由をコメントに残した。
- `modalKeydownHandler` / `useModalKeyboard` の 2 段構成は、4 つのダイアログで listener の付け外しの
  タイミングだけが違うため（mount 中ずっと / 開いた瞬間だけ / watch 駆動）。

## User Prompt

> 重複減らす
> https://github.com/receptron/mulmoterminal/security/code-scanning

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build`
- `yarn test` — 515 files / 7508 tests passed
- jscpd 5.0.12（CI と同じ `--format typescript,vue` + 同じ ignore）→ **Found 0 clones.**
- **実サーバでの動作確認**（build が通る ≠ 動く、なので ws-routes の変更は実際に繋いで確認した）。
  scratch の `HOME` と別ポートでサーバを起動し、`ws` クライアントで接続:
  - `/ws/launch?shell=1` — `session` フレームが来て、`echo MULMO_SMOKE_OK` の出力が実際に返る
  - `/ws`（claude）/ `/ws/codex` — どちらも `session` フレーム + 端末出力
  - managed worktree に claude を 2 本張る → 2 本目は `session` フレームなしで
    「this worktree's session is open in another terminal ...」の refusal が返る
    （＝拒否が session 通知より前、という壊れやすい順序が保たれている）

refs #1289

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard accessibility across copy, setup, settings, and timeline modals, including Escape-to-close, focus trapping, and initial focus.
  * Improved reliability when connecting agent sessions and handling queued terminal or chat requests.
  * Standardized notification sound event handling.

* **Bug Fixes**
  * Prevented stale handlers and inconsistent request processing during connection and navigation flows.

* **Tests**
  * Added coverage for modal accessibility behavior, request queuing, cleanup, ordering, and reset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->