### PR TITLE
fix: 3ファイルの as を3箇所外す (#1231)

### DIFF
--- a/server/backends/remoteHost/collectionPage.ts
+++ b/server/backends/remoteHost/collectionPage.ts
@@ -9,6 +9,7 @@ import { clampLimit, clampOffset } from "@mulmoclaude/core/remote-view";
 import { deriveAll, type DerivableFieldSpec, type DerivableRecord } from "@mulmoclaude/core/collection";
 import type { JsonObject } from "@mulmoclaude/core/remote-host";
 import { jsonPayload } from "./jsonPayload.js";
+import { isRecord } from "../../../common/isRecord.js";
 
 export { clampLimit, clampOffset };
 
@@ -17,7 +18,7 @@ export { clampLimit, clampOffset };
  *  the channel, so formulas that dereference `ref` fields stay absent (parity
  *  with MulmoClaude's channel path). */
 export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec> }, items: unknown[]): DerivableRecord[] =>
-  items.map((item) => deriveAll({ fields: schema.fields ?? {} }, item as DerivableRecord, {}));
+  items.flatMap((item) => (isRecord(item) ? [deriveAll({ fields: schema.fields ?? {} }, item, {})] : []));
 
 /** Build the paginated result.
  *

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -31,10 +31,14 @@ export const manageCollectionHandler = tool.handler;
  *  applies to XTool-shaped server tools. The core definition types its
  *  inputSchema loosely (`type: string`); the runtime value is the literal
  *  "object" the protocol type wants, so re-stamp it. */
+// Annotated, not asserted: the spread widens `type` back to `string`, and an annotation makes the
+// compiler check the result against what the protocol wants instead of being told.
+const collectionToolParameters: NonNullable<ToolDefinition["parameters"]> = { ...tool.definition.inputSchema, type: "object" };
+
 export const MANAGE_COLLECTION: ToolDefinition = {
   type: "function",
   name: tool.definition.name,
   description: tool.definition.description,
   prompt: tool.prompt,
-  parameters: { ...tool.definition.inputSchema, type: "object" } as NonNullable<ToolDefinition["parameters"]>,
+  parameters: collectionToolParameters,
 };

--- a/src/composables/useMcpToolGroups.ts
+++ b/src/composables/useMcpToolGroups.ts
@@ -9,10 +9,12 @@ import { queueMcpWrite } from "../components/mcpWriteQueue";
 //
 // One record per group rather than a flag per group: the switches differ only in the group they
 // name, so adding one to TOOL_GROUPS should not mean another copy of this block.
-// The cast is Object.fromEntries's signature, which types every key as `string` and so cannot say
-// that a mapping over TOOL_GROUPS covers exactly the groups; writing the four keys out instead
-// would defeat the point of deriving them.
-const byToolGroup = <T>(value: T): Record<ToolGroup, T> => Object.fromEntries(TOOL_GROUPS.map((group) => [group, value])) as Record<ToolGroup, T>;
+// The four groups spelled out, which reads like a step back from deriving them — and is not.
+// `Object.fromEntries` types every key as `string`, so it cannot say the result covers ToolGroup;
+// the assertion that used to bridge that gap ACCEPTS a missing key silently. Written out against a
+// `Record<ToolGroup, T>` annotation, a group added to TOOL_GROUPS makes this a compile error
+// instead — the reminder arrives, rather than a switch quietly never appearing.
+const byToolGroup = <T>(value: T): Record<ToolGroup, T> => ({ render: value, data: value, media: value, external: value });
 
 interface Switches {
   // The directory the switches currently describe. Null means there is nothing to show — either


### PR DESCRIPTION
## Summary

#1231。3 ファイル・**3 箇所**。**13 → 10**。allowlist は **0 件**。

## Items to Confirm / Review

### `useMcpToolGroups` — 一見「導出をやめた」ように見えますが、逆です

```diff
-const byToolGroup = <T>(value: T): Record<ToolGroup, T> => Object.fromEntries(TOOL_GROUPS.map((g) => [g, value])) as Record<ToolGroup, T>;
+const byToolGroup = <T>(value: T): Record<ToolGroup, T> => ({ render: value, data: value, media: value, external: value });
```

元のコメントはこう書いていました。

> writing the four keys out instead would defeat the point of deriving them.

**ですが、アサーションはキーが欠けても黙って通します。** グループを増やしたとき、`Object.fromEntries` は実行時には拾いますが、この関数を使う側の型は `Record<ToolGroup, T>` のままなので、**型の上では何も起きません**。

書き下すと逆に**コンパイルエラーになります**。実際に 5 つ目を足して確認しました。

```
src/composables/useMcpToolGroups.ts:17:61 - error TS2741:
  Property 'probe' is missing in type '{ render: T; data: T; media: T; external: T; }'
  but required in type 'Record<"data" | "render" | "external" | "probe" | "media", T>'.
```

つまり「グループ追加時にここを直す必要がある」のは同じで、**違いは気づけるかどうか**です。

> 余談ですが、`yarn typecheck`（`vue-tsc -b`）はインクリメンタルなのでこの検証では検出できず、`--force` が必要でした。

### 残り 2 件は素直なもの

- `collectionPage.ts` — `DerivableRecord` の定義は `Record<string, unknown>` なので `isRecord` で足ります。オブジェクトでない要素は飛ばします（`deriveAll` に渡しても意味がないため）。
- `collection-tool.ts` — spread が `type` を `string` へ広げるのが原因。**注釈**にすればコンパイラが検査します。

## 検証

`yarn lint`（0 error、15 problems ← 18）/ `typecheck` ×3 / `build` / `test` **7525 passed**。

refs #1231

work in mulmoterminal3
