### PR TITLE
fix: 自前ジェネリック2つをやめて as を2箇所外す (#1231)

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -8,6 +8,7 @@ import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups"
 import { reconcileCollectionCard } from "../../common/collectionSeed";
 import { collapseByIdentity } from "../utils/canvasCollapse";
 import { useCanvasCardHeight } from "../composables/useCanvasCardHeight";
+import { isRecord } from "../../common/isRecord";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -39,6 +40,22 @@ const emit = defineEmits<{ toggleTools: [] }>();
 
 const results = ref<ToolResult[]>([]);
 
+// One card off the live channel. The channel carries untrusted JSON, and this panel keys and
+// dedupes by uuid — a card without one is not something it can render. The optional fields are
+// carried through as they arrive (each is `unknown` or a string the views check themselves).
+function readToolResult(raw: unknown): ToolResult | null {
+  if (!isRecord(raw) || typeof raw.uuid !== "string" || typeof raw.toolName !== "string") return null;
+  return {
+    uuid: raw.uuid,
+    toolName: raw.toolName,
+    ...(typeof raw.title === "string" ? { title: raw.title } : {}),
+    ...(typeof raw.message === "string" ? { message: raw.message } : {}),
+    ...(raw.data !== undefined ? { data: raw.data } : {}),
+    ...(raw.jsonData !== undefined ? { jsonData: raw.jsonData } : {}),
+    ...(raw.viewState !== undefined ? { viewState: raw.viewState } : {}),
+  };
+}
+
 // Auto-follow state. Declared HERE, above useSessionFeed: its session watcher is `immediate`, so
 // the onSessionChange below runs during that call — a declaration further down would still be in
 // its temporal dead zone when it fires.
@@ -55,6 +72,9 @@ const { upsert } = useSessionFeed(results, {
   historyKey: "toolResults",
   channel: (id) => `session:${id}`,
   identify: (result) => result.uuid,
+  // The channel carries untrusted JSON; a card with no uuid cannot be deduped or keyed, so it is
+  // not a result this panel can render.
+  parse: readToolResult,
   // The one pair uuid dedupe cannot relate: a collection placeholder seeded by the browser at
   // spawn, and the agent's own presentCollection card for the same collection. Different writers,
   // different uuids, one thing on screen — the real card wins. The server applies the same rule to

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -2,6 +2,7 @@
 import { ref, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
+import { isRecord } from "../../common/isRecord";
 
 // The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
 // (the GUI plugin tools, with collapsible descriptions) and a "Tool Call History"
@@ -39,6 +40,24 @@ const guiOnlyHistory = ref(false);
 
 const availableTools = ref<AvailableTool[]>([]);
 const toolCalls = ref<ToolCall[]>([]);
+
+// One call off the live channel. `toolName`, `status` and `at` are what every row renders from;
+// without them there is no row to draw.
+const CALL_STATUSES: readonly ToolCall["status"][] = ["running", "completed", "failed"];
+function readToolCall(raw: unknown): ToolCall | null {
+  if (!isRecord(raw) || typeof raw.toolName !== "string" || typeof raw.at !== "number") return null;
+  const status = CALL_STATUSES.find((known) => known === raw.status);
+  if (!status) return null;
+  return {
+    toolName: raw.toolName,
+    status,
+    at: raw.at,
+    ...(typeof raw.toolUseId === "string" ? { toolUseId: raw.toolUseId } : {}),
+    ...(raw.toolInput !== undefined ? { toolInput: raw.toolInput } : {}),
+    ...(raw.toolOutput !== undefined ? { toolOutput: raw.toolOutput } : {}),
+    ...(typeof raw.durationMs === "number" ? { durationMs: raw.durationMs } : {}),
+  };
+}
 const expandedTools = ref<Set<string>>(new Set());
 const expandedCalls = ref<Set<string>>(new Set());
 
@@ -105,6 +124,7 @@ useSessionFeed(toolCalls, {
   historyKey: "toolCalls",
   channel: (id) => `toolcalls:${id}`,
   identify: (call) => call.toolUseId,
+  parse: readToolCall,
   onSessionChange: () => {
     expandedCalls.value = new Set();
   },

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -3,7 +3,7 @@ import { presetLabel, type CwdPreset } from "../components/presets";
 import type { Launcher } from "../components/launchers";
 import type { UserMcpServer } from "../components/userMcp";
 import type { QuickCommand } from "../../common/quickCommands";
-import type { PushKind } from "../../common/pushKinds";
+import { isPushKind, type PushKind } from "../../common/pushKinds";
 import { DEFAULT_SOUND_KINDS, isNotifyKind, type NotifyKind } from "../../common/notifyKinds";
 import { isRecord } from "../../common/isRecord";
 import { readSoundMap, type SoundMap } from "./soundSettings";
@@ -99,16 +99,23 @@ function readLegacyRecents(): string[] {
 // POST a single config field as a partial update; the server keeps the other fields, so
 // this never clobbers them. Returns the server's echoed value for that field (or
 // `{ ok: false }` on failure) so each caller can update just its own singleton ref.
-async function postConfigField<T>(field: string, value: unknown): Promise<{ ok: true; value: T } | { ok: false }> {
+async function postConfigField(field: string, value: unknown): Promise<{ ok: true; value: unknown } | { ok: false }> {
   try {
     const res = await fetch("/api/config", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ [field]: value }) });
     if (!res.ok) return { ok: false };
-    const body: Record<string, unknown> = await res.json();
-    return { ok: true, value: body[field] as T };
+    const body: unknown = await res.json();
+    // `unknown`, not a caller-named `T`: this is the server's echo, and the type argument used to
+    // let each caller DECLARE the shape it wanted. Several already narrowed it anyway; now all do.
+    return { ok: true, value: isRecord(body) ? body[field] : undefined };
   } catch {
     return { ok: false };
   }
 }
+
+const stringsOf = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
+const isQuickCommand = (value: unknown): value is QuickCommand => isRecord(value) && typeof value.label === "string" && typeof value.command === "string";
+const isUserMcpServer = (value: unknown): value is UserMcpServer => isRecord(value) && typeof value.name === "string";
+const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typeof value.label === "string" && typeof value.command === "string";
 
 // The record/remove/migrate preset mutations. Each preset write POSTs the whole array, so
 // concurrent record/remove calls (two grid cells launching at once) must not each derive
@@ -216,20 +223,20 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
 // they're module-level (no per-composable state) — useAppConfig just re-exports them.
 // Persist just the custom attention sound (a file path, or null to use the chime).
 async function saveSound(file: string | null): Promise<boolean> {
-  const r = await postConfigField<unknown>("soundFile", file);
+  const r = await postConfigField("soundFile", file);
   if (r.ok) soundFile.value = typeof r.value === "string" ? r.value : null;
   return r.ok;
 }
 // Persist the "send a Web Push on task finish" toggle (partial update).
 async function savePushEnabled(on: boolean): Promise<boolean> {
-  const r = await postConfigField<unknown>("pushEnabled", on);
+  const r = await postConfigField("pushEnabled", on);
   if (r.ok) pushEnabled.value = r.value === true;
   return r.ok;
 }
 // Persist the cross-repo PR list's repos (partial update, other fields untouched).
 async function savePrRepos(next: string[]): Promise<boolean> {
-  const r = await postConfigField<string[]>("prRepos", next);
-  if (r.ok) prRepos.value = r.value ?? [];
+  const r = await postConfigField("prRepos", next);
+  if (r.ok) prRepos.value = stringsOf(r.value);
   return r.ok;
 }
 
@@ -280,45 +287,45 @@ const readRepoDirs = (raw: Record<string, unknown>): Record<string, string> => {
 // replacing it: this is called with one repo's answer, and a whole-map write would drop every
 // other repo's choice.
 async function saveRepoDir(repo: string, dir: string): Promise<boolean> {
-  const r = await postConfigField<Record<string, unknown>>("repoDirs", { ...repoDirs.value, [repo]: dir });
+  const r = await postConfigField("repoDirs", { ...repoDirs.value, [repo]: dir });
   if (r.ok) repoDirs.value = isRecord(r.value) ? readRepoDirs(r.value) : repoDirs.value;
   return r.ok;
 }
 // Persist the cell-launcher commands (partial update).
 async function saveLaunchers(next: Launcher[]): Promise<boolean> {
-  const r = await postConfigField<Launcher[]>("launchers", next);
-  if (r.ok) launchers.value = r.value ?? [];
+  const r = await postConfigField("launchers", next);
+  if (r.ok) launchers.value = Array.isArray(r.value) ? r.value.filter(isLauncher) : [];
   return r.ok;
 }
 // Persist which kinds of push to send (partial update).
 async function savePushKinds(next: PushKind[]): Promise<boolean> {
-  const r = await postConfigField<PushKind[]>("pushKinds", next);
-  if (r.ok) pushKinds.value = r.value ?? [];
+  const r = await postConfigField("pushKinds", next);
+  if (r.ok) pushKinds.value = Array.isArray(r.value) ? r.value.filter(isPushKind) : [];
   return r.ok;
 }
 // Persist which moments beep (partial update).
 async function saveSoundKinds(next: NotifyKind[]): Promise<boolean> {
-  const r = await postConfigField<NotifyKind[]>("soundKinds", next);
-  if (r.ok) soundKinds.value = r.value ?? [];
+  const r = await postConfigField("soundKinds", next);
+  if (r.ok) soundKinds.value = Array.isArray(r.value) ? r.value.filter(isNotifyKind) : [];
   return r.ok;
 }
 // Persist the per-kind sounds (partial update). The whole map goes each time — the server
 // merges by FIELD, not by key, so sending one kind would drop the others.
 async function saveSounds(next: SoundMap): Promise<boolean> {
-  const r = await postConfigField<SoundMap>("sounds", next);
-  if (r.ok) sounds.value = r.value ?? {};
+  const r = await postConfigField("sounds", next);
+  if (r.ok) sounds.value = isRecord(r.value) ? readSoundMap(r.value) : {};
   return r.ok;
 }
 // Persist the phone quick commands (partial update).
 async function saveQuickCommands(next: QuickCommand[]): Promise<boolean> {
-  const r = await postConfigField<QuickCommand[]>("quickCommands", next);
-  if (r.ok) quickCommands.value = r.value ?? [];
+  const r = await postConfigField("quickCommands", next);
+  if (r.ok) quickCommands.value = Array.isArray(r.value) ? r.value.filter(isQuickCommand) : [];
   return r.ok;
 }
 // Persist the user MCP servers (partial update).
 async function saveUserMcpServers(next: UserMcpServer[]): Promise<boolean> {
-  const r = await postConfigField<UserMcpServer[]>("userMcpServers", next);
-  if (r.ok) userMcpServers.value = r.value ?? [];
+  const r = await postConfigField("userMcpServers", next);
+  if (r.ok) userMcpServers.value = Array.isArray(r.value) ? r.value.filter(isUserMcpServer) : [];
   return r.ok;
 }
 

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -113,8 +113,8 @@ async function postConfigField(field: string, value: unknown): Promise<{ ok: tru
 }
 
 const stringsOf = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
-const isQuickCommand = (value: unknown): value is QuickCommand => isRecord(value) && typeof value.label === "string" && typeof value.command === "string";
-const isUserMcpServer = (value: unknown): value is UserMcpServer => isRecord(value) && typeof value.name === "string";
+const isQuickCommand = (value: unknown): value is QuickCommand => isRecord(value) && typeof value.label === "string" && typeof value.text === "string";
+const isUserMcpServer = (value: unknown): value is UserMcpServer => isRecord(value) && typeof value.id === "string" && typeof value.url === "string";
 const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typeof value.label === "string" && typeof value.command === "string";
 
 // The record/remove/migrate preset mutations. Each preset write POSTs the whole array, so

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -11,6 +11,13 @@ interface SessionFeedOptions<T> {
   historyKey: string;
   channel: (id: string) => string;
   identify: (item: T) => string | undefined;
+  /**
+   * Read one item off the live channel, or null to drop it.
+   *
+   * The channel carries `unknown`, and this used to be `data as T` — the composable naming a shape
+   * only the CALLER knows (#1231). Each caller supplies the reader for its own item instead.
+   */
+  parse: (raw: unknown) => T | null;
   onSessionChange?: () => void;
   /**
    * Fold an arriving item into the list by something OTHER than its identity, before the dedupe
@@ -43,8 +50,17 @@ function mergeSettled<T>(snapshot: readonly T[], buffered: readonly T[], identif
   return settled;
 }
 
+// The channel listener: read the frame with the CALLER's reader, and drop what it rejects. At
+// module scope so the composable stays inside its line budget.
+const receiver =
+  <T>(parse: (raw: unknown) => T | null, upsert: (item: T) => void) =>
+  (data: unknown): void => {
+    const item = parse(data);
+    if (item) upsert(item);
+  };
+
 export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
-  const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange, reconcile } = options;
+  const { sessionId, historyUrl, historyKey, channel, identify, parse, onSessionChange, reconcile } = options;
 
   // What the live channel delivered while a history request was in flight. The response is
   // authoritative as of when it was SENT, so these have to survive it (#620 F1).
@@ -105,7 +121,7 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
     unsubscribe?.();
     unsubscribe = undefined;
     if (!id) return;
-    unsubscribe = subscribe(channel(id), (data) => upsert(data as T));
+    unsubscribe = subscribe(channel(id), receiver(parse, upsert));
   }
 
   watch(

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -139,3 +139,40 @@ describe("useAppConfig — auto preset recording", () => {
     expect(presets.value.map((p) => p.path).sort()).toEqual(["/a", "/b"]);
   });
 });
+
+// A saver reads the server's ECHO back into its ref. When the reader that validates that echo
+// disagrees with the real interface, every entry is filtered out and the list silently EMPTIES on
+// save — which is what a wrong field name did here (Codex review on #1294).
+describe("useAppConfig — a save keeps what the server echoed", () => {
+  // Echo whatever was posted, as the real /api/config does for a partial update.
+  function echoPosted() {
+    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
+      const body: Record<string, unknown> = init?.body ? JSON.parse(init.body) : {};
+      return { ok: true, json: async () => body };
+    }) as unknown as typeof fetch;
+  }
+
+  beforeEach(echoPosted);
+
+  it("keeps quick commands after saving them", async () => {
+    const { quickCommands, saveQuickCommands } = useAppConfig();
+    const next = [{ label: "Deploy", text: "/deploy" }];
+    expect(await saveQuickCommands(next)).toBe(true);
+    expect(quickCommands.value).toEqual(next);
+  });
+
+  it("keeps user MCP servers after saving them", async () => {
+    const { userMcpServers, saveUserMcpServers } = useAppConfig();
+    const next = [{ id: "docs", url: "https://example.test/mcp" }];
+    expect(await saveUserMcpServers(next)).toBe(true);
+    expect(userMcpServers.value).toEqual(next);
+  });
+
+  it("keeps launchers and pr repos after saving them", async () => {
+    const { launchers, saveLaunchers, prRepos, savePrRepos } = useAppConfig();
+    expect(await saveLaunchers([{ label: "zsh", command: "/bin/zsh" }])).toBe(true);
+    expect(launchers.value).toEqual([{ label: "zsh", command: "/bin/zsh" }]);
+    expect(await savePrRepos(["receptron/mulmoterminal"])).toBe(true);
+    expect(prRepos.value).toEqual(["receptron/mulmoterminal"]);
+  });
+});

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { defineComponent, h, ref, nextTick } from "vue";
 import { flushPromises, mount } from "@vue/test-utils";
+import { isRecord } from "../../../common/isRecord";
 
 const handlers = new Map<string, (data: unknown) => void>();
 vi.mock("../../../src/composables/usePubSub", () => ({
@@ -37,6 +38,9 @@ function mountFeed(respond: () => Promise<{ ok: boolean; json?: () => Promise<un
           historyKey: "items",
           channel: (id) => `feed:${id}`,
           identify: (item) => item.id,
+          // The channel carries untrusted JSON; the composable no longer names the item type for
+          // its caller (#1231), so the test supplies the same reader a real caller would.
+          parse: (raw) => (isRecord(raw) && typeof raw.id === "string" && typeof raw.text === "string" ? { id: raw.id, text: raw.text } : null),
           ...(reconcile ? { reconcile } : {}),
         });
         return () => h("div");


### PR DESCRIPTION
## Summary

#1231。4 ファイル・**2 箇所**。**10 → 8**。allowlist は **0 件**。

どちらも「呼び出し側が型を名乗り、実装側は検証できない `T` を作らされる」形です。gui-chat-protocol の `dispatch<T>` と構造は同じですが、**こちらはこのリポジトリが自分で導入したジェネリック**なので変えられます。

## Items to Confirm / Review

### 1. `postConfigField<T>` — 呼び出し側の一部は既に narrow していました

戻りは `body[field] as T` で、サーバのエコー（untrusted JSON）を呼び出し側の宣言どおりだと信じていました。**ところが実際には、一部の呼び出し側は既に narrow していました。**

```ts
if (r.ok) soundFile.value = typeof r.value === "string" ? r.value : null;   // 検証している
if (r.ok) repoDirs.value  = isRecord(r.value) ? readRepoDirs(r.value) : …;  // 検証している
if (r.ok) prRepos.value   = r.value ?? [];                                  // 信じている
```

**同じ関数の戻り値を、片方は疑い片方は信じる**という状態だったので、戻りを `unknown` にして全員が narrow する形に揃えました。既存の `isPushKind` / `isNotifyKind` / `readSoundMap` を再利用し、無かった 3 つ（`isLauncher` / `isQuickCommand` / `isUserMcpServer`）だけ足しています。

### 2. `useSessionFeed<T>` — `parse` を呼び出し側から受け取る

`upsert(data as T)` を `parse` オプションに置き換えました。GuiPanel と ToolsPane がそれぞれ自分のアイテムの読み方を渡します。必須フィールド（`uuid` / `toolName` / `status` / `at`）を欠くフレームは落ちます — **どれもその行を描画するのに要るもの**なので、無ければ描ける行がありません。

`receiver` は module scope に置いています（`max-lines-per-function` の 60 行を超えたため）。

## 検証

`yarn lint`（0 error、13 problems ← 15）/ `typecheck` / `typecheck:server` / **`typecheck:test`** / `build` / `test` **7525 passed**。

> `typecheck` は通るのに `typecheck:test` が落ちる場面がまたありました（`vue-tsc -b` のインクリメンタルキャッシュが古い結果を返す）。4 つとも回しています。

Canvas と Tools ペインのデータ経路なので、実ブラウザでも描画と console error 0 を確認しました。

refs #1231

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of incoming session-feed and tool-call data.
  * Invalid, incomplete, or unsupported records are now discarded instead of being displayed.
  * Configuration updates now verify server responses before applying changes.
  * Preserved optional values only when they use supported formats, improving feed and configuration reliability.

* **Tests**
  * Added coverage for accepting valid feed entries and rejecting malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->