### PR TITLE
fix: プラグインへ渡す引数の as を2箇所外す (#1231)

### DIFF
--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -17,7 +17,7 @@
 //      from a second, uncontained mount — `/htmlfile` (mountHtmlFileRoute below).
 import path from "node:path";
 import type { Express, Request, Response, NextFunction } from "express";
-import { executeHtmlDispatch, HTML_FILE_MOUNT } from "@mulmoclaude/html-plugin";
+import { executeHtmlDispatch, isHtmlDispatchArgs, HTML_FILE_MOUNT } from "@mulmoclaude/html-plugin";
 import { SANDBOXED_VIEW_CDN_ALLOWLIST } from "@mulmoclaude/core/remote-view";
 import { artifactsFileOps } from "./artifacts.js";
 import { htmlByPath, resolveHtmlRequest } from "./openPath.js";
@@ -77,11 +77,18 @@ export function mountHtmlDispatchRoute(app: Express): void {
     const args: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     // A tool-call (no `kind`) is left to the package execute via the catch-all.
     if (args.kind !== "loadHtml" && args.kind !== "saveHtml") return next();
+    // The package's OWN guard, rather than an assertion here: it exists because `saveHtml` with a
+    // non-string `html` would reach `files.artifacts.write` and BLANK the artifact (its contract
+    // says so). Asserting the shape skipped exactly that check.
+    if (!isHtmlDispatchArgs(args)) {
+      res.status(400).json({ error: "invalid presentHtml dispatch args" });
+      return;
+    }
     try {
       // `byPath` is what lets the source editor load/save a page OUTSIDE
       // artifacts/html — presentHtml's `path` form takes any .html on disk. Without
       // it the package degrades to its old artifacts-only behaviour.
-      const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps, byPath: htmlByPath } }, args as never);
+      const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps, byPath: htmlByPath } }, args);
       if (args.kind === "saveHtml" && typeof args.path === "string") {
         // Live-refresh via the shared publisher: the "html" scope forwards to
         // plugin:html:file:<path>, the channel the open View subscribes to.

--- a/server/backends/mulmoscript.ts
+++ b/server/backends/mulmoscript.ts
@@ -122,7 +122,16 @@ async function handleToolCall(body: Record<string, unknown>, res: Response, inst
     res.json({ message: guard.error });
     return;
   }
-  const outcome = await executeMulmoScriptSave({ files: { artifacts: instance.backend.artifacts } }, body as SaveMulmoScriptArgs);
+  // Built from the checked fields rather than asserted: every field of SaveMulmoScriptArgs is
+  // optional, so a body that is missing or mistypes one is a valid call the package rejects on its
+  // own terms — while the assertion handed it, say, a numeric `filePath` typed as a string.
+  const args: SaveMulmoScriptArgs = {
+    ...(body.script !== undefined ? { script: body.script } : {}),
+    ...(typeof body.filename === "string" ? { filename: body.filename } : {}),
+    ...(typeof body.filePath === "string" ? { filePath: body.filePath } : {}),
+    ...(typeof body.autoGenerateMovie === "boolean" ? { autoGenerateMovie: body.autoGenerateMovie } : {}),
+  };
+  const outcome = await executeMulmoScriptSave({ files: { artifacts: instance.backend.artifacts } }, args);
   if (!outcome.ok) {
     res.json({ message: outcome.error, instructions: "Acknowledge the error and retry with a valid `script` (new) or an existing `filePath`." });
     return;


### PR DESCRIPTION
## Summary

#1231。2 ファイル・**2 箇所**。**8 → 6**。allowlist は **0 件**。

どちらも「untyped な `req.body` をパッケージの型付き関数へ渡す」形です。

## Items to Confirm / Review

### 1. `html.ts` — パッケージが guard を export していました

`args as never` を消そうとして、`@mulmoclaude/html-plugin` が **`isHtmlDispatchArgs` を export している**ことに気づきました。しかもその contract にこう書いてあります。

> `saveHtml` additionally requires `html` to be a string — without that, `undefined` would reach `files.artifacts.write` and blank the artifact.

**アサーションはまさにその検査を飛ばしていました。** `kind` だけ見て、`html` が文字列かは見ていません。パッケージ自身の guard を使い、通らなければ 400 を返します。

```diff
+    if (!isHtmlDispatchArgs(args)) {
+      res.status(400).json({ error: "invalid presentHtml dispatch args" });
+      return;
+    }
-    const result = await executeHtmlDispatch({ … }, args as never);
+    const result = await executeHtmlDispatch({ … }, args);
```

### 2. `mulmoscript.ts` — 全フィールドが optional なので組み立てられます

`SaveMulmoScriptArgs` は `{ script?, filename?, filePath?, autoGenerateMovie? }` で全て optional です。**検査済みの値から組み立てれば cast は要りません**。数値の `filePath` が string として渡ることもなくなります。

## 検証

`yarn lint`（0 error、11 problems ← 13）/ `typecheck` ×3 / `build` / `test` **7528 passed**。

## 残り 6 箇所 — 次が最後です

| 箇所 | 状況 |
|---|---|
| `useTheme.ts` (1) | 設計判断。正直な `Partial` にすると 3 つの呼び出し側に連鎖します |
| `useDirConfig.ts` (1) | Vue の `ref()` が `UnwrapRef` でジェネリックを展開する既知の癖 |
| `mcp-routes.ts` (1) | MCP SDK の宣言バグ（[upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083)） |
| `pluginRuntime.ts` (2) | gui-chat-protocol のジェネリック（変更しない方針） |
| `collectionUi.ts`? | ※ 既に解消済み |

次の PR で残りを詰め、**allowlist に理由付きで載せて `error` へ昇格**します。

refs #1231

work in mulmoterminal3
