### PR TITLE
fix: useTheme と useDirConfig の as を外す — 通常作業はこれで完了 (#1231)

### DIFF
--- a/common/themeVars.ts
+++ b/common/themeVars.ts
@@ -69,7 +69,9 @@ export interface CustomThemeInput {
 
 /** The full variable set for a theme: the base it extends, with its own colours on top.
  *  `builtins` supplies the base sets so this stays pure — the client reads them from the
- *  stylesheet's source of truth, the specs from a fixture. */
+ *  stylesheet's source of truth, the specs from a fixture. PARTIAL because a base can genuinely be
+ *  missing (a stylesheet read that found no block for that id), and the `?? {}` below has always
+ *  handled that — the map only ever needed one key, never all of them. */
 // Every variable present, which is what separates a set we can paint with from one we cannot.
 // A guard rather than a length check on the missing keys: both ask the same question, but only
 // this one hands the answer to the compiler.
@@ -77,7 +79,7 @@ function isCompleteThemeVars(vars: Partial<ThemeVars>): vars is ThemeVars {
   return THEME_VAR_KEYS.every((key) => !!vars[key]);
 }
 
-export function resolveThemeVars(theme: CustomThemeInput, builtins: Record<ThemeId, ThemeVars>): ThemeVars | null {
+export function resolveThemeVars(theme: CustomThemeInput, builtins: Partial<Record<ThemeId, ThemeVars>>): ThemeVars | null {
   const base = theme.extends ? builtins[theme.extends] : null;
   const merged: Partial<ThemeVars> = { ...(base ?? {}), ...theme.colors };
   // No base and an incomplete list is the one case we cannot paint: report it rather than

--- a/src/composables/customThemes.ts
+++ b/src/composables/customThemes.ts
@@ -79,7 +79,11 @@ export function findCustomTheme(id: string): CustomThemeInput | null {
 /** Paint a custom theme: its variables onto the root element, and the light/dark flag the
  *  status-pill rules key on. Returns false when the theme cannot be completed — the caller
  *  falls back to a built-in rather than leaving a half-painted element. */
-export function applyCustomTheme(theme: CustomThemeInput, builtins: Record<ThemeId, ThemeVars>, root: HTMLElement = document.documentElement): boolean {
+export function applyCustomTheme(
+  theme: CustomThemeInput,
+  builtins: Partial<Record<ThemeId, ThemeVars>>,
+  root: HTMLElement = document.documentElement,
+): boolean {
   const vars = resolveThemeVars(theme, builtins);
   if (!vars) return false;
   THEME_VAR_KEYS.forEach((key) => root.style.setProperty(key, vars[key]));
@@ -94,7 +98,7 @@ export function clearCustomTheme(root: HTMLElement = document.documentElement): 
 }
 
 /** The xterm palette for a custom theme, or null when it can't be resolved. */
-export function customTermTheme(theme: CustomThemeInput, builtins: Record<ThemeId, ThemeVars>) {
+export function customTermTheme(theme: CustomThemeInput, builtins: Partial<Record<ThemeId, ThemeVars>>) {
   const vars = resolveThemeVars(theme, builtins);
   return vars ? termThemeFromVars(vars) : null;
 }

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onScopeDispose, type Ref } from "vue";
+import { ref, shallowRef, watch, onScopeDispose, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 import type { ITheme } from "@xterm/xterm";
 import { isThemeIdLike } from "../../common/themeVars";
@@ -145,7 +145,11 @@ function releaseDir(cwd: string, listener: (config: DirConfig) => void): void {
 // Directories where `pick` returns null are ABSENT from the map rather than present-as-null, so
 // "unset" is a plain lookup miss for the caller.
 export function useDirField<T>(cwds: Ref<string[]>, pick: (config: DirConfig) => T | null) {
-  const values = ref<Record<string, T>>({}) as Ref<Record<string, T>>;
+  // shallowRef, not ref: `ref<Record<string, T>>` returns `Ref<UnwrapRef<Record<string, T>>>`,
+  // and for a generic T that unwrap is not provably the same type — which is what the assertion
+  // here used to undo. The map is always REPLACED wholesale below, never mutated in place, so the
+  // deep reactivity `ref` adds is unused anyway.
+  const values = shallowRef<Record<string, T>>({});
   subscribeToDirConfigChanges();
   const listeners = new Map<string, (config: DirConfig) => void>();
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -111,11 +111,18 @@ export function isThemeId(value: unknown): value is ThemeId {
 export const missingThemeId = ref<string | null>(null);
 
 // Built-in palettes, read once from the stylesheet the first time a custom theme needs a base.
-let builtinVars: Record<ThemeId, ThemeVars> | null = null;
-function builtins(): Record<ThemeId, ThemeVars> {
+// PARTIAL, honestly: `readBuiltinVars` returns null when the stylesheet has no block for an id,
+// so a key can be absent — which the assertion this replaces claimed could not happen. Every
+// consumer looks up ONE key and already handles a miss, so nothing needed the stronger promise.
+let builtinVars: Partial<Record<ThemeId, ThemeVars>> | null = null;
+function builtins(): Partial<Record<ThemeId, ThemeVars>> {
   if (!builtinVars) {
-    const entries = THEME_IDS.map((id) => [id, readBuiltinVars(id)] as const).filter(([, vars]) => vars !== null);
-    builtinVars = Object.fromEntries(entries) as Record<ThemeId, ThemeVars>;
+    const vars: Partial<Record<ThemeId, ThemeVars>> = {};
+    for (const id of THEME_IDS) {
+      const read = readBuiltinVars(id);
+      if (read) vars[id] = read;
+    }
+    builtinVars = vars;
   }
   return builtinVars;
 }


### PR DESCRIPTION
## Summary

#1231。4 ファイル・**2 箇所**。**6 → 4**。allowlist は **0 件**。

**これで通常作業は完了**です。残る 4 箇所は upstream 由来か方針判断で、次の PR で理由付きの allowlist に載せて `error` へ昇格します。

## Items to Confirm / Review

### 1. `useTheme` — 前回「連鎖する」と判断して差し戻した箇所ですが、連鎖しませんでした

`readBuiltinVars` は null を返し得るので**キーが欠けることがある**のに、アサーションは「完全な map」だと主張していました。正直に `Partial` にすると 3 つの呼び出し側が完全な `Record` を要求していて連鎖する、と前回判断して差し戻しました（#1263）。

**今回中を読んだら、連鎖しませんでした。**

```ts
export function resolveThemeVars(theme, builtins) {
  const base = theme.extends ? builtins[theme.extends] : null;
  const merged: Partial<ThemeVars> = { ...(base ?? {}), ...theme.colors };
  return isCompleteThemeVars(merged) ? merged : null;
}
```

**1 回引くだけで、その結果を `?? {}` で受けています。** つまり最初から欠損を扱えていて、`Record<ThemeId, ThemeVars>` という**要求が過剰だっただけ**でした。3 つの引数型を `Partial<...>` に広げれば済みます。`applyCustomTheme` / `customTermTheme` も同様に通すだけです。

「設計判断が要る」と報告しましたが、実際には**呼び出し側を読めば決まる話**でした。

### 2. `useDirConfig` — `shallowRef` で足りました

`ref<Record<string, T>>` は `Ref<UnwrapRef<Record<string, T>>>` を返し、ジェネリック `T` ではその展開が同じ型だと証明できません。これがアサーションの理由でした。

この map は常に**丸ごと置き換え**られ、その場で書き換えないので、`ref` の深い反応性は使っていません。`shallowRef` にすれば型もそのままで cast も消えます。

## 検証

`yarn lint`（0 error、11 problems）/ `typecheck` ×3 / `build` / `test` **7528 passed**。

テーマは実ブラウザでも確認しました。

```
data-theme: midnight   data-appearance: dark   --bg-base: #1a1a2e   console errors: 0
```

## 次で最後です

| 箇所 | 理由 |
|---|---|
| `mcp-routes.ts` (1) | MCP SDK の宣言バグ（[upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083)） |
| `pluginRuntime.ts` (2) | gui-chat-protocol の不健全なジェネリック（プロトコル変更は全プラグインを壊すため見送り） |
| もう 1 箇所 | 次の PR で確定させます |

refs #1231

work in mulmoterminal3
