### PR TITLE
fix(lint): consistent-type-assertions を error に上げ、残る2ファイルを理由付きで allowlist (#1231)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,13 +118,41 @@ export default [
     // A cast asserts a type the compiler could not prove; a type guard PROVES it, and the
     // difference shows up at runtime, on the data you least control.
     //
-    // WARN while the existing ones are worked off file by file (#1231), so CI keeps passing and
-    // the remaining count stays visible. It goes to ERROR once the last one is resolved — the
-    // allowlist below is the only way to keep one, with a reason, since inline eslint-disable
-    // is forbidden and hides the debt at the scene.
+    // ERROR since #1231 finished: the 149 assertions the app started with are gone, and the
+    // allowlist below is the only way to keep one — with a reason, since inline eslint-disable is
+    // forbidden and hides the debt at the scene.
     files: ["**/*.{ts,tsx,mts,cts}", "**/*.vue"],
     rules: {
-      "@typescript-eslint/consistent-type-assertions": ["warn", { assertionStyle: "never" }],
+      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
+    },
+  },
+  {
+    // Type-assertion allowlist. Every entry is a place where NO amount of local typing can
+    // express the truth, because the type that is wrong belongs to someone else. Each says which
+    // upstream and what would remove it — delete the entry when that lands.
+    //
+    // Nothing here is "we could not be bothered": a host-side fix was written and merged for the
+    // one case that had one (mulmoclaude#2721 widened `modalTeleportTarget`, and the assertion it
+    // forced is gone from this repo as of collection-plugin 1.2.3).
+    files: [
+      // @modelcontextprotocol/sdk declares `class StreamableHTTPServerTransport implements
+      // Transport` while typing that class's onclose/onerror/onmessage accessors `T | undefined`
+      // where Transport spells them `?: T`. Under exactOptionalPropertyTypes the class therefore
+      // fails the interface it claims to implement. Upstream issue (open, and it names this exact
+      // workaround): https://github.com/modelcontextprotocol/typescript-sdk/issues/2083
+      "server/routes/mcp-routes.ts",
+      // gui-chat-protocol declares `dispatch<T = unknown>(args): Promise<T>` and
+      // `subscribe<T>(name, handler: (payload: T) => void)`. The PLUGIN chooses T and the HOST has
+      // to produce it from an untyped response / channel frame — unverifiable by construction, so
+      // any implementation asserts. (The same shape in OUR OWN generics — wikiApi's getJson,
+      // useSessionFeed, postConfigField — was fixed by taking a reader from the caller; that is
+      // not open here, because changing the protocol's signatures breaks every plugin that
+      // annotates its handler.) Moving the assertion onto the payload (`handler(data as T)`)
+      // relocates it rather than removing it, so it stays where the unprovable claim is made.
+      "src/composables/pluginRuntime.ts",
+    ],
+    rules: {
+      "@typescript-eslint/consistent-type-assertions": "off",
     },
   },
   {

--- a/plans/fix-1231-no-type-assertions.md
+++ b/plans/fix-1231-no-type-assertions.md
@@ -42,11 +42,37 @@ issue の段階的導入に従う。
 - **`as unknown as T` は原則として直す**。二段にしないと通らない = 型が重なっていない、
   つまり「コンパイラが強く反対している」という意味。
 
-## 進捗
+## 結果: 149 → 4（allowlist 2 ファイル）、ルールは `error`
+
+```
+149 → 137 → 125 → 112 → 91 → 73 → 52 → 36 → 34 → 31 → 29 → 24 → 20 → 13 → 10 → 8 → 6 → 4
+```
+
+残った 4 箇所（3 サイト）は**いずれも他人の型が間違っている**もので、ローカルな型付けでは
+表現できない。`eslint.config.js` の allowlist に理由と「何が入れば消えるか」を書いた。
+
+| ファイル | 理由 |
+|---|---|
+| `server/routes/mcp-routes.ts` | `@modelcontextprotocol/sdk` の宣言バグ（upstream issue #2083） |
+| `src/composables/pluginRuntime.ts` | gui-chat-protocol の不健全なジェネリック。署名変更は全プラグインを壊す |
+
+**upstream に直せるものは直した**: `modalTeleportTarget` の型が狭すぎた件は
+mulmoclaude#2721 を出してマージされ、1.2.3 で publish されたので、ホスト側の
+二段キャストは消えている（#1278）。
+
+### 完了条件の確認
+
+- [x] `consistent-type-assertions` が `error` で入っている
+- [x] テストは対象外（`*.spec.*` / `*.test.*` / `test/**`）
+- [x] 残る例外は `eslint.config.js` に理由付きで 2 ファイルのみ
+- [x] インラインの `eslint-disable` は 0 件
+- [x] `CLAUDE.md` の規約と、実際に止まるものが一致
+
+## 進捗（着手順）
 
 | # | ファイル | 箇所 | 対応 | PR |
 |---|---|---|---|---|
-| 1 | `src/plugins-registry.ts` | 12 | 型ガード + 注釈 + 不要キャスト削除 | this |
+| 1 | `src/plugins-registry.ts` | 12 | 型ガード + 注釈 + 不要キャスト削除 | #1234 |
 
 ## 直しながら見つかった問題（#1231 に記録する）
 


### PR DESCRIPTION
## Summary

**#1231 の完了 PR。** `consistent-type-assertions` を `warn` → **`error`** に上げ、残る 2 ファイルを理由付きで allowlist に載せます。

```
149 → 137 → 125 → 112 → 91 → 73 → 52 → 36 → 34 → 31 → 29 → 24 → 20 → 13 → 10 → 8 → 6 → 4
```

## Items to Confirm / Review

### 1. 完了条件（issue 本文）の確認

- [x] `consistent-type-assertions` が **`error`** で入っている
- [x] テストは対象外（`*.spec.*` / `*.test.*` / `test/**`）
- [x] 残る例外は `eslint.config.js` に**理由付きで 2 ファイルのみ**
- [x] インラインの `eslint-disable` は **0 件**
- [x] `CLAUDE.md` の規約と、実際に止まるものが一致している

**実際に効くことを確かめました。**

```
アプリコードに新しい cast    → error  Do not use any type assertions
テストに同じものを書く       → 何も出ない（意図どおり）
allowlist 2 ファイルの中身   → eslint-disable 0 件
```

### 2. allowlist に載せた 2 ファイル — どちらも「他人の型が間違っている」

| ファイル | 理由 | 消える条件 |
|---|---|---|
| `server/routes/mcp-routes.ts` | `@modelcontextprotocol/sdk` が `implements Transport` と書きながら、`exactOptionalPropertyTypes` 下でそのインターフェースを満たさない（accessor が `T \| undefined` vs `?: T`） | [upstream issue #2083](https://github.com/modelcontextprotocol/typescript-sdk/issues/2083) がマージされたら |
| `src/composables/pluginRuntime.ts` | gui-chat-protocol の `dispatch<T>` / `subscribe<T>`。**T を選ぶのはプラグインで、ホストは検証不能な T を作らされます** | プロトコルの署名が変わったら（下記の理由で見送り） |

**「同じ形なら自前のものは直した」という線引き**をしています。`wikiApi` の `getJson<T>`、`useSessionFeed<T>`、`postConfigField<T>` は構造的に同一でしたが、**このリポジトリが定義したもの**なので、呼び出し側から reader を受け取る形にして消しました（#1282 / #1294）。プロトコル側は署名を変えるとハンドラに型注釈を書いている**全プラグインが壊れる**ので取っていません。

`handler(data as T)` のように**アサーションを payload 側へ移す**案も試しましたが、消えずに移動するだけなので戻しました。主張が立つ場所に置いてあります。

### 3. upstream に直せるものは直しました

allowlist は「面倒だから」ではありません。直せた 1 件は実際に直しています。

```
mulmoterminal で発見 → mulmoclaude#2721 → マージ → 1.2.3 publish → 依存更新して cast 削除（#1278）
```

`modalTeleportTarget` の型が `string | HTMLElement` で、**宣言のコメント自身が指定していた ShadowRoot を許していなかった**件です。

## この作業で見つかった実害の可能性（抜粋）

`as` は「型の嘘」ですが、いくつかは実際に壊れる経路でした。

- **`useAppConfig`** — guard のフィールド名を間違えて、**保存のたびに一覧が空になる**バグを一度入れました（Codex が指摘）。往復テストで固定済み。
- **`gridTabs`** — `isUuid()` に非文字列が渡り得ました（localStorage 由来）。
- **`html.ts`** — パッケージの guard を飛ばしていました。contract には「`html` が文字列でないと**アーティファクトを空にする**」と書かれています。
- **`rosterPhase`** — 同じ JSON なのに 1 フィールドだけ検査していました。
- **`jsonPayload`** — Date が `{}` になる、`"__proto__"` キーが消える等。最終的に「stringify を模倣する」のをやめ、**stringify そのものを通す**設計に変えました（Codex 5 巡）。

## 検証

`yarn lint`（**0 error**、5 warnings はいずれも既存の `max-lines`）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7528 passed**。

Closes #1231

work in mulmoterminal3
