### PR TITLE
fix(tsconfig): 0件で入る2フラグ + promise 系の型情報 lint (#1301)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,6 +127,52 @@ export default [
     },
   },
   {
+    // Type-aware lint, on the APP ONLY — the two promise rules from #1301's sibling (#1300).
+    //
+    // Scoped to server/src/common rather than everything: the type program is the whole cost of
+    // this pass, so keeping tests out of it keeps that program smaller. WARN, not error, for the
+    // same reason #1231 started at warn — the count stays visible without CI going red while the
+    // real ones are read one at a time.
+    //
+    // Only these two: they catch things NO syntactic rule can. A missing `await` makes a rejection
+    // vanish and the call look like it succeeded; an async callback handed to an API that ignores
+    // the returned promise does the same. The `no-unsafe-*` family is the rest of #1300 and is a
+    // separate piece of work — 139 findings that mostly say "this is untyped", not "this is wrong".
+    //
+    // .ts only. A .vue file needs vue-eslint-parser as the PARSER (with tseslint.parser underneath
+    // for the script block), and pointing tseslint.parser straight at one fails to parse the SFC.
+    // Wiring type info through the Vue block is its own change; the promise mistakes this catches
+    // live in the composables and the server either way.
+    files: ["server/**/*.ts", "src/**/*.ts", "common/**/*.ts"],
+    // Specs are out, as #1300 asks: they are not in either project, so the parser cannot place
+    // them — and keeping them out is what keeps the type program small.
+    ignores: ["**/*.spec.ts", "**/*.test.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      // Explicit projects, not `projectService: true`: the root tsconfig.json references only
+      // app and node, so the service could not place any server/** file and reported 321 parse
+      // errors. Naming both projects is what actually covers the code these rules are for.
+      parserOptions: { project: ["./tsconfig.app.json", "./tsconfig.server.json"], tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "warn",
+      "@typescript-eslint/no-misused-promises": "warn",
+      // Type-aware sonarjs rules that were ALREADY configured as errors and never ran, because
+      // nothing built a type program until this block did. Turning them on is not what this change
+      // is for, and 30 findings would hide the promise ones — so they are visible at warn and get
+      // read in #1300 with the rest of the type-aware pass. They were never enforced, so this
+      // takes nothing away.
+      "sonarjs/different-types-comparison": "warn",
+      "sonarjs/deprecation": "warn",
+      "sonarjs/no-alphabetical-sort": "warn",
+      "sonarjs/void-use": "warn",
+      "sonarjs/function-return-type": "warn",
+      "sonarjs/reduce-initial-value": "warn",
+      "sonarjs/no-selector-parameter": "warn",
+      "sonarjs/no-misleading-array-reverse": "warn",
+    },
+  },
+  {
     // Type-assertion allowlist. Every entry is a place where NO amount of local typing can
     // express the truth, because the type that is wrong belongs to someone else. Each says which
     // upstream and what would remove it — delete the entry when that lands.

--- a/plans/fix-1301-strict-flags.md
+++ b/plans/fix-1301-strict-flags.md
@@ -1,0 +1,59 @@
+# fix(tsconfig): 厳格化フラグ + 型情報を要する promise ルール (#1301 / #1300 の一部)
+
+## 実測: issue の「全部 0 件で入る」は成立しなかった
+
+#1301 は 5 つのフラグすべてが 0 件だと書いている。**server と app を個別に
+`tsc -p ... --flag` で測ると確かに 0 だが、CI が実際に走らせる形（設定ファイルに
+書いて `yarn typecheck` / `typecheck:server` / `typecheck:test`）で測ると違う。**
+
+| フラグ | app | server | test | 判定 |
+|---|---|---|---|---|
+| `useUnknownInCatchVariables` | 0 | 0 | 0 | **入れた** |
+| `noImplicitOverride` | 0 | 0 | 0 | **入れた** |
+| `noImplicitReturns` | 0 | 31 | 27 | 見送り |
+| `noUncheckedIndexedAccess` | 47 | 71 | 327 | 見送り |
+| `noPropertyAccessFromIndexSignature` | 337 | 609 | 839 | 見送り |
+
+なぜ個別計測が 0 になったのかは追い切れていないが、`tsBuildInfoFile` による増分
+キャッシュか、`-p` と build mode の差である可能性が高い。**どちらにせよ、計測は
+「CI が動かすコマンド」でやらないと意味がない**というのが教訓。
+
+### 見送った 3 つについて
+
+- `noImplicitReturns`（58 件）— ほぼ Express ハンドラの
+  `if (bad) return res.status(400)...` と fall-through の混在。**Express の書き方として
+  正しい**ものを機械的に書き換えることになるので、価値と churn が釣り合わない。
+- `noUncheckedIndexedAccess`（445 件）— #1301 が「最優先」とする通り価値は高い
+  （`arr[i]` が `T` ではなく `T | undefined` になる）。ただし 445 件は独立した作業。
+- `noPropertyAccessFromIndexSignature`（1785 件）— `obj.key` を `obj["key"]` に
+  書き換えるだけで、型の穴は塞がらない。優先度は最も低い。
+
+## 型情報を要する lint（#1300 のうち promise 2 つ）
+
+`no-floating-promises` / `no-misused-promises` を **warn** で導入した。
+`no-unsafe-*` 系（139 件）は #1300 に残す。
+
+### 途中で踏んだもの
+
+1. **`projectService: true` では server が拾えない。** root の `tsconfig.json` は
+   app と node しか参照していないので、`server/**` が「プロジェクトに無い」と 321 件の
+   パースエラーになった。`project: ["./tsconfig.app.json", "./tsconfig.server.json"]` と
+   明示するのが正解。
+2. **`.vue` に `tseslint.parser` を直接指すと SFC がパースできない。** `.ts` のみに
+   絞った。Vue ブロックへ型情報を通すのは別の作業。
+3. **spec は除外が必要。** どちらのプロジェクトにも含まれないため。
+4. **型情報が入った瞬間、既に error 設定なのに動いていなかった sonarjs ルールが
+   8 種 30 件起動した。** これまで一度も強制されていなかったので、**warn にして
+   #1300 で読む**ことにした（取り上げてはいない）。
+
+### floating-promises 34 件を読んだ結果
+
+サンプルした範囲では**実バグは見つかっていない**。
+
+- `tool-store.ts` の 4 件 — `save` は宣言に「best-effort, fire-and-forget」と書かれ、
+  内部で try/catch している。**await しないのが設計**。
+- `router.push(...)` 系 — Vue Router の戻り値を待たないのは通常。
+- `onMounted(() => load())` — 意図的な fire-and-forget。
+
+つまりこのルールの価値は、いまのところ「意図を明示させること」にある。34 件を
+`void` で明示するかは #1300 で判断する。

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,11 @@
     /* See tsconfig.server.json for why: `field?: T` must mean "key absent", not
        "key present holding undefined". */
     "exactOptionalPropertyTypes": true,
+    /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
+       The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
+       measured counts and why they are their own piece of work. */
+    "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,7 +14,13 @@
     "moduleDetection": "force",
     "noEmit": true,
 
+    /* `strict` was absent here while every other project had it. Only vite.config.ts is in scope,
+       so nothing was riding on it — but there is no reason for one project to be the loose one. */
+    "strict": true,
+
     /* Linting */
+    "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -19,6 +19,11 @@
        Without this, `{ work: undefined }` type-checks against `work?: Summary` and
        reaches Firestore, which rejects undefined at any depth (#1042). */
     "exactOptionalPropertyTypes": true,
+    /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
+       The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
+       measured counts and why they are their own piece of work. */
+    "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
## Summary

#1301 の 5 フラグのうち **0 件で入る 2 つ**と、#1300 の **promise 2 ルール（warn）** を入れます。

## Items to Confirm / Review

### 1. #1301 の「全部 0 件で入ります / 移行作業ゼロ」は成立しませんでした

issue のとおり `tsc -p tsconfig.server.json --noEmit --noUncheckedIndexedAccess` などで測ると、確かに全部 0 になります。**ですが CI が実際に走らせる形**（設定ファイルに書いて `yarn typecheck` / `typecheck:server` / `typecheck:test`）で測ると違いました。

| フラグ | app | server | test | |
|---|---|---|---|---|
| `useUnknownInCatchVariables` | 0 | 0 | 0 | **入れました** |
| `noImplicitOverride` | 0 | 0 | 0 | **入れました** |
| `noImplicitReturns` | 0 | 31 | 27 | 見送り |
| `noUncheckedIndexedAccess` | 47 | 71 | 327 | 見送り |
| `noPropertyAccessFromIndexSignature` | 337 | 609 | 839 | 見送り |

**計測は「CI が動かすコマンド」でやらないと意味がない**、という #1231 で何度も踏んだ話と同じでした（`vue-tsc -b` の増分キャッシュ、`-p` と build mode の差）。

見送った 3 つの理由:

- **`noImplicitReturns`（58）** — ほぼ Express ハンドラの `if (bad) return res.status(400)…` と fall-through の混在です。**Express の書き方として正しい**ものを機械的に書き換えることになり、churn に見合いません。
- **`noUncheckedIndexedAccess`（445）** — issue の言うとおり価値は高い（`arr[i]` が `T | undefined` になる）ですが、独立した作業です。
- **`noPropertyAccessFromIndexSignature`（1785）** — `obj.key` を `obj["key"]` にするだけで、**型の穴は塞がりません**。優先度は最低と判断しました。

`tsconfig.node.json` に欠けていた `strict` も付けています（`vite.config.ts` 1 ファイルなので影響はありませんが、揃わない理由もないため）。

### 2. `projectService: true` では server が拾えませんでした

root の `tsconfig.json` は app と node しか参照していないので、`server/**` が「プロジェクトに無い」と **321 件のパースエラー**になります。`project: ["./tsconfig.app.json", "./tsconfig.server.json"]` と明示するのが正解でした。

ほかに、`.vue` に `tseslint.parser` を直接指すと SFC がパースできない（`.ts` のみに絞りました）、spec は除外が必要、という点も踏んでいます。

### 3. 型情報が入った瞬間、動いていなかったルールが 8 種 30 件起動しました

**`sonarjs/different-types-comparison` などは既に `error` で設定されているのに、型プログラムが無いので一度も走っていませんでした。**

この PR の目的ではなく、30 件が promise の指摘を埋めてしまうので、**warn にして #1300 で読む**ことにしました。これまで一度も強制されていないので、取り上げたことにはなりません。

### 4. floating-promises 34 件 — 読んだ範囲では実バグなし

- `tool-store.ts` の 4 件 — `save` は宣言に **「best-effort, fire-and-forget」** と書かれ、内部で try/catch しています。**await しないのが設計**でした。
- `router.push(…)` — Vue Router の戻り値を待たないのは通常。
- `onMounted(() => load())` — 意図的な fire-and-forget。

いまのところこのルールの価値は「意図を明示させること」にあります。34 件を `void` で明示するかは #1300 で判断するのが筋だと考えています（この PR で 34 箇所に `void` を撒くと、レビューの主題がぼやけるため）。

## 検証

`yarn lint` **0 error / 71 warnings**（内訳: floating-promises 34、misused 2、新しく起動した sonarjs 30、既存の max-lines 5）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7556 passed**。

refs #1301, refs #1300

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Code Quality**
  * Strengthened TypeScript checks across application, server, and tooling code.
  * Improved handling of caught errors and overridden methods.
  * Added lint checks for unhandled and incorrectly used promises.

* **Documentation**
  * Added planning documentation describing strictness improvements, deferred checks, and identified promise-related findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->