### PR TITLE
fix: ファイル名ソートを明示的・ロケール非依存にする (#1300)

### DIFF
--- a/common/byCodeUnit.ts
+++ b/common/byCodeUnit.ts
@@ -1,0 +1,11 @@
+// Sort filenames and directory names deterministically.
+//
+// `.sort()` with no comparator is flagged (sonarjs/no-alphabetical-sort) because the default is
+// implementation-defined for non-ASCII. The rule suggests `localeCompare`, which would be WRONG
+// here: these are filenames — zero-padded date directories and ISO-stamped rollout files — and
+// ordering them by the user's locale makes the answer depend on who is running the app. Code-unit
+// order is what the callers actually mean, and it is the same everywhere.
+export function byCodeUnit(a: string, b: string): number {
+  if (a < b) return -1;
+  return a > b ? 1 : 0;
+}

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -100,5 +100,7 @@ export async function listAntigravitySessions(
       return { id: record.conversationId, title: summary?.title ?? DEFAULT_TITLE, mtime: summary?.mtime ?? record.startedAt };
     }),
   );
-  return summaries.sort((a, b) => b.mtime - a.mtime).slice(0, limit);
+  // toSorted, not sort: sort mutates and returns the SAME array, so reading the return value
+  // reads like a copy when it is not (sonarjs/no-misleading-array-reverse).
+  return summaries.toSorted((a, b) => b.mtime - a.mtime).slice(0, limit);
 }

--- a/server/agents/codex-sessions.ts
+++ b/server/agents/codex-sessions.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import { cleanTitle, parseJsonRecord, readTranscriptHead } from "./transcript-head.js";
+import { byCodeUnit } from "../../common/byCodeUnit.js";
 
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -52,7 +53,7 @@ function subdirsDesc(dir: string): string[] {
     return readdirSync(dir, { withFileTypes: true })
       .filter((e) => e.isDirectory())
       .map((e) => e.name)
-      .sort()
+      .sort(byCodeUnit)
       .reverse();
   } catch {
     return [];
@@ -69,7 +70,7 @@ function dayDirsDesc(root: string): string[] {
 function rolloutsInDay(dayDir: string): string[] {
   return readdirSync(dayDir)
     .filter((n) => ROLLOUT_RE.test(n))
-    .sort()
+    .sort(byCodeUnit)
     .reverse()
     .map((f) => path.join(dayDir, f));
 }

--- a/server/files/backup-store.ts
+++ b/server/files/backup-store.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
+import { byCodeUnit } from "../../common/byCodeUnit.js";
 
 /** Newest-first; older ones are dropped. Three is enough to reach past "opened it again",
  *  which is what rotates the oldest out. */
@@ -25,7 +26,7 @@ export function backupDirFor(absFile: string, root: string): string {
 export function expiredBackups(names: string[], keep = BACKUP_GENERATIONS): string[] {
   return names
     .filter((n) => n.endsWith(BACKUP_SUFFIX))
-    .sort()
+    .sort(byCodeUnit)
     .reverse()
     .slice(keep);
 }
@@ -59,7 +60,7 @@ function newestBackup(dir: string): string | null {
     const names = fs
       .readdirSync(dir)
       .filter((n) => n.endsWith(BACKUP_SUFFIX))
-      .sort();
+      .sort(byCodeUnit);
     return names.length ? path.join(dir, names[names.length - 1]) : null;
   } catch {
     return null;

--- a/test/common/byCodeUnit.spec.ts
+++ b/test/common/byCodeUnit.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { byCodeUnit } from "../../common/byCodeUnit.js";
+
+describe("byCodeUnit", () => {
+  it("orders zero-padded date directories chronologically", () => {
+    expect(["2026", "2025", "2024"].sort(byCodeUnit)).toEqual(["2024", "2025", "2026"]);
+    expect(["10", "02", "01"].sort(byCodeUnit)).toEqual(["01", "02", "10"]);
+  });
+
+  it("orders ISO-stamped rollout filenames chronologically", () => {
+    const names = ["rollout-2026-08-02T09-00-00-b.jsonl", "rollout-2026-08-02T08-00-00-a.jsonl"];
+    expect(names.sort(byCodeUnit)[0]).toBe("rollout-2026-08-02T08-00-00-a.jsonl");
+  });
+
+  // The point of not using localeCompare: the answer must not depend on who is running the app.
+  // "a" vs "B" is where the two disagree — code units put uppercase first, most locales do not.
+  it("is locale-independent where localeCompare is not", () => {
+    expect(byCodeUnit("B", "a")).toBeLessThan(0);
+    expect(["a", "B"].sort(byCodeUnit)).toEqual(["B", "a"]);
+  });
+
+  it("reports equality as 0 and is symmetric", () => {
+    expect(byCodeUnit("x", "x")).toBe(0);
+    expect(Math.sign(byCodeUnit("a", "b"))).toBe(-Math.sign(byCodeUnit("b", "a")));
+  });
+});


### PR DESCRIPTION
## Summary

#1300 で型情報 lint を入れて見えるようになった指摘のうち、**直すべきものだけ**を直します。5 件（`no-alphabetical-sort` 4 + `no-misleading-array-reverse` 1）。**71 → 66 warnings**。

残りを直さない理由は下に全部書きました（多くは**偽陽性**です）。

## Items to Confirm / Review

### 1. `localeCompare` は使いませんでした — ここでは誤りだからです

ルールの文言は "Provide a compare function that depends on `String.localeCompare`" ですが、対象は**ファイル名**です。

```
2026/08/02/rollout-2026-08-02T09-00-00-<uuid>.jsonl
```

ゼロ埋めの日付ディレクトリと ISO タイムスタンプ入りのファイル名を**ロケール順に並べると、答えが実行者によって変わります**。呼び出し側が実際に意味しているのはコード単位順なので、それを `common/byCodeUnit.ts` に明示しました。

テストには **localeCompare と結果が分かれるケース**（`"B"` vs `"a"`）を入れて、意図を固定しています。

### 2. `toSorted` — 戻り値がコピーに見えていた

`summaries.sort(...)` は**同じ配列**を変更して返すので、戻り値を読むとコピーのように見えます。`toSorted` にしました（server の target は es2023）。

## 直さなかったもの — 内訳と理由

### `different-types-comparison` 7 件は**すべて偽陽性**です（重要）

これは **#1301 が予言していたとおり**でした。

> `noUncheckedIndexedAccess` が off だと…**実行時に必要なガードまで「常に真」に見える**ので、消すと落ちる。

実際に 7 件すべてがその形でした。

| 箇所 | 指摘 | 実際 |
|---|---|---|
| `cli-google.ts:57` | `command === undefined` は常に偽 | `process.argv[2]` は**本当に undefined になり得る** |
| `googleCalendar.ts:45,66` | 同上 | `params[key]` は**キーが無ければ undefined** |
| `translation.ts:106` | `hit !== undefined` は常に真 | `dict.sentences[s]?.[lang]` は**辞書に無ければ undefined** |
| `repo-dirs.ts:72` | 同上 | `recorded[repo]` も同じ |
| `screen-rows.ts:37` | 同上 | `const [code] = params` の分割代入も同じ |
| `gridTabs.ts:190` | 同上 | `order[idx - 1]` も同じ |

**指摘に従ってガードを消すと、実際に落ちます。** `noUncheckedIndexedAccess`（#1301 の残り）が入るまでは偽陽性のままです。#1301 の「設定の欠落が別の設定の欠落を呼んでいる」という見立ての、具体的な証拠になりました。

### その他

- **`reduce-initial-value` 2 件** — どちらも直前に空チェックがあります（`if (near.length === 0) return null`、`if (start === -1) return ""`）。初期値を足すと**意味が変わります**。
- **`void-use` 3 件** — `void` は fire-and-forget を明示する**推奨される書き方**で、`no-floating-promises` が求めているものそのものです。2 つのルールが矛盾しています。
- **`function-return-type` 3 件** — `JsonValue | undefined` を返すなど、**設計どおり**です。
- **`deprecation` 7 件** — Node の型（`UnhandledRejectionListener`）、MCP SDK の `Server`、`document.execCommand`、`event.returnValue`。いずれも**外部由来か代替が無い**ものです。
- **`no-selector-parameter` 1 件** — boolean 引数でメソッドを分けろという設計指摘。この PR の範囲外です。

## 検証

`yarn lint` **0 error / 66 warnings**（← 71）/ `typecheck` ×3 / `build` / `test` **7560 passed**（新規 4 件）。

refs #1300

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency when sorting session records, backup entries, directory names, and rollout files.
  * Ordering is now deterministic and independent of locale, producing stable results across environments.
  * Sorting operations preserve existing data while organizing results by modification time or name as appropriate.

* **Tests**
  * Added coverage for ordering, equality, symmetry, and mixed-case filenames and dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->