### PR TITLE
fix(lint): .vue にも型情報を通す — floating-promises が34→66件見えるように (#1300)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,9 @@ export default [
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,
+        project: ["./tsconfig.app.json"],
+        tsconfigRootDir: import.meta.dirname,
+        extraFileExtensions: [".vue"],
       },
       globals: {
         ...globals.browser,
@@ -170,6 +173,23 @@ export default [
       "sonarjs/reduce-initial-value": "warn",
       "sonarjs/no-selector-parameter": "warn",
       "sonarjs/no-misleading-array-reverse": "warn",
+    },
+  },
+  {
+    // The same two rules for .vue. RULES ONLY — no `languageOptions` here on purpose: setting
+    // `parser` would replace vue-eslint-parser and every SFC would fail to parse ("'>' expected").
+    // The type program for these comes from the `**/*.vue` block above, which passes
+    // `project` + `extraFileExtensions` THROUGH vue-eslint-parser to tseslint.parser.
+    files: ["src/**/*.vue"],
+    rules: {
+      "@typescript-eslint/no-floating-promises": "warn",
+      "@typescript-eslint/no-misused-promises": "warn",
+      // Another rule that only became reachable with a type program, and it is wrong here: it
+      // calls an interface holding nothing but CALL signatures "a type without members", so
+      // `SoundEmits & { (e: "…"): void }` reads as a useless intersection. That composition is
+      // how Vue's type-based `defineEmits<>` reuses a child's contract — dropping it would drop
+      // the child's events. At warn pending #1300, like the others it woke.
+      "sonarjs/no-useless-intersection": "warn",
     },
   },
   {


### PR DESCRIPTION
## Summary

**できました。** #1300 に「未着手」として残していた `.vue` への型情報配線です。`no-floating-promises` が **34 → 66 件**（`.vue` から 32 件）見えるようになります。**102 warnings / 0 errors**、CI は緑のままです。

## Items to Confirm / Review

### 配線は2点。片方を間違えると全 SFC がパースできなくなります

**1. 既存の `**/*.vue` ブロックに `project` を足す**

```diff
 files: ["**/*.vue"],
 languageOptions: {
   parserOptions: {
     parser: tseslint.parser,
+    project: ["./tsconfig.app.json"],
+    tsconfigRootDir: import.meta.dirname,
+    extraFileExtensions: [".vue"],
   },
```

`vue-eslint-parser` はこれを**下の `tseslint.parser` へ通す**ので、型プログラムが SFC にも届きます。

**2. ルールは `languageOptions` を持たない別ブロックで足す**

ここで `parser` を指定すると **vue-eslint-parser を置き換えてしまい**、全 SFC が落ちます。

```
1:8  error  Parsing error: '>' expected
```

一度これを踏みました（`.vue` を型情報ブロックの `files` に足しただけで発生）。flat config は後のブロックが前を上書きするためで、**ルールだけのブロックに分ける**のが正解です。

### `sonarjs/no-useless-intersection` 4 件は偽陽性です

型情報が入って初めて動いたルールがまた1つ。**呼び出しシグネチャだけを持つ interface を「メンバーの無い型」と判定**するので、これが無駄な交差に見えます。

```ts
const emit = defineEmits<
  SoundEmits & {                                    // ← ここを指摘される
    (e: "update-push-enabled", on: boolean): void;
```

`SoundEmits` は `(e: "update-sound", file: string | null): void` などの呼び出しシグネチャだけを持つ interface で、これは **Vue の型ベース `defineEmits<>` で子コンポーネントの契約を再利用する書き方そのもの**です。指摘に従って交差を外すと、**子のイベントが全部落ちます**。

他の起動組（`different-types-comparison` など）と同じく warn にして #1300 に残しました。

### コスト

`yarn lint` が **31s → 41s**。型プログラムが `.vue` を含むぶん増えます。

## 検証

`yarn lint` **0 error / 102 warnings**（← 66。増えた 36 は `.vue` の floating-promises 32 + no-useless-intersection 4）/ `typecheck` ×3 / `build` / `test` **7560 passed**。

新しく見えた 32 件が本物かどうかの精査は #1300 に残します（`.ts` 側の 34 件と同じく、多くは意図的な fire-and-forget に見えます）。

refs #1300

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting support for Vue and TypeScript projects.
  * Added additional warnings for potentially unsafe promise usage and unnecessary type intersections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->