### PR TITLE
fix: 待たない promise 66件を void で明示する — 102→33 warnings (#1300)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -168,7 +168,10 @@ export default [
       "sonarjs/different-types-comparison": "warn",
       "sonarjs/deprecation": "warn",
       "sonarjs/no-alphabetical-sort": "warn",
-      "sonarjs/void-use": "warn",
+      // OFF, not warn: it forbids the `void` operator, which is exactly what
+      // `no-floating-promises` asks for to mark a promise as deliberately not awaited. The two
+      // rules contradict each other and we chose the one that catches a forgotten `await`.
+      "sonarjs/void-use": "off",
       "sonarjs/function-return-type": "warn",
       "sonarjs/reduce-initial-value": "warn",
       "sonarjs/no-selector-parameter": "warn",

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -137,7 +137,7 @@ export const createTerminalInputSender = (deps: TerminalInputDeps) => {
     const link = run.catch(() => undefined);
     chains.set(sessionId, link);
     // Drop the entry once it is the last one, so sessions don't accumulate forever.
-    link.then(() => {
+    void link.then(() => {
       if (chains.get(sessionId) === link) {
         chains.delete(sessionId);
       }

--- a/server/backends/translation.ts
+++ b/server/backends/translation.ts
@@ -233,7 +233,7 @@ export function mountTranslationRoutes(app: Express, deps: TranslationDeps): voi
     const next = prev.catch(() => undefined).then(runner);
     const tracked = next.catch(() => undefined);
     chains.set(namespace, tracked);
-    tracked.then(() => {
+    void tracked.then(() => {
       if (chains.get(namespace) === tracked) chains.delete(namespace);
     });
     return next;

--- a/server/infra/pubsub.ts
+++ b/server/infra/pubsub.ts
@@ -31,10 +31,10 @@ export function createPubSub(server: HttpServer, isAllowedOrigin: (origin: strin
 
   io.on("connection", (socket) => {
     socket.on("subscribe", (channel) => {
-      if (typeof channel === "string") socket.join(channel);
+      if (typeof channel === "string") void socket.join(channel);
     });
     socket.on("unsubscribe", (channel) => {
-      if (typeof channel === "string") socket.leave(channel);
+      if (typeof channel === "string") void socket.leave(channel);
     });
   });
 

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -107,8 +107,8 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     // the same thing to the runtime but not to the type — the option is exact-optional.
     const transport = new StreamableHTTPServerTransport({});
     res.on("close", () => {
-      transport.close();
-      server.close();
+      void transport.close();
+      void server.close();
     });
     try {
       // A cast, which this codebase otherwise refuses — and it asserts only what the SDK itself declares.

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -167,7 +167,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
     const list = await toolResultsStore.get(sessionId);
     if (reconcileCollectionCard(list, result) === "skip") {
       // The list may still have changed above; save so a supersede is not lost on restart.
-      toolResultsStore.save(sessionId);
+      void toolResultsStore.save(sessionId);
       return false;
     }
     const idx = list.findIndex((r) => r.uuid === result.uuid);
@@ -177,7 +177,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
       list.push(result);
       if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
     }
-    toolResultsStore.save(sessionId);
+    void toolResultsStore.save(sessionId);
     return true;
   }
 
@@ -205,7 +205,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
     list.push(call);
     if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
     publish(toolCallsChannel(sessionId), call);
-    toolCallsStore.save(sessionId);
+    void toolCallsStore.save(sessionId);
   }
 
   // PostToolUse (status "completed") or PostToolUseFailure (status "failed"):
@@ -226,7 +226,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
       if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
     }
     publish(toolCallsChannel(sessionId), call);
-    toolCallsStore.save(sessionId);
+    void toolCallsStore.save(sessionId);
   }
 
   return { toolResultsStore, toolCallsStore, storeToolResult, recordToolCallStart, recordToolCallEnd };

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -101,7 +101,7 @@ const accountingActive = computed(() => accountingOpen.value);
 const wikiActive = computed(() => wikiOpen.value);
 const prsActive = computed(() => prsOpen.value);
 function showGrid(): void {
-  router.push("/terminals");
+  void router.push("/terminals");
 }
 function showCollections(): void {
   browseGotoIndex("collection");

--- a/src/components/CopyCodeBlock.vue
+++ b/src/components/CopyCodeBlock.vue
@@ -57,7 +57,7 @@ async function copyLastBlock(): Promise<void> {
     } catch {
       // Permission or focus refused it. The text is already in hand, so offer it rather than
       // reporting a failure the user cannot act on.
-      showForManualCopy(outcome.text);
+      void showForManualCopy(outcome.text);
     }
   } catch {
     flash("Could not read this session's last turn");

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -252,7 +252,7 @@ async function discardAndReload(): Promise<void> {
     fileError.value = "could not back up your version — nothing was discarded";
     return;
   }
-  loadFile(openPath.value, true);
+  void loadFile(openPath.value, true);
 }
 
 /** Conflict banner — keep the buffer, adopting the disk's version as the new baseline so the
@@ -261,7 +261,7 @@ function overwrite(): void {
   if (!conflict.value) return;
   baseVersion.value = conflict.value.version;
   conflict.value = null;
-  save();
+  void save();
 }
 
 async function requestClose(): Promise<void> {
@@ -273,7 +273,7 @@ async function requestClose(): Promise<void> {
 function onKeydown(e: KeyboardEvent): void {
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
     e.preventDefault();
-    save();
+    void save();
   }
 }
 
@@ -299,7 +299,7 @@ async function checkForExternalChange(): Promise<void> {
     // Still the version we loaded, or the answer arrived after the user moved on.
     if (onDisk === baseVersion.value || pathRel !== openPath.value) return;
     if (dirty.value) conflict.value = { version: onDisk };
-    else loadFile(pathRel, true);
+    else void loadFile(pathRel, true);
   } catch {
     // Offline or the server restarted: the next tick asks again, and the save still can't clobber.
   }
@@ -308,7 +308,7 @@ async function checkForExternalChange(): Promise<void> {
 function watchExternalChanges(): () => void {
   externalTimer = setInterval(checkForExternalChange, EXTERNAL_CHECK_MS);
   const unsubscribe = usePubSub().subscribe(FILE_WRITE_CHANNEL, (data) => {
-    if (isFileWriteEvent(data) && isWriteToOpenFile(data.file, props.cwd, openPath.value)) checkForExternalChange();
+    if (isFileWriteEvent(data) && isWriteToOpenFile(data.file, props.cwd, openPath.value)) void checkForExternalChange();
   });
   return () => {
     if (externalTimer !== null) clearInterval(externalTimer);
@@ -335,7 +335,7 @@ async function start(): Promise<void> {
   await restore(props.initialState ?? null);
   // An explicitly requested path wins over whatever was remembered — it is the more recent
   // intent (a clicked path in terminal output).
-  if (props.requestedPath) loadFile(props.requestedPath);
+  if (props.requestedPath) void loadFile(props.requestedPath);
 }
 
 /** Put a remembered tree back: open its directories parents-first (each fetches its children),
@@ -363,7 +363,7 @@ function findNode(nodes: Node[], target: string): Node | null {
 watch(
   () => props.requestedPath,
   (pathRel) => {
-    if (pathRel) loadFile(pathRel);
+    if (pathRel) void loadFile(pathRel);
   },
 );
 
@@ -377,15 +377,15 @@ function onPageHide(): void {
   // Both, unconditionally: there is no awaiting an answer here, so the only way to honour
   // "your version is kept either way" is to bank it whether or not the write wins the race.
   // The cost is one redundant generation per tab-close with unsaved edits.
-  bankText(pathRel, text, true);
-  writeBuffer(pathRel, text, baseVersion.value, true);
+  void bankText(pathRel, text, true);
+  void writeBuffer(pathRel, text, baseVersion.value, true);
 }
 
 let stopWatchingExternal: (() => void) | null = null;
 onMounted(() => {
   window.addEventListener("pagehide", onPageHide);
   stopWatchingExternal = watchExternalChanges();
-  start();
+  void start();
 });
 onBeforeUnmount(() => {
   window.removeEventListener("pagehide", onPageHide);

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -189,7 +189,7 @@ const latestCardKey = computed(() => {
 // After the pending layout — the new/resized card's height is what we are scrolling past.
 function followToEnd() {
   if (!stickToBottom.value) return;
-  nextTick(() => {
+  void nextTick(() => {
     const element = scrollRef.value;
     if (element) element.scrollTop = element.scrollHeight;
   });
@@ -254,7 +254,7 @@ watch(() => props.sessionId, loadAvailableTools, { immediate: true });
 // while claude is still being spawned, so its MCP client has not connected to the group URLs yet
 // and the server has not learned which tools this cell got.
 onToolGroupsAnnounced((announcement) => {
-  if (announcement.sessionId === props.sessionId) loadAvailableTools(props.sessionId);
+  if (announcement.sessionId === props.sessionId) void loadAvailableTools(props.sessionId);
 });
 
 // What this session can be asked for, grouped. Ordered by TOOL_GROUPS (blast radius, least

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -340,7 +340,7 @@ watch(
     // here means a surviving timer only ever reflects the cell's current, unchanged state.
     clearTimeout(refocusTimer);
     if (!shouldRefocusOnZoomChange(!!expanded, props.zoomed)) return;
-    nextTick(() => conn.focus(slotKey));
+    void nextTick(() => conn.focus(slotKey));
     refocusTimer = setTimeout(() => conn.focus(slotKey), FLIP_MS + 30);
   },
 );
@@ -356,7 +356,7 @@ watch(
   () => props.expanded,
   () => {
     clearTimeout(refitTimer);
-    nextTick(() => conn.fit(slotKey));
+    void nextTick(() => conn.fit(slotKey));
     refitTimer = setTimeout(() => conn.fit(slotKey), FLIP_MS + 30);
   },
 );

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -370,11 +370,11 @@ onMounted(() => {
   // on reconnect re-seed from the authoritative snapshot (guarded by activityGen), or a turn
   // that started during the outage stays showing idle until it ends.
   offReconnect = onReconnect(() => {
-    if (sessionId.value) loadInitial(sessionId.value);
+    if (sessionId.value) void loadInitial(sessionId.value);
   });
   if (sessionId.value) {
-    loadInitial(sessionId.value);
-    loadDiff(); // a resumed worktree cell shows its diff on restore
+    void loadInitial(sessionId.value);
+    void loadDiff(); // a resumed worktree cell shows its diff on restore
   }
 });
 onUnmounted(() => {
@@ -398,7 +398,7 @@ function launchIn(dir: string | null) {
   launched.value = true;
   emit("agent", agent.value); // let the grid persist which agent this cell launched
   recordNextCwd = true;
-  loadDiff(); // no-op for a non-worktree dir
+  void loadDiff(); // no-op for a non-worktree dir
 }
 // The provider/model picked in the launch form, for the session this cell is about to
 // start. Null — the usual case — means the directory's own default decides. Kept for the
@@ -429,7 +429,7 @@ function resumeSession({ id, cwd: dir, agent: resumeAgent }: { id: string; cwd: 
   connectKey.value++;
   launched.value = true;
   recordNextCwd = false; // resuming isn't a fresh launch — don't record its cwd
-  loadDiff(); // an already-idle worktree session shows its badge right away
+  void loadDiff(); // an already-idle worktree session shows its badge right away
 }
 
 // Reveal this cell's working directory in the OS file manager. The browser can't
@@ -683,7 +683,7 @@ onUnmounted(() => document.removeEventListener("keydown", onCloseKey));
 function onSession(id: string) {
   sessionId.value = id;
   emit("session", id);
-  loadInitial(id);
+  void loadInitial(id);
 }
 
 // ~-anchored, front-truncated path for the header (keeps the tail). For a managed
@@ -855,7 +855,7 @@ async function loadDiff() {
 function openDiff() {
   diffOpen.value = true;
   prMsg.value = null;
-  loadDiff(); // refresh on open
+  void loadDiff(); // refresh on open
 }
 
 // Outward-facing actions (push / open PR) for the worktree's branch. `prBusy`
@@ -920,9 +920,9 @@ async function openPR() {
 // turn's token usage is final.
 watch(working, (now, prev) => {
   if (prev && !now) {
-    loadDiff();
-    refreshUsage();
-    refreshGit(); // branch/dirty may have changed (commit, checkout, edits)
+    void loadDiff();
+    void refreshUsage();
+    void refreshGit(); // branch/dirty may have changed (commit, checkout, edits)
     void refreshWorkItem(); // a turn that pushed or opened a PR changes what this cell is on
   }
 });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -127,7 +127,7 @@ function onFocusIn(e: FocusEvent) {
 // zoomed slot). Grid cells' durable connections are keyed `cell-<uid>`.
 onActivated(() => {
   const uid = focusedUid.value;
-  if (uid !== null) nextTick(() => conn.focus(`cell-${uid}`));
+  if (uid !== null) void nextTick(() => conn.focus(`cell-${uid}`));
 });
 // Per-cell class: `flipping` drives the zoom FLIP, `focused` the in-place lift of the active cell —
 // suppressed while expanded or mid-flip so it never fights those animations.
@@ -741,7 +741,7 @@ function flipCells(before: Map<number, DOMRect>) {
     flippingUids.value = new Set();
   };
   // The batch shares one duration + easing, so the last to finish settles them all.
-  Promise.allSettled(batch.map((a) => a.finished)).then(settle);
+  void Promise.allSettled(batch.map((a) => a.finished)).then(settle);
 }
 
 // Pre-flush, so the cells are still in the slots they are leaving when we measure them.
@@ -752,7 +752,7 @@ watch(
   (to, from) => {
     if (!shouldFlipZoom(to, from, window.matchMedia("(prefers-reduced-motion: reduce)").matches)) return;
     const before = measureCells(props.cells.map((c) => c.uid));
-    nextTick(() => flipCells(before));
+    void nextTick(() => flipCells(before));
   },
 );
 
@@ -764,7 +764,7 @@ watch(
   () => props.expandedUid,
   (uid) => {
     if (uid === null) return;
-    nextTick(() => {
+    void nextTick(() => {
       const row = rosterRoot.value?.querySelector(`[data-uid="${uid}"]`);
       // `nearest` so a row already in view is left alone — re-centring on every step would
       // make the list jump under a user who can already see what they picked.

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -76,10 +76,10 @@ watch(
       document.removeEventListener("keydown", onKeydown);
       return;
     }
-    load();
+    void load();
     if (!oldVals?.[0]) {
       document.addEventListener("keydown", onKeydown);
-      nextTick(() => modalEl.value?.focus());
+      void nextTick(() => modalEl.value?.focus());
     }
   },
   { immediate: true },

--- a/src/composables/useAccountingView.ts
+++ b/src/composables/useAccountingView.ts
@@ -14,12 +14,12 @@ import { overlayOriginState, overlayReturnPath } from "./overlayOrigin";
 
 /** Open the accounting overlay. */
 export function accountingViewOpen(): void {
-  router.push({ path: "/accounting", state: overlayOriginState() });
+  void router.push({ path: "/accounting", state: overlayOriginState() });
 }
 
 /** Close the accounting overlay → back to the view it was opened from. */
 export function accountingViewClose(): void {
-  router.push(overlayReturnPath());
+  void router.push(overlayReturnPath());
 }
 
 export function useAccountingView(): { isOpen: ComputedRef<boolean>; close: () => void } {

--- a/src/composables/useCollectionBrowse.ts
+++ b/src/composables/useCollectionBrowse.ts
@@ -50,13 +50,13 @@ function pathFor(kind: ShortcutKind, slug?: string): string {
 /** Open the index for a kind (collections / feeds). */
 export function browseGotoIndex(kind: ShortcutKind): void {
   clearRecord();
-  router.push({ path: pathFor(kind), state: overlayOriginState() });
+  void router.push({ path: pathFor(kind), state: overlayOriginState() });
 }
 
 /** Open one collection / feed's detail page. */
 export function browseGotoDetail(kind: ShortcutKind, slug: string): void {
   clearRecord();
-  router.push({ path: pathFor(kind, slug), state: overlayOriginState() });
+  void router.push({ path: pathFor(kind, slug), state: overlayOriginState() });
 }
 
 /** A ref/embed hop into another collection, optionally deep-linking a record. */
@@ -66,7 +66,7 @@ export function browseNavigateToRecord(targetSlug: string, recordId?: string): v
   // path. Always assign — a hop to the CURRENT page (no path change → no watcher
   // fire) with no recordId must still close any stale modal, not reuse it.
   const targetPath = pathFor("collection", targetSlug);
-  router.push({ path: targetPath, state: overlayOriginState() }).then(() => {
+  void router.push({ path: targetPath, state: overlayOriginState() }).then(() => {
     state.recordPath = recordId ? targetPath : null;
     state.selectedId = recordId ?? null;
   });
@@ -98,7 +98,7 @@ export function browseSetSelectedId(itemId: string | null): void {
 /** Close the browser overlay → back to the view it was opened from. */
 export function browseClose(): void {
   clearRecord();
-  router.push(overlayReturnPath());
+  void router.push(overlayReturnPath());
 }
 
 /** Derive the legacy BrowseView shape from the current route + record state. */

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -111,7 +111,7 @@ export function invalidateDirConfig(cwd: string): void {
   if (!targets?.size) return;
   const seq = generationOf(cwd) + 1;
   generation.set(cwd, seq);
-  fetchDirConfig(cwd).then((config) => {
+  void fetchDirConfig(cwd).then((config) => {
     if (generationOf(cwd) !== seq) return; // a newer invalidation superseded this response
     targets.forEach((apply) => apply(config));
   });

--- a/src/composables/useFilesView.ts
+++ b/src/composables/useFilesView.ts
@@ -18,12 +18,12 @@ export function filesGotoFile(cwd: string | null, path: string): void {
 }
 
 function pushFilesRoute(query: Record<string, string>): void {
-  router.push({ name: "files", query, state: overlayOriginState() });
+  void router.push({ name: "files", query, state: overlayOriginState() });
 }
 
 /** Close the Files view → back to the view it was opened from. */
 export function filesClose(): void {
-  router.push(overlayReturnPath());
+  void router.push(overlayReturnPath());
 }
 
 export function useFilesView(): {

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -34,12 +34,12 @@ export function useGitStatus(cwd: Ref<string | null>) {
   }
 
   const refreshIfVisible = () => {
-    if (document.visibilityState === "visible") refresh();
+    if (document.visibilityState === "visible") void refresh();
   };
 
   let timer: ReturnType<typeof setInterval> | undefined;
   onMounted(() => {
-    refresh();
+    void refresh();
     window.addEventListener("focus", refreshIfVisible);
     timer = setInterval(refreshIfVisible, POLL_MS);
   });

--- a/src/composables/useModalKeyboard.ts
+++ b/src/composables/useModalKeyboard.ts
@@ -40,7 +40,7 @@ export function useModalKeyboard(options: ModalKeyboardOptions & { focusSelector
   const onKeydown = modalKeydownHandler(options);
   onMounted(() => {
     document.addEventListener("keydown", onKeydown);
-    nextTick(() => options.modalEl.value?.querySelector<HTMLElement>(options.focusSelector)?.focus());
+    void nextTick(() => options.modalEl.value?.querySelector<HTMLElement>(options.focusSelector)?.focus());
   });
   onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 }

--- a/src/composables/usePrsView.ts
+++ b/src/composables/usePrsView.ts
@@ -11,12 +11,12 @@ const isPrsRoute = (): boolean => router.currentRoute.value.name === "prs";
 
 /** Open the cross-repo PR list. */
 export function prsGotoIndex(): void {
-  router.push({ path: "/prs", state: overlayOriginState() });
+  void router.push({ path: "/prs", state: overlayOriginState() });
 }
 
 /** Close the PR view → back to the view it was opened from. */
 export function prsClose(): void {
-  router.push(overlayReturnPath());
+  void router.push(overlayReturnPath());
 }
 
 export function usePrsView(): { isOpen: ComputedRef<boolean>; close: () => void } {

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -128,7 +128,7 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
     sessionId,
     (id) => {
       onSessionChange?.();
-      if (id) loadHistory(id);
+      if (id) void loadHistory(id);
       else items.value = [];
       subscribeTo(id);
     },

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -142,7 +142,7 @@ export function useSessions() {
   let offReconnect: (() => void) | undefined;
 
   onMounted(() => {
-    load();
+    void load();
     unsubscribe = subscribe("sessions", () => load());
     // pub-sub replays room membership but not events missed while disconnected, so a
     // dropped socket can leave the list stale until the next push — refetch on reconnect.

--- a/src/composables/useWikiBrowse.ts
+++ b/src/composables/useWikiBrowse.ts
@@ -15,13 +15,13 @@ export type WikiView = { mode: "closed" } | { mode: "index" } | { mode: "page"; 
 
 /** Open the wiki index (the page catalog). */
 export function wikiGotoIndex(): void {
-  router.push({ path: "/wiki", state: overlayOriginState() });
+  void router.push({ path: "/wiki", state: overlayOriginState() });
 }
 
 /** Open the wiki index pre-filtered to a tag (e.g. the Worklog shortcut → `#worklog`).
  *  WikiIndexView reads `?tag=` into its initial selection. */
 export function wikiGotoTag(tag: string): void {
-  router.push({ path: "/wiki", query: { tag }, state: overlayOriginState() });
+  void router.push({ path: "/wiki", query: { tag }, state: overlayOriginState() });
 }
 
 /** Open one page by slug. Unsafe slugs are coerced to the index rather than pushing a
@@ -29,25 +29,25 @@ export function wikiGotoTag(tag: string): void {
 export function wikiGotoPage(slug: string): void {
   const state = overlayOriginState();
   if (!isSafeWikiSlug(slug)) {
-    router.push({ path: "/wiki", state });
+    void router.push({ path: "/wiki", state });
     return;
   }
-  router.push({ path: `/wiki/pages/${encodeURIComponent(slug)}`, state });
+  void router.push({ path: `/wiki/pages/${encodeURIComponent(slug)}`, state });
 }
 
 /** Open the link graph. */
 export function wikiGotoGraph(): void {
-  router.push({ path: "/wiki/graph", state: overlayOriginState() });
+  void router.push({ path: "/wiki/graph", state: overlayOriginState() });
 }
 
 /** Open the lint report. */
 export function wikiGotoLint(): void {
-  router.push({ path: "/wiki/lint", state: overlayOriginState() });
+  void router.push({ path: "/wiki/lint", state: overlayOriginState() });
 }
 
 /** Close the wiki overlay → back to the view it was opened from. */
 export function wikiClose(): void {
-  router.push(overlayReturnPath());
+  void router.push(overlayReturnPath());
 }
 
 /** Current page slug when on a page route, else undefined. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,4 +33,4 @@ installPageZoomGuard();
 // attach the durable "single" PTY — before the route flips to the grid, leaking a
 // hidden Claude session. router.isReady() guarantees the initial URL is honored first.
 const app = createApp(App).use(router);
-router.isReady().then(() => app.mount("#app"));
+void router.isReady().then(() => app.mount("#app"));


### PR DESCRIPTION
## Summary

`no-floating-promises` の **66 件を全部読み**、`void` で意図を明示しました。**102 → 33 warnings**。

## Items to Confirm / Review

### 1. 66 件に実バグはありませんでした

全部が意図的な fire-and-forget です。

| パターン | 件数 |
|---|---|
| `router.push(…)` | 16 |
| `nextTick(…)` | 7 |
| 意図的な再取得（`loadDiff` / `refreshUsage` / `loadInitial` / `loadFile` / `save` …） | 約30 |
| `.then(…)` 連鎖 | 5 |
| `socket.join` / `socket.leave` | 2 |
| `transport.close()` / `server.close()` | 2 |

### 2. なぜ 66 件に手を入れる価値があるか

`void` はルールが求めるマーカーで、**「意図的に待たない」がコードに書かれます**。

**66 件が出続ける状態では、本物の await 忘れが紛れても気づけません。** これ以降 floating promise の警告が出たら、それは本当に「誰かが await を忘れた」を意味します。それがこの変更の価値です。

### 3. `sonarjs/void-use` を off にしました

`void` 演算子を禁じるルールで、`no-floating-promises` が求めるものと**正面から矛盾**します。await 忘れを捕まえる方を選びました（理由は config にコメントで残しています）。

### 4. `void` は unhandled rejection を防ぎません — それでよい理由

**これは調べたうえでの判断です。** `void p` は lint を黙らせるだけで、拒否ハンドラは付きません。それでも正直な表明である理由:

- **サーバ**: `server/infra/process-guards.ts` が `unhandledRejection` を拾い、スタックをログに出してプロセスを保ちます。
- **クライアント**: ブラウザが未処理の拒否をコンソールに報告します。

つまり「待たないが、拒否は共通経路で見える」という状態が維持されます。`.catch()` を 66 箇所に足すと**その共通経路から消える**ので、かえって見えにくくなります。

## 検証

`yarn lint` **0 error / 33 warnings**（← 102）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` **7560 passed**。

**実際に起動して確認**しました（挙動が変わっていないことの担保として）。

- 画面描画・プラグイン登録 OK、uncaught console error **0**
- サーバログの `unhandledRejection` **0 件**

## 残り 33 warnings の内訳

| ルール | 件数 | 状態 |
|---|---|---|
| `different-types-comparison` | 9 | **偽陽性** — `noUncheckedIndexedAccess` 待ち（#1301） |
| `deprecation` | 7 | **すべて正当** — Node の型、MCP SDK、`execCommand`/`returnValue` は「legacy Chrome/Edge に必要」とコメント済み |
| `max-lines` | 5 | 既存 |
| `no-useless-intersection` | 4 | **偽陽性** — Vue の `defineEmits<>` 合成 |
| `function-return-type` | 3 | 設計どおり |
| `reduce-initial-value` | 2 | **偽陽性** — 直前に空チェックあり |
| `no-misused-promises` | 2 | 未精査 |
| `no-selector-parameter` | 1 | 設計指摘 |

**33 件のうち 15 件が偽陽性**で、うち 9 件は #1301 の `noUncheckedIndexedAccess` が入れば自動的に消えます。

refs #1300

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of intentionally unawaited asynchronous operations across navigation, loading, cleanup, and background tasks.
  * Preserved existing application behavior while reducing linting noise and clarifying fire-and-forget operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->