### PR TITLE
feat(tsconfig): noUncheckedIndexedAccess を本体に入れる — 118件すべて修正 (#1301)

### DIFF
--- a/common/codeBlocks.ts
+++ b/common/codeBlocks.ts
@@ -59,8 +59,12 @@ export function fencedBlocks(markdown: string): FencedBlock[] {
   const lines = markdown.split("\n");
   const blocks: FencedBlock[] = [];
   let i = 0;
+  // Each line is read into a const before use: with noUncheckedIndexedAccess, `lines[i]` is
+  // `string | undefined` even inside `i < lines.length`, and the loop condition is what actually
+  // rules the undefined out.
   while (i < lines.length) {
-    const open = fenceOf(lines[i]);
+    const line = lines[i];
+    const open = line === undefined ? null : fenceOf(line);
     if (!open) {
       i++;
       continue;
@@ -69,12 +73,12 @@ export function fencedBlocks(markdown: string): FencedBlock[] {
     const info = open.info.trim();
     const body: string[] = [];
     i++;
-    while (i < lines.length && !closes(lines[i], fence)) {
-      body.push(lines[i]);
+    for (let next = lines[i]; next !== undefined && !closes(next, fence); next = lines[i]) {
+      body.push(next);
       i++;
     }
     i++; // step over the closing fence (or past the end, for an unclosed block)
-    blocks.push({ lang: info ? (info.split(/\s+/)[0].toLowerCase() ?? null) : null, body: body.join("\n") });
+    blocks.push({ lang: info ? (info.split(/\s+/)[0]?.toLowerCase() ?? null) : null, body: body.join("\n") });
   }
   return blocks;
 }
@@ -84,5 +88,5 @@ export function fencedBlocks(markdown: string): FencedBlock[] {
  *  exactly like a copy that silently failed. */
 export function lastFencedBlock(markdown: string): FencedBlock | null {
   const withBody = fencedBlocks(markdown).filter((b) => b.body.trim() !== "");
-  return withBody.length ? withBody[withBody.length - 1] : null;
+  return withBody[withBody.length - 1] ?? null;
 }

--- a/common/issueStartPlan.ts
+++ b/common/issueStartPlan.ts
@@ -47,7 +47,8 @@ export function issueStartPlan(entry: RepoDirs | undefined, repo: string): Issue
   // the two cases the same keeps "recorded" from being a state the UI has to distinguish.
   const recorded = entry?.primary;
   if (recorded) return { kind: "ready", dir: recorded };
-  if (dirs.length === 1) return { kind: "ready", dir: dirs[0].path };
+  const only = dirs.length === 1 ? dirs[0] : undefined;
+  if (only) return { kind: "ready", dir: only.path };
   return { kind: "choose", dirs };
 }
 

--- a/common/keymap.ts
+++ b/common/keymap.ts
@@ -87,6 +87,7 @@ export function parseKeyBinding(input: string): KeyBinding | null {
   const parts = input.split("+").map((part) => part.trim());
   if (parts.length === 0 || parts.some((part) => part === "")) return null;
   const key = parts[parts.length - 1];
+  if (key === undefined) return null; // unreachable: parts.length was checked above
   const binding: KeyBinding = { key, shift: false, alt: false, ctrl: false, meta: false };
   for (const part of parts.slice(0, -1)) {
     const flag = MODIFIERS[part.toLowerCase()];
@@ -226,6 +227,7 @@ function duplicateWarnings(bound: Map<string, Claim[]>): KeymapProblem[] {
   return [...bound.values()].flatMap((claims) => {
     if (claims.length < 2) return [];
     const [winner, ...losers] = [...claims].sort((a, b) => a.rank - b.rank);
+    if (!winner) return []; // unreachable: claims.length >= 2 was checked above
     return losers.map(({ label, binding }) => ({
       action: label,
       binding,

--- a/common/median.ts
+++ b/common/median.ts
@@ -8,6 +8,11 @@ export const median = (values: number[]): number | null => {
   if (values.length === 0) return null;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) return sorted[mid];
-  return (sorted[mid - 1] + sorted[mid]) / 2;
+  // Read once each: `sorted[mid]` is `number | undefined` under noUncheckedIndexedAccess, and the
+  // length checks above are what actually rule that out.
+  const middle = sorted[mid];
+  if (middle === undefined) return null;
+  if (sorted.length % 2 === 1) return middle;
+  const below = sorted[mid - 1];
+  return below === undefined ? middle : (below + middle) / 2;
 };

--- a/common/prPhase.ts
+++ b/common/prPhase.ts
@@ -83,7 +83,7 @@ function toIssueNumber(digits: string): number | null {
 // shown next to this cell's PR has to belong to the same repo to be clickable and true.
 export function issueRefFromPrBody(body: string | null | undefined): number | null {
   const found = typeof body === "string" ? CLOSING_KEYWORD.exec(body) : null;
-  return found ? toIssueNumber(found[1]) : null;
+  return found?.[1] === undefined ? null : toIssueNumber(found[1]);
 }
 
 // Whether the body ALREADY states what merging it closes, in either form GitHub honours. Broader
@@ -105,7 +105,7 @@ const BRANCH_ISSUE = /^[a-z][a-z-]*\/([1-9]\d*)-/;
 // somebody else's issue. Named for the doubt so a call site can't forget it.
 export function issueCandidateFromBranch(branch: string | null | undefined): number | null {
   const found = typeof branch === "string" ? BRANCH_ISSUE.exec(branch) : null;
-  return found ? toIssueNumber(found[1]) : null;
+  return found?.[1] === undefined ? null : toIssueNumber(found[1]);
 }
 
 // The prefix this app gives a branch it creates FOR an issue (#1171). Shared because the two
@@ -121,5 +121,5 @@ const ANCHORED_ISSUE = new RegExp(`^${ISSUE_BRANCH_PREFIX}([1-9]\\d*)-`);
 // else's issue the moment the PR merges, which no amount of confirming afterwards undoes.
 export function issueFromAnchoredBranch(branch: string | null | undefined): number | null {
   const found = typeof branch === "string" ? ANCHORED_ISSUE.exec(branch) : null;
-  return found ? toIssueNumber(found[1]) : null;
+  return found?.[1] === undefined ? null : toIssueNumber(found[1]);
 }

--- a/common/repoEntry.ts
+++ b/common/repoEntry.ts
@@ -30,8 +30,9 @@ export interface RepoEntry {
 export function parseRepoEntry(entry: string): RepoEntry | null {
   const segments = entry.trim().split("/");
   if (segments.some((segment) => segment === "")) return null;
-  const declared = segments.length > 1 && HOST_SEGMENT.test(segments[0]);
-  return declared ? { host: segments[0].toLowerCase(), path: segments.slice(1), declared } : { host: GITHUB_HOST, path: segments, declared };
+  const first = segments[0];
+  const host = segments.length > 1 && first !== undefined && HOST_SEGMENT.test(first) ? first : null;
+  return host === null ? { host: GITHUB_HOST, path: segments, declared: false } : { host: host.toLowerCase(), path: segments.slice(1), declared: true };
 }
 
 /** The identity a repository is known by ON ITS OWN HOST — `owner/repo` for GitHub, the group path

--- a/server/agents/antigravity-session.ts
+++ b/server/agents/antigravity-session.ts
@@ -46,7 +46,7 @@ export function snapshotAntigravitySessions(root: string = antigravityBrainRoot(
 // The one conversation this session created, or null while that is still ambiguous.
 export function pickFreshAntigravitySession(root: string, before: ReadonlySet<string>, claimed?: ReadonlySet<string>): string | null {
   const found = listAntigravityConversationIds(root).filter((id) => !before.has(id) && !claimed?.has(id));
-  return found.length === 1 ? found[0] : null;
+  return found.length === 1 ? (found[0] ?? null) : null;
 }
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -41,7 +41,7 @@ function promptText(content: string): string {
   const wrapped = USER_REQUEST_RE.exec(content);
   // No wrapper means a shape we have not seen. Dropping the blocks we DO know keeps a usable
   // title instead of pasting agy's metadata into the row.
-  return wrapped ? wrapped[1] : content.replace(APPENDED_BLOCK_RE, "");
+  return wrapped?.[1] ?? content.replace(APPENDED_BLOCK_RE, "");
 }
 
 /** The conversation's title, from the head of its transcript. */

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -32,7 +32,7 @@ export function nextReadRange(offset: number, size: number): { from: number; to:
 // than parsed as a line. Text ending in a newline leaves nothing pending.
 export function takeCompleteLines(pending: string, chunk: string): { lines: string[]; pending: string } {
   const parts = (pending + chunk).split("\n");
-  return { lines: parts.slice(0, -1).filter((line) => line.trim()), pending: parts[parts.length - 1] };
+  return { lines: parts.slice(0, -1).filter((line) => line.trim()), pending: parts[parts.length - 1] ?? "" };
 }
 
 // The `event_msg` payload type of a line, or null for anything else. A `turn_context` row

--- a/server/agents/codex-rate-limits.ts
+++ b/server/agents/codex-rate-limits.ts
@@ -63,7 +63,7 @@ export function extractCodexRateLimits(rateLimits: unknown): RateLimits | null {
  */
 export function latestRateLimitsInRollout(lines: readonly string[]): RateLimits | null {
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i].trim();
+    const line = lines[i]?.trim() ?? "";
     if (!line.includes("rate_limits")) continue;
     try {
       const parsed: unknown = JSON.parse(line);

--- a/server/agents/codex-session.ts
+++ b/server/agents/codex-session.ts
@@ -91,9 +91,11 @@ export function pickFreshSession(root: string, before: Set<string>, cwd: string 
     .filter((file) => !before.has(file) && !claimed?.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
-  if (found.length === 1) return { ...found[0].meta, file: found[0].file };
+  const sole = found.length === 1 ? found[0] : undefined;
+  if (sole) return { ...sole.meta, file: sole.file };
   const matches = cwd ? found.filter((x) => x.meta.cwd === cwd) : [];
-  if (matches.length === 1) return { ...matches[0].meta, file: matches[0].file };
+  const soleMatch = matches.length === 1 ? matches[0] : undefined;
+  if (soleMatch) return { ...soleMatch.meta, file: soleMatch.file };
   return null;
 }
 

--- a/server/backends/remoteHost/attachment-path.ts
+++ b/server/backends/remoteHost/attachment-path.ts
@@ -26,7 +26,7 @@ const MIME_EXT: Readonly<Record<string, string>> = {
 // A Content-Type may carry parameters ("text/plain; charset=utf-8") or surrounding space;
 // the extension map is keyed by the bare type, so strip everything from the first ";" and
 // trim before the lower-cased lookup — otherwise a charset-bearing text upload falls to .bin.
-export const extensionForMime = (mimeType: string): string => MIME_EXT[mimeType.split(";")[0].trim().toLowerCase()] ?? ".bin";
+export const extensionForMime = (mimeType: string): string => MIME_EXT[(mimeType.split(";")[0] ?? "").trim().toLowerCase()] ?? ".bin";
 
 // UTC YYYY/MM partition so a workspace with many uploads stays browsable. getUTCMonth is
 // 0-indexed, hence +1; zero-padded to two digits. UTC (not local) so the partition a file lands

--- a/server/backends/remoteHost/skills.ts
+++ b/server/backends/remoteHost/skills.ts
@@ -59,7 +59,7 @@ export const parseSkillDescription = (raw: string): string | null => {
 // the common quoted-string case.
 const unquote = (value: string): string => {
   const quoted = /^(['"])(.*)\1$/.exec(value);
-  return quoted ? quoted[2] : value;
+  return quoted?.[2] ?? value;
 };
 
 // Read `dir/SKILL.md` and return its description, or null when the dir isn't a

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -207,7 +207,8 @@ async function updateViaView(
   // Shape the returned item like a getItems item — same host-computed fields
   // (derived, toggle, embed) — then inline the view's declared image fields.
   const [enriched] = await deps.enrichItems(collection, [result.item]);
-  const item = enriched;
+  // enrichItems answers one item per input, so the single element is there — read it as such.
+  const item = enriched ?? result.item;
   const baseBytes = Buffer.byteLength(JSON.stringify(item), "utf8");
   if (baseBytes > REMOTE_VIEW_ITEMS_MAX_BYTES) return { kind: "too-large", bytes: baseBytes };
   const imageFields = inlineFields(view, collection.schema, undefined);

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -54,6 +54,7 @@ function isValidDailyTime(value: string): boolean {
   const parts = value.split(":");
   if (parts.length !== 2) return false;
   const [hourStr, minStr] = parts;
+  if (hourStr === undefined || minStr === undefined) return false; // unreachable: length checked above
   if (hourStr.length !== 2 || minStr.length !== 2 || !allDigits(hourStr) || !allDigits(minStr)) return false;
   return Number(hourStr) <= 23 && Number(minStr) <= 59;
 }

--- a/server/backends/translation.ts
+++ b/server/backends/translation.ts
@@ -116,7 +116,7 @@ export function mergeTranslations(dict: DictionaryFile, lang: string, fresh: Rea
     safeAssign(next, source, { ...langs });
   }
   for (const [source, translated] of fresh) {
-    const existing = Object.hasOwn(next, source) ? next[source] : {};
+    const existing = (Object.hasOwn(next, source) ? next[source] : undefined) ?? {};
     // `lang` is regex-validated upstream so it can't be a dangerous key; the only
     // unsafe site is the user-supplied `source`, handled by safeAssign.
     existing[lang] = translated;
@@ -250,7 +250,11 @@ export function mountTranslationRoutes(app: Express, deps: TranslationDeps): voi
       throw new Error(`[translation] LLM returned ${translated.length} translations for ${misses.length} sentences`);
     }
     const fresh = new Map<string, string>();
-    misses.forEach((sentence, index) => fresh.set(sentence, translated[index]));
+    // Length equality was checked immediately above, so every index is present.
+    misses.forEach((sentence, index) => {
+      const line = translated[index];
+      if (line !== undefined) fresh.set(sentence, line);
+    });
     await saveDictionary(deps.workspace, req.namespace, mergeTranslations(dict, req.targetLanguage, fresh));
     return assembleResult(req.sentences, cached, fresh);
   }

--- a/server/config/header-title.ts
+++ b/server/config/header-title.ts
@@ -86,8 +86,8 @@ function stripQuotes(text: string): string {
   const chars = [...text];
   let start = 0;
   let end = chars.length;
-  while (start < end && EDGE_QUOTES.has(chars[start])) start++;
-  while (end > start && EDGE_QUOTES.has(chars[end - 1])) end--;
+  while (start < end && EDGE_QUOTES.has(chars[start] ?? "")) start++;
+  while (end > start && EDGE_QUOTES.has(chars[end - 1] ?? "")) end--;
   return chars.slice(start, end).join("").trim();
 }
 

--- a/server/files/backup-store.ts
+++ b/server/files/backup-store.ts
@@ -61,7 +61,8 @@ function newestBackup(dir: string): string | null {
       .readdirSync(dir)
       .filter((n) => n.endsWith(BACKUP_SUFFIX))
       .sort(byCodeUnit);
-    return names.length ? path.join(dir, names[names.length - 1]) : null;
+    const newest = names[names.length - 1];
+    return newest === undefined ? null : path.join(dir, newest);
   } catch {
     return null;
   }

--- a/server/files/pathContainment.ts
+++ b/server/files/pathContainment.ts
@@ -98,7 +98,7 @@ export function namesAWindowsDevice(rel: string, platform: NodeJS.Platform = pro
     // `.` and `:` both end the stem: `CON.txt` is CON, and so is `NUL:$DATA` — a colon opens
     // an NTFS alternate data stream (and `NUL:` is the legacy device spelling), neither of
     // which stops the name in front of it being a device.
-    const stem = trimTrailingDotsAndSpaces(segment.split(/[.:]/)[0]);
+    const stem = trimTrailingDotsAndSpaces(segment.split(/[.:]/)[0] ?? "");
     return WINDOWS_DEVICE_NAMES.has(stem.toUpperCase());
   });
 }

--- a/server/files/renderedDoc.ts
+++ b/server/files/renderedDoc.ts
@@ -144,6 +144,7 @@ export function tableHtmlDoc(text: string, title: string, delimiter: string): st
   const rows = parseDelimited(text, delimiter);
   if (rows.length === 0) return htmlDoc(`<p>${escapeHtml(title)} is empty.</p>`, title, TABLE_STYLE);
   const [header, ...body] = rows;
+  if (!header) return htmlDoc(`<p>${escapeHtml(title)} is empty.</p>`, title, TABLE_STYLE);
   const cells = (values: string[], tag: "th" | "td") => values.map((v) => `<${tag}>${escapeHtml(v)}</${tag}>`).join("");
   const bodyRows = body.map((r) => `<tr>${cells(r, "td")}</tr>`).join("");
   const table = `<table><thead><tr>${cells(header, "th")}</tr></thead><tbody>${bodyRows}</tbody></table>`;

--- a/server/files/scripts.ts
+++ b/server/files/scripts.ts
@@ -54,6 +54,7 @@ export function resolveScript(workspaceDir: string, index: number): { command: s
   const scripts = loadScripts(workspaceDir);
   if (!Number.isInteger(index) || index < 0 || index >= scripts.length) return null;
   const def = scripts[index];
+  if (!def) return null; // unreachable: the bounds were checked above
   const cwd = def.cwd ? path.resolve(workspaceDir, def.cwd) : workspaceDir;
   try {
     if (!statSync(cwd).isDirectory()) return null;

--- a/server/git/git-parse.ts
+++ b/server/git/git-parse.ts
@@ -10,7 +10,7 @@ export function lastGhUrl(stdout: string): string | null {
   const urls = splitLines(stdout)
     .map((line) => line.trim())
     .filter((line) => line.startsWith("http"));
-  return urls.length ? urls[urls.length - 1] : null;
+  return urls[urls.length - 1] ?? null;
 }
 
 export interface NumstatEntry {
@@ -25,7 +25,7 @@ export interface NumstatEntry {
 export function parseNumstatLine(line: string, toCount: (s: string) => number): NumstatEntry {
   const [add, del, ...rest] = line.split("\t");
   const num = (s: string) => (s === "-" ? -1 : toCount(s));
-  return { path: rest.join("\t"), additions: num(add), deletions: num(del) };
+  return { path: rest.join("\t"), additions: num(add ?? "-"), deletions: num(del ?? "-") };
 }
 
 // Cap a diff patch so a huge one does not bloat the payload over the socket; `truncated` tells

--- a/server/git/remote-ref.ts
+++ b/server/git/remote-ref.ts
@@ -20,7 +20,7 @@ export function parseRemoteRef(remoteUrl: string): RemoteRef | null {
   if (!url) return null;
   // The scp-like form has no scheme (user@host:path), so the URL parser can't read it.
   const scp = /^[^/@]+@([^/:]+):([^:]+)$/.exec(url);
-  const { host, rawPath } = scp ? { host: scp[1], rawPath: scp[2] } : fromUrl(url);
+  const { host, rawPath } = scp ? { host: scp[1] ?? "", rawPath: scp[2] ?? "" } : fromUrl(url);
   const cleaned = cleanPath(rawPath);
   return host && cleaned ? { host: host.toLowerCase(), path: cleaned } : null;
 }

--- a/server/infra/accounting-tool.ts
+++ b/server/infra/accounting-tool.ts
@@ -54,8 +54,8 @@ export const MANAGE_ACCOUNTING: ToolDefinition = {
       },
       fiscalYearEnd: {
         type: "integer",
-        minimum: FISCAL_YEAR_END_MONTHS[0],
-        maximum: FISCAL_YEAR_END_MONTHS[FISCAL_YEAR_END_MONTHS.length - 1],
+        minimum: FISCAL_YEAR_END_MONTHS[0] ?? 1,
+        maximum: FISCAL_YEAR_END_MONTHS[FISCAL_YEAR_END_MONTHS.length - 1] ?? 12,
         description:
           "For 'createBook' / 'updateBook': the calendar month (1-12) on whose LAST DAY this book's fiscal year closes — e.g. 3 = March 31, 8 = August 31, 12 = December 31 (calendar year, the default). Any month is allowed. Drives the date-range shortcuts in the UI ('current quarter', 'current year', etc.). Pure metadata: changing it does not move existing entries.",
       },

--- a/server/infra/pluginRuntime.ts
+++ b/server/infra/pluginRuntime.ts
@@ -59,7 +59,7 @@ function scopedFiles(pkg: string): { data: FileOps; config: FileOps; artifacts: 
 // the server side is a snapshot), read from the usual POSIX env with an en fallback.
 function hostLocale(): string {
   const raw = process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANG || "en";
-  return raw.split(".")[0].replace("_", "-") || "en";
+  return (raw.split(".")[0] ?? "").replace("_", "-") || "en";
 }
 
 const hostFetch = async (url: string, opts?: PluginFetchOptions): Promise<Response> => {

--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -59,6 +59,7 @@ export function isLauncherPathEntry(entry: string): boolean {
   const segments = entry.split(/[\\/]/).filter((segment) => segment !== "");
   if (segments.length === 0) return false; // "" and "/" name no directory of ours
   const last = segments[segments.length - 1];
+  if (last === undefined) return false; // unreachable: length was checked above
   const parent = segments[segments.length - 2];
   return YARN_SHIM_DIR.test(last) || (last === ".bin" && parent === "node_modules") || last === "node-gyp-bin";
 }

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -118,7 +118,7 @@ export function planMsOverride(showStdout: string): MsOverridePlan {
     const entry = /^terminal-overrides\[(\d+)\] (.*)$/.exec(line);
     if (!entry) continue;
     const [, index, value] = entry;
-    if (!value.includes("Ms=") || !value.includes("]52;")) continue; // someone else's override
+    if (value === undefined || !value.includes("Ms=") || !value.includes("]52;")) continue; // someone else's override
     return value.includes("Ms=\\\\E]52;") ? { kind: "ok" } : { kind: "replace", index: Number(index) };
   }
   return { kind: "append" };
@@ -357,7 +357,7 @@ export function redrawTargets(stdout: string, clientPid: number): string[] {
   const clients = splitLines(stdout)
     .map((line) => line.trim().split(/\s+/))
     .filter((parts) => parts.length >= 2)
-    .map(([pid, tty]) => ({ pid: Number(pid), tty }));
+    .map(([pid, tty]) => ({ pid: Number(pid), tty: tty ?? "" }));
   const ours = clients.filter((client) => client.pid === clientPid);
   return (ours.length > 0 ? ours : clients).map((client) => client.tty);
 }

--- a/server/session/command-summary.ts
+++ b/server/session/command-summary.ts
@@ -46,7 +46,7 @@ export const DEFAULT_LOCALE = "en";
 // The value is interpolated into the claude prompt, so anything unexpected falls back
 // to the default rather than injecting a free-form string.
 export function normalizeLocale(v: unknown): string {
-  const base = typeof v === "string" ? v.split("-")[0].toLowerCase() : "";
+  const base = typeof v === "string" ? (v.split("-")[0] ?? "").toLowerCase() : "";
   return /^[a-z]{2,8}$/.test(base) ? base : DEFAULT_LOCALE;
 }
 

--- a/server/session/decision-scan.ts
+++ b/server/session/decision-scan.ts
@@ -75,7 +75,10 @@ async function mapWithLimit<T, R>(items: T[], limit: number, run: (item: T) => P
   const results = new Array<R>(items.length);
   let next = 0;
   const worker = async (): Promise<void> => {
-    for (let i = next++; i < items.length; i = next++) results[i] = await run(items[i]);
+    for (let i = next++; i < items.length; i = next++) {
+      const item = items[i];
+      if (item !== undefined) results[i] = await run(item);
+    }
   };
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
   return results;

--- a/server/session/decisions.ts
+++ b/server/session/decisions.ts
@@ -155,7 +155,7 @@ function questionsOf(input: unknown, text: string | null): DecisionQuestion[] {
     const question = str(q.question);
     const options = optionsOf(q.options);
     const later = starts.slice(i + 1).filter((at) => at >= 0);
-    const parsed = text === null ? { answer: null, fromOptions: false } : answerFor(question, text, starts[i], later, options);
+    const parsed = text === null ? { answer: null, fromOptions: false } : answerFor(question, text, starts[i] ?? 0, later, options);
     return {
       question,
       header: str(q.header),

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -52,7 +52,8 @@ const trimmedString = (value: unknown): string | null => (typeof value === "stri
 function codexPromptForTurn(docs: Record<string, unknown>[], completeIndex: number, turnId: string | null): string | null {
   let start = -1;
   for (let i = completeIndex - 1; i >= 0; i--) {
-    const started = eventPayload(docs[i], "task_started");
+    const doc = docs[i];
+    const started = doc === undefined ? null : eventPayload(doc, "task_started");
     if (started && (turnId === null || started.turn_id === turnId)) {
       start = i;
       break;
@@ -60,7 +61,8 @@ function codexPromptForTurn(docs: Record<string, unknown>[], completeIndex: numb
   }
   if (start < 0) return null;
   for (let i = start + 1; i < completeIndex; i++) {
-    const message = eventPayload(docs[i], "user_message");
+    const doc = docs[i];
+    const message = doc === undefined ? null : eventPayload(doc, "user_message");
     if (message) {
       const text = trimmedString(message.message);
       if (text) return text;
@@ -80,7 +82,8 @@ export function lastTurnFromCodexRollout(raw: string): LastTurn {
  *  doesn't have to rebuild a string just to hand it back. */
 export function lastTurnFromCodexRolloutDocs(docs: Record<string, unknown>[]): LastTurn {
   for (let i = docs.length - 1; i >= 0; i--) {
-    const complete = eventPayload(docs[i], "task_complete");
+    const doc = docs[i];
+    const complete = doc === undefined ? null : eventPayload(doc, "task_complete");
     if (!complete) continue;
     const reply = trimmedString(complete.last_agent_message);
     if (!reply) continue;

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -66,7 +66,7 @@ export function launcherCommandWithGuiMcp(command: string, servers: readonly Gui
   //
   // Two index walks rather than one anchored regex: `^(\s*)(\S+)([\s\S]*)$` backtracks
   // super-linearly on a long command (sonarjs flags it), and this says the same thing.
-  const isSpace = (index: number): boolean => /\s/.test(command[index]);
+  const isSpace = (index: number): boolean => /\s/.test(command[index] ?? "");
   let start = 0;
   while (start < command.length && isSpace(start)) start++;
   if (start === command.length) return command; // whitespace only — nothing to run

--- a/server/session/screen-rows.ts
+++ b/server/session/screen-rows.ts
@@ -43,7 +43,7 @@ const dimAfter = (dim: boolean, params: readonly string[]): boolean => {
 
 const dimAfterEscape = (sequence: string, dim: boolean): boolean => {
   const sgr = SGR.exec(sequence);
-  return sgr === null ? dim : dimAfter(dim, sgr[1].split(";"));
+  return sgr === null ? dim : dimAfter(dim, (sgr[1] ?? "").split(";"));
 };
 
 interface RowScan {
@@ -119,5 +119,7 @@ const wrappedRows = (rows: readonly ScreenRow[]): readonly ScreenRow[] => {
 export const suggestionFromRows = (rows: readonly ScreenRow[]): string => {
   const start = rows.findLastIndex(offersSuggestion);
   if (start === -1) return "";
-  return [rows[start], ...wrappedRows(rows.slice(start + 1))].map((row) => row.dim.trim()).reduce(joinWrapped);
+  const head = rows[start];
+  if (head === undefined) return ""; // unreachable: findLastIndex answered a real index
+  return [head, ...wrappedRows(rows.slice(start + 1))].map((row) => row.dim.trim()).reduce(joinWrapped);
 };

--- a/server/session/shell-command.ts
+++ b/server/session/shell-command.ts
@@ -24,5 +24,5 @@ export function shellInvocation(command: string, replaceShell: boolean, platform
  *  browser sends only an index — the configured list is the allowlist — so a fractional,
  *  negative, or past-the-end index has to resolve to nothing rather than to undefined. */
 export function launcherAt<T>(list: readonly T[], index: number): T | null {
-  return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
+  return Number.isInteger(index) && index >= 0 && index < list.length ? (list[index] ?? null) : null;
 }

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -118,7 +118,8 @@ export const countUserTurnsFromJsonl = (raw: string): number => countUserTurnsFr
 export function latestAssistantTextFromParsed(records: Record<string, unknown>[]): string | null {
   const turns = conversationTurnsFromParsed(records);
   for (let i = turns.length - 1; i >= 0; i--) {
-    if (turns[i].role === "assistant") return turns[i].text;
+    const turn = turns[i];
+    if (turn?.role === "assistant") return turn.text;
   }
   return null;
 }
@@ -202,8 +203,8 @@ function normalizeForAck(text: string): string {
   const chars = [...text.trim().toLowerCase()];
   let start = 0;
   let end = chars.length;
-  while (start < end && EDGE_PUNCT.has(chars[start])) start++;
-  while (end > start && EDGE_PUNCT.has(chars[end - 1])) end--;
+  while (start < end && EDGE_PUNCT.has(chars[start] ?? "")) start++;
+  while (end > start && EDGE_PUNCT.has(chars[end - 1] ?? "")) end--;
   return chars.slice(start, end).join("").trim();
 }
 
@@ -230,7 +231,8 @@ export function preferredHeaderPrompt(current: string | null, incoming: string):
 export function latestMeaningfulUserPromptFromParsed(records: Record<string, unknown>[]): string | null {
   const { prompts, lastPromptRecord } = collectPrompts(records);
   for (let i = prompts.length - 1; i >= 0; i--) {
-    if (!isTrivialPrompt(prompts[i])) return prompts[i];
+    const prompt = prompts[i];
+    if (prompt !== undefined && !isTrivialPrompt(prompt)) return prompt;
   }
   return prompts[prompts.length - 1] ?? lastPromptRecord;
 }

--- a/src/components/ModelPicker.vue
+++ b/src/components/ModelPicker.vue
@@ -30,7 +30,7 @@ const selected = computed({
   set: (value: string) => {
     if (!value) return emit("update:modelValue", null);
     const [provider, model] = value.split(SEPARATOR);
-    emit("update:modelValue", { provider: provider || null, model });
+    emit("update:modelValue", { provider: provider || null, ...(model === undefined ? {} : { model }) });
   },
 });
 </script>

--- a/src/components/cwdDisplay.ts
+++ b/src/components/cwdDisplay.ts
@@ -39,5 +39,5 @@ export function worktreeLabel(cwd: string | null): { repo: string; task: string 
   const task = parts[i + 2];
   if (i < 0 || !dir || !task) return null;
   const m = MANAGED_DIR.exec(dir);
-  return m ? { repo: m[1], task } : null;
+  return m?.[1] === undefined ? null : { repo: m[1], task };
 }

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -102,7 +102,7 @@ export function addCell(state: GridState): GridState {
 // cancelable, so it's excluded.
 export function cancelableLaunchUid(state: GridState): number | null {
   const last = state.cells[state.cells.length - 1];
-  return state.cells.length > 1 && isLaunchCell(last) ? last.uid : null;
+  return state.cells.length > 1 && last !== undefined && isLaunchCell(last) ? last.uid : null;
 }
 
 export function setSession(state: GridState, uid: number, id: string | null): GridState {
@@ -300,7 +300,7 @@ export function nextAttention(
   // NEVER enlarges or collapses — that is toggleZoom's job alone. Zoomed, this moves which
   // terminal is enlarged; un-zoomed, it brings the candidate's page on screen and leaves the
   // grid a grid. A key that sometimes changed the whole layout would be unpredictable.
-  return zoomedUid(state) !== null ? { ...state, expanded: order[at] } : { ...state, page: Math.floor(at / PAGE_SIZE) };
+  return zoomedUid(state) !== null ? { ...state, expanded: order[at] ?? null } : { ...state, page: Math.floor(at / PAGE_SIZE) };
 }
 
 /** The uid of the terminal `nextAttention` would move to, or null. Exported so the caller can
@@ -312,7 +312,7 @@ export function nextAttentionUid(
   fromUid: number | null = null,
 ): number | null {
   const at = nextCandidate(state, order, statusByUid, zoomedUid(state) ?? fromUid);
-  return at === undefined ? null : order[at];
+  return at === undefined ? null : (order[at] ?? null);
 }
 
 // The index in `order` of the next terminal worth going to, starting after `from`, or undefined
@@ -333,7 +333,10 @@ function nextCandidate(state: GridState, order: readonly number[], statusByUid: 
   for (const status of ATTENTION_ORDER) {
     // Absent = idle, the convention AttentionStatus documents: a cell whose status has not been
     // reported yet must not fall out of the search entirely.
-    const at = rotated.find((i) => occupied.has(order[i]) && (statusByUid[order[i]] ?? "idle") === status);
+    const at = rotated.find((i) => {
+      const uid = order[i];
+      return uid !== undefined && occupied.has(uid) && (statusByUid[uid] ?? "idle") === status;
+    });
     if (at !== undefined) return at;
   }
   return undefined;
@@ -371,7 +374,10 @@ export function moveCell(state: GridState, uid: number, dir: -1 | 1): GridState 
   if (!canMoveCell(state.cells, uid, dir)) return state;
   const i = state.cells.findIndex((c) => c.uid === uid);
   const cells = state.cells.slice();
-  [cells[i], cells[i + dir]] = [cells[i + dir], cells[i]];
+  const here = cells[i];
+  const there = cells[i + dir];
+  if (!here || !there) return state; // out of range — nothing to swap
+  [cells[i], cells[i + dir]] = [there, here];
   return { ...state, cells };
 }
 
@@ -511,7 +517,8 @@ export function migrateLegacy(raw: string | null): GridState | null {
     parsed.sessions.forEach((s: unknown, i: number) => {
       if (isUuid(s)) cells.push({ uid: cells.length, session: s, cwd: typeof parsed.cwds?.[i] === "string" ? parsed.cwds[i] : null });
     });
-    const expanded = typeof parsed.expanded === "number" && parsed.expanded >= 0 && parsed.expanded < cells.length ? cells[parsed.expanded].uid : null;
+    const expanded =
+      typeof parsed.expanded === "number" && parsed.expanded >= 0 && parsed.expanded < cells.length ? (cells[parsed.expanded]?.uid ?? null) : null;
     return clampPage(ensureEntry({ cells, expanded, page: 0, nextUid: cells.length, sortMode: "manual" }));
   } catch {
     return null;

--- a/src/components/settings/ThemeSection.vue
+++ b/src/components/settings/ThemeSection.vue
@@ -29,7 +29,9 @@ function onThemeKey(e: KeyboardEvent, index: number) {
   if (!forward && !backward) return;
   e.preventDefault();
   const next = (index + (forward ? 1 : themes.value.length - 1)) % themes.value.length;
-  setTheme(themes.value[next].id);
+  const target = themes.value[next];
+  if (!target) return;
+  setTheme(target.id);
   themesEl.value?.querySelectorAll<HTMLElement>('[role="radio"]')[next]?.focus();
 }
 </script>

--- a/src/components/wikiTagFilter.ts
+++ b/src/components/wikiTagFilter.ts
@@ -20,7 +20,8 @@ const rankMeaningfulTags = (counts: Map<string, number>): TagCount[] =>
 // slicing the row at an arbitrary boundary — so the bar can exceed the target on ties.
 const adaptiveCutoff = (ranked: TagCount[], target: number): TagCount[] => {
   if (ranked.length <= target) return ranked;
-  const cutoffCount = ranked[target - 1][1];
+  const cutoffCount = ranked[target - 1]?.[1];
+  if (cutoffCount === undefined) return ranked; // unreachable: length > target was checked above
   return ranked.filter(([, count]) => count >= cutoffCount);
 };
 

--- a/src/composables/terminalFilePathLinkProvider.ts
+++ b/src/composables/terminalFilePathLinkProvider.ts
@@ -38,18 +38,18 @@ export function computeFilePathLinks(cells: TerminalCell[]): ColumnLink[] {
   const colEnd: number[] = [];
   for (let col = 0; col < cells.length; col++) {
     const cell = cells[col];
-    if (cell.width === 0) continue; // trailing half of the preceding wide glyph
+    if (!cell || cell.width === 0) continue; // absent, or the trailing half of a wide glyph
     const chars = cell.chars.length ? cell.chars : " "; // an unwritten cell renders as a space
     for (let k = 0; k < chars.length; k++) {
-      units.push(chars[k]);
+      units.push(chars[k] ?? "");
       colStart.push(col);
       colEnd.push(col + cell.width - 1);
     }
   }
   return findFilePathLinks(units.join("")).map((hit) => ({
     text: hit.text,
-    startX: colStart[hit.start] + 1,
-    endX: colEnd[hit.end - 1] + 1,
+    startX: (colStart[hit.start] ?? 0) + 1,
+    endX: (colEnd[hit.end - 1] ?? 0) + 1,
   }));
 }
 

--- a/src/composables/terminalFilePathLinks.ts
+++ b/src/composables/terminalFilePathLinks.ts
@@ -25,7 +25,7 @@ const HAS_LETTER = /[A-Za-z]/;
 // / `a.tar.gz` qualify but a fraction like `1/2.5` does not.
 function endsInFileExtension(text: string): boolean {
   const ext = TRAILING_EXTENSION.exec(text);
-  return ext !== null && HAS_LETTER.test(ext[1]);
+  return ext?.[1] !== undefined && HAS_LETTER.test(ext[1]);
 }
 
 export function findFilePathLinks(line: string): FilePathLink[] {

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -176,7 +176,9 @@ export function termThemeFor(id: string): Theme["term"] {
   // colours come from the base it extends — hence the spread over that base's palette.
   const derived = custom ? customTermTheme(custom, builtins()) : null;
   const base = THEMES.find((t) => t.id === custom?.extends) ?? THEMES[0];
-  return derived ? { ...base.term, ...derived } : THEMES[0].term;
+  const fallback = THEMES[0];
+  if (!fallback) return {};
+  return derived ? { ...(base?.term ?? fallback.term), ...derived } : fallback.term;
 }
 
 // Called from main.ts before mount so the persisted theme is on <html> before
@@ -196,7 +198,8 @@ export function refreshTheme() {
 function swatchFor(id: string): Theme["swatch"] {
   const custom = findCustomTheme(id);
   const vars = custom ? resolveThemeVars(custom, builtins()) : null;
-  if (!vars) return THEMES[0].swatch;
+  const fallbackSwatch = THEMES[0]?.swatch ?? { base: "", panel: "", accent: "" };
+  if (!vars) return fallbackSwatch;
   return { base: vars["--bg-base"], panel: vars["--bg-panel"], accent: vars["--accent"] };
 }
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -223,7 +223,7 @@ for (const name of cfg.packages ?? []) {
 const localEnabled = new Set(cfg.local ?? []);
 for (const [modulePath, mod] of Object.entries(localModules)) {
   // ".../plugins/<name>/index.ts" -> "<name>"
-  const name = modulePath.split("/").slice(-2)[0];
+  const name = modulePath.split("/").slice(-2)[0] ?? "";
   if (!localEnabled.has(name)) continue;
   registry[mod.REGISTRATION.toolName] = mod.REGISTRATION;
 }

--- a/src/utils/browserLocale.ts
+++ b/src/utils/browserLocale.ts
@@ -9,5 +9,5 @@
 // `en-GB` and `en-US` want the same one. A caller that needs the full tag should read
 // `navigator.language` itself and say why.
 export function browserLocale(): string {
-  return (navigator.language || "en").split("-")[0];
+  return (navigator.language || "en").split("-")[0] ?? "en";
 }

--- a/src/utils/canvasCollapse.ts
+++ b/src/utils/canvasCollapse.ts
@@ -36,6 +36,7 @@ export function collapseByIdentity<T>(results: readonly T[], identityOf: (result
   const kept: T[] = [];
   for (let i = results.length - 1; i >= 0; i--) {
     const result = results[i];
+    if (result === undefined) continue;
     const identity = identityOf(result);
     if (identity !== null) {
       if (seen.has(identity)) continue;

--- a/src/utils/focusTrap.ts
+++ b/src/utils/focusTrap.ts
@@ -13,6 +13,7 @@ export function trapTabKey(e: KeyboardEvent, container: HTMLElement, selector = 
   if (focusable.length === 0) return;
   const first = focusable[0];
   const last = focusable[focusable.length - 1];
+  if (!first || !last) return; // unreachable: the length check above answered
   if (e.shiftKey && document.activeElement === first) {
     e.preventDefault();
     last.focus();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,7 @@
     /* See tsconfig.server.json for why: `field?: T` must mean "key absent", not
        "key present holding undefined". */
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
        The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
        measured counts and why they are their own piece of work. */

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -19,6 +19,7 @@
        Without this, `{ work: undefined }` type-checks against `work?: Summary` and
        reaches Firestore, which rejects undefined at any depth (#1042). */
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
        The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
        measured counts and why they are their own piece of work. */

--- a/tsconfig.test-server.json
+++ b/tsconfig.test-server.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.server.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test-server.tsbuildinfo"
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test-server.tsbuildinfo",
+    /* The flag stays OFF for specs (#1301). A spec indexes fixtures it just built — `rows[0]` on an
+       array it wrote two lines above — so `T | undefined` there is noise about a value the test
+       itself guarantees. The value of the flag is in shipped code, which has it on. */
+    "noUncheckedIndexedAccess": false
   },
   "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "server/**/*.spec.ts"],
   "exclude": []

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo"
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    /* The flag stays OFF for specs (#1301). A spec indexes fixtures it just built — `rows[0]` on an
+       array it wrote two lines above — so `T | undefined` there is noise about a value the test
+       itself guarantees. The value of the flag is in shipped code, which has it on. */
+    "noUncheckedIndexedAccess": false
   },
   "include": ["test/src/**/*.ts", "test/common/**/*.ts", "test/*.ts"]
 }


### PR DESCRIPTION
## Summary

**入りました。** #1301 が「445 件で独立した作業」と見積もっていた `noUncheckedIndexedAccess` を、**本体 118 件を全部直して**有効化します。

`arr[i]` の型が `T` から `T | undefined` になります。実行時に undefined になり得るインデックスアクセスが、これまで型の上では見えていませんでした。

## Items to Confirm / Review

### 1. 118 件はすべて機械的でした — 設計判断は不要

読み方は主に 4 つで、どれも「コンパイラが正しく、コードが暗黙に知っていたことを書く」だけです。

| 直し方 | 例 |
|---|---|
| 一度 const に受けて undefined を弾く | `const line = lines[i]; if (line === undefined) …` |
| `??` で既定値 | `MIME_EXT[(mimeType.split(";")[0] ?? "").trim()…]` |
| `?.` にする | `wrapped?.[1] ?? content.replace(…)` |
| 境界チェック済みなら早期 return | `if (!def) return null; // unreachable: bounds were checked above` |

### 2. spec は対象外にしました

`tsconfig.test.json` / `tsconfig.test-server.json` で**明示的に off**（理由をコメント）。テストは自分で作った fixture を `rows[0]` で引くので、そこの `T | undefined` は**テスト自身が保証している値についての雑音**です。**233 件が 0 件**になります。

フラグの価値は出荷されるコードにあり、そちらは on です。

### 3. 副次効果 — lint の偽陽性が減りました（33 → 25 warnings）

**#1300 / #1301 に記録した見立てが、そのまま実証されました。**

`sonarjs/different-types-comparison` が **9 → 4 件**。`process.argv[2] === undefined` のようなガードが「常に偽」に見えていたのは、まさにこのフラグが無かったせいです。入れたことで**型が実態に追いつき、正しく評価される**ようになりました。

残った 4 件は**私の修正が生んだ冗長さ**でした（narrowing を明示した結果、後段の再チェックが本当に不要になった）ので、あわせて整理しています。

### 4. 一度壊して直した箇所があります

`gridTabs.ts` の複数行にまたがる `const expanded = …` を行単位置換で潰してしまい、`TS1005: '>' expected` が出ました。`typecheck` が即座に捕まえたので復旧済みです。**51 ファイルに触れる変更で型検査が効いている**ことの裏返しでもあります。

## 検証

- `yarn typecheck` / `typecheck:server` / `typecheck:test` **すべて 0 エラー**
- `yarn lint` **0 error / 25 warnings**（← 33）
- `yarn build` / `yarn test` **7560 passed**
- **実ブラウザ**: 画面描画、プラグイン登録、テーマ解決（`data-theme=midnight` / `--bg-base` 解決）、uncaught console error **0**

## 残り

#1301 の 3 フラグのうち、残るは `noImplicitReturns`（58 件、ほぼ Express の正しい書き方）と `noPropertyAccessFromIndexSignature`（1785 件、型の穴は塞がらない）です。どちらも**入れないことを推奨**する立場は変わりません。

refs #1301, refs #1300

work in mulmoterminal3
