### PR TITLE
fix(build): make yarn typecheck cover the whole repo (#1312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,11 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      # Covers app, server and the specs: root tsconfig.json references all five
+      # projects. Specs need their own step's worth of attention because vitest
+      # strips types rather than checking them.
       - name: Typecheck
         run: yarn typecheck
-
-      - name: Typecheck (server)
-        run: yarn typecheck:server
-
-      # Specs are excluded from the app/server projects, so without this step a
-      # type error in a test file reaches main unnoticed — vitest strips types
-      # rather than checking them.
-      - name: Typecheck (tests)
-        run: yarn typecheck:test
 
       - name: Build
         run: yarn build

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -220,7 +220,7 @@ jobs:
           linter or the build: vitest, eslint and vue-tsc are all
           absent, and the attempt only costs you time. Running them
           is the CI job's role — ci.yml installs dependencies and
-          runs lint, three typechecks, the build and the full test
+          runs lint, the typecheck, the build and the full test
           suite on ubuntu AND macOS for every PR — so a second
           execution here would buy nothing the PR does not already
           report. Review by READING the diff and the surrounding

--- a/.github/workflows/windows-daily.yaml
+++ b/.github/workflows/windows-daily.yaml
@@ -75,9 +75,6 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
-      - name: Typecheck (server)
-        run: yarn typecheck:server
-
       - name: Build
         run: yarn build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,10 @@ anything not covered here.
 ## Run after changes
 - `yarn format` — Prettier. `.prettierignore` excludes `*.md`, so Markdown is not reformatted.
 - `yarn lint` — ESLint.
-- `yarn typecheck` — `vue-tsc -b`. **App code only — it does NOT compile the specs.**
-- `yarn typecheck:server` / `yarn typecheck:test` — CI runs these too. `typecheck:test`
-  (`tsconfig.test.json` + `tsconfig.test-server.json`) is the one that type-checks the specs,
-  including the ones colocated under `server/` rather than in `test/`. Change a shared type or
-  a wire shape and run **all three**: `yarn typecheck` alone passes while CI fails.
+- `yarn typecheck` — `vue-tsc -b`, and it covers the whole repo: the root `tsconfig.json`
+  references all five projects (app, node, server, and the two spec ones — including the specs
+  colocated under `server/` rather than in `test/`). Adding a project means adding it there too,
+  or nothing type-checks it and CI will not tell you.
 - `yarn build` — `vue-tsc -b && vite build`.
 - `yarn test` — **Vitest** (`test/**/*.spec.ts`). Mock external APIs; tests must run without API keys.
 - `yarn dev` — server + Vite together (local development).

--- a/README.md
+++ b/README.md
@@ -740,22 +740,21 @@ yarn dev                # backend (:34567) + Vite UI (:6856), concurrently — o
 yarn dev:server         # backend only  (node --import tsx --env-file-if-exists=.env server/index.ts)
 yarn dev:client         # Vite dev server only
 
-yarn build              # type-check (vue-tsc) + vite build -> dist/
-yarn typecheck:server   # type-check the server (tsconfig.server.json)
-yarn typecheck:test     # type-check the specs (tsconfig.test*.json)
+yarn typecheck          # type-check everything (vue-tsc -b)
+yarn build              # type-check + vite build -> dist/
 yarn server             # run backend; serves dist/ + the APIs on :34567
 yarn test               # vitest run
 ```
 
-The backend is TypeScript run directly via `tsx` (no build step); `server/` is
-type-checked separately through `tsconfig.server.json` (`strict`), kept out of
-the main `build` so the two type-check independently.
-
-Specs sit outside both of those projects, and vitest strips types rather than
-checking them — so `yarn typecheck:test` is what keeps them honest. It mirrors
-the same split: `tsconfig.test.json` (client specs, DOM + `.vue`) and
-`tsconfig.test-server.json` (server specs, node). CI runs it alongside the
-other two.
+`yarn typecheck` covers the whole repo. The root `tsconfig.json` is a solution
+file that references all five projects, so one `vue-tsc -b` builds them:
+`tsconfig.app.json` (client), `tsconfig.node.json` (vite config),
+`tsconfig.server.json` (backend, run directly via `tsx` with no build step),
+plus `tsconfig.test.json` and `tsconfig.test-server.json` for the specs — which
+need checking of their own because vitest strips types rather than checking
+them. They exist as separate projects because each has its own compiler options
+(the client ones DOM + `.vue`, the server ones node, the specs with
+`noUncheckedIndexedAccess` off).
 
 In dev, open the Vite URL; its proxy forwards `/ws`, `/ws/pubsub`, and `/api` to
 `:34567`. In production, run `yarn build` then `yarn server` and open

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoterminal",
   "version": "4.1.1",
-  "description": "Run multiple Claude Code and Codex sessions in parallel — a browser terminal grid that shows which agent needs you. Local, tmux-backed.",
+  "description": "Run multiple Claude Code and Codex sessions in parallel \u2014 a browser terminal grid that shows which agent needs you. Local, tmux-backed.",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -42,8 +42,6 @@
     "dev:client": "vite",
     "build": "vue-tsc -b && vite build",
     "typecheck": "vue-tsc -b",
-    "typecheck:server": "tsc -p tsconfig.server.json",
-    "typecheck:test": "vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/plans/fix-1312-typecheck-one-command.md
+++ b/plans/fix-1312-typecheck-one-command.md
@@ -1,0 +1,58 @@
+# fix(build): `yarn typecheck` を1本にして repo 全体を見せる (#1312)
+
+## 何が壊れていたか
+
+root の `tsconfig.json` が **app と node しか参照していなかった**。`yarn typecheck` は
+`vue-tsc -b`、つまりこの solution file を build するだけなので、**`server/**` と `test/**` は
+最初から視界に入っていなかった**。
+
+CLAUDE.md に書いてあった「**`yarn typecheck` alone passes while CI fails**」「3つ全部走らせろ」
+は、この欠落を運用でカバーするための注意書きだった。
+
+## 実証（passed を信用しない）
+
+「5つ参照して clean だった」は「5つとも検査している」の証拠にならないので、**4領域それぞれに
+`const x: number = "nope"` を仕込んで、検出されることを確認した**。
+
+| 仕込んだ場所 | 検出 |
+|---|---|
+| `server/config/workspace.ts` | ✓ |
+| `src/utils/focusTrap.ts` | ✓ |
+| `test/common/readString.spec.ts` | ✓ |
+| `test/server/git/prs.spec.ts` | ✓ |
+
+修正前の root tsconfig で同じ server のエラーを測ると **0 errors**（完全に素通り）。
+
+## `composite` について
+
+どの project にも `composite` は設定されていない（`tsc --showConfig` で確認、全部 `null`）。
+そのため「参照される project は全ファイルを include に列挙しなければならない」という
+composite の制約には当たらず、spec 用 project が src / server を include せず import だけで
+使っている現状のままで参照できる。
+
+## 速度
+
+1本にまとめた方が**速い**。`-b` が project 間で作業を共有するため。
+
+| | cold |
+|---|---|
+| 新: `yarn typecheck` 1本（5 refs） | **13.3s** |
+| 旧: `typecheck` + `typecheck:server` + `typecheck:test` | 14.1s |
+
+（参考: 旧 `yarn typecheck` 単体は 3.5s だったが、それは server と test を見ていなかったから。）
+
+`build` / `prepack` も `vue-tsc -b` を通るので、spec の型エラーで build が落ちるようになる。
+CI では Typecheck ステップの後なので `-b` が warm でほぼ無コスト。publish 時（`prepack`）だけ
+cold を払うが、spec が型エラーの状態で publish が止まるのは望ましい方向と判断した。
+
+## 変更
+
+- `tsconfig.json` — `references` に `server` / `test` / `test-server` を追加（2 → 5）
+- `package.json` — 冗長になった `typecheck:server` / `typecheck:test` を削除
+- `.github/workflows/ci.yml` — typecheck 3ステップ → 1ステップ
+- `.github/workflows/windows-daily.yaml` — typecheck 2ステップ → 1ステップ
+- `.github/workflows/codex_review.yaml` — 「three typechecks」の記述を修正
+- `CLAUDE.md` / `README.md` — 「3つ走らせろ」を削除し、**project を足したら root の
+  `references` にも足す**という新しい注意書きに置き換え
+
+`plans/` の過去の記録に残る `typecheck:server` の記述は、当時の事実なので触っていない。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.server.json" },
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.test-server.json" }
+  ]
 }


### PR DESCRIPTION
## Summary

`yarn typecheck` は **server と test を一切見ていませんでした**。root の `tsconfig.json` が
app と node しか参照しておらず、`yarn typecheck` = `vue-tsc -b` はその solution file を build
するだけだからです。

CLAUDE.md の「**`yarn typecheck` alone passes while CI fails**」「3つ全部走らせろ」は、この
欠落を運用でカバーするための注意書きでした。root の `references` を 2 → 5 にして、**1本で
repo 全体を見る**ようにしました。

`typecheck:server` / `typecheck:test` は冗長になったので削除、CI の typecheck ステップも1本に
畳んでいます。

## Items to Confirm / Review

1. **`build` / `prepack` が spec の型エラーで落ちるようになります。** `vue-tsc -b` を通るため
   です。CI では Typecheck の後なので `-b` が warm でほぼ無コストですが、**publish 時
   （`prepack`）だけ cold を払います**。spec が型エラーの状態で publish が止まるのは望ましい
   方向と判断しましたが、ここは意見が分かれるかもしれません。
2. **`typecheck:server` / `typecheck:test` の削除。** server だけ速く回したい場面が残っている
   なら `npx tsc -p tsconfig.server.json` で足ります（`-b` は incremental なので warm 10.9s）。
3. **`plans/` と `docs/ChangeLog.md` に残る `typecheck:server` の記述は触っていません。**
   当時の事実の記録なので。

## User Prompt

> \> projectService で server 側が見えていない状態
>
> これって直す必要ある？

（eslint 側は対処済みだが `yarn typecheck` に別の穴があると報告したのに対し）

> 2はなおしてシンプルにしよう

## 実証 — 「clean だった」は「検査している」の証拠ではない

5つ参照して緑になっても、それは検査した証拠になりません。**4領域それぞれに
`const x: number = "nope"` を仕込んで、検出されることを確認しました。**

| 仕込んだ場所 | 検出 |
|---|---|
| `server/config/workspace.ts` | ✓ |
| `src/utils/focusTrap.ts` | ✓ |
| `test/common/readString.spec.ts` | ✓ |
| `test/server/git/prs.spec.ts` | ✓ |

修正**前**の root tsconfig で同じ server のエラーを測ると **0 errors** — 完全に素通りでした。

## `composite` について

どの project にも `composite` は設定されていません（`tsc --showConfig` で全部 `null` を確認）。
そのため「参照される project は全ファイルを include に列挙しなければならない」という composite
の制約には当たらず、spec 用 project が src / server を include せず import だけで使っている
現状のまま参照できます。

## 速度は落ちません（むしろ速い）

| | cold |
|---|---|
| 新: `yarn typecheck` 1本（5 refs） | **13.3s** |
| 旧: `typecheck` + `typecheck:server` + `typecheck:test` | 14.1s |

`-b` が project 間で作業を共有するためです。旧 `yarn typecheck` 単体の 3.5s と比べると遅く
見えますが、それは **server と test を見ていなかったから**です。

## 変更

| ファイル | 内容 |
|---|---|
| `tsconfig.json` | `references` に `server` / `test` / `test-server` を追加（2 → 5） |
| `package.json` | `typecheck:server` / `typecheck:test` を削除 |
| `.github/workflows/ci.yml` | typecheck 3ステップ → 1 |
| `.github/workflows/windows-daily.yaml` | typecheck 2ステップ → 1 |
| `.github/workflows/codex_review.yaml` | 「three typechecks」の記述を修正 |
| `CLAUDE.md` / `README.md` | 「3つ走らせろ」を削除し、**project を足したら root の `references` にも足す**という注意書きに置換 |

ローカルで `format` / `lint`（0 errors）/ `typecheck`（cold, 0 errors）/ `build` / `test`
（7565 passed）green。ワークフロー3本は YAML parser で構文と step 構成を確認済みです。

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3