### PR TITLE
fix(terminal): 落とした入力を全経路で伝え、通知が消えたらもう一度言う (#1315, #1316)

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -177,7 +177,7 @@ calling the render callback, so a renderer that throws still repaints on the nex
 ### The other silence: input the socket never took
 
 A slot only writes to the socket when it is `OPEN` — during the reconnect backoff, or after a
-`superseded`, input is dropped and **nothing changes on screen**, which is indistinguishable
+`superseded` message, input is dropped and **nothing changes on screen**, which is indistinguishable
 from a terminal that received it and printed nothing. The status pill says `disconnected`, but it
 lives in a header the filmstrip hides and nobody watches a pill while typing.
 
@@ -192,8 +192,10 @@ Three details, each of which was wrong once:
 - **Every path into the PTY reports, not just the keyboard.** `submitText` / `pasteText` /
   `pasteAndSubmit` used to answer a closed socket with `false` and nothing else, and only one
   caller ever read it — so a header button or a picked skill did nothing and explained nothing
-  (#1315). A button press is the worse case: whoever pressed it never typed, so the natural reading
-  is "this button is broken". Empty text is not a drop and stays silent.
+  (#1315). `insertText` is the quietest of them: a dictated sentence, a dropped path, a pasted
+  screenshot's path, all of which the user waits to see appear in the input box. A GUI press is
+  the worse case in general: whoever made it never typed, so the natural reading is "this button
+  is broken". Empty text is not a drop and stays silent.
 - **The banner is on a cooldown, not once per stretch.** A stretch has no upper bound (the backoff
   retries forever at a 5s cap) while the banner lives six seconds, so "once per stretch" meant the
   person who came back and typed again got the silence back (#1316). The **log** line stays one per

--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -174,19 +174,33 @@ all confirmed against `@xterm/headless@6.0.0` by reproducing the upstream flight
 Rendering itself survives: `RenderDebouncer._innerRefresh` clears its animation frame *before*
 calling the render callback, so a renderer that throws still repaints on the next refresh.
 
-### The other silence: a keystroke the socket never took
+### The other silence: input the socket never took
 
 A slot only writes to the socket when it is `OPEN` — during the reconnect backoff, or after a
-`superseded`, a keystroke is dropped and **nothing changes on screen**, which is indistinguishable
+`superseded`, input is dropped and **nothing changes on screen**, which is indistinguishable
 from a terminal that received it and printed nothing. The status pill says `disconnected`, but it
 lives in a header the filmstrip hides and nobody watches a pill while typing.
 
 So the manager tells the view (`ConnHandlers.onInputDropped`) and `Terminal.vue` shows the same
-transient banner the drop/paste hints use. **Once per disconnected stretch** — cleared in
-`sock.onopen` — because a held-down key would otherwise be a stream of notices. There is a
-`console.warn` on the same path, which is what makes "I typed and nothing happened" diagnosable
-after the fact: it distinguishes a socket that was down from a terminal that had stopped drawing
-(the #846 case above, which logs its own line when it rebuilds).
+transient banner the drop/paste hints use. There is a `console.warn` on the same path, which is
+what makes "I did something and nothing happened" diagnosable after the fact: it distinguishes a
+socket that was down from a terminal that had stopped drawing (the #846 case above, which logs its
+own line when it rebuilds).
+
+Three details, each of which was wrong once:
+
+- **Every path into the PTY reports, not just the keyboard.** `submitText` / `pasteText` /
+  `pasteAndSubmit` used to answer a closed socket with `false` and nothing else, and only one
+  caller ever read it — so a header button or a picked skill did nothing and explained nothing
+  (#1315). A button press is the worse case: whoever pressed it never typed, so the natural reading
+  is "this button is broken". Empty text is not a drop and stays silent.
+- **The banner is on a cooldown, not once per stretch.** A stretch has no upper bound (the backoff
+  retries forever at a 5s cap) while the banner lives six seconds, so "once per stretch" meant the
+  person who came back and typed again got the silence back (#1316). The **log** line stays one per
+  stretch — a post-mortem needs one, not fifty. Both reset in `sock.onopen`.
+- **`willReconnect` decides the wording.** `connectionWillReturn` in `reconnectPolicy.ts`, not
+  `shouldReconnect`: that one is blind to an armed retry (it answers "schedule another?"), so it
+  would deny a reconnect mid-backoff and promise one after an exit.
 
 ### Renderer (canvas vs DOM)
 

--- a/plans/fix-1315-1316-dropped-input-notice.md
+++ b/plans/fix-1315-1316-dropped-input-notice.md
@@ -1,0 +1,53 @@
+# The two gaps left in the dropped-input notice (#1315, #1316)
+
+#1306 made a keystroke that never reached the PTY say so. Two things it left open, both found
+reviewing it, both in the same function — so one change.
+
+## #1315 — the GUI paths are still silent
+
+`submitText` / `pasteText` / `pasteAndSubmit` return `false` when the socket is not `OPEN` and
+tell nobody. Of their callers only `TerminalCell.vue` reads the result (it shows "Couldn't reach
+the session"); the header button (`useHeaderAction.ts`) and the Skill menu (`Terminal.vue`) drop
+it, so pressing either while disconnected does nothing and explains nothing.
+
+Worse than the keystroke case it was fixed alongside: someone who pressed a button has no sense
+of having typed, so the natural reading is "this button is broken", not "I am disconnected".
+
+**Fix.** The three send functions call `reportDroppedInput(c)` on the closed-socket branch. Every
+host then gets the banner without touching a call site — including hosts written later, which is
+the point: the silence came from each caller having to remember.
+
+Empty text is NOT a drop (`pasteText("")` never had anything to deliver), so it must not notify.
+
+**Wording.** "what you typed" is wrong for a button press. Both sentences move to "what you sent",
+which covers a keystroke and a button equally.
+
+## #1316 — the banner is shown once per disconnected stretch
+
+`warnedDroppedInput` clears only in `sock.onopen`, and the backoff retries forever at a 5s cap.
+A server that stays down leaves one stretch running for hours while the banner lives 6 seconds,
+so the second time someone comes back and types they get the silence this exists to break.
+
+**Fix.** Keep the once-per-stretch rule for the LOG line (a post-mortem needs one line, not
+fifty) and put the banner on a cooldown that matches its own on-screen life. Key repeat still
+cannot produce a stream — the next notice cannot land until the previous one is gone.
+
+Both fields reset in `sock.onopen`: a new stretch deserves an immediate notice, not the tail of
+the previous stretch's cooldown.
+
+## Tests
+
+- each of the three send functions notifies (and returns false) on a closed socket
+- empty text notifies nothing
+- two drops inside the cooldown produce one banner, one log line
+- a drop after the cooldown produces a second banner, still one log line
+- a successful reconnect re-arms both
+
+`Date.now` is stubbed rather than the timers faked: the cooldown is the only clock involved, and
+the specs around this already drive real `setTimeout` for the #846 probe.
+
+## Not in scope
+
+The delayed submit byte inside `submitText` / `pasteAndSubmit` skips when the socket changed
+mid-flight. That is deliberate (it must never submit a stray turn into a reconnected session) and
+the text itself did arrive, so it is not the same silence.

--- a/plans/fix-1315-1316-dropped-input-notice.md
+++ b/plans/fix-1315-1316-dropped-input-notice.md
@@ -13,9 +13,13 @@ it, so pressing either while disconnected does nothing and explains nothing.
 Worse than the keystroke case it was fixed alongside: someone who pressed a button has no sense
 of having typed, so the natural reading is "this button is broken", not "I am disconnected".
 
-**Fix.** The three send functions call `reportDroppedInput(c)` on the closed-socket branch. Every
-host then gets the banner without touching a call site — including hosts written later, which is
-the point: the silence came from each caller having to remember.
+**Fix.** Every send function calls `reportDroppedInput(c)` on the closed-socket branch. Every host
+then gets the banner without touching a call site — including hosts written later, which is the
+point: the silence came from each caller having to remember.
+
+`insertText` belongs in that set too (Codex caught it missing): voice transcription, a dropped
+path and a pasted screenshot's path all arrive through it, and there the user is watching the
+input box rather than waiting for a reply — so nothing on screen moves at all.
 
 Empty text is NOT a drop (`pasteText("")` never had anything to deliver), so it must not notify.
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -461,16 +461,19 @@ function onDragOver(e: DragEvent) {
 // otherwise fall back to advice that always holds.
 const DROP_HINT_PICKER_EN = "This browser doesn't share a dropped file's path. Use the paperclip button in the header (Insert a file path) instead.";
 const DROP_HINT_TYPE_EN = "This browser doesn't share a dropped file's path — type or paste the path instead.";
-// Typing into a terminal whose socket is down. The status pill says "disconnected", but it is in a
-// header a grid cell hides (filmstrip) and nobody watches a pill while typing — so a keystroke that
-// went nowhere looks exactly like a terminal that received it and printed nothing. Said once per
-// disconnected stretch (useTerminalConnections rate-limits it), and it names the recovery, because
-// the reconnect is automatic and waiting IS the right move.
-const INPUT_DROPPED_EN = "Not connected — what you typed didn't reach the terminal. Reconnecting…";
+// Input into a terminal whose socket is down. The status pill says "disconnected", but it is in a
+// header a grid cell hides (filmstrip) and nobody watches a pill while typing — so input that went
+// nowhere looks exactly like a terminal that received it and printed nothing. Rate-limited by
+// useTerminalConnections, and it names the recovery, because the reconnect is automatic and
+// waiting IS the right move.
+//
+// "sent" rather than "typed": the same banner now answers for a header button and a picked skill
+// (#1315), and someone who pressed a button did not type anything.
+const INPUT_DROPPED_EN = "Not connected — what you sent didn't reach the terminal. Reconnecting…";
 // The same silence, but nothing is coming to end it: an exited session, a superseded tab, a Run
 // cell whose command finished. Telling those to wait for a reconnect would replace one misleading
 // message with another, which is the very thing this banner exists to stop.
-const INPUT_DROPPED_ENDED_EN = "This session has ended — what you typed didn't reach the terminal.";
+const INPUT_DROPPED_ENDED_EN = "This session has ended — what you sent didn't reach the terminal.";
 const dropHint = ref(false);
 const dropHintText = ref("");
 // The banner started as the file-drop hint and is now shared, so the icon travels with the

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -205,6 +205,8 @@ interface Conn {
   // A drop has already been LOGGED for this disconnected stretch. One line is all a post-mortem
   // needs; fifty say nothing more. The banner is timed separately below. Both clear on open.
   warnedDroppedInput: boolean;
+  // -Infinity rather than 0 so "never notified" outlasts any cooldown: a spec that stubs Date.now
+  // to a small number would otherwise lose the FIRST banner and still read as passing.
   lastDroppedInputNoticeMs: number;
 }
 
@@ -572,7 +574,7 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     font,
     lastRebuildMs: 0,
     warnedDroppedInput: false,
-    lastDroppedInputNoticeMs: 0,
+    lastDroppedInputNoticeMs: Number.NEGATIVE_INFINITY,
   };
   conns.set(key, c);
   connView.set(key, { status: "connecting", serverCwd: target.cwd });
@@ -666,7 +668,7 @@ function connect(c: Conn) {
     // A new stretch: worth a line again, and worth saying at once rather than after whatever was
     // left of the previous stretch's cooldown.
     c.warnedDroppedInput = false;
-    c.lastDroppedInputNoticeMs = 0;
+    c.lastDroppedInputNoticeMs = Number.NEGATIVE_INFINITY;
     setStatus(c, "connected");
     sock.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
   };
@@ -915,10 +917,16 @@ export function listSlots(): SlotInfo[] {
 // Insert text (a path, or space-joined paths) at the cursor via the normal input
 // channel — no trailing CR, so the user reviews and submits.
 export function insertText(key: string, text: string) {
-  if (!text) return;
+  if (!text) return; // nothing to deliver — not a drop
   const c = conns.get(key);
   if (!c) return;
-  if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "input", data: text }));
+  // The quietest of the GUI paths: what arrives here was dictated, dropped or pasted, so the user
+  // is watching for text to appear in the input box rather than for a reply (#1315).
+  if (c.ws?.readyState === WebSocket.OPEN) {
+    c.ws.send(JSON.stringify({ type: "input", data: text }));
+  } else {
+    reportDroppedInput(c);
+  }
   c.term.focus();
 }
 

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -157,11 +157,13 @@ export interface ConnHandlers {
   // and pastes all funnel through on their way to the socket, so it cannot be reached by output
   // the server writes back or by anything the app renders — only by someone using the session.
   onInput?: () => void;
-  // …and that keystroke went nowhere, because the socket is not open. Once per disconnected
-  // stretch, so holding a key down doesn't turn into a stream of notices. The view exists to say
-  // so: a dropped keystroke is otherwise indistinguishable from a terminal that received it and
-  // chose to print nothing. `willReconnect` is false for a session that ended and for a Run cell,
-  // neither of which comes back — telling those to wait would be a promise nothing will keep.
+  // …and it went nowhere, because the socket is not open. Fired for a keystroke and for anything
+  // the GUI sends into the PTY (a header button, a picked skill, a pasted block), because the
+  // silence is the same either way and a button press is the worse of the two: whoever pressed it
+  // has no sense of having typed, so nothing points at the connection (#1315). Rate-limited, so a
+  // held-down key doesn't turn into a stream of notices. `willReconnect` is false for a session
+  // that ended and for a Run cell, neither of which comes back — telling those to wait would be a
+  // promise nothing will keep.
   onInputDropped?: (willReconnect: boolean) => void;
 }
 
@@ -200,19 +202,30 @@ interface Conn {
   theme: ITheme | undefined; // last applied, so a rebuilt terminal keeps the cell's colours
   font: TerminalFont; // same reason as `theme` — a rebuilt terminal must not snap back to the default
   lastRebuildMs: number; // rate-limits the #846 recovery so a stuck reading can't spin
-  // A dropped keystroke has already been reported for THIS disconnected stretch. Held so a user
-  // typing into a dead cell logs one line rather than one per key; cleared when the socket opens.
+  // A drop has already been LOGGED for this disconnected stretch. One line is all a post-mortem
+  // needs; fifty say nothing more. The banner is timed separately below. Both clear on open.
   warnedDroppedInput: boolean;
+  lastDroppedInputNoticeMs: number;
 }
 
-// Typing into a slot whose socket is down. One line per stretch — see the caller for why it is
-// worth saying at all.
+// The banner is re-armed on a timer rather than shown once per stretch, because a stretch has no
+// upper bound: the backoff retries forever at a 5s cap, so a server that stays down outlives the
+// notice by hours, and whoever comes back and types again meets the silence this exists to break
+// (#1316). One notice per banner-lifetime still cannot become a stream — the next one can only
+// land once the previous has left the screen. Matches DROP_HINT_MS in Terminal.vue.
+const DROPPED_INPUT_NOTICE_MS = 6_000;
+
+// Input that reached a socket which is not open — a keystroke, or anything the GUI sends.
 function reportDroppedInput(c: Conn): void {
-  if (c.warnedDroppedInput) return;
-  c.warnedDroppedInput = true;
   const willReconnect = connectionWillReturn({ released: c.released, sawExit: c.sawExit, isCommand: !!c.target.command });
-  const fate = willReconnect ? "reconnecting" : "not reconnecting";
-  console.warn(`[terminal] slot ${c.key}: dropped a keystroke — the socket is not open (status ${connView.get(c.key)?.status ?? "unknown"}, ${fate})`);
+  if (!c.warnedDroppedInput) {
+    c.warnedDroppedInput = true;
+    const fate = willReconnect ? "reconnecting" : "not reconnecting";
+    console.warn(`[terminal] slot ${c.key}: dropped input — the socket is not open (status ${connView.get(c.key)?.status ?? "unknown"}, ${fate})`);
+  }
+  const now = Date.now();
+  if (now - c.lastDroppedInputNoticeMs < DROPPED_INPUT_NOTICE_MS) return;
+  c.lastDroppedInputNoticeMs = now;
   c.handlers.onInputDropped?.(willReconnect);
 }
 
@@ -559,6 +572,7 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     font,
     lastRebuildMs: 0,
     warnedDroppedInput: false,
+    lastDroppedInputNoticeMs: 0,
   };
   conns.set(key, c);
   connView.set(key, { status: "connecting", serverCwd: target.cwd });
@@ -649,7 +663,10 @@ function connect(c: Conn) {
   sock.onopen = () => {
     if (sock !== c.ws) return;
     c.reconnectAttempts = 0;
-    c.warnedDroppedInput = false; // a new stretch: the next dropped keystroke is worth a line again
+    // A new stretch: worth a line again, and worth saying at once rather than after whatever was
+    // left of the previous stretch's cooldown.
+    c.warnedDroppedInput = false;
+    c.lastDroppedInputNoticeMs = 0;
     setStatus(c, "connected");
     sock.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
   };
@@ -817,7 +834,13 @@ export function submitText(key: string, text: string): boolean {
   const c = conns.get(key);
   if (!c) return false;
   const sock = c.ws;
-  if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+  // The `false` used to be the whole answer, and only one caller ever read it — the rest pressed
+  // a button into a closed socket and showed nothing (#1315). Saying so here reaches every host,
+  // including the ones written after this line.
+  if (!sock || sock.readyState !== WebSocket.OPEN) {
+    reportDroppedInput(c);
+    return false;
+  }
   const submit = submitBytesFor(c);
   sock.send(JSON.stringify({ type: "input", data: submittableFor(c, text) }));
   setTimeout(() => {
@@ -837,7 +860,12 @@ const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 export function pasteText(key: string, text: string): boolean {
   const c = conns.get(key);
-  if (!text || c?.ws?.readyState !== WebSocket.OPEN) return false;
+  // Empty text is not a dropped paste — there was nothing to deliver, so it stays silent (#1315).
+  if (!text || !c) return false;
+  if (c.ws?.readyState !== WebSocket.OPEN) {
+    reportDroppedInput(c);
+    return false;
+  }
   c.ws.send(JSON.stringify({ type: "input", data: `${PASTE_START}${text}${PASTE_END}` }));
   c.term.focus();
   return true;
@@ -852,7 +880,11 @@ const PASTE_SUBMIT_MS = 200;
 export function pasteAndSubmit(key: string, text: string): boolean {
   const c = conns.get(key);
   const sock = c?.ws;
-  if (!text || !c || !sock || sock.readyState !== WebSocket.OPEN) return false;
+  if (!text || !c) return false; // nothing to deliver — not a drop (#1315)
+  if (!sock || sock.readyState !== WebSocket.OPEN) {
+    reportDroppedInput(c);
+    return false;
+  }
   const submit = submitBytesFor(c);
   // The guard's space rides INSIDE the paste, where the TUI takes it as text — after the
   // terminator it would be a keystroke, and an open completion menu is what reads those (#1142).

--- a/test/src/composables/useTerminalConnections.spec.ts
+++ b/test/src/composables/useTerminalConnections.spec.ts
@@ -585,6 +585,17 @@ describe("a keystroke with nowhere to go tells the view", () => {
       expect(onInputDropped).toHaveBeenCalledWith(true);
     });
 
+    // The quietest one: a dictated sentence, a dropped path, a pasted screenshot's path. The user
+    // is watching the input box for text to appear, so nothing about the terminal changes at all.
+    it("tells the view when inserted text hits a closed socket", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+
+      conn.insertText(KEY, "~/shots/pasted.png ");
+
+      expect(onInputDropped).toHaveBeenCalledWith(true);
+    });
+
     // Empty text never had anything to deliver, so its `false` is not a drop — reporting it would
     // put a "not connected" banner on a paste of nothing.
     it("says nothing for empty text", () => {
@@ -593,6 +604,7 @@ describe("a keystroke with nowhere to go tells the view", () => {
 
       expect(conn.pasteText(KEY, "")).toBe(false);
       expect(conn.pasteAndSubmit(KEY, "")).toBe(false);
+      conn.insertText(KEY, "");
 
       expect(onInputDropped).not.toHaveBeenCalled();
     });

--- a/test/src/composables/useTerminalConnections.spec.ts
+++ b/test/src/composables/useTerminalConnections.spec.ts
@@ -463,7 +463,9 @@ describe("a keystroke with nowhere to go tells the view", () => {
     return ws;
   }
 
-  it("reports once per disconnected stretch, however much the user types", () => {
+  const droppedInputLines = () => warn.mock.calls.filter((args: unknown[]) => String(args[0]).includes("dropped input"));
+
+  it("reports once while the notice is still on screen, however much the user types", () => {
     const onInputDropped = vi.fn();
     attachClosedSlot(onInputDropped);
 
@@ -471,6 +473,28 @@ describe("a keystroke with nowhere to go tells the view", () => {
     mockTermState.emitData("i");
 
     expect(onInputDropped).toHaveBeenCalledOnce();
+  });
+
+  // A stretch has no upper bound — the backoff retries forever at a 5s cap — so "once per stretch"
+  // meant a server left down said it once and never again, and whoever came back and typed got the
+  // silence this notice exists to break (#1316). The log line is the one that stays single: it is
+  // read afterwards, where a repeat adds nothing.
+  it("reports again once the notice has left the screen, though the stretch is the same", () => {
+    const now = vi.spyOn(Date, "now");
+    try {
+      now.mockReturnValue(1_000_000);
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+      mockTermState.emitData("h");
+
+      now.mockReturnValue(1_006_000); // the banner's six seconds are up
+      mockTermState.emitData("h");
+
+      expect(onInputDropped).toHaveBeenCalledTimes(2);
+      expect(droppedInputLines()).toHaveLength(1);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("reports again after a reconnect, because that is a new stretch", () => {
@@ -527,5 +551,61 @@ describe("a keystroke with nowhere to go tells the view", () => {
     mockTermState.emitData(clickReportSequences(1, 1)[0]);
 
     expect(onInputDropped).not.toHaveBeenCalled();
+  });
+
+  // The GUI reaches the same socket without going through the keyboard: a header button's text, a
+  // skill picked from the menu, a pasted block. Those returned `false` and told nobody, and the one
+  // caller that read the result was the exception (#1315) — so the report belongs in the manager,
+  // where every host gets it, rather than in each caller that remembers to ask.
+  describe("input the GUI sends", () => {
+    it("tells the view when a button's text hits a closed socket", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+
+      expect(conn.submitText(KEY, "/commit")).toBe(false);
+
+      expect(onInputDropped).toHaveBeenCalledWith(true);
+    });
+
+    it("tells the view when a paste hits a closed socket", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+
+      expect(conn.pasteText(KEY, "a block")).toBe(false);
+
+      expect(onInputDropped).toHaveBeenCalledWith(true);
+    });
+
+    it("tells the view when a paste-and-submit hits a closed socket", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+
+      expect(conn.pasteAndSubmit(KEY, "a block")).toBe(false);
+
+      expect(onInputDropped).toHaveBeenCalledWith(true);
+    });
+
+    // Empty text never had anything to deliver, so its `false` is not a drop — reporting it would
+    // put a "not connected" banner on a paste of nothing.
+    it("says nothing for empty text", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped);
+
+      expect(conn.pasteText(KEY, "")).toBe(false);
+      expect(conn.pasteAndSubmit(KEY, "")).toBe(false);
+
+      expect(onInputDropped).not.toHaveBeenCalled();
+    });
+
+    // The same "nothing is coming" the keyboard gets, since the wording follows the flag: a Run
+    // cell's button must not be told to wait for a reconnect that would re-run its command.
+    it("says no reconnect is coming for a Run cell", () => {
+      const onInputDropped = vi.fn();
+      attachClosedSlot(onInputDropped, { command: { source: "script", index: 0, label: "echo", cwd: null } });
+
+      expect(conn.submitText(KEY, "/commit")).toBe(false);
+
+      expect(onInputDropped).toHaveBeenCalledWith(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

#1306 のレビューで見つかった残り 2 件。どちらも #1306 が追加した `reportDroppedInput` まわりなので 1 PR にまとめています。

- **#1315** — `submitText` / `pasteText` / `pasteAndSubmit` が閉じたソケットで `false` を返すだけだった。戻り値を見ているのは `TerminalCell.vue` だけで、ヘッダボタン（`useHeaderAction.ts`）と Skill メニュー（`Terminal.vue`）は捨てていたので、**切断中に押すと何も起きず何の説明も出なかった**。通知を manager 側（3 関数の閉ソケット分岐）に置き、呼び出し側は一切変更していない。空文字は「配るものが無かった」だけなのでドロップ扱いにしない。
- **#1316** — バナーが「切断 1 回につき 1 度」で、`sock.onopen` でしかリセットされなかった。バックオフは 5 秒上限で無限リトライするので 1 stretch が数時間になり得るのに対しバナーの寿命は 6 秒 → **2 回目以降が無言**。バナーは自分の表示時間と同じクールダウンで再武装し、`console.warn` は 1 stretch 1 行のまま（事後の切り分けに繰り返しは要らない）。

文言は `what you typed` → `what you sent`。ボタンを押した人は「typed」していないため。

## Items to Confirm / Review

1. **文言の変更**（`INPUT_DROPPED_EN` / `INPUT_DROPPED_ENDED_EN`）。翻訳はサーバ側で文単位にキャッシュされるので、英文が変わると新しい翻訳が引かれます。日本語として自然かは要確認。
2. **`TerminalCell.vue:871` は二重表示になります**。commit ボタンは自前で `"Couldn't reach the session"` をセル内に出すので、今後はバナーと 2 つ出る。害は無いと判断しましたが、片方に寄せるなら別 PR で。
3. **クールダウンの 6 秒は `Terminal.vue` の `DROP_HINT_MS` と同じ値のハードコード**です。共有モジュールに切り出すほどでもないと判断し、コメントで対応関係を明示するに留めています。
4. **遅延 submit バイト**（`submitText` / `pasteAndSubmit` の `setTimeout` 側）は通知していません。ソケットが差し替わったら送らないのは意図的な安全策で、本文自体は届いているため別の沈黙だと整理しました（plan に記載）。
5. **実機確認は未実施**（下記）。

## User Prompt

- PR #1306 について「以前に似たことをしなかったか」を確認し、関係が本文に書かれていなければコメントを追加してレビューに回すこと
- レビュー結果を踏まえ、#1306 を完璧にするための修正 PR を作れるか検討すること
- 著者の追加コメントとレビューを突き合わせ、妥当性と取り込み可否を判断すること
- いったん取り込んで後で直す方針とし、レビュー結果をコメントしたうえで merge すること
- 残った指摘のうち実害があるものを判断し、指摘 3（GUI 送信の無言ドロップ）と指摘 2（バナーの再武装）を issue にして対応すること

## 実装

- `reportDroppedInput` を「ログ（1 stretch 1 行）」と「バナー（クールダウンで再武装）」の 2 系統に分離。`Conn` に `lastDroppedInputNoticeMs` を追加し、`sock.onopen` で `warnedDroppedInput` と併せてリセット
- `submitText` / `pasteText` / `pasteAndSubmit` の閉ソケット分岐で `reportDroppedInput(c)` を呼ぶ。`pasteText` / `pasteAndSubmit` は空文字ガードを先に分離して、空文字が通知されないようにしている
- `docs/terminal-notes.md` の「The other silence」節を、3 つの落とし穴（全経路が報告する / バナーはクールダウン / `willReconnect` は `connectionWillReturn` で決める）として書き直し
- 設計メモ: `plans/fix-1315-1316-dropped-input-notice.md`

## 検証

- 新規スペック 5 本。**修正を外すと 5 本とも落ちることを確認済み**（`git checkout origin/main -- src/composables/useTerminalConnections.ts` して実行）
- `yarn format` / `yarn lint`（0 error）/ `yarn typecheck` / `yarn build` / `yarn test` **7585 passed**
- **実機確認は未実施**です。この checkout に Playwright が入っておらず、追加は本 PR のスコープ外と判断しました。手動で見る場合は次の 3 手順です:
  1. `yarn dev` でセッションを開く
  2. サーバを落とす（セルが `disconnected` になる）
  3. ヘッダの入力ボタンを押す / Skill を選ぶ → バナーが出ること。さらに 10 秒待って打鍵 → **もう一度**出ること（これが #1316）

## やっていないこと

- レビューの指摘 4（`Terminal.vue` のアイコンだけリテラル `"cloud_off"`、文言側は定数化済み）。実害ゼロなので触っていません
- `useHeaderAction.ts` / `Terminal.vue` の呼び出し側は変更していません（戻り値を捨てたままで正しく動くようにするのが今回の設計）

Closes #1315
Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added notifications when terminal input is dropped because the connection is closed, including pasted text and interface actions.
  * Empty submissions remain silent, while non-empty dropped input is reported clearly.
  * Limited repeated banners during disconnections and reset notifications after reconnecting.
  * Updated messages to accurately describe sent input across terminal interactions.
* **Tests**
  * Expanded coverage for dropped-input alerts, reconnect behavior, rate limits, and empty submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->