### PR TITLE
fix(server): take no-unsafe-* to zero on the server (#1300)

### DIFF
--- a/common/isUnknownArray.ts
+++ b/common/isUnknownArray.ts
@@ -1,0 +1,8 @@
+// The array counterpart to isRecord, and it exists for a reason that is easy to miss:
+// `Array.isArray(value)` on an `unknown` narrows it to **`any[]`**, not `unknown[]`. So the
+// obvious `Array.isArray(x) ? x : []` hands back an array whose elements are outside the type
+// checker entirely, and every read off them type-checks against anything.
+//
+// Declaring the guard's result as `unknown[]` keeps the elements unverified-but-visible, which is
+// what the callers want: they check each element before using it.
+export const isUnknownArray = (value: unknown): value is unknown[] => Array.isArray(value);

--- a/plans/fix-1300-no-unsafe-server.md
+++ b/plans/fix-1300-no-unsafe-server.md
@@ -1,0 +1,116 @@
+# fix(server): `no-unsafe-*` を server 側だけ 0 にする (#1300 の一部)
+
+## 範囲
+
+`no-unsafe-*` 5 ルールの **407 件のうち、server/ の 145 件**を全部消す。`src/` の 262 件は
+この PR では触らない（同じ手が使えるので続きは別 PR）。
+
+| | before | after |
+|---|---|---|
+| server/ | **145** | **0** |
+| 全体 | 407 | 262 |
+
+## `any` の入口は 3 つしか無かった
+
+145 件は散らばって見えるが、出どころは 3 種類だけだった。
+
+### 1. `await import(name)` — `server/infra/plugins-registry.ts`（64 件、単一ファイル最大）
+
+動的 import の戻り値は `any`。そこから `mod.default` / `mod.TOOL_DEFINITION` /
+`mod.pluginCore?.execute` と辿るので、**プラグインの定義も実行関数も型検査の外**にいた。
+
+`isRecord` で受けてから、`isToolDefinition`（`type` / `name` / `description` の必須3フィールド）
+と `isExecutor` で確認する形にした。`isExecutor` は `server-tool-load.ts` に既にあったものを
+export して再利用（`typeof x === "function"` は `Function` にしか絞れず、`Function` の呼び出しは
+`any` を返すので、これが無いと結果がまた型検査の外に出る）。
+
+### 2. `JSON.parse(...)` — 7 ファイル
+
+`plugins.json` / activity-state / scheduled-sessions / cleared-transcripts / tool-store /
+app config / PTY のクライアントフレーム。全部 `: unknown` で受けてからガード。
+
+PTY のフレームは 2 箇所で同じことをしていたので `parseClientFrame` に集約した
+（**ここは PTY に書き込む値なので、境界を 1 つにする価値が特に高い**）。
+
+### 3. `req.body` — 8 ファイル
+
+express の `req.body` は `any`。`server/routes/requestBody.ts` に
+
+```ts
+export const requestBody = (body: unknown): Record<string, unknown> => (isRecord(body) ? body : {});
+```
+
+を置いて全箇所を通した。ハンドラ側は元から
+`typeof req.body?.x === "string" ? ... : default` と書かれていたので、**ガードはそのまま。
+違うのは、そのガードが型検査の対象になったこと**。
+
+## 型が通って初めて消せたもの
+
+`server/git/worktree-routes.ts` に、この `any` を回避するためのコメント付き再チェックがあった。
+
+```ts
+// Re-checked rather than reusing the guard above: `req.body` is `any`, and narrowing it there
+// does not survive to here — the call would take `any` and typecheck would not notice.
+const wt = await createWorktree(repoDir, task, isIssueNumber(issue) ? issue : undefined);
+```
+
+`requestBody` を通すと上のガードがちゃんと効くので、**再チェックごと削除**した。
+
+## 型が嘘をついていた箇所（実際の穴）
+
+### `translation-worker.ts` — `Promise<string[]>` が検証していなかった
+
+`pendingTranslations` の `resolve` が `(translations: string[]) => void` と宣言されていたが、
+中身は**ワーカーが submitTranslation に渡した何か**で、誰も検証していなかった。
+`submitTranslation` 側が `Array.isArray(x) ? x : []` としており、`x` が `any` なので
+`any[]` → `string[]` に黙って化けていた。
+
+- 待っている側（`runTranslationWorkerOnce`）は**既にこれを信用しておらず** `const translations:
+  unknown = await submitted;` と受け直して `isValidTranslationResult` で検証していた。
+- なので `resolve` の型を `unknown` にした。検証は 1 箇所（`isValidTranslationResult`）のまま。
+
+**副作用としてエラーメッセージが正確になった。** 非配列を渡したとき、以前は `[]` に潰してから
+検証していたので「`0 strings for 1 inputs`」= 件数不一致として報告されていた。実際には型が
+違うので、いまは「`a non-array for 1 inputs`」と出る。**この古い挙動を固定していたテストが
+あったので、正しい方に更新した**（テスト名も含めて）。
+
+配列を `filter` で string だけにする案は取らなかった。**この配列は位置対応**で、長さが
+`expected` と一致することが検証条件だから、落とすと意味が変わる。
+
+### `tool-store.ts` — 自分が書いたファイルを読み戻して `T[]` と名乗っていた
+
+`createSessionStore<T>` が `Array.isArray(parsed) ? parsed : []` で `any[]` を `T[]` にしていた。
+手で編集されたり、クラッシュで切れたり、古いバージョンが書いた JSON でも、**型引数だけを根拠に
+T[] になる**。
+
+`isEntry: (value: unknown) => value is T` を**必須**引数にした（optional にすると既定が
+「全部通す」になり元に戻る）。呼び出し 2 箇所には `isToolResult` / `isToolCall` を書いた
+（必須フィールドと、存在する場合の optional フィールドを両方見る）。spec 10 箇所も更新。
+
+こちらは**位置対応でない**ので、壊れた要素だけ落とす。
+
+## `Array.isArray` の罠
+
+`Array.isArray(value)` は `unknown` を **`any[]`** に絞る（`unknown[]` ではない）。つまり
+`Array.isArray(x) ? x : []` は要素が `any` の配列を返し、そこから先が全部型検査の外に出る。
+今日 `transcript.ts` でも踏んだ形なので、`common/isUnknownArray.ts` に guard を置いた。
+
+## 検証
+
+**「lint が 0 になった」は「壊していない」の証拠にならない**ので、プラグインレジストリは
+実際にロードして突き合わせた。
+
+```
+X_BEARER_TOKEN=dummy npx tsx <probe>   # main と本ブランチの両方で
+```
+
+ツール名 13 個・`toolSummaries` 13 件・`parameters` を持つ定義 13/13 が **完全一致**。
+factory 形式（google）と server-tool 形式（readXPost / searchX）の両経路を含む。
+
+`yarn typecheck` 0 / `yarn lint` 0 errors（warning 23 は main と同数）/ `yarn build` /
+`yarn test` 7585 passed。
+
+## この PR で直していないもの
+
+`src/` の 262 件。入口は同じ（`JSON.parse`、`await import`、socket のメッセージ）なので
+同じ手が使える。#1300 に残す。

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -67,6 +67,7 @@ import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
 import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
 import { isRecord } from "../../common/isRecord.js";
+import { requestBody } from "../routes/requestBody.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
 // (prefix, message, optional structured data) — shared with the other engines'
@@ -282,9 +283,10 @@ const registryImportHandler: RequestHandler = async (req, res) => {
     res.status(503).json({ error: "collections backend not initialized" });
     return;
   }
-  const author = typeof req.body?.author === "string" ? req.body.author : "";
-  const slug = typeof req.body?.slug === "string" ? req.body.slug : "";
-  const registry = typeof req.body?.registry === "string" && req.body.registry ? req.body.registry : null;
+  const body = requestBody(req.body);
+  const author = typeof body.author === "string" ? body.author : "";
+  const slug = typeof body.slug === "string" ? body.slug : "";
+  const registry = typeof body.registry === "string" && body.registry ? body.registry : null;
   if (!author || !slug) {
     res.status(400).json({ error: "author and slug are required" });
     return;

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -30,6 +30,7 @@ import { getUpdateStatus } from "./update-status.js";
 import { readSoundPreset } from "./sound-presets.js";
 import { isNotifyKind } from "../../common/notifyKinds.js";
 import { parsePresetRef, soundPresetById } from "../../common/notifySounds.js";
+import { requestBody } from "../routes/requestBody.js";
 
 export const APP_CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 const CONFIG_FILE = APP_CONFIG_FILE;
@@ -162,7 +163,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   });
 
   app.post("/api/config", (req, res) => {
-    const body = req.body ?? {};
+    const body = requestBody(req.body);
     // Partial update: keep the field the request omits so saving the sound doesn't
     // wipe the presets (and vice-versa). cwdPresets, when present, must be an array.
     const badField = badArrayField(body);

--- a/server/files/files-browse.ts
+++ b/server/files/files-browse.ts
@@ -16,6 +16,7 @@ import { hasErrnoCode } from "../errors.js";
 import { backupCurrentFile, storeBackup } from "./backup-store.js";
 import { resolveBase, resolveContained } from "./pathContainment.js";
 import { htmlDoc, jsonHtmlDoc, tableHtmlDoc, delimiterForExtension } from "./renderedDoc.js";
+import { requestBody } from "../routes/requestBody.js";
 
 // Cap on the bytes served to the editor / accepted on write — a text editor, not a
 // blob store. Large/binary files are refused rather than streamed into a textarea.
@@ -203,8 +204,9 @@ function mountWriteRoute(app: Express, { defaultCwd, backupRoot }: BrowseDeps): 
   app.put("/api/files/browse/write", (req, res) => {
     const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
-    const text = req.body?.text;
-    const baseVersion = req.body?.baseVersion;
+    const body = requestBody(req.body);
+    const text = body.text;
+    const baseVersion = body.baseVersion;
     if (typeof text !== "string") return res.status(400).json({ error: "body.text (string) required" });
     if (baseVersion !== null && typeof baseVersion !== "string") return res.status(400).json({ error: "body.baseVersion (string|null) required" });
     if (Buffer.byteLength(text, "utf8") > MAX_EDIT_BYTES) return res.status(413).json({ error: "content too large" });
@@ -230,7 +232,7 @@ function mountBackupRoute(app: Express, { defaultCwd, backupRoot }: BrowseDeps):
   app.put("/api/files/browse/backup", (req, res) => {
     const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
-    const text = req.body?.text;
+    const { text } = requestBody(req.body);
     if (typeof text !== "string") return res.status(400).json({ error: "body.text (string) required" });
     if (Buffer.byteLength(text, "utf8") > MAX_EDIT_BYTES) return res.status(413).json({ error: "content too large" });
     res.json({ stored: storeBackup(abs, text, backupRoot) !== null });

--- a/server/git/gitRemote.ts
+++ b/server/git/gitRemote.ts
@@ -15,7 +15,7 @@ function readOriginUrl(dir: string): Promise<string | null> {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool resolved from PATH in this local dev server; dir is passed via -C as a separate argv (no shell)
     const child = spawn("git", ["-C", dir, "config", "--get", "remote.origin.url"], { stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
-    child.stdout.on("data", (chunk) => (out += chunk.toString()));
+    child.stdout.on("data", (chunk: Buffer) => (out += chunk.toString()));
     child.on("error", () => resolve(null)); // git not installed
     child.on("close", () => resolve(out.trim() || null));
   });

--- a/server/git/worktree-routes.ts
+++ b/server/git/worktree-routes.ts
@@ -10,6 +10,7 @@ import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 import { isIssueNumber } from "../../common/prPhase.js";
 import { dirSession } from "../session/dir-session.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
+import { requestBody } from "../routes/requestBody.js";
 
 interface WorktreeRouteOptions {
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
@@ -53,7 +54,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
 
   app.post("/api/worktrees/create", async (req, res) => {
     if (!requestOriginAllowed(req, isAllowedOrigin)) return res.status(403).end();
-    const { repoDir, task, issue } = req.body ?? {};
+    const { repoDir, task, issue } = requestBody(req.body);
     if (typeof repoDir !== "string" || typeof task !== "string" || !task.trim()) {
       return res.status(400).json({ error: "repoDir and a non-empty task are required" });
     }
@@ -63,9 +64,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     if (issue !== undefined && !isIssueNumber(issue)) {
       return res.status(400).json({ error: "issue must be a positive integer" });
     }
-    // Re-checked rather than reusing the guard above: `req.body` is `any`, and narrowing it there
-    // does not survive to here — the call would take `any` and typecheck would not notice.
-    const wt = await createWorktree(repoDir, task, isIssueNumber(issue) ? issue : undefined);
+    const wt = await createWorktree(repoDir, task, issue);
     if (!wt) return res.status(500).json({ error: "could not create the worktree (is this a git repo?)" });
     res.json(wt);
   });
@@ -75,7 +74,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
   // failure the client can't fix by retrying.
   app.post("/api/worktrees/remove", async (req, res) => {
     if (!requestOriginAllowed(req, isAllowedOrigin)) return res.status(403).end();
-    const { repoDir, path: worktreePath, deleteBranch, force } = req.body ?? {};
+    const { repoDir, path: worktreePath, deleteBranch, force } = requestBody(req.body);
     if (typeof repoDir !== "string" || typeof worktreePath !== "string") {
       return res.status(400).json({ error: "repoDir and path are required" });
     }
@@ -90,7 +89,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
   // Push the worktree's branch to origin (the first half of "取り込み").
   app.post("/api/worktrees/push", async (req, res) => {
     if (!requestOriginAllowed(req, isAllowedOrigin)) return res.status(403).end();
-    const { cwd } = req.body ?? {};
+    const { cwd } = requestBody(req.body);
     if (typeof cwd !== "string") return res.status(400).json({ error: "cwd is required" });
     const result = await pushWorktree(cwd);
     res.status(statusFor(result)).json(result);
@@ -100,7 +99,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
   // returns the URL for the client to open and which path produced it (`via`).
   app.post("/api/worktrees/pr", async (req, res) => {
     if (!requestOriginAllowed(req, isAllowedOrigin)) return res.status(403).end();
-    const { cwd } = req.body ?? {};
+    const { cwd } = requestBody(req.body);
     if (typeof cwd !== "string") return res.status(400).json({ error: "cwd is required" });
     const result = await createOrOpenPR(cwd);
     res.status(statusFor(result)).json(result);

--- a/server/index.ts
+++ b/server/index.ts
@@ -331,9 +331,10 @@ const { translateViaHiddenChat } = createTranslationWorker({
 // Before anything binds a port: a typo'd key binding must stop the boot with a message
 // naming it, not disappear into a shortcut that silently never fires.
 enforceKeymap(APP_CONFIG_FILE, {
-  readConfig: () => {
+  readConfig: (): unknown => {
     try {
-      return JSON.parse(readFileSync(APP_CONFIG_FILE, "utf8"));
+      const parsed: unknown = JSON.parse(readFileSync(APP_CONFIG_FILE, "utf8"));
+      return parsed;
     } catch {
       return undefined; // missing or unparseable — not this check's business to report
     }

--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -25,7 +25,7 @@ import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import type { Express } from "express";
 import { isPluginFactory } from "gui-chat-protocol";
-import type { PluginRuntime, PluginFactoryResult } from "gui-chat-protocol";
+import type { PluginRuntime, PluginFactoryResult, ToolDefinition } from "gui-chat-protocol";
 import { generateImage } from "../backends/image-gen.js";
 import { markdownHostApp } from "../backends/markdown.js";
 import { artifactsFileOps } from "../backends/artifacts.js";
@@ -34,7 +34,7 @@ import { createPluginRuntime } from "./pluginRuntime.js";
 import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
 import { groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
-import { missingRequiredEnv, soleExecutor } from "./server-tool-load.js";
+import { missingRequiredEnv, soleExecutor, isExecutor } from "./server-tool-load.js";
 import { isRecord } from "../../common/isRecord.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -67,13 +67,39 @@ const APP_CONTEXT = { generateImage, ...markdownHostApp };
 // assembles the context per route.
 const FILES_CONTEXT = { artifacts: artifactsFileOps, byPath: htmlByPath };
 
+// The normalized shape every loader below answers with, and the only one the broker and the
+// dispatch route consume. Stated once because four loaders have to agree on it.
+interface LoadedPlugin {
+  toolName: string;
+  definition: ToolDefinition;
+  execute: (args?: unknown) => unknown;
+}
+
+// The three required fields of a gui-chat-protocol ToolDefinition. A guard rather than a cast:
+// a definition arrives from an imported module, so nothing here has checked it before now.
+const isToolDefinition = (value: unknown): value is ToolDefinition =>
+  isRecord(value) && value.type === "function" && typeof value.name === "string" && typeof value.description === "string";
+
+// plugins.json entries are module specifiers, so a non-string is a config error rather than a
+// plugin. Dropped, but never in silence: it would otherwise vanish between the file and the tool
+// list with nothing anywhere to read.
+function moduleNames(value: unknown, field: string): string[] {
+  if (!Array.isArray(value)) return [];
+  const names = value.filter((entry): entry is string => typeof entry === "string");
+  if (names.length !== value.length) {
+    console.warn(`[plugins] plugins.json "${field}": ignored ${value.length - names.length} non-string entries`);
+  }
+  return names;
+}
+
 function loadConfig() {
   const raw = fs.readFileSync(path.join(PLUGINS_DIR, "plugins.json"), "utf8");
-  const parsed = JSON.parse(raw);
+  const parsed: unknown = JSON.parse(raw);
+  const fields = isRecord(parsed) ? parsed : {};
   return {
-    packages: Array.isArray(parsed.packages) ? parsed.packages : [],
-    servers: Array.isArray(parsed.servers) ? parsed.servers : [],
-    local: Array.isArray(parsed.local) ? parsed.local : [],
+    packages: moduleNames(fields.packages, "packages"),
+    servers: moduleNames(fields.servers, "servers"),
+    local: moduleNames(fields.local, "local"),
   };
 }
 
@@ -83,11 +109,11 @@ function loadConfig() {
 // named after the tool, so there's no bare `execute` for loadPackage to find. Build the
 // package's scoped runtime, call the factory once at load, and adapt the result.
 // `isPluginFactory` is the protocol's own detector, so this tracks the spec.
-function loadFactoryPackage(name: string, factory: (runtime: PluginRuntime) => PluginFactoryResult) {
+function loadFactoryPackage(name: string, factory: (runtime: PluginRuntime) => PluginFactoryResult): LoadedPlugin {
   const plugin = factory(createPluginRuntime(name));
   const definition = plugin.TOOL_DEFINITION;
   const execute = plugin[definition.name];
-  if (typeof execute !== "function") {
+  if (!isExecutor(execute)) {
     throw new Error(`Plugin factory "${name}" exports no "${definition.name}" executor matching its TOOL_DEFINITION.`);
   }
   // A factory's executor takes only args — its host capabilities came from the runtime.
@@ -99,17 +125,19 @@ function loadFactoryPackage(name: string, factory: (runtime: PluginRuntime) => P
 // result envelope. We invoke it in-process when the broker dispatches, passing the
 // host backends as context.app (image generation, etc.). Factory-style packages are
 // a different shape entirely, so they branch off to loadFactoryPackage first.
-async function loadPackage(name: string) {
-  const mod = await import(name);
+async function loadPackage(name: string): Promise<LoadedPlugin> {
+  const mod: unknown = await import(name);
+  if (!isRecord(mod)) throw new Error(`Package "${name}" did not resolve to a module namespace object.`);
   if (isPluginFactory(mod.default)) return loadFactoryPackage(name, mod.default);
-  const definition = mod.TOOL_DEFINITION ?? mod.pluginCore?.toolDefinition;
+  const core = isRecord(mod.pluginCore) ? mod.pluginCore : undefined;
+  const definition = mod.TOOL_DEFINITION ?? core?.toolDefinition;
   // Some packages (e.g. @mulmoclaude/core/collection) export their executor under
   // a descriptive name like `executePresentCollection` rather than a bare `execute`,
   // and ship no `pluginCore` on the core entry (their origin host registers the tool
   // as a built-in). Fall back to a sole `execute*` function export so such packages
   // still load without hardcoding their name.
-  const execute = mod.pluginCore?.execute ?? mod.execute ?? soleExecutor(mod);
-  if (!definition || typeof execute !== "function") {
+  const execute = core?.execute ?? mod.execute ?? soleExecutor(mod);
+  if (!isToolDefinition(definition) || !isExecutor(execute)) {
     throw new Error(`Package "${name}" is not a gui-chat-protocol plugin (missing TOOL_DEFINITION/execute).`);
   }
   return { toolName: definition.name, definition, execute: (args?: unknown) => execute({ app: APP_CONTEXT, files: FILES_CONTEXT }, args ?? {}) };
@@ -119,16 +147,34 @@ async function loadPackage(name: string) {
 // definition + an async handler returning a plain string for claude, with no GUI
 // data. `requiredEnv` lists env vars (e.g. X_BEARER_TOKEN) the handler needs.
 interface ServerTool {
-  definition: { name: string; description: string; inputSchema: object };
+  definition: { name: string; description: string; inputSchema: ToolDefinition["parameters"] };
   requiredEnv?: string[];
   prompt?: string;
   handler: (args: Record<string, unknown>) => Promise<string>;
 }
 
+// An XTool's inputSchema IS the JSON-schema object a ToolDefinition carries as `parameters`, and
+// it is adapted into one below — so its shape is checked here rather than assumed there. Only the
+// container is: every JsonSchemaProperty field is optional, and the property values are forwarded
+// to the broker without this file ever reading inside them.
+const isInputSchema = (value: unknown): value is ToolDefinition["parameters"] =>
+  isRecord(value) &&
+  value.type === "object" &&
+  isRecord(value.properties) &&
+  Object.values(value.properties).every(isRecord) &&
+  Array.isArray(value.required) &&
+  value.required.every((key) => typeof key === "string");
+
 function isServerTool(value: unknown): value is ServerTool {
   if (!isRecord(value)) return false;
   const definition = value.definition;
-  return isRecord(definition) && typeof definition.name === "string" && typeof value.handler === "function";
+  return (
+    isRecord(definition) &&
+    typeof definition.name === "string" &&
+    typeof definition.description === "string" &&
+    isInputSchema(definition.inputSchema) &&
+    typeof value.handler === "function"
+  );
 }
 
 // A server-only tool package. Import it, pick every XTool-shaped export, and adapt
@@ -136,9 +182,9 @@ function isServerTool(value: unknown): value is ServerTool {
 // requiredEnv is not fully satisfied are dropped (and logged) so they never reach
 // the broker's tool list. The handler's string result becomes the envelope
 // `message`; with no `data`, the broker publishes nothing to the GUI.
-async function loadServerToolPackage(name: string) {
-  const mod = await import(name);
-  const tools = Object.values(mod).filter(isServerTool);
+async function loadServerToolPackage(name: string): Promise<LoadedPlugin[]> {
+  const mod: unknown = await import(name);
+  const tools = Object.values(isRecord(mod) ? mod : {}).filter(isServerTool);
   if (tools.length === 0) {
     throw new Error(`Server-tool package "${name}" exports no XTool-shaped tools ({ definition, handler }).`);
   }
@@ -155,12 +201,15 @@ async function loadServerToolPackage(name: string) {
       toolName: tool.definition.name,
       // Adapt the XTool definition into a gui-chat-protocol ToolDefinition the
       // broker lists: inputSchema -> parameters; prompt folds into the description.
+      // Spread rather than assigned: both are optional on ToolDefinition, and under
+      // exactOptionalPropertyTypes writing `prompt: undefined` is a present key holding
+      // undefined — a different thing from an absent one, and not what the broker is given.
       definition: {
         type: "function" as const,
         name: tool.definition.name,
         description: tool.definition.description,
-        prompt: tool.prompt,
-        parameters: tool.definition.inputSchema,
+        ...(tool.prompt === undefined ? {} : { prompt: tool.prompt }),
+        ...(tool.definition.inputSchema === undefined ? {} : { parameters: tool.definition.inputSchema }),
       },
       execute: async (args?: unknown) => ({ message: await tool.handler(isRecord(args) ? args : {}) }),
     }));
@@ -168,14 +217,19 @@ async function loadServerToolPackage(name: string) {
 
 // A local plugin: definition.js exports TOOL_DEFINITION (a gui-chat-protocol
 // ToolDefinition), server.js exports execute(args).
-async function loadLocal(name: string) {
+async function loadLocal(name: string): Promise<LoadedPlugin> {
   const dir = path.join(PLUGINS_DIR, name);
-  const importJs = (file: string) => import(pathToFileURL(path.join(dir, file)).href);
-  const [{ TOOL_DEFINITION }, { execute }] = await Promise.all([importJs("definition.js"), importJs("server.js")]);
-  if (!TOOL_DEFINITION || typeof execute !== "function") {
+  const importJs = async (file: string): Promise<Record<string, unknown>> => {
+    const mod: unknown = await import(pathToFileURL(path.join(dir, file)).href);
+    return isRecord(mod) ? mod : {};
+  };
+  const [definitionModule, serverModule] = await Promise.all([importJs("definition.js"), importJs("server.js")]);
+  const definition = definitionModule.TOOL_DEFINITION;
+  const execute = serverModule.execute;
+  if (!isToolDefinition(definition) || !isExecutor(execute)) {
     throw new Error(`Local plugin "${name}" must export TOOL_DEFINITION and execute().`);
   }
-  return { toolName: TOOL_DEFINITION.name, definition: TOOL_DEFINITION, execute: (args?: unknown) => execute(args ?? {}) };
+  return { toolName: definition.name, definition, execute: (args?: unknown) => execute(args ?? {}) };
 }
 
 const config = loadConfig();

--- a/server/infra/server-tool-load.ts
+++ b/server/infra/server-tool-load.ts
@@ -20,15 +20,20 @@ export function serverToolEnabled(requiredEnv: readonly string[] | undefined, en
   return missingRequiredEnv(requiredEnv, env).length === 0;
 }
 
+// What a plugin's entry point is, as far as the loaders can know. Named because `typeof x ===
+// "function"` narrows to `Function`, whose call signature returns `any` — so a bare typeof check
+// hands the result straight back out of the type checker.
+export type Executor = (...args: unknown[]) => unknown;
+
 // Callable is all JavaScript lets anyone check; the signature is the caller's contract with the
 // package, which nothing here can verify. A guard rather than an assertion so the check and the
 // type it grants are the same statement.
-const isExecutor = (value: unknown): value is (...args: unknown[]) => unknown => typeof value === "function";
+export const isExecutor = (value: unknown): value is Executor => typeof value === "function";
 
 // The sole `execute*` function export, or undefined when there is not exactly one — the
 // fallback executor for packages that name their entry point descriptively and ship no
 // `execute`. Undefined for zero (nothing to pick) and for two or more (ambiguous).
-export function soleExecutor(mod: Record<string, unknown>): ((...args: unknown[]) => unknown) | undefined {
+export function soleExecutor(mod: Record<string, unknown>): Executor | undefined {
   const fns = Object.entries(mod).flatMap(([key, value]) => (key.startsWith("execute") && isExecutor(value) ? [value] : []));
   return fns.length === 1 ? fns[0] : undefined;
 }

--- a/server/routes/gui-mcp-routes.ts
+++ b/server/routes/gui-mcp-routes.ts
@@ -7,6 +7,7 @@ import { claudeAdapter } from "../agents/claude.js";
 import { TOOL_GROUPS, isToolGroup } from "../../common/toolGroups.js";
 import { registerGuiMcpGroup, unregisterGuiMcpGroup, registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
+import { requestBody } from "./requestBody.js";
 
 export function mountGuiMcpRoutes(app: Express): void {
   // Which GUI tool groups this directory has registered with Claude Code, so the launcher can
@@ -35,8 +36,9 @@ export function mountGuiMcpRoutes(app: Express): void {
   // in the directory — so that file is rewritten from the registry the switch just changed. One
   // switch, every agent, and still only one place that RECORDS the answer.
   app.post("/api/gui-mcp-groups", async (req, res) => {
-    const cwd = existingWorkspace(typeof req.body?.cwd === "string" ? req.body.cwd : null);
-    const { group, enabled } = req.body ?? {};
+    const body = requestBody(req.body);
+    const cwd = existingWorkspace(typeof body.cwd === "string" ? body.cwd : null);
+    const { group, enabled } = body;
     if (!cwd) return res.status(400).json({ ok: false, message: "unknown directory" });
     if (!isToolGroup(group)) return res.status(400).json({ ok: false, message: `unknown tool group: ${group}` });
     // Checked rather than coerced: this writes to the user's Claude Code config, and a missing

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -4,6 +4,7 @@
 // (#548 step 3g) — the fan-out is what made the route long, not the route itself.
 import type { Express, Request, Response } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
+import { isRecord } from "../../common/isRecord.js";
 import { dirConfigWriteTarget } from "../config/dir-config.js";
 import { writtenFilePath } from "../files/tool-writes.js";
 import { activityHookEffects, pushKindFor, resolveHookCwd, resolveHookSessionId } from "../session/activity-hook.js";
@@ -17,7 +18,7 @@ import { notifyTaskFinished } from "../session/task-push.js";
 import { preferredHeaderPrompt } from "../session/transcript.js";
 import { failPendingTranslation } from "../session/translation-worker.js";
 import type { SessionActivityDeps } from "../session/session-activity-deps.js";
-import { publishesDirConfig, toolHookRecord, type ToolCallEnd, type ToolCallStart } from "../session/tool-hook.js";
+import { publishesDirConfig, toolHookRecord, type ToolCallEnd, type ToolCallStart, type ToolHookPayload } from "../session/tool-hook.js";
 
 // The header shows one line, so a longer prompt is stored truncated rather than in full.
 
@@ -56,18 +57,20 @@ function handleActivityHook(deps: HookDeps, sessionId: string, event: string, ac
   if (event === "Stop") void runCompletionHook(sessionId, { didError: false }).catch((err) => console.error(`[completion-hook] ${messageOf(err)}`));
 }
 
-interface HookToolPayload {
-  tool_use_id?: string;
-  tool_name?: string;
-  tool_input?: unknown;
-  tool_output?: unknown;
-  tool_response?: unknown;
-  duration_ms?: number;
-}
+// The tool fields of a hook body. Read rather than trusted: the payload is whatever the hook
+// POSTed, and the `unknown` fields are forwarded to toolHookRecord without being opened here.
+const toolPayload = (body: Record<string, unknown>): ToolHookPayload => ({
+  tool_use_id: typeof body.tool_use_id === "string" ? body.tool_use_id : undefined,
+  tool_name: typeof body.tool_name === "string" ? body.tool_name : undefined,
+  tool_input: body.tool_input,
+  tool_output: body.tool_output,
+  tool_response: body.tool_response,
+  duration_ms: typeof body.duration_ms === "number" ? body.duration_ms : undefined,
+});
 
 // Pre/PostToolUse hooks feed the per-session tool-call history; toolHookRecord decides what
 // each event means and this applies it.
-async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: HookToolPayload, cwd: string | undefined) {
+async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: ToolHookPayload, cwd: string | undefined) {
   const record = toolHookRecord(event, p);
   if (record?.phase === "start") await deps.recordToolCallStart(sessionId, record.call);
   if (record?.phase === "end") await deps.recordToolCallEnd(sessionId, record.call);
@@ -141,12 +144,28 @@ async function applyHeaderHooks(deps: HookDeps, sessionId: string, event: string
   void deps.maybeGenerateTitle(sessionId, cwd);
 }
 
+// The scalar fields the handler reads straight off a hook body, checked once here so the flow
+// below reads as flow. Every one is a string on a well-formed payload and anything at all on a
+// malformed one, which is why none of them is taken on trust.
+function hookFields(body: Record<string, unknown>) {
+  return {
+    event: typeof body.hook_event_name === "string" ? body.hook_event_name : "",
+    toolName: typeof body.tool_name === "string" ? body.tool_name : undefined,
+    message: typeof body.message === "string" ? body.message : "",
+    // Which KIND of notification — a subagent finishing arrives here as `agent_completed`, and
+    // must not be read as the agent waiting on the user (#874).
+    notificationType: typeof body.notification_type === "string" ? body.notification_type : undefined,
+  };
+}
+
 // Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
 // we can flag which background sessions have new activity / build tool history.
 async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
-  const body = req.body || {};
+  // express hands `req.body` back as `any`, so every field below is read through a check —
+  // this is a request body from outside, not a shape anything has verified.
+  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
   const sessionId = resolveHookSessionId(req.headers["x-mt-session"], body.session_id, (id) => SESSION_ID_RE.test(id));
-  const event = body.hook_event_name;
+  const { event, toolName, message, notificationType } = hookFields(body);
   if (!sessionId && body.session_id) {
     // Rejecting silently would make hooks look simply broken; the id shape is the
     // precondition for using it as a Firestore doc id and as push routing.
@@ -162,18 +181,9 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     // Live sessions only: a tracked turn is reclaimed by reap, which itself does nothing without a
     // pty — so tracking an id with no pty (any well-formed uuid may be posted here) would never be
     // reclaimed. A session whose pty is gone simply reports no phase, as it does before its first tool.
-    if (entry) deps.noteWorkPhase(sessionId, event, typeof body.tool_name === "string" ? body.tool_name : undefined);
-    handleActivityHook(
-      deps,
-      sessionId,
-      event,
-      active,
-      typeof body.message === "string" ? body.message : "",
-      // Which KIND of notification — a subagent finishing arrives here as
-      // `agent_completed`, and must not be read as the agent waiting on the user (#874).
-      typeof body.notification_type === "string" ? body.notification_type : undefined,
-    );
-    await handleToolHook(deps, sessionId, event, body, cwd);
+    if (entry) deps.noteWorkPhase(sessionId, event, toolName);
+    handleActivityHook(deps, sessionId, event, active, message, notificationType);
+    await handleToolHook(deps, sessionId, event, toolPayload(body), cwd);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID
     // submit, the entry is already resolved and this reject is a no-op.)

--- a/server/routes/issue-work-routes.ts
+++ b/server/routes/issue-work-routes.ts
@@ -14,6 +14,7 @@ import type { SpawnClaudeOptions } from "../session/spawn-claude.js";
 import { isIssueNumber } from "../../common/prPhase.js";
 import { isRepoEntry, repoIdentity } from "../../common/repoEntry.js";
 import { requestOriginAllowed } from "./same-origin-guard.js";
+import { requestBody } from "./requestBody.js";
 
 export interface IssueWorkRouteDeps {
   /** Returns `unknown` on purpose: this route ignores the PtyEntry the spawner hands back, and
@@ -30,7 +31,7 @@ const STATUS_FOR_REASON: Record<string, number> = { "issue-not-found": 409, "wor
 export function mountIssueWorkRoutes(app: Express, deps: IssueWorkRouteDeps): void {
   app.post("/api/issues/start", async (req, res) => {
     if (!requestOriginAllowed(req, deps.isAllowedOrigin)) return res.status(403).end();
-    const { repo, issue, dir } = req.body ?? {};
+    const { repo, issue, dir } = requestBody(req.body);
     if (typeof repo !== "string" || !isRepoEntry(repo) || !isIssueNumber(issue) || typeof dir !== "string") {
       return res.status(400).json({ error: "repo ([host/]owner/repo), a positive issue number and dir are required" });
     }

--- a/server/routes/requestBody.ts
+++ b/server/routes/requestBody.ts
@@ -1,0 +1,14 @@
+// Reading a POST body without `any`.
+//
+// Express types `req.body` as `any`, so `req.body.slug` type-checks against every use and every
+// value read out of it stays `any` all the way to whatever it is handed to. That is the widest
+// `any` door in the server: the value came from outside, and nothing has checked it.
+//
+// Answering a plain record makes each field `unknown`, which the handlers already treat correctly
+// — they were written as `typeof req.body?.x === "string" ? ... : default`, and that guard is now
+// the thing the type checker follows rather than decoration on an `any`.
+
+import { isRecord } from "../../common/isRecord.js";
+
+/** A POST body as a record of unverified fields; `{}` when the request carried no JSON object. */
+export const requestBody = (body: unknown): Record<string, unknown> => (isRecord(body) ? body : {});

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -52,6 +52,7 @@ import type { SessionMeta } from "../session/types.js";
 import { parseActivityIds, selectSessionRows } from "../session/session-list.js";
 import { sessionDetailView } from "../session/session-detail-view.js";
 import { clearedTranscripts } from "../session/cleared-transcripts.js";
+import { requestBody } from "./requestBody.js";
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
@@ -100,7 +101,7 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
 async function setMemo(req: Request<{ id: string }>, res: Response, publishActivity: SessionRouteDeps["publishActivity"]) {
   const { id } = req.params;
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
-  const { text } = req.body ?? {};
+  const { text } = requestBody(req.body);
   if (typeof text !== "string") return res.status(400).json({ error: "text must be a string" });
   await sessionMemosHydrated; // or a write during startup is undone by the file it raced
   try {

--- a/server/session/cleared-transcripts.ts
+++ b/server/session/cleared-transcripts.ts
@@ -93,7 +93,7 @@ export function forgetClearedTranscript(id: string, dir: string = CLEARED_DIR): 
 const readMark = (dir: string, id: string): Promise<unknown> =>
   fs
     .readFile(markerFile(dir, id), "utf8")
-    .then((text) => JSON.parse(text))
+    .then((text): unknown => JSON.parse(text))
     .catch(() => null);
 
 async function restoreMark(dir: string, file: string): Promise<void> {

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -9,6 +9,7 @@ import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
 import { messageOf } from "../errors.js";
 import { isResizeFrame } from "./ws-frames.js";
+import { isRecord } from "../../common/isRecord.js";
 import { stripTerminalQueries, terminalModePrefix } from "./terminal-replay.js";
 import type { PtyEntry } from "./types.js";
 
@@ -43,15 +44,23 @@ export interface ConnectionDeps {
   cancelTerminalSizeCheck: (id: string) => void;
 }
 
+// The one place a browser's bytes become data. Answers a plain record so every field below is
+// read through a check — `JSON.parse` alone hands back `any`, which would put the whole frame,
+// including whatever gets written to the PTY, outside the type checker.
+function parseClientFrame(raw: WireFrame): Record<string, unknown> | null {
+  try {
+    const msg: unknown = JSON.parse(raw.toString());
+    return isRecord(msg) ? msg : null; // not an object — never write arbitrary payloads to the PTY
+  } catch {
+    return null; // not JSON at all
+  }
+}
+
 // browser -> command PTY. Like handleClientFrame but for the session-less command
 // terminal: only input/resize (no terminate/session machinery).
 export function handleCommandFrame(term: IPty, raw: WireFrame) {
-  let msg;
-  try {
-    msg = JSON.parse(raw.toString());
-  } catch {
-    return; // not JSON — never write arbitrary payloads to the PTY
-  }
+  const msg = parseClientFrame(raw);
+  if (!msg) return;
   try {
     if (msg.type === "input" && typeof msg.data === "string") {
       term.write(msg.data);
@@ -118,12 +127,8 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
   function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: WireFrame, sessionId: string) {
     // Ignore frames from a socket that a newer client has already superseded.
     if (entry.ws !== ws) return;
-    let msg;
-    try {
-      msg = JSON.parse(raw.toString());
-    } catch {
-      return; // not JSON — never write arbitrary payloads to the PTY
-    }
+    const msg = parseClientFrame(raw);
+    if (!msg) return;
     try {
       if (msg.type === "terminate") {
         // Explicit close (the cell's close button) — reap now instead of waiting out the

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -641,7 +641,7 @@ export function resetSessionToolGroups(sessionId: string): void {
 const ACTIVITY_STATE_FILE = path.join(MULMOTERMINAL_HOME, "activity-state.json");
 export const activityStateHydrated: Promise<void> = (async () => {
   try {
-    const parsed = JSON.parse(await fs.readFile(ACTIVITY_STATE_FILE, "utf8"));
+    const parsed: unknown = JSON.parse(await fs.readFile(ACTIVITY_STATE_FILE, "utf8"));
     for (const { id, working, waiting, event } of parseActivityState(parsed, (x) => SESSION_ID_RE.test(x))) {
       // Don't clobber a live update that already landed while hydration was in flight.
       if (!activity.has(id)) activity.set(id, { working, waiting, event, at: Date.now() });

--- a/server/session/scheduled-sessions.ts
+++ b/server/session/scheduled-sessions.ts
@@ -130,7 +130,7 @@ export function createScheduledSessionRegistry(deps: ScheduledSessionRegistryDep
   const readEntry = async (name: string): Promise<ScheduledSessionRecord | null> => {
     if (!name.endsWith(".json")) return null;
     try {
-      const raw = JSON.parse(await fs.readFile(path.join(deps.dir, name), "utf8"));
+      const raw: unknown = JSON.parse(await fs.readFile(path.join(deps.dir, name), "utf8"));
       return parseScheduledSessionRecord(name.slice(0, -".json".length), raw, deps.isValidId);
     } catch {
       return null; // unreadable / not JSON — not something we can act on

--- a/server/session/tool-hook.ts
+++ b/server/session/tool-hook.ts
@@ -10,13 +10,16 @@
 // reload. Letting the failure event through makes every rejected write to
 // .mulmoterminal.json tell every watching client to re-read a file that did not change.
 
+// `| undefined` on each, matching ToolCallStart below: under exactOptionalPropertyTypes an absent
+// key and a key holding undefined are different types, and the hook route reads these fields off
+// an unverified request body, so it answers undefined rather than omitting them.
 export interface ToolHookPayload {
-  tool_use_id?: string;
-  tool_name?: string;
+  tool_use_id?: string | undefined;
+  tool_name?: string | undefined;
   tool_input?: unknown;
   tool_output?: unknown;
   tool_response?: unknown;
-  duration_ms?: number;
+  duration_ms?: number | undefined;
 }
 
 export interface ToolCallStart {

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -13,6 +13,8 @@ import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import type { ToolCall, ToolResult } from "./types.js";
 import { reconcileCollectionCard } from "../../common/collectionSeed.js";
+import { isUnknownArray } from "../../common/isUnknownArray.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface ToolStoreDeps {
   /** Fan a change out to the panel; a no-op before pub/sub exists. */
@@ -45,7 +47,10 @@ async function fileMtimeMs(file: string): Promise<number> {
 // re-read when the file's mtime is newer than the copy it cached, so the non-owner picks up the
 // owner's appends instead of holding a stale copy until it restarts. `statMtimeMs` is a
 // parameter so a test can drive the mtime deterministically. (#705)
-export function createSessionStore<T>(dirName: string, root: string = MULMOTERMINAL_HOME, statMtimeMs: (file: string) => Promise<number> = fileMtimeMs) {
+// `isEntry` is required rather than optional: the file is JSON this process wrote, but it can be
+// hand-edited, truncated by a crash, or left behind by an older version — and with no check the
+// list is promoted to T[] on nothing but the type argument, so every read off an entry lies.
+export function createSessionStore<T>(dirName: string, isEntry: (value: unknown) => value is T, root = MULMOTERMINAL_HOME, statMtimeMs = fileMtimeMs) {
   const dir = path.join(root, dirName);
   const fileFor = (id: string) => path.join(dir, `${id}.json`);
   const map = new Map<string, T[]>(); // id -> list (the working copy; mutate in place)
@@ -61,8 +66,9 @@ export function createSessionStore<T>(dirName: string, root: string = MULMOTERMI
     const file = fileFor(sessionId);
     const mtimeMs = await statMtimeMs(file);
     try {
-      const parsed = JSON.parse(await fs.readFile(file, "utf8"));
-      return { list: Array.isArray(parsed) ? parsed : [], mtimeMs };
+      // A bad entry is dropped rather than failing the read: the list is a set, not positional.
+      const parsed: unknown = JSON.parse(await fs.readFile(file, "utf8"));
+      return { list: isUnknownArray(parsed) ? parsed.filter(isEntry) : [], mtimeMs };
     } catch {
       return { list: [], mtimeMs: 0 };
     }
@@ -147,12 +153,25 @@ interface ToolCallEndRecord extends ToolCallStartRecord {
 }
 
 /** The panel's stores, bound to one pub/sub and one directory root. */
+// What each store accepts back off disk. Every REQUIRED field is checked, and the optional ones
+// are checked when present — a guard that waved those through would be asserting a type the value
+// does not have.
+const isToolResult = (value: unknown): value is ToolResult => isRecord(value) && typeof value.uuid === "string";
+
+const isToolCall = (value: unknown): value is ToolCall =>
+  isRecord(value) &&
+  typeof value.status === "string" &&
+  typeof value.at === "number" &&
+  (value.toolUseId === undefined || typeof value.toolUseId === "string") &&
+  (value.toolName === undefined || typeof value.toolName === "string") &&
+  (value.durationMs === undefined || typeof value.durationMs === "number");
+
 export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolStoreDeps) {
   // GUI toolResults per session, persisted under ~/.mulmoterminal/toolresults so
   // the panel replays the rendered views even after a server reboot. (Chat +
   // message history live in the terminal and Claude's .jsonl; this is the GUI-side
   // store.) Each entry is an array of toolResults, capped to the most recent N.
-  const toolResultsStore = createSessionStore<ToolResult>("toolresults", root);
+  const toolResultsStore = createSessionStore("toolresults", isToolResult, root);
   const GUI_HISTORY_LIMIT = 50;
 
   // Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
@@ -195,7 +214,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
   //
   // Persisted under ~/.mulmoterminal/toolcalls via the same disk-backed store as
   // the toolResults, so the history survives a server reboot.
-  const toolCallsStore = createSessionStore<ToolCall>("toolcalls", root);
+  const toolCallsStore = createSessionStore("toolcalls", isToolCall, root);
   const TOOLCALLS_LIMIT = 200;
   // PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
   async function recordToolCallStart(sessionId: string, { toolUseId, toolName, toolInput }: ToolCallStartRecord) {

--- a/server/session/translation-worker.ts
+++ b/server/session/translation-worker.ts
@@ -26,14 +26,18 @@ export interface TranslationWorkerDeps {
 // In-flight worker requests. `resolve` comes from the worker's own submitTranslation call;
 // `reject` from the Stop hook when a worker ends its turn WITHOUT submitting, so a
 // misbehaved turn fails fast instead of waiting out the full timeout.
-const pendingTranslations = new Map<string, { resolve: (translations: string[]) => void; reject: (err: Error) => void }>();
+// `unknown`, not `string[]`: what arrives is whatever the worker passed to submitTranslation, and
+// the ONE place that decides whether it is a translation result is isValidTranslationResult at the
+// await below. Declaring string[] here made the promise assert a shape nothing had checked — the
+// awaiting code already distrusted it and re-declared the value as unknown.
+const pendingTranslations = new Map<string, { resolve: (translations: unknown) => void; reject: (err: Error) => void }>();
 
 /** Hand a worker's answer to the request waiting for it. False when no request is
  *  in flight for that id — already settled, timed out, or not a worker at all. */
 export function submitTranslation(sessionId: string, translations: unknown): boolean {
   const pending = pendingTranslations.get(sessionId);
   if (!pending) return false;
-  pending.resolve(Array.isArray(translations) ? translations : []);
+  pending.resolve(translations);
   return true;
 }
 
@@ -73,7 +77,7 @@ export function createTranslationWorker(deps: TranslationWorkerDeps) {
     translationWorkerIds.add(sessionId);
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const submitted = new Promise<string[]>((resolve, reject) => {
+    const submitted = new Promise<unknown>((resolve, reject) => {
       timeoutId = setTimeout(() => reject(new Error(`[translation] hidden chat timed out after ${TRANSLATION_TIMEOUT_MS}ms`)), TRANSLATION_TIMEOUT_MS);
       pendingTranslations.set(sessionId, { resolve, reject });
     });
@@ -86,7 +90,7 @@ export function createTranslationWorker(deps: TranslationWorkerDeps) {
       // pending entry now so this internal worker never surfaces as a sidebar row (the
       // /api/sessions filter on translationWorkerIds covers its on-disk transcript).
       knownSessions.delete(sessionId);
-      const translations: unknown = await submitted;
+      const translations = await submitted;
       if (!isValidTranslationResult(translations, expected)) {
         const got = Array.isArray(translations) ? `${translations.length} strings` : "a non-array";
         throw new Error(`[translation] submitTranslation returned ${got} for ${expected} inputs`);

--- a/test/server/session/tool-store.spec.ts
+++ b/test/server/session/tool-store.spec.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { capToolOutput, createSessionStore, createToolStores, toolCallsChannel } from "../../../server/session/tool-store.js";
+import { isRecord } from "../../../common/isRecord.js";
 
 const SESSION = "11111111-2222-4333-8444-555555555555";
 const OTHER = "99999999-2222-4333-8444-555555555555";
@@ -40,6 +41,9 @@ describe("toolCallsChannel", () => {
   });
 });
 
+// The store now validates what it reads back, so the spec's element type needs a guard too.
+const isThing = (value: unknown): value is { n: number } => isRecord(value) && typeof value.n === "number";
+
 describe("createSessionStore", () => {
   let root = "";
 
@@ -52,7 +56,7 @@ describe("createSessionStore", () => {
   });
 
   it("starts empty and persists what it is given", async () => {
-    const store = createSessionStore<{ n: number }>("things", root);
+    const store = createSessionStore("things", isThing, root);
     const list = await store.get(SESSION);
     expect(list).toEqual([]);
     list.push({ n: 1 });
@@ -63,24 +67,24 @@ describe("createSessionStore", () => {
   it("reloads a session's list from disk in a fresh store", async () => {
     await fs.mkdir(path.join(root, "things"), { recursive: true });
     await fs.writeFile(path.join(root, "things", `${SESSION}.json`), JSON.stringify([{ n: 7 }]));
-    expect(await createSessionStore<{ n: number }>("things", root).get(SESSION)).toEqual([{ n: 7 }]);
+    expect(await createSessionStore("things", isThing, root).get(SESSION)).toEqual([{ n: 7 }]);
   });
 
   it("hands back the SAME array each time, since callers mutate in place", async () => {
-    const store = createSessionStore<{ n: number }>("things", root);
+    const store = createSessionStore("things", isThing, root);
     const first = await store.get(SESSION);
     first.push({ n: 1 });
     expect(await store.get(SESSION)).toBe(first);
   });
 
   it("dedupes concurrent first loads into one list", async () => {
-    const store = createSessionStore<{ n: number }>("things", root);
+    const store = createSessionStore("things", isThing, root);
     const [a, b] = await Promise.all([store.get(SESSION), store.get(SESSION)]);
     expect(a).toBe(b);
   });
 
   it("keeps sessions apart", async () => {
-    const store = createSessionStore<{ n: number }>("things", root);
+    const store = createSessionStore("things", isThing, root);
     (await store.get(SESSION)).push({ n: 1 });
     expect(await store.get(OTHER)).toEqual([]);
   });
@@ -88,14 +92,14 @@ describe("createSessionStore", () => {
   it("starts empty when the file is corrupt or not an array", async () => {
     await fs.mkdir(path.join(root, "things"), { recursive: true });
     await fs.writeFile(path.join(root, "things", `${SESSION}.json`), "{not json");
-    expect(await createSessionStore("things", root).get(SESSION)).toEqual([]);
+    expect(await createSessionStore("things", isThing, root).get(SESSION)).toEqual([]);
     await fs.writeFile(path.join(root, "things", `${OTHER}.json`), '{"a":1}');
-    expect(await createSessionStore("things", root).get(OTHER)).toEqual([]);
+    expect(await createSessionStore("things", isThing, root).get(OTHER)).toEqual([]);
   });
 
   // The id becomes a filename, so a bad one must never reach the disk.
   it("refuses to read or write an id that is not a session uuid", async () => {
-    const store = createSessionStore<{ n: number }>("things", root);
+    const store = createSessionStore("things", isThing, root);
     const list = await store.get("../escape");
     expect(list).toEqual([]);
     list.push({ n: 1 });
@@ -112,7 +116,7 @@ describe("createSessionStore", () => {
     const file = path.join(root, "things", `${SESSION}.json`);
     await fs.writeFile(file, JSON.stringify([{ n: 1 }]));
     let mtime = 100;
-    const store = createSessionStore<{ n: number }>("things", root, async () => mtime);
+    const store = createSessionStore("things", isThing, root, async () => mtime);
     expect(await store.get(SESSION)).toEqual([{ n: 1 }]); // cached at mtime 100
 
     await fs.writeFile(file, JSON.stringify([{ n: 1 }, { n: 2 }])); // the owning instance appended
@@ -126,7 +130,7 @@ describe("createSessionStore", () => {
   // returns the same working array it mutates in place, never re-reading its own write.
   it("does not re-read the store's own write (keeps the working array)", async () => {
     let mtime = 0;
-    const store = createSessionStore<{ n: number }>("things", root, async () => mtime);
+    const store = createSessionStore("things", isThing, root, async () => mtime);
     const list = await store.get(SESSION);
     list.push({ n: 1 });
     mtime = 500; // the write below lands at this mtime

--- a/test/server/session/translation-worker.spec.ts
+++ b/test/server/session/translation-worker.spec.ts
@@ -80,11 +80,12 @@ describe("translateViaHiddenChat", () => {
     await expect(h.translateViaHiddenChat("ja", ["a", "b"])).rejects.toThrow(/2 inputs/);
   });
 
-  it("rejects a non-array answer, which arrives normalized to an empty list", async () => {
-    // submitTranslation substitutes [] for anything that isn't an array, so a junk
-    // payload reaches validation as a count mismatch rather than as a bad type.
+  it("rejects a non-array answer, and says it was a non-array", async () => {
+    // submitTranslation passes the worker's answer through untouched, so validation sees what
+    // actually arrived. It used to substitute [], which made a junk payload report itself as
+    // "0 strings" — a count mismatch, and the wrong thing to go looking for.
     const h = harness((id) => submitTranslation(id, "not an array"));
-    await expect(h.translateViaHiddenChat("ja", ["a"])).rejects.toThrow(/0 strings for 1 inputs/);
+    await expect(h.translateViaHiddenChat("ja", ["a"])).rejects.toThrow(/a non-array for 1 inputs/);
   });
 
   it("retries a fresh worker and succeeds on a later attempt", async () => {


### PR DESCRIPTION
## Summary

#1300 に残っていた `no-unsafe-*` **407 件のうち、server/ の 145 件を全部消しました**。
`src/` の 262 件はこの PR では触っていません（入口は同じなので続きは別 PR）。

| | before | after |
|---|---|---|
| **server/** | **145** | **0** |
| 全体 | 407 | 262 |

lint 0 errors（warning 23 は main と同数）/ typecheck 0 / build / test 7585 passed。

## Items to Confirm / Review

1. **`tool-store.ts` の `createSessionStore` に必須引数が増えました。** `isEntry` を optional に
   すると既定が「全部通す」になって元の不健全さに戻るので必須にしています。呼び出しは本体 2 箇所
   + spec 10 箇所。**読み戻した壊れた要素は落とす**挙動になります（この配列は位置対応でないため）。
2. **`translation-worker` のエラー文言が変わります。** 非配列が来たとき
   `0 strings for 1 inputs` → `a non-array for 1 inputs`。後者が事実です（詳細は下）。
3. **`isToolDefinition` が実プラグインを弾かないこと**は、8 パッケージ全部を実際に import して
   `type`/`name`/`description` を確認したうえで書いています。さらにレジストリを**実ロードして
   main と突き合わせ**ました（下記）。

## User Prompt

> 1300でできるものはやろう。1301はやらない、という判断ならそうかいてissueは閉じよう。

（#1301 は「残り2フラグは入れない」と明記して close 済み。この PR は #1300 側です。）

## `any` の入口は 3 つしか無かった

145 件は散らばって見えますが、出どころは 3 種類だけでした。

### 1. `await import(name)` — `server/infra/plugins-registry.ts`（64 件、単一ファイル最大）

動的 import は `any` を返すので、そこから辿る `mod.default` / `mod.TOOL_DEFINITION` /
`mod.pluginCore?.execute` は**プラグインの定義も実行関数も型検査の外**でした。
`isRecord` → `isToolDefinition` / `isExecutor` で確認する形に。

`isExecutor` は `server-tool-load.ts` にあったものを export して再利用しています。
**`typeof x === "function"` は `Function` にしか絞れず、`Function` の呼び出しは `any` を返す**
ので、これが無いと結果がまた型検査の外に出ます。

### 2. `JSON.parse(...)` — 7 ファイル

全部 `: unknown` で受けてからガード。PTY のクライアントフレームは 2 箇所で同じことをしていた
ので `parseClientFrame` に集約しました（**PTY に書き込む値なので境界を 1 つにする価値が高い**）。

### 3. `req.body` — 8 ファイル

`server/routes/requestBody.ts` を新設して全箇所を通しました。

```ts
export const requestBody = (body: unknown): Record<string, unknown> => (isRecord(body) ? body : {});
```

ハンドラ側のガードは**元のまま**です。違うのは、そのガードが型検査の対象になったこと。

## 型が通って初めて消せた回避策

`server/git/worktree-routes.ts` に、この `any` のための再チェックとコメントがありました。

```ts
// Re-checked rather than reusing the guard above: `req.body` is `any`, and narrowing it there
// does not survive to here — the call would take `any` and typecheck would not notice.
const wt = await createWorktree(repoDir, task, isIssueNumber(issue) ? issue : undefined);
```

いまは上のガードが効くので、**再チェックごと削除**しました。

## 型が嘘をついていた 2 箇所（実際の穴）

### `translation-worker.ts`

`resolve` が `(translations: string[]) => void` と宣言されていましたが、中身は**ワーカーが
`submitTranslation` に渡した何か**で誰も検証していません。`Array.isArray(x) ? x : []` の `x` が
`any` なので、`any[]` → `string[]` に黙って化けていました。

待つ側は**既に信用しておらず** `const translations: unknown = await submitted;` と受け直して
`isValidTranslationResult` で検証しています。なので `resolve` を `unknown` にしました。
検証は 1 箇所のままです。

**副作用としてエラーメッセージが正確になりました。** 以前は非配列を `[]` に潰してから検証して
いたので「`0 strings`」= 件数不一致として報告され、**実際の原因（型が違う）を隠していました**。
この古い挙動を固定していたテストがあったので、正しい方に更新しています。

`filter` で string だけ残す案は取っていません。**この配列は位置対応**で、長さが `expected` と
一致することが検証条件だからです。

### `tool-store.ts`

`createSessionStore<T>` が `Array.isArray(parsed) ? parsed : []` で `any[]` を `T[]` にしていま
した。手で編集されても、クラッシュで切れても、**型引数だけを根拠に T[] になります**。
`isEntry` を必須引数にし、`isToolResult` / `isToolCall` を書きました。

## `Array.isArray` の罠

`Array.isArray(value)` は `unknown` を **`any[]`**（`unknown[]` ではない）に絞ります。
`common/isUnknownArray.ts` を置きました。

## 検証 — 「lint が 0」は「壊していない」の証拠ではない

プラグインレジストリを **main と本ブランチの両方で実際にロード**して突き合わせました。

```
TOOLS: generateImage,google,manageAccounting,manageCollection,presentChart,presentCollection,
       presentDocument,presentForm,presentHtml,presentMulmoScript,readXPost,searchX,spawnBackgroundChat
SUMMARIES: 13 / PARAMS: 13 of 13
```

**完全一致**。factory 形式（google）と server-tool 形式（readXPost / searchX、env を与えた場合）の
両経路を含みます。

## 別件（この PR では直しません）

`test/src/components/GridView.spec.ts` の 1 件がローカルで決定的に 15 秒タイムアウトします。
**main 単体でも再現**し、CI では green なので無関係です → **#1320** に切りました。

refs #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3