### PR TITLE
fix(src): cut no-unsafe-* in the UI from 262 to 108 (#1300)

### DIFF
--- a/plans/fix-1300-no-unsafe-src.md
+++ b/plans/fix-1300-no-unsafe-src.md
@@ -1,0 +1,84 @@
+# fix(src): `no-unsafe-*` を UI 側でも減らす (#1300 の続き)
+
+server を 0 にした #1321 の続き。`src/` の 262 件を **108 件**まで減らした。
+
+| | before | after |
+|---|---|---|
+| 本物の `any` | 262 | **53** |
+| SFC 型が解決できない偽陽性 | 0（未分離） | 55 |
+| 合計 | 262 | 108 |
+
+## 先に分かったこと: **55 件はコードでは直せない**
+
+`TerminalGrid.vue` などの指摘の多くは `any` ではなく **「型が解決できない」** だった。
+
+```ts
+const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
+filesPane.value?.flush();   // ← Unsafe call of a type that could not be resolved
+```
+
+eslint の型プログラムは **`.vue` の component 型を生成できない**ので `InstanceType<typeof
+FilesPane>` が error 型になる。`vue-tsc` は解決できるため `yarn typecheck` は 0 のまま。
+
+### 推測ではなく実証した
+
+存在しないメソッドを呼んでみて、vue-tsc が**型付きで拒否する**ことを確認した。
+
+```
+error TS2339: Property 'thisMethodDoesNotExist' does not exist on type
+  '{ $: ComponentInternalInstance; $data: {}; $props: { readonly cwd: string | null; ... }'
+```
+
+つまりこのコードは完全に型検査されている。**この 55 件は lint 側の限界**で、ルールを error に
+上げるなら `.vue` をこの 5 ルールから除外する必要がある。#1300 に記録した。
+
+## 入口は server と同じだった
+
+| 入口 | 対応 |
+|---|---|
+| `Response.json()` → `any` | **`src/jsonBody.ts`** を新設（server の `requestBody` と対） |
+| `JSON.parse` | `: unknown` + ガード |
+| socket の `event.data` | `parseServerFrame` を `serverMessage.ts` に新設（server の `parseClientFrame` と対） |
+
+## 見つかった実際の穴
+
+### `useAppConfig.loadConfig` が保存パスより甘かった
+
+`isLauncher` / `isQuickCommand` / `isUserMcpServer` は既にあり、**保存パス（297/322/328 行）は
+通していた**が、**毎回のページ表示で走る `loadConfig` は素通し**だった。手で編集された、あるいは
+古いバージョンが書いた config が、そのまま `launchers.value` に載る状態。
+
+`listOf(value, guard)` を足して全リストを保存パスと同じ厳しさに揃えた。`cwdPresets` には guard が
+無かったので `isCwdPreset` を追加。**この挙動変更にテストを 2 件足した**。
+
+### `useSessions` の型注釈が嘘だった
+
+```ts
+(data.sessions ?? []).map((s: { id: string; title: string; mtime: number }): Session => ...)
+```
+
+`s` は `any` で、注釈はコンパイルを通すためだけのもの。`isSessionRow` / `isSession` を足した。
+`id` はルーティング、`mtime` はソートに使うので、欠けた行は落とす。
+
+### `TerminalCell` の `SessionDetail` が実在しない形だった
+
+`type SessionDetail = ActivityMsg & { usage?; context? }` は `id: string` を要求するが、
+**`/api/session/:id` は `id` を返さない**（ガードを足したらテストが 4 件落ちて分かった）。
+`applyActivityPush` も `id` を読んでいない。型を消して record として読むようにし、
+`activityPushOf` で **absent と null の区別**（`cellActivity.ts` 冒頭が説明している、
+「no news」対「there is none now」）を保ったまま読む。
+
+## ついでに動かしたもの
+
+- **`guardMouseTracking`** を `useTerminalConnections.ts` → `terminalMouseInput.ts` へ。
+  `guardMouseWheel` / `guardMouseClicks` と同じモジュールに属する関数で、`max-lines`（600）を
+  超えたぶんの置き場所としても正しい。
+- **`parseServerFrame`** は `serverMessage.ts` へ（「サーバのメッセージが何を意味するか」を
+  既に持っているモジュール）。
+
+## この PR で直していないもの
+
+本物の 53 件（`useHeaderButtons` 7 / `GuiPanel` 7 ほか、19 ファイルに小さく分散）と、
+`src/utils/fetchJson.ts` の `fetchJson<T>` —— **呼び出し側が名乗った T を検証せずに返す**
+不健全な generic で、`gui-chat-protocol` が `parse` 必須にして解決したのと同じ形。呼び出しは
+6 箇所なので直せるが、この PR とは別の判断として #1300 に残す。

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -18,6 +18,8 @@ import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import LaunchChipList from "./LaunchChipList.vue";
 import ModelPicker from "./ModelPicker.vue";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // What an EMPTY grid cell shows: pick a directory, pick what to run in it, and start — or resume
 // a session that already exists there, run one of its scripts, or isolate the work in a worktree.
@@ -191,8 +193,8 @@ async function pickDir(): Promise<void> {
   try {
     const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ directory: true }) });
     if (!res.ok) return;
-    const data = await res.json();
-    const dir = Array.isArray(data?.paths) ? data.paths.find((p: unknown): p is string => typeof p === "string") : undefined;
+    const data = await jsonBody(res);
+    const dir = isUnknownArray(data.paths) ? data.paths.find((p): p is string => typeof p === "string") : undefined;
     if (dir) fillDir(dir);
   } catch {
     // best-effort — the native dialog is unavailable or the user canceled
@@ -279,7 +281,7 @@ async function createWorktreeAndLaunch(): Promise<void> {
       body: JSON.stringify({ repoDir, task }),
     });
     if (!res.ok) return;
-    const wt = await res.json();
+    const wt = await jsonBody(res);
     if (typeof wt.path === "string") {
       worktreeTask.value = "";
       await syncMcpGroupsInto(wt.path);

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -13,6 +13,9 @@ import { expandedPaths, restoreOrder } from "./filesTreeState";
 import { isWriteToOpenFile } from "../composables/fileWriteMatch";
 import { usePubSub } from "../composables/usePubSub";
 import { FILE_WRITE_CHANNEL, isFileWriteEvent } from "../../common/fileWriteChannel";
+import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 interface Node {
   name: string;
@@ -28,6 +31,12 @@ interface Entry {
   dir: boolean;
   size: number;
 }
+
+// The listing arrives off the wire, so an entry is checked before it becomes one — the tree
+// renders `name` and branches on `dir`, and a malformed entry would render as blank rather than
+// as absent.
+const isEntry = (value: unknown): value is Entry =>
+  isRecord(value) && typeof value.name === "string" && typeof value.dir === "boolean" && typeof value.size === "number";
 
 /** What a host hands back so a revisited directory looks the way it was left. */
 export interface FilesPaneState {
@@ -82,8 +91,8 @@ function makeNode(e: Entry, parentPath: string): Node {
 async function fetchEntries(pathRel: string): Promise<Entry[]> {
   const res = await fetch(`/api/files/browse/list?${qs(pathRel)}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = await res.json();
-  return Array.isArray(data.entries) ? data.entries : [];
+  const data = await jsonBody(res);
+  return isUnknownArray(data.entries) ? data.entries.filter(isEntry) : [];
 }
 
 async function loadRoot(): Promise<void> {
@@ -136,10 +145,10 @@ async function writeBuffer(pathRel: string, text: string, base: string | null, k
       body: JSON.stringify({ text, baseVersion: base }),
       keepalive,
     });
-    const data = await res.json().catch(() => ({}));
+    const data = await jsonBody(res);
     const version = typeof data.version === "string" ? data.version : null;
     if (res.status === 409) return { status: "conflict", version };
-    if (!res.ok) return { status: "error", message: data.error || `HTTP ${res.status}` };
+    if (!res.ok) return { status: "error", message: typeof data.error === "string" ? data.error : `HTTP ${res.status}` };
     return { status: "saved", version };
   } catch (e) {
     return { status: "error", message: e instanceof Error ? e.message : String(e) };
@@ -193,6 +202,11 @@ async function openFile(node: Node): Promise<void> {
 
 // Open a project-relative path in the editor. Split out from openFile because the other way
 // in has no tree node to hand over: a clicked source path in terminal output arrives as
+// Every /api route answers a failure as `res.status(4xx).json({ error })`, so the reason a read
+// was refused is in the body — reporting only the status turns a fixable problem into a mystery.
+const failureReason = (body: Record<string, unknown>, status: number): string =>
+  typeof body.error === "string" && body.error !== "" ? body.error : `HTTP ${status}`;
+
 // ?path= and opens the same file (#808).
 // `force` re-reads the file already open and skips the unsaved-edits prompt — the
 // conflict banner's "Reload", where discarding is the button the user just pressed.
@@ -209,8 +223,8 @@ async function loadFile(pathRel: string, force = false): Promise<void> {
   showPreview.value = false;
   try {
     const res = await fetch(`/api/files/browse/text?${qs(pathRel)}`);
-    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await jsonBody(res);
+    if (!res.ok) throw new Error(failureReason(data, res.status));
     if (id !== fileReqId) return;
     openPath.value = pathRel;
     baseVersion.value = typeof data.version === "string" ? data.version : null;
@@ -294,7 +308,7 @@ async function checkForExternalChange(): Promise<void> {
   try {
     const res = await fetch(`/api/files/browse/version?${qs(pathRel)}`);
     if (!res.ok) return;
-    const data = await res.json();
+    const data = await jsonBody(res);
     const onDisk = typeof data.version === "string" ? data.version : null;
     // Still the version we loaded, or the answer arrived after the user moved on.
     if (onDisk === baseVersion.value || pathRel !== openPath.value) return;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -13,7 +13,7 @@ import type { LaunchAgent } from "../../common/launchAgent";
 import { unsavedWork } from "./unsavedWork";
 import { shouldPromptTidy } from "./mergedTidy";
 import { usageBadge } from "./cellDisplay";
-import { applyActivityPush, cellHeaderText } from "./cellActivity";
+import { applyActivityPush, cellHeaderText, type ActivityPush } from "./cellActivity";
 import { MEMO_MAX_LENGTH, normalizeMemo } from "../../common/sessionMemo";
 import { preferredLaunchDir, shouldSyncLaunchDir } from "./launchDir";
 import CellLaunchForm from "./CellLaunchForm.vue";
@@ -54,6 +54,8 @@ import { runOneExchange, liveCrossTalkDeps } from "../composables/useCrossTalk";
 import { outcomeMessage } from "../composables/exchangeRules";
 import { worktreeFailureMessage } from "./cellChromeRules";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // How long a handoff failure stays on the cell before it clears itself.
 const ASK_MSG_MS = 4000;
@@ -248,7 +250,7 @@ let latestSeed = 0;
 // flight at once. Neither path bumps latestSeed for badges, so a stale read resolving last
 // would clobber the newer numbers. This token makes the newest badge fetch win. (#620.)
 let latestBadgeReq = 0;
-function applyActivity(d: ActivityMsg) {
+function applyActivity(d: ActivityPush) {
   activityGen++;
   const next = applyActivityPush(
     {
@@ -277,15 +279,29 @@ function applyActivity(d: ActivityMsg) {
 // the answer would leak the old session's state into the new one.
 //
 // The cell's dir goes along so the server can read the transcript and report the session's
-// most recent prompt rather than the bare id after a resume.
-type SessionDetail = ActivityMsg & { usage?: unknown; context?: unknown };
+// most recent prompt rather than the bare id after a resume. It is read as a plain record: the
+// endpoint answers the session's own fields and sends no `id`, so it is not an ActivityMsg.
 
-async function fetchSessionDetail(id: string): Promise<SessionDetail | null> {
+// Reads the activity fields off an untrusted body while KEEPING the absent/null distinction
+// applyActivityPush is built on: a key the server did not send must stay absent ("keep what is
+// shown"), which is a different instruction from an explicit null ("there is none now").
+function activityPushOf(d: Record<string, unknown>): ActivityPush {
+  const push: ActivityPush = {};
+  if (typeof d.working === "boolean") push.working = d.working;
+  if (typeof d.waiting === "boolean") push.waiting = d.waiting;
+  for (const key of ["event", "lastPrompt", "aiTitle", "memo"] as const) {
+    const value = d[key];
+    if (value === null || typeof value === "string") push[key] = value;
+  }
+  return push;
+}
+
+async function fetchSessionDetail(id: string): Promise<Record<string, unknown> | null> {
   try {
     const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
     const res = await fetch(`/api/session/${id}${q}`);
     if (!res.ok) return null;
-    const data = await res.json();
+    const data = await jsonBody(res);
     return id === sessionId.value ? data : null;
   } catch {
     return null;
@@ -296,7 +312,7 @@ async function fetchSessionDetail(id: string): Promise<SessionDetail | null> {
 // (EMPTY_USAGE / EMPTY_CONTEXT when it has nothing to report), so an unrenderable one means
 // something is actually broken — and a badge showing the previous turn's numbers as if they
 // were current is the failure the guards exist to stop.
-function applyBadges(data: SessionDetail) {
+function applyBadges(data: Record<string, unknown>) {
   usage.value = isCellUsage(data.usage) ? data.usage : null;
   context.value = isCellContext(data.context) ? data.context : null;
 }
@@ -312,7 +328,7 @@ async function loadInitial(id: string) {
   // A live push landed while we were fetching: it is newer than this snapshot, so keep it
   // and don't let a stale seed put the cell back to idle. Badges have no such push, so they
   // always refresh — unless a newer badge fetch has since superseded this one.
-  if (activityGen === genBeforeFetch) applyActivity(data);
+  if (activityGen === genBeforeFetch) applyActivity(activityPushOf(data));
   if (badgeReq === latestBadgeReq) applyBadges(data);
 }
 
@@ -483,9 +499,9 @@ async function refreshGithubUrl() {
       body: JSON.stringify({ path: cwd.value }),
     });
     if (reqId !== githubReq) return; // a newer cwd superseded this lookup
-    const data = res.ok ? await res.json() : null;
+    const data = res.ok ? await jsonBody(res) : {};
     if (reqId !== githubReq) return; // re-check after awaiting the body
-    githubUrl.value = data && typeof data.githubUrl === "string" ? data.githubUrl : null;
+    githubUrl.value = typeof data.githubUrl === "string" ? data.githubUrl : null;
   } catch {
     if (reqId === githubReq) githubUrl.value = null; // best-effort — the link just won't appear
   }
@@ -827,6 +843,18 @@ interface WorktreeDiffData {
   patch: string;
   truncated: boolean;
 }
+// The diff arrives off /api/worktrees/diff; the badge and the overlay read every field, so a
+// response that is missing one is treated as "no diff" rather than rendered with holes.
+const isWorktreeDiffData = (value: unknown): value is WorktreeDiffData =>
+  isRecord(value) &&
+  typeof value.isWorktree === "boolean" &&
+  (value.base === null || typeof value.base === "string") &&
+  typeof value.ahead === "number" &&
+  typeof value.dirty === "number" &&
+  isUnknownArray(value.files) &&
+  typeof value.patch === "string" &&
+  typeof value.truncated === "boolean";
+
 const diff = ref<WorktreeDiffData | null>(null);
 const diffOpen = ref(false);
 const isWorktreeCell = computed(() => worktreeLabel(cwd.value) !== null);
@@ -844,9 +872,9 @@ async function loadDiff() {
   try {
     const res = await fetch(`/api/worktrees/diff?cwd=${encodeURIComponent(cwd.value)}`);
     if (reqId !== diffReq) return;
-    const data = res.ok ? await res.json() : null;
+    const data = res.ok ? await jsonBody(res) : {};
     if (reqId !== diffReq) return;
-    diff.value = data && data.isWorktree ? data : null;
+    diff.value = isWorktreeDiffData(data) && data.isWorktree ? data : null;
   } catch {
     if (reqId === diffReq) diff.value = null;
   }
@@ -886,11 +914,12 @@ async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, u
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ cwd: cwd.value }),
     });
-    const data = await res.json().catch(() => null);
-    // A non-JSON / empty-body response (e.g. a 403 from the origin guard) must not
-    // leave the UI stuck on the optimistic "Pushing…" text.
-    if (!data) prMsg.value = res.status === 403 ? "Not allowed (origin)" : "Request failed";
-    return data;
+    // jsonBody answers {} for a non-JSON / empty body (e.g. a 403 from the origin guard); an
+    // empty answer must not leave the UI stuck on the optimistic "Pushing…" text.
+    const data = await jsonBody(res);
+    const empty = Object.keys(data).length === 0;
+    if (empty) prMsg.value = res.status === 403 ? "Not allowed (origin)" : "Request failed";
+    return empty ? null : data;
   } catch {
     prMsg.value = endpoint === "push" ? "Push failed" : "PR failed";
     return null;

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -2,6 +2,7 @@ import type { RunCommand } from "./runCommand";
 import { dirPriority } from "../../common/dirPriorityOrder";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
 import type { AttentionStatus } from "./attentionStatus";
 
 // The grid is ONE flat, ordered list of terminal cells, split into pages of 9
@@ -478,8 +479,9 @@ const isCell = (c: unknown): c is Cell => {
 
 export function parseGridState(raw: string | null): GridState | null {
   try {
-    const parsed = JSON.parse(raw ?? "");
-    if (!Array.isArray(parsed?.cells)) return null;
+    const parsed: unknown = JSON.parse(raw ?? "");
+    if (!isRecord(parsed) || !isUnknownArray(parsed.cells)) return null;
+    const { expanded: storedExpanded, page: storedPage } = parsed;
     // Keep only running cells (the trailing launch cell is ephemeral) and renumber
     // uids from position. Persisted uids are untrusted: duplicates would collide
     // v-for keys, and a near-MAX_SAFE_INTEGER value would overflow the nextUid
@@ -487,21 +489,26 @@ export function parseGridState(raw: string | null): GridState | null {
     // count) is always safe and in range.
     const running = parsed.cells
       .filter(isCell)
-      .filter((c: Cell) => c.session !== null)
+      .filter((c) => c.session !== null)
       .slice(0, MAX_TERMINALS);
     // Every field a cell keeps across a reload is named HERE — a persisted key this literal does
     // not rebuild is dropped silently, with nothing to typecheck against.
-    const cells: Cell[] = running.map((c: Cell, i: number) => ({
-      uid: i,
-      session: c.session,
-      cwd: c.cwd,
-      launcher: asLauncher(c.launcher),
-      agent: storedCellAgent(asTerminalAgent(c.agent)),
-      ...(c.parked === true ? { parked: true as const } : {}),
-    }));
-    const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
-    const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
-    const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;
+    const cells: Cell[] = running.map((c, i) => {
+      // Spread, not assigned: `agent` is absent for a Claude cell, and under
+      // exactOptionalPropertyTypes a key holding undefined is not the same as no key.
+      const agent = storedCellAgent(asTerminalAgent(c.agent));
+      return {
+        uid: i,
+        session: c.session,
+        cwd: c.cwd,
+        launcher: asLauncher(c.launcher),
+        ...(agent === undefined ? {} : { agent }),
+        ...(c.parked === true ? { parked: true as const } : {}),
+      };
+    });
+    const expandedIdx = running.findIndex((c) => c.uid === storedExpanded);
+    const expanded = typeof storedExpanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
+    const page = typeof storedPage === "number" && Number.isSafeInteger(storedPage) && storedPage >= 0 ? storedPage : 0;
     return clampPage(ensureEntry({ cells, expanded, page, nextUid: cells.length, sortMode: asSortMode(parsed.sortMode) }));
   } catch {
     return null;
@@ -511,14 +518,15 @@ export function parseGridState(raw: string | null): GridState | null {
 // Migrate the legacy single-grid shape ({ sessions, cwds, expanded:position }).
 export function migrateLegacy(raw: string | null): GridState | null {
   try {
-    const parsed = JSON.parse(raw ?? "");
-    if (!Array.isArray(parsed?.sessions)) return null;
+    const parsed: unknown = JSON.parse(raw ?? "");
+    if (!isRecord(parsed) || !isUnknownArray(parsed.sessions)) return null;
+    const cwds = isUnknownArray(parsed.cwds) ? parsed.cwds : [];
     const cells: Cell[] = [];
-    parsed.sessions.forEach((s: unknown, i: number) => {
-      if (isUuid(s)) cells.push({ uid: cells.length, session: s, cwd: typeof parsed.cwds?.[i] === "string" ? parsed.cwds[i] : null });
+    parsed.sessions.forEach((s, i) => {
+      if (isUuid(s)) cells.push({ uid: cells.length, session: s, cwd: typeof cwds[i] === "string" ? cwds[i] : null });
     });
-    const expanded =
-      typeof parsed.expanded === "number" && parsed.expanded >= 0 && parsed.expanded < cells.length ? (cells[parsed.expanded]?.uid ?? null) : null;
+    const { expanded: storedExpanded } = parsed;
+    const expanded = typeof storedExpanded === "number" && storedExpanded >= 0 && storedExpanded < cells.length ? (cells[storedExpanded]?.uid ?? null) : null;
     return clampPage(ensureEntry({ cells, expanded, page: 0, nextUid: cells.length, sortMode: "manual" }));
   } catch {
     return null;

--- a/src/composables/serverMessage.ts
+++ b/src/composables/serverMessage.ts
@@ -7,6 +7,22 @@
 // cell offers to re-run a session that is alive in another tab — and if it were treated as
 // retryable, the two tabs would evict each other forever. This is exactly why it wants a test.
 
+import { isRecord } from "../../common/isRecord";
+
+// The one place a server frame becomes data — the mirror of the server's own parseClientFrame.
+// `JSON.parse` answers `any`, which would put everything read off the frame outside the type
+// checker, including the bytes written into the terminal. A frame that is not a JSON object is
+// dropped rather than thrown: the caller runs inside `sock.onmessage`, where nothing catches it.
+export function parseServerFrame(data: unknown): Record<string, unknown> | null {
+  if (typeof data !== "string") return null;
+  try {
+    const msg: unknown = JSON.parse(data);
+    return isRecord(msg) ? msg : null;
+  } catch {
+    return null;
+  }
+}
+
 // The non-output effects of a message. `output` is handled directly (a hot path, just a
 // write) and is not modelled here.
 export interface MessageEffect {

--- a/src/composables/terminalMouseInput.ts
+++ b/src/composables/terminalMouseInput.ts
@@ -3,7 +3,19 @@
 // (what the app wants, where the pointer is, click vs drag, the byte sequences) are pure and
 // live in ./mouseReports; what is here is the wiring onto a live Terminal.
 import type { Terminal } from "@xterm/xterm";
-import { cellFromPoint, clickReportSequences, createWheelTicker, isClickGesture, wantsMouseReports, wheelNotches, wheelReportSequence } from "./mouseReports";
+import {
+  cellFromPoint,
+  clearResetModes,
+  clickReportSequences,
+  createWheelTicker,
+  isClickGesture,
+  recordSwallowedModes,
+  wantsMouseReports,
+  wheelNotches,
+  wheelReportSequence,
+} from "./mouseReports";
+import { swallowsMouseTracking } from "./mouseTrackingModes";
+import { getTerminalScrollSpeed } from "./useTerminalScrollSpeed";
 import type { GridCell, PointerPosition } from "./mouseReports";
 
 // xterm's Linkifier marks the screen element while a link is under the pointer. That click
@@ -105,4 +117,17 @@ export function guardMouseClicks(term: Terminal, swallowedMouseModes: ReadonlySe
     const cell = cellUnderPointer(term, ev);
     clickReportSequences(cell.col, cell.row).forEach((seq) => term.input(seq, false));
   });
+}
+
+export function guardMouseTracking(term: Terminal, swallowedMouseModes: Set<number>): void {
+  term.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    const swallowed = swallowsMouseTracking(params);
+    if (swallowed) recordSwallowedModes(swallowedMouseModes, params);
+    return swallowed;
+  });
+  term.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    clearResetModes(swallowedMouseModes, params);
+    return false;
+  });
+  guardMouseWheel(term, swallowedMouseModes, getTerminalScrollSpeed);
 }

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -6,6 +6,7 @@ import type { QuickCommand } from "../../common/quickCommands";
 import { isPushKind, type PushKind } from "../../common/pushKinds";
 import { DEFAULT_SOUND_KINDS, isNotifyKind, type NotifyKind } from "../../common/notifyKinds";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
 import { readSoundMap, type SoundMap } from "./soundSettings";
 import type { SoundConfig } from "./useAttentionSound";
 import { DEFAULT_TERMINAL_SUBMIT_MODE, isTerminalSubmitMode } from "../../common/terminalSubmit";
@@ -112,7 +113,12 @@ async function postConfigField(field: string, value: unknown): Promise<{ ok: tru
   }
 }
 
+// The elements of a config list that pass their own guard. Anything else is dropped rather than
+// loaded: the list is a set of independent entries, so one bad entry costs only itself.
+const listOf = <T>(value: unknown, isEntry: (entry: unknown) => entry is T): T[] => (isUnknownArray(value) ? value.filter(isEntry) : []);
+
 const stringsOf = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
+const isCwdPreset = (value: unknown): value is CwdPreset => isRecord(value) && typeof value.label === "string" && typeof value.path === "string";
 const isQuickCommand = (value: unknown): value is QuickCommand => isRecord(value) && typeof value.label === "string" && typeof value.text === "string";
 const isUserMcpServer = (value: unknown): value is UserMcpServer => isRecord(value) && typeof value.id === "string" && typeof value.url === "string";
 const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typeof value.label === "string" && typeof value.command === "string";
@@ -200,7 +206,8 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
     try {
       const res = await fetch("/api/config", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwdPresets: next }) });
       if (!res.ok) throw new Error(`save failed (${res.status})`);
-      presets.value = (await res.json()).cwdPresets ?? [];
+      const saved: unknown = await res.json();
+      presets.value = isRecord(saved) && isUnknownArray(saved.cwdPresets) ? saved.cwdPresets.filter(isCwdPreset) : [];
       version++;
       return true;
     } catch {
@@ -213,7 +220,7 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
 
   const snapshotVersion = (): number => version;
   const adoptServerPresets = (list: unknown, capturedVersion: number): void => {
-    if (version === capturedVersion) presets.value = Array.isArray(list) ? list : [];
+    if (version === capturedVersion) presets.value = isUnknownArray(list) ? list.filter(isCwdPreset) : [];
   };
 
   return { savePresets, ...createPresetMutations(presets, savePresets), snapshotVersion, adoptServerPresets };
@@ -270,7 +277,7 @@ function applyGlobalSettings(c: Record<string, unknown>): void {
 // The two GitHub-repo fields, adopted together — like adoptSoundConfig, so loadConfig keeps
 // reading as a list of facts rather than growing a ternary per field.
 function adoptRepoConfig(c: Record<string, unknown>): void {
-  prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
+  prRepos.value = stringsOf(c.prRepos);
   repoDirs.value = isRecord(c.repoDirs) ? readRepoDirs(c.repoDirs) : {};
 }
 
@@ -357,17 +364,21 @@ export function useAppConfig() {
     try {
       const res = await fetch("/api/config");
       if (!res.ok) return;
-      const c = await res.json();
-      defaultCwd.value = c.cwd ?? null;
-      home.value = c.home ?? null;
+      const body: unknown = await res.json();
+      if (!isRecord(body)) return;
+      const c = body;
+      defaultCwd.value = typeof c.cwd === "string" ? c.cwd : null;
+      home.value = typeof c.home === "string" ? c.home : null;
       adoptServerPresets(c.cwdPresets, version);
       adoptSoundConfig(c);
       pushEnabled.value = c.pushEnabled === true;
-      pushKinds.value = Array.isArray(c.pushKinds) ? c.pushKinds : [];
+      // Each list is filtered by the SAME guard its own save path uses (postConfigField below).
+      // They used to differ: a save validated, the load on every page open did not.
+      pushKinds.value = listOf(c.pushKinds, isPushKind);
       adoptRepoConfig(c);
-      launchers.value = Array.isArray(c.launchers) ? c.launchers : [];
-      quickCommands.value = Array.isArray(c.quickCommands) ? c.quickCommands : [];
-      userMcpServers.value = Array.isArray(c.userMcpServers) ? c.userMcpServers : [];
+      launchers.value = listOf(c.launchers, isLauncher);
+      quickCommands.value = listOf(c.quickCommands, isQuickCommand);
+      userMcpServers.value = listOf(c.userMcpServers, isUserMcpServer);
       applyGlobalSettings(c);
       await migrateLegacyRecents();
     } catch {

--- a/src/composables/useMcpToolGroups.ts
+++ b/src/composables/useMcpToolGroups.ts
@@ -1,6 +1,8 @@
 import { ref, type Ref } from "vue";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups";
 import { queueMcpWrite } from "../components/mcpWriteQueue";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // Which GUI tool groups a directory hands its agents, one switch per group in TOOL_GROUPS
 // (render, data, media, external). NOT MulmoTerminal state: each is an MCP server registered in
@@ -46,12 +48,12 @@ async function load(switches: Switches, target: string | null): Promise<void> {
   try {
     const res = await fetch(`/api/gui-mcp-groups?cwd=${encodeURIComponent(target)}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await jsonBody(res);
     // A slower reply for a directory the user has since moved off would show its answer under the
     // new directory's name.
     if (reqId !== switches.req) return;
     switches.dir.value = target;
-    const registered: unknown[] = Array.isArray(data.groups) ? data.groups : [];
+    const registered: unknown[] = isUnknownArray(data.groups) ? data.groups : [];
     switches.enabled.value = byToolGroup(false);
     for (const group of TOOL_GROUPS) switches.enabled.value[group] = registered.includes(group);
     switches.failed.value = byToolGroup(null);
@@ -91,8 +93,8 @@ async function write(switches: Switches, group: ToolGroup, target: string, wante
       body: JSON.stringify({ cwd: target, group, enabled: wanted }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    if (!data.ok) throw new Error(data.message || "claude mcp failed");
+    const data = await jsonBody(res);
+    if (data.ok !== true) throw new Error(typeof data.message === "string" && data.message ? data.message : "claude mcp failed");
   } catch (e) {
     // Only if the switches still belong to the directory this write was for. Moved on, they are
     // showing what the NEW directory has registered, and putting one back would report another
@@ -158,8 +160,8 @@ async function registeredIn(dir: string): Promise<unknown[] | null> {
   try {
     const res = await fetch(`/api/gui-mcp-groups?cwd=${encodeURIComponent(dir)}`);
     if (!res.ok) return null;
-    const data = await res.json();
-    return Array.isArray(data.groups) ? data.groups : null;
+    const data = await jsonBody(res);
+    return isUnknownArray(data.groups) ? data.groups : null;
   } catch {
     return null;
   }

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -1,6 +1,29 @@
 import { ref, onMounted, onUnmounted } from "vue";
 import { usePubSub } from "./usePubSub";
 import type { TerminalAgent } from "../../common/sessionAgent";
+import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
+
+// The rows arrive off /api/sessions, so a row becomes a Session only after its three
+// load-bearing fields are checked: `id` routes every later request, `title` is rendered, and
+// `mtime` decides the sort. A row missing one of them would sort to the top as NaN or route
+// nowhere, so it is dropped rather than admitted.
+interface SessionRow {
+  id: string;
+  title: string;
+  mtime: number;
+}
+
+const isSessionRow = (value: unknown): value is SessionRow =>
+  isRecord(value) && typeof value.id === "string" && typeof value.title === "string" && typeof value.mtime === "number";
+
+const listOfSessionRows = (value: unknown): SessionRow[] => (isUnknownArray(value) ? value.filter(isSessionRow) : []);
+
+const isSession = (value: unknown): value is Session =>
+  isRecord(value) && isSessionRow(value) && typeof value.working === "boolean" && typeof value.waiting === "boolean";
+
+const listOfSessions = (value: unknown): Session[] => (isUnknownArray(value) ? value.filter(isSession) : []);
 
 export interface Session {
   id: string;
@@ -82,8 +105,8 @@ export function useSessions() {
     try {
       const res = await fetch("/api/codex/sessions");
       if (!res.ok) return [];
-      const data = await res.json();
-      return (data.sessions ?? []).map((s: { id: string; title: string; mtime: number }): Session => ({
+      const data = await jsonBody(res);
+      return listOfSessionRows(data.sessions).map((s): Session => ({
         id: s.id,
         title: s.title,
         mtime: s.mtime,
@@ -112,10 +135,10 @@ export function useSessions() {
     try {
       const [res, codex] = await Promise.all([fetch("/api/sessions"), fetchCodexSessions()]);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await jsonBody(res);
       if (request <= lastAppliedRequest) return; // an equal-or-newer answer is already on screen
       lastAppliedRequest = request;
-      const incoming = [...(data.sessions ?? []), ...codex].sort((a: Session, b: Session) => b.mtime - a.mtime);
+      const incoming = [...listOfSessions(data.sessions), ...codex].sort((a, b) => b.mtime - a.mtime);
       sessions.value = mergeStable(sessions.value, incoming, resort);
       error.value = null;
     } catch (e) {

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -31,9 +31,8 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
-import { swallowsMouseTracking } from "./mouseTrackingModes";
-import { clearResetModes, recordSwallowedModes } from "./mouseReports";
-import { guardMouseClicks, guardMouseWheel } from "./terminalMouseInput";
+import { guardMouseClicks, guardMouseTracking } from "./terminalMouseInput";
+import { getTerminalScrollSpeed } from "./useTerminalScrollSpeed";
 import { isTypedInput } from "./terminalUserInput";
 import { bufferIsShort, readBufferShape } from "./terminalBufferHealth";
 import { CanvasAddon } from "@xterm/addon-canvas";
@@ -42,7 +41,7 @@ import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
 import { connectionWillReturn, reconnectDelayMs, shouldReconnect } from "./reconnectPolicy";
 import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
-import { exitCodeOf, messageEffect } from "./serverMessage";
+import { exitCodeOf, messageEffect, parseServerFrame } from "./serverMessage";
 import {
   enterKeyOverride,
   submitSequence,
@@ -54,7 +53,6 @@ import {
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../../common/terminalFontSize";
 import { TERMINAL_FONT_FAMILY_DEFAULT } from "../../common/terminalFontFamily";
 import { getTerminalSubmitMode } from "./terminalSubmitMode";
-import { getTerminalScrollSpeed } from "./useTerminalScrollSpeed";
 import { clipboardActionFor, selectionToCopy } from "../../common/terminalClipboard";
 import { sendBytesFor, type Keymap, type KeymapKeyEvent } from "../../common/keymap";
 import { getActiveKeymap } from "./activeKeymap";
@@ -384,18 +382,6 @@ export const isOpenableTerminalLink = (uri: string): boolean => /^https?:\/\//i.
 //
 // The record is owned by the connection, not this closure, because it is per SESSION: connect()
 // clears it alongside term.reset() so a crashed app's modes can't outlive it.
-function guardMouseTracking(term: Terminal, swallowedMouseModes: Set<number>): void {
-  term.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
-    const swallowed = swallowsMouseTracking(params);
-    if (swallowed) recordSwallowedModes(swallowedMouseModes, params);
-    return swallowed;
-  });
-  term.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
-    clearResetModes(swallowedMouseModes, params);
-    return false;
-  });
-  guardMouseWheel(term, swallowedMouseModes, getTerminalScrollSpeed);
-}
 
 // Terminal input -> the slot's CURRENT socket (survives reconnects: `c.ws` is re-read
 // each keystroke, so input always targets the live socket). The Enter-family key handler
@@ -687,34 +673,44 @@ function connect(c: Conn) {
   };
 }
 
+// The live session id, so a later reconnect resumes THIS session (esp. a brand-new one that had
+// no id yet), plus the effective cwd.
+function applySessionFrame(c: Conn, msg: Record<string, unknown>): void {
+  if (typeof msg.id === "string") {
+    c.knownSessionId = msg.id;
+    c.handlers.onSession?.(msg.id);
+  }
+  if (typeof msg.cwd === "string") {
+    c.knownCwd = msg.cwd;
+    const v = connView.get(c.key);
+    if (v) v.serverCwd = msg.cwd;
+    c.handlers.onCwd?.(msg.cwd);
+  }
+}
+
+// exit / superseded / error — a terminal message. messageEffect decides which retries, which
+// fires onExit (NOT superseded — the session is alive in another tab), and the wording.
+function applyTerminalFrame(c: Conn, msg: Record<string, unknown>): void {
+  const effect = messageEffect(typeof msg.type === "string" ? msg.type : undefined, !!c.target.command, msg.message, exitCodeOf(msg));
+  if (!effect.terminal) return;
+  c.sawExit = true;
+  if (effect.banner) c.term.write(effect.banner);
+  setStatus(c, "disconnected");
+  if (effect.callsOnExit) c.handlers.onExit?.(exitCodeOf(msg));
+}
+
 function handleMessage(c: Conn, event: MessageEvent) {
-  const msg = JSON.parse(event.data);
+  const msg = parseServerFrame(event.data);
+  if (!msg) return;
   if (msg.type === "output") {
     // Checked here as well as on fit() because a slot that is only receiving output would
     // otherwise sit frozen until something happened to resize it (#846).
     guardBufferHealth(c);
-    c.term.write(msg.data);
+    if (typeof msg.data === "string") c.term.write(msg.data);
   } else if (msg.type === "session") {
-    // Server reports the live session id — remember it so a later reconnect resumes
-    // THIS session (esp. brand-new sessions that had no id yet) and the effective cwd.
-    c.knownSessionId = msg.id;
-    c.handlers.onSession?.(msg.id);
-    if (typeof msg.cwd === "string") {
-      c.knownCwd = msg.cwd;
-      const v = connView.get(c.key);
-      if (v) v.serverCwd = msg.cwd;
-      c.handlers.onCwd?.(msg.cwd);
-    }
+    applySessionFrame(c, msg);
   } else {
-    // exit / superseded / error — a terminal message. messageEffect decides which retries,
-    // which fires onExit (NOT superseded — the session is alive in another tab), and the
-    // wording; this applies it.
-    const effect = messageEffect(msg.type, !!c.target.command, msg.message, exitCodeOf(msg));
-    if (!effect.terminal) return;
-    c.sawExit = true;
-    if (effect.banner) c.term.write(effect.banner);
-    setStatus(c, "disconnected");
-    if (effect.callsOnExit) c.handlers.onExit?.(exitCodeOf(msg));
+    applyTerminalFrame(c, msg);
   }
 }
 

--- a/src/jsonBody.ts
+++ b/src/jsonBody.ts
@@ -1,0 +1,27 @@
+// Reading a JSON response without `any` — the browser-side counterpart to the server's
+// `requestBody`.
+//
+// `Response.json()` is typed `Promise<any>`, so `(await res.json()).entries` type-checks against
+// anything and every value read out of it stays `any` all the way to wherever it is used. That is
+// the widest `any` door in the UI: the body came off the wire, and nothing has checked it.
+//
+// Answering a plain record makes each field `unknown`, which is what the callers already assume —
+// they were written as `typeof data.version === "string" ? ... : null`, and that guard becomes the
+// thing the type checker follows rather than decoration on an `any`.
+
+import { isRecord } from "../common/isRecord";
+
+/**
+ * The response body as a record of unverified fields; `{}` when it is not a JSON object or not
+ * JSON at all. Absorbing the parse failure matches what the callers did by hand
+ * (`res.json().catch(() => ({}))`) and keeps a truncated body from throwing past an error path
+ * that was already handling the HTTP status.
+ */
+export const jsonBody = async (res: Response): Promise<Record<string, unknown>> => {
+  try {
+    const body: unknown = await res.json();
+    return isRecord(body) ? body : {};
+  } catch {
+    return {};
+  }
+};

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -176,3 +176,49 @@ describe("useAppConfig — a save keeps what the server echoed", () => {
     expect(prRepos.value).toEqual(["receptron/mulmoterminal"]);
   });
 });
+
+// loadConfig runs on every page open, and it used to take the server's arrays at face value while
+// the SAVE paths filtered them through isLauncher/isQuickCommand/isUserMcpServer. A config file
+// that was hand-edited (or written by an older version) therefore loaded entries the rest of the
+// app assumes are well-formed — a launcher with no `command`, a quick command with no `text`.
+describe("useAppConfig — loadConfig validates what the server sends", () => {
+  function mockConfigGet(payload: Record<string, unknown>) {
+    globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => payload })) as unknown as typeof fetch;
+  }
+
+  it("keeps well-formed entries and drops malformed ones, per list", async () => {
+    mockConfigGet({
+      launchers: [{ label: "shell", command: "zsh" }, { label: "broken" }, "not an object"],
+      quickCommands: [{ label: "hi", text: "hello" }, { label: "no text" }],
+      userMcpServers: [{ id: "a", url: "https://x" }, { id: "b" }],
+      pushKinds: ["finished", "not-a-kind"],
+      prRepos: ["owner/repo", 42],
+      cwdPresets: [{ label: "proj", path: "/p" }, { label: "no path" }],
+    });
+    const { loadConfig, launchers, quickCommands, userMcpServers, pushKinds, prRepos, presets } = useAppConfig();
+
+    await loadConfig();
+
+    expect(launchers.value).toEqual([{ label: "shell", command: "zsh" }]);
+    expect(quickCommands.value).toEqual([{ label: "hi", text: "hello" }]);
+    expect(userMcpServers.value).toEqual([{ id: "a", url: "https://x" }]);
+    expect(pushKinds.value).toEqual(["finished"]);
+    expect(prRepos.value).toEqual(["owner/repo"]);
+    expect(presets.value).toEqual([{ label: "proj", path: "/p" }]);
+  });
+
+  // A body that is not a JSON object at all must leave what is already shown alone rather than
+  // throw past the caller — loadConfig is fire-and-forget on mount. The refs are module-level
+  // singletons, so "unchanged" is the observable behaviour, not "empty".
+  it("survives a non-object body and leaves the current lists alone", async () => {
+    mockConfigGet({ launchers: [{ label: "shell", command: "zsh" }] });
+    const { loadConfig, launchers } = useAppConfig();
+    await loadConfig();
+    const before = [...launchers.value];
+
+    mockConfigGet([] as unknown as Record<string, unknown>);
+    await expect(loadConfig()).resolves.toBeUndefined();
+
+    expect(launchers.value).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary

server を 0 にした #1321 の続きです。`src/` の **262 件を 108 件**まで減らしました。

| | before | after |
|---|---|---|
| **本物の `any`** | **262** | **53** |
| SFC 型が解決できない偽陽性 | （未分離） | 55 |
| 合計 | 262 | 108 |

lint 0 errors（warning 23 は main と同数）/ typecheck 0 / build / test 7614 passed。

## Items to Confirm / Review

1. **`useAppConfig.loadConfig` が厳しくなります。** 壊れた設定エントリは**読み込み時に落ちる**
   ようになります（従来は保存パスだけが検証していました）。テスト2件で固定しています。
2. **`TerminalCell` の `SessionDetail` 型を削除しました。** `/api/session/:id` が `id` を
   返さないためです（ガードを入れたらテストが4件落ちて判明）。
3. **`guardMouseTracking` を別モジュールへ移動**しました（振る舞いは不変）。

## User Prompt

> レビューしてマージした？そのあとsrc以下もできるならしてほしい

（#1321 は Codex LGTM・11/11 green で `ce2d63c7` としてマージ済みです。）

## まず分かったこと: **55 件はコードでは直せません**

`TerminalGrid.vue` などの指摘の多くは `any` ではなく **「型が解決できない」** でした。

```ts
const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
filesPane.value?.flush();   // ← Unsafe call of a type that could not be resolved
```

eslint の型プログラムは **`.vue` の component 型を生成できない**ので error 型になります。
`vue-tsc` は解決できるため `yarn typecheck` は 0 のままです。

### 推測ではなく実証しました

存在しないメソッドを呼んで、vue-tsc が**型付きで拒否する**ことを確認しました。

```
error TS2339: Property 'thisMethodDoesNotExist' does not exist on type
  '{ $: ComponentInternalInstance; $data: {}; $props: { readonly cwd: string | null; ... }'
```

**このコードは完全に型検査されています。** ルールを error に上げるなら `.vue` をこの5ルールから
除外する必要があります。#1300 に記録します。

## 入口は server と同じでした

| 入口 | 対応 |
|---|---|
| `Response.json()` → `any` | **`src/jsonBody.ts`** を新設（server の `requestBody` と対） |
| `JSON.parse` | `: unknown` + ガード |
| socket の `event.data` | `parseServerFrame`（server の `parseClientFrame` と対） |

## 見つかった実際の穴

### `loadConfig` が保存パスより甘かった

`isLauncher` / `isQuickCommand` / `isUserMcpServer` は**既にあり、保存パスは通していた**のに、
**毎回のページ表示で走る `loadConfig` は素通し**でした。手で編集された設定や古いバージョンが
書いた設定が、そのまま `launchers.value` に載ります。

`listOf(value, guard)` で全リストを揃え、`cwdPresets` 用に `isCwdPreset` を追加しました。

### `useSessions` の型注釈が嘘だった

```ts
(data.sessions ?? []).map((s: { id: string; title: string; mtime: number }): Session => ...)
```

`s` は `any` で、注釈はコンパイルを通すためだけのものでした。`id` はルーティング、`mtime` は
ソートに使うので、欠けた行は落とします。

### `TerminalCell` の `SessionDetail` が実在しない形だった

`ActivityMsg & {...}` は `id: string` を要求しますが、**`/api/session/:id` は `id` を返しません**。
`applyActivityPush` も `id` を読んでいません。record として読み、`activityPushOf` で
**absent と null の区別**（`cellActivity.ts` 冒頭が説明している「no news」対「there is none now」）
を保っています。

## 別件

`test/server/backends/scheduler.spec.ts` と `mulmoscript.spec.ts` がフルスイートで散発的に落ち、
**単体では通り、再実行で全 green** になりました。#1314（`presentPathRoot.spec.ts`）と同じ
順序依存で、これで3つ目の spec です。#1314 に追記します。

## この PR で直していないもの

本物の 53 件（19 ファイルに小さく分散）と、`src/utils/fetchJson.ts` の `fetchJson<T>` ——
**呼び出し側が名乗った T を検証せずに返す**不健全な generic で、`gui-chat-protocol` が
`parse` 必須にして解決したのと同じ形です。呼び出しは6箇所なので直せますが、別判断として
#1300 に残します。

refs #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3