### PR TITLE
fix(lint): put the no-unsafe-* family on error (#1300)

### DIFF
--- a/common/isRecord.ts
+++ b/common/isRecord.ts
@@ -11,3 +11,9 @@ import { isObject } from "graphai";
 // graphai's own `isPlainObject` is exactly this (it also rejects Map/Date/class instances), but
 // it is not exported from the package root, so the array check stays here.
 export const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value) && !Array.isArray(value);
+
+// "Absent, or of this type" — what an OPTIONAL field on a wire shape has to satisfy. A guard that
+// skips these asserts a type it has not seen: absent is meaningful (an older server never said the
+// field), but a present one of the wrong type is a lie the rest of the code then reads.
+export const optionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
+export const optionalBoolean = (value: unknown): boolean => value === undefined || typeof value === "boolean";

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -166,6 +166,15 @@ export default [
       // literal text "[object Object]" — a wrong value that travels instead of throwing.
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-base-to-string": "error",
+      // The `any` family (#1300). All five are at ZERO, and they are the rules that catch what
+      // `no-explicit-any` cannot: an `any` that arrives from outside — JSON.parse, a dynamic
+      // import, express's req.body, Response.json() — and then type-checks against every use it
+      // reaches. See the exclusion block below for the ONE place they cannot be trusted.
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
       // Type-aware sonarjs rules that were ALREADY configured as errors and never ran, because
       // nothing built a type program until this block did. Turning them on is not what this change
       // is for, and 30 findings would hide the promise ones — so they are visible at warn and get
@@ -202,6 +211,34 @@ export default [
     },
   },
   {
+    // The `any` family is OFF wherever a `.vue` component type is in play, and that is a LIMIT OF
+    // THE LINTER rather than a hole in the code.
+    //
+    // ESLint's type program does not generate SFC component types, so `InstanceType<typeof
+    // SomeComponent>` — and any type imported from a `.vue` — resolves to the error type. Every
+    // read through such a value is then reported as unsafe. `vue-tsc` resolves them fully: calling
+    // a made-up method through one of these refs is rejected with the whole instance type, so this
+    // code IS type-checked, just not by this pass (measured on #1300: 58 reports, 0 fixable).
+    //
+    // The `.ts` files listed here are the ones that import a type or component FROM a `.vue`; they
+    // inherit the same blind spot. A new file that does the same belongs on this list — with the
+    // import named, so the entry can be deleted if the type program ever learns SFCs.
+    files: [
+      "**/*.vue",
+      "src/main.ts", // App.vue
+      "src/plugins-registry.ts", // CollectionCardView.vue
+      "src/composables/collectionUi.ts", // PinToggle.vue
+      "src/components/filesPaneStore.ts", // FilesPaneState from FilesPane.vue
+    ],
+    rules: {
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
+  {
     // Type-assertion allowlist. Every entry is a place where NO amount of local typing can
     // express the truth, because the type that is wrong belongs to someone else. Each says which
     // upstream and what would remove it — delete the entry when that lands.
@@ -225,6 +262,16 @@ export default [
       // annotates its handler.) Moving the assertion onto the payload (`handler(data as T)`)
       // relocates it rather than removing it, so it stays where the unprovable claim is made.
       "src/composables/pluginRuntime.ts",
+      // The same shape one layer out: @mulmoclaude/accounting-plugin declares
+      // `AccountingApiCall = <T = unknown>(path, opts) => Promise<ApiResult<T>>`, and the
+      // collection package's CollectionApiResult<T> seam matches it. The PLUGIN picks T; the host
+      // can only hand it a body nothing has checked. `fetchJson` itself now REQUIRES a reader
+      // (#1300), so every caller that can check does — these two cannot, and say so at the seam
+      // with a one-line `asDeclared` rather than pushing the hole back into fetchJson for all of
+      // them. Removing these needs the packages to take a reader, as gui-chat-protocol's own
+      // `fetchJson<T>` already does: receptron/gui-chat-protocol#30.
+      "src/composables/accountingUi.ts",
+      "src/composables/collectionUi.ts",
     ],
     rules: {
       "@typescript-eslint/consistent-type-assertions": "off",

--- a/plans/fix-1300-no-unsafe-error.md
+++ b/plans/fix-1300-no-unsafe-error.md
@@ -1,0 +1,73 @@
+# fix(lint): `no-unsafe-*` 5 ルールを error にする (#1300 完了)
+
+残り 53 件（本物）を 0 にして、5 ルールを **error** で常設した。
+
+| | before | after |
+|---|---|---|
+| 本物の `any` | 53 | **0** |
+| 型が解決できない偽陽性 | 55 | 58（除外） |
+
+## 「`.vue` を除外」だけでは足りなかった
+
+当初の見立ては「SFC の型が解決できないので `.vue` を除外すれば良い」だった。**それでは CI が
+赤いままになる。**
+
+偽陽性は `.vue` に限らず、**`.vue` から型やコンポーネントを import している `.ts`** にも出る。
+
+| ファイル | import 元 |
+|---|---|
+| `src/main.ts` | `App.vue` |
+| `src/plugins-registry.ts` | `CollectionCardView.vue` |
+| `src/composables/collectionUi.ts` | `PinToggle.vue` |
+| `src/components/filesPaneStore.ts` | `FilesPaneState` from `FilesPane.vue` |
+
+除外リストにはこの 4 つも入れ、**どの `.vue` を import しているか**を各行に書いた。新しく同じ
+ことをするファイルが出たらここに足す（型プログラムが SFC を理解するようになったら削除できる）。
+
+## 分類の正規表現を間違えていた
+
+途中まで偽陽性を `could not be resolved|error typed value` で数えていたが、eslint は
+`of type error` や `error typed assigned` とも書く。**取りこぼしていたぶんが「本物」に混ざって
+いた**ので、`could not be resolved|cannot be resolved|error typed|of type error` で数え直した。
+
+## `fetchJson<T>` — 呼び出し側が名乗った型を検証せず返していた
+
+`src/utils/fetchJson.ts` は**この repo のファイル**（gui-chat-protocol のものではない）。
+`read: (raw: unknown) => T` を**必須引数**にした。`wikiApi` の `getJson` が既に使っている形。
+
+- **`useShortcuts`** — 自前のエンドポイントなので `readShortcuts` を書いた。slug / title / icon
+  を欠く pin は落とす（ナビゲートできない、あるいは空チップになる）。
+- **`accountingUi` / `collectionUi`** — プラグインパッケージが
+  `AccountingApiCall = <T = unknown>(path, opts) => Promise<ApiResult<T>>` と**generic を宣言して
+  いる**ので、T を選ぶのはプラグイン、作るのはホスト。構造的に検証不可能。`asDeclared` を seam に
+  置き、`consistent-type-assertions` の allowlist に理由付きで追加した
+  （`pluginRuntime.ts` と同じ扱い）。**upstream に issue を立てた: receptron/gui-chat-protocol#30。**
+
+## 見つかった実際の穴
+
+### `useSessionFeed` の履歴経路がライブ経路より甘かった
+
+`parse: (raw: unknown) => T | null` は**ライブチャンネル用に既にあり**、コメントにも
+「The channel carries `unknown`, and this used to be `data as T`」と書いてある。ところが
+**履歴の初回ロードだけ `data[historyKey] ?? []` を素通し**していた。チャンネルなら落とされる形が
+初回表示には載る。同じ reader を通すようにした。
+
+（#1325 の `loadConfig` と同じ構図: 片方の経路だけ検証している。）
+
+### `useDirLists` の `rowsOf<T>`
+
+`rowsOf<ResumableSession>(body.sessions)` は「サーバに聞いていない形を名乗る」形。ガードを取る
+形に変え、3 リストぶんのガードを書いた。
+
+### `useGridActivity` の seed が誤った reader を指していた
+
+`const data: Record<string, CellActivity> = await res.json()` を注釈だけで通していた。seed の
+エンドポイントは **id をキーにしたマップ**を返し、値の中に `id` は入っていない。既存の
+`parseSessionActivityPayload` は `id` で判定するので**この形には使えない**。
+`readCellActivity` を新設した。
+
+## その他
+
+`useHeaderButtons` / `ToolsPane` / `SkillMenu` / `useLaunchOptions` など、`res.json()` を
+`jsonBody` + 要素ガードに置き換え。ガードは「その画面が**描画・操作に使う**フィールド」を見る
+（例: ヘッダーボタンは `id`（実行時に再解決するキー）/ `label`（描画）/ `run`（押した時の挙動））。

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -92,7 +92,11 @@ async function fetchEntries(pathRel: string): Promise<Entry[]> {
   const res = await fetch(`/api/files/browse/list?${qs(pathRel)}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await jsonBody(res);
-  return isUnknownArray(data.entries) ? data.entries.filter(isEntry) : [];
+  // A directory with no children answers `{ entries: [] }`, so an ABSENT array is a body we could
+  // not read — different from an empty directory, and the callers treat the two differently (one
+  // marks the node loaded, the other collapses it again).
+  if (!isUnknownArray(data.entries)) throw new Error("GET /api/files/browse/list → body has no entries array");
+  return data.entries.filter(isEntry);
 }
 
 async function loadRoot(): Promise<void> {

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -9,6 +9,8 @@ import { reconcileCollectionCard } from "../../common/collectionSeed";
 import { collapseByIdentity } from "../utils/canvasCollapse";
 import { useCanvasCardHeight } from "../composables/useCanvasCardHeight";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -238,11 +240,11 @@ async function loadAvailableTools(sessionId: string | null) {
   try {
     const res = await fetch(sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const body = await res.json();
+    const body = await jsonBody(res);
     // Late reply for a session we have since walked away from would list another cell's tools.
     if (sessionId !== props.sessionId) return;
-    if (!Array.isArray(body.tools)) return;
-    availableTools.value = body.tools.map((tool: { toolName?: unknown }) => tool?.toolName).filter((name: unknown): name is string => typeof name === "string");
+    if (!isUnknownArray(body.tools)) return;
+    availableTools.value = body.tools.map((tool) => (isRecord(tool) ? tool.toolName : undefined)).filter((name): name is string => typeof name === "string");
   } catch {
     // Leave it unknown rather than empty — the hint falls back to the full list, which is a
     // better answer than telling a working session it has nothing.

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -11,6 +11,8 @@ import { useIssueStart } from "../composables/useIssueStart";
 import { relativeTimeFromIso } from "./cellDisplay";
 import IssueStartButton from "./IssueStartButton.vue";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 const { isOpen, close } = usePrsView();
 const { loadRepoDirs, startError } = useIssueStart();
@@ -33,8 +35,8 @@ async function loadSection(path: string): Promise<{ rows: unknown[]; error: stri
   try {
     const res = await fetch(path);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    return { rows: Array.isArray(data.repos) ? data.repos : [], error: null };
+    const data = await jsonBody(res);
+    return { rows: isUnknownArray(data.repos) ? data.repos : [], error: null };
   } catch (e) {
     return { rows: [], error: e instanceof Error ? e.message : String(e) };
   }

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -29,6 +29,7 @@ import { remoteHostAlarm, remoteHostView } from "./remoteHostView";
 import { usePubSub } from "../composables/usePubSub";
 import type { RunnerHealth } from "../../common/remoteHostHealth";
 import { isRecord } from "../../common/isRecord";
+import { jsonBody } from "../jsonBody";
 
 // Mobile companion PWA — shown in the dropdown as help text (not fetched here).
 const MOBILE_URL = "https://mulmoserver.web.app";
@@ -76,8 +77,8 @@ async function fetchStatus(url: string, method: "GET" | "POST", body?: unknown):
       ...(body ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) } : {}),
     });
     if (!res.ok) {
-      const detail = await res.json().catch(() => null);
-      return { ok: false, error: (detail && typeof detail.error === "string" && detail.error) || `HTTP ${res.status}`, httpStatus: res.status };
+      const detail = await jsonBody(res);
+      return { ok: false, error: typeof detail.error === "string" && detail.error ? detail.error : `HTTP ${res.status}`, httpStatus: res.status };
     }
     const data: unknown = await res.json();
     const status = isRecord(data) ? data.status : undefined;

--- a/src/components/SkillMenu.vue
+++ b/src/components/SkillMenu.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref, watch, useTemplateRef } from "vue";
 import { useDropdownMenu } from "../composables/useDropdownMenu";
+import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // A header dropdown that lists the open project's discoverable skills (user +
 // project `.claude/skills`) and emits the slug picked, so the parent can invoke it
@@ -37,9 +40,12 @@ async function loadSkills() {
   }
   try {
     const res = await fetch(`/api/skills?cwd=${encodeURIComponent(dir)}`);
-    const data = res.ok ? await res.json() : { skills: [] };
+    const data = res.ok ? await jsonBody(res) : {};
     if (reqId !== req) return;
-    skills.value = Array.isArray(data.skills) ? data.skills : [];
+    // A skill with no slug cannot be launched, and one with no description renders a blank row.
+    skills.value = isUnknownArray(data.skills)
+      ? data.skills.filter((skill): skill is DiscoveredSkill => isRecord(skill) && typeof skill.slug === "string" && typeof skill.description === "string")
+      : [];
   } catch {
     if (reqId === req) skills.value = [];
   }

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -45,6 +45,7 @@ import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 import type { TerminalAgent } from "../../common/sessionAgent";
 import { jsonBody } from "../jsonBody";
+import { isUnknownArray } from "../../common/isUnknownArray";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -343,6 +344,10 @@ watch(
       const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = await jsonBody(res);
+      // THROWN rather than read as "no groups": jsonBody answers {} for a body that is truncated
+      // or not JSON, and the catch below deliberately leaves `canvasChecked` false so a failure to
+      // ASK is not recorded as an answer. Defaulting here would record one.
+      if (!isUnknownArray(body.groups)) throw new Error("GET /api/tools → body has no groups array");
       // Late reply for a cell we have since walked away from would show the wrong button.
       if (sessionId !== expandedSessionId.value) return;
       // The GROUPS, not the tool names. Every cell here is a grid cell, so "has a canvas group"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -44,6 +44,7 @@ import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 import type { TerminalAgent } from "../../common/sessionAgent";
+import { jsonBody } from "../jsonBody";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -341,7 +342,7 @@ watch(
     try {
       const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await jsonBody(res);
       // Late reply for a cell we have since walked away from would show the wrong button.
       if (sessionId !== expandedSessionId.value) return;
       // The GROUPS, not the tool names. Every cell here is a grid cell, so "has a canvas group"

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -2,7 +2,7 @@
 import { ref, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
-import { isRecord } from "../../common/isRecord";
+import { isRecord, optionalString } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 
@@ -18,6 +18,12 @@ interface AvailableTool {
   title?: string;
   description?: string;
 }
+// `toolName` is the field the pane cannot do without: it keys the row and is what a click sends.
+// The other two are display text and may legitimately be absent — but a PRESENT one of the wrong
+// type would be asserted as a string and rendered.
+const isAvailableTool = (value: unknown): value is AvailableTool =>
+  isRecord(value) && typeof value.toolName === "string" && optionalString(value.title) && optionalString(value.description);
+
 interface ToolCall {
   toolUseId?: string;
   toolName: string;
@@ -88,11 +94,7 @@ async function loadAvailableTools(sessionId: string | null) {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body = await jsonBody(res);
     if (overtaken()) return;
-    // `toolName` is the only field the pane cannot do without: it keys the row and is what a
-    // click sends. The two optional ones are display text and may legitimately be absent.
-    availableTools.value = isUnknownArray(body.tools)
-      ? body.tools.filter((tool): tool is AvailableTool => isRecord(tool) && typeof tool.toolName === "string")
-      : [];
+    availableTools.value = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
   } catch {
     if (overtaken()) return;

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -3,6 +3,8 @@ import { ref, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
 // (the GUI plugin tools, with collapsible descriptions) and a "Tool Call History"
@@ -84,9 +86,13 @@ async function loadAvailableTools(sessionId: string | null) {
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const body = await res.json();
+    const body = await jsonBody(res);
     if (overtaken()) return;
-    availableTools.value = body.tools ?? [];
+    // `toolName` is the only field the pane cannot do without: it keys the row and is what a
+    // click sends. The two optional ones are display text and may legitimately be absent.
+    availableTools.value = isUnknownArray(body.tools)
+      ? body.tools.filter((tool): tool is AvailableTool => isRecord(tool) && typeof tool.toolName === "string")
+      : [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
   } catch {
     if (overtaken()) return;

--- a/src/composables/accountingUi.ts
+++ b/src/composables/accountingUi.ts
@@ -15,6 +15,13 @@ import { browserLocale } from "../utils/browserLocale";
 
 const { subscribe } = usePubSub();
 
+// The plugin package declares the generic — `AccountingApiCall = <T = unknown>(path, opts) =>
+// Promise<ApiResult<T>>` — so the PLUGIN chooses T and the host has to produce it from a body
+// nothing has checked. Unprovable by construction, exactly like gui-chat-protocol's `dispatch<T>`
+// (see the type-assertion allowlist in eslint.config.js). The claim is made HERE, at the seam,
+// rather than hidden inside fetchJson where it would apply to every caller.
+const asDeclared = <T>(raw: unknown): T => raw as T;
+
 // Network seam — normalise fetch into the package's ApiResult union (the View
 // pattern-matches on `.ok`). Mirrors MulmoClaude's apiCall shape so the View's
 // `apiCall("/api/accounting", { method, body })` calls just work.
@@ -22,7 +29,7 @@ function apiCall<T = unknown>(path: string, opts: { method: "GET" | "POST" | "PU
   // RequestInit spells its fields exact, so a bodyless call omits both keys rather than
   // sending them as undefined.
   const hasBody = opts.body !== undefined;
-  return fetchJson<T>(path, {
+  return fetchJson<T>(path, asDeclared, {
     method: opts.method,
     ...(hasBody ? { headers: { "content-type": "application/json" }, body: JSON.stringify(opts.body) } : {}),
   });

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -68,12 +68,18 @@ export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): v
   if (i >= 0) teleportStack.splice(i, 1);
 }
 
+// The plugin package declares the generic — the collection package's `CollectionApiResult<T>` seam — so the PLUGIN chooses T and the host has to produce it from a body
+// nothing has checked. Unprovable by construction, exactly like gui-chat-protocol's `dispatch<T>`
+// (see the type-assertion allowlist in eslint.config.js). The claim is made HERE, at the seam,
+// rather than hidden inside fetchJson where it would apply to every caller.
+const asDeclared = <T>(raw: unknown): T => raw as T;
+
 // Read helper: normalise fetch into the package's CollectionApiResult (the view
 // treats `ok:false` with `status` 404 as not-found, any other failure as a skip).
-const apiGet = <T>(url: string): Promise<CollectionApiResult<T>> => fetchJson<T>(url);
+const apiGet = <T>(url: string): Promise<CollectionApiResult<T>> => fetchJson<T>(url, asDeclared);
 
 const apiSend = <T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> =>
-  fetchJson<T>(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+  fetchJson<T>(url, asDeclared, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
 const apiPost = <T>(url: string, body: unknown) => apiSend<T>("POST", url, body);
 const apiPut = <T>(url: string, body: unknown) => apiSend<T>("PUT", url, body);
 

--- a/src/composables/sessionActivity.ts
+++ b/src/composables/sessionActivity.ts
@@ -10,6 +10,14 @@ export interface CellActivity {
   event: string | null;
 }
 
+/** One session's attention state, read off an untrusted body. The seed endpoint answers a MAP of
+ *  id -> this, with no `id` inside each value, so parseSessionActivityPayload (which keys on `id`)
+ *  is the wrong reader for it. */
+export function readCellActivity(value: unknown): CellActivity | null {
+  if (!isRecord(value)) return null;
+  return { working: !!value.working, waiting: !!value.waiting, event: typeof value.event === "string" ? value.event : null };
+}
+
 export type SessionActivityUpdate = { id: string; closed: true } | { id: string; activity: CellActivity };
 
 export function parseSessionActivityPayload(data: unknown): SessionActivityUpdate | null {

--- a/src/composables/useDirLists.ts
+++ b/src/composables/useDirLists.ts
@@ -2,6 +2,9 @@ import { shallowRef } from "vue";
 import type { PartialWorkerStatus } from "../../common/workerStatus";
 import type { PartialSessionOccupancy, SessionOccupancy } from "../../common/sessionOccupancy";
 import type { TerminalAgent } from "../../common/sessionAgent";
+import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 // What the launch form can offer for the directory currently in its field: the sessions that can
 // be resumed there, the script.json entries that can be run there, and the worktrees the
@@ -65,7 +68,23 @@ type ListBody = Record<string, unknown>;
 // The server answers 200 with an empty list for a directory that simply has none, so a refused
 // read parses as an empty body: the two show the same thing, and the fallbacks below then fill in
 // per field exactly as each list's own error path used to.
-const rowsOf = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
+// Takes the row guard rather than a type argument. It used to be `rowsOf<T>(value)`, which named
+// a shape the server had not been asked about — the same thing #1231 removed from the assertions.
+const rowsOf = <T>(value: unknown, isRow: (row: unknown) => row is T): T[] => (isUnknownArray(value) ? value.filter(isRow) : []);
+
+// Each list's rows are checked on the fields it cannot render or act without.
+const isResumableSession = (row: unknown): row is ResumableSession =>
+  isRecord(row) && typeof row.id === "string" && typeof row.title === "string" && typeof row.mtime === "number";
+
+const isRunnableScript = (row: unknown): row is RunnableScript =>
+  isRecord(row) && typeof row.index === "number" && typeof row.label === "string" && typeof row.command === "string";
+
+const isWorktree = (row: unknown): row is Worktree =>
+  isRecord(row) &&
+  typeof row.path === "string" &&
+  (row.branch === null || typeof row.branch === "string") &&
+  typeof row.task === "string" &&
+  typeof row.dirty === "boolean";
 const dirOf = (value: unknown, fallback: string): string => (typeof value === "string" ? value : fallback);
 
 function useDirList<T>(url: (dir: string) => string, parse: (body: ListBody, dir: string) => T, empty: () => T) {
@@ -83,7 +102,7 @@ function useDirList<T>(url: (dir: string) => string, parse: (body: ListBody, dir
     try {
       const res = await fetch(url(dir));
       if (reqId !== req) return; // a newer request superseded this one
-      const body: ListBody = res.ok ? await res.json() : {};
+      const body: ListBody = res.ok ? await jsonBody(res) : {};
       if (reqId !== req) return; // re-check after awaiting the body
       value.value = parse(body, dir);
     } catch {
@@ -98,7 +117,7 @@ function useDirList<T>(url: (dir: string) => string, parse: (body: ListBody, dir
 export const useResumableSessions = () =>
   useDirList<ResumableList>(
     (dir) => `/api/sessions?cwd=${encodeURIComponent(dir)}`,
-    (body, dir) => ({ sessions: rowsOf<ResumableSession>(body.sessions), cwd: dirOf(body.cwd, dir) }),
+    (body, dir) => ({ sessions: rowsOf(body.sessions, isResumableSession), cwd: dirOf(body.cwd, dir) }),
     () => ({ sessions: [], cwd: null }),
   );
 
@@ -107,7 +126,7 @@ export const useResumableSessions = () =>
 export const useDirScripts = () =>
   useDirList<ScriptList>(
     (dir) => `/api/scripts?cwd=${encodeURIComponent(dir)}`,
-    (body, dir) => ({ scripts: rowsOf<RunnableScript>(body.scripts), cwd: dirOf(body.cwd, dir) }),
+    (body, dir) => ({ scripts: rowsOf(body.scripts, isRunnableScript), cwd: dirOf(body.cwd, dir) }),
     () => ({ scripts: [], cwd: null }),
   );
 
@@ -117,6 +136,6 @@ export const useDirScripts = () =>
 export const useDirWorktrees = () =>
   useDirList<WorktreeList>(
     (dir) => `/api/worktrees?cwd=${encodeURIComponent(dir)}`,
-    (body) => ({ isGit: !!body.isGit, worktrees: rowsOf<Worktree>(body.worktrees) }),
+    (body) => ({ isGit: !!body.isGit, worktrees: rowsOf(body.worktrees, isWorktree) }),
     () => ({ isGit: false, worktrees: [] }),
   );

--- a/src/composables/useDirLists.ts
+++ b/src/composables/useDirLists.ts
@@ -1,8 +1,8 @@
 import { shallowRef } from "vue";
 import type { PartialWorkerStatus } from "../../common/workerStatus";
 import type { PartialSessionOccupancy, SessionOccupancy } from "../../common/sessionOccupancy";
-import type { TerminalAgent } from "../../common/sessionAgent";
-import { isRecord } from "../../common/isRecord";
+import { isTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
+import { isRecord, optionalBoolean } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 
@@ -74,17 +74,32 @@ const rowsOf = <T>(value: unknown, isRow: (row: unknown) => row is T): T[] => (i
 
 // Each list's rows are checked on the fields it cannot render or act without.
 const isResumableSession = (row: unknown): row is ResumableSession =>
-  isRecord(row) && typeof row.id === "string" && typeof row.title === "string" && typeof row.mtime === "number";
+  isRecord(row) &&
+  typeof row.id === "string" &&
+  typeof row.title === "string" &&
+  typeof row.mtime === "number" &&
+  // PartialWorkerStatus / PartialSessionOccupancy: absent is meaningful (an older server never
+  // said), but a PRESENT one of the wrong type would be asserted as a boolean and read as truthy.
+  optionalBoolean(row.hidden) &&
+  optionalBoolean(row.failed) &&
+  optionalBoolean(row.attached);
 
 const isRunnableScript = (row: unknown): row is RunnableScript =>
   isRecord(row) && typeof row.index === "number" && typeof row.label === "string" && typeof row.command === "string";
+
+// The nested `session` too, when present: the row's resume decision reads `id` / `agent` /
+// `attached` off it (worktreeAction in CellLaunchForm), so a half-formed one would be asserted
+// into the Worktree type and then produce an invalid resume request.
+const isWorktreeSession = (value: unknown): value is SessionOccupancy & { id: string; agent: TerminalAgent } =>
+  isRecord(value) && typeof value.id === "string" && typeof value.agent === "string" && isTerminalAgent(value.agent) && typeof value.attached === "boolean";
 
 const isWorktree = (row: unknown): row is Worktree =>
   isRecord(row) &&
   typeof row.path === "string" &&
   (row.branch === null || typeof row.branch === "string") &&
   typeof row.task === "string" &&
-  typeof row.dirty === "boolean";
+  typeof row.dirty === "boolean" &&
+  (row.session === undefined || row.session === null || isWorktreeSession(row.session));
 const dirOf = (value: unknown, fallback: string): string => (typeof value === "string" ? value : fallback);
 
 function useDirList<T>(url: (dir: string) => string, parse: (body: ListBody, dir: string) => T, empty: () => T) {

--- a/src/composables/useGridActivity.ts
+++ b/src/composables/useGridActivity.ts
@@ -1,6 +1,7 @@
 import { reactive, watch, onMounted, onUnmounted, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
-import { parseSessionActivityPayload, type CellActivity } from "./sessionActivity";
+import { parseSessionActivityPayload, readCellActivity, type CellActivity } from "./sessionActivity";
+import { jsonBody } from "../jsonBody";
 
 // Live attention state (working / waiting / event) for a set of grid cell sessions,
 // keyed by session id. Unlike the sidebar's /api/sessions list this includes
@@ -40,10 +41,13 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
       // Overtaken while we waited: this answer is older than what is on screen. Returning
       // also leaves the newer seed's record alone — it is the one that will replay.
       if (seedId !== latestSeed || !res.ok) return;
-      const data: Record<string, CellActivity> = await res.json();
+      // Each row goes through the SAME reader the live channel uses; the seed used to take the
+      // whole map as CellActivity on the strength of the annotation alone.
+      const data = await jsonBody(res);
       if (seedId !== latestSeed) return;
-      for (const [id, a] of Object.entries(data)) {
-        activity.set(id, { working: !!a.working, waiting: !!a.waiting, event: a.event ?? null });
+      for (const [id, raw] of Object.entries(data)) {
+        const a = readCellActivity(raw);
+        if (a) activity.set(id, a);
       }
       // Stop recording before replaying, or each replayed update records itself again.
       if (pushedDuringSeed === pushed) pushedDuringSeed = null;

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -6,7 +6,7 @@
 import { ref, type Ref } from "vue";
 import { useAutoRefresh } from "./useAutoRefresh";
 import type { TerminalAgent } from "../../common/sessionAgent";
-import { isRecord } from "../../common/isRecord";
+import { isRecord, optionalBoolean, optionalString } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 
@@ -38,7 +38,21 @@ const isHeaderButton = (value: unknown): value is HeaderButton =>
   isRecord(value) &&
   typeof value.id === "string" &&
   typeof value.label === "string" &&
-  (value.run === "shell" || value.run === "input" || value.run === "open");
+  (value.run === "shell" || value.run === "input" || value.run === "open") &&
+  optionalString(value.emoji) &&
+  optionalString(value.icon) &&
+  optionalString(value.text) &&
+  // `open` is nested and IS read — hasPickFileButton reaches into `open.pickFile`.
+  (value.open === undefined || isOpenTarget(value.open));
+
+const isOpenTarget = (value: unknown): value is OpenTarget =>
+  isRecord(value) &&
+  optionalString(value.url) &&
+  optionalString(value.reveal) &&
+  optionalString(value.files) &&
+  optionalString(value.view) &&
+  optionalString(value.terminal) &&
+  optionalBoolean(value.pickFile);
 
 const isResolvedChip = (value: unknown): value is ResolvedChip =>
   isRecord(value) &&

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -6,6 +6,9 @@
 import { ref, type Ref } from "vue";
 import { useAutoRefresh } from "./useAutoRefresh";
 import type { TerminalAgent } from "../../common/sessionAgent";
+import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 export interface OpenTarget {
   url?: string;
@@ -26,6 +29,21 @@ export interface HeaderButton {
   open?: OpenTarget;
 }
 export type ResolvedChip = { kind: "builtin"; id: string } | { kind: "custom"; label: string; text: string };
+
+// The header arrives off /api/header, so a button becomes one only once the fields the header
+// RENDERS and ACTS on are there: `label` is drawn, `id` re-resolves the command server-side at
+// exec time, and `run` decides what pressing it does. A button missing one of those would draw
+// blank or do nothing, which is worse than not offering it.
+const isHeaderButton = (value: unknown): value is HeaderButton =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  typeof value.label === "string" &&
+  (value.run === "shell" || value.run === "input" || value.run === "open");
+
+const isResolvedChip = (value: unknown): value is ResolvedChip =>
+  isRecord(value) &&
+  ((value.kind === "builtin" && typeof value.id === "string") ||
+    (value.kind === "custom" && typeof value.label === "string" && typeof value.text === "string"));
 
 // Whether the resolved header offers a file-path picker (an `open` button with `pickFile`).
 // Header buttons are user-configurable and the default picker can be removed, so anything that
@@ -60,10 +78,10 @@ export function useHeaderButtons(params: Params) {
     try {
       const res = await fetch(`/api/header?${query.toString()}`);
       if (seq !== requestSeq) return;
-      const data = res.ok ? await res.json() : { buttons: [], chips: null };
+      const data = res.ok ? await jsonBody(res) : {};
       if (seq !== requestSeq) return;
-      buttons.value = Array.isArray(data.buttons) ? data.buttons : [];
-      chips.value = Array.isArray(data.chips) ? data.chips : null;
+      buttons.value = isUnknownArray(data.buttons) ? data.buttons.filter(isHeaderButton) : [];
+      chips.value = isUnknownArray(data.chips) ? data.chips.filter(isResolvedChip) : null;
     } catch {
       if (seq === requestSeq) {
         buttons.value = [];

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -6,14 +6,49 @@
 // the settings screen rather than a poll.
 import { ref } from "vue";
 import type { LaunchOptions, LaunchProviderOption } from "../../common/launchOptions";
+import type { ModelPreset, ModelTrials } from "../../common/modelPresets";
 import { isRecord } from "../../common/isRecord";
-
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 
-// The picker renders a provider by id/label and launches by id, so a row missing either is
-// dropped rather than shown as an unlabelled button that does nothing.
-const isLaunchProviderOption = (row: unknown): row is LaunchProviderOption => isRecord(row) && typeof row.id === "string" && typeof row.label === "string";
+// EVERY required field, not just the two the list renders. The guard asserts the whole
+// LaunchProviderOption, and the picker goes on to read the rest of it — `sortedModels(provider.
+// models)` iterates `models`, and `ready` / `tokenEnv` drive the disabled state and the setup
+// hint. Checking only id/label would let a malformed row through under a type that promises them.
+// `trials` is a discriminated union, and the picker's label branches on its `status` — an
+// unrecognised one would render neither a measurement nor an honest "unmeasured".
+const isModelTrials = (value: unknown): value is ModelTrials =>
+  isRecord(value) &&
+  ((value.status === "measured" &&
+    typeof value.passed === "number" &&
+    typeof value.of === "number" &&
+    (value.medianSeconds === null || typeof value.medianSeconds === "number") &&
+    typeof value.measuredAt === "string") ||
+    (value.status === "unreachable" && typeof value.reason === "string" && typeof value.measuredAt === "string") ||
+    value.status === "unmeasured");
+
+// Every required field: the option label reads `contextLength` and `trials`, and the badge reads
+// the price. A guard that stopped at id/label would assert a ModelPreset it had not seen.
+const isModelPreset = (row: unknown): row is ModelPreset =>
+  isRecord(row) &&
+  typeof row.provider === "string" &&
+  typeof row.id === "string" &&
+  typeof row.label === "string" &&
+  typeof row.contextLength === "number" &&
+  isRecord(row.pricePerMTok) &&
+  typeof row.pricePerMTok.input === "number" &&
+  typeof row.pricePerMTok.output === "number" &&
+  isModelTrials(row.trials);
+
+const isLaunchProviderOption = (row: unknown): row is LaunchProviderOption =>
+  isRecord(row) &&
+  typeof row.id === "string" &&
+  typeof row.label === "string" &&
+  typeof row.ready === "boolean" &&
+  typeof row.tokenEnv === "string" &&
+  isUnknownArray(row.models) &&
+  row.models.every(isModelPreset) &&
+  (row.reason === undefined || typeof row.reason === "string");
 
 const EMPTY: LaunchOptions = { providers: [], anyReady: false };
 const FETCH_TIMEOUT_MS = 8000;

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -8,11 +8,12 @@ import { ref } from "vue";
 import type { LaunchOptions, LaunchProviderOption } from "../../common/launchOptions";
 import { isRecord } from "../../common/isRecord";
 
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
+
 // The picker renders a provider by id/label and launches by id, so a row missing either is
 // dropped rather than shown as an unlabelled button that does nothing.
 const isLaunchProviderOption = (row: unknown): row is LaunchProviderOption => isRecord(row) && typeof row.id === "string" && typeof row.label === "string";
-import { isUnknownArray } from "../../common/isUnknownArray";
-import { jsonBody } from "../jsonBody";
 
 const EMPTY: LaunchOptions = { providers: [], anyReady: false };
 const FETCH_TIMEOUT_MS = 8000;

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -69,12 +69,14 @@ async function fetchOptions(): Promise<void> {
     const res = await fetch("/api/launch-options", { signal: abort.signal });
     if (!res.ok) throw new Error(`GET /api/launch-options → ${res.status}`);
     const body = await jsonBody(res);
-    // The picker branches on `anyReady` and lists `providers`; a body missing either shows an
-    // empty picker rather than a broken one.
-    options.value =
-      isUnknownArray(body.providers) && typeof body.anyReady === "boolean"
-        ? { providers: body.providers.filter(isLaunchProviderOption), anyReady: body.anyReady }
-        : EMPTY;
+    // THROWN, not defaulted to EMPTY: `jsonBody` answers `{}` for a body that is truncated or not
+    // JSON at all, and treating that as a successful empty list would set `loaded` below and stop
+    // every later mount from retrying — the exact failure the `loaded` flag exists to prevent.
+    // A 200 we cannot read is a failed read, so it goes down the catch with the rest.
+    if (!isUnknownArray(body.providers) || typeof body.anyReady !== "boolean") {
+      throw new Error("GET /api/launch-options → body is not { providers, anyReady }");
+    }
+    options.value = { providers: body.providers.filter(isLaunchProviderOption), anyReady: body.anyReady };
     loaded = true;
   } catch (err) {
     // A picker that cannot load its list is not an error the user can act on — the launch

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -5,7 +5,14 @@
 // restarts the server with a different environment, so `reloadLaunchOptions` is there for
 // the settings screen rather than a poll.
 import { ref } from "vue";
-import type { LaunchOptions } from "../../common/launchOptions";
+import type { LaunchOptions, LaunchProviderOption } from "../../common/launchOptions";
+import { isRecord } from "../../common/isRecord";
+
+// The picker renders a provider by id/label and launches by id, so a row missing either is
+// dropped rather than shown as an unlabelled button that does nothing.
+const isLaunchProviderOption = (row: unknown): row is LaunchProviderOption => isRecord(row) && typeof row.id === "string" && typeof row.label === "string";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 const EMPTY: LaunchOptions = { providers: [], anyReady: false };
 const FETCH_TIMEOUT_MS = 8000;
@@ -25,7 +32,13 @@ async function fetchOptions(): Promise<void> {
   try {
     const res = await fetch("/api/launch-options", { signal: abort.signal });
     if (!res.ok) throw new Error(`GET /api/launch-options → ${res.status}`);
-    options.value = await res.json();
+    const body = await jsonBody(res);
+    // The picker branches on `anyReady` and lists `providers`; a body missing either shows an
+    // empty picker rather than a broken one.
+    options.value =
+      isUnknownArray(body.providers) && typeof body.anyReady === "boolean"
+        ? { providers: body.providers.filter(isLaunchProviderOption), anyReady: body.anyReady }
+        : EMPTY;
     loaded = true;
   } catch (err) {
     // A picker that cannot load its list is not an error the user can act on — the launch

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -3,6 +3,7 @@
 // also need live activity/usage (TerminalCell) fetch the same endpoint alongside those concerns.
 import { ref, type Ref } from "vue";
 import { useAutoRefresh } from "./useAutoRefresh";
+import { jsonBody } from "../jsonBody";
 
 export interface SessionContext {
   model: string | null;
@@ -34,7 +35,7 @@ export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string
     try {
       const res = await fetch(`/api/session/${id}${query}`);
       if (seq !== requestSeq || !res.ok) return;
-      const data = await res.json();
+      const data = await jsonBody(res);
       // Guard against a stale response: the terminal may have switched session mid-flight.
       if (seq === requestSeq && id === sessionId.value && isContext(data.context)) {
         context.value = data.context;

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -4,6 +4,8 @@
 import { onUnmounted, watch, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 import { mergeLiveIntoSnapshot } from "./liveMerge";
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
 
 interface SessionFeedOptions<T> {
   sessionId: () => string | null;
@@ -42,6 +44,16 @@ type Reconcile<T> = (items: T[], incoming: T) => "store" | "skip";
  * the one it replaces. Replaying the rule over the merged list, in arrival order, is the same fold
  * the live path does one item at a time, so both directions settle to the same answer.
  */
+// The stored rows, through the SAME reader the live channel uses. The history path used to take
+// them as-is, so a shape the channel would have dropped still reached the list on first load.
+function readHistory<T>(rows: unknown, parse: (raw: unknown) => T | null): T[] {
+  if (!isUnknownArray(rows)) return [];
+  return rows.flatMap((raw) => {
+    const item = parse(raw);
+    return item === null ? [] : [item];
+  });
+}
+
 function mergeSettled<T>(snapshot: readonly T[], buffered: readonly T[], identify: (item: T) => string | undefined, reconcile?: Reconcile<T>): T[] {
   const merged = mergeLiveIntoSnapshot(snapshot, buffered, identify);
   if (!reconcile) return merged;
@@ -98,9 +110,9 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
       const res = await fetch(historyUrl(id));
       if (overtaken()) return;
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await jsonBody(res);
       if (overtaken()) return;
-      items.value = mergeSettled(data[historyKey] ?? [], arrivedDuringLoad, identify, reconcile);
+      items.value = mergeSettled(readHistory(data[historyKey], parse), arrivedDuringLoad, identify, reconcile);
     } catch {
       // A failed history read must not take the live events with it.
       if (!overtaken()) items.value = mergeSettled([], arrivedDuringLoad, identify, reconcile);

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -8,7 +8,8 @@
 // client owns the full array and replaces it wholesale. Mutations are optimistic
 // with rollback, and serialized so overlapping replace-all PUTs can't reorder.
 import { computed, ref, type ComputedRef } from "vue";
-import { sameShortcut, type Shortcut, type ShortcutKind } from "../../common/shortcuts";
+import { sameShortcut, SHORTCUT_KINDS, type Shortcut, type ShortcutKind } from "../../common/shortcuts";
+import { isRecord } from "../../common/isRecord";
 import { reconcileShortcuts } from "./reconcileShortcuts";
 import { fetchJson } from "../utils/fetchJson";
 
@@ -24,12 +25,25 @@ interface ShortcutsResponse {
   shortcuts: Shortcut[];
 }
 
+// The reader `fetchJson` requires. It checks rather than names: a pin the UI cannot navigate to
+// (no slug) or cannot label (no title/icon) is dropped instead of rendered as a blank chip.
+const isShortcut = (value: unknown): value is Shortcut =>
+  isRecord(value) &&
+  SHORTCUT_KINDS.some((kind) => kind === value.kind) &&
+  typeof value.slug === "string" &&
+  typeof value.title === "string" &&
+  typeof value.icon === "string";
+
+const readShortcuts = (raw: unknown): ShortcutsResponse => ({
+  shortcuts: isRecord(raw) && Array.isArray(raw.shortcuts) ? raw.shortcuts.filter(isShortcut) : [],
+});
+
 /** Load once per session (deduped). A FAILED load is not cached so the next call
  *  retries. */
 async function load(force = false): Promise<void> {
   if (loadPromise && !force) return loadPromise;
   loadPromise = (async () => {
-    const result = await fetchJson<ShortcutsResponse>("/api/shortcuts");
+    const result = await fetchJson("/api/shortcuts", readShortcuts);
     if (!result.ok) {
       loadError.value = result.error;
       loadPromise = null; // allow retry
@@ -58,7 +72,7 @@ function enqueue<T>(task: () => Promise<T>): Promise<T> {
 /** Persist `next`, rolling back to `previous` on failure. Call only inside enqueue. */
 async function persist(next: Shortcut[], previous: Shortcut[]): Promise<boolean> {
   shortcuts.value = next;
-  const result = await fetchJson<ShortcutsResponse>("/api/shortcuts", {
+  const result = await fetchJson("/api/shortcuts", readShortcuts, {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ shortcuts: next }),

--- a/src/composables/useUpdateStatus.ts
+++ b/src/composables/useUpdateStatus.ts
@@ -1,5 +1,6 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { parseUpdateNotice } from "./updateNotice";
+import { jsonBody } from "../jsonBody";
 
 // The server runs the check at startup and it reaches the network (git ls-remote can take
 // several seconds), so an early read returns null before it lands. Poll a few times to catch a
@@ -18,10 +19,10 @@ export function useUpdateStatus() {
     try {
       const res = await fetch("/api/update-status");
       if (!res.ok) return;
-      const data = await res.json();
+      const data = await jsonBody(res);
       // Assign both ways: a null answer must CLEAR a notice an earlier read picked up (e.g.
       // after a `git pull` + restart), not just be ignored.
-      notice.value = typeof data?.notice === "string" ? data.notice : null;
+      notice.value = typeof data.notice === "string" ? data.notice : null;
     } catch {
       // best-effort — no badge is fine
     }

--- a/src/jsonBody.ts
+++ b/src/jsonBody.ts
@@ -16,6 +16,12 @@ import { isRecord } from "../common/isRecord";
  * JSON at all. Absorbing the parse failure matches what the callers did by hand
  * (`res.json().catch(() => ({}))`) and keeps a truncated body from throwing past an error path
  * that was already handling the HTTP status.
+ *
+ * **That absorption is the thing to be careful about.** A caller that RECORDS having succeeded —
+ * `loaded = true`, `checked = true`, a cache entry — must not treat `{}` as an answer, or an
+ * unreadable 200 is remembered as a real one and nothing retries. Throw on a body whose required
+ * field is missing, so the failure stays on the failure path. (Caught in review on #1300: three
+ * call sites had exactly this.)
  */
 export const jsonBody = async (res: Response): Promise<Record<string, unknown>> => {
   try {

--- a/src/utils/fetchJson.ts
+++ b/src/utils/fetchJson.ts
@@ -13,12 +13,22 @@ export function errorMessage(body: unknown, status: number): string {
   return isRecord(body) && typeof body.error === "string" && body.error !== "" ? body.error : `HTTP ${status}`;
 }
 
-export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<FetchResult<T>> {
+/** Reads a response body into the caller's shape. See `fetchJson` for why it is not optional. */
+export type JsonReader<T> = (raw: unknown) => T;
+
+/**
+ * `read` is required, and that is the point: `Response.json()` answers `any`, so a bare
+ * `fetchJson<T>(url)` used to hand back whatever the server sent under the name the CALLER chose —
+ * a claim about the server rather than a question asked of it. Taking the reader from the caller
+ * is the same fix wikiApi's `getJson` already uses.
+ */
+export async function fetchJson<T>(input: RequestInfo | URL, read: JsonReader<T>, init?: RequestInit): Promise<FetchResult<T>> {
   try {
     const res = await fetch(input, init);
     // `status` is the HTTP status on an HTTP failure, or 0 on a transport failure (no response).
     if (!res.ok) return { ok: false, error: errorMessage(await readErrorBody(res), res.status), status: res.status };
-    return { ok: true, data: await res.json() };
+    const body: unknown = await res.json();
+    return { ok: true, data: read(body) };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
   }

--- a/src/utils/translateUi.ts
+++ b/src/utils/translateUi.ts
@@ -1,5 +1,6 @@
 import { browserLocale } from "./browserLocale";
 import { isRecord } from "../../common/isRecord";
+import { isUnknownArray } from "../../common/isUnknownArray";
 
 const REQUEST_TIMEOUT_MS = 8000;
 
@@ -22,7 +23,7 @@ export async function translateUiSentence(english: string, namespace: string): P
     });
     if (!res.ok) return english;
     const data: unknown = await res.json();
-    const first = isRecord(data) && Array.isArray(data.translations) ? data.translations[0] : undefined;
+    const first = isRecord(data) && isUnknownArray(data.translations) ? data.translations[0] : undefined;
     return typeof first === "string" ? first : english;
   } catch {
     return english;

--- a/test/src/utils/fetchJson.spec.ts
+++ b/test/src/utils/fetchJson.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { fetchJson, errorMessage } from "../../../src/utils/fetchJson";
 import { isRecord } from "../../../common/isRecord";
+import { jsonBody } from "../../../src/jsonBody";
 
 // These cases are about transport and status handling, not about reading a shape, so the reader
 // passes the body through untouched.
@@ -112,5 +113,19 @@ describe("errorMessage", () => {
     ["the body is an array", ["nope"], 500],
   ])("falls back to HTTP <status> when %s", (_case, body, status) => {
     expect(errorMessage(body, status)).toBe(`HTTP ${status}`);
+  });
+});
+
+// jsonBody absorbs a parse failure into {}, which is right for a caller that only reads fields —
+// and a trap for one that records having succeeded. These pin the callers that must not.
+describe("a body that cannot be read stays on the failure path", () => {
+  it("jsonBody answers {} for a truncated body rather than throwing", async () => {
+    const res = { json: async () => JSON.parse("{oops") } as unknown as Response;
+    await expect(jsonBody(res)).resolves.toEqual({});
+  });
+
+  it("jsonBody answers {} for a JSON body that is not an object", async () => {
+    const res = { json: async () => [1, 2, 3] } as unknown as Response;
+    await expect(jsonBody(res)).resolves.toEqual({});
   });
 });

--- a/test/src/utils/fetchJson.spec.ts
+++ b/test/src/utils/fetchJson.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { fetchJson, errorMessage } from "../../../src/utils/fetchJson";
+import { isRecord } from "../../../common/isRecord";
+
+// These cases are about transport and status handling, not about reading a shape, so the reader
+// passes the body through untouched.
+const readAny = (raw: unknown): unknown => raw;
 
 // Callers branch on `status`: the collection UI treats 404 as "not found" and anything else
 // as "skip". A transport failure reports 0 — there was no response to have a status — and
@@ -8,22 +13,31 @@ import { fetchJson, errorMessage } from "../../../src/utils/fetchJson";
 afterEach(() => vi.unstubAllGlobals());
 
 describe("fetchJson", () => {
-  it("returns the parsed body on success", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ a: 1 }) }));
-    expect(await fetchJson<{ a: number }>("/api/x")).toEqual({ ok: true, data: { a: 1 } });
+  it("returns what the reader made of the body, not the body", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ a: 1, extra: "dropped" }) }));
+    const readA = (raw: unknown): { a: number } => ({ a: isRecord(raw) && typeof raw.a === "number" ? raw.a : 0 });
+    expect(await fetchJson("/api/x", readA)).toEqual({ ok: true, data: { a: 1 } });
+  });
+
+  // The reader is required precisely so this cannot be skipped: a body that does not match gets
+  // the reader's answer rather than being handed on under the caller's type name.
+  it("hands the reader a body that does not match, and returns what it decided", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => "not an object" }));
+    const readA = (raw: unknown): { a: number } => ({ a: isRecord(raw) && typeof raw.a === "number" ? raw.a : 0 });
+    expect(await fetchJson("/api/x", readA)).toEqual({ ok: true, data: { a: 0 } });
   });
 
   // A stub with no `json` at all — and the shape every /api route sends on failure.
   it("reports the HTTP status when the failure carries no body", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
-    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "HTTP 404", status: 404 });
+    expect(await fetchJson("/api/x", readAny)).toEqual({ ok: false, error: "HTTP 404", status: 404 });
   });
 
   // #913: the server says WHY. Reporting only the status turned a fixable setting into an
   // unexplained "HTTP 400" — the sister app (MulmoClaude) has always read this body.
   it("surfaces the server's own reason from the error body", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 400, json: async () => ({ error: "declare googleCalendar first" }) }));
-    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "declare googleCalendar first", status: 400 });
+    expect(await fetchJson("/api/x", readAny)).toEqual({ ok: false, error: "declare googleCalendar first", status: 400 });
   });
 
   it.each([
@@ -40,25 +54,25 @@ describe("fetchJson", () => {
     ["a JSON body whose error is empty", 500, async () => ({ error: "" })],
   ])("falls back to HTTP <status> for %s", async (_case, status, json) => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status, json }));
-    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: `HTTP ${status}`, status });
+    expect(await fetchJson("/api/x", readAny)).toEqual({ ok: false, error: `HTTP ${status}`, status });
   });
 
   // Callers branch on `status`, not on the message: the collection UI reads 404 as "not found".
   // Reading the body must not disturb that.
   it("keeps the status intact while reading the body", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({ error: "no such collection" }) }));
-    expect(await fetchJson("/api/x")).toMatchObject({ status: 404 });
+    expect(await fetchJson("/api/x", readAny)).toMatchObject({ status: 404 });
   });
 
   // The distinction the callers depend on.
   it("reports status 0 when the request never reached a server", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Failed to fetch")));
-    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "Failed to fetch", status: 0 });
+    expect(await fetchJson("/api/x", readAny)).toEqual({ ok: false, error: "Failed to fetch", status: 0 });
   });
 
   it("survives a rejection that is not an Error", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue("boom"));
-    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "boom", status: 0 });
+    expect(await fetchJson("/api/x", readAny)).toEqual({ ok: false, error: "boom", status: 0 });
   });
 
   // A 200 whose body is not JSON must not be reported as success with garbage data.
@@ -72,14 +86,14 @@ describe("fetchJson", () => {
         },
       }),
     );
-    const result = await fetchJson("/api/x");
+    const result = await fetchJson("/api/x", readAny);
     expect(result).toMatchObject({ ok: false, status: 0 });
   });
 
   it("passes the request options through", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     vi.stubGlobal("fetch", fetchMock);
-    await fetchJson("/api/x", { method: "POST" });
+    await fetchJson("/api/x", readAny, { method: "POST" });
     expect(fetchMock).toHaveBeenCalledWith("/api/x", { method: "POST" });
   });
 });


### PR DESCRIPTION
## Summary

残り **53 件を 0** にして、`no-unsafe-*` 5 ルールを **error** で常設しました。#1300 の本丸です。

| | 当初 | 現在 |
|---|---|---|
| server/ | 145 | **0** |
| src/（本物） | 262 | **0** |
| **合計（本物）** | **407** | **0** |

lint 0 errors（warning 23 は main と同数）/ typecheck 0 / build / test 7622 passed。

## Items to Confirm / Review

1. **「`.vue` を除外」では足りませんでした。** `.vue` から型を import している `.ts` 4 本も
   同じ盲点を継承します（下記）。除外リストには**どの `.vue` を import しているか**を各行に
   書いてあります。
2. **`fetchJson` に必須引数が増えました**（`read`）。呼び出しは 6 箇所。
3. **`accountingUi` / `collectionUi` を type-assertion allowlist に追加**しました。理由は
   `pluginRuntime.ts` と同じで、**upstream に issue を立てて番号を書いています**。

## User Prompt

> no-unsafe-* を error に上げ .vue をこの5ルールから除外
>
> これって、、、gui-chat-protocolにまずはissueたてる？こっちで他にできることない？

**`src/utils/fetchJson.ts` は gui-chat-protocol のものではなく、この repo のファイル**でした
（前回の私の書き方が紛らわしくてすみません）。なので issue は不要で、そのまま直せます。
一方 **gui-chat-protocol 自身の generic には issue を立てました**: receptron/gui-chat-protocol#30。

## 「`.vue` を除外」だけでは CI が赤いままになります

報告の実体は `any` ではなく **SFC の型が解決できないこと**です。そしてこの盲点は
**import を辿って `.ts` にも伝染**します。

| ファイル | import 元 |
|---|---|
| `src/main.ts` | `App.vue` |
| `src/plugins-registry.ts` | `CollectionCardView.vue` |
| `src/composables/collectionUi.ts` | `PinToggle.vue` |
| `src/components/filesPaneStore.ts` | `FilesPaneState` from `FilesPane.vue` |

`vue-tsc` は全部解決するので `yarn typecheck` は 0 のままです（前 PR で、存在しないメソッドを
呼んで型付きで拒否されることを実証済み）。

### 数え方を間違えていた点

途中まで偽陽性を `could not be resolved|error typed value` で数えていましたが、eslint は
`of type error` や `error typed assigned` とも書きます。**取りこぼしが「本物」に混ざっていた**
ので、数え直しました。

## `fetchJson<T>` — 呼び出し側が名乗った型を検証せず返していた

`read: (raw: unknown) => T` を**必須**にしました。`wikiApi` の `getJson` が既に使っている形です。

- **`useShortcuts`** — 自前エンドポイントなので `readShortcuts` を書きました。slug / title /
  icon を欠く pin は落とします（ナビゲートできない、空チップになる）。
- **`accountingUi` / `collectionUi`** — プラグインが
  `AccountingApiCall = <T = unknown>(path, opts) => Promise<ApiResult<T>>` と**generic を宣言**
  しており、T を選ぶのはプラグイン、作るのはホスト。構造的に検証不可能なので `asDeclared` を
  seam に置き allowlist に追加しました。

  **upstream issue の要点**: gui-chat-protocol は**同じ問題を自分の `fetchJson<T>` では既に
  解決済み**です（`parse` 必須、JSDoc に「so callers never get a strongly-typed value out of
  unvalidated JSON」と明記）。`dispatch<T>` / `subscribe<T>` / `getConfig<T>` だけ逆の答えに
  なっている、という指摘です。

## 見つかった実際の穴（2件）

どちらも **#1325 の `loadConfig` と同じ構図** —— 片方の経路だけ検証していました。

- **`useSessionFeed`** — `parse: (raw: unknown) => T | null` は**ライブチャンネル用に既にあり**、
  コメントにも `this used to be data as T` と書いてあるのに、**履歴の初回ロードだけ素通し**
  でした。チャンネルなら落とされる形が初回表示には載ります。
- **`useGridActivity`** — seed が `Record<string, CellActivity>` と注釈だけで通していました。
  seed のエンドポイントは **id をキーにしたマップ**を返し、値の中に `id` は入っていないため、
  既存の `parseSessionActivityPayload`（`id` で判定）は**この形には使えません**。
  `readCellActivity` を新設しました。

## そのほか

`useHeaderButtons` / `ToolsPane` / `SkillMenu` / `useLaunchOptions` / `useDirLists` などを
`jsonBody` + 要素ガードに。ガードは「**その画面が描画・操作に使う**フィールド」を見ます
（例: ヘッダーボタンは `id`（実行時に再解決するキー）/ `label`（描画）/ `run`（押した時の挙動））。

refs #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3