### PR TITLE
test: 最初のテストがモジュール読み込み代を払っていたのをやめる（#1314 の timeout）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,23 @@ anything not covered here.
 - `yarn test` — **Vitest** (`test/**/*.spec.ts`). Mock external APIs; tests must run without API keys.
 - `yarn dev` — server + Vite together (local development).
 
+### Import a component at module scope, never inside a test
+
+`await import("…/Foo.vue")` inside an `it` (or a helper an `it` awaits) pulls the component's
+whole module graph through the transform, and **the first test to reach it is billed that time
+against `testTimeout`**. On this repo that was 2132ms of loading against an 18ms mount — so the
+file's first test looked 100x slower than its siblings, and on a loaded runner it was the one
+that crossed 15s and went red (#1314). The test was never the slow part.
+
+Load it once at module scope instead — `const Foo = (await import("…/Foo.vue")).default;`, a
+top-level await, or a plain static import. Collection has no per-test budget, so the same work
+costs nothing there.
+
+The exception is a module that must be evaluated AFTER a non-hoisted mock: `vi.doMock` and
+`vi.resetModules` only take effect on a later import, so those specs (`codeBlockCopy.spec.ts`,
+several under `test/server/`) keep the import inside the test on purpose. `vi.mock` is hoisted
+and needs no such thing.
+
 ## No emojis
 **Never use emojis anywhere in this project** — UI, source comments, docs, changelog, commit
 messages, skills, CLI output. Icons are **Material Symbols (outlined)**, self-hosted via the

--- a/plans/fix-1314-first-test-pays-module-load.md
+++ b/plans/fix-1314-first-test-pays-module-load.md
@@ -1,0 +1,68 @@
+# fix #1314（続き） — 「最初のテストがモジュール読み込み代を払う」問題
+
+#1323 でソケット往復は外したが、#1314 を閉じるにはもう一方の症状 —
+**負荷時に `Error: Test timed out in 15000ms` で落ちるテスト** — の原因を潰す必要がある。
+
+## 見つけ方
+
+負荷（20コアに `yes` 24本）をかけてフルスイートを回すと、
+`test/src/components/GridView.spec.ts` の**最初のテスト**が 3/3 回タイムアウトした。
+そこで「機械が遅いから」で終わらせず、スイート全体で 300ms を超えるテストを実測して並べた。
+
+## 根本原因（計測で確定）
+
+同じファイルの中で **最初のテストだけ 2453ms、残り30本は 2〜10ms**。
+その1本を計測器で割ると：
+
+```
+import=2132ms  mount=18ms  flush=2ms
+```
+
+つまり 2.4 秒の正体は**モジュール読み込み**であって、テストの仕事ではない。
+
+`await import("…/GridView.vue")` をテスト本体（や `it` が await するヘルパ）の中で呼ぶと、
+そのコンポーネントの**モジュールグラフ全体の transform** が走る。キャッシュされるので払うのは
+一度きりだが、**払わされるのはそのファイルで最初に走ったテスト**で、しかもそれが
+`testTimeout` に課金される。アイドルなら 2.4s で収まるが、ランナーが混むとここが最初に 15s を越える。
+
+「一番重い処理をしていたテストが犠牲になる」という #903 / #1314 の見立ては合っているが、
+**その重い処理はテストのものではなかった**、というのがこの件の答え。
+
+## 対応
+
+モジュールスコープで一度だけ読む（`GuiPanelCollapse.spec.ts` が既にこの形だった）。
+collection 時に払われるので、テストごとの予算に一切乗らない。
+
+```ts
+const GridView = (await import("../../../src/components/GridView.vue")).default;
+```
+
+### 直した4ファイルと効果（そのファイルの最遅テスト）
+
+| spec | before | after |
+|---|---|---|
+| `cellChromeColors.spec.ts` | 11084ms | 44ms |
+| `terminalViewInput.spec.ts` | 7452ms | 16ms |
+| `TerminalDirFontApply.spec.ts` | 6540ms | 17ms |
+| `GridView.spec.ts` | 2453ms | 28ms |
+
+この4テストだけで **27.5秒 → 約0.1秒**。`cellChromeColors` は 11.0s で 15s の上限まで
+あと4秒しかなく、次に CI を赤くするのはこれだった。
+
+### 触らなかったもの（同じ形に見えるが違う）
+
+- `codeBlockCopy.spec.ts` と `test/server/**` の数本 — `vi.doMock` / `vi.resetModules` は
+  **ホイストされない**ので、後から import しないとモックが効かない。意図的な形なので残す。
+- `probe-transcript.spec.ts`（9700ms）— 600個のファイルを実際に作って掃く規模テスト。本物の I/O。
+- `terminalBufferHealth.spec.ts`（6554ms）— 実 xterm を動かす。import は既に静的。
+- 残りの in-body `await import()` は小さいモジュールで、300ms を超えるテストに一つも現れない。
+
+## 再発防止
+
+`CLAUDE.md` の「Run after changes」に節を追加した。`vi.doMock` / `vi.resetModules` の例外も
+明記してあるので、次に spec を書く人が一律に禁止と読まないようにしている。
+
+## 検証
+
+- `format` / `lint`（0 error）/ `typecheck` / `build` — green
+- フルスイート **3回連続で 7621 passed / 45 skipped / 0 failed**

--- a/plans/fix-1314-first-test-pays-module-load.md
+++ b/plans/fix-1314-first-test-pays-module-load.md
@@ -14,7 +14,7 @@
 同じファイルの中で **最初のテストだけ 2453ms、残り30本は 2〜10ms**。
 その1本を計測器で割ると：
 
-```
+```text
 import=2132ms  mount=18ms  flush=2ms
 ```
 
@@ -65,4 +65,4 @@ const GridView = (await import("../../../src/components/GridView.vue")).default;
 ## 検証
 
 - `format` / `lint`（0 error）/ `typecheck` / `build` — green
-- フルスイート **3回連続で 7621 passed / 45 skipped / 0 failed**
+- フルスイート **4回連続で 7621 passed / 45 skipped / 0 failed**（うち1回はコメント整理後）

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -105,8 +105,14 @@ const SettingsStub = {
 // A toolbar stub that lets us open the settings modal (GridView: @settings="showSettings = true").
 const ToolbarStub = { name: "AppToolbar", emits: ["settings"], template: '<button class="open-settings" @click="$emit(\'settings\')" />' };
 
+// At module scope, not inside a test. Measured on this file: the import was 2132ms while the
+// mount it feeds was 18ms — so the first test to run was billed two seconds of module loading
+// against `testTimeout`, and on a loaded runner that is what crossed 15s (#1314). Collection
+// has no per-test budget, so the same work costs nothing here.
+const GridView = (await import("../../../src/components/GridView.vue")).default;
+
 const mountGrid = async () => {
-  const w = mount((await import("../../../src/components/GridView.vue")).default, {
+  const w = mount(GridView, {
     global: { stubs: { TerminalGrid: true, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
   });
   await flushPromises(); // onMounted loadConfig
@@ -136,7 +142,7 @@ describe("GridView roster ordering (#720)", () => {
         sortMode: "auto",
       }),
     );
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mount(GridView, {
       global: { stubs: { TerminalGrid: OrderStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();
@@ -166,7 +172,7 @@ describe("GridView roster ordering (#720)", () => {
         sortMode: "manual",
       }),
     );
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mount(GridView, {
       global: { stubs: { TerminalGrid: OrderStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();
@@ -190,7 +196,7 @@ const ListModeGridStub = { name: "TerminalGrid", props: ["listMode", "expandedUi
 describe("GridView view toggle wiring", () => {
   it("shows the toggle only while zoomed and flips the grid's listMode when the header fires toggle-view", async () => {
     localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 10, session: IDS.idleA, cwd: "/w" }], expanded: 10, page: 0, sortMode: "manual" }));
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mount(GridView, {
       global: { stubs: { TerminalGrid: ListModeGridStub, AppToolbar: ViewToggleToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();
@@ -209,7 +215,7 @@ describe("GridView view toggle wiring", () => {
 
   it("hides the toggle when nothing is expanded", async () => {
     localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 10, session: IDS.idleA, cwd: "/w" }], expanded: null, page: 0, sortMode: "manual" }));
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mount(GridView, {
       global: { stubs: { TerminalGrid: ListModeGridStub, AppToolbar: ViewToggleToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();
@@ -231,7 +237,7 @@ describe("GridView guide help (empty state)", () => {
 
     // A running session cell (occupied) — the newcomer hint must step out of the way.
     localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 1, session: IDS.idleA, cwd: "/w" }], expanded: null, page: 0, sortMode: "manual" }));
-    const running = mount((await import("../../../src/components/GridView.vue")).default, {
+    const running = mount(GridView, {
       global: { stubs: { TerminalGrid: true, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();
@@ -307,7 +313,7 @@ const mountShortcutGrid = async (count: number, extra: Record<string, unknown> =
       ...extra,
     }),
   );
-  const w = mount((await import("../../../src/components/GridView.vue")).default, {
+  const w = mount(GridView, {
     global: { stubs: { TerminalGrid: ShortcutGridStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
   });
   await flushPromises();
@@ -462,7 +468,7 @@ describe("GridView skill launch (#1111)", () => {
       }
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -529,7 +535,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       if (String(url).includes("spawnBackgroundChat")) return { ok: true, json: async () => ({ jsonData: { chatId: SPAWNED } }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -570,7 +576,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
         return { ok: true, json: async () => ({ sessions: [{ id: UNPLACED, agent: "codex", cwd: "/proj" }] }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -597,7 +603,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       if (String(url).includes("/api/sessions/unplaced")) return { ok: true, json: async () => ({ sessions: rows }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises(); // the mount sweep: nothing waiting yet
@@ -632,7 +638,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       }
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises(); // the mount sweep is now parked inside its fetch
@@ -659,7 +665,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       if (String(url).includes("/api/sessions/unplaced")) return { ok: true, json: async () => ({ sessions: rows }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -685,7 +691,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       }
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -714,7 +720,6 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       return realFetch(url, init);
     }) as typeof fetch;
 
-    const GridView = (await import("../../../src/components/GridView.vue")).default;
     const holder = defineComponent({
       props: { show: { type: Boolean, default: true } },
       render() {
@@ -747,7 +752,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
         return { ok: true, json: async () => ({ sessions: [{ id: DUPE, agent: "claude", cwd: "/w" }] }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -772,7 +777,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
         return () => {};
       },
     };
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CanvasGridStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -805,7 +810,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
         return () => {};
       },
     };
-    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated(GridView, {
       global: { stubs: { TerminalGrid: CanvasGridStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -830,7 +835,7 @@ const ShellLaunchStub = {
 
 describe("GridView launcher picks (#1114)", () => {
   it("turns the cell into a shell launcher cell when the form picks Shell", async () => {
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mount(GridView, {
       global: { stubs: { TerminalGrid: ShellLaunchStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
     });
     await flushPromises();

--- a/test/src/components/TerminalDirFontApply.spec.ts
+++ b/test/src/components/TerminalDirFontApply.spec.ts
@@ -58,8 +58,11 @@ beforeEach(() => {
   globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
 });
 
+// At module scope, not inside a test: a component's module load is not the test's work, and
+// billing it to `testTimeout` is what makes the first test of a file the one that flakes.
+const Terminal = (await import("../../../src/components/Terminal.vue")).default;
+
 async function mountTerminal(slot: string) {
-  const Terminal = (await import("../../../src/components/Terminal.vue")).default;
   return mount(Terminal, { props: { sessionId: null, connectKey: 1, persistKey: slot, cwd: `/proj/${slot}` } });
 }
 
@@ -114,7 +117,6 @@ describe("Terminal.vue resolves its directory's look from its own cwd", () => {
 describe("Terminal.vue falls back to the dirCwd hint when it has no cwd", () => {
   it("resolves the directory's font from dirCwd alone", async () => {
     serveDirConfig({ fontSize: 18, fontFamily: "Cica, monospace" });
-    const Terminal = (await import("../../../src/components/Terminal.vue")).default;
     const w = mount(Terminal, { props: { sessionId: null, connectKey: 1, persistKey: "hinted", dirCwd: "/proj/hinted" } });
     await flushPromises();
 

--- a/test/src/components/cellChromeColors.spec.ts
+++ b/test/src/components/cellChromeColors.spec.ts
@@ -43,8 +43,13 @@ beforeEach(() => {
   }) as unknown as typeof fetch;
 });
 
+// At module scope, not inside a test: a component's module load is not the test's work, and
+// billing it to `testTimeout` is what makes the first test of a file the one that flakes.
+const TerminalCell = (await import("../../../src/components/TerminalCell.vue")).default;
+const LauncherCell = (await import("../../../src/components/LauncherCell.vue")).default;
+const CommandCell = (await import("../../../src/components/CommandCell.vue")).default;
+
 async function mountClaudeCell(cwd: string) {
-  const TerminalCell = (await import("../../../src/components/TerminalCell.vue")).default;
   return mount(TerminalCell, {
     props: {
       uid: 1,
@@ -63,14 +68,12 @@ async function mountClaudeCell(cwd: string) {
 }
 
 async function mountLauncherCell(cwd: string) {
-  const LauncherCell = (await import("../../../src/components/LauncherCell.vue")).default;
   return mount(LauncherCell, {
     props: { uid: 2, expanded: false, zoomed: false, launcher: { index: 0, label: "shell" }, session: null, cwd, home: "/home/me" },
   });
 }
 
 async function mountCommandCell(cwd: string) {
-  const CommandCell = (await import("../../../src/components/CommandCell.vue")).default;
   return mount(CommandCell, {
     props: { uid: 3, expanded: false, zoomed: false, command: { source: "script", index: 0, label: "build", cwd }, home: "/home/me" },
   });

--- a/test/src/components/terminalViewInput.spec.ts
+++ b/test/src/components/terminalViewInput.spec.ts
@@ -39,8 +39,11 @@ class ResizeObserverStub {
   disconnect() {}
 }
 
+// At module scope, not inside a test: a component's module load is not the test's work, and
+// billing it to `testTimeout` is what makes the first test of a file the one that flakes.
+const Terminal = (await import("../../../src/components/Terminal.vue")).default;
+
 const mountTerminal = async () => {
-  const Terminal = (await import("../../../src/components/Terminal.vue")).default;
   return mount(Terminal, { props: { sessionId: null, connectKey: 1, persistKey: "input-spec", cwd: "/proj/input-spec" } });
 };
 
@@ -80,7 +83,6 @@ describe("Terminal.vue reports the user typing", () => {
   // silently becomes a native listener — firing on composition and bypassing the pointer/focus
   // filtering in terminalUserInput entirely, which is the whole reason the event exists.
   it("declares `input` as a component emit, which is what shadows the native one", async () => {
-    const Terminal = (await import("../../../src/components/Terminal.vue")).default;
     expect(declaredEmits(Terminal)).toContain("input");
   });
 });


### PR DESCRIPTION
## Summary

#1314 のもう一方の症状 — 負荷時の `Error: Test timed out in 15000ms` — の根本原因を潰す。
**機械が遅いからではなく、テストがモジュール読み込み代を払わされていた**。

`await import("…/Foo.vue")` をテスト本体（や `it` が await するヘルパ）の中で呼ぶと、
コンポーネントのモジュールグラフ全体の transform が走る。キャッシュされるので払うのは一度きりだが、
**払わされるのはそのファイルで最初に走ったテスト**で、しかもそれが `testTimeout` に課金される。

計測すると `GridView.spec.ts` の最初のテストは **import=2132ms / mount=18ms / flush=2ms**。
2.4 秒の正体はテストの仕事ではなかった。

モジュールスコープで一度だけ読む形に変えた（`GuiPanelCollapse.spec.ts` が既にこの形）。

| spec（そのファイルの最遅テスト） | before | after |
|---|---|---|
| `cellChromeColors.spec.ts` | **11084ms** | 44ms |
| `terminalViewInput.spec.ts` | 7452ms | 16ms |
| `TerminalDirFontApply.spec.ts` | 6540ms | 17ms |
| `GridView.spec.ts` | 2453ms | 28ms |

この4テストだけで **27.5秒 → 約0.1秒**。`cellChromeColors` は 15s の上限まで残り4秒しかなく、
次に CI を赤くするのはこれだった。

## Items to Confirm / Review

1. **触らなかったものの線引き**を見てほしい。`vi.doMock` / `vi.resetModules` は**ホイストされない**ので、
   後から import しないとモックが効かない。`codeBlockCopy.spec.ts` と `test/server/**` の該当分は
   意図的にそのままにしている。ここを一律に直すと壊れる。
2. **`CLAUDE.md` にルールを追記**している（例外つき）。文面と置き場所が妥当か。
3. `probe-transcript.spec.ts`（9700ms）と `terminalBufferHealth.spec.ts`（6554ms）は
   **本物の仕事**（600ファイルの実 I/O、実 xterm）なので触っていない。前者は 15s まで 5.3 秒しかないので、
   別途どうするか判断が要るかもしれない。
4. A/B のために `git archive origin/main` で作った素の main コピーは、**コンポーネント spec が
   環境要因で全滅する**（symlink 先の `node_modules/…/style.css?inline` を Vite が "Denied ID" で拒否）。
   そのため before の数値は**修正前の実リポジトリで測った値**を使っている。

## User Prompt

> issue #1314 はクローズにむけてtimeoutのことも原因調査してfixして。

> これと同様な問題がもしあればなおしてほしい。そうすればciの高速化になるよね。

## 調査の進め方

1. 負荷（20コアに `yes` 24本）でフルスイートを回し、`GridView.spec.ts` の最初のテストが 3/3 回
   タイムアウトすることを確認。
2. 「機械が遅い」で終わらせず、**スイート全体で 300ms を超えるテストを実測して並べた**。
3. 同一ファイル内で最初の1本だけ桁違いに遅いことに気づき、その1本を `import` / `mount` / `flush` に
   割って計測 → 原因がモジュール読み込みだと確定。
4. 同じ形を全 spec から洗い出し、**`vi.doMock` / `vi.resetModules` 由来のものと区別**して4本に絞った。

## 検証

- `yarn format` / `yarn lint`（0 error、警告23は既存）/ `yarn typecheck` / `yarn build` — green
- フルスイート **3回連続で 7621 passed | 45 skipped | 0 failed**（コメント整理後にもう1回、計4回 green）

refs #1314

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution reliability by loading shared components before individual tests run.
  * Reduced delays and timeout risk for the first tests in affected component test suites.

* **Documentation**
  * Added guidance on component imports in tests, including exceptions for cases requiring dynamic module mocking or resets.
  * Documented the investigation, affected scenarios, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->