### PR TITLE
fix(lint): judge the type-aware sonarjs rules one finding at a time (#1300)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,22 +175,44 @@ export default [
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-return": "error",
-      // Type-aware sonarjs rules that were ALREADY configured as errors and never ran, because
-      // nothing built a type program until this block did. Turning them on is not what this change
-      // is for, and 30 findings would hide the promise ones — so they are visible at warn and get
-      // read in #1300 with the rest of the type-aware pass. They were never enforced, so this
-      // takes nothing away.
-      "sonarjs/different-types-comparison": "warn",
+      // The type-aware sonarjs rules, read one finding at a time in #1300. They had been configured
+      // as errors for a long time and never ran, because nothing built a type program until this
+      // block did — so what looks like a demotion below is the first time any of them was judged.
+      //
+      // ERROR — at zero, and each catches something real:
+      "sonarjs/different-types-comparison": "error",
+      "sonarjs/no-alphabetical-sort": "error",
+      "sonarjs/no-misleading-array-reverse": "error",
+      // ERROR here, off for `.vue` below: Vue composes emit types by intersecting call-signature
+      // interfaces, which this rule reads as "a type without members".
+      "sonarjs/no-useless-intersection": "error",
+      //
+      // WARN — the findings are external APIs we use ON PURPOSE, so this cannot reach zero, but a
+      // NEW deprecation is worth seeing. The five standing ones: `Server` from the MCP SDK (x3),
+      // whose own notice says to keep using it for the low-level `setRequestHandler` API we are on;
+      // `document.execCommand("copy")`, the synchronous copy that works on an existing selection
+      // where the async Clipboard API does not; and `e.returnValue`, which legacy Chrome/Edge still
+      // require to raise the beforeunload prompt.
       "sonarjs/deprecation": "warn",
-      "sonarjs/no-alphabetical-sort": "warn",
-      // OFF, not warn: it forbids the `void` operator, which is exactly what
-      // `no-floating-promises` asks for to mark a promise as deliberately not awaited. The two
-      // rules contradict each other and we chose the one that catches a forgotten `await`.
+      //
+      // OFF — every finding was a false positive, and the reason is structural rather than
+      // incidental, so the rule will keep producing them:
+      //
+      // `void` is what no-floating-promises asks for to mark a deliberate fire-and-forget. The two
+      // rules contradict each other; we chose the one that catches a forgotten `await`.
       "sonarjs/void-use": "off",
-      "sonarjs/function-return-type": "warn",
-      "sonarjs/reduce-initial-value": "warn",
-      "sonarjs/no-selector-parameter": "warn",
-      "sonarjs/no-misleading-array-reverse": "warn",
+      // Flags a function whose returns differ in type — but all three findings DECLARED a union
+      // return type (`"tool" | { said } | null`, `JsonValue`, `HeaderChip | null`). The union is
+      // the contract; collapsing it would mean boxing every answer to satisfy the rule.
+      "sonarjs/function-return-type": "off",
+      // Wants an initial value on `reduce()`. Both findings are provably non-empty — one guards
+      // `length === 0` on the line above, the other reduces `[head, ...rest]` — and the rule cannot
+      // see either. An initial value there would be dead code that also changes the result type.
+      "sonarjs/reduce-initial-value": "off",
+      // Wants two functions instead of a boolean parameter. Its one finding takes `secret` from a
+      // caller that COMPUTES it (`Object.keys(env).length > 0`), so splitting the function just
+      // moves the same branch to the call site.
+      "sonarjs/no-selector-parameter": "off",
     },
   },
   {
@@ -202,12 +224,12 @@ export default [
     rules: {
       "@typescript-eslint/no-floating-promises": "warn",
       "@typescript-eslint/no-misused-promises": "warn",
-      // Another rule that only became reachable with a type program, and it is wrong here: it
-      // calls an interface holding nothing but CALL signatures "a type without members", so
-      // `SoundEmits & { (e: "…"): void }` reads as a useless intersection. That composition is
-      // how Vue's type-based `defineEmits<>` reuses a child's contract — dropping it would drop
-      // the child's events. At warn pending #1300, like the others it woke.
-      "sonarjs/no-useless-intersection": "warn",
+      // OFF here, error everywhere else (#1300). The rule calls an interface holding nothing but
+      // CALL signatures "a type without members", so `GridCellEmits & { (e: "session", id): void }`
+      // reads as a useless intersection. That composition is how Vue's type-based `defineEmits<>`
+      // reuses a child's contract, and dropping it would drop the child's events — all four
+      // findings were that, and every one of them was in a `.vue`.
+      "sonarjs/no-useless-intersection": "off",
     },
   },
   {

--- a/plans/fix-1300-sonarjs-decisions.md
+++ b/plans/fix-1300-sonarjs-decisions.md
@@ -1,0 +1,88 @@
+# fix(lint): 型情報つき sonarjs 8 種を1件ずつ判断する (#1300 の残り)
+
+型プログラムが入って初めて動き出し、`warn` で放置していた sonarjs ルール群。**18 件を1件ずつ
+読んで**、ルールごとに error / warn / off を決めた。
+
+| | before | after |
+|---|---|---|
+| sonarjs の warning | 18 | **5** |
+| lint warning 合計 | 23 | **10** |
+
+## 直したもの（3件）
+
+### `different-types-comparison` — 死にコードだった（1件）
+
+`terminalFilePathLinks.ts` の `if (start === undefined) continue;`。**`matchAll` は global 正規表現を
+要求し、返すマッチには仕様上つねに `index` が入る**ので型も `number`。ガードは常に偽だった。
+
+前回この規則が挙げた 9 件は `noUncheckedIndexedAccess` 欠落による偽陽性だったが、**それは
+#1310 で解消済み**で、今回のこれは本物。削除して **error** に上げた。
+
+消したガードが何を守っていたつもりだったのかを固定するテストを 2 件追加（index 0 から始まる
+パス、1行に複数マッチして range が本文に戻ること）。この関数の spec は元々あった。
+
+### `deprecation` — Node の型エイリアス（2件）
+
+`NodeJS.UnhandledRejectionListener` / `UncaughtExceptionListener` は `@types/node` が deprecate
+済みで、**doc が代替を名指し**している（`ProcessEventMap['unhandledRejection']`）。そのとおりに
+書き換えた。
+
+## error に上げたもの
+
+| ルール | 理由 |
+|---|---|
+| `different-types-comparison` | 0 件。型上つねに偽の比較は本物のバグの匂い |
+| `no-alphabetical-sort` | 0 件。`sort()` の既定は文字列比較で、数値配列では壊れる |
+| `no-misleading-array-reverse` | 0 件。`reverse()` は破壊的 |
+| `no-useless-intersection` | `.ts` では 0 件（`.vue` は下記で off） |
+
+## off にしたもの — **偽陽性の理由が構造的**で、放っておくと出続ける
+
+### `function-return-type`（3件）
+
+3 件とも **union の戻り値型を宣言している**関数だった。
+
+| 箇所 | 宣言 |
+|---|---|
+| `probeEvidenceIn` | `"tool" \| { said: string } \| null` |
+| `fromParsed` | `JsonValue`（それ自体が union） |
+| `sanitizeChip` | `HeaderChip \| null` |
+
+union が契約そのもの。潰すには全部を箱に入れることになり、ルールを満たすためだけに型が悪くなる。
+
+### `reduce-initial-value`（2件）
+
+どちらも**空になり得ない**。
+
+- `codex-rate-limits.ts` — 直前の行が `if (near.length === 0) return null;`
+- `screen-rows.ts` — `[head, ...rest]` を畳んでいるので必ず 1 要素以上
+
+ルールはどちらも見えない。初期値を足すと**死にコードであるうえに戻り値の型まで変わる**。
+
+### `no-selector-parameter`（1件）
+
+`settingsArgument(sessionId, json, secret, platform)`。唯一の本番呼び出しが
+`Object.keys(resolved.env).length > 0` と**計算した値**を渡している。関数を 2 つに割っても、
+同じ分岐が呼び出し側に移るだけ。
+
+### `no-useless-intersection` — `.vue` のみ off（4件）
+
+**Vue の `defineEmits<>` は呼び出しシグネチャだけを持つ interface を交差させて emit 型を合成する**
+（`GridCellEmits & { (e: "session", id: string): void }`）。ルールはそれを「メンバーの無い型」と
+読む。外せば子の emit が消える。4 件すべて `.vue` で、`.ts` では 0 件だったので **`.vue` だけ off、
+他は error**。
+
+### `void-use`（変更なし・off のまま）
+
+`no-floating-promises` が求める `void` を禁じる。両立しないので、await 忘れを捕まえる方を採る。
+
+## warn のまま残したもの — `deprecation`（5件）
+
+**意図的に使っている外部 API なので 0 にはならない**が、**新しい deprecation が出たときは見たい**。
+残る 5 件と、それぞれ残す理由:
+
+| 箇所 | 理由 |
+|---|---|
+| MCP SDK の `Server`（3件） | SDK 自身の注記が「**低レベル API を使う advanced use case では `Server` を使え**」と言っている。私たちは `setRequestHandler` を使う低レベル利用 |
+| `document.execCommand("copy")` | 既存の選択範囲に対して**同期で**効くコピー。非同期の Clipboard API では置き換えられない |
+| `e.returnValue` | legacy Chrome/Edge が beforeunload のプロンプトを出すのに今も要求する（コード側にも元からコメントあり） |

--- a/server/infra/process-guards.ts
+++ b/server/infra/process-guards.ts
@@ -12,13 +12,16 @@
 // logged stack is also what lets us find and fix the real emitter (Step B). A genuinely
 // fatal bind failure still exits, because server.on("error") in index.ts runs its own
 // process.exit before anything reaches here.
+import type { ProcessEventMap } from "node:process";
 import { messageOf } from "../errors.js";
 
-const onUnhandledRejection: NodeJS.UnhandledRejectionListener = (reason) => {
+// The listener signatures come from ProcessEventMap rather than the NodeJS.*Listener aliases:
+// @types/node deprecated those and names this as the replacement.
+const onUnhandledRejection = (...[reason]: ProcessEventMap["unhandledRejection"]) => {
   console.error("[fatal] unhandledRejection — process kept alive:", reason instanceof Error ? (reason.stack ?? reason) : reason);
 };
 
-const onUncaughtException: NodeJS.UncaughtExceptionListener = (err) => {
+const onUncaughtException = (...[err]: ProcessEventMap["uncaughtException"]) => {
   console.error(`[fatal] uncaughtException — process kept alive: ${messageOf(err)}`);
   if (err instanceof Error && err.stack) console.error(err.stack);
 };

--- a/src/composables/terminalFilePathLinks.ts
+++ b/src/composables/terminalFilePathLinks.ts
@@ -31,8 +31,9 @@ function endsInFileExtension(text: string): boolean {
 export function findFilePathLinks(line: string): FilePathLink[] {
   const links: FilePathLink[] = [];
   for (const match of line.matchAll(PATH_TOKEN)) {
+    // No `undefined` guard: matchAll requires a global regex and the spec sets `index` on every
+    // match it yields, which is why the type is `number` rather than `number | undefined`.
     const start = match.index;
-    if (start === undefined) continue;
     let text = match[0];
     let end = start + text.length;
     while (text.endsWith(".")) {

--- a/test/src/terminalFilePathLinks.spec.ts
+++ b/test/src/terminalFilePathLinks.spec.ts
@@ -62,3 +62,21 @@ describe("findFilePathLinks", () => {
     expect(texts("no paths on this line at all")).toEqual([]);
   });
 });
+
+// The loop used to `continue` on `match.index === undefined`. That guard was dead: matchAll
+// requires a global regex and the spec sets `index` on every match it yields, which is why the
+// type is `number`. These pin what it was silently protecting — the FIRST match, at index 0, and
+// a run of them — so removing it stays a no-op.
+describe("every match carries its index (the removed undefined guard)", () => {
+  it("finds a path that starts at index 0", () => {
+    expect(findFilePathLinks("src/main.ts is the entry")).toEqual([{ start: 0, end: 11, text: "src/main.ts" }]);
+  });
+
+  it("finds every path on a line, in order, with ranges that slice back to the text", () => {
+    const line = "see src/a.ts and lib/b.css and docs/c.md";
+    const hits = findFilePathLinks(line);
+
+    expect(hits.map((h) => h.text)).toEqual(["src/a.ts", "lib/b.css", "docs/c.md"]);
+    for (const hit of hits) expect(line.slice(hit.start, hit.end)).toBe(hit.text);
+  });
+});


### PR DESCRIPTION
## Summary

型プログラムが入って初めて動き出し、`warn` で放置していた sonarjs 8 種。**18 件を1件ずつ読んで**
ルールごとに error / warn / off を決めました。#1300 の最後の残課題です。

| | before | after |
|---|---|---|
| sonarjs の warning | 18 | **5** |
| lint warning 合計 | 23 | **10** |

**本物は 3 件、残り 15 件は偽陽性か意図的な使用**でした。しかも偽陽性の理由が**構造的**なので、
放置すると出続けます。だからルールごと off にしています（1件ずつ握りつぶす形にはしていません）。

## Items to Confirm / Review

1. **`terminalFilePathLinks.ts` からガードを1つ削除**しました。`matchAll` の仕様上つねに `index`
   が入るため常に偽です。消したガードが守っていたつもりのものを**テスト2件で固定**しています。
2. **`deprecation` は warn のまま**です。0 にはなりませんが、新しい deprecation は見たいので。
3. **`no-useless-intersection` は `.vue` だけ off**、`.ts` は error です（`.ts` は 0 件でした）。

## User Prompt

> sonarjs 8種も判断して、できそうなものやって

## 直したもの（3件）

### `different-types-comparison` — 死にコードでした

`if (start === undefined) continue;` —— **`matchAll` は global 正規表現を要求し、返すマッチには
仕様上つねに `index` が入る**ので、型も `number` です。常に偽でした。

> このルールが前回挙げた 9 件は `noUncheckedIndexedAccess` 欠落による偽陽性でしたが、**それは
> #1310 で解消済み**です。今回のは本物でした。

削除して **error** に上げました。

### `deprecation` — Node の型エイリアス（2件）

`NodeJS.UnhandledRejectionListener` / `UncaughtExceptionListener` は `@types/node` が deprecate
済みで、**doc が代替を名指し**しています（`ProcessEventMap['unhandledRejection']`）。そのとおりに。

## error に上げたもの

`different-types-comparison` / `no-alphabetical-sort` / `no-misleading-array-reverse` /
`no-useless-intersection`（`.ts`）—— いずれも 0 件で、それぞれ実害のある形を捕まえます。

## off にしたもの — 偽陽性の理由が構造的

| ルール | 件数 | なぜルールが今後も間違え続けるか |
|---|---|---|
| `function-return-type` | 3 | 3件とも **union の戻り値型を宣言**（`"tool" \| {said} \| null` / `JsonValue` / `HeaderChip \| null`）。union が契約そのもの |
| `reduce-initial-value` | 2 | どちらも**空になり得ない**（直前に `length === 0` ガード／`[head, ...rest]`）。初期値は死にコードかつ戻り値型を変える |
| `no-selector-parameter` | 1 | 唯一の本番呼び出しが `Object.keys(env).length > 0` と**計算した値**を渡す。割っても分岐が呼び出し側に移るだけ |
| `no-useless-intersection`（`.vue` のみ） | 4 | **Vue の `defineEmits<>` は呼び出しシグネチャだけの interface を交差**させて emit 型を合成する。外すと子の emit が消える |

## warn のまま — `deprecation`（5件）

**意図的に使っている外部 API**なので 0 にはなりません。

| 箇所 | 残す理由 |
|---|---|
| MCP SDK の `Server`（3件） | **SDK 自身の注記**が「Only use `Server` for advanced use cases」。私たちは `setRequestHandler` の低レベル利用 |
| `document.execCommand("copy")` | 既存の選択範囲に**同期で**効くコピー。非同期の Clipboard API では代替できない |
| `e.returnValue` | legacy Chrome/Edge が beforeunload のプロンプトに今も要求（コード側に元からコメントあり） |

`yarn lint` 0 errors / `typecheck` 0 / `build` / `test` 7626 passed。

refs #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3