### PR TITLE
feat: Canvas と Tools ペインを端末領域いっぱいに広げられるようにする

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -28,7 +28,9 @@ interface ToolResult {
 const props = defineProps<{
   sessionId: string | null;
   sendTextMessage: (text: string) => boolean;
-  toolsOpen?: boolean;
+  // Whether the panel currently covers the terminal area. Owned by the grid (it is the grid's
+  // layout that changes), shown here because the button that flips it lives in this toolbar.
+  expanded?: boolean;
   // Why this panel cannot show anything, when that is knowable. The pane outlives the cell it
   // was opened on — walking the zoom to a launcher or to a directory with no render MCP leaves
   // it mounted — and the empty-state hint below ("ask Claude to use one of these") is a LIE in
@@ -36,7 +38,7 @@ const props = defineProps<{
   // panel is usable, which keeps the single view (where it always is) unchanged.
   unavailable?: "no-session" | "no-canvas-mcp" | null;
 }>();
-const emit = defineEmits<{ toggleTools: [] }>();
+const emit = defineEmits<{ toggleExpand: []; close: [] }>();
 
 const results = ref<ToolResult[]>([]);
 
@@ -283,16 +285,34 @@ const hasTools = computed(() => toolSections.value.some((section) => section.too
   <section class="flex h-full min-w-0 flex-1 flex-col border-l border-border bg-deep">
     <div class="py-2 px-4 bg-panel text-fg font-sans text-[14px] flex items-center justify-between">
       <span class="font-semibold">Canvas</span>
-      <button
-        v-if="!toolsOpen"
-        type="button"
-        class="bg-transparent border-0 text-dim text-[15px] leading-none py-0.5 px-1 cursor-pointer rounded hover:text-fg"
-        title="Tools & tool-call history"
-        aria-label="Open tools pane"
-        @click="emit('toggleTools')"
-      >
-        <span class="material-symbols-outlined" aria-hidden="true">build</span>
-      </button>
+      <!-- Close sits at the RIGHT END, where the files and tools panes put theirs — three panes
+           share one slot, so the button that dismisses whichever one is showing has to be in the
+           same place each time. Expand is the pane's own control and sits inside it. -->
+      <div class="flex items-center gap-1">
+        <!-- Same glyph pair as a cell's own enlarge/restore button (CellChromeButtons), because it
+             is the same gesture one level in: give this thing the whole area beside the roster. -->
+        <button
+          type="button"
+          data-testid="canvas-expand-btn"
+          class="bg-transparent border-0 text-dim text-[15px] leading-none py-0.5 px-1 cursor-pointer rounded hover:text-fg"
+          :title="expanded ? 'Restore the terminal beside the canvas' : 'Expand the canvas over the terminal'"
+          :aria-label="expanded ? 'Restore canvas width' : 'Expand canvas'"
+          :aria-pressed="expanded === true"
+          @click="emit('toggleExpand')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
+        </button>
+        <button
+          type="button"
+          data-testid="canvas-close-btn"
+          class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
+          title="Close canvas pane"
+          aria-label="Close canvas pane"
+          @click="emit('close')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
+        </button>
+      </div>
     </div>
     <div ref="scrollRef" data-testid="canvas-scroll" class="flex-1 overflow-y-auto px-4 py-3 font-sans text-[14px] leading-normal text-fg" @scroll="onScroll">
       <!-- Unavailable outranks empty: both look like "nothing here", but only one of them is

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -196,6 +196,12 @@ const paneFull = computed(() => paneExpanded.value && (rightPane.value === "canv
 function togglePaneExpanded(): void {
   paneExpanded.value = !paneExpanded.value;
 }
+// Collapsing the zoom is the other way out of the takeover, and it does not go through
+// setRightPane: the pane stays mounted, merely hidden with the row. Without this, zooming back in
+// — on ANY cell — would come up full-width. Reported by CodeRabbit on PR #1333.
+watch(zoomed, (is) => {
+  if (!is) paneExpanded.value = false;
+});
 const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
 const zoomRow = ref<HTMLElement | null>(null);
 // A separator is `flex-none` and belongs to NEITHER side, so counting its 5px as usable is how a
@@ -652,6 +658,25 @@ function setRosterWidth(width: number): void {
   if (rightPane.value && !paneFull.value) setPaneWidth(paneWidth.value, available - rosterWidth.value - PANE_CHROME_PX);
 }
 
+// Both floors change under a full-width transition, so both geometries are re-clamped after it.
+// GOING FULL, the roster's floor rises from the terminal's to the pane's (MIN_GUI is the larger),
+// so a roster already at its old maximum would leave the pane under its minimum. COMING BACK, a
+// roster widened while the pane was full has taken room the split row needs, and the paneWidth
+// waiting to be restored was clamped against the row as it was BEFORE that — restoring it
+// unclamped is what squeezes the terminal to nothing. Reported by Codex on PR #1333.
+//
+// The pane is re-clamped only on the way back: while it is full its remembered split width is not
+// in play, and clamping it against a row it does not currently share would shrink it for nothing.
+watch(paneFull, async (full) => {
+  await nextTick();
+  // In list mode setRosterWidth re-clamps the pane itself, from the width it COMPUTES for the row
+  // rather than one measured off a row the browser may not have laid out yet — the same reason
+  // setPaneWidth takes an `available` parameter at all. Strip mode has no roster, so there the
+  // pane is re-clamped directly.
+  if (props.listMode) setRosterWidth(rosterWidth.value);
+  else if (!full) setPaneWidth(paneWidth.value);
+});
+
 function setStripHeight(height: number): void {
   const available = stageHeight();
   stageHeightNow.value = available;
@@ -901,7 +926,14 @@ watch(
          in strip mode (terminal / filmstrip), so only nesting puts the pane beside the terminal
          in both. Hidden outright when nothing is zoomed, like .zoom-main itself. -->
     <div ref="zoomRow" :class="[zoomed ? 'zoom-row flex min-h-0 min-w-0 flex-auto' : 'hidden', paneFull ? 'pane-full' : '']">
-      <div ref="zoomMain" class="zoom-main" />
+      <!-- Off-screen but still MOUNTED is what keeps xterm measurable (#1125) — and a terminal has
+           plenty to focus: its header buttons and xterm's own textarea. Without `inert`, Shift+Tab
+           from the pane's first control walks into controls nobody can see. Reported by Codex on
+           PR #1333. `inert` takes the subtree out of the tab order and off the accessibility tree
+           without touching layout, which is exactly the half we need to keep. -->
+      <!-- `|| undefined` rather than the boolean: `inert` is Booleanish to Vue, so `false` reaches
+           the DOM as inert="false" — which is an inert element. -->
+      <div ref="zoomMain" class="zoom-main" :inert="paneFull || undefined" />
       <template v-if="rightPane">
         <div
           v-if="!paneFull"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -183,6 +183,19 @@ function restoredPane(value: string | null): RightPane | null {
 }
 const rightPane = ref<RightPane | null>(restoredPane(stored(PANE_OPEN_KEY)));
 const filesOpen = computed(() => rightPane.value === "files");
+// A pane taken full-width: it covers the enlarged terminal, NOT the roster — a document the agent
+// drew is read, and 480px of a split row is not a reading width. Canvas and Tools can ask for it;
+// the files pane is edited beside the terminal and does not.
+//
+// Deliberately NOT remembered, unlike the pane's width and open-state (and unlike the first cut of
+// this, which was): a pane that opens on top of the terminal is a surprise every time but the one
+// where you asked for it, and the thing it hid is the thing you were working in. So it lasts as
+// long as the pane does — closing it, or switching to another one, is the end of the takeover.
+const paneExpanded = ref(false);
+const paneFull = computed(() => paneExpanded.value && (rightPane.value === "canvas" || rightPane.value === "tools"));
+function togglePaneExpanded(): void {
+  paneExpanded.value = !paneExpanded.value;
+}
 const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
 const zoomRow = ref<HTMLElement | null>(null);
 // A separator is `flex-none` and belongs to NEITHER side, so counting its 5px as usable is how a
@@ -209,6 +222,9 @@ function setRightPane(pane: RightPane | null): void {
   const leavingFiles = filesOpen.value && pane !== "files";
   if (leavingFiles) rememberPaneState(paneUid.value);
   rightPane.value = pane;
+  // Every arrival at a pane is a split row. See paneExpanded: the takeover is asked for, never
+  // inherited — including by the same pane reopened later.
+  paneExpanded.value = false;
   // Leaving files drops the cell it was on, so coming back lands on whichever cell is enlarged
   // THEN rather than resuming a directory the user has since walked away from.
   if (leavingFiles) {
@@ -608,7 +624,12 @@ const stageHeight = () => Math.max(0, (stage.value?.clientHeight ?? 0) - SEPARAT
 // but its separator is real estate that exists whenever it is open, so the terminal's floor has
 // to be stated on top of it. Without this the roster happily takes the pane's separator too and
 // the terminal lands a few pixels under its minimum.
-const rosterFloors = computed(() => ({ primary: MIN_TERMINAL + (rightPane.value ? PANE_CHROME_PX : 0), secondary: MIN_ROSTER }));
+// While the canvas is full-width there is no terminal beside it and no separator between them, so
+// what has to survive to the right of the roster is the canvas's own floor and nothing else.
+const rosterFloors = computed(() => {
+  if (paneFull.value) return { primary: MIN_GUI, secondary: MIN_ROSTER };
+  return { primary: MIN_TERMINAL + (rightPane.value ? PANE_CHROME_PX : 0), secondary: MIN_ROSTER };
+});
 // Mirrored into refs for the same reason paneMax is: a plain call would not re-render the
 // separator's announced range when the stage resizes.
 const stageWidthNow = ref(0);
@@ -626,7 +647,9 @@ function setRosterWidth(width: number): void {
   // The row the terminal shares with the file pane is what the roster just took from, so the
   // pane is re-clamped against the width the row is ABOUT to have. Computed rather than measured
   // for the reason setPaneWidth's parameter exists.
-  if (rightPane.value) setPaneWidth(paneWidth.value, available - rosterWidth.value - PANE_CHROME_PX);
+  // Skipped while the canvas is full-width: it is not sharing the row with a terminal, so its
+  // remembered split width has nothing to be re-clamped against and must survive the drag intact.
+  if (rightPane.value && !paneFull.value) setPaneWidth(paneWidth.value, available - rosterWidth.value - PANE_CHROME_PX);
 }
 
 function setStripHeight(height: number): void {
@@ -877,10 +900,11 @@ watch(
          siblings of the stage: the stage is a ROW in list mode (roster | terminal) and a COLUMN
          in strip mode (terminal / filmstrip), so only nesting puts the pane beside the terminal
          in both. Hidden outright when nothing is zoomed, like .zoom-main itself. -->
-    <div ref="zoomRow" :class="zoomed ? 'flex min-h-0 min-w-0 flex-auto' : 'hidden'">
+    <div ref="zoomRow" :class="[zoomed ? 'zoom-row flex min-h-0 min-w-0 flex-auto' : 'hidden', paneFull ? 'pane-full' : '']">
       <div ref="zoomMain" class="zoom-main" />
       <template v-if="rightPane">
         <div
+          v-if="!paneFull"
           class="w-[5px] flex-none cursor-col-resize bg-border hover:bg-accent focus-visible:bg-accent"
           role="separator"
           aria-orientation="vertical"
@@ -917,14 +941,20 @@ watch(
           :session-id="expandedSessionId"
           :send-text-message="sendToExpandedCell"
           :unavailable="canvasUnavailable"
-          :style="{ flex: `0 0 ${paneWidth}px` }"
-          @toggle-tools="toggleRightPane('tools')"
+          :expanded="paneFull"
+          :style="{ flex: paneFull ? '1 1 0%' : `0 0 ${paneWidth}px` }"
+          @toggle-expand="togglePaneExpanded"
+          @close="setRightPane(null)"
         />
+        <!-- `width: auto` only while full: the pane sets its own w-[340px], and a fixed width
+             beside `flex: 1` is the one combination where the class outlives the layout. -->
         <ToolsPane
           v-else-if="rightPane === 'tools'"
           :session-id="expandedSessionId"
-          :style="{ flex: `0 0 ${paneWidth}px` }"
+          :expanded="paneFull"
+          :style="paneFull ? { flex: '1 1 0%', width: 'auto' } : { flex: `0 0 ${paneWidth}px` }"
           class="border-l border-border"
+          @toggle-expand="togglePaneExpanded"
           @close="setRightPane(null)"
         />
       </template>
@@ -1093,6 +1123,23 @@ watch(
 
 .stage.zoomed:not(.listmode) .zoom-main {
   padding: 6px 6px 0;
+}
+
+/* Canvas taken full-width: it covers the terminal, and only the terminal. The row it is in is
+   nested inside the stage, so BOTH zoomed modes reach this — in strip mode the filmstrip below
+   and in list mode the roster to the left are outside the row and stay exactly where they were.
+   The terminal is parked OFF-SCREEN at a real size rather than `display: none`, for the same
+   reason list mode parks the tiled grid there (#1125): a hidden xterm fits itself to zero and
+   comes back reflowed. Selector carries four classes so it outranks both modes' padding above,
+   whatever the source order. */
+.stage.zoomed .zoom-row.pane-full .zoom-main {
+  position: absolute;
+  left: -99999px;
+  top: 0;
+  width: 900px;
+  height: 600px;
+  flex: none;
+  padding: 0;
 }
 
 .stage.zoomed:not(.listmode) .grid {

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -26,8 +26,13 @@ interface ToolCall {
   durationMs?: number;
 }
 
-const props = defineProps<{ sessionId: string | null }>();
-const emit = defineEmits<{ close: [] }>();
+const props = defineProps<{
+  sessionId: string | null;
+  // Whether this pane currently covers the terminal area. Owned by the grid (it is the grid's
+  // layout that changes), shown here because the button that flips it lives in this header.
+  expanded?: boolean;
+}>();
+const emit = defineEmits<{ close: []; toggleExpand: [] }>();
 
 // Whether this session's history holds the GUI tools ALONE (the broker fed it) rather than every
 // tool (claude's hooks fed it). An empty GUI-only history looks exactly like an agent that ran
@@ -183,15 +188,31 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   <section class="flex h-full w-[340px] shrink-0 flex-col border-l border-border bg-deep">
     <div class="flex items-center justify-between bg-panel px-4 py-2 font-sans text-[14px] text-fg">
       <span class="font-semibold">Tools</span>
-      <button
-        type="button"
-        class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
-        title="Close tools pane"
-        aria-label="Close tools pane"
-        @click="emit('close')"
-      >
-        <span class="material-symbols-outlined" aria-hidden="true">close</span>
-      </button>
+      <!-- Expand then close, in that order, exactly as the Canvas header has them: the two panes
+           share one slot, so the same control must be in the same place in both. -->
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          data-testid="tools-expand-btn"
+          class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
+          :title="expanded ? 'Restore the terminal beside the tools' : 'Expand the tools over the terminal'"
+          :aria-label="expanded ? 'Restore tools pane width' : 'Expand tools pane'"
+          :aria-pressed="expanded === true"
+          @click="emit('toggleExpand')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
+        </button>
+        <button
+          type="button"
+          data-testid="tools-close-btn"
+          class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
+          title="Close tools pane"
+          aria-label="Close tools pane"
+          @click="emit('close')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
+        </button>
+      </div>
     </div>
     <div class="flex-1 overflow-y-auto font-sans text-[13px] text-fg">
       <!-- Available tools -->

--- a/test/src/components/GuiPanelExpand.spec.ts
+++ b/test/src/components/GuiPanelExpand.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import GuiPanel from "../../../src/components/GuiPanel.vue";
+
+// The Canvas toolbar's buttons. They only ASK — the grid owns the layout and the state — so what
+// this pins is that the expand button reports the state it was handed, in the glyph and to a
+// screen reader. The layout it produces is pinned in paneExpand.spec.ts, and the Tools pane's
+// matching header in ToolsPaneExpand.spec.ts.
+
+const mountPanel = (expanded?: boolean) =>
+  mount(GuiPanel, {
+    props: { sessionId: "s1", sendTextMessage: () => true, ...(expanded === undefined ? {} : { expanded }) },
+    global: { stubs: { PluginFrame: true } },
+  });
+
+describe("the Canvas toolbar", () => {
+  it("asks the grid to expand, and says which way it would go", async () => {
+    const w = mountPanel(false);
+    const btn = w.get('[data-testid="canvas-expand-btn"]');
+    expect(btn.text()).toBe("open_in_full");
+    expect(btn.attributes("aria-pressed")).toBe("false");
+
+    await btn.trigger("click");
+    expect(w.emitted("toggleExpand")).toHaveLength(1);
+  });
+
+  it("flips to restore once expanded", () => {
+    const btn = mountPanel(true).get('[data-testid="canvas-expand-btn"]');
+    expect(btn.text()).toBe("close_fullscreen");
+    expect(btn.attributes("aria-pressed")).toBe("true");
+  });
+
+  // Three panes share one slot, so the button that dismisses the one showing has to be in the
+  // same place whichever it is: last in the header, the `close` glyph, like files and tools.
+  it("closes from the right end of the header, as the other panes do", async () => {
+    const w = mountPanel(false);
+    const buttons = w.findAll("header button, div button");
+    expect(buttons[buttons.length - 1].attributes("data-testid")).toBe("canvas-close-btn");
+    expect(buttons[buttons.length - 1].text()).toBe("close");
+
+    await w.get('[data-testid="canvas-close-btn"]').trigger("click");
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+
+  // The Tools pane has its own button on every cell's header; a second way in from here was one
+  // more thing in a toolbar that now has a job of its own.
+  it("no longer offers the tools pane", () => {
+    expect(mountPanel().text()).not.toContain("build");
+  });
+});

--- a/test/src/components/ToolsPaneExpand.spec.ts
+++ b/test/src/components/ToolsPaneExpand.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import ToolsPane from "../../../src/components/ToolsPane.vue";
+
+// The Tools header carries the same pair as the Canvas one, in the same order — the two panes
+// share one slot, so a control that moved between them would be a control the user has to look
+// for. Kept as its own file rather than folded into GuiPanelExpand.spec.ts so that a change to
+// either header fails on the header it changed.
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+const mountPane = (expanded?: boolean) => mount(ToolsPane, { props: { sessionId: "s1", ...(expanded === undefined ? {} : { expanded }) } });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ groups: [], tools: [], calls: [] }) })),
+  );
+});
+
+describe("the Tools pane header", () => {
+  it("asks the grid to expand, and says which way it would go", async () => {
+    const w = mountPane(false);
+    const btn = w.get('[data-testid="tools-expand-btn"]');
+    expect(btn.text()).toBe("open_in_full");
+    expect(btn.attributes("aria-pressed")).toBe("false");
+
+    await btn.trigger("click");
+    expect(w.emitted("toggleExpand")).toHaveLength(1);
+  });
+
+  it("flips to restore once expanded", () => {
+    const btn = mountPane(true).get('[data-testid="tools-expand-btn"]');
+    expect(btn.text()).toBe("close_fullscreen");
+    expect(btn.attributes("aria-pressed")).toBe("true");
+  });
+
+  it("keeps close last, as the Canvas header does", async () => {
+    const w = mountPane(false);
+    const buttons = w.findAll("button");
+    expect(buttons[0].attributes("data-testid")).toBe("tools-expand-btn");
+    expect(buttons[1].attributes("data-testid")).toBe("tools-close-btn");
+
+    await buttons[1].trigger("click");
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+});

--- a/test/src/components/paneExpand.spec.ts
+++ b/test/src/components/paneExpand.spec.ts
@@ -162,6 +162,52 @@ describe("expanding a pane over the terminal", () => {
     expect(w.find('[aria-label="Resize side pane"]').exists()).toBe(true);
   });
 
+  // Off-screen is not out of reach: the parked cell keeps its header buttons and xterm's textarea,
+  // so without `inert` a Shift+Tab out of the pane lands on controls nobody can see.
+  it("takes the parked terminal out of the tab order, and puts it back", async () => {
+    const w = mountGrid();
+    await open(w);
+    expect(w.find(".zoom-main").attributes("inert")).toBeUndefined();
+
+    await clickExpand(w);
+    expect(w.find(".zoom-main").attributes("inert")).toBeDefined();
+
+    await clickExpand(w);
+    expect(w.find(".zoom-main").attributes("inert")).toBeUndefined();
+  });
+
+  // The roster's floor is the PANE's while full and the TERMINAL's while split, so a roster
+  // dragged out while full has taken room the split row needs back. Restoring the remembered
+  // paneWidth unclamped is what squeezes the terminal to nothing.
+  it("re-clamps the split row after the roster moved while it was full", async () => {
+    const widths = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(1200);
+    try {
+      const w = mountGrid();
+      await open(w);
+      await clickExpand(w);
+
+      // End = give the roster everything the pane's floor allows.
+      await w.get('[aria-label="Resize the roster"]').trigger("keydown", { key: "End" });
+      await clickExpand(w);
+
+      const roster = Number(
+        w
+          .get('[data-testid="cockpit"]')
+          .attributes("style")
+          ?.match(/flex-basis: (\d+)px/)?.[1],
+      );
+      const paneW = Number(
+        pane(w)
+          .attributes("style")
+          ?.match(/flex: 0 0 (\d+)px/)?.[1],
+      );
+      // Whatever the two took, the terminal keeps its floor (MIN_TERMINAL = 320) out of the stage.
+      expect(1200 - 5 - roster - 6 - paneW).toBeGreaterThanOrEqual(320);
+    } finally {
+      widths.mockRestore();
+    }
+  });
+
   it("closes from its own header, full-width or not", async () => {
     const w = mountGrid();
     await open(w);
@@ -201,6 +247,19 @@ describe("the takeover is not remembered", () => {
 
     await open(w);
     expect(pane(w).props("expanded")).toBe(false);
+  });
+
+  // The other way out: collapsing the zoom hides the row without unmounting the pane, so nothing
+  // in setRightPane runs. Zooming back in — on this cell or another — must still be a split row.
+  it("does not survive collapsing the zoom", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+
+    await w.setProps({ expandedUid: null });
+    await w.setProps({ expandedUid: 2 });
+    expect(pane(w).props("expanded")).toBe(false);
+    expect(w.find(".zoom-row").classes()).not.toContain("pane-full");
   });
 
   it("does not survive a reload", async () => {

--- a/test/src/components/paneExpand.spec.ts
+++ b/test/src/components/paneExpand.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { h, type VNode } from "vue";
+import TerminalGrid from "../../../src/components/TerminalGrid.vue";
+import type { Cell } from "../../../src/components/gridTabs.js";
+
+// The Canvas or the Tools pane taken full-width. Two things are pinned here.
+//
+// WHICH PARTS OF THE SCREEN it may take: the enlarged terminal and nothing else — the roster on
+// the left and the filmstrip below are outside the row it lives in — and the terminal it covers
+// stays MOUNTED off-screen, because a hidden xterm fits itself to zero and comes back reflowed
+// (#1125).
+//
+// HOW LONG it lasts: exactly as long as the pane does. It is not remembered, and it does not
+// survive a close, a reopen, or a switch to another pane.
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+vi.mock("../../../src/components/TerminalCell.vue", () => ({
+  default: {
+    name: "TerminalCell",
+    props: ["expanded", "rightPane", "canvasAvailable"],
+    emits: ["toggle-expand", "toggle-files", "toggle-canvas", "open-canvas", "toggle-tools", "session", "cwd", "run", "close", "move", "status"],
+    template: '<div class="stub-cell" />',
+  },
+}));
+vi.mock("../../../src/components/CommandCell.vue", () => ({
+  default: { name: "CommandCell", props: ["expanded", "command"], emits: ["toggle-expand", "close", "move", "status"], template: "<div />" },
+}));
+vi.mock("../../../src/components/LauncherCell.vue", () => ({
+  default: { name: "LauncherCell", props: ["expanded", "launcher"], emits: ["toggle-expand", "close", "move", "status", "session"], template: "<div />" },
+}));
+// The real toolbars are exercised in GuiPanelExpand.spec.ts / ToolsPaneExpand.spec.ts; here both
+// panes are stubs that re-emit, so this file tests the grid's layout response, not their markup.
+vi.mock("../../../src/components/GuiPanel.vue", () => ({
+  default: {
+    name: "GuiPanel",
+    props: ["sessionId", "sendTextMessage", "unavailable", "expanded"],
+    emits: ["toggleExpand", "close"],
+    template: '<div class="stub-canvas" />',
+  },
+}));
+vi.mock("../../../src/components/ToolsPane.vue", () => ({
+  default: { name: "ToolsPane", props: ["sessionId", "expanded"], emits: ["toggleExpand", "close"], template: '<div class="stub-tools" />' },
+}));
+vi.mock("../../../src/components/FilesPane.vue", () => ({
+  default: {
+    name: "FilesPane",
+    props: ["cwd", "requestedPath", "initialState"],
+    emits: ["close", "dirty"],
+    setup: (_p: unknown, { expose, slots }: { expose: (e: Record<string, unknown>) => void; slots: { title?: () => VNode[] } }) => {
+      expose({ flush: async () => undefined, reload: () => {}, snapshot: () => ({ openPath: "README.md", expanded: [] }) });
+      return () => h("div", { class: "stub-files-pane" }, slots.title?.());
+    },
+  },
+}));
+
+const cell = (uid: number, session: string | null = null): Cell => ({ uid, session, cwd: "/work" });
+
+const mountGrid = (listMode = true) =>
+  mount(TerminalGrid, {
+    props: {
+      cells: [cell(1, "s1"), cell(2, "s2")],
+      expandedUid: 1,
+      listRows: [],
+      cancelUid: null,
+      defaultCwd: "/work",
+      presets: [],
+      launchers: [],
+      home: "/work",
+      openSessionIds: [],
+      openCwds: [],
+      reorderable: false,
+      listMode,
+    },
+    attachTo: document.body,
+  });
+
+type Grid = ReturnType<typeof mountGrid>;
+type PaneName = "GuiPanel" | "ToolsPane";
+const pane = (w: Grid, name: PaneName = "GuiPanel") => w.findComponent({ name });
+// The cell's buttons TOGGLE, and which pane is showing is remembered in localStorage — so a
+// second mount in the same test may already have one open and a blind toggle would close it.
+const open = async (w: Grid, name: PaneName = "GuiPanel") => {
+  if (pane(w, name).exists()) return;
+  w.findComponent({ name: "TerminalCell" }).vm.$emit(name === "GuiPanel" ? "toggle-canvas" : "toggle-tools");
+  await flushPromises();
+};
+const clickExpand = async (w: Grid, name: PaneName = "GuiPanel") => {
+  pane(w, name).vm.$emit("toggleExpand");
+  await flushPromises();
+};
+
+beforeEach(() => {
+  vi.stubGlobal("matchMedia", () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }));
+  localStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ groups: ["render"], tools: [] }) })),
+  );
+});
+
+describe("expanding a pane over the terminal", () => {
+  it("hands the whole row to the canvas and drops the splitter between them", async () => {
+    const w = mountGrid();
+    await open(w);
+    expect(pane(w).props("expanded")).toBe(false);
+    expect(pane(w).attributes("style")).toContain("flex: 0 0 480px");
+    expect(w.find('[aria-label="Resize side pane"]').exists()).toBe(true);
+
+    await clickExpand(w);
+    expect(pane(w).props("expanded")).toBe(true);
+    expect(pane(w).attributes("style")).toContain("flex: 1 1 0%");
+    // The separator divides two things. With the terminal gone there is nothing to drag.
+    expect(w.find('[aria-label="Resize side pane"]').exists()).toBe(false);
+  });
+
+  // The tools pane sets its own w-[340px], which would otherwise outlive the layout.
+  it("does the same for the tools pane, width class and all", async () => {
+    const w = mountGrid();
+    await open(w, "ToolsPane");
+    await clickExpand(w, "ToolsPane");
+    expect(pane(w, "ToolsPane").props("expanded")).toBe(true);
+    expect(pane(w, "ToolsPane").attributes("style")).toContain("flex: 1 1 0%");
+    expect(pane(w, "ToolsPane").attributes("style")).toContain("width: auto");
+    expect(w.find('[aria-label="Resize side pane"]').exists()).toBe(false);
+  });
+
+  // The whole point of the off-screen park (#1125): `display: none` would refit xterm to zero.
+  it("leaves the covered terminal mounted", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+    expect(w.findAllComponents({ name: "TerminalCell" })).toHaveLength(2);
+    expect(w.find(".zoom-main").classes()).not.toContain("hidden");
+    expect(w.find(".zoom-row").classes()).toContain("pane-full");
+  });
+
+  // The roster is a sibling of the row, so it is never what gets covered — in either zoom mode.
+  it("keeps the roster and the filmstrip out of it", async () => {
+    for (const listMode of [true, false]) {
+      const w = mountGrid(listMode);
+      await open(w);
+      await clickExpand(w);
+      expect(w.find('[data-testid="cockpit"]').exists()).toBe(listMode);
+      expect(w.find(".grid").exists()).toBe(true);
+      const row = w.find(".zoom-row");
+      expect(row.classes()).toContain("pane-full");
+      expect(row.element.contains(w.find(".grid").element)).toBe(false);
+      w.unmount();
+    }
+  });
+
+  it("restores the split row", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+    await clickExpand(w);
+    expect(pane(w).props("expanded")).toBe(false);
+    expect(pane(w).attributes("style")).toContain("flex: 0 0 480px");
+    expect(w.find('[aria-label="Resize side pane"]').exists()).toBe(true);
+  });
+
+  it("closes from its own header, full-width or not", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+    pane(w).vm.$emit("close");
+    await flushPromises();
+    expect(pane(w).exists()).toBe(false);
+    expect(w.find(".zoom-row").classes()).not.toContain("pane-full");
+  });
+});
+
+// A pane that opens ON TOP of the terminal is a surprise every time but the one where it was
+// asked for — and what it hides is what the user was working in. So the takeover is never
+// inherited: not by the pane reopened, not by the pane switched to, not by a fresh load.
+describe("the takeover is not remembered", () => {
+  it("is gone when the same pane is closed and reopened", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+    pane(w).vm.$emit("close");
+    await flushPromises();
+
+    await open(w);
+    expect(pane(w).props("expanded")).toBe(false);
+    expect(pane(w).attributes("style")).toContain("flex: 0 0 480px");
+  });
+
+  it("does not follow a switch to another pane, or come back with the first one", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+
+    w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await flushPromises();
+    expect(w.findComponent({ name: "FilesPane" }).attributes("style")).toContain("flex: 0 0 480px");
+    expect(w.find(".zoom-row").classes()).not.toContain("pane-full");
+
+    await open(w);
+    expect(pane(w).props("expanded")).toBe(false);
+  });
+
+  it("does not survive a reload", async () => {
+    const first = mountGrid();
+    await open(first);
+    await clickExpand(first);
+    first.unmount();
+
+    // Which PANE was open is still remembered — only the takeover is not.
+    const second = mountGrid();
+    await open(second);
+    expect(pane(second).props("expanded")).toBe(false);
+  });
+});


### PR DESCRIPTION
## なにを

Canvas に描かれたドキュメントを、手動で端末領域いっぱいまで広げられるようにする。Canvas ヘッダーの拡大ボタン（`open_in_full` / `close_fullscreen`）を押している間、ペインが `zoomRow` を丸ごと取る。

覆うのは**拡大中の端末だけ**。左のロスターも下のフィルムストリップも、ペインの入っている行の外にあるので動かない（両ズームモードで検証済み）。端末は `display: none` ではなく実サイズのまま画面外へ退避させる — 隠された xterm はゼロに合わせて縮み、戻ったときに崩れるため（#1125 と同じ理由、list モードがタイルグリッドに対してやっているのと同じ手）。

ついでに:

- **Tools ペインにも同じボタン対を同じ順序で追加**。1 つのスロットを共有する 2 つのペインなので、同じ操作が同じ場所にないと探すことになる。Tools は自前で `w-[340px]` を持つため、全幅時は `width: auto` も併せて渡す。
- **Canvas ヘッダーに Close を追加**（右端、Files / Tools と同じ `close` アイコン・同じ文言）。
- **Canvas ヘッダーの tools ボタンを削除**。Tools ペインは各セルのヘッダーボタンから引き続き開ける。

## 拡大状態は記憶しない

最初の実装では localStorage に持たせていたが、閉じて開き直すと端末の上に載った状態で復活する。端末の上に開くペインは、それを求めた瞬間以外は毎回不意打ちで、しかも隠すのは作業中のものそのもの。よってセッション内の ref にとどめ、`setRightPane` で毎回リセットする — 同じペインを開き直しても、別のペインに切り替えても、リロードしても分割行から始まる。どのペインが開いていたか／その幅は従来どおり記憶する。

状態は Canvas と Tools で共有（`paneFull`）なので、端末を覆うものは常に高々 1 つ。Files は端末の横で編集するものなのでボタンを持たない。ロスターのドラッグ時の下限も、全幅時は見えていない端末ではなくペイン自身の下限で clamp するようにした。

## テスト

- `test/src/components/paneExpand.spec.ts` — 全幅化のレイアウト（スプリッター消滅、端末がマウントされたまま、ロスター／フィルムストリップ不変を両モードで）と、記憶しないこと 3 ケース
- `test/src/components/GuiPanelExpand.spec.ts` / `ToolsPaneExpand.spec.ts` — 各ヘッダーのボタン（グリフ、`aria-pressed`、Close が右端）

`yarn lint`（エラー 0）・`yarn typecheck`・`yarn test`（7628 passed）・`yarn build` 通過。実ブラウザでの目視確認は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expand and restore controls for Canvas and Tools panes.
  * Expanded panes now use the full available width while keeping navigation strips visible.
  * Added clear accessibility labels and pressed-state indicators.
  * Added close controls and improved pane switching behavior.

* **Bug Fixes**
  * Pane expansion now resets when panes are closed, reopened, or switched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->