### PR TITLE
chore(test): サーバー系 spec 153本を node 環境で走らせる（#1331）

### DIFF
--- a/server/agents/codex-rate-limits.spec.ts
+++ b/server/agents/codex-rate-limits.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { extractCodexRateLimits, latestRateLimitsInRollout } from "./codex-rate-limits";
 

--- a/server/agents/codex-rollout.spec.ts
+++ b/server/agents/codex-rollout.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/server/agents/probe-session.spec.ts
+++ b/server/agents/probe-session.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { newProbeSessionId, isProbeSessionId, PROBE_SESSION_PREFIX } from "./probe-session";
 import { SESSION_ID_RE } from "../config/env";

--- a/server/agents/probe-stall.spec.ts
+++ b/server/agents/probe-stall.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/server/agents/rate-limit-persist.spec.ts
+++ b/server/agents/rate-limit-persist.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/server/agents/rate-limit-probe.spec.ts
+++ b/server/agents/rate-limit-probe.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { startRateLimitProbe, probeArgs, PROBE_PROMPT } from "./rate-limit-probe";
 import { createRateLimitStore } from "./rate-limit-store";

--- a/server/agents/rate-limit-store.spec.ts
+++ b/server/agents/rate-limit-store.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   createRateLimitStore,

--- a/server/agents/statusline.spec.ts
+++ b/server/agents/statusline.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { extractRateLimits, hadApiResponse, readClaudeStatus, statusLineCommand } from "./statusline";
 

--- a/server/backends/remoteHost/routes.spec.ts
+++ b/server/backends/remoteHost/routes.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import express, { type Express } from "express";
 import request from "supertest";

--- a/server/backends/remoteHost/session.spec.ts
+++ b/server/backends/remoteHost/session.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { RemoteHostSessionExpiredError, reconnectErrorStatus } from "./session.js";
 

--- a/test/server/agents/antigravity-args.spec.ts
+++ b/test/server/agents/antigravity-args.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { buildAntigravityArgs } from "../../../server/agents/antigravity-args.js";
 

--- a/test/server/agents/appended-prompt.spec.ts
+++ b/test/server/agents/appended-prompt.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { appendedSystemPrompt } from "../../../server/agents/appended-prompt.js";
 import { SESSION_SUMMARY_PROMPT } from "../../../server/agents/session-summary-prompt.js";

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { buildClaudeArgs, type ClaudeArgsInput } from "../../../server/agents/claude-args.js";
 import { SESSION_SUMMARY_PROMPT } from "../../../server/agents/session-summary-prompt.js";

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { nextReadRange, takeCompleteLines, turnBoundaries, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
 

--- a/test/server/agents/codex-args.spec.ts
+++ b/test/server/agents/codex-args.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { buildCodexArgs } from "../../../server/agents/codex-args.js";
 

--- a/test/server/agents/codex-session.spec.ts
+++ b/test/server/agents/codex-session.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/agents/codex-sessions.spec.ts
+++ b/test/server/agents/codex-sessions.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/agents/registry.spec.ts
+++ b/test/server/agents/registry.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
 import { getAgentAdapter } from "../../../server/agents/registry.js";
 import { claudeAdapter } from "../../../server/agents/claude.js";

--- a/test/server/agents/session-summary-prompt.spec.ts
+++ b/test/server/agents/session-summary-prompt.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { SESSION_SUMMARY_PROMPT } from "../../../server/agents/session-summary-prompt.js";
 

--- a/test/server/backends/byte-range.spec.ts
+++ b/test/server/backends/byte-range.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { parseByteRange } from "../../../server/backends/byte-range.js";

--- a/test/server/backends/remoteHost/healthNotice.spec.ts
+++ b/test/server/backends/remoteHost/healthNotice.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Before #823 a dropped command channel left one line in the server log and nothing else,
 // so the first sign was the phone failing to connect. These pin the bell entry that now
 // says so — and, just as importantly, that a self-healed blip does NOT raise one.

--- a/test/server/backends/remoteHost/launchTerminal.spec.ts
+++ b/test/server/backends/remoteHost/launchTerminal.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { decideLaunchTerminal } from "../../../../server/backends/remoteHost/launchTerminal.js";
 

--- a/test/server/backends/remoteHost/quickCommands.spec.ts
+++ b/test/server/backends/remoteHost/quickCommands.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { quickCommandsForAgent } from "../../../../server/backends/remoteHost/quickCommands.js";
 import type { QuickCommand } from "../../../../common/quickCommands.js";

--- a/test/server/backends/worklog.spec.ts
+++ b/test/server/backends/worklog.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { worklogSystemTask, WORKLOG_PROMPT } from "../../../server/backends/worklog.js";

--- a/test/server/config/add-dirs.spec.ts
+++ b/test/server/config/add-dirs.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { resolveAddDirs, MAX_ADD_DIRS } from "../../../server/config/config-schema";

--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { isRecord } from "../../../common/isRecord.js";
 import {

--- a/test/server/config/custom-themes.spec.ts
+++ b/test/server/config/custom-themes.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { sanitizeCustomThemes, toPublicAppConfig, emptyConfig, mergeConfigUpdate } from "../../../server/config/app-config";
 import { THEME_VAR_KEYS } from "../../../common/themeVars";

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/config/dir-config-preview.spec.ts
+++ b/test/server/config/dir-config-preview.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";

--- a/test/server/config/header-config.spec.ts
+++ b/test/server/config/header-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   sanitizeButtons,

--- a/test/server/config/header-context.spec.ts
+++ b/test/server/config/header-context.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { worktreeTask } from "../../../server/config/header-context.js";

--- a/test/server/config/header-resolve.spec.ts
+++ b/test/server/config/header-resolve.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   substitute,

--- a/test/server/config/header-title.spec.ts
+++ b/test/server/config/header-title.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import {
   shouldRegenerateTitle,

--- a/test/server/config/hue-rotate.spec.ts
+++ b/test/server/config/hue-rotate.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { rotateHue } from "../../../server/config/hue-rotate";
 

--- a/test/server/config/keymap-check.spec.ts
+++ b/test/server/config/keymap-check.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { checkKeymap, enforceKeymap } from "../../../server/config/keymap-check.js";
 

--- a/test/server/config/sound-config.spec.ts
+++ b/test/server/config/sound-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { sanitizeSoundKinds, sanitizeSounds, sanitizeSoundValue } from "../../../server/config/app-config.js";

--- a/test/server/config/sound-presets.spec.ts
+++ b/test/server/config/sound-presets.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/config/update-status.spec.ts
+++ b/test/server/config/update-status.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // vi.mock is hoisted above imports, so the doubles it returns must be created inside a

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { makeTempDirAsync } from "../../support/tempDir.js";
 import { promises as fs } from "node:fs";

--- a/test/server/config/worktree-dir-config.spec.ts
+++ b/test/server/config/worktree-dir-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { writeFileSync, readFileSync, existsSync } from "node:fs";
 import path from "node:path";

--- a/test/server/crlf-line-parsing.spec.ts
+++ b/test/server/crlf-line-parsing.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Every rule in this repo that turns a blob of text into lines does it with `split("\n")` —
 // about twenty places, over `git` / `gh` / `tmux` output, JSONL transcripts and bundled
 // markdown. That is fine while the text arrives LF-terminated and silently wrong when it does

--- a/test/server/errors.spec.ts
+++ b/test/server/errors.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { hasErrnoCode, messageOf } from "../../server/errors.js";
 

--- a/test/server/files/atomic-write-sync.spec.ts
+++ b/test/server/files/atomic-write-sync.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // `writeFileSync` truncates the destination and then writes into it, so a crash — or a full
 // disk — in between leaves a half-written file. For the app config that means every provider,
 // launcher and header button read as corrupt on the next boot, i.e. as no configuration at

--- a/test/server/files/atomic-write.spec.ts
+++ b/test/server/files/atomic-write.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";

--- a/test/server/files/backup-store.spec.ts
+++ b/test/server/files/backup-store.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/files/dirRequest.spec.ts
+++ b/test/server/files/dirRequest.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import type { Request, Response } from "express";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";

--- a/test/server/files/files-browse.spec.ts
+++ b/test/server/files/files-browse.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { writeFileSync, mkdirSync, rmSync, readFileSync, readdirSync, realpathSync } from "node:fs";

--- a/test/server/files/open-dir.spec.ts
+++ b/test/server/files/open-dir.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { openCommand } from "../../../server/files/open-dir.js";
 

--- a/test/server/files/pathContainment.spec.ts
+++ b/test/server/files/pathContainment.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { pickFileCommand, parsePickerOutput } from "../../../server/files/pick-file.js";
 import { PS_UTF8_STDOUT } from "../../../server/files/win-powershell-utf8.js";

--- a/test/server/files/renderedDoc.spec.ts
+++ b/test/server/files/renderedDoc.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { escapeHtml, htmlDoc, jsonHtmlDoc, tableHtmlDoc, parseDelimited, delimiterForExtension } from "../../../server/files/renderedDoc";
 

--- a/test/server/files/scripts.spec.ts
+++ b/test/server/files/scripts.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/files/tool-writes.spec.ts
+++ b/test/server/files/tool-writes.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { writtenFilePath } from "../../../server/files/tool-writes";

--- a/test/server/files/win-picker-encoding.spec.ts
+++ b/test/server/files/win-picker-encoding.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Windows-only: does a chosen path survive the pipe from PowerShell back to us? (#1146)
 //
 // Nothing else in the suite can answer that. pick-file.spec asserts the SHAPE of the script from any

--- a/test/server/git/forge-host.spec.ts
+++ b/test/server/git/forge-host.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Which forge a remote points at. The distinction this layer exists to make is the one
 // `parseGithubWebUrl` cannot: "a repo we do not support" vs "no remote at all" — both of which the
 // GitHub-shaped answer reports as null (#981).

--- a/test/server/git/forge-support.spec.ts
+++ b/test/server/git/forge-support.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Whether a configured repo can be listed, and what the row says when it cannot. The message is
 // the feature: an unsupported forge used to produce an empty section with no explanation (#981).
 import { describe, it, expect } from "vitest";

--- a/test/server/git/gh-argv.spec.ts
+++ b/test/server/git/gh-argv.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // What every read-side feature ASKS `gh` for, pinned exactly — the command, the flags, the JSON

--- a/test/server/git/git-status.spec.ts
+++ b/test/server/git/git-status.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { rmSync, writeFileSync } from "node:fs";

--- a/test/server/git/gitRemote.spec.ts
+++ b/test/server/git/gitRemote.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import type { Express } from "express";
 import { mkdtempSync, rmSync } from "node:fs";

--- a/test/server/git/glab-items.spec.ts
+++ b/test/server/git/glab-items.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // GitLab's JSON turned into the rows this app already renders. The two fixtures below were
 // CAPTURED from gitlab.com (gitlab-org/cli, 2026-08-01) rather than written by hand, so a field
 // GitLab renames breaks this instead of quietly emptying a row.

--- a/test/server/git/issue-work.spec.ts
+++ b/test/server/git/issue-work.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Starting work on an issue: what the seed says, and that a failed step stops rather than
 // leaving half the work behind.
 import { describe, it, expect, vi } from "vitest";

--- a/test/server/git/issues.spec.ts
+++ b/test/server/git/issues.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { normalizeIssue, ISSUE_LIMIT } from "../../../server/git/issues";
 

--- a/test/server/git/pr-finalize-body.spec.ts
+++ b/test/server/git/pr-finalize-body.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { finalizePrBody, type Runner } from "../../../server/git/worktree-pr.js";
 import type { SpawnResult } from "../../../server/git/spawn-collect.js";

--- a/test/server/git/pr-footer.spec.ts
+++ b/test/server/git/pr-footer.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { withFooter, withIssueRef, workdirFooter } from "../../../server/git/pr-footer.js";
 

--- a/test/server/git/pr-for-branch.spec.ts
+++ b/test/server/git/pr-for-branch.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parsePrUrl, prUrlForBranch, clearPrUrlCache } from "../../../server/git/pr-for-branch.js";
 

--- a/test/server/git/prs.spec.ts
+++ b/test/server/git/prs.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { rollupCiState, normalizePr } from "../../../server/git/prs";
 

--- a/test/server/git/remote-ref.spec.ts
+++ b/test/server/git/remote-ref.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { parseRemoteRef, topSegments } from "../../../server/git/remote-ref.js";
 

--- a/test/server/git/repo-dirs.spec.ts
+++ b/test/server/git/repo-dirs.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // The reverse lookup: given `owner/repo`, which local clones can work on it, in what order, and
 // which one was chosen. Several clones of one repo run side by side in real setups, so almost
 // every case here is about a repo with more than one candidate.

--- a/test/server/git/repo-root-sync.spec.ts
+++ b/test/server/git/repo-root-sync.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";

--- a/test/server/git/worktree-diff.spec.ts
+++ b/test/server/git/worktree-diff.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { rmSync, writeFileSync } from "node:fs";

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { writeFileSync } from "node:fs";

--- a/test/server/git/worktree-routes.spec.ts
+++ b/test/server/git/worktree-routes.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import type { Express } from "express";

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { canSymlink } from "../../support/canSymlink.js";
 import { makeTempDir } from "../../support/tempDir.js";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";

--- a/test/server/infra/allowed-origin.spec.ts
+++ b/test/server/infra/allowed-origin.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } from "../../../server/infra/allowed-origin.js";

--- a/test/server/infra/cmd-escape.spec.ts
+++ b/test/server/infra/cmd-escape.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { batchCommandLine, escapeBatchArgument, UnsafeArgumentError } from "../../../server/infra/cmd-escape";
 

--- a/test/server/infra/fs-cleanup.spec.ts
+++ b/test/server/infra/fs-cleanup.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { rmSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";

--- a/test/server/infra/has-binary.spec.ts
+++ b/test/server/infra/has-binary.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { binaryProblemMessage, diagnoseBinary, hasBinary, type BinaryProbe } from "../../../server/infra/has-binary";

--- a/test/server/infra/hide-error-stacks.spec.ts
+++ b/test/server/infra/hide-error-stacks.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Express decides whether a thrown error's stack goes into the response body, and it decides it
 // from NODE_ENV at app creation. #955 removed the launcher's NODE_ENV=production — which was
 // leaking into every user terminal — so the guarantee has to come from the app itself now.

--- a/test/server/infra/install-bundled-skills.spec.ts
+++ b/test/server/infra/install-bundled-skills.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { chmodSync, mkdtempSync, mkdirSync, readdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/infra/jsonl-file.spec.ts
+++ b/test/server/infra/jsonl-file.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/test/server/infra/loopback.spec.ts
+++ b/test/server/infra/loopback.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { isLoopbackAddress, isLoopbackBinding } from "../../../server/infra/loopback.js";
 

--- a/test/server/infra/path-within.spec.ts
+++ b/test/server/infra/path-within.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { isSamePath, isWithin, isStrictlyWithin } from "../../../server/infra/path-within";
 

--- a/test/server/infra/process-guards.spec.ts
+++ b/test/server/infra/process-guards.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { installProcessGuards } from "../../../server/infra/process-guards.js";

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { isLauncherEnvVar, isPathVar, pathFromEnv, sanitizePathEntries, sanitizePtyEnv } from "../../../server/infra/pty-env";
 

--- a/test/server/infra/read-text-file.spec.ts
+++ b/test/server/infra/read-text-file.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // A config file a human edited on Windows may start with a byte-order mark: Notepad,
 // `Set-Content` and PowerShell 5.1's `Out-File -Encoding utf8` all write one, and node keeps
 // it as a leading U+FEFF. `JSON.parse` then throws on the first character — and every config

--- a/test/server/infra/resolve-bin.spec.ts
+++ b/test/server/infra/resolve-bin.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { resolveWindowsExecutable, resolveWindowsBatch, resolvePtyLaunch } from "../../../server/infra/resolve-bin";
 

--- a/test/server/infra/server-exit.spec.ts
+++ b/test/server/infra/server-exit.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import path from "node:path";

--- a/test/server/infra/spa-fallback.spec.ts
+++ b/test/server/infra/spa-fallback.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import express from "express";
 import path from "node:path";

--- a/test/server/infra/spawn-cwd.spec.ts
+++ b/test/server/infra/spawn-cwd.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { cwdProblemMessage, diagnoseSpawnCwd, fsCwdProbe, type CwdKind, type CwdProbe } from "../../../server/infra/spawn-cwd";

--- a/test/server/infra/tmux-routes.spec.ts
+++ b/test/server/infra/tmux-routes.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import type { Express } from "express";
 import { mountTmuxRoutes, type TmuxRouteDeps } from "../../../server/infra/tmux-routes.js";

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   tmuxSessionName,

--- a/test/server/infra/tool-group-map.spec.ts
+++ b/test/server/infra/tool-group-map.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { TOOL_GROUPS, groupOfTool } from "../../../common/toolGroups.js";

--- a/test/server/infra/tool-precedence.spec.ts
+++ b/test/server/infra/tool-precedence.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { resolvePluginTools } from "../../../server/infra/tool-precedence.js";

--- a/test/server/infra/web-push.spec.ts
+++ b/test/server/infra/web-push.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { sendWebPush } from "../../../server/infra/web-push";
 

--- a/test/server/mcp/broker-history.spec.ts
+++ b/test/server/mcp/broker-history.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // The broker feeding the tools pane's call history — the only source codex / agy have, since
 // neither reports tool calls the way claude's hooks do (server/mcp/gui-call-history.ts).
 //

--- a/test/server/mcp/gui-call-history.spec.ts
+++ b/test/server/mcp/gui-call-history.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 
 import { brokerRecordsGuiCalls, guiCallRecorderFor, historyIsGuiOnly, type ToolCallSink } from "../../../server/mcp/gui-call-history.js";

--- a/test/server/mcp/tool-gate.spec.ts
+++ b/test/server/mcp/tool-gate.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import {

--- a/test/server/median.spec.ts
+++ b/test/server/median.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { median } from "../../common/median.js";
 

--- a/test/server/modelPresets.spec.ts
+++ b/test/server/modelPresets.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { presetsForProvider, MODEL_PRESETS } from "../../common/modelPresets.js";
 

--- a/test/server/routes/issue-work-route.spec.ts
+++ b/test/server/routes/issue-work-route.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // POST /api/issues/start. The case that matters most is the guard: `dir` arrives from the browser
 // and becomes a spawn's working directory, so it has to be one of the clones the server itself
 // resolved for that repo — not any path a request cares to name.

--- a/test/server/routes/narrowed-tools.spec.ts
+++ b/test/server/routes/narrowed-tools.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { narrowedTools, type ToolSummary } from "../../../server/routes/tool-routes.js";

--- a/test/server/routes/plugin-narration.spec.ts
+++ b/test/server/routes/plugin-narration.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { upstreamFailureMessage } from "../../../server/routes/plugin-narration.js";

--- a/test/server/routes/repo-dirs-route.spec.ts
+++ b/test/server/routes/repo-dirs-route.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // GET /api/repo-dirs end to end: real temp git repos with real `origin` remotes, so the route,
 // the remote resolution and the grouping are exercised together rather than mocked apart. The
 // config layer IS mocked — importing it for real reads the developer's own ~/.mulmoterminal.

--- a/test/server/routes/same-origin-guard.spec.ts
+++ b/test/server/routes/same-origin-guard.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import type { NextFunction, Request, Response } from "express";
 import { needsSameOrigin, requestOriginAllowed, sameOriginGuard } from "../../../server/routes/same-origin-guard.js";

--- a/test/server/routes/start-and-wire.spec.ts
+++ b/test/server/routes/start-and-wire.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { startAndWire } from "../../../server/routes/ws-routes.js";

--- a/test/server/routes/start-failure-message.spec.ts
+++ b/test/server/routes/start-failure-message.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { startFailureMessageFor } from "../../../server/routes/ws-routes.js";

--- a/test/server/routes/toolResultPlan.spec.ts
+++ b/test/server/routes/toolResultPlan.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { planToolResultUpdate } from "../../../server/routes/toolResultPlan.js";

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { activityHookEffects, buildPushText, pushKindFor, resolveHookCwd, resolveHookSessionId } from "../../../server/session/activity-hook.js";

--- a/test/server/session/activity-state.spec.ts
+++ b/test/server/session/activity-state.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   buildActivitySnapshot,

--- a/test/server/session/activity-transition.spec.ts
+++ b/test/server/session/activity-transition.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { nextActivity, sessionRow, shouldRefreshReply } from "../../../server/session/activity-transition.js";
 

--- a/test/server/session/background-chat.spec.ts
+++ b/test/server/session/background-chat.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../../../server/session/background-chat.js";
 

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { watchCodexActivity, type CodexActivityDeps } from "../../../server/session/codex-activity-watch.js";
 import type { CodexTurnBoundary } from "../../../server/agents/codex-activity.js";

--- a/test/server/session/command-summary.spec.ts
+++ b/test/server/session/command-summary.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, type Mock } from "vitest";
 import {
   truncateLog,

--- a/test/server/session/completion-hooks.spec.ts
+++ b/test/server/session/completion-hooks.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { registerCompletionHook, runCompletionHook, unregisterCompletionHook } from "../../../server/session/completion-hooks.js";
 

--- a/test/server/session/cost.spec.ts
+++ b/test/server/session/cost.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { rateForModel, costForUsage, costFromJsonl } from "../../../server/session/cost.js";
 

--- a/test/server/session/decision-digest.spec.ts
+++ b/test/server/session/decision-digest.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import type { DecisionQuestion, DecisionRecord } from "../../../common/decisionLog";
 import { decisionDigestMarkdown } from "../../../server/session/decision-digest";

--- a/test/server/session/decisions.spec.ts
+++ b/test/server/session/decisions.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { byNewest, decisionsFromJsonl } from "../../../server/session/decisions";
 

--- a/test/server/session/dir-session.spec.ts
+++ b/test/server/session/dir-session.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { pickDirSession, type DirSessionCandidate } from "../../../server/session/dir-session";
 

--- a/test/server/session/early-frames.spec.ts
+++ b/test/server/session/early-frames.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { bufferEarlyFrames } from "../../../server/session/early-frames.js";
 

--- a/test/server/session/file-cache.spec.ts
+++ b/test/server/session/file-cache.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { createFileCache } from "../../../server/session/file-cache.js";
 

--- a/test/server/session/handoff-text.spec.ts
+++ b/test/server/session/handoff-text.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { formatHandoff, DEFAULT_HANDOFF_LIMITS } from "../../../server/session/handoff-text.js";
 

--- a/test/server/session/hook-settings.spec.ts
+++ b/test/server/session/hook-settings.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { hookSettingsJson } from "../../../server/session/hook-settings.js";

--- a/test/server/session/last-turn.spec.ts
+++ b/test/server/session/last-turn.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { lastTurnFromClaudeJsonl, lastTurnFromClaudeParsed, lastTurnFromCodexRollout, EMPTY_TURN } from "../../../server/session/last-turn.js";
 import { parseJsonl } from "../../../server/session/transcript.js";

--- a/test/server/session/launcher-gui-mcp.spec.ts
+++ b/test/server/session/launcher-gui-mcp.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { launcherProgram, launcherCommandWithGuiMcp, launcherRunsAgent, launcherAgent } from "../../../server/session/launcher-gui-mcp.js";
 

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { mcpConfigJson, guiMcpEnv, codexGuiMcpServers } from "../../../server/session/mcp-config.js";

--- a/test/server/session/project-dir.spec.ts
+++ b/test/server/session/project-dir.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import os from "node:os";
 import path from "node:path";

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { createConnectionHandlers, handleCommandFrame } from "../../../server/session/pty-connection.js";
 import type { PtyEntry } from "../../../server/session/types.js";

--- a/test/server/session/pty-exit-log.spec.ts
+++ b/test/server/session/pty-exit-log.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { diedDuringStartup, formatLifetime, ptyExitLine, ptyStartLine, STARTUP_WINDOW_MS } from "../../../server/session/pty-exit-log";

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Windows-only: the real node-pty spawns that #794 and #798 are about. Skipped everywhere
 // else, so this runs in .github/workflows/windows-daily.yaml (which already runs `yarn test`)
 // rather than in the PR matrix — the rules themselves are covered by the pure tests in

--- a/test/server/session/pty-text.spec.ts
+++ b/test/server/session/pty-text.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { sanitizeDraftText, sanitizeMultilineText } from "../../../server/session/pty-text.js";
 

--- a/test/server/session/reap-policy.spec.ts
+++ b/test/server/session/reap-policy.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { reapDecisionFor, reapTimerDelay, parseWaitGraceMs, MAX_TIMER_MS, shouldForgetActivity } from "../../../server/session/reap-policy.js";
 

--- a/test/server/session/scheduled-sessions.spec.ts
+++ b/test/server/session/scheduled-sessions.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";

--- a/test/server/session/session-id-log.spec.ts
+++ b/test/server/session/session-id-log.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { parseSessionIdLog, sessionIdLogLine } from "../../../server/session/session-id-log.js";

--- a/test/server/session/session-list.spec.ts
+++ b/test/server/session/session-list.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { parseActivityIds, selectSessionRows, type SessionRow } from "../../../server/session/session-list.js";
 

--- a/test/server/session/session-resolve.spec.ts
+++ b/test/server/session/session-resolve.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { resolveSession, type SessionFacts, resolveReattachableId, canStartLauncher, isContinuingSession } from "../../../server/session/session-resolve.js";
 

--- a/test/server/session/session-title.spec.ts
+++ b/test/server/session/session-title.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";

--- a/test/server/session/session-tool-groups.spec.ts
+++ b/test/server/session/session-tool-groups.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET } from "../../../server/session/session-tool-groups.js";

--- a/test/server/session/shell-command.spec.ts
+++ b/test/server/session/shell-command.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { shellInvocation, launcherAt } from "../../../server/session/shell-command.js";
 

--- a/test/server/session/shell-spawn-win.spec.ts
+++ b/test/server/session/shell-spawn-win.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Windows-only: the terminal paths that run a SHELL rather than an agent — the Run menu's
 // one-off command and a configured launcher. Both compose shellInvocation() with spawnPty(),
 // and on Windows that means `powershell.exe -NoLogo -Command <command>`.

--- a/test/server/session/summary-scan.spec.ts
+++ b/test/server/session/summary-scan.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { createSummaryScan } from "../../../server/session/summary-scan.js";
 import {

--- a/test/server/session/terminal-replay.spec.ts
+++ b/test/server/session/terminal-replay.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { appendBoundedOutput, stripTerminalQueries, terminalModePrefix } from "../../../server/session/terminal-replay.js";
 

--- a/test/server/session/tmux-size-sync.spec.ts
+++ b/test/server/session/tmux-size-sync.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // The rule under test is "only a size tmux CAN report and that DIFFERS earns a nudge" — anything
 // looser resizes a healthy session, anything tighter leaves #957's blank screen in place.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";

--- a/test/server/session/tool-store.spec.ts
+++ b/test/server/session/tool-store.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";

--- a/test/server/session/transcript.spec.ts
+++ b/test/server/session/transcript.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   latestUserPromptFromJsonl,

--- a/test/server/session/translation-prompt.spec.ts
+++ b/test/server/session/translation-prompt.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { buildTranslationPrompt, isValidTranslationResult } from "../../../server/session/translation-prompt.js";
 

--- a/test/server/session/translation-submit.spec.ts
+++ b/test/server/session/translation-submit.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 
 import { translationSubmitOutcome } from "../../../server/session/translation-submit.js";

--- a/test/server/session/translation-worker.spec.ts
+++ b/test/server/session/translation-worker.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createTranslationWorker, submitTranslation, failPendingTranslation } from "../../../server/session/translation-worker.js";
 import { hiddenSessions, translationWorkerIds, knownSessions, activity, lastPrompts } from "../../../server/session/registry.js";

--- a/test/server/session/ws-frames.spec.ts
+++ b/test/server/session/ws-frames.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { sendFrame, sendExitAndClose, closeWithError, isResizeFrame, type FrameSocket } from "../../../server/session/ws-frames.js";
 

--- a/test/server/sourceIsText.spec.ts
+++ b/test/server/sourceIsText.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // No source file may hold a control character that makes it BINARY to the ordinary tools.
 //
 // `server/git/issue-work.ts` held a literal NUL — meant as a key separator, written as the byte


### PR DESCRIPTION
## Summary

#1331 の対応。`test/server/**` と `server/**` の spec 285本のうち、**153本が DOM に一切触れないのに
jsdom で走っていた**。既に132本は `// @vitest-environment node` を宣言済みで、残りが漏れていた形。

差分は **153ファイルに1行ずつ**、追加のみ（153 insertions / 0 deletions）。テストの中身は変えていない。

## 効果（CI ランナーを模して `--maxWorkers=4` で計測）

手元は20コアあり並列で吸収されてしまうため、GitHub Actions のコア数に近い条件で測った。5回ずつ交互に実行。

| | main | このブランチ |
|---|---|---|
| Duration（中央値） | 84.30s | **62.88s**（-25%） |
| Duration（最小） | 68.74s | **58.74s**（-15%） |
| environment（中央値） | 181.32s | **104.70s**（-42%） |

`environment` はワーカー合計の CPU 時間で、今回動かしたのはまさにそこ。
30本を抜き出した対照実験では **34.14s → 7ms**（テスト結果はどちらも 476 passed で同一）だった。

**数字のばらつきは正直に書いておく**: 手元のマシンは他の作業と競合するため wall-clock は 58〜117秒の幅で
揺れる。上の表は5サンプルの中央値と最小値。`environment` の方が交絡が少なく、そちらは一貫して下がる。

## Items to Confirm / Review

1. **DOM 系の語を含む22本**を個別に確認した。いずれも**散文中の単語**で、実際の DOM 利用は無い：
   - `tmux.spec.ts` / `pty-connection.spec.ts` — tmux の "window"
   - `statusline.spec.ts` / `rate-limit-*.spec.ts` — レート制限の "window"
   - `files-browse.spec.ts` — コメント中の "document"

   とはいえ機械判定ではなくフルスイートの green が根拠。**7626 passed / 0 failed**。
2. **1 PR にまとめた**。#1331 ではディレクトリ単位の分割を案として書いたが、差分が全ファイル同一の1行
   追加なので、まとめて見る方がレビューしやすいと判断した。分けた方がよければ言ってほしい。
3. **正しさの面**でも直っている。fs と子プロセスしか触らないコードを、DOM のグローバルが生えた環境で
   検証していた状態が解消される。

## User Prompt

> ok、できるものはやろう。

（#1331 に対して。#1328 → #1329 の流れの続き）

## 検証

- `yarn format` / `yarn lint`（0 error）/ `yarn typecheck` / `yarn build` — green
- フルスイート **7626 passed | 45 skipped | 0 failed**
- マージ後に新しく jsdom で走るサーバー系 spec が残っていないことも確認（0本）

Closes #1331

work in mulmoterminal4
