### PR TITLE
fix(lint): as 禁止と非 null 禁止を Vue テンプレートにも届かせる (#1339)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,11 @@ export default [
       "vue/no-restricted-syntax": [
         "error",
         {
-          selector: "TSAsExpression",
+          // `as const` is excluded, because consistent-type-assertions excludes it too and the
+          // two halves of one SFC must not disagree. It is also not what the ban is about: a
+          // const assertion narrows a literal the compiler can already see, rather than claiming
+          // a type the compiler could not prove.
+          selector: 'TSAsExpression:not([typeAnnotation.typeName.name="const"])',
           message: "Do not use type assertions — narrow in <script> and pass the result to the template.",
         },
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,23 @@ export default [
             "Use Tailwind utilities (see docs/styling.md). If this genuinely can't be a utility, add the file to the scoped-CSS allowlist in eslint.config.js with a reason.",
         },
       ],
+      // The assertion bans below reach `<script>` only: typescript-eslint's rules never visit
+      // the TEMPLATE body, which vue-eslint-parser exposes as a separate AST. So
+      // `@input="…($event.target as HTMLInputElement).value"` was invisible to
+      // consistent-type-assertions even at `error`, and `!` was invisible to
+      // no-non-null-assertion. `vue/no-restricted-syntax` is the one rule that walks that AST,
+      // so the same two bans are spelled here as selectors.
+      "vue/no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSAsExpression",
+          message: "Do not use type assertions — narrow in <script> and pass the result to the template.",
+        },
+        {
+          selector: "TSNonNullExpression",
+          message: "Do not use non-null assertions — narrow in <script> and pass the result to the template.",
+        },
+      ],
     },
   },
   {
@@ -124,6 +141,10 @@ export default [
     // ERROR since #1231 finished: the 149 assertions the app started with are gone, and the
     // allowlist below is the only way to keep one — with a reason, since inline eslint-disable is
     // forbidden and hides the debt at the scene.
+    //
+    // `**/*.vue` here reaches the SCRIPT block only — typescript-eslint's rules never walk the
+    // template AST, so an `as` inside `@input="…"` passed this rule at `error` (#1339). The same
+    // ban for the template is the `vue/no-restricted-syntax` selectors in the `.vue` block above.
     files: ["**/*.{ts,tsx,mts,cts}", "**/*.vue"],
     rules: {
       "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
@@ -235,6 +256,10 @@ export default [
   {
     // The `any` family is OFF wherever a `.vue` component type is in play, and that is a LIMIT OF
     // THE LINTER rather than a hole in the code.
+    //
+    // This exclusion is the `any` family ONLY. It is not a general "linter cannot see `.vue`":
+    // the assertion bans DO cover SFCs, script side through consistent-type-assertions and
+    // template side through the `vue/no-restricted-syntax` selectors (#1339).
     //
     // ESLint's type program does not generate SFC component types, so `InstanceType<typeof
     // SomeComponent>` — and any type imported from a `.vue` — resolves to the error type. Every

--- a/plans/fix-1339-template-assertions.md
+++ b/plans/fix-1339-template-assertions.md
@@ -26,6 +26,11 @@ Straight to `error`, as the issue proposed: the whole repo had two findings, so 
 guarded nothing. Same severity as the script-side rules they extend, which is the point — a
 template is not a place where the house style is looser.
 
+`as const` is excluded from the `TSAsExpression` selector. `consistent-type-assertions` exempts it
+in the script half, so without the exclusion one SFC would disagree with itself: legal above the
+`<template>` line, an error below it. It is also outside what the ban is for — a const assertion
+narrows a literal the compiler can already see, rather than claiming a type it could not prove.
+
 ## The two findings
 
 Both fixed by narrowing in `<script>` rather than by asserting, which is what the ban is for.

--- a/plans/fix-1339-template-assertions.md
+++ b/plans/fix-1339-template-assertions.md
@@ -1,0 +1,58 @@
+# The `as` ban never reached a Vue template (#1339)
+
+`@typescript-eslint/consistent-type-assertions` is `error` with `assertionStyle: "never"` and its
+`files` list already names `**/*.vue`. It still reported nothing for
+
+```vue
+@input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+```
+
+because `vue-eslint-parser` exposes the template as a **separate AST** and typescript-eslint's
+rules only walk the script one. So the rule was configured, enabled, at error — and blind. When
+#1231 took the app from 149 assertions to 0, this one was never in the count.
+
+`@typescript-eslint/no-non-null-assertion` (on via `tseslint.configs.strict`) has exactly the same
+blind spot, and the repo had one template `!` to prove it.
+
+## Fix
+
+`vue/no-restricted-syntax` is the one rule that does walk that AST, so the same two bans are
+spelled there as selectors, in the existing `**/*.vue` block:
+
+- `TSAsExpression` — the `as` cast
+- `TSNonNullExpression` — the `!`
+
+Straight to `error`, as the issue proposed: the whole repo had two findings, so `warn` would have
+guarded nothing. Same severity as the script-side rules they extend, which is the point — a
+template is not a place where the house style is looser.
+
+## The two findings
+
+Both fixed by narrowing in `<script>` rather than by asserting, which is what the ban is for.
+
+- `SettingsField.vue` — the inline `$emit` becomes a named `onInput(e: Event)` that narrows with
+  `e.target instanceof HTMLInputElement`. Matches `WebPushSection.vue` / `WaitingRowsSection.vue`,
+  which already do this.
+- `CellLaunchForm.vue` — `:title="mcpGroupFailed[group]!"` sat next to `v-else-if` on the same
+  value, asserting in the hover what the branch had just tested. One accessor, `mcpGroupFailure`,
+  now answers both, so they cannot disagree and neither asserts.
+
+## What stops it coming back
+
+A clean tree does not prove a rule fires — that is the whole failure here. `test/scripts/
+eslint-template-assertions.spec.ts` reads the rule's options out of the REAL config
+(`calculateConfigForFile`) and runs them over SFC text containing an `as` and a `!`. Deleting a
+selector from `eslint.config.js` fails it; deleting the rule fails all of it.
+
+Linted as text, not as a fixture file: anything under `src/**/*.vue` is parsed against
+`tsconfig.app.json`, and a path outside it produces a parse error instead of a finding.
+
+Component specs pin the two behaviours the narrowing moved: `SettingsField` still emits every
+keystroke, and a failed MCP group write still puts its reason on the row's hover.
+
+## The `.vue` exclusion note from #1300 is narrower than it read
+
+#1300 closed saying ".vue exclusions are a limit of the linter". True of the `no-unsafe-*` family
+— ESLint's type program does not generate SFC component types — and NOT true of the assertion
+bans, which now cover both halves of an SFC. Both comment blocks in `eslint.config.js` say which
+they are.

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -267,6 +267,11 @@ const relativeTime = (ms: number): string => relativeTimeFrom(ms, Date.now());
 const mcpGroupTitle = (group: ToolGroup): string =>
   `Registers the MCP server "${toolGroupServerId(group)}" for this directory — tools: ${toolsInGroup(group).join(", ")}`;
 
+// The last write's error for this group, if it failed. One accessor for both the branch that
+// shows "failed" and the hover that carries the message, so the two cannot disagree about
+// whether there is one — the alternative asserts in the hover what the branch already decided.
+const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed.value[group] ?? undefined;
+
 const worktreeTask = ref("");
 
 // Create a fresh worktree for the typed task and start the selected agent in it.
@@ -487,7 +492,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
         >
         <span class="flex items-center gap-2">
           <span v-if="mcpGroupBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
-          <span v-else-if="mcpGroupFailed[group]" class="font-sans text-[11px] text-err-text" :title="mcpGroupFailed[group]!">failed</span>
+          <span v-else-if="mcpGroupFailure(group)" class="font-sans text-[11px] text-err-text" :title="mcpGroupFailure(group)">failed</span>
           <input
             v-model="mcpGroupEnabled[group]"
             :data-testid="`cell-mcp-toggle-${group}`"

--- a/src/components/SettingsField.vue
+++ b/src/components/SettingsField.vue
@@ -3,7 +3,11 @@
 // aria-label, spellcheck, @change / @keydown, and any extra layout classes
 // (flex-auto, font-mono, …) fall through to the underlying <input>.
 defineProps<{ modelValue: string }>();
-defineEmits<{ (e: "update:modelValue", value: string): void }>();
+const emit = defineEmits<{ (e: "update:modelValue", value: string): void }>();
+
+function onInput(e: Event) {
+  if (e.target instanceof HTMLInputElement) emit("update:modelValue", e.target.value);
+}
 </script>
 
 <template>
@@ -11,6 +15,6 @@ defineEmits<{ (e: "update:modelValue", value: string): void }>();
     type="text"
     :value="modelValue"
     class="box-border rounded-md border border-border bg-input px-2.5 py-[7px] text-[12px] text-fg focus:border-accent focus:outline-none"
-    @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    @input="onInput"
   />
 </template>

--- a/test/scripts/eslint-template-assertions.spec.ts
+++ b/test/scripts/eslint-template-assertions.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from "vitest";
+import { ESLint, Linter } from "eslint";
+import pluginVue from "eslint-plugin-vue";
+import vueParser from "vue-eslint-parser";
+import tseslint from "typescript-eslint";
+
+// `@typescript-eslint/consistent-type-assertions` and `no-non-null-assertion` are configured at
+// error for `.vue`, and both were blind to the TEMPLATE: typescript-eslint's rules only walk the
+// script AST, so an `as` inside `@input="…"` passed a ban set to "never" (#1339). The template
+// side is `vue/no-restricted-syntax`, and the failure it fixes is a rule that is CONFIGURED but
+// never reports — which no amount of clean source proves. So this lints real SFC text.
+const RULE = "vue/no-restricted-syntax";
+
+// Linted as text rather than as a fixture file: anything under `src/**/*.vue` is parsed against
+// tsconfig.app.json, and a path outside it is a parse error instead of a finding. The rule is
+// syntactic, so the template AST from vue-eslint-parser is all it needs — with the options read
+// from the real config, which is what makes deleting a selector there fail here.
+let ruleOptions: Linter.RuleEntry;
+
+const lintTemplate = (body: string): Linter.LintMessage[] =>
+  new Linter().verify(`<template>\n  ${body}\n</template>\n`, {
+    // The template's expressions are TypeScript, and vue-eslint-parser hands them to whatever
+    // `parserOptions.parser` names — espree without this, which produces no TSAsExpression node
+    // for the rule to match and no error either. Same wiring as the `.vue` block in the config.
+    languageOptions: { parser: vueParser, parserOptions: { parser: tseslint.parser } },
+    plugins: { vue: pluginVue },
+    rules: { [RULE]: ruleOptions },
+  });
+
+describe("the template-side assertion ban", () => {
+  beforeAll(async () => {
+    const config = await new ESLint().calculateConfigForFile("src/components/SettingsField.vue");
+    ruleOptions = config.rules[RULE];
+  });
+
+  it("is configured at error for .vue files", () => {
+    expect(Array.isArray(ruleOptions) ? ruleOptions[0] : ruleOptions).toBe(2);
+  });
+
+  it("reports an `as` cast written in a template expression", () => {
+    const messages = lintTemplate(`<input @input="emit('v', ($event.target as HTMLInputElement).value)" />`);
+    expect(messages.map((m) => m.ruleId)).toEqual([RULE]);
+  });
+
+  it("reports a non-null assertion written in a template expression", () => {
+    const messages = lintTemplate(`<span :title="failed[group]!">failed</span>`);
+    expect(messages.map((m) => m.ruleId)).toEqual([RULE]);
+  });
+
+  it("leaves a template that narrows in <script> alone", () => {
+    expect(lintTemplate(`<span :title="failure(group)">failed</span>`)).toEqual([]);
+  });
+});

--- a/test/scripts/eslint-template-assertions.spec.ts
+++ b/test/scripts/eslint-template-assertions.spec.ts
@@ -51,4 +51,11 @@ describe("the template-side assertion ban", () => {
   it("leaves a template that narrows in <script> alone", () => {
     expect(lintTemplate(`<span :title="failure(group)">failed</span>`)).toEqual([]);
   });
+
+  // A const assertion is legal in the script half (consistent-type-assertions exempts it), so a
+  // template that rejected it would make one SFC disagree with itself — and it is not what the ban
+  // is about: it narrows a literal already in front of the compiler, it does not claim a type.
+  it("leaves `as const` alone, as the script-side rule does", () => {
+    expect(lintTemplate(`<span :title="pick(['a', 'b'] as const)">failed</span>`)).toEqual([]);
+  });
 });

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -223,3 +223,34 @@ describe("a resume row", () => {
     expect(w.emitted("resume")).toBeUndefined();
   });
 });
+
+// A write into the user's Claude Code config that fails has to SAY so — the checkbox goes back and
+// the row reads "failed", with the reason on the hover. The branch and the hover read the same
+// accessor since #1339 (the hover used to assert non-null what the branch had just tested), so
+// what is pinned here is that the message still arrives at the title.
+describe("an MCP group row whose write failed", () => {
+  it("puts the checkbox back and carries the reason on the hover", async () => {
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") return { ok: false, status: 500, json: async () => ({}) };
+        return { ok: true, json: async () => ({ groups: [] }) };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+
+    const w = mountForm();
+    await flushPromises();
+    const toggle = w.find<HTMLInputElement>('[data-testid="cell-mcp-toggle-render"]');
+    await toggle.setValue(true);
+    await flushPromises();
+
+    const failed = w.findAll("span.text-err-text");
+    expect(failed).toHaveLength(1);
+    expect(failed[0].text()).toBe("failed");
+    expect(failed[0].attributes("title")).toBe("HTTP 500");
+    expect(toggle.element.checked).toBe(false);
+  });
+});

--- a/test/src/components/SettingsField.spec.ts
+++ b/test/src/components/SettingsField.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SettingsField from "../../../src/components/SettingsField.vue";
+
+// The v-model contract of the settings modal's shared text input. It used to be written inline in
+// the template, where the cast to HTMLInputElement was invisible to the assertion ban (#1339); the
+// narrowing moved into <script>, and what must not have moved with it is the emit itself.
+describe("SettingsField", () => {
+  it("emits every keystroke as update:modelValue", async () => {
+    const w = mount(SettingsField, { props: { modelValue: "before" } });
+    const input = w.get("input");
+    await input.setValue("after");
+    expect(w.emitted("update:modelValue")).toEqual([["after"]]);
+  });
+
+  it("shows the value it is given rather than its own", () => {
+    const w = mount(SettingsField, { props: { modelValue: "from the parent" } });
+    expect(w.get("input").element.value).toBe("from the parent");
+  });
+});


### PR DESCRIPTION
## Summary

`@typescript-eslint/consistent-type-assertions` は `error` / `assertionStyle: "never"` で、`files` に `**/*.vue` も入っている。それでも `<template>` の中の `as` は**一度も報告されていなかった** — `vue-eslint-parser` がテンプレートを**別の AST として公開**しており、typescript-eslint のルールはそこを歩かないため。`strict` 由来の `no-non-null-assertion` も同じ穴で、`!` が1件残っていた。

その AST を歩く唯一のルール `vue/no-restricted-syntax` に、同じ禁止を **`TSAsExpression` / `TSNonNullExpression`** のセレクタとして書いた。リポジトリ全体で **2件** しか無かったので、issue の見立てどおり warn を挟まず **`error`** から。

検出された2件は、キャストで素通りさせるのではなく `<script>` 側の絞り込みで解消した。

## Items to Confirm / Review

- **`error` 直行でよいか** — 全体で2件（`as` 1件・`!` 1件）、どちらも本 PR で解消済み。CI は緑。
- **`!` も同時に禁止した** — issue のチェックリスト2番目。`no-non-null-assertion` が `<script>` では既に error なので、テンプレートだけ緩いのは非対称という判断。mulmoclaude (#2734) は `TSAsExpression` のみで、**ここは意図的に一歩進んでいる**。
- **`as const` の除外** — Claude 自身のレビューで見つけたもの（bot はどちらも未指摘）。実 SFC で「`as const` は通る / 本物のキャストは落ちる」を確認済み、spec でも固定。
- **`CellLaunchForm.vue` の `mcpGroupFailure`** — `undefined` を返す形にしたのは `:title` が `string | null` を受けないため。`v-else-if` と `:title` が同じアクセサを読むので両者が食い違えない。
- **spec の作り方** — 「設定されているのに報告しない」が今回の不具合なので、綺麗なソースでは再発を防げない。実際の config から `calculateConfigForFile` でルール設定を読み出し、SFC のテキストに当てている。`src/**/*.vue` 配下のフィクスチャファイルにしなかったのは、`tsconfig.app.json` の外のパスだと finding ではなく **parse error** になるため。
- **`#1300` の「`.vue` の除外は linter の限界」** — `no-unsafe-*` については今も正しいが、assertion については当てはまらなくなった。両方のコメントブロックにどちらの話かを明記した（issue のチェックリスト3番目）。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1339

## 再現（修正前）

```console
$ npx eslint --print-config src/components/SettingsField.vue | jq '.rules["@typescript-eslint/consistent-type-assertions"]'
[2, {"assertionStyle": "never"}]          ← error として効いている

$ npx eslint src/components/SettingsField.vue
                                          ← 何も出ない
```

## 変更内容

### 1. ルール（`eslint.config.js`）

既存の `**/*.vue` ブロックに追加:

```js
"vue/no-restricted-syntax": [
  "error",
  { selector: 'TSAsExpression:not([typeAnnotation.typeName.name="const"])', message: "Do not use type assertions — narrow in <script> and pass the result to the template." },
  { selector: "TSNonNullExpression", message: "Do not use non-null assertions — narrow in <script> and pass the result to the template." },
],
```

`as const` を除外しているのは、script 側の `consistent-type-assertions` が const アサーションを対象外にしているため。素の `TSAsExpression` だと **1つの SFC が自分自身と食い違う**（`<script>` では通る `['a','b'] as const` が `<template>` ではエラー）。ban の趣旨からも外れる — const アサーションはコンパイラが既に見えているリテラルを絞るだけで、証明できない型を主張していない。

あわせてコメントを2箇所訂正した。`consistent-type-assertions` のブロックには「`**/*.vue` は script ブロックにしか届かない」、`no-unsafe-*` の `.vue` 除外ブロックには「この除外は `any` ファミリー**だけ**であって、`.vue` 全般が見えないという話ではない」。

### 2. 検出された2件

| ファイル | 修正 |
|---|---|
| `SettingsField.vue` | インラインの `$emit(… ($event.target as HTMLInputElement).value)` を、`e.target instanceof HTMLInputElement` で絞る名前付き `onInput` へ。既存の `WebPushSection.vue` / `WaitingRowsSection.vue` と同じ形 |
| `CellLaunchForm.vue` | `:title="mcpGroupFailed[group]!"` が、直前の `v-else-if` が判定済みの値を非 null 断言していた。`mcpGroupFailure(group)` 1つを分岐と hover の両方が読む形へ |

### 3. 再発防止の spec

- **`test/scripts/eslint-template-assertions.spec.ts`** — 実 config からルール設定を読み、`as` と `!` を含む SFC テキストに当てて **報告されること** を確認する。
  - 検証済みの negative control: `TSNonNullExpression` セレクタを消すと1件 fail、ルールごと消すと4件とも fail。
- **`test/src/components/SettingsField.spec.ts`** — キーストロークが `update:modelValue` として出ること。
- **`CellLaunchForm.spec.ts`** — MCP グループの書き込み失敗時、チェックボックスが戻り、hover に理由（`HTTP 500`）が乗ること。
  - negative control: `mcpGroupFailure` を `undefined` 固定にすると fail。

## 検証

`yarn format` / `yarn lint`（0 errors / 11 warnings、いずれも既存）/ `yarn typecheck` / `yarn build` / `yarn test`（**7703 passed, 45 skipped**）。フルスイートは build 同時実行の負荷下を含め4回連続で緑。

Closes #1339

refs #1231, refs #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal6
