### PR TITLE
docs(guide): state how the workspace directory is settled

### DIFF
--- a/docs/guide/en/basics.md
+++ b/docs/guide/en/basics.md
@@ -89,7 +89,7 @@ cell it opens is a persistent terminal (running / exited), not an agent session.
 
 **What you put in WORKING DIRECTORY decides which GUI tools that cell gets.**
 The reference point is the **workspace** — the server's default working directory (`CLAUDE_CWD`).
-By default it is the directory you ran `npx mulmoterminal` in; `--cwd` and the `CLAUDE_CWD` environment variable take precedence over that.
+It is settled in this order: `--cwd`, then the `CLAUDE_CWD` environment variable, then the directory you ran `npx mulmoterminal` in.
 When you lose track of which one it is, the `Workspace: …` line printed at startup is the answer.
 Collections, Wiki and Accounting read and write there whichever cell you are in (only the Files pane beside an enlarged cell follows that cell's directory).
 

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -1303,7 +1303,7 @@ there to look at.
 
 | Variable | Default | Role |
 |---|---|---|
-| `CLAUDE_CWD` / `--cwd` | The directory you run `npx mulmoterminal@latest` in (only `~/mulmoclaude` when the server is started directly) | The default working directory (the PTY's cwd); also set via `--cwd`. **Only a Claude cell launched in this same directory carries the whole GUI MCP** (→ [which directory to launch in](basics.html#launch-dir)) |
+| `CLAUDE_CWD` / `--cwd` | The directory you run `npx mulmoterminal@latest` in (only `~/mulmoclaude` when the server is started directly) | The default working directory (the PTY's cwd), settled in the order `--cwd`, the `CLAUDE_CWD` environment variable, then the directory you ran the launcher in. **Only a Claude cell launched in this same directory carries the whole GUI MCP** (→ [which directory to launch in](basics.html#launch-dir)) |
 | `PORT` | `34567` | The server port |
 | `MULMOTERMINAL_HOST` | `127.0.0.1` | The interface the server binds to (→ [below](#bind-host)) |
 | `MULMOTERMINAL_ALLOWED_ORIGINS` | *(none)* | Extra browser origins allowed to attach a terminal, comma-separated. Only needed alongside a wider `MULMOTERMINAL_HOST` (→ [below](#bind-host)) |

--- a/docs/guide/en/glossary.md
+++ b/docs/guide/en/glossary.md
@@ -76,7 +76,7 @@ panel moved to the zoomed cell, which is the same thing — one agent with the w
 
 ## Workspace {#workspace}
 
-The server's **default working directory** (`CLAUDE_CWD`) — by default the directory you ran `npx mulmoterminal` in, with `--cwd` and the `CLAUDE_CWD` environment variable taking precedence.
+The server's **default working directory** (`CLAUDE_CWD`) — settled in the order `--cwd`, the `CLAUDE_CWD` environment variable, then the directory you ran `npx mulmoterminal` in; a server started directly falls back to `~/mulmoclaude`.
 It is printed as `Workspace: …` at startup.
 Collections, Wiki and Accounting read and write there, and if you also run MulmoClaude it should be **the same directory for both** (`~/mulmoclaude` by default) — not the directory you cloned MulmoClaude into.
 

--- a/docs/guide/ja/basics.md
+++ b/docs/guide/ja/basics.md
@@ -86,7 +86,7 @@ MCP 登録・worktree がないので、選んでいる間はその 3 つの欄�
 
 **WORKING DIRECTORY に何を入れるかで、そのセルが持つ GUI ツールが変わります。**
 基準になるのは**ワークスペース** — サーバの既定の作業ディレクトリ（`CLAUDE_CWD`）です。
-既定では `npx mulmoterminal` を実行したディレクトリで、`--cwd` と環境変数 `CLAUDE_CWD` が優先されます。
+決まり方は `--cwd` > 環境変数 `CLAUDE_CWD` > `npx mulmoterminal` を実行したディレクトリ の順です。
 今どこなのか分からなくなったら、起動時に出る `Workspace: …` が答えです。
 Collections・Wiki・Accounting が読み書きするのは、どのセルにいても常にここです（拡大したセルの横に開く Files ペインだけは、そのセルのディレクトリを見ます）。
 

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -1264,7 +1264,7 @@ Merged in #983. Work done in `mulmoterminal5`.
 
 | 変数 | 既定 | 役割 |
 |---|---|---|
-| `CLAUDE_CWD` / `--cwd` | 実行したディレクトリ（`npx mulmoterminal@latest`。サーバを直接起動した場合のみ `~/mulmoclaude`） | 既定の作業ディレクトリ（PTY の cwd）。`--cwd` でも指定可。**ここと同じディレクトリで起動した Claude のセルだけが GUI MCP をフルで持ちます**（→ [どのディレクトリで起動するか](basics.html#launch-dir)） |
+| `CLAUDE_CWD` / `--cwd` | 実行したディレクトリ（`npx mulmoterminal@latest`。サーバを直接起動した場合のみ `~/mulmoclaude`） | 既定の作業ディレクトリ（PTY の cwd）。決まり方は `--cwd` > 環境変数 `CLAUDE_CWD` > 実行したディレクトリ の順。**ここと同じディレクトリで起動した Claude のセルだけが GUI MCP をフルで持ちます**（→ [どのディレクトリで起動するか](basics.html#launch-dir)） |
 | `PORT` | `34567` | サーバのポート |
 | `MULMOTERMINAL_HOST` | `127.0.0.1` | サーバが待ち受けるインターフェース（→ [下記](#bind-host)） |
 | `MULMOTERMINAL_ALLOWED_ORIGINS` | *(なし)* | ターミナルに接続してよいブラウザのオリジンを追加（カンマ区切り）。`MULMOTERMINAL_HOST` を広げたときにだけ必要（→ [下記](#bind-host)） |

--- a/docs/guide/ja/glossary.md
+++ b/docs/guide/ja/glossary.md
@@ -77,7 +77,7 @@ MulmoTerminal はこのやり方を**ターミナルで**やるための画面�
 ## ワークスペース（workspace） {#workspace}
 
 サーバの**既定の作業ディレクトリ**（`CLAUDE_CWD`）。
-既定では `npx mulmoterminal` を実行したディレクトリで、`--cwd` と環境変数 `CLAUDE_CWD` が優先されます。
+決まり方は `--cwd` > 環境変数 `CLAUDE_CWD` > `npx mulmoterminal` を実行したディレクトリ の順で、サーバを直接起動したときは `~/mulmoclaude` です。
 起動時に `Workspace: …` と表示されるのがその答えです。
 Collections・Wiki・Accounting が読み書きするのはここで、MulmoClaude と併用するなら**両者で同じディレクトリ**（既定 `~/mulmoclaude`）にします。
 MulmoClaude を clone したディレクトリのことではありません。


### PR DESCRIPTION
## Summary

#1309 のフォローアップとして、ワークスペース（`CLAUDE_CWD`）が**どう決まるか**の優先順位をガイドに明記しました。en / ja 両方、6 ファイル 6 行です。

- **対象**: `basics.md` と `glossary.md`（ja / en）の本文、および `config.md`（ja / en）の環境変数表の `CLAUDE_CWD` の行
- **内容**: 「`--cwd` と環境変数 `CLAUDE_CWD` が優先される」という書き方だと 2 つのどちらが勝つか分からないので、`--cwd` > 環境変数 `CLAUDE_CWD` > 実行したディレクトリ の順に直しました。`glossary.md` には、サーバを直接起動したときの `~/mulmoclaude` も追記しています
- **起点**: #1309 に CodeRabbit が出した指摘です。適用する前に #1309 が merge されたため、独立した PR にしました

## Items to Confirm / Review

- **優先順位の根拠**。`bin/cli-args.js` が `--cwd` → 環境変数 `CLAUDE_CWD` → 実行したディレクトリ の順に解決し、`server/config/env.ts` が直起動時に `~/mulmoclaude` へフォールバックします。この読み取りで合っているか
- **意図的に見送った点**。`basics.md` には直起動時の `~/mulmoclaude` を書いていません。あの節はランチャでディレクトリを選ぶ話で、読者は npx 経由です。しかも同じ節の note が「MulmoClaude と併用するならワークスペースを `~/mulmoclaude` にする」と書いているため、2 行違いで同じパスを「既定」として出すと矛盾して読めます。環境変数リファレンス（`config.html#env`）には残っていて、note からリンクしています。この判断でよいか

## User Prompt

- #1309 のレビューで CodeRabbit が出した指摘に、提示した triage のとおり対応してほしい（優先順位の明記は対応する、`basics.md` への直起動フォールバックの追記は見送る）

## 変更内容

| ファイル | 変更 |
|---|---|
| `docs/guide/{ja,en}/basics.md` | 決まり方を `--cwd` > `CLAUDE_CWD` > 実行したディレクトリ の順に明記 |
| `docs/guide/{ja,en}/glossary.md` | 同上 + サーバ直起動時の `~/mulmoclaude` |
| `docs/guide/{ja,en}/config.md` | 環境変数表の `CLAUDE_CWD` の行に同じ優先順位を追記（直起動時のフォールバックは元から記載あり） |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified workspace directory precedence: `--cwd`, then `CLAUDE_CWD`, then the launch directory.
  - Documented that direct server launches default to `~/mulmoclaude`.
  - Updated both English and Japanese guides for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->