### PR TITLE
fix(tsconfig): bring the last three unchecked files into a project (#1348)

### DIFF
--- a/test/helpers/appRequest.spec.ts
+++ b/test/helpers/appRequest.spec.ts
@@ -11,10 +11,10 @@ describe("appRequest", () => {
   app.use(express.json());
   app.get("/echo", (req, res) => res.json({ method: req.method, query: req.query, agent: req.get("user-agent") ?? null }));
   app.post("/echo", (req, res) => res.status(201).json(req.body));
-  app.get("/empty", (req, res) => res.status(204).end());
-  app.get("/unchanged", (req, res) => res.status(304).end());
-  app.get("/bytes", (req, res) => res.type("image/png").send(Buffer.from([0x89, 0x50, 0x4e, 0x47])));
-  app.get("/two-cookies", (req, res) => {
+  app.get("/empty", (_req, res) => res.status(204).end());
+  app.get("/unchanged", (_req, res) => res.status(304).end());
+  app.get("/bytes", (_req, res) => res.type("image/png").send(Buffer.from([0x89, 0x50, 0x4e, 0x47])));
+  app.get("/two-cookies", (_req, res) => {
     res.append("set-cookie", "a=1");
     res.append("set-cookie", "b=2");
     res.end("ok");

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -26,5 +26,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "scripts/**/*.ts"]
 }

--- a/tsconfig.test-server.json
+++ b/tsconfig.test-server.json
@@ -7,6 +7,6 @@
        itself guarantees. The value of the flag is in shipped code, which has it on. */
     "noUncheckedIndexedAccess": false
   },
-  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "server/**/*.spec.ts"],
+  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "server/**/*.spec.ts", "test/helpers/**/*.spec.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary

追跡ファイルのうち3つが**どの tsconfig にも属さず、`yarn typecheck` が一度も見ていませんでした**。

5プロジェクトすべての `--listFiles` を集合和し、`git ls-files` と突き合わせた結果:

```
追跡 1171 / 被覆 1169
  scripts/model-trials.ts
  test/helpers/appRequest.spec.ts
  vitest.config.ts
```

`tsconfig.node.json` に `vitest.config.ts` と `scripts/**/*.ts` を追加（既に `vite.config.ts` でやっていることと同じ）。`tsconfig.test-server.json` に `test/helpers/**/*.spec.ts` を追加（他の server 側 spec glob の隣）。

## Items to Confirm / Review

**1. 3つの中で `appRequest.spec.ts` が最も問題です。** ヘルパーの契約を pin するために書かれた spec 自体が、検証されていませんでした。

**2. 初めて検査したことで4件出ました。** `noUnusedParameters` に対する未使用の `req`（リクエストを読まない Express ハンドラ）。`_req` に改名しただけで挙動は変えていません。

**3. 追加したパスが実際に到達することを probe で実証しました**（緑の実行を信用しない）:

```
scripts/__probe.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.
test/helpers/__probe.spec.ts   検出
```

**最初の `scripts/` 用 probe は何も報告せず、危うく「まだ未検査」と記録するところでした。** `xs[0].length` を使っていたためで、これは `noUncheckedIndexedAccess` がある場合しか落ちません。このプロジェクトにそのフラグは無いので、**設定ではなく probe が間違っていた**という話でした。

**4. 計測時の注意** — `.vue` を含むプロジェクトは `vue-tsc` で測る必要があります。plain `tsc` は `.vue` を展開しないため、当初この方法で `.vue` が大量に「未被覆」と誤検出されました。

## 検証

`main` @ `eef72e47` 上で、被覆 **0 未検査**。`typecheck` / `lint` / `format:check` / `test` すべて green。

Refs #1348 — `noImplicitReturns`（実測 **74件**）は設定ではなくソース修正なので、別作業として残します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test route clarity without changing behavior.
  * Expanded TypeScript coverage for test helpers and development configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->