### PR TITLE
fix(tsconfig): どの project にも属さないファイルを無くす / noImplicitReturns を決着させる (#1348)

### DIFF
--- a/plans/fix-1348-tsconfig-coverage.md
+++ b/plans/fix-1348-tsconfig-coverage.md
@@ -1,0 +1,74 @@
+# fix(tsconfig): どの project にも属さないファイルを無くす (#1348)
+
+## ① 未被覆 3 ファイル — 実測して再現
+
+5 つの project すべてで `--listFiles` を取り、その和集合を追跡ファイルと突き合わせた。
+
+```console
+$ for p in app node server test test-server; do npx vue-tsc -p "tsconfig.$p.json" --listFiles --noEmit > /tmp/$p.txt; done
+$ comm -23 <tracked> <covered>
+scripts/model-trials.ts
+test/helpers/appRequest.spec.ts
+vitest.config.ts
+```
+
+issue の報告どおり 3 件。**`yarn typecheck` / `build` / CI のどれもこの 3 つを見ていない。**
+
+`.vue` を含む project は `vue-tsc` で取る必要がある（plain `tsc` は `.vue` を展開しないので大量の誤検出になる）。
+
+### 直し方
+
+| project | include | 理由 |
+| --- | --- | --- |
+| `tsconfig.node.json` | `["vite.config.ts"]` → `["*.config.ts", "scripts/**/*.ts"]` | 1 ファイル名を直書きしていたのが主因。パターンにすれば次に増える root config / script は書いた日から被覆される |
+| `tsconfig.test-server.json` | `test/helpers/**/*.ts` を追加、`test/helpers/xtermDouble.ts` を exclude | `appRequest.spec.ts` がどこにも属していなかった |
+
+`test/helpers/` は両サイドの helper が同居している。`xtermDouble.ts` は `HTMLElement` / `document` を
+参照するため `types: ["node"]` の project では通らない。**ディレクトリごと include して 1 ファイルだけ
+exclude する**形にしたのは、ファイル名の列挙こそが今回 spec を取りこぼした原因だから。`xtermDouble.ts`
+自体は `test/src` の spec 経由で `tsconfig.test.json` が DOM lib 付きで見ている（被覆は確認済み）。
+
+### 被覆したら見つかったもの
+
+`test/helpers/appRequest.spec.ts` に **TS6133 が 4 件**（未使用の `req`）。検査されていなかったから
+残っていたわけで、issue の主張がそのまま実証された形。`_req` に直した。
+
+### 検証は「clean」ではなく「検出される」で行う
+
+追跡 1173 ファイルすべてが被覆されたことに加え、**3 ファイルそれぞれに型エラーを仕込んで検出される
+ことを確認した**。緑であることは検査されている証拠にならない（#1313 と同じ理由）。
+
+## ② `noImplicitReturns` — 入れないと決めた
+
+issue は「mulmoclaude では 0 件で導入できた」としていたが、**このリポジトリでは成立しない**。
+
+| project | 件数 |
+| --- | --- |
+| app | 0 |
+| node | 0 |
+| server | **31** |
+| test-server | **27**（server のファイルを再検査した分） |
+
+合計は #1301 が記録した 58 件と一致する。実体は **33 個の Express ハンドラ**で、すべて
+
+```ts
+if (bad) return res.status(400).json({ error: "…" });
+```
+
+という形。TS7030 が鳴るのは「片方の経路が `res` を返し、フォールスルーが何も返さない」ためで、
+これは Express ハンドラの正しい書き方そのもの。**欠陥の指摘ではなくハウススタイルの指摘**であり、
+33 個のルートハンドラを書き換えても安全性は増えない。
+
+よって **app / node のみ on**、server 系は off で確定。`tsconfig.server.json` に「意図的に無い」ことと
+実測値を書き、`tsconfig.app.json` からそこを指した — 片方だけ見て「揃っていない」と足されるのを防ぐため。
+
+### 測定時に踏んだ罠（記録）
+
+最初 `grep -cE "error TS7030"` で数えて **全 project 0 件**という誤った結果を得た。`vue-tsc` の出力は
+`error` と `TS7030` の間に ANSI カラーコードが入るので、この正規表現は永久に一致しない。
+**色を落としてから grep する**（`sed 's/\x1b\[[0-9;]*m//g'`）。同じ間違いで
+`tsconfig.test-server.json` の検証も一度すり抜けた。
+
+## 補足
+
+`<template>` 内の `as`（`SettingsField.vue`）は #1341 で解消済みで、現在 0 件。issue の記述どおり。

--- a/test/helpers/appRequest.spec.ts
+++ b/test/helpers/appRequest.spec.ts
@@ -11,10 +11,10 @@ describe("appRequest", () => {
   app.use(express.json());
   app.get("/echo", (req, res) => res.json({ method: req.method, query: req.query, agent: req.get("user-agent") ?? null }));
   app.post("/echo", (req, res) => res.status(201).json(req.body));
-  app.get("/empty", (req, res) => res.status(204).end());
-  app.get("/unchanged", (req, res) => res.status(304).end());
-  app.get("/bytes", (req, res) => res.type("image/png").send(Buffer.from([0x89, 0x50, 0x4e, 0x47])));
-  app.get("/two-cookies", (req, res) => {
+  app.get("/empty", (_req, res) => res.status(204).end());
+  app.get("/unchanged", (_req, res) => res.status(304).end());
+  app.get("/bytes", (_req, res) => res.type("image/png").send(Buffer.from([0x89, 0x50, 0x4e, 0x47])));
+  app.get("/two-cookies", (_req, res) => {
     res.append("set-cookie", "a=1");
     res.append("set-cookie", "b=2");
     res.end("ok");

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,11 +10,12 @@
        "key present holding undefined". */
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
-    /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
-       The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
-       measured counts and why they are their own piece of work. */
+    /* Added in #1301, both measured at 0 across app / server / test before going in. */
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
+    /* On here and in node, where #1348 measured it at 0. Deliberately NOT on for the server — see
+       tsconfig.server.json for the decision and the numbers behind it. */
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,10 +21,16 @@
     /* Linting */
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
+    /* See tsconfig.app.json for the measured counts (#1348). */
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  /* `*.config.ts` rather than naming vite.config.ts: this listed that one file, so `vitest.config.ts`
+     and `scripts/model-trials.ts` belonged to NO project and were checked by nothing — not by
+     `yarn typecheck`, not by CI (#1348). A pattern means the next root config or script is covered
+     the day it is written, which is the part a hand-maintained list keeps getting wrong. */
+  "include": ["*.config.ts", "scripts/**/*.ts"]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -20,11 +20,17 @@
        reaches Firestore, which rejects undefined at any depth (#1042). */
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
-    /* Added in #1301. Both measured at 0 errors across app / server / test before going in.
-       The other three the issue listed are NOT free — see plans/fix-1301-strict-flags.md for the
-       measured counts and why they are their own piece of work. */
+    /* Added in #1301, both measured at 0 across app / server / test before going in. */
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
+    /* `noImplicitReturns` is deliberately ABSENT here, and this note exists so it is not added by
+       someone matching this file to tsconfig.app.json (where it IS on, along with node — both 0).
+       Measured twice, #1301 and again for #1348: 31 findings here plus 27 in test-server, which is
+       the same server files re-checked — 33 distinct Express handlers. Every one is
+       `if (bad) return res.status(400).json(…)`, which is how an Express handler is supposed to be
+       written; TS7030 fires because one path yields `res` and the fallthrough yields nothing. That
+       is a report about a house style, not about a defect, and rewriting 33 route handlers to
+       silence it buys no safety. Decided in #1348 rather than deferred again. */
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true

--- a/tsconfig.test-server.json
+++ b/tsconfig.test-server.json
@@ -7,6 +7,13 @@
        itself guarantees. The value of the flag is in shipped code, which has it on. */
     "noUncheckedIndexedAccess": false
   },
-  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "server/**/*.spec.ts"],
-  "exclude": []
+  /* `test/helpers/**` is here because `appRequest.spec.ts` belonged to no project at all — a spec
+     that nothing type-checked, and it had four findings waiting once something did (#1348). Claimed
+     as a directory rather than by filename so the next server-side helper is covered the day it is
+     written; a hand-maintained list is what orphaned this one.
+     `xtermDouble.ts` is the browser half of the same directory — it names HTMLElement and document,
+     which do not exist under `types: ["node"]`. It is reached through the `test/src` specs that
+     import it, so tsconfig.test.json checks it with the DOM lib it needs. */
+  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "test/helpers/**/*.ts", "server/**/*.spec.ts"],
+  "exclude": ["test/helpers/xtermDouble.ts"]
 }


### PR DESCRIPTION
## Summary

**3 ファイルがどの tsconfig project にも属さず、`yarn typecheck` / `build` / CI のいずれからも検査されていませんでした。** それを解消し、`noImplicitReturns` は実測のうえ **app / node のみ有効化、server 系は入れない**で決着させました。

refs #1348

## Items to Confirm / Review

1. **issue の前提「mulmoclaude では 0 件で導入できた」は、このリポジトリでは成立しませんでした。** 実測は **server 31 / test-server 27**（後者は server のファイルを再検査した分）で、合計は #1301 が記録した 58 件と一致します。実体は **33 個の Express ハンドラ**で、すべて `if (bad) return res.status(400).json(…)` という形。TS7030 が鳴るのは「片方の経路が `res` を返し、フォールスルーが何も返さない」ためで、**これは Express ハンドラの正しい書き方**です。欠陥ではなくハウススタイルの指摘であり、33 個のルートハンドラを書き換えても安全性は増えないため、**入れないと決めました**（ユーザー判断）。`tsconfig.server.json` に「意図的に無い」ことと実測値を明記し、`tsconfig.app.json` からそこを指しています — 片方だけ見て「揃っていない」と足されるのを防ぐためです。ここが一番レビューしてほしい点です。

2. **`test/helpers/**` をディレクトリごと include し、`xtermDouble.ts` だけ exclude しています。** 同ディレクトリにサーバ側とブラウザ側の helper が同居しており、`xtermDouble.ts` は `HTMLElement` / `document` を参照するので `types: ["node"]` の project では通りません。ファイル名を列挙する形にしなかったのは、**それこそが今回 spec を取りこぼした原因**だからです。`xtermDouble.ts` 自体は `test/src` の spec 経由で `tsconfig.test.json` が DOM lib 付きで見ていることを確認済みです。

3. **`tsconfig.node.json` の include を `["vite.config.ts"]` → `["*.config.ts", "scripts/**/*.ts"]`** にしました。1 ファイル名の直書きが今回の主因なので、パターンにして次に増える root config / script が書いた日から被覆されるようにしています。

## ① 未被覆 3 ファイル

5 project すべてで `--listFiles` を取り、和集合を追跡ファイルと突き合わせて再現しました（issue と同じ 3 件）。

```console
$ comm -23 <tracked> <covered>
scripts/model-trials.ts
test/helpers/appRequest.spec.ts
vitest.config.ts
```

**被覆した瞬間に `test/helpers/appRequest.spec.ts` から TS6133 が 4 件**出ました（未使用の `req`）。検査されていなかったから残っていたわけで、issue の主張がそのまま実証されています。`_req` に直しました。

### 検証は「clean」ではなく「検出される」で

追跡 **1173 ファイルすべてが被覆**（未被覆 0）に加えて、**3 ファイルそれぞれに型エラーを仕込んで検出されることを確認**しました。緑であることは検査されている証拠になりません（#1313 と同じ理由）。

```
scripts/model-trials.ts        -> 検出 1
test/helpers/appRequest.spec.ts -> 検出 1
vitest.config.ts               -> 検出 1
```

## 測定時に踏んだ罠（記録として plan にも残しています）

最初 `grep -cE "error TS7030"` で数えて **全 project 0 件**という誤った結果を得ました。`vue-tsc` の出力は `error` と `TS7030` の間に ANSI カラーコードが入るため、この正規表現は永久に一致しません。**色を落としてから grep する**必要があります（`sed 's/\x1b\[[0-9;]*m//g'`）。同じ間違いで `tsconfig.test-server.json` の検証も一度すり抜け、「`test/helpers` 全体が通る」という誤った結論を出しかけました。

## 検証

- `yarn lint` 0 errors（warning 11 は既存）/ `yarn typecheck` / `yarn build` / `yarn test` **7719 passed**
- 追跡 1173 ファイル中、未被覆 **0**
- 新規被覆 3 ファイルすべてで、仕込んだ型エラーが検出されることを確認

## 補足

`<template>` 内の `as`（`SettingsField.vue`）は #1341 で解消済みで、現在 0 件です。issue の記述どおりでした。

work in mulmoterminal3