### PR TITLE
docs: 検索語でページを名乗り直す + 他ツールとの比較ページ + facts.json

### DIFF
--- a/docs/facts.json
+++ b/docs/facts.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://receptron.github.io/mulmoterminal/facts.schema.json",
+  "name": "MulmoTerminal",
+  "tagline": "Run multiple Claude Code and Codex sessions in parallel — and see which one needs you.",
+  "category": "parallel AI coding agent supervision",
+  "repository": "https://github.com/receptron/mulmoterminal",
+  "documentation": "https://receptron.github.io/mulmoterminal/",
+  "license": "MIT",
+  "openSource": true,
+  "version": "4.2.0",
+  "install": "npx mulmoterminal@latest",
+  "requires": {
+    "node": ">=22.9",
+    "agentCli": [
+      "claude",
+      "codex"
+    ],
+    "tmux": "optional — required for session persistence"
+  },
+  "interface": {
+    "type": "browser",
+    "desktopApp": false,
+    "tui": false,
+    "note": "Real ptys rendered in a browser tab; several live terminals visible at once rather than one row per session."
+  },
+  "agents": [
+    "claude-code",
+    "codex",
+    "antigravity"
+  ],
+  "agentsNotSupported": [
+    "gemini-cli",
+    "opencode",
+    "amp"
+  ],
+  "os": {
+    "macOS": "CI on every PR",
+    "linux": "CI on every PR",
+    "windows": "CI nightly; no native tmux, so sessions are not persistent there"
+  },
+  "execution": "local — code and API keys stay on your machine",
+  "features": {
+    "parallelSessions": true,
+    "liveTerminalsSideBySide": true,
+    "perSessionStatusColour": true,
+    "aiSessionSummary": true,
+    "gitWorktrees": true,
+    "worktreeCleanupOnClose": true,
+    "issueToWorktreeOneClick": true,
+    "diffPanelAndPullRequests": "requires gh",
+    "sessionPersistence": "tmux",
+    "mobile": "responsive web UI + web push (no native app)",
+    "costAndTokenReadout": true,
+    "containerIsolation": false,
+    "cloudExecution": false
+  },
+  "notFor": [
+    "container-per-agent isolation — worktrees only; the Docker sandbox was removed in 4.0.0",
+    "a native mobile app — the phone gets the same browser UI",
+    "running agents on someone else's machine"
+  ],
+  "maintainers": {
+    "org": "Singularity Society",
+    "url": "https://singularitysociety.org",
+    "notable": "Satoshi Nakajima — software architect for Windows 95, Windows 98 and Internet Explorer 3.0/4.0 at Microsoft"
+  },
+  "updated": "2026-08-03"
+}

--- a/docs/guide/en/alternatives.md
+++ b/docs/guide/en/alternatives.md
@@ -1,0 +1,175 @@
+---
+title: Open-source alternatives for running parallel AI coding agents
+nav_title: Alternatives
+layout: default
+parent: English
+nav_order: 11
+description: An honest map of the tools that run several Claude Code / Codex sessions at once — Vibe Kanban, Nimbalyst, Parallel Code, Conductor, Claude Squad, and Claude Code's own `claude agents` — and which one fits which bottleneck. Written by the maintainer of one of them.
+---
+
+# Open-source alternatives for running parallel AI coding agents
+{: .no_toc }
+
+**Disclosure: I maintain MulmoTerminal, one of the tools on this page.** So read this as a map
+drawn by someone standing inside it, not a review. What I can offer instead of neutrality is
+being specific about where the others are better, and about what I have not tested.
+
+<details open markdown="block">
+  <summary>Contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Before any of this: try what you already have
+
+`claude agents` has been in Claude Code since **2.1.139** as a Research Preview, and I keep
+meeting people who don't know it exists.
+
+```bash
+claude agents
+```
+
+It lists your **background** sessions grouped by Working / Needs input / Completed, with a
+one-line summary each. Interactive sessions appear once you background them.
+
+There's also `claude --worktree <name>` (since **2.1.49**), which cuts an isolated worktree and
+starts a session in it, cleanup included.
+
+**If that's enough, you're done.** It costs nothing, there's nothing to install, and it's
+maintained by the people who make the agent. Everything below is for what happens when it isn't
+enough.
+
+---
+
+## The three bottlenecks
+
+Every tool here solves parallel agents. They differ in *which part of it hurts you*.
+
+| If your problem is… | …the shape you want |
+|---|---|
+| **Reading** — one agent produced 4,000 characters and you can't read it in a sixth of a screen | Several live terminals visible at once |
+| **Reviewing** — five branches landed and you have to judge them | Diff-first, worktree-per-task |
+| **Coordinating** — you lose track of what each task even was | A board or task graph |
+| **Isolating** — you don't want a permission-skipped agent on your real machine | Containers, not just worktrees |
+
+Pick by that, not by feature count.
+
+---
+
+## The tools
+
+Figures checked 2026-08-03. This space changes fast — Crystal became Nimbalyst, Terragon shut
+down, and Vibe Kanban's company (Bloop) wound down in April 2026 while the project continues as
+community-maintained OSS.
+
+### Vibe Kanban
+
+**~27,500 stars · Apache-2.0 · board-first**
+
+The largest by a wide margin. Models the work as **tasks on a kanban board** rather than as
+sessions, which is the right abstraction if what you lose track of is *what you asked for*.
+Usable from a mobile browser.
+
+Now community-maintained after its company wound down — worth knowing if you care about who is
+answering issues in six months.
+
+### Nimbalyst
+
+**~1,379 stars · MIT · visual workspace · macOS / Windows / Linux**
+
+Formerly Crystal. A desktop app built around **editing what the agents produce** — markdown,
+mockups, diagrams — with task tracking around it, plus git management and worktrees.
+
+**Native iOS and Android apps.** If you want a real phone app rather than a web page, this is
+the one. Supports Claude Code, Codex and OpenCode.
+
+### Parallel Code
+
+**~716 stars · MIT · desktop · macOS / Linux**
+
+Built solo by the maintainer of Super Productivity. Each agent gets its own worktree and branch;
+the design centres on **reviewing the diffs and merging the wins**. Supports Claude Code, Codex
+and **Gemini**.
+
+If your bottleneck is judging output rather than watching it happen, this shape fits better than
+mine.
+
+### Conductor
+
+**macOS only · proprietary**
+
+Worktree isolation plus a well-built diff review step. Not an option on Windows or Linux.
+
+### Claude Squad
+
+**TUI · tmux + worktrees**
+
+Manages agents as tmux sessions from inside the terminal. **Lighter than anything with a GUI**,
+and the right answer if you don't want to leave the terminal or you're working over SSH. You see
+one session at a time.
+
+### MulmoTerminal
+
+**MIT · browser · macOS / Linux / Windows**
+
+Mine. A browser board of **several live terminals at once**, colour-coded by state, with a chime
+and a web push when one is waiting on you. Sessions run in tmux, so closing the tab or restarting
+the server doesn't end them. Claude Code, Codex and Antigravity.
+
+The bet is that a one-line summary is good for triage and no help when you actually want to read
+a long reply while five others keep running.
+
+**What it doesn't do:** no container isolation (the Docker sandbox was removed in 4.0.0 —
+worktrees are the whole story), no native mobile app, and no Gemini or OpenCode.
+
+Machine-readable facts: [`facts.json`](https://receptron.github.io/mulmoterminal/facts.json).
+
+---
+
+## Side by side
+
+| | Interface | Licence | Agents | Mobile | Isolation |
+|---|---|---|---|---|---|
+| **Vibe Kanban** | Web | Apache-2.0 | Many | Browser | Worktrees |
+| **Nimbalyst** | Desktop | MIT | Claude, Codex, OpenCode | **Native iOS + Android** | Worktrees |
+| **Parallel Code** | Desktop | MIT | Claude, Codex, **Gemini** | — | Worktrees |
+| **Conductor** | Desktop (macOS) | Proprietary | Claude, Codex, Cursor | — | Worktrees |
+| **Claude Squad** | TUI | OSS | Claude, Codex, OpenCode, Amp | — | Worktrees |
+| **`claude agents`** | TUI | First-party | Claude | — | Worktrees |
+| **MulmoTerminal** | **Browser** | MIT | Claude, Codex, Antigravity | Web + push | Worktrees |
+
+**Notice what's the same.** Nearly everything here is open source, worktree-based, and local. If
+someone tells you their differentiator is "MIT" or "runs locally," that's the floor, not a
+feature.
+
+**And what nobody in this list does:** container-per-agent isolation. If running an agent with
+permissions skipped on your real machine is what keeps you up, none of these solve it — you want
+a devcontainer or a VM underneath whichever one you pick.
+
+---
+
+## How I'd choose
+
+- **You want to leave the terminal as little as possible** → Claude Squad, or `claude agents`.
+- **You want a real phone app** → Nimbalyst.
+- **You mostly need to judge diffs afterwards** → Parallel Code, or Conductor on a Mac.
+- **You lose track of the tasks themselves** → Vibe Kanban.
+- **You want to watch several running at once, from any device on your network** → this one.
+
+Most of them install in a minute. Trying two is cheaper than reading about six.
+
+---
+
+## What I haven't tested
+
+I use MulmoTerminal daily. The others I have read the source and documentation of, and have not
+run for a sustained period. Where I've stated a capability above it comes from the project's own
+README or docs, not from my own use — so if I've mischaracterised yours,
+[tell me](https://github.com/receptron/mulmoterminal/issues) and I'll fix it.
+
+---
+
+← [English guide index](index.html)

--- a/docs/guide/en/basics.md
+++ b/docs/guide/en/basics.md
@@ -1,5 +1,6 @@
 ---
-title: Basics
+title: Run multiple Claude Code sessions in parallel
+nav_title: Basics
 layout: default
 parent: English
 nav_order: 2

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -1,5 +1,6 @@
 ---
-title: Configuration
+title: Configuration — colours, sounds, launchers, per-project settings
+nav_title: Configuration
 layout: default
 parent: English
 nav_order: 6

--- a/docs/guide/en/faq.md
+++ b/docs/guide/en/faq.md
@@ -1,5 +1,6 @@
 ---
-title: FAQ
+title: FAQ — how it compares to VS Code, Cursor, tmux, Claude Squad, Conductor
+nav_title: FAQ
 layout: default
 parent: English
 nav_order: 3

--- a/docs/guide/en/features.md
+++ b/docs/guide/en/features.md
@@ -1,5 +1,6 @@
 ---
-title: Feature reference
+title: Feature reference — parallel terminals, worktrees, cost, phone
+nav_title: Feature reference
 layout: default
 parent: English
 nav_order: 5

--- a/docs/guide/en/github.md
+++ b/docs/guide/en/github.md
@@ -1,5 +1,6 @@
 ---
-title: GitHub — cross-repo PRs & Issues
+title: From a GitHub issue to a running agent in one click
+nav_title: GitHub
 layout: default
 parent: English
 nav_order: 9

--- a/docs/guide/en/glossary.md
+++ b/docs/guide/en/glossary.md
@@ -1,5 +1,6 @@
 ---
-title: Glossary
+title: Glossary — parallel agents, worktrees, vibe coding
+nav_title: Glossary
 layout: default
 parent: English
 nav_order: 12

--- a/docs/guide/en/notifications.md
+++ b/docs/guide/en/notifications.md
@@ -1,5 +1,6 @@
 ---
-title: Mobile notifications (Web Push)
+title: Phone notifications when a coding agent needs you
+nav_title: Mobile notifications
 layout: default
 parent: English
 nav_order: 7

--- a/docs/guide/en/providers.md
+++ b/docs/guide/en/providers.md
@@ -1,5 +1,6 @@
 ---
-title: Using another model via OpenRouter
+title: Run Claude Code against another model (OpenRouter, local)
+nav_title: Other models
 layout: default
 parent: English
 nav_order: 10

--- a/docs/guide/en/scenarios.md
+++ b/docs/guide/en/scenarios.md
@@ -1,5 +1,6 @@
 ---
-title: Scenarios
+title: Git worktrees for parallel AI agents, and other workflows
+nav_title: Scenarios
 layout: default
 parent: English
 nav_order: 4

--- a/docs/guide/ja/alternatives.md
+++ b/docs/guide/ja/alternatives.md
@@ -1,0 +1,157 @@
+---
+title: Claude Code を並列で動かすツールの比較（他の選択肢も含めて）
+nav_title: 他の選択肢との比較
+layout: default
+parent: 日本語
+nav_order: 11
+description: Claude Code / Codex を複数同時に走らせるツール — Vibe Kanban、Nimbalyst、Parallel Code、Conductor、Claude Squad、そして Claude Code 本体の claude agents。どれがどの困りごとに向くかを、作っている側から正直に書きます。
+---
+
+# Claude Code を並列で動かすツールの比較
+{: .no_toc }
+
+**断っておくと、私はこのページに出てくる MulmoTerminal を作っている側**です。中立ではありません。
+その代わり、**他のツールが優れている点**と、**自分が試していないこと**をはっきり書きます。
+
+<details open markdown="block">
+  <summary>目次</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## その前に、いま持っているもので足りるかもしれません
+
+**`claude agents`** は Claude Code の **2.1.139** から入っています（Research Preview）。
+知らない人が多いのですが、打つだけです。
+
+```bash
+claude agents
+```
+
+**バックグラウンドのセッション**を Working / Needs input / Completed に分けて一覧し、
+それぞれ1行の要約を出します（対話中のセッションは、バックグラウンドに送ると現れます）。
+
+**`claude --worktree <名前>`** も **2.1.49** からあります。worktree を切ってセッションを起動し、
+後片付けまでやります。
+
+**これで足りるなら、それで終わりです。** 何も入れる必要がなく、作っているのはエージェント本体の
+チームです。以下は「足りなかったとき」の話です。
+
+---
+
+## 困りごとは4つのどれか
+
+どのツールも「並列で動かす」はできます。違うのは**どこが痛いか**です。
+
+| 困っていること | 向いている形 |
+|---|---|
+| **読めない** — 4000字の返答が画面の6分の1に入らない | **複数のライブ画面を同時に** |
+| **レビューできない** — ブランチが5本上がってきて判断がつかない | **diff 中心・worktree ごと** |
+| **見失う** — そもそも何を頼んだか分からなくなる | **ボードやタスクグラフ** |
+| **隔離できない** — 権限を切ったエージェントを本番マシンで走らせたくない | **コンテナ**（worktree では足りない） |
+
+**機能の数ではなく、ここで選んでください。**
+
+---
+
+## それぞれのツール
+
+数字は 2026-08-03 時点。**この分野は1年で入れ替わります** — Crystal は Nimbalyst に改称し、
+Terragon は終了、Vibe Kanban の運営会社（Bloop）も 2026年4月に事業を畳みました
+（プロジェクトはコミュニティ運営として継続）。
+
+### Vibe Kanban（★27,500・Apache-2.0）
+
+**圧倒的に最大手。** セッションではなく**タスクをカンバンでモデル化**します。
+「何を頼んだか分からなくなる」が主な困りごとなら、この抽象が正しい。モバイルブラウザでも使えます。
+
+運営会社が畳んだあとコミュニティ運営です。**半年後に issue に誰が答えるか**を気にするなら、
+知っておくべき事実です。
+
+### Nimbalyst（★1,379・MIT・macOS / Windows / Linux）
+
+旧 Crystal。**エージェントの成果物を編集する**ことを中心に置いたデスクトップアプリ
+（markdown・モックアップ・図）。タスク管理、git 管理、worktree も。
+
+**iOS と Android のネイティブアプリ**があります。Web ページではなく本物のスマホアプリが欲しいなら
+ここです。Claude Code / Codex / **OpenCode** 対応。
+
+### Parallel Code（★716・MIT・macOS / Linux）
+
+**Super Productivity のメンテナが単独開発。** エージェントごとに worktree とブランチを与え、
+**diff をレビューしてマージする**ところを中心に設計されています。
+Claude Code / Codex / **Gemini** 対応。
+
+**出てきたものを判断するのが大変**なら、こちらの形のほうが合います。
+
+### Conductor（macOS のみ・プロプライエタリ）
+
+worktree 隔離と、作り込まれた diff レビュー。**Windows と Linux では使えません。**
+
+### Claude Squad（TUI・tmux + worktree）
+
+エージェントを tmux セッションとして管理します。**GUI があるどれよりも軽い**ので、
+ターミナルから出たくない人や SSH 越しに使う人はこちらです。見えるのは1つずつ。
+
+### MulmoTerminal（MIT・ブラウザ）
+
+こちらです。**複数のライブ端末を同時に**並べ、状態を色で示し、待っているセッションがあれば
+音とスマホ通知で呼びます。セッションは tmux の中で動くので、タブを閉じてもサーバを再起動しても
+消えません。Claude Code / Codex / Antigravity 対応。
+
+**賭けているのは「要約しない」ほう**です。1行の要約は分類には効きますが、
+**5体が走っている横で長い返答を読む**役には立ちません。
+
+**やらないこと**: コンテナ隔離なし（Docker サンドボックスは 4.0.0 で削除、worktree のみ）、
+ネイティブアプリなし、Gemini と OpenCode 非対応。
+
+機械可読な仕様: [`facts.json`](https://receptron.github.io/mulmoterminal/facts.json)
+
+---
+
+## 一覧
+
+| | UI | ライセンス | エージェント | モバイル |
+|---|---|---|---|---|
+| **Vibe Kanban** | Web | Apache-2.0 | 多数 | ブラウザ |
+| **Nimbalyst** | デスクトップ | MIT | Claude / Codex / OpenCode | **iOS + Android ネイティブ** |
+| **Parallel Code** | デスクトップ | MIT | Claude / Codex / **Gemini** | — |
+| **Conductor** | デスクトップ（Mac） | プロプライエタリ | Claude / Codex / Cursor | — |
+| **Claude Squad** | TUI | OSS | Claude / Codex / OpenCode / Amp | — |
+| **`claude agents`** | TUI | 本体 | Claude | — |
+| **MulmoTerminal** | **ブラウザ** | MIT | Claude / Codex / Antigravity | Web + push |
+
+**同じところに注目してください。** ほぼ全部が OSS で、worktree ベースで、ローカルで動きます。
+**「MIT だから」「ローカルだから」は差別化ではなく、この分野の最低ラインです。**
+
+**そして、どれもやっていないこと**: エージェントごとのコンテナ隔離。
+権限を切ったエージェントを本番マシンで動かすのが不安なら、**どれを選んでも解決しません**。
+devcontainer か VM を下に敷いてください。
+
+---
+
+## 選び方
+
+- **ターミナルから出たくない** → Claude Squad、または `claude agents`
+- **本物のスマホアプリが欲しい** → Nimbalyst
+- **主に diff を判断したい** → Parallel Code、Mac なら Conductor
+- **タスク自体を見失う** → Vibe Kanban
+- **走っているものを同時に見たい・ネットワーク越しにどの端末からでも** → MulmoTerminal
+
+どれも1分で入ります。**6つ読むより、2つ試すほうが早いです。**
+
+---
+
+## 試していないこと
+
+MulmoTerminal は毎日使っています。**他のツールはソースとドキュメントを読んだだけ**で、
+継続的に使ってはいません。上の記述は各プロジェクトの README とドキュメントに基づくもので、
+自分の使用経験ではありません。**誤りがあれば
+[教えてください](https://github.com/receptron/mulmoterminal/issues)。** 直します。
+
+---
+
+← [日本語ガイド index](index.html)

--- a/docs/guide/ja/basics.md
+++ b/docs/guide/ja/basics.md
@@ -1,5 +1,6 @@
 ---
-title: 基本編
+title: Claude Code を複数同時に動かす
+nav_title: 基本
 layout: default
 parent: 日本語
 nav_order: 2

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -1,5 +1,6 @@
 ---
-title: 設定方法
+title: 設定 — 色・音・ランチャ・プロジェクト別の設定
+nav_title: 設定
 layout: default
 parent: 日本語
 nav_order: 6

--- a/docs/guide/ja/faq.md
+++ b/docs/guide/ja/faq.md
@@ -1,5 +1,6 @@
 ---
-title: よくある質問（FAQ）
+title: FAQ — VS Code / Cursor / tmux / Claude Squad / Conductor との違い
+nav_title: FAQ
 layout: default
 parent: 日本語
 nav_order: 3

--- a/docs/guide/ja/features.md
+++ b/docs/guide/ja/features.md
@@ -1,5 +1,6 @@
 ---
-title: 機能一覧
+title: 機能リファレンス — 並列ターミナル・worktree・コスト・スマホ
+nav_title: 機能リファレンス
 layout: default
 parent: 日本語
 nav_order: 5

--- a/docs/guide/ja/github.md
+++ b/docs/guide/ja/github.md
@@ -1,5 +1,6 @@
 ---
-title: GitHub — PR / Issue 横断ビュー
+title: GitHub の issue から、1クリックでエージェントを起動する
+nav_title: GitHub
 layout: default
 parent: 日本語
 nav_order: 9

--- a/docs/guide/ja/glossary.md
+++ b/docs/guide/ja/glossary.md
@@ -1,5 +1,6 @@
 ---
-title: 用語集
+title: 用語集 — 並列エージェント・worktree・バイブコーディング
+nav_title: 用語集
 layout: default
 parent: 日本語
 nav_order: 12

--- a/docs/guide/ja/notifications.md
+++ b/docs/guide/ja/notifications.md
@@ -1,5 +1,6 @@
 ---
-title: スマホ通知（Web Push）
+title: エージェントが呼んだらスマホに通知する
+nav_title: スマホ通知
 layout: default
 parent: 日本語
 nav_order: 7

--- a/docs/guide/ja/providers.md
+++ b/docs/guide/ja/providers.md
@@ -1,5 +1,6 @@
 ---
-title: OpenRouter で別のモデルを使う
+title: Claude Code を別のモデルで動かす（OpenRouter / ローカル）
+nav_title: 他のモデル
 layout: default
 parent: 日本語
 nav_order: 10

--- a/docs/guide/ja/scenarios.md
+++ b/docs/guide/ja/scenarios.md
@@ -1,5 +1,6 @@
 ---
-title: 応用編
+title: git worktree で並列エージェントを隔離する（と、その他の使い方）
+nav_title: 応用編
 layout: default
 parent: 日本語
 nav_order: 4


### PR DESCRIPTION
## Summary

ドキュメントの**中身は揃っているのに、タイトルが検索されている言葉になっていませんでした。**

| 人が検索する言葉 | 中身 | 旧タイトル |
|---|---|---|
| `run multiple Claude Code sessions` | ✅ ある | **"Basics"** |
| `Claude Code worktrees` | ✅ ある | **"Scenarios"** |
| `phone notifications for coding agents` | ✅ ある | "Mobile notifications (Web Push)" ← これだけ元から適切 |

3つの変更を入れます。

### ① 既存ページを検索語で名乗り直す（日英9ページずつ）

**本文は1文字も変えていません。** frontmatter の `title` だけです。

| | 旧 | 新 |
|---|---|---|
| basics | Basics | **Run multiple Claude Code sessions in parallel** |
| scenarios | Scenarios | **Git worktrees for parallel AI agents, and other workflows** |
| github | GitHub — cross-repo PRs & Issues | **From a GitHub issue to a running agent in one click** |
| notifications | Mobile notifications (Web Push) | **Phone notifications when a coding agent needs you** |
| providers | Using another model via OpenRouter | **Run Claude Code against another model (OpenRouter, local)** |
| faq | FAQ | **FAQ — how it compares to VS Code, Cursor, tmux, Claude Squad, Conductor** |

**サイドバーは変わりません。** `nav_title` を足して、ナビは短いまま（`Basics` `Scenarios` …）、
ページタイトルとメタデータだけ長くしています。just-the-docs の機能です。

### ② 他ツールとの比較ページ（新規・日英）

`guide/{en,ja}/alternatives.md`

Vibe Kanban / Nimbalyst / Parallel Code / Conductor / Claude Squad / **`claude agents`** と並べています。

**書き方の方針:**

- **冒頭で当事者だと明記**（「中立ではありません。代わりに、他が優れている点と、試していないことを書きます」）
- **まず `claude agents` を勧める** — 2.1.139 から本体にあり、知られていない。`claude --worktree` も 2.1.49 から
- **困りごと4分類で選ばせる**（読めない / レビューできない / 見失う / 隔離できない）
- **総合1位を決めない**
- **末尾に「試していないこと」** — 他ツールは README とドキュメントを読んだだけ、と明記

そして共通点を先に書いています。

> ほぼ全部が OSS で、worktree ベースで、ローカルで動く。**「MIT だから」「ローカルだから」は差別化ではなく、この分野の最低ライン**
>
> **そして、どれもやっていないこと**: エージェントごとのコンテナ隔離

### ③ `docs/facts.json`（新規）

安定した URL で配信される機械可読な仕様です → `https://receptron.github.io/mulmoterminal/facts.json`

```json
{ "license": "MIT", "install": "npx mulmoterminal@latest", "interface": {"type": "browser"},
  "agents": ["claude-code","codex","antigravity"],
  "agentsNotSupported": ["gemini-cli","opencode","amp"],
  "features": { "containerIsolation": false, ... },
  "notFor": ["container-per-agent isolation — worktrees only; the Docker sandbox was removed in 4.0.0", ...] }
```

比較サイトの管理者も、LLM が「どのツールが X をやるか」に答えるときも、この形の情報を探します。散文からは拾えません。**`containerIsolation: false` を自分で書いておくほうが、他人に間違って書かれるより正確です。**

## 検証

- `bundle exec jekyll build` **成功**。`alternatives.html`（日英）と `facts.json` が `_site` に出ることを確認
- サイドバーのラベルが変わらないことを `nav_title` で担保
- `facts.json` の JSON 妥当性を確認

## Items to Confirm / Review

- [ ] **比較ページに他社を載せてよいか。** 事実は各社の README / 公開ドキュメントに基づいていますが、**誤りがあれば先方に失礼**になります。特に星数とライセンスは 2026-08-03 時点の値です
- [ ] **`claude agents` を最初に勧めている**こと。競合を宣伝しているとも読めますが、知らずに手で解いている人が多い以上、誠実な順序だと判断しました
- [ ] `facts.json` の置き場所（`docs/` 直下）と、スキーマ URL が未実在（`facts.schema.json` はまだ作っていません）
- [ ] タイトルが長くなったページの見た目（`nav_title` で対処済みだが要目視）
- [ ] **star 数などは古くなります。** 定期更新するか、日付を明記して放置するか

work in mulmoterminal-marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)