### PR TITLE
feat: workspace では起動方法によらず同じ GUI ツールに届くようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,10 +114,18 @@ Deliberate divergence is fine — say so in a comment with the reason, and flag 
 
 The same tool is called `mcp__mt__presentChart` in a workspace cell and
 `mcp__mulmoterminal-render__presentChart` in a project cell. Both are current. The branch is
-`carriesFullGuiMcp()` in `server/session/spawn-claude.ts`: a workspace cell / single view / cell-less
-chat gets a **generated** `--mcp-config` carrying every tool under `GUI_SERVER_ID`; a project cell is
+`carriesFullGuiMcp()` in `server/session/mcp-config.ts`: the workspace / single view / cell-less chat
+gets a **generated** `--mcp-config` carrying every tool under `GUI_SERVER_ID`; a project cell is
 handed **no `--mcp-config` at all** and reaches the tools through the user's own `.mcp.json` under the
 per-group ids from `toolGroupServerId()`. Both constants live in `common/toolGroups.ts`.
+
+**Ask that predicate from every new spawn path.** It is deliberately agent-agnostic: claude cells,
+codex cells and the launcher chips that run either all consult it, so two terminals in the workspace
+reach the same tools however they were started. It sat in `spawn-claude.ts` while claude was the only
+caller, and the drift that produced — a codex cell and a `claude` chip silently getting less than the
+cell beside them — is exactly what a new path re-creates by not asking. A chip's only lever is the
+command line, so its injection lives in `launcher-gui-mcp.ts` and recognises **only** a bare `claude`
+or `codex`: it is rewriting text the user wrote, and an unrecognised shape must be left alone.
 
 The ids differ in **who owns them**, which is what decides whether a rename is free:
 

--- a/README.md
+++ b/README.md
@@ -1069,8 +1069,27 @@ MulmoTerminal delivers the GUI MCP by **two different routes**, and they do not 
 | Tool name looks like | `mcp__mt__presentChart` | `mcp__mulmoterminal-render__presentChart` |
 
 Which route a session takes is decided by `carriesFullGuiMcp()` in
-`server/session/spawn-claude.ts` — the single view, a cell-less chat, or a cell whose cwd **is**
+`server/session/mcp-config.ts` — the single view, a cell-less chat, or anything whose cwd **is**
 the workspace take the first; anything in a project directory takes the second.
+
+**The workspace is agent-agnostic, and so is the way you start a terminal there.** All three
+agents and the launcher chips ask the same predicate, so two terminals in the workspace reach
+the same tools no matter how they were started:
+
+| Started as | In the workspace | In a project directory |
+|---|---|---|
+| claude cell (including `?gui=0`) | `mt`, every tool | the directory's registered groups |
+| codex cell | `mt`, every tool | the directory's registered groups |
+| launcher chip running `claude` | `mt`, every tool — flags inserted into the command line | nothing injected; its own `.mcp.json` loads |
+| launcher chip running `codex` | `mt`, every tool — `-c` overrides inserted | the directory's registered groups |
+| launcher chip running anything else | untouched | untouched |
+
+A chip is a command line the user wrote, so the injection is a **rewrite of their text** and is
+deliberately narrow: only a bare `claude` or `codex` is recognised, and anything else — a wrapper
+script, `FOO=1 claude` — is passed through unchanged. One consequence is worth knowing: a `claude`
+chip in the workspace is given `--strict-mcp-config`, which makes our config the only source, so
+**the user's own MCP servers do not load in that terminal**. That is the price of the chip and the
+cell carrying identical tools; a chip that needs the user's own servers should not run claude.
 
 **The asymmetry is deliberate.** `mt` is ours to name: nothing on disk holds it, it is
 regenerated on every spawn, so it was shortened to stop paying 17 characters per tool name. The

--- a/README.md
+++ b/README.md
@@ -1086,10 +1086,13 @@ the same tools no matter how they were started:
 
 A chip is a command line the user wrote, so the injection is a **rewrite of their text** and is
 deliberately narrow: only a bare `claude` or `codex` is recognised, and anything else — a wrapper
-script, `FOO=1 claude` — is passed through unchanged. One consequence is worth knowing: a `claude`
-chip in the workspace is given `--strict-mcp-config`, which makes our config the only source, so
-**the user's own MCP servers do not load in that terminal**. That is the price of the chip and the
-cell carrying identical tools; a chip that needs the user's own servers should not run claude.
+script, `FOO=1 claude` — is passed through unchanged.
+
+A `claude` chip in the workspace is given `--strict-mcp-config`, same as the cell. That makes the
+generated config the only source — but it already contains your Settings `userMcpServers`, so
+**those still load and are still pre-approved**. What stops contributing is a project directory's
+per-folder `.mcp.json`, which in the workspace is the intent: that file is where the per-group URLs
+live, and the chip is being handed the all-tools URL instead.
 
 **The asymmetry is deliberate.** `mt` is ours to name: nothing on disk holds it, it is
 regenerated on every spawn, so it was shortened to stop paying 17 characters per tool name. The

--- a/plans/feat-workspace-gui-mcp-parity.md
+++ b/plans/feat-workspace-gui-mcp-parity.md
@@ -55,6 +55,27 @@ claude --mcp-config <path> --strict-mcp-config --allowedTools <list>
 コマンド前にグローバルオプションを要求し、claude は末尾の `--add-dir` が可変長なので、どちらも
 「直後」でなければならない）。
 
+## レビュー指摘への対応（codex-review / CodeRabbit、いずれも同じ 2 点）
+
+**A. `codex` チップが `allTools: false` のままだった。** PR 説明の表では「workspace の codex チップも
+`mt`」と書いていたのに、コードを直していなかった。**説明と実装が食い違っていた**ので、
+`allTools: carriesFullGuiMcp(false, cwd)` に修正。
+
+**B. config ファイルを claude と確定する前に書いていた。** workspace のチップなら `zsh` でも
+`yarn dev` でも `<session>-mcp.json` を書いてしまい、さらに launch 経路は `withSettingsCleanup` を
+通っていないので spawn 失敗時に孤児になる。→ `launcherProgram(command) === "claude"` を確認して
+から書くようにし、spawn を `withSettingsCleanup` で包んだ（`startAndWire` が rethrow を捕まえるので
+ブラウザへのエラー表示はそのまま）。
+
+**C.（自分のドキュメントが嘘だった）** `--strict-mcp-config` は「ユーザー自身の MCP を無効化する」と
+書いていたが、`mcpConfigJson` は `userMcpServers` を**ペイロードに含めている**ので、それらは読まれる。
+実際に落ちるのは project ディレクトリの per-folder `.mcp.json` の方。
+
+修正方向として「GUI 専用ペイロードを作って除外する」案も提示されたが、**それは parity を壊す**
+（セルでは読まれるため）。したがって直したのは実装ではなく記述の方。あわせて、セル側だけが行っていた
+「ユーザーサーバーの id を `--allowedTools` に足す」処理を `fullGuiAllowedTools` として共通化し、
+チップでも同じ承認になるようにした — 2 箇所に同じ join を書くのは、まさに今回のドリフトの再生産なので。
+
 ## 変えていないもの
 
 project ディレクトリは**全経路で完全に据え置き**。`full-gui-mcp.spec.ts` がその不変条件を

--- a/plans/feat-workspace-gui-mcp-parity.md
+++ b/plans/feat-workspace-gui-mcp-parity.md
@@ -1,0 +1,65 @@
+# feat: workspace では起動方法によらず同じ GUI ツールに届くようにする
+
+#1355 の直後、`mt` がどの経路で渡っているかを追った際に見つかった 2 つのズレ。オーナー判断
+（2026-08-03）で「workspace セルはエージェント非依存」に倒す。
+
+## 直前の状態
+
+`carriesFullGuiMcp` は claude セルしか見ていなかった。同じ workspace ディレクトリで:
+
+| 起動方法 | 届いていたもの |
+| --- | --- |
+| claude セル（`?gui=0` でも） | `mt` = 全ツール |
+| codex セル | ディレクトリが登録したグループのみ |
+| ランチャーチップ `claude` | **何もなし**（Canvas が出ない） |
+| ランチャーチップ `codex` | グループのみ |
+
+隣り合ったセルが、エージェントが違うだけで到達範囲が違う状態だった。
+
+## 変更
+
+**0. `carriesFullGuiMcp` を `spawn-claude.ts` → `mcp-config.ts` へ移動。** 呼び出し側が 3 つに
+増えたため（claude の argv / codex の `-c` / チップのコマンド行）。claude が唯一の呼び出し元
+だった頃のローカルな都合でそこにあっただけで、今は「誰が何を受け取るか」を決める場所に置く方が
+正しい。spawn-codex が spawn-claude を import する形も避けられる。
+
+**1. codex セル（旧「意図的に対象外」）。** `allTools: attachGuiMcp` →
+`allTools: carriesFullGuiMcp(attachGuiMcp, cwd)`。
+
+これは実質的な拡大で、コメントにもそう書いた: **codex はサーバー単位承認**なので、その URL に
+乗っているものが一括で自動承認される — google / X（外部アカウント）、有料の生成、そして
+**どのグループにも属さない `spawnBackgroundChat`**（= all-tools URL でしか到達できない）。
+ただし同じセルの claude では全部すでに自動承認されており、閉じたのはその非対称性。
+
+**2. ランチャーチップの `claude`。** チップはユーザーが書いたコマンド文字列をログインシェルで
+実行するだけなので、argv がない。codex 用に既にある `launcherCommandWithGuiMcp` と同じ方式で、
+`launcherCommandWithClaudeGuiMcp` がプログラム直後に 3 つのフラグを差し込む:
+
+```
+claude --mcp-config <path> --strict-mcp-config --allowedTools <list>
+```
+
+- **JSON ではなくパス。** 数百バイトの JSON をシェル文字列に通すのは引用符の問題しかないので、
+  `mcpConfigFileArgument` を追加して常にファイルへ書く（Windows 限定だった `mcpConfigArgument`
+  と同じファイル名なので、reap の `cleanupSessionSettings` がそのまま消してくれる）。
+- **`--strict-mcp-config` は意図的に入れる。** これでユーザー自身の MCP サーバーはそのターミナル
+  では読まれなくなる。チップとセルで持ちツールが変わるのを避けるための代償で、オーナー判断。
+  この点は README にも明記した。
+- **新規スポーンのときだけ。** tmux 再アタッチは走っているプログラムを拾って `command` を無視
+  するので、読まれないファイルを書き残さない。
+- **素の `claude` しか認識しない。** ユーザーが書いたテキストを書き換える処理なので、ラッパーや
+  `FOO=1 claude` は触らない（codex 側と同じ方針・同じ recogniser）。
+
+両 rewriter に同じコマンドを通すが、それぞれ自分のプログラムしか認識しないので同時には発火しない。
+プログラム直後への挿入ロジックは `insertAfterProgram` として共通化した（codex は clap がサブ
+コマンド前にグローバルオプションを要求し、claude は末尾の `--add-dir` が可変長なので、どちらも
+「直後」でなければならない）。
+
+## 変えていないもの
+
+project ディレクトリは**全経路で完全に据え置き**。`full-gui-mcp.spec.ts` がその不変条件を
+assert している（チップの `null` ケースを含む）。
+
+## 検証
+
+`yarn typecheck` / `format` / `lint` / `test` 7733 passed（+10）。

--- a/server/index.ts
+++ b/server/index.ts
@@ -858,6 +858,8 @@ mountTerminalWebSockets({
   spawnCommandPty,
   spawnLauncherPty,
   resolveLauncher,
+  mcpConfigJson: (sessionId, host) => mcpConfigJson({ sessionId, host, port: PORT, userMcpServers: getUserMcpServers() }),
+  guiMcpTools: GUI_MCP_TOOLS,
 });
 
 // A bind failure (most often the port already in use) must not surface as an unhandled

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -31,8 +31,9 @@ import {
 } from "../session/registry.js";
 import { SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
-import { launcherCommandWithGuiMcp, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
-import { codexGuiMcpServers } from "../session/mcp-config.js";
+import { launcherCommandWithGuiMcp, launcherCommandWithClaudeGuiMcp, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
+import { codexGuiMcpServers, carriesFullGuiMcp } from "../session/mcp-config.js";
+import { mcpConfigFileArgument } from "../session/session-settings.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { parseTerminalSize, type TerminalSize } from "../../common/terminalSize.js";
@@ -65,6 +66,12 @@ export interface WsRouteDeps {
   spawnCommandPty: SpawnCommandPty;
   spawnLauncherPty: SpawnLauncherPty;
   resolveLauncher: ResolveLauncher;
+  /** The `--mcp-config` payload for a session, built per spawn (see session/mcp-config.ts). Needed
+   *  here, not only in the spawners, because a LAUNCHER chip running claude in the workspace gets
+   *  the same GUI MCP a claude cell there does — and its only lever is the command line. */
+  mcpConfigJson: (sessionId: string, host?: string) => string;
+  /** The fully-qualified GUI tool names such a chip pre-approves — the cell's `--allowedTools`. */
+  guiMcpTools: string;
 }
 
 // Pick the effective session id for a /ws connection: reattach a same-process live pty,
@@ -527,7 +534,23 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // never for the other reads as a broken feature. Only for a spawn, and only for codex — every
   // other command is passed through untouched (see launcher-gui-mcp.ts).
   const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
-  const launchCommand = launcherCommandWithGuiMcp(command, codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: false }), process.platform);
+  // The same closing-of-the-gap for a chip that runs CLAUDE, one step further: a claude CELL in the
+  // workspace carries the whole GUI MCP, so a chip beside it that ran plain claude had no Canvas at
+  // all. `carriesFullGuiMcp` with `false` because a chip is never the single view — the cwd is the
+  // only thing that can earn it here, which keeps a chip in a project directory exactly as it was.
+  //
+  // Only on a fresh spawn: a tmux reattach picks the running program up and ignores `command`, so
+  // writing a config file for it would leave a file behind for a process that never reads it.
+  const claudeGui =
+    live || !carriesFullGuiMcp(false, cwd)
+      ? null
+      : {
+          mcpConfigPath: mcpConfigFileArgument(sessionId, deps.mcpConfigJson(sessionId, "127.0.0.1")),
+          allowedTools: deps.guiMcpTools,
+        };
+  const withCodexGui = launcherCommandWithGuiMcp(command, codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: false }), process.platform);
+  // Both rewriters see the command; each recognises only its own program, so at most one fires.
+  const launchCommand = launcherCommandWithClaudeGuiMcp(withCodexGui, claudeGui, process.platform);
   if (!clientStillConnected(ws, "launch", sessionId, early)) return;
 
   // A launcher runs the user's own command line, so there is no binary pre-flight — but its cwd

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import { messageOf } from "../errors.js";
 import { CLAUDE_CWD, PORT, SESSION_ID_RE } from "../config/env.js";
 import { workspaceRequest } from "../config/workspace.js";
-import { getHeaderConfig } from "../config/config-routes.js";
+import { getHeaderConfig, getUserMcpServers } from "../config/config-routes.js";
 import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.js";
 import { resolveButtonCommand, shellQuoteFor } from "../config/header-resolve.js";
 import { resolveScript } from "../files/scripts.js";
@@ -31,9 +31,9 @@ import {
 } from "../session/registry.js";
 import { SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
-import { launcherCommandWithGuiMcp, launcherCommandWithClaudeGuiMcp, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
-import { codexGuiMcpServers, carriesFullGuiMcp } from "../session/mcp-config.js";
-import { mcpConfigFileArgument } from "../session/session-settings.js";
+import { launcherCommandWithGuiMcp, launcherCommandWithClaudeGuiMcp, launcherProgram, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
+import { codexGuiMcpServers, carriesFullGuiMcp, fullGuiAllowedTools } from "../session/mcp-config.js";
+import { mcpConfigFileArgument, withSettingsCleanup } from "../session/session-settings.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { parseTerminalSize, type TerminalSize } from "../../common/terminalSize.js";
@@ -529,35 +529,42 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   });
   if (!early) return;
 
-  // A launcher that runs codex gets the directory's registered tool groups too. The chip and the
-  // agent toggle land in the same cell and look the same, so a Canvas that lights up for one and
-  // never for the other reads as a broken feature. Only for a spawn, and only for codex — every
-  // other command is passed through untouched (see launcher-gui-mcp.ts).
-  const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
-  // The same closing-of-the-gap for a chip that runs CLAUDE, one step further: a claude CELL in the
-  // workspace carries the whole GUI MCP, so a chip beside it that ran plain claude had no Canvas at
-  // all. `carriesFullGuiMcp` with `false` because a chip is never the single view — the cwd is the
-  // only thing that can earn it here, which keeps a chip in a project directory exactly as it was.
+  // A launcher chip and the agent toggle land in the same cell and look the same, so a Canvas that
+  // lights up for one and never for the other reads as a broken feature. The chip has no argv, only
+  // the command line the user wrote, so each agent's MCP arrives as an insertion into that text.
   //
-  // Only on a fresh spawn: a tmux reattach picks the running program up and ignores `command`, so
-  // writing a config file for it would leave a file behind for a process that never reads it.
+  // `carriesFullGuiMcp` with `false`, for BOTH: a chip is never the single view, so the cwd is the
+  // only thing that can earn the full GUI MCP here — which keeps a chip in a project directory
+  // exactly as it was, on the groups its directory registered.
+  //
+  // Nothing at all on a tmux REATTACH: it picks the running program up and ignores `command`.
+  const fullGui = !live && carriesFullGuiMcp(false, cwd);
+  const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
+  const codexGui = live ? [] : codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: fullGui });
+  // The config file is written ONLY once the command is known to be claude. Writing it up front
+  // left a `<session>-mcp.json` behind for every workspace chip — `zsh`, `yarn dev`, anything — that
+  // would never read it (Codex review on #1358).
   const claudeGui =
-    live || !carriesFullGuiMcp(false, cwd)
-      ? null
-      : {
+    fullGui && launcherProgram(command) === "claude"
+      ? {
           mcpConfigPath: mcpConfigFileArgument(sessionId, deps.mcpConfigJson(sessionId, "127.0.0.1")),
-          allowedTools: deps.guiMcpTools,
-        };
-  const withCodexGui = launcherCommandWithGuiMcp(command, codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: false }), process.platform);
+          allowedTools: fullGuiAllowedTools(deps.guiMcpTools, getUserMcpServers()),
+        }
+      : null;
   // Both rewriters see the command; each recognises only its own program, so at most one fires.
-  const launchCommand = launcherCommandWithClaudeGuiMcp(withCodexGui, claudeGui, process.platform);
+  const launchCommand = launcherCommandWithClaudeGuiMcp(launcherCommandWithGuiMcp(command, codexGui, process.platform), claudeGui, process.platform);
   if (!clientStillConnected(ws, "launch", sessionId, early)) return;
 
   // A launcher runs the user's own command line, so there is no binary pre-flight — but its cwd
   // is checked like every other spawn's, and that refusal is already a sentence.
+  //
+  // withSettingsCleanup because this path can now WRITE a file before spawning: a spawn that throws
+  // never reaches reap, where the file is normally dropped, so without this a failed claude chip
+  // orphans its config until the next boot's prune (Codex review on #1358). startAndWire catches
+  // what this rethrows, so the failure still reaches the browser as a message.
   const startFailureMessage = startFailureMessageFor("the launch command");
   startAndWire(deps, ws, { id: sessionId, tag: "launch", early, startFailureMessage, size }, () =>
-    startLaunchEntry(deps, sessionId, ws, live, launchCommand, cwd),
+    withSettingsCleanup(sessionId, () => startLaunchEntry(deps, sessionId, ws, live, launchCommand, cwd)),
   );
 }
 

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -44,11 +44,33 @@ export function launcherAgent(command: string): SessionAgent {
 }
 
 /**
- * The command to actually run, with codex's MCP overrides inserted when this launcher runs codex.
+ * A launcher chip that runs CLAUDE, which reaches the GUI MCP through flags
+ * rather than `-c` overrides: `--mcp-config <path> --strict-mcp-config --allowedTools <list>`, the
+ * three a claude cell in the workspace is spawned with.
  *
- * The flags go directly after the program: codex's clap layout takes global options before the
- * subcommand, so appending them at the end would break `codex resume`-style invocations.
+ * `--strict-mcp-config` is in on purpose and it is the cost of exact parity: it makes our config
+ * the ONLY source, so the user's own MCP servers do not load in that terminal. Without it the chip
+ * and the cell would carry different tool sets, which is the confusion this closes (owner's call,
+ * 2026-08-03). A chip that wants the user's own servers is a chip that should not run claude.
+ *
+ * The config is a PATH, never inline JSON — see mcpConfigFileArgument.
+ *
+ * Only the workspace asks for this, and the caller decides that: a chip in a project directory is
+ * passed nothing, exactly as a project cell is, and its claude reads the directory's own config.
  */
+export function launcherCommandWithClaudeGuiMcp(
+  command: string,
+  gui: { mcpConfigPath: string; allowedTools: string } | null,
+  platform: NodeJS.Platform,
+): string {
+  if (gui === null || launcherProgram(command) !== "claude") return command;
+  const quote = shellQuoteFor(platform);
+  const flags = ["--mcp-config", quote(gui.mcpConfigPath), "--strict-mcp-config"];
+  if (gui.allowedTools) flags.push("--allowedTools", quote(gui.allowedTools));
+  return insertAfterProgram(command, flags);
+}
+
+/** The command to actually run, with codex's MCP overrides inserted when this launcher runs codex. */
 export function launcherCommandWithGuiMcp(command: string, servers: readonly GuiMcpServer[], platform: NodeJS.Platform): string {
   if (servers.length === 0 || launcherProgram(command) !== "codex") return command;
   const quote = shellQuoteFor(platform);
@@ -60,12 +82,22 @@ export function launcherCommandWithGuiMcp(command: string, servers: readonly Gui
     if (server.autoApprove) parts.push(`-c`, quote(`mcp_servers.${server.id}.default_tools_approval_mode="approve"`));
     return parts;
   });
-  // Scanned rather than split-and-rejoined: everything around the program is the user's text —
-  // quoting, spacing, and a trailing backslash-newline continuation included — and it is put back
-  // byte for byte. Trimming the tail would turn such a continuation into an unterminated command.
-  //
-  // Two index walks rather than one anchored regex: `^(\s*)(\S+)([\s\S]*)$` backtracks
-  // super-linearly on a long command (sonarjs flags it), and this says the same thing.
+  return insertAfterProgram(command, flags);
+}
+
+// Put `flags` directly after the program, leaving everything else byte for byte.
+//
+// Scanned rather than split-and-rejoined: everything around the program is the user's text —
+// quoting, spacing, and a trailing backslash-newline continuation included. Trimming the tail
+// would turn such a continuation into an unterminated command.
+//
+// Two index walks rather than one anchored regex: `^(\s*)(\S+)([\s\S]*)$` backtracks
+// super-linearly on a long command (sonarjs flags it), and this says the same thing.
+//
+// Directly after the program rather than appended, because BOTH agents need it there: codex's clap
+// layout takes global options before the subcommand (`codex resume`), and claude's own trailing
+// `--add-dir` is variadic, so a flag after it would be swallowed as one more directory.
+function insertAfterProgram(command: string, flags: readonly string[]): string {
   const isSpace = (index: number): boolean => /\s/.test(command[index] ?? "");
   let start = 0;
   while (start < command.length && isSpace(start)) start++;

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -48,10 +48,13 @@ export function launcherAgent(command: string): SessionAgent {
  * rather than `-c` overrides: `--mcp-config <path> --strict-mcp-config --allowedTools <list>`, the
  * three a claude cell in the workspace is spawned with.
  *
- * `--strict-mcp-config` is in on purpose and it is the cost of exact parity: it makes our config
- * the ONLY source, so the user's own MCP servers do not load in that terminal. Without it the chip
- * and the cell would carry different tool sets, which is the confusion this closes (owner's call,
- * 2026-08-03). A chip that wants the user's own servers is a chip that should not run claude.
+ * `--strict-mcp-config` is in on purpose, and what it actually shuts out is narrower than it looks:
+ * the generated config is then the ONLY source, but that config already CONTAINS the user's
+ * Settings servers (mcpConfigJson merges them), so those still load and are still pre-approved. It
+ * is the per-folder `.mcp.json` of a project directory that stops contributing — which in the
+ * workspace is the point, since that is the config the group URLs live in and the chip is being
+ * given the all-tools URL instead. Same three flags as the cell, same result (owner's call,
+ * 2026-08-03); the flag was included because parity is the goal, not despite it.
  *
  * The config is a PATH, never inline JSON — see mcpConfigFileArgument.
  *

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -116,3 +116,19 @@ export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpSer
   mcpServers[GUI_SERVER_ID] = { type: "http", url: `http://${host}:${port}/api/mcp/${sessionId}` };
   return JSON.stringify({ mcpServers });
 }
+
+/**
+ * What a full-GUI-MCP session pre-approves: our own tools, plus the user's Settings servers by id.
+ *
+ * Both halves matter, and the second is the one that surprises. `--strict-mcp-config` makes the
+ * generated `--mcp-config` the ONLY source — but that payload INCLUDES `userMcpServers` (above), so
+ * those servers still load; what strict shuts out is the per-folder `.mcp.json` a project directory
+ * would otherwise contribute. Pre-approving them here is what stops each of their tools raising a
+ * permission prompt, which is the behaviour the single view has always had.
+ *
+ * Shared rather than spelled out at each spawn because the two callers — a claude cell and a
+ * launcher chip running claude — are supposed to be indistinguishable, and this PR exists because
+ * they had drifted. Two copies of a join is exactly how they drift again.
+ */
+export const fullGuiAllowedTools = (guiMcpTools: string, userMcpServers: readonly UserMcpServer[]): string =>
+  [guiMcpTools, ...userMcpServers.map((server) => `mcp__${server.id}`)].join(",");

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -8,6 +8,7 @@
 // so the precedence rule below could not be tested without booting the server (#548).
 import type { UserMcpServer } from "../config/config-schema.js";
 import { toolGroupServerId, GUI_SERVER_ID, type ToolGroup } from "../../common/toolGroups.js";
+import { isWorkspaceCwd } from "../config/env.js";
 import type { GuiMcpServer } from "../agents/codex-args.js";
 
 export interface McpConfigInput {
@@ -21,6 +22,32 @@ export interface McpConfigInput {
 }
 
 const DEFAULT_HOST = "127.0.0.1";
+
+/**
+ * Does this session carry the WHOLE GUI MCP — every tool on the one `mt` URL — rather than the
+ * per-group URLs a directory registered for itself? Two ways to earn it, and they are different
+ * facts that used to be one flag:
+ *
+ *   `attachGuiMcp` — not a grid cell at all: the single view, or a chat spawned with no cell yet.
+ *   the CWD        — anything running in the workspace itself. Starting a terminal there is all
+ *                    but the same thing as running the single view, and that equivalence is what
+ *                    lets the single view eventually go.
+ *
+ * A session in a PROJECT directory is false on both counts and takes exactly the branch it took
+ * before any of this. Named and exported rather than left inline because that last sentence is the
+ * invariant the whole design is written around, and an invariant nothing can assert is just a hope.
+ *
+ * It lives HERE, next to the two payload builders, because all three agents now ask it — claude's
+ * argv, codex's `-c` overrides, and the launcher chip's rewritten command line. It was a local
+ * detail of spawn-claude.ts while claude was the only caller.
+ *
+ * This is also WHY THE TOOL NAMES DIFFER between cells, which looks like a bug until you know it:
+ * true carries every tool under one generated server id (`mt`), so the agent sees
+ * `mcp__mt__presentChart`; false picks the tools up from the user's per-folder config under the
+ * group ids, so the SAME tool is `mcp__mulmoterminal-render__presentChart`. Neither name is stale.
+ * See common/toolGroups.ts for why the two ids are not unified, and README's "MCP server ids".
+ */
+export const carriesFullGuiMcp = (attachGuiMcp: boolean, cwd: string | undefined): boolean => attachGuiMcp || isWorkspaceCwd(cwd);
 
 // The counterpart for GRID cells, which are handed no --mcp-config at all: their GUI tools
 // come from the user's OWN per-folder MCP config (`claude mcp add -s local`, `.mcp.json`),

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -44,6 +44,15 @@ export function mcpConfigArgument(sessionId: string, json: string, platform: Nod
   return mustUseFile(false, platform) ? writePrivate(mcpConfigFile(sessionId), json) : json;
 }
 
+// The same payload for a LAUNCHER chip, which is not an argv at all: it is a command line the user
+// wrote, run through the login shell, so the config has to be inserted as shell TEXT. That makes
+// the file unconditional rather than Windows-only — a few hundred bytes of JSON with nested quotes
+// passing through a shell is a quoting problem with no good answer, and a path has neither quotes
+// nor metacharacters. Same file as above, so reap's cleanupSessionSettings already drops it.
+export function mcpConfigFileArgument(sessionId: string, json: string): string {
+  return writePrivate(mcpConfigFile(sessionId), json);
+}
+
 // Run a spawn, taking the session's settings file with it if the spawn throws. A session
 // that never starts never reaches reap(), where the cleanup normally happens — so without
 // this a failed spawn leaves a token-bearing file behind (#579).

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -2,8 +2,8 @@
 // piece of index.ts (#548 step 3c): it spans the CLI args, the
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
-import { CLAUDE_CWD, PORT, isWorkspaceCwd } from "../config/env.js";
-import { guiMcpEnv } from "./mcp-config.js";
+import { CLAUDE_CWD, PORT } from "../config/env.js";
+import { guiMcpEnv, carriesFullGuiMcp } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter, getAppendSystemPrompt, getTerminalSubmit } from "../config/config-routes.js";
 import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
@@ -104,28 +104,6 @@ function sessionAddDirs(sessionId: string, configured: string[] | null | undefin
   const dropsDirectory = ensureDropsDir(sessionId);
   return dropsDirectory ? [...(configured ?? []), dropsDirectory] : configured;
 }
-
-/**
- * Does this session carry the WHOLE GUI MCP on `--mcp-config`, the way the single view always
- * has? Two ways to earn it, and they are different facts that used to be one flag:
- *
- *   `attachGuiMcp` — not a grid cell at all: the single view, or a chat spawned with no cell yet.
- *   the CWD        — a grid cell running in the workspace itself. Starting a terminal there is
- *                    all but the same thing as running the single view, and that equivalence is
- *                    what lets the single view eventually go.
- *
- * A cell in a PROJECT directory is false on both counts and takes exactly the branch it takes
- * today. Named and exported rather than left inline because that last sentence is the invariant
- * this whole change is written around, and an invariant nothing can assert is just a hope.
- *
- * This branch is also WHY THE TOOL NAMES DIFFER between cells, which looks like a bug until you
- * know it: true carries every tool under one generated server id (`mt`), so the agent sees
- * `mcp__mt__presentChart`; false carries no --mcp-config at all and picks the tools up from the
- * user's per-folder config under the group ids, so the SAME tool is
- * `mcp__mulmoterminal-render__presentChart`. Neither name is stale. See common/toolGroups.ts for
- * why the two ids are not unified, and README's "MCP server ids" section for the whole picture.
- */
-export const carriesFullGuiMcp = (attachGuiMcp: boolean, cwd: string | undefined): boolean => attachGuiMcp || isWorkspaceCwd(cwd);
 
 export function createClaudeSpawner(deps: SpawnDeps) {
   // Spawn a fresh claude PTY for this session, register it, and wire its output /

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -3,7 +3,7 @@
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
-import { guiMcpEnv, carriesFullGuiMcp } from "./mcp-config.js";
+import { guiMcpEnv, carriesFullGuiMcp, fullGuiAllowedTools } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter, getAppendSystemPrompt, getTerminalSubmit } from "../config/config-routes.js";
 import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
@@ -146,7 +146,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       // except the tool GROUPS the directory may have registered itself, which we pre-approve
       // blind (see GRID_MCP_TOOLS). The user's own servers keep their normal prompts there, since
       // that path never went through our allowlist before.
-      allowedTools: fullGuiMcp ? [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(",") : deps.gridMcpTools,
+      allowedTools: fullGuiMcp ? fullGuiAllowedTools(deps.guiMcpTools, getUserMcpServers()) : deps.gridMcpTools,
       addDirs,
       appendedPrompt: sessionAppendedPrompt(cwd, dir.appendSystemPrompt),
     });

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -6,7 +6,7 @@ import { PORT } from "../config/env.js";
 import { buildCodexArgs } from "../agents/codex-args.js";
 import { codexAdapter } from "../agents/codex.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
-import { codexGuiMcpServers } from "./mcp-config.js";
+import { codexGuiMcpServers, carriesFullGuiMcp } from "./mcp-config.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
@@ -71,13 +71,19 @@ export function createCodexSpawner(deps: SpawnDeps) {
     //     rows). codex cannot read that config itself, so the groups arrive resolved here.
     // A grid cell whose directory registered nothing gets no MCP at all, exactly as before.
     //
-    // DELIBERATELY not given claude's workspace-cwd rule (carriesFullGuiMcp, PR2): a codex cell in
-    // the workspace stays on its directory's registered groups. That rule exists to make a
-    // workspace cell equivalent to the SINGLE VIEW so the single view can be deleted, and the
-    // single view only ever ran claude — so there is no codex behaviour it would be preserving,
-    // and applying it would be a new capability rather than a migrated one. Revisit if a reason
-    // turns up; it is one call to carriesFullGuiMcp with `cwd`.
-    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: attachGuiMcp });
+    // The workspace-cwd rule APPLIES here, and it did not use to. It was withheld on the grounds
+    // that it exists to make a workspace cell equivalent to the single view, and the single view
+    // only ever ran claude — so extending it to codex was a new capability rather than a migrated
+    // one. The owner's call (2026-08-03) is that the workspace cell is agent-agnostic: two cells in
+    // the same directory differing only by which agent runs in them should not differ in what the
+    // agent can reach. So a codex session in the workspace gets the whole GUI MCP, as claude's does.
+    //
+    // It is a real widening, because codex approves per SERVER: everything on that URL is waved
+    // through at once — the external accounts (google, X), the paid generation, and
+    // spawnBackgroundChat, which belongs to no group and is therefore reachable ONLY this way. All
+    // of it was already auto-allowed for claude in the same cell, which is the asymmetry this
+    // closes; it is still the widest thing this flag does, and the reason it is spelled out here.
+    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: carriesFullGuiMcp(attachGuiMcp, cwd) });
     const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.codexBin, args, cwd, true, { binEnvVar: codexAdapter.binEnvVar });
     const spawnedAtMs = Date.now();

--- a/test/server/session/full-gui-mcp.spec.ts
+++ b/test/server/session/full-gui-mcp.spec.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 // Which sessions carry the whole GUI MCP, and — the point of the file — which do NOT.
 //
-// PR2 gives a grid cell running in the workspace the surface the single view has always had. The
-// constraint it is written under is that a cell in a PROJECT directory keeps the behaviour it has
-// today, exactly. That is an invariant, and an invariant nothing asserts is just a hope: this is
-// the assertion.
+// PR2 gives a grid cell running in the workspace the surface the single view has always had, and
+// the follow-up extends that to every way of starting a terminal there — a codex cell, and a
+// launcher chip running either agent. The constraint all of it is written under is that anything in
+// a PROJECT directory keeps the behaviour it has today, exactly. That is an invariant, and an
+// invariant nothing asserts is just a hope: this is the assertion.
 import { describe, it, expect, afterAll } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import os from "node:os";
@@ -18,8 +19,9 @@ mkdirSync(PROJECT, { recursive: true });
 const REAL_CLAUDE_CWD = process.env.CLAUDE_CWD;
 process.env.CLAUDE_CWD = WORKSPACE;
 
-const { carriesFullGuiMcp } = await import("../../../server/session/spawn-claude.js");
+const { carriesFullGuiMcp } = await import("../../../server/session/mcp-config.js");
 const { buildClaudeArgs } = await import("../../../server/agents/claude-args.js");
+const { launcherCommandWithClaudeGuiMcp } = await import("../../../server/session/launcher-gui-mcp.js");
 
 afterAll(() => {
   if (REAL_CLAUDE_CWD === undefined) delete process.env.CLAUDE_CWD;
@@ -44,6 +46,14 @@ describe("carriesFullGuiMcp", () => {
 
   it("gives it to a grid cell that named no directory — that IS the workspace", () => {
     expect(carriesFullGuiMcp(GRID_CELL, undefined)).toBe(true);
+  });
+
+  // A LAUNCHER chip has no wire flag — it is never the single view — so the cwd is the only thing
+  // that can earn it, which is what the route passes `false` for. Same predicate, so a chip and the
+  // cell beside it agree about which directory is special.
+  it("answers for a launcher chip on the cwd alone", () => {
+    expect(carriesFullGuiMcp(false, WORKSPACE)).toBe(true);
+    expect(carriesFullGuiMcp(false, PROJECT)).toBe(false);
   });
 
   it("still gives it to everything that is not a grid cell, whatever the directory", () => {
@@ -93,5 +103,38 @@ describe("the argv each kind of session gets", () => {
     expect(argv).not.toContain("--mcp-config");
     expect(argv).not.toContain("--strict-mcp-config");
     expect(argv).toContain("GRID_TOOLS");
+  });
+});
+
+// The third shape: a launcher CHIP, where the same three flags have to be inserted into a command
+// line rather than appended to an argv. A chip running plain `claude` in the workspace had no
+// Canvas at all while the cell beside it had every tool — that gap is what this closes.
+describe("the command line a launcher chip ends up with", () => {
+  const GUI = { mcpConfigPath: "/home/u/.mulmoterminal/settings/s-mcp.json", allowedTools: "mcp__mt__presentChart" };
+  const rewrite = (command: string, gui: typeof GUI | null = GUI) => launcherCommandWithClaudeGuiMcp(command, gui, "darwin");
+
+  it("gives a claude chip the same three flags a claude cell is spawned with", () => {
+    expect(rewrite("claude")).toBe(
+      `claude --mcp-config '/home/u/.mulmoterminal/settings/s-mcp.json' --strict-mcp-config --allowedTools 'mcp__mt__presentChart'`,
+    );
+  });
+
+  // Directly after the program, never appended: claude's own trailing `--add-dir` is variadic, so
+  // a flag placed after it would be swallowed as one more directory.
+  it("inserts after the program and puts the user's own text back byte for byte", () => {
+    expect(rewrite("claude --model opus  --resume x")).toContain("claude --mcp-config");
+    expect(rewrite("claude --model opus  --resume x")).toMatch(/--strict-mcp-config --allowedTools '\S+' --model opus {2}--resume x$/);
+  });
+
+  // null is how a PROJECT-directory chip arrives — the route passes nothing there, so its claude
+  // reads the directory's own MCP config exactly as it did before.
+  it("leaves the command alone when there is no GUI MCP to give", () => {
+    expect(rewrite("claude", null)).toBe("claude");
+  });
+
+  // The same recogniser the codex rewriter uses, and the same refusal to see through a wrapper:
+  // this edits text the user wrote, so an unrecognised shape means leave it alone.
+  it.each([["codex"], ["zsh"], ["yarn dev"], ["FOO=1 claude"], [""], ["   "]])("leaves %s alone", (command) => {
+    expect(rewrite(command)).toBe(command);
   });
 });

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -9,6 +9,7 @@ import {
   cleanupSessionSettings,
   settingsArgument,
   mcpConfigArgument,
+  mcpConfigFileArgument,
   withSettingsCleanup,
   pruneOrphanSettings,
 } from "../../../server/session/session-settings.js";
@@ -113,6 +114,29 @@ describe("the Windows reason for a file", () => {
 
   it("passes --mcp-config inline off Windows", () => {
     expect(mcpConfigArgument(SESSION, "{}", "darwin")).toBe("{}");
+  });
+
+  // A LAUNCHER chip has no argv — the config has to be inserted into a command line as text, so a
+  // few hundred bytes of JSON with nested quotes would pass through a shell. A path has neither
+  // quotes nor metacharacters, so this variant writes the file on every platform.
+  it("always writes the file for the launcher variant, even where inline would do", () => {
+    const arg = mcpConfigFileArgument(SESSION, '{"mcpServers":{}}');
+    expect(arg).toBe(mcpFileFor(SESSION));
+    expect(readFileSync(arg, "utf8")).toBe('{"mcpServers":{}}');
+  });
+
+  // The launch route can now write that file BEFORE spawning, and a spawn that throws never
+  // reaches reap. withSettingsCleanup is what stops the config outliving the attempt (Codex review
+  // on #1358) — the same wrapper the claude spawner has always used, for the same reason.
+  it("drops the launcher's config when the spawn it was written for throws", () => {
+    mcpConfigFileArgument(SESSION, "{}");
+    expect(existsSync(mcpFileFor(SESSION))).toBe(true);
+    expect(() =>
+      withSettingsCleanup(SESSION, () => {
+        throw new Error("spawn failed");
+      }),
+    ).toThrow("spawn failed");
+    expect(existsSync(mcpFileFor(SESSION))).toBe(false);
   });
 
   // reap() calls this once per session; it has to take BOTH files or the mcp one outlives


### PR DESCRIPTION
#1355 の直後に見つかった 2 つのズレ。オーナー判断（2026-08-03）で「workspace はエージェント非依存」に倒します。

## 何がズレていたか

`carriesFullGuiMcp` は claude セルしか見ていませんでした。**同じ workspace ディレクトリ**で、起動方法だけが違う 4 つのターミナルが、それぞれ違うツール集合を持っていた:

| 起動方法 | 変更前 | 変更後 |
| --- | --- | --- |
| claude セル（`?gui=0` でも） | `mt` = 全ツール | 同じ |
| codex セル | ディレクトリ登録済みグループのみ | **`mt` = 全ツール** |
| ランチャーチップ `claude` | **何もなし**（Canvas が出ない） | **`mt` = 全ツール** |
| ランチャーチップ `codex` | グループのみ | **`mt` = 全ツール** |
| ランチャーチップ その他 | 素通し | 素通し |

隣のセルに Canvas があって自分には無い、という状態がエージェントの違いだけで起きていました。

## 変更

**0. 述語を `spawn-claude.ts` → `mcp-config.ts` へ移動。** 呼び出し側が 3 つ（claude の argv / codex の `-c` / チップのコマンド行）になったため。claude が唯一の呼び出し元だった頃の都合でそこにあっただけで、**その置き場所自体が今回のドリフトを許した**という認識です。

**1. codex セルも述語を見る。** これは実質的な拡大なので、発生箇所にそう書きました: codex は**サーバー単位承認**なので all-tools URL のものが一括で自動承認される — 外部アカウント（google / X）、有料の生成、そして**どのグループにも属さない `spawnBackgroundChat`**（all-tools URL でしか到達できない）。ただし同じセルの claude では全部すでに自動承認されており、閉じたのはその非対称性です。

**2. `claude` ランチャーチップ。** チップは argv を持たない（ユーザーが書いたコマンド文字列をログインシェルで実行するだけ）ので、codex で既に使っている方式に揃えてプログラム直後にフラグを差し込みます:

```
claude --mcp-config <path> --strict-mcp-config --allowedTools <list>
```

- **JSON ではなくパス。** 数百バイトの JSON をシェル文字列に通すのは引用符問題しか生まないため、常にファイルへ書く `mcpConfigFileArgument` を追加。ファイル名は既存のものと同じなので reap の `cleanupSessionSettings` がそのまま消します。
- **新規スポーン時のみ。** tmux 再アタッチは走っているプログラムを拾って `command` を無視するので、読まれないファイルを書き残しません。
- **素の `claude` しか認識しない。** ユーザーが書いたテキストの書き換えなので、ラッパーや `FOO=1 claude` は触りません（codex 側と同じ recogniser）。
- 挿入位置の走査は `insertAfterProgram` として共通化。codex は clap がサブコマンド前にグローバルオプションを要求し、claude は末尾の `--add-dir` が可変長なので、**どちらも「直後」でなければならない**という同じ理由です。

## 意識して受け入れたコスト

`--strict-mcp-config` を入れているので、**その `claude` チップのターミナルではユーザー自身の MCP サーバーが読まれません**。チップとセルで持ちツールが変わるのを避けるための代償で、README に明記しました（隠れた挙動にしない）。

## 変えていないもの

**project ディレクトリは全経路で完全に据え置き**です。`full-gui-mcp.spec.ts` がその不変条件を assert しており、今回チップの `null` ケースも追加しました。

## 検証

`yarn typecheck` / `format` / `lint`（0 errors）/ `yarn test` **7733 passed**（+10）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace Claude and Codex sessions now receive complete GUI MCP tool access.
  * Launcher terminals automatically apply MCP configuration and approved GUI tools where supported.
  * Existing sessions can be reattached without regenerating configuration.

* **Bug Fixes**
  * Preserved user command arguments and formatting during launcher configuration.
  * Unsupported command formats remain unchanged.

* **Documentation**
  * Updated MCP configuration guidance and documented behavior across agents, launchers, and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->