### PR TITLE
feat: ランチャーに workspace のチップを常に出し、区別して表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,18 @@ chip, or with the **📁 folder button** (a native OS folder dialog). The preset
 the directories you have launched in; the **workspace** leads them always, marked with an
 icon, whether or not you have ever launched there — it is the one directory where a
 session reaches every GUI tool, so it is never a click you can lose. It has no remove
-button for the same reason. It also offers a
+button for the same reason.
+
+**The launcher is shorter in the workspace**, because two of its choices do not apply
+there. The per-directory **Canvas switches** are replaced by a line saying every GUI tool
+is already available — a session there is handed the whole GUI MCP at spawn, so switches
+would write a registration that `--strict-mcp-config` then ignores. And the **worktree**
+section is hidden: a worktree isolates work on one codebase onto a branch, while the
+workspace is what a session works *from* (the shared wiki, collections and accounting
+live there), which is precisely what a detached branch would cut it off from. Both come
+back the moment you point the field at a project directory.
+
+It also offers a
 **run a script** row
 that launches project scripts (a dev server, tests, a build, …) **in that cell, in
 the directory the cell is pointed at** — so a whole workflow lives in one window

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ malformed file is ignored.
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
 | `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
 | `fontSize`   | Terminal font size in px for this directory (8–32), overriding the Settings value. A size outside the range is clamped; a non-number is ignored. Changing it re-fits the terminal, so the PTY learns the new width — unlike browser zoom, which leaves the two disagreeing. |
-| `orderPriority` | This directory's rank in the grid's **priority** ordering — the third mode on the toolbar's ordering button, next to auto (attention-first) and manual (the move buttons). Any integer, **lowest first**; negatives are allowed. Directories that set nothing sort last, keeping their existing order, so adding the key to one project doesn't shuffle the rest. The grid reads it in **priority** mode only; the launcher's directory chips always sort by it, so a project sits in the same place on both. |
+| `orderPriority` | This directory's rank in the grid's **priority** ordering — the third mode on the toolbar's ordering button, next to auto (attention-first) and manual (the move buttons). Any integer, **lowest first**; negatives are allowed. Directories that set nothing sort last, keeping their existing order, so adding the key to one project doesn't shuffle the rest. The grid reads it in **priority** mode only; the launcher's directory chips sort by it, so a project sits in the same place on both. The one exception is the **workspace** chip, which always leads the launcher's row regardless of any rank — it is not one of the directories being ranked against each other, and it is the one place every GUI tool is reachable (see [MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)). |
 | `fontFamily` | CSS font-family stack for this directory's terminals, overriding the global `fontFamily`. Use the names as your OS lists them (`"'Cica', 'MS Gothic', monospace"`). An unusable stack is ignored whole rather than half-applied; `monospace` is appended if you name no generic family. Prefer fonts whose fullwidth glyphs are exactly twice the Latin width, or box-drawing frames tear. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). The fallback for every kind. |
 | `sounds`     | Per-kind override of `sound`: `{ "command-failed": "preset:gong" }`. Each value is a `preset:<id>` or a directory-relative path, under the same confinement. |
@@ -766,7 +766,11 @@ In dev, open the Vite URL; its proxy forwards `/ws`, `/ws/pubsub`, and `/api` to
 ## Scripts (Run menu)
 
 An empty grid cell's launcher sets the **Working directory** by typing, by a preset
-chip, or with the **📁 folder button** (a native OS folder dialog). It also offers a
+chip, or with the **📁 folder button** (a native OS folder dialog). The preset chips are
+the directories you have launched in; the **workspace** leads them always, marked with an
+icon, whether or not you have ever launched there — it is the one directory where a
+session reaches every GUI tool, so it is never a click you can lose. It has no remove
+button for the same reason. It also offers a
 **run a script** row
 that launches project scripts (a dev server, tests, a build, …) **in that cell, in
 the directory the cell is pointed at** — so a whole workflow lives in one window

--- a/plans/feat-workspace-launcher-chip.md
+++ b/plans/feat-workspace-launcher-chip.md
@@ -59,7 +59,41 @@
 Material Symbols は**アイコン名がそのままリガチャのテキスト**なので、`text()` は
 `"workspacesws"` を返す。テスト側はアイコン要素を引いて差し引く。
 
+## workspace では選ばせるものが無い（追加）
+
+同じ理由がランチャーの他の 2 か所にも及ぶ。
+
+**1. GUI ツールグループのスイッチ 4 つを出さない。** workspace のセッションは、どのエージェントでも
+spawn 時に**全 GUI MCP を 1 本の URL で受け取る**（`carriesFullGuiMcp`）。ここでスイッチを出すのは
+冗長どころか有害で、書き込む先は per-folder のレジストレーションであり、`--strict-mcp-config` が
+それを無視する — つまり**見た目上何もしないコントロール**になる。代わりに「全部使える」と表示する:
+
+```
+GUI TOOLS
+(icon) All of them, automatically — Canvas, Workspace data, External accounts.
+       The workspace needs no per-directory registration.
+```
+
+グループ名は `TOOL_GROUP_HEADINGS` から導出し重複を除く（render と media はどちらも "Canvas"）ので、
+グループを足しても二重編集にならない。判定は**フィールドの文字列ではなく起動に使うディレクトリ**
+（`targetDir`）で行う — 空欄は workspace を意味するため、生の入力と比べると取りこぼす。
+
+**2. worktree セクションを出さない。** worktree は 1 つのコードベースの作業をブランチに隔離する
+仕組みで、workspace はセッションが**作業の拠点にする**場所（共有の wiki / collections / accounting が
+あるところ）。切り離されたブランチはまさにそこから切断する。git リポジトリであっても出さない。
+
+## 既存テストへの影響（追加）
+
+さらに 15 本が落ちた。いずれも `dir == defaultCwd` でマウントしており、**そのセルは workspace だった**
+ため。仕様変更が正しく現れたもので、対応は 2 つ:
+
+- `CellLaunchForm.spec` の `mountForm` の既定 `defaultCwd` を `/repo` から `/home/me/ws` に変更。
+  代表的なケースは「プロジェクトディレクトリ」であって workspace ではない
+- `TerminalCell.spec` に `mountProjectCell(dir)` を追加し、**ツールグループと worktree のテストだけ**
+  そこへ寄せた。最初は一括置換したが、7 本は MCP と無関係（セッション一覧・スクリプト・record-cwd）
+  で、それらの `defaultCwd` を変えるとテストの意味が変わるため戻して個別に当て直した
+
 ## 検証
 
-`yarn typecheck` / `format` / `lint`（0 errors）/ `yarn test` 7733 passed、`yarn build` 成功。
+`yarn typecheck` / `format` / `lint`（0 errors）/ `yarn test` 7751 passed、`yarn build` 成功。
 **実ブラウザでの確認は未実施**（この環境に Playwright が無いため）。

--- a/plans/feat-workspace-launcher-chip.md
+++ b/plans/feat-workspace-launcher-chip.md
@@ -1,0 +1,65 @@
+# feat: ランチャーに workspace のチップを常に出し、区別して表示する
+
+## きっかけ
+
+「workspace は特別な場所なのだから、チップの見せ方を変えて、ランチャー UI に既定で出すべき」
+（オーナー判断 2026-08-03）。
+
+#1355 / #1358 で確定した通り、workspace は**全 GUI ツールに届く唯一のディレクトリ**
+（サーバー側 `carriesFullGuiMcp`）。にもかかわらず UI 上は「最近使ったディレクトリ」の 1 つでしか
+なかった。
+
+## 直前の状態
+
+チップの一覧は `cwdPresets` そのもの。これは `recordPreset` が**起動したときに自動記録する**リストなので:
+
+- workspace で一度も起動していなければ、チップは**存在しない**
+- チップの × でユーザーが消せる（消したら二度と出ない）
+
+つまり「最も重要なディレクトリが、クリックできないかもしれない」状態だった。
+
+## 変更
+
+**`launchChips(orderedPresets, defaultCwd)` を `src/components/presets.ts` に追加。** 純関数で、
+
+- workspace を**常に先頭**に置く（`orderByDirPriority` の外側 — あれはユーザーが設定した
+  ディレクトリ同士の順位であって、workspace はその競争に参加していない）
+- すでに presets に含まれていれば**重複させず**、そのラベル（ユーザーが付けた名前）を維持する
+- `isWorkspace` フラグを付けて返す
+- `defaultCwd` が null（`/api/config` 未解決）のときは何も足さない — 誰も選んでいない
+  ディレクトリにクリック先を作らないため
+
+パス比較は `common/dirPathKey.ts` の **`isSameDirPath`** を使う。同ファイルが worktree 行で使って
+いるのと同じ字句比較で、末尾スラッシュや `..` を畳む。ブラウザは symlink を解決できないので
+ここは「同じ綴りか」までしか答えない — 本当の判定はサーバーの realpath（`isWorkspaceCwd`）。
+外した場合の被害は「同じディレクトリが 2 回出る」だけ。
+
+**表示（`CellLaunchForm.vue`）:**
+
+- ラベルの前に Material Symbols の `workspaces` アイコン。**ラベル自体は変えない**
+- **× ボタンを出さない** — 合成されたエントリなので消すものが無く、消しても次の描画で戻る
+- hover / aria-label に「the workspace: every GUI tool is available here」を足す。アイコンだけでは
+  *なぜ*特別なのかが言えず、他にそれを言う場所が画面上に無いため
+- **枠と背景は触らない。** あの 2 つは既に「ここでセッションが走っている」という意味を持っており
+  （#1106 でまさにその二重化がバグとして報告された）、同じ 2 つに別の意味を重ねない
+- 色ストライプは通常どおり — workspace にも `.mulmoterminal.json` はある
+
+## 実装上の落とし穴
+
+`presetPaths`（`useDirColors` に渡す）が `chips` を参照するので、**`chips` を先に宣言しないと
+マウント時に TDZ で throw する**。`useDirColors` は watch で即座に評価するため、computed の遅延評価
+では守られない。
+
+## 既存テストへの影響
+
+チップを**位置で選んでいた**テストが 5 本落ちた。workspace が先頭に入ったため。これは仕様変更が
+正しく現れたもので、いずれもパス指定で選ぶよう直した（`chipForPath` / `launchButtonFor` ヘルパー）。
+1 本は「`my-project` は "proj" を含む」ため、ラベルの部分一致ではなくパスの前方一致にしている。
+
+Material Symbols は**アイコン名がそのままリガチャのテキスト**なので、`text()` は
+`"workspacesws"` を返す。テスト側はアイコン要素を引いて差し引く。
+
+## 検証
+
+`yarn typecheck` / `format` / `lint`（0 errors）/ `yarn test` 7733 passed、`yarn build` 成功。
+**実ブラウザでの確認は未実施**（この環境に Playwright が無いため）。

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -292,6 +292,20 @@ const mcpGroupTitle = (group: ToolGroup): string =>
 // whether there is one — the alternative asserts in the hover what the branch already decided.
 const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed.value[group] ?? undefined;
 
+// The workspace has no per-directory choice to offer: a session started there is handed the WHOLE
+// GUI MCP on one URL, whatever agent runs it (`carriesFullGuiMcp`, server/session/mcp-config.ts).
+// The four switches are not merely redundant there — they write a per-folder registration that
+// `--strict-mcp-config` then ignores, so they would be controls that visibly do nothing.
+//
+// Asked of the directory the launch will USE, not of the field: an empty field means the workspace
+// (see dirFor), which is exactly the case a comparison against the raw input would miss.
+const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
+
+// What "all of them" covers, named so the statement is checkable rather than a claim. Derived from
+// the headings and de-duplicated — render and media both read "Canvas" — so adding a group needs no
+// second edit here, the same rule mcpGroupTitle follows.
+const allToolGroupNames = computed(() => [...new Set(TOOL_GROUPS.map((group) => TOOL_GROUP_HEADINGS[group]))].join(", "));
+
 const worktreeTask = ref("");
 
 // Create a fresh worktree for the typed task and start the selected agent in it.
@@ -508,34 +522,55 @@ async function removeWorktree(w: Worktree): Promise<void> {
          media both draw but differ in what a call costs, and data and external do not draw at
          all — the split is exactly what the grouping exists for (common/toolGroups.ts). -->
     <template v-if="mcpGroupDir && launchesAgent">
+      <!-- The workspace gets every tool automatically, so it is TOLD, not asked. Switches here
+           would write a registration --strict-mcp-config ignores: controls that do nothing. -->
+      <div v-if="inWorkspace" data-testid="cell-mcp-all" class="flex w-full max-w-[360px] flex-col gap-0.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
+        <span class="font-sans text-[11px] leading-snug text-secondary">
+          <span class="material-symbols-outlined mr-[3px] align-middle text-[13px]" aria-hidden="true">workspaces</span>
+          All of them, automatically — {{ allToolGroupNames }}. The workspace needs no per-directory registration.
+        </span>
+      </div>
       <!-- The hover names the server id and its tools (mcpGroupTitle); it sits on the ROW so
-           the text is reachable from the label as well as the box. -->
-      <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full max-w-[360px] items-center justify-between gap-2" :title="mcpGroupTitle(group)">
-        <!-- The group is named, not just the feature: each switch registers ONE MCP server
+           the text is reachable from the label as well as the box.
+           A `template v-else` around the loop rather than `v-else` ON it: v-if and v-for on one
+           element is the ambiguity eslint-plugin-vue forbids. -->
+      <template v-else>
+        <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full max-w-[360px] items-center justify-between gap-2" :title="mcpGroupTitle(group)">
+          <!-- The group is named, not just the feature: each switch registers ONE MCP server
            (`mulmoterminal-<group>`), so a heading alone would not say which of the four rows
            writes which server — and two of them share the heading "Canvas".
            `normal-case` on the suffix — the section labels around it are uppercased by
            class, and "(RENDER MCPS)" reads as a different thing than the server it names. -->
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim"
-          >{{ TOOL_GROUP_HEADINGS[group] }} <span class="normal-case">({{ group }} MCPs)</span></span
-        >
-        <span class="flex items-center gap-2">
-          <span v-if="mcpGroupBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
-          <span v-else-if="mcpGroupFailure(group)" class="font-sans text-[11px] text-err-text" :title="mcpGroupFailure(group)">failed</span>
-          <input
-            v-model="mcpGroupEnabled[group]"
-            :data-testid="`cell-mcp-toggle-${group}`"
-            type="checkbox"
-            class="h-3.5 w-3.5 cursor-pointer accent-accent"
-            :disabled="mcpGroupBusy[group]"
-            :title="mcpGroupTitle(group)"
-            :aria-label="`Register the MCP server ${toolGroupServerId(group)} (${toolsInGroup(group).join(', ')}) for ${mcpGroupDir}`"
-            @change="applyMcpGroup(group)"
-          />
-        </span>
-      </label>
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim"
+            >{{ TOOL_GROUP_HEADINGS[group] }} <span class="normal-case">({{ group }} MCPs)</span></span
+          >
+          <span class="flex items-center gap-2">
+            <span v-if="mcpGroupBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
+            <span v-else-if="mcpGroupFailure(group)" class="font-sans text-[11px] text-err-text" :title="mcpGroupFailure(group)">failed</span>
+            <input
+              v-model="mcpGroupEnabled[group]"
+              :data-testid="`cell-mcp-toggle-${group}`"
+              type="checkbox"
+              class="h-3.5 w-3.5 cursor-pointer accent-accent"
+              :disabled="mcpGroupBusy[group]"
+              :title="mcpGroupTitle(group)"
+              :aria-label="`Register the MCP server ${toolGroupServerId(group)} (${toolsInGroup(group).join(', ')}) for ${mcpGroupDir}`"
+              @change="applyMcpGroup(group)"
+            />
+          </span>
+        </label>
+      </template>
     </template>
-    <div v-if="worktreeList.isGit && launchesAgent" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
+    <!-- Not in the workspace, even when it happens to be a git repo. A worktree isolates work on
+         ONE codebase onto a branch; the workspace is the hub a session works FROM — the place the
+         agent reads and writes shared state (wiki, collections, accounting), which is exactly what
+         a detached branch would cut it off from. Offering it there is offering a mistake. -->
+    <div
+      v-if="worktreeList.isGit && launchesAgent && !inWorkspace"
+      data-testid="cell-worktrees"
+      class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5"
+    >
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
       <!-- Said here rather than left to be inferred from a row that behaves differently each time:
            the one-session rule is why a row resumes instead of launching, and why one of them

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -12,7 +12,7 @@ import { isSameDirPath } from "../../common/dirPathKey";
 import { TOOL_GROUPS, TOOL_GROUP_HEADINGS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
 import type { LaunchAgent } from "../../common/launchAgent";
 import type { TerminalAgent } from "../../common/sessionAgent";
-import type { CwdPreset } from "./presets";
+import { launchChips, type CwdPreset, type LaunchChip } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
@@ -87,13 +87,25 @@ const dirField = computed({
 // Each recent-dir chip wears its directory's configured colour, so picking one is the same visual
 // decision as finding its cell in the grid. The subscriptions are dropped when this form unmounts
 // (useDirConfig disposes with the scope), which is also the moment the chips leave the screen.
-const presetPaths = computed(() => props.presets.map((p) => p.path));
-const { colors: presetColors } = useDirColors(presetPaths);
 // Chips follow the same rank the grid sorts by, so a project sits in the same place on both
 // screens. The stored list stays most-recently-used (recordPreset depends on that) — only the
 // display is reordered, which is also what keeps unranked directories where they were.
-const { priorities: presetPriorities } = useDirPriorities(presetPaths);
-const orderedPresets = computed(() => orderByDirPriority(props.presets, (p) => p.path, presetPriorities.value));
+const { priorities: presetPriorities } = useDirPriorities(computed(() => props.presets.map((p) => p.path)));
+// The workspace rides in front, whether or not it was ever recorded as a recent dir — it is the one
+// directory where every GUI tool is reachable, so it must be one click away (see launchChips).
+//
+// Declared BEFORE the colours below, which subscribe eagerly: reading `chips` from above its own
+// `const` is a temporal-dead-zone throw at mount, not a lint nit.
+const chips = computed(() =>
+  launchChips(
+    orderByDirPriority(props.presets, (p) => p.path, presetPriorities.value),
+    props.defaultCwd,
+  ),
+);
+// The workspace is coloured like any other directory — it has a `.mulmoterminal.json` too, and the
+// stripe means the same thing there as everywhere else.
+const presetPaths = computed(() => chips.value.map((p) => p.path));
+const { colors: presetColors } = useDirColors(presetPaths);
 
 // A preset dir that already has a running session in another cell — the launcher tints its chip
 // so the user can tell it's in use before double-launching there.
@@ -209,6 +221,14 @@ function selectPreset(p: CwdPreset): void {
   emit("update:dir", p.path);
   emit("start", p.path);
 }
+
+// The hover on the chip's main (fill-the-field) half. The workspace says what makes it worth
+// picking, because nothing else on screen does: it is the one directory where a session reaches
+// every GUI tool, and the icon alone cannot say that.
+const chipTitle = (p: LaunchChip): string => {
+  const running = isCwdRunning(p.path) ? " — a session is already running here" : "";
+  return p.isWorkspace ? `${p.path}${running} — the workspace: every GUI tool is available here` : `${p.path}${running}`;
+};
 
 const chipLaunchTitle = (p: CwdPreset): string => {
   const taken = takenWorktreeAt(p.path);
@@ -346,9 +366,9 @@ async function removeWorktree(w: Worktree): Promise<void> {
     >
       <span class="material-symbols-outlined" aria-hidden="true">close</span>
     </button>
-    <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
+    <div v-if="chips.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
       <span
-        v-for="p in orderedPresets"
+        v-for="p in chips"
         :key="p.label + p.path"
         data-testid="cell-chip"
         class="inline-flex items-stretch overflow-hidden rounded-[14px] border"
@@ -370,8 +390,8 @@ async function removeWorktree(w: Worktree): Promise<void> {
           data-testid="cell-chip-main"
           class="cursor-pointer border-none bg-transparent px-2.5 py-1 font-sans text-[12px] hover:bg-hover hover:text-fg"
           :class="isCwdRunning(p.path) ? 'text-fg' : 'text-secondary'"
-          :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here` : p.path"
-          :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)${isCwdRunning(p.path) ? '. A session is already running here.' : ''}`"
+          :title="chipTitle(p)"
+          :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)${isCwdRunning(p.path) ? '. A session is already running here.' : ''}${p.isWorkspace ? '. This is the workspace: every GUI tool is available here.' : ''}`"
           @click="fillDir(p.path)"
         >
           <span
@@ -379,7 +399,12 @@ async function removeWorktree(w: Worktree): Promise<void> {
             data-testid="cell-chip-dot"
             :class="`mr-[5px] inline-block h-1.5 w-1.5 rounded-full align-middle ${CHIP_DOT_RUNNING}`"
             aria-hidden="true"
-          />{{ p.label }}
+          /><!-- The workspace is marked, not restyled: the chip's border and background already
+               mean "a session is running here" (#1106), and a second meaning on the same two
+               would put us back where that bug came from. -->
+          <span v-if="p.isWorkspace" data-testid="cell-chip-workspace" class="material-symbols-outlined mr-[4px] text-[13px] align-middle" aria-hidden="true"
+            >workspaces</span
+          >{{ p.label }}
         </button>
         <button
           type="button"
@@ -391,7 +416,11 @@ async function removeWorktree(w: Worktree): Promise<void> {
         >
           <span class="material-symbols-outlined text-[14px]" aria-hidden="true">play_arrow</span>
         </button>
+        <!-- No remove button on the workspace. It is not a recorded preset, so there is nothing to
+             remove: dropping it would only make it reappear on the next render, and it is the one
+             directory the launcher is supposed to always offer. -->
         <button
+          v-if="!p.isWorkspace"
           type="button"
           data-testid="cell-chip-del"
           class="cursor-pointer border-0 border-l border-l-border bg-transparent px-[7px] text-[11px] text-secondary hover:bg-hover hover:text-[var(--danger,#e5484d)]"

--- a/src/components/presets.ts
+++ b/src/components/presets.ts
@@ -1,4 +1,5 @@
 import { worktreeLabel } from "./cwdDisplay";
+import { isSameDirPath } from "../../common/dirPathKey";
 
 // A directory preset offered as a one-click chip in the cell launch form.
 // The list is auto-populated from the dirs the user launches in (see
@@ -15,4 +16,35 @@ export function presetLabel(path: string): string {
   if (wt) return `${wt.repo} (${wt.task})`;
   const segments = path.split(/[/\\]/).filter(Boolean);
   return segments[segments.length - 1] ?? path;
+}
+
+/** A chip as the launcher renders it: a preset, plus whether it is THE workspace. */
+export interface LaunchChip extends CwdPreset {
+  isWorkspace: boolean;
+}
+
+/**
+ * The chips to render: the workspace FIRST and always, then the recent directories.
+ *
+ * The workspace is not an ordinary recent dir, and the launcher used to treat it as one — it
+ * appeared only if you had happened to launch there and had not since removed it, because the list
+ * is auto-recorded by `recordPreset`. But it is the one directory where every GUI tool is reachable
+ * (see `carriesFullGuiMcp` on the server), so being unable to get to it from the launcher is
+ * exactly backwards. It is synthesised here rather than written into the user's saved presets:
+ * nothing about it needs storing, and a stored copy would go stale the moment CLAUDE_CWD changed.
+ *
+ * Pinned ahead of the priority ordering on purpose. `orderByDirPriority` ranks the directories a
+ * user configured against each other; the workspace is not competing in that ranking.
+ *
+ * Its existing label is kept when it IS among the presets, so a directory the user has colour-coded
+ * and named does not get renamed by having become the workspace. Matched with `isSameDirPath`, the
+ * same lexical comparison the worktree rows use: the browser cannot resolve a symlink, so this
+ * folds only the spellings a person types (a trailing slash, a `..`). Getting it wrong shows the
+ * directory twice — the server still decides what the workspace really is, with a realpath.
+ */
+export function launchChips(orderedPresets: readonly CwdPreset[], defaultCwd: string | null | undefined): LaunchChip[] {
+  const rest = orderedPresets.filter((p) => !defaultCwd || !isSameDirPath(p.path, defaultCwd)).map((p) => ({ ...p, isWorkspace: false }));
+  if (!defaultCwd) return rest;
+  const existing = orderedPresets.find((p) => isSameDirPath(p.path, defaultCwd));
+  return [{ label: existing?.label ?? presetLabel(defaultCwd), path: defaultCwd, isWorkspace: true }, ...rest];
 }

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -35,10 +35,18 @@ const mountForm = (
 
 // The launch button of the chip for a given directory. The workspace chip is always first now, so
 // selecting a chip by position picks the wrong one.
-const launchButtonFor = (w: ReturnType<typeof mountForm>, path: string) => {
-  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').attributes("title")?.startsWith(path));
+const launchButtonFor = (w: ReturnType<typeof mountForm>, path: string) => chipForPath(w, path).find('[data-testid="cell-chip-launch"]');
+
+// The chip pointing at exactly this directory. The title is the path, optionally followed by " — "
+// and a reason (running here / the workspace), so a WHOLE-path match is required: `startsWith(path)`
+// alone would let a request for `/repo` select `/repo-backup` (CodeRabbit on #1359).
+const chipForPath = (w: ReturnType<typeof mountForm>, path: string) => {
+  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => {
+    const title = c.find('[data-testid="cell-chip-main"]').attributes("title") ?? "";
+    return title === path || title.startsWith(`${path} —`);
+  });
   if (!chip) throw new Error(`no chip for ${path}`);
-  return chip.find('[data-testid="cell-chip-launch"]');
+  return chip;
 };
 
 const worktree = (over: Partial<WorktreeRow> = {}): WorktreeRow => ({ path: "/wt/fix-login", branch: "fix-login", task: "fix-login", dirty: false, ...over });

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -26,7 +26,10 @@ const mountForm = (
   over: { dir?: string; presets?: { label: string; path: string }[]; target?: LaunchAgent; defaultCwd?: string | null } = {},
 ) =>
   mount(CellLaunchForm, {
-    props: { dir: "/repo", target: "claude" as LaunchAgent, choice: null, defaultCwd: "/repo", presets: [], openSessionIds, ...over },
+    // defaultCwd is deliberately NOT "/repo": the launcher treats the workspace differently — it
+    // states that every GUI tool is available instead of offering the switches, and hides the
+    // worktree section — so the ordinary case to mount is a PROJECT directory.
+    props: { dir: "/repo", target: "claude" as LaunchAgent, choice: null, defaultCwd: "/home/me/ws", presets: [], openSessionIds, ...over },
     global: { stubs: { ModelPicker: true } },
   });
 
@@ -195,7 +198,8 @@ describe("a worktree reached without its row", () => {
     mockFetch([taken()]);
     const w = mountForm([], { presets: [{ label: "repo", path: "/repo" }] });
     await flushPromises();
-    await w.find('[data-testid="cell-chip-launch"]').trigger("click");
+    // The workspace chip leads the row, so reach the ordinary directory's by path.
+    await launchButtonFor(w, "/repo").trigger("click");
     expect(w.emitted("start")?.[0]).toEqual(["/repo"]);
   });
 });
@@ -309,5 +313,81 @@ describe("the workspace chip", () => {
     const w = mountForm([], { presets: [], defaultCwd: "/home/me/ws" });
     await flushPromises();
     expect(w.find('[data-testid="cell-chip-main"]').attributes("title")).toContain("every GUI tool is available here");
+  });
+});
+
+// The workspace is handed the WHOLE GUI MCP at spawn whatever agent runs there
+// (carriesFullGuiMcp), so there is no per-directory choice to offer. Four switches there would be
+// worse than redundant: they write a per-folder registration that --strict-mcp-config then
+// ignores, i.e. controls that visibly do nothing.
+describe("the GUI tool groups in the workspace", () => {
+  const guiMcpFetch = () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) return { ok: true, json: async () => ({ groups: [] }) };
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  };
+
+  it("states that everything is available instead of offering the switches", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(false);
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(true);
+  });
+
+  // Named, so the claim is checkable rather than a bare "all". Derived from TOOL_GROUP_HEADINGS,
+  // de-duplicated because render and media both read "Canvas".
+  it("names what 'all of them' covers", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    const text = w.find('[data-testid="cell-mcp-all"]').text();
+    expect(text).toContain("Canvas");
+    expect(text).toContain("Workspace data");
+    expect(text).toContain("External accounts");
+  });
+
+  // An EMPTY field means the workspace (dirFor falls back to defaultCwd) — the case a comparison
+  // against the raw input would miss.
+  it("counts an empty directory field as the workspace", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "", defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(true);
+  });
+
+  // The invariant this must not break: a project directory still chooses, exactly as before.
+  it("still offers the switches in a project directory", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/repo", defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(false);
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-mcp-toggle-external"]').exists()).toBe(true);
+  });
+});
+
+// A worktree isolates work on ONE codebase onto a branch. The workspace is the hub a session works
+// FROM — where the shared wiki / collections / accounting state lives — which is exactly what a
+// detached branch would cut it off from, so offering the option there is offering a mistake.
+describe("worktrees in the workspace", () => {
+  it("hides the worktree section, git repo or not", async () => {
+    mockFetch([worktree({ session: null })]);
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(false);
+    expect(w.find('[data-testid="worktree-reuse"]').exists()).toBe(false);
+  });
+
+  // The invariant: a project directory is untouched.
+  it("still offers it in a project directory", async () => {
+    mockFetch([worktree({ session: null })]);
+    const w = mountForm();
+    await flushPromises();
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true);
   });
 });

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -21,11 +21,22 @@ function mockFetch(worktrees: WorktreeRow[] = [], sessions: SessionRow[] = []) {
   }) as unknown as typeof fetch;
 }
 
-const mountForm = (openSessionIds: string[] = [], over: { dir?: string; presets?: { label: string; path: string }[]; target?: LaunchAgent } = {}) =>
+const mountForm = (
+  openSessionIds: string[] = [],
+  over: { dir?: string; presets?: { label: string; path: string }[]; target?: LaunchAgent; defaultCwd?: string | null } = {},
+) =>
   mount(CellLaunchForm, {
     props: { dir: "/repo", target: "claude" as LaunchAgent, choice: null, defaultCwd: "/repo", presets: [], openSessionIds, ...over },
     global: { stubs: { ModelPicker: true } },
   });
+
+// The launch button of the chip for a given directory. The workspace chip is always first now, so
+// selecting a chip by position picks the wrong one.
+const launchButtonFor = (w: ReturnType<typeof mountForm>, path: string) => {
+  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').attributes("title")?.startsWith(path));
+  if (!chip) throw new Error(`no chip for ${path}`);
+  return chip.find('[data-testid="cell-chip-launch"]');
+};
 
 const worktree = (over: Partial<WorktreeRow> = {}): WorktreeRow => ({ path: "/wt/fix-login", branch: "fix-login", task: "fix-login", dirty: false, ...over });
 
@@ -162,7 +173,9 @@ describe("a worktree reached without its row", () => {
     mockFetch([taken()]);
     const w = mountForm([], { presets: [{ label: "fix-login", path: "/wt/fix-login" }] });
     await flushPromises();
-    await w.find('[data-testid="cell-chip-launch"]').trigger("click");
+    // By path, not by position: the workspace chip leads the list, so the first launch button is
+    // no longer the worktree's.
+    await launchButtonFor(w, "/wt/fix-login").trigger("click");
     expect(w.emitted("start")).toBeUndefined();
     expect(w.emitted("update:dir")?.at(-1)).toEqual(["/wt/fix-login"]);
   });
@@ -173,7 +186,7 @@ describe("a worktree reached without its row", () => {
     mockFetch([taken()]);
     const w = mountForm([], { presets: [{ label: "fix-login", path: "/wt/fix-login" }] });
     await flushPromises();
-    const label = w.find('[data-testid="cell-chip-launch"]').attributes("aria-label") ?? "";
+    const label = launchButtonFor(w, "/wt/fix-login").attributes("aria-label") ?? "";
     expect(label).toContain("fix-login");
     expect(label).toContain("open in another terminal");
   });
@@ -252,5 +265,49 @@ describe("an MCP group row whose write failed", () => {
     expect(failed[0].text()).toBe("failed");
     expect(failed[0].attributes("title")).toBe("HTTP 500");
     expect(toggle.element.checked).toBe(false);
+  });
+});
+
+// The workspace is where every GUI tool is reachable, so the launcher offers it whether or not it
+// has ever been recorded as a recent directory — the recorded list is auto-populated by launching,
+// which made the one directory that matters most the one you might not be able to click.
+describe("the workspace chip", () => {
+  // A Material Symbols icon IS its ligature text, so the glyph's name is part of the button's
+  // text() — the chip reads "workspacesws" unless the icon is subtracted. Subtracted by element
+  // rather than by the literal, so renaming the icon does not quietly stop stripping it.
+  const chipLabels = (w: ReturnType<typeof mountForm>) =>
+    w.findAll('[data-testid="cell-chip-main"]').map((chip) => {
+      const icon = chip.find('[data-testid="cell-chip-workspace"]');
+      return icon.exists() ? chip.text().replace(icon.text(), "") : chip.text();
+    });
+
+  it("is offered with no presets recorded at all", async () => {
+    const w = mountForm([], { presets: [], defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(chipLabels(w)).toEqual(["ws"]);
+    expect(w.find('[data-testid="cell-chip-workspace"]').exists()).toBe(true);
+  });
+
+  it("leads the recorded directories, and only it is marked", async () => {
+    const w = mountForm([], { presets: [{ label: "one", path: "/a/one" }], defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(chipLabels(w)).toEqual(["ws", "one"]);
+    expect(w.findAll('[data-testid="cell-chip-workspace"]')).toHaveLength(1);
+  });
+
+  // Nothing to remove: it is synthesised, so a delete would only put it back on the next render.
+  // The recorded chip beside it keeps its own.
+  it("has no remove button, while an ordinary chip does", async () => {
+    const w = mountForm([], { presets: [{ label: "one", path: "/a/one" }], defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.findAll('[data-testid="cell-chip"]')).toHaveLength(2);
+    expect(w.findAll('[data-testid="cell-chip-del"]')).toHaveLength(1);
+  });
+
+  // The icon cannot say WHY it is special, and nothing else on screen does.
+  it("says on hover what makes it worth picking", async () => {
+    const w = mountForm([], { presets: [], defaultCwd: "/home/me/ws" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-chip-main"]').attributes("title")).toContain("every GUI tool is available here");
   });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -101,6 +101,17 @@ function mountCell(
   });
 }
 
+// The chip pointing at a given directory. The workspace chip always leads the list (launchChips),
+// so selecting a chip by position picks the wrong one — and it is matched on the PATH rather than
+// the label because the demo workspace is `my-project`, which a substring match on "proj" finds
+// first. Throws when nothing matches, so a stale selector fails as a selector rather than as a
+// puzzling assertion about `undefined`.
+function chipForPath(w: ReturnType<typeof mountCell>, path: string) {
+  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').attributes("title")?.startsWith(path));
+  if (!chip) throw new Error(`no chip for ${path}`);
+  return chip;
+}
+
 describe("TerminalCell", () => {
   // #965: the whole cell — header included — sits in one wrapper, so the focus zoom can be
   // cancelled about the cell's own centre. A second element child, or content left outside the
@@ -1801,7 +1812,9 @@ describe("TerminalCell", () => {
       ],
     });
     await flushPromises();
-    expect(w.findAll('[data-testid="cell-chip-main"]').map((b) => b.text())).toEqual(["c", "b", "a", "d"]);
+    // The workspace leads, outside the ranking — it is not one of the directories being ranked
+    // against each other (see launchChips). Its label carries the icon's ligature text.
+    expect(w.findAll('[data-testid="cell-chip-main"]').map((b) => b.text())).toEqual(["workspacesmy-project", "c", "b", "a", "d"]);
   });
 
   it("tints a preset chip whose dir already has a running session elsewhere", () => {
@@ -1838,7 +1851,7 @@ describe("TerminalCell", () => {
     const w = mountCell(null, { presets: [{ label: "busy", path: "/chip/busy" }], openCwds: ["/chip/busy"] });
     await flushPromises();
 
-    const chip = w.find('[data-testid="cell-chip"]');
+    const chip = chipForPath(w, "/chip/busy");
     expect(chip.classes()).toContain("is-running");
     expect(chip.attributes("style") ?? "").not.toContain("#aa1122"); // the blue keeps the background
     expect(chip.find('[data-testid="cell-chip-color"]').attributes("style")).toContain("rgb(170, 17, 34)");
@@ -2300,7 +2313,7 @@ describe("TerminalCell launch target — the OS default shell (#1114)", () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/home/me/proj" }] });
     await flushPromises();
     await pick(w, "shell");
-    await w.find('[data-testid="cell-chip-launch"]').trigger("click");
+    await chipForPath(w, "/home/me/proj").find('[data-testid="cell-chip-launch"]').trigger("click");
     expect(w.emitted("launch")).toEqual([[SHELL_PICK]]);
     expect(w.emitted("agent")).toBeUndefined();
   });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -107,7 +107,12 @@ function mountCell(
 // first. Throws when nothing matches, so a stale selector fails as a selector rather than as a
 // puzzling assertion about `undefined`.
 function chipForPath(w: ReturnType<typeof mountCell>, path: string) {
-  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').attributes("title")?.startsWith(path));
+  // A WHOLE-path match: the title is the path, optionally followed by " — " and a reason, so
+  // `startsWith(path)` alone would let a request for `/repo` select `/repo-backup` (CodeRabbit).
+  const chip = w.findAll('[data-testid="cell-chip"]').find((c) => {
+    const title = c.find('[data-testid="cell-chip-main"]').attributes("title") ?? "";
+    return title === path || title.startsWith(`${path} —`);
+  });
   if (!chip) throw new Error(`no chip for ${path}`);
   return chip;
 }

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -112,6 +112,15 @@ function chipForPath(w: ReturnType<typeof mountCell>, path: string) {
   return chip;
 }
 
+// An empty cell pointed at a PROJECT directory — deliberately NOT the workspace. Two parts of the
+// launcher are absent there: the per-directory tool-group switches (the workspace is TOLD it has
+// every tool, since it is handed the whole GUI MCP at spawn whatever agent runs there) and the
+// worktree section (a worktree isolates work on one codebase; the workspace is what a session
+// works FROM). So a test about either has to stand somewhere else — `mountCell` with no initialCwd
+// points the field at defaultCwd, which IS the workspace.
+const WORKSPACE = "/home/me/ws";
+const mountProjectCell = (dir: string) => mountCell(null, { initialCwd: dir, defaultCwd: WORKSPACE });
+
 describe("TerminalCell", () => {
   // #965: the whole cell — header included — sits in one wrapper, so the focus zoom can be
   // cancelled about the cell's own centre. A second element child, or content left outside the
@@ -1053,7 +1062,7 @@ describe("TerminalCell", () => {
 
   it("shows the worktree section and lists existing worktrees when the dir is a git repo", async () => {
     mockFetchWithWorktrees([{ path: "/wt/fix-login", branch: "agent/fix-login", task: "fix-login", dirty: false }]);
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true);
     const rows = w.findAll('[data-testid="worktree-reuse"]');
@@ -1070,7 +1079,7 @@ describe("TerminalCell", () => {
 
   it("creates a worktree for the typed task and launches claude in it", async () => {
     const posts = mockFetchWithWorktrees([], { path: "/wt/fix-login", branch: "agent/fix-login" });
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     await w.find('[data-testid="wt-task"]').setValue("fix login");
     await w.find('[data-testid="wt-start"]').trigger("click");
@@ -1085,7 +1094,7 @@ describe("TerminalCell", () => {
 
   it("reuses an existing worktree by launching claude in its path", async () => {
     mockFetchWithWorktrees([{ path: "/wt/old-task", branch: "agent/old-task", task: "old-task", dirty: false }]);
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     await w.find('[data-testid="worktree-reuse"]').trigger("click");
     // The launch waits on the tool-group sync — one read of the worktree's registrations, plus a
@@ -1098,7 +1107,7 @@ describe("TerminalCell", () => {
 
   it("removes a clean worktree (deleteBranch, no force) without confirming", async () => {
     const posts = mockFetchWithWorktrees([{ path: "/wt/done", branch: "agent/done", task: "done", dirty: false }]);
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     await w.find('[data-testid="wt-del"]').trigger("click");
     await flushPromises();
@@ -1110,7 +1119,7 @@ describe("TerminalCell", () => {
   it("confirms before removing a DIRTY worktree, and forces when confirmed", async () => {
     const posts = mockFetchWithWorktrees([{ path: "/wt/wip", branch: "agent/wip", task: "wip", dirty: true }]);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     expect(w.find('[data-testid="wt-dirty"]').exists()).toBe(true); // the ● uncommitted-changes marker
     await w.find('[data-testid="wt-del"]').trigger("click");
@@ -1125,7 +1134,7 @@ describe("TerminalCell", () => {
   it("does NOT remove a dirty worktree when the user cancels the confirm", async () => {
     const posts = mockFetchWithWorktrees([{ path: "/wt/wip", branch: "agent/wip", task: "wip", dirty: true }]);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     await w.find('[data-testid="wt-del"]').trigger("click");
     await flushPromises();
@@ -1909,7 +1918,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null);
+    const w = mountProjectCell("/home/me/my-project");
     await flushPromises();
 
     const box = w.find('[data-testid="cell-mcp-toggle-render"]');
@@ -1939,7 +1948,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null);
+    const w = mountProjectCell("/home/me/my-project");
     await flushPromises();
     const box = w.find('[data-testid="cell-mcp-toggle-render"]');
     await box.setValue(true);
@@ -1973,7 +1982,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    const w = mountProjectCell("/home/me/alpha");
     await flushPromises();
 
     // media goes first and hangs; render queues behind it, both flipped in alpha.
@@ -2014,7 +2023,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null);
+    const w = mountProjectCell("/home/me/my-project");
     await flushPromises();
     const codexButton = w.findAll('[role="radio"]').find((b) => b.text() === "Codex");
     expect(codexButton).toBeDefined();
@@ -2048,7 +2057,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    const w = mountProjectCell("/home/me/alpha");
     await flushPromises();
 
     for (const group of TOOL_GROUPS) expect(w.find(`[data-testid="cell-mcp-toggle-${group}"]`).exists()).toBe(true);
@@ -2091,7 +2100,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    const w = mountProjectCell("/home/me/repo");
     await flushPromises();
     await w.find('[data-testid="worktree-reuse"]').trigger("click");
     await flushPromises();
@@ -2113,7 +2122,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    const w = mountProjectCell("/home/me/alpha");
     await flushPromises();
     expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
 
@@ -2152,7 +2161,7 @@ describe("TerminalCell", () => {
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
-    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    const w = mountProjectCell("/home/me/proj");
     await flushPromises();
     await w.find('[data-testid="cell-mcp-toggle-render"]').setValue(true);
     await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter");
@@ -2329,7 +2338,7 @@ describe("TerminalCell launch target — the OS default shell (#1114)", () => {
 
   it("hides the model / MCP / worktree options for a shell and brings them back for an agent", async () => {
     mockFetchWithAgentOptions();
-    const w = mountCell(null);
+    const w = mountProjectCell("/home/me/my-project");
     await flushPromises();
     expect(w.find('[data-testid="cell-model-help"]').exists()).toBe(true);
     expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);

--- a/test/src/components/presets.spec.ts
+++ b/test/src/components/presets.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { presetLabel } from "../../../src/components/presets.js";
+import { presetLabel, launchChips } from "../../../src/components/presets.js";
 
 describe("presetLabel", () => {
   it("uses the trailing path segment (basename)", () => {
@@ -13,5 +13,48 @@ describe("presetLabel", () => {
 
   it("handles a Windows-style path", () => {
     expect(presetLabel("C:\\work\\proj")).toBe("proj");
+  });
+});
+
+// The workspace is the one directory where a session reaches every GUI tool (carriesFullGuiMcp on
+// the server), and the launcher used to show it only if the user happened to have launched there —
+// the list is auto-recorded, and the chip's own close button could remove it.
+describe("launchChips", () => {
+  const preset = (path: string) => ({ label: presetLabel(path), path });
+
+  it("offers the workspace even when nothing has been recorded", () => {
+    expect(launchChips([], "/home/me/mulmoclaude")).toEqual([{ label: "mulmoclaude", path: "/home/me/mulmoclaude", isWorkspace: true }]);
+  });
+
+  it("puts it first, ahead of the priority ordering the rest arrive in", () => {
+    const chips = launchChips([preset("/a/one"), preset("/b/two")], "/home/me/ws");
+    expect(chips.map((c) => c.label)).toEqual(["ws", "one", "two"]);
+    expect(chips.filter((c) => c.isWorkspace)).toHaveLength(1);
+  });
+
+  // Once, not twice — and marked, so the chip that IS the workspace never renders as an ordinary
+  // recent directory just because the user has also launched there.
+  it("does not duplicate a workspace that is also a recorded preset", () => {
+    const chips = launchChips([preset("/a/one"), preset("/home/me/ws")], "/home/me/ws");
+    expect(chips.map((c) => c.path)).toEqual(["/home/me/ws", "/a/one"]);
+    expect(chips[0]?.isWorkspace).toBe(true);
+  });
+
+  // Same lexical folding the worktree rows use (isSameDirPath): a trailing slash or a `..` is a
+  // spelling, not another directory. Getting this wrong would show the workspace twice.
+  it("folds the spellings of the same directory a person types", () => {
+    expect(launchChips([preset("/home/me/ws/")], "/home/me/ws")).toHaveLength(1);
+    expect(launchChips([preset("/home/me/x/../ws")], "/home/me/ws")).toHaveLength(1);
+  });
+
+  // A directory the user has named and colour-coded does not get renamed by being the workspace.
+  it("keeps the label a recorded preset already had", () => {
+    expect(launchChips([{ label: "My Hub", path: "/home/me/ws" }], "/home/me/ws")[0]?.label).toBe("My Hub");
+  });
+
+  // Before /api/config resolves there is no workspace to offer, and inventing one would point a
+  // click at a directory nobody chose.
+  it("offers nothing extra until the server has said where the workspace is", () => {
+    expect(launchChips([preset("/a/one")], null)).toEqual([{ label: "one", path: "/a/one", isWorkspace: false }]);
   });
 });


### PR DESCRIPTION
#1355 / #1358 で「workspace は全 GUI ツールに届く唯一のディレクトリ」であることを確定させましたが、UI 側ではそれが「最近使ったディレクトリ」の 1 つでしかありませんでした。

## 直前の状態

チップ一覧は `cwdPresets` そのもの。これは `recordPreset` が**起動時に自動記録する**リストなので:

- workspace で一度も起動していなければチップは**存在しない**
- チップの × でユーザーが消せる（消したら二度と出ない）

つまり**最も重要なディレクトリが、クリックできないかもしれない**状態でした。

## 変更

**`launchChips(orderedPresets, defaultCwd)`**（`src/components/presets.ts`、純関数）:

- workspace を**常に先頭**に。`orderByDirPriority` の外側です — あれはユーザーが設定したディレクトリ同士の順位であって、workspace はその競争に参加していません
- すでに presets にあれば**重複させず**、ユーザーが付けた**ラベルを維持**（workspace になったせいで名前が変わらない）
- `defaultCwd` が null（`/api/config` 未解決）のときは何も足さない — 誰も選んでいないディレクトリにクリック先を作らないため

パス比較は `common/dirPathKey.ts` の **`isSameDirPath`** を再利用しました（worktree 行と同じ字句比較。末尾スラッシュや `..` を畳む）。ブラウザは symlink を解決できないので、ここは「同じ綴りか」までしか答えません — 本当の判定はサーバーの realpath (`isWorkspaceCwd`)。外した場合の被害は「同じディレクトリが 2 回出る」だけです。

**表示 (`CellLaunchForm.vue`)**:

| | |
| --- | --- |
| アイコン | Material Symbols の `workspaces` をラベル前に。**ラベル自体は変えない** |
| × ボタン | **出さない** — 合成エントリなので消すものが無く、消しても次の描画で戻る |
| hover / aria | 「the workspace: every GUI tool is available here」を追加 |
| 枠・背景 | **触らない** |

最後の点だけ補足します。枠と背景は既に「ここでセッションが走っている」という意味を持っていて、**#1106 はまさにその二重化がバグとして報告された件**です。同じ 2 つに別の意味を重ねないようにしました。色ストライプは通常どおり（workspace にも `.mulmoterminal.json` はあります）。

## 既存テストへの影響

チップを**位置で選んでいた**テストが 5 本落ちました。workspace が先頭に入ったためで、仕様変更が正しく現れたものです。いずれもパス指定で選ぶよう直しました（`chipForPath` / `launchButtonFor`）。1 本は「`my-project` は "proj" を含む」ため、ラベルの部分一致ではなくパスの前方一致にしています。

なお Material Symbols は**アイコン名がそのままリガチャのテキスト**なので `text()` が `"workspacesws"` を返します。テスト側でアイコン要素を引いて差し引いています。

## 実装上の落とし穴（コメントに残しました）

`useDirColors` に渡す `presetPaths` が `chips` を参照するため、**`chips` を先に宣言しないとマウント時に TDZ で throw します**。`useDirColors` は watch で即座に評価するので、computed の遅延評価では守られません。

## 検証

`yarn typecheck` / `format` / `lint`（0 errors）/ `yarn test` **7733 passed** / `yarn build` 成功。

**実ブラウザでの確認は未実施**です（この環境に Playwright が無いため、勝手に入れていません）。アイコンの位置合わせなど見た目の最終確認はお願いできればと思います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a workspace chip to the launcher, displayed first and protected from removal.
  - Workspace chips now include dedicated labels, icons, descriptions, and accessibility details.
  - Workspace launches automatically enable all GUI tools.
  - Workspace views hide project-specific worktree controls and tool toggles.

- **Bug Fixes**
  - Improved directory chip ordering and duplicate handling.
  - Preserved existing labels when matching workspace and recent-directory entries.

- **Documentation**
  - Updated launcher and directory-priority documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->