### PR TITLE
fix(cell): セッションメモの Enter が IME の変換確定を食うのを直す (#1353)

### DIFF
--- a/plans/fix-1353-memo-ime-enter.md
+++ b/plans/fix-1353-memo-ime-enter.md
@@ -1,0 +1,60 @@
+# fix: セッションメモの Enter が IME の変換確定を食う (#1353)
+
+## 症状
+
+セルヘッダーのメモ入力欄で「れびゅー」→変換→「レビュー」が未確定の状態で Enter を押すと、
+**変換が適用されないまま保存されて入力欄が閉じる**。1 回目の Enter で閉じるので回避手段が無い。
+
+```
+@keydown.enter.prevent="saveMemo"
+@keydown.escape.prevent="cancelMemoEdit"
+```
+
+リポジトリの他の Enter 処理（`common/terminalSubmit.ts` / `common/keymap.ts` /
+`common/terminalClipboard.ts` / `src/composables/gridShortcut.ts`）はいずれも `isComposing` を
+見ているのに、メモ欄だけ漏れていた。
+
+## 素朴な `isComposing` ガードでは足りない
+
+`if (e.isComposing) return` は **Chrome / Firefox でしか正しくない**。
+
+| ブラウザ | `compositionend` と確定 Enter の順序 | 素朴なガードの結果 |
+| --- | --- | --- |
+| Chrome / Firefox | keydown が先、`isComposing === true` | 正しく弾ける |
+| **Safari** | **`compositionend` が先** → keydown 時点で `isComposing === false` | **素通りして保存される** |
+
+MulmoClaude は同じ問題を先に踏んでおり、`src/composables/useImeAwareEnter.ts` で
+「`compositionend` 直後の短い時間窓」を使って Safari 側を潰している。ChatInput /
+PageChatComposer / manageRoles の編集フィールドがすべてこれを使っている。
+
+**その実装を移植する**。CLAUDE.md の「MulmoClaude is the reference host」に従い、形も定数も
+合わせる — 両方のアプリを使う人が、1 つのキー操作で 2 つの挙動を受け取ることがないように。
+
+窓は 30ms。Safari のシーケンスは同期（マイクロ秒）で、人間の 2 回目の Enter は 100ms 以上
+かかるので、両者が混ざることはない。
+
+## Escape も同じ穴
+
+issue は「未確認」としていたが、**再現した**。変換中の Escape は候補を取り消す操作なのに、
+`cancelMemoEdit` に食われてメモ編集ごと消える。Enter より被害が大きい（書きかけの文が消える）。
+
+MulmoClaude の composable は Enter しか見ないが、`isImeConfirmation` を「他のキーの consumer が
+問い合わせるため」に公開している。Escape はそれを使う。
+
+## 実装
+
+1. **`src/composables/useImeAwareEnter.ts`（新規）** — MulmoClaude から移植。出所と Safari の
+   理由をファイル先頭に書く（再導出を間違えやすい部分なので）。
+2. **`src/components/TerminalCell.vue`** — メモ欄を素の `@keydown` に結線し、
+   `@compositionstart` / `@compositionend` / `@blur` を composable に渡す。
+   - Vue の `.enter` / `.escape` 修飾子を使わないのは MulmoClaude と同じ理由。加えて
+     **修飾子の `.prevent` は IME の判定より先に走る**ので、判定を先にするならここでは使えない。
+   - `@blur` は従来どおり保存する。composable の `onBlur` は composition 状態を落とすだけ。
+
+## 検証
+
+- **旧実装に戻すと新規 spec が 3 本赤くなる**ことを確認する（Enter 2 本 + Escape 1 本）。
+  ガードを足したことではなく、**報告された症状が再現し、修正で消える**ことが受け入れ条件。
+- `yarn lint` / `typecheck` / `build` / `test`
+- 実ブラウザでの IME 操作は自動化できないため、jsdom 上の合成 composition イベントと、
+  MulmoClaude で実際に出荷されている実装からの移植であることを根拠とする。この点は PR に明記する。

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,6 +2,7 @@
 import { ref, computed, nextTick, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
+import { useImeAwareEnter } from "../composables/useImeAwareEnter";
 import { useCellChrome } from "../composables/useCellChrome";
 import { useGitStatus } from "../composables/useGitStatus";
 import { useWorkItem } from "../composables/useWorkItem";
@@ -763,6 +764,33 @@ function cancelMemoEdit() {
   memoEditing.value = false;
 }
 
+// Enter here has to mean "confirm the IME candidate" while a conversion is open, or a note typed in
+// Japanese is saved half-converted and the box closes on the first press with no way back (#1353).
+const memoIme = useImeAwareEnter(() => void saveMemo());
+
+// One plain `keydown` rather than Vue's `.enter` / `.escape` modifiers: the composable reads
+// `event.key` itself, which is what the modifiers do — but binding them here would put the
+// modifier's own `.prevent` ahead of the IME decision, and the whole point is that the decision
+// comes first.
+function onMemoKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    // Escape mid-composition drops the candidate. Closing the editor on it would throw away the
+    // sentence the user is still writing, which is worse than the Enter case it mirrors.
+    if (memoIme.isImeConfirmation(event)) return;
+    event.preventDefault();
+    cancelMemoEdit();
+    return;
+  }
+  memoIme.onKeydown(event);
+}
+
+// Blur still saves — clicking away is the ordinary way to leave a text field. The composable's own
+// blur only clears its composition state, so a stale "mid-composition" flag cannot outlive the box.
+function onMemoBlur() {
+  memoIme.onBlur();
+  void saveMemo();
+}
+
 // Save, then let the server's answer win: it normalizes and caps, so what is shown here after a
 // save is what a reload will show. Blur saves too — closing the box by clicking away is the
 // ordinary way to leave a text field, and losing the sentence to it would be the bug.
@@ -1082,9 +1110,10 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               aria-label="Note for this session"
               spellcheck="false"
               @click.stop
-              @keydown.enter.prevent="saveMemo"
-              @keydown.escape.prevent="cancelMemoEdit"
-              @blur="saveMemo"
+              @keydown="onMemoKeydown"
+              @compositionstart="memoIme.onCompositionStart"
+              @compositionend="memoIme.onCompositionEnd"
+              @blur="onMemoBlur"
             />
             <span
               v-else

--- a/src/composables/useImeAwareEnter.ts
+++ b/src/composables/useImeAwareEnter.ts
@@ -1,0 +1,64 @@
+/**
+ * Make Enter mean "confirm the IME candidate" while a Japanese / Chinese / Korean composition is
+ * open, and "the user pressed Enter" only after it closes.
+ *
+ * Ported from MulmoClaude's `src/composables/useImeAwareEnter.ts`, which the same input problem
+ * produced there first (its ChatInput, PageChatComposer and manageRoles edit-name field all use
+ * it). Kept the same shape deliberately: someone running both apps must not get two behaviours
+ * from one keypress, and the Safari reasoning below is the part that is easy to re-derive wrongly.
+ *
+ * The `isComposing` guard alone is not enough. **Safari fires `compositionend` BEFORE the
+ * confirming Enter's `keydown`**, so `event.isComposing` is already `false` when the handler runs
+ * and the naive guard lets the action through — on Chrome and Firefox `compositionend` comes after
+ * and `isComposing` is still true, which is why those two look correct without any of this. A tight
+ * window after `compositionend` covers the Safari case: that sequence is synchronous (microseconds),
+ * while a human pressing Enter a second time takes >= 100ms and never lands inside it.
+ */
+export const SAFARI_IME_RACE_WINDOW_MS = 30;
+
+export interface ImeAwareEnterHandlers {
+  onCompositionStart: () => void;
+  onCompositionEnd: () => void;
+  onKeydown: (event: KeyboardEvent) => void;
+  onBlur: () => void;
+  /**
+   * True when this keydown is (or is likely) an IME confirmation rather than a deliberate
+   * keypress. Exposed so ANOTHER key on the same field can ask — the memo input's Escape uses it,
+   * because Escape mid-composition means "drop this candidate", not "abandon what I typed".
+   */
+  isImeConfirmation: (event: KeyboardEvent) => boolean;
+}
+
+export function useImeAwareEnter(onEnter: () => void, now: () => number = () => performance.now()): ImeAwareEnterHandlers {
+  let isImeComposing = false;
+  let lastCompositionEndAt = 0;
+
+  function isImeConfirmation(event: KeyboardEvent): boolean {
+    if (event.isComposing || isImeComposing) return true;
+    return now() - lastCompositionEndAt < SAFARI_IME_RACE_WINDOW_MS;
+  }
+
+  return {
+    isImeConfirmation,
+    onCompositionStart() {
+      isImeComposing = true;
+    },
+    onCompositionEnd() {
+      isImeComposing = false;
+      lastCompositionEndAt = now();
+    },
+    onBlur() {
+      isImeComposing = false;
+      lastCompositionEndAt = 0;
+    },
+    onKeydown(event: KeyboardEvent) {
+      if (event.key !== "Enter" || event.shiftKey) return;
+      if (isImeConfirmation(event)) {
+        event.preventDefault();
+        return;
+      }
+      event.preventDefault();
+      onEnter();
+    },
+  };
+}

--- a/test/src/components/cellMemoIme.spec.ts
+++ b/test/src/components/cellMemoIme.spec.ts
@@ -1,0 +1,158 @@
+// The session-note input's Enter and Escape while a Japanese IME candidate is open (#1353). Its own
+// file rather than more lines in TerminalCell.spec.ts, which already trips the max-lines warning.
+//
+// The reported bug: typing れびゅー, converting to レビュー, and pressing Enter to confirm saved the
+// UNCONVERTED text and closed the box — the IME's confirm keypress was eaten by saveMemo, and since
+// the box was gone there was no second chance.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import TerminalCell from "../../../src/components/TerminalCell.vue";
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+vi.mock("../../../src/components/Terminal.vue", () => ({
+  default: {
+    name: "TerminalView",
+    props: ["sessionId", "connectKey", "cwd", "hideHeader"],
+    template: '<div class="stub-term"><slot v-if="!hideHeader" name="header-actions" /></div>',
+  },
+}));
+
+const SESSION = "44444444-4444-4444-4444-444444444444";
+
+let posted: { url: string; text: unknown }[] = [];
+
+beforeEach(() => {
+  posted = [];
+  globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("/memo")) {
+      const text: unknown = init?.body ? (JSON.parse(String(init.body)) as { text: unknown }).text : null;
+      posted.push({ url: u, text });
+      return { ok: true, json: async () => ({ memo: text }) };
+    }
+    return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+  }) as unknown as typeof fetch;
+});
+
+function mountCell() {
+  return mount(TerminalCell, {
+    props: {
+      uid: 1,
+      expanded: false,
+      zoomed: false,
+      initialSessionId: SESSION,
+      initialCwd: null,
+      defaultCwd: "/home/me/my-project",
+      presets: [],
+      home: "/home/me",
+      cancellable: false,
+      openSessionIds: [],
+      openCwds: [],
+    },
+  });
+}
+
+/** Open the note editor and put `text` in it, as the user typing would. */
+async function openMemo(w: ReturnType<typeof mountCell>, text: string) {
+  await w.find('[data-testid="cell-memo-edit"]').trigger("click");
+  await flushPromises();
+  const input = w.find('[data-testid="cell-memo-input"]');
+  await input.setValue(text);
+  return input;
+}
+
+const isOpen = (w: ReturnType<typeof mountCell>) => w.find('[data-testid="cell-memo-input"]').exists();
+
+describe("session note: Enter while an IME candidate is open", () => {
+  // Chrome and Firefox keep `isComposing` true on the confirming keydown.
+  it("neither saves nor closes when the Enter is still composing", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "れびゅー");
+
+    await input.trigger("compositionstart");
+    await input.trigger("keydown", { key: "Enter", isComposing: true });
+    await flushPromises();
+
+    expect(posted).toEqual([]);
+    expect(isOpen(w)).toBe(true);
+  });
+
+  // Safari fires compositionend BEFORE the confirming keydown, so `isComposing` is already false —
+  // the naive guard the rest of this repo uses would let this one save the half-converted text.
+  it("neither saves nor closes on the keydown that immediately follows compositionend", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "れびゅー");
+
+    await input.trigger("compositionstart");
+    await input.trigger("compositionend");
+    await input.trigger("keydown", { key: "Enter", isComposing: false });
+    await flushPromises();
+
+    expect(posted).toEqual([]);
+    expect(isOpen(w)).toBe(true);
+  });
+
+  // The whole point: the box is still there, so the user's SECOND Enter saves the converted text.
+  it("saves the converted text on the next Enter, once the conversion is settled", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "れびゅー");
+
+    await input.trigger("compositionstart");
+    await input.trigger("compositionend");
+    await input.setValue("レビュー");
+    // A human's second press is >= 100ms later; the Safari race window is 30ms.
+    await new Promise((r) => setTimeout(r, 50));
+    await input.trigger("keydown", { key: "Enter", isComposing: false });
+    await flushPromises();
+
+    expect(posted.map((p) => p.text)).toEqual(["レビュー"]);
+    expect(isOpen(w)).toBe(false);
+  });
+
+  it("still saves on a plain Enter when no IME was involved", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "review this");
+
+    await input.trigger("keydown", { key: "Enter" });
+    await flushPromises();
+
+    expect(posted.map((p) => p.text)).toEqual(["review this"]);
+    expect(isOpen(w)).toBe(false);
+  });
+});
+
+describe("session note: Escape while an IME candidate is open", () => {
+  // Escape mid-composition means "drop this candidate". Closing the editor on it would throw away
+  // the sentence still being written — the same class of bug as the Enter one, one key over.
+  it("keeps the editor open when the Escape is still composing", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "れびゅー");
+
+    await input.trigger("compositionstart");
+    await input.trigger("keydown", { key: "Escape", isComposing: true });
+    await flushPromises();
+
+    expect(isOpen(w)).toBe(true);
+    expect(posted).toEqual([]);
+  });
+
+  it("still closes without saving on a plain Escape", async () => {
+    const w = mountCell();
+    await flushPromises();
+    const input = await openMemo(w, "never mind");
+
+    await input.trigger("keydown", { key: "Escape" });
+    await flushPromises();
+
+    expect(isOpen(w)).toBe(false);
+    expect(posted).toEqual([]);
+  });
+});

--- a/test/src/composables/useImeAwareEnter.spec.ts
+++ b/test/src/composables/useImeAwareEnter.spec.ts
@@ -1,0 +1,145 @@
+// What Enter means while an IME candidate is open. The naive `isComposing` guard is right on
+// Chrome and Firefox and WRONG on Safari, which fires `compositionend` before the confirming
+// keydown — so the interesting cases here are the ones where `isComposing` is already false.
+import { describe, it, expect, vi } from "vitest";
+
+import { useImeAwareEnter, SAFARI_IME_RACE_WINDOW_MS } from "../../../src/composables/useImeAwareEnter";
+
+const key = (over: Partial<KeyboardEvent> = {}): KeyboardEvent => {
+  const preventDefault = vi.fn();
+  return { key: "Enter", shiftKey: false, isComposing: false, preventDefault, ...over } as unknown as KeyboardEvent;
+};
+
+// A clock the test drives, so "30ms later" is exact rather than a sleep.
+const clock = () => {
+  let t = 1000;
+  return { now: () => t, advance: (ms: number) => (t += ms) };
+};
+
+describe("useImeAwareEnter", () => {
+  it("runs the action on a plain Enter", () => {
+    const onEnter = vi.fn();
+    const ime = useImeAwareEnter(onEnter, clock().now);
+    const e = key();
+
+    ime.onKeydown(e);
+
+    expect(onEnter).toHaveBeenCalledOnce();
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  // Chrome and Firefox: `isComposing` is still true on the confirming keydown.
+  it("does not run the action when the event is still composing", () => {
+    const onEnter = vi.fn();
+    const ime = useImeAwareEnter(onEnter, clock().now);
+
+    ime.onKeydown(key({ isComposing: true }));
+
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  // The same, driven by compositionstart rather than the flag on the event.
+  it("does not run the action between compositionstart and compositionend", () => {
+    const onEnter = vi.fn();
+    const ime = useImeAwareEnter(onEnter, clock().now);
+
+    ime.onCompositionStart();
+    ime.onKeydown(key());
+
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  // Safari: compositionend has ALREADY fired, so `isComposing` is false and the naive guard would
+  // let this through. This is the case the window exists for — deleting it turns this red.
+  it("does not run the action on the keydown that immediately follows compositionend", () => {
+    const onEnter = vi.fn();
+    const c = clock();
+    const ime = useImeAwareEnter(onEnter, c.now);
+
+    ime.onCompositionStart();
+    ime.onCompositionEnd();
+    ime.onKeydown(key({ isComposing: false }));
+
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it("runs the action on a second Enter once the race window has passed", () => {
+    const onEnter = vi.fn();
+    const c = clock();
+    const ime = useImeAwareEnter(onEnter, c.now);
+
+    ime.onCompositionStart();
+    ime.onCompositionEnd();
+    c.advance(SAFARI_IME_RACE_WINDOW_MS);
+
+    ime.onKeydown(key());
+
+    expect(onEnter).toHaveBeenCalledOnce();
+  });
+
+  it("leaves other keys alone", () => {
+    const onEnter = vi.fn();
+    const ime = useImeAwareEnter(onEnter, clock().now);
+    const e = key({ key: "a" });
+
+    ime.onKeydown(e);
+
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("leaves Shift+Enter alone", () => {
+    const onEnter = vi.fn();
+    const ime = useImeAwareEnter(onEnter, clock().now);
+    const e = key({ shiftKey: true });
+
+    ime.onKeydown(e);
+
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  // Otherwise a composition abandoned by clicking away leaves the flag set, and the next Enter in
+  // a freshly-opened box does nothing.
+  it("forgets an unfinished composition on blur", () => {
+    const onEnter = vi.fn();
+    const c = clock();
+    const ime = useImeAwareEnter(onEnter, c.now);
+
+    ime.onCompositionStart();
+    ime.onBlur();
+    ime.onKeydown(key());
+
+    expect(onEnter).toHaveBeenCalledOnce();
+  });
+
+  it("clears the race window on blur too", () => {
+    const onEnter = vi.fn();
+    const c = clock();
+    const ime = useImeAwareEnter(onEnter, c.now);
+
+    ime.onCompositionEnd();
+    ime.onBlur();
+    ime.onKeydown(key());
+
+    expect(onEnter).toHaveBeenCalledOnce();
+  });
+
+  describe("isImeConfirmation", () => {
+    it("is true mid-composition and inside the window, false outside it", () => {
+      const c = clock();
+      const ime = useImeAwareEnter(vi.fn(), c.now);
+
+      expect(ime.isImeConfirmation(key({ isComposing: true }))).toBe(true);
+
+      ime.onCompositionStart();
+      expect(ime.isImeConfirmation(key())).toBe(true);
+
+      ime.onCompositionEnd();
+      expect(ime.isImeConfirmation(key())).toBe(true);
+
+      c.advance(SAFARI_IME_RACE_WINDOW_MS);
+      expect(ime.isImeConfirmation(key())).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

セッションメモの入力欄で、IME の変換確定に使うつもりの Enter が `saveMemo` に食われ、**変換前のまま保存されて入力欄が閉じて**いました。1 回目の Enter で閉じるため回避手段がありません。

MulmoClaude が同じ問題を先に踏んで持っている `useImeAwareEnter` を移植して直しました。**素朴な `isComposing` ガードでは Safari で直りません**（後述）。

reporter が「未確認」としていた **Escape 側も再現し、あわせて直しています**。

refs #1353

## Items to Confirm / Review

1. **`isComposing` 単独では不十分な理由** — ここが一番見てほしい点です。**Safari は `compositionend` を確定 Enter の keydown より先に発火する**ので、ハンドラが走る時点で `isComposing` は既に `false` です。Chrome / Firefox は逆順で `true` のままなので、素朴なガードでも直って見えます。issue が挙げていた「このリポジトリの他の 4 箇所」も同じ素朴な形で、Safari では同じ穴があります（**本 PR ではそこは触っていません** — ターミナル側の別経路で、影響範囲が違うため。必要なら別 issue に切ります）。

2. **MulmoClaude からの移植で、形と定数（30ms）を意図的に揃えています。** CLAUDE.md の「MulmoClaude is the reference host」に従いました。両方のアプリを使う人が 1 つのキー操作で 2 つの挙動を受け取らないようにするためです。向こうでは ChatInput / PageChatComposer / manageRoles の編集フィールドが同じ composable を使っています。

3. **Escape も塞ぎました。** 変換中の Escape は「候補を取り消す」操作なのに、`cancelMemoEdit` に食われて**書きかけの文ごと消えて**いました。Enter より被害が大きいです。MulmoClaude の composable は Enter しか見ませんが、`isImeConfirmation` を「他のキーの consumer が問い合わせるため」に公開しているので、それを使っています。

4. **テンプレートを Vue の `.enter` / `.escape` 修飾子から素の `@keydown` に変えています。** MulmoClaude の結線と同じ形にしたのに加えて、**修飾子の `.prevent` はハンドラが判定するより先に走る**ためです。判定を先にすることがこの修正の主旨なので、修飾子のままでは形が合いません。

5. **実ブラウザでの IME 操作は自動化できていません。** jsdom 上の合成 composition イベントによる検証と、「MulmoClaude で実際に出荷されている実装からの移植である」ことを根拠にしています。macOS + Safari の実機で一度触っていただけると確実です。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `src/composables/useImeAwareEnter.ts`（新規） | MulmoClaude から移植。出所と Safari の理由をファイル先頭に記載 |
| `src/components/TerminalCell.vue` | メモ欄を素の `@keydown` に結線し、`compositionstart` / `compositionend` / `blur` を composable へ |
| `test/src/composables/useImeAwareEnter.spec.ts`（新規, 10本） | composable の挙動。時計を注入して「30ms 後」を厳密に再現 |
| `test/src/components/cellMemoIme.spec.ts`（新規, 6本） | 報告された症状そのもの |

`@blur` は従来どおり保存します（クリックで抜けるのは普通の操作で、そこで文が消える方がバグ）。composable の `onBlur` は composition 状態を落とすだけです。

## 検証

**「ガードを足した」ではなく「報告された症状が再現し、修正で消える」で判定しています。** 旧ハンドラに戻すと新規 spec が **3 本赤くなる**ことを確認しました。

```
× neither saves nor closes when the Enter is still composing        (Chrome/Firefox の経路)
× neither saves nor closes on the keydown that immediately following compositionend  (Safari の経路)
× keeps the editor open when the Escape is still composing          (reporter が未確認としていた件)
```

- `yarn lint` 0 errors（warning 11 は既存）/ `yarn typecheck` / `yarn build`
- `yarn test` **7767 passed**（+48）

work in mulmoterminal3