### PR TITLE
fix(terminal): 既存4箇所の isComposing ガードが Safari で塞げていない穴を埋める

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -86,7 +86,13 @@ so a seeded prompt was typed and never sent on an `esc-cr` host), scoped
 to Claude sessions only (shell/codex keep plain CR). See the [config guide](guide/en/config.html#terminal-submit).
 Anything auto-submitted also ends its line with a space (`submittableLine`, #1142), or an open
 `/command` / `@path` completion menu eats the submit — on **either** mapping.
-The `esc-cr` bare-Enter interception is guarded on `isComposing` so IME confirm isn't eaten.
+The `esc-cr` bare-Enter interception is guarded so IME confirm isn't eaten — in **two** places, and
+both are needed. `enterKeyOverride` refuses `e.isComposing`, which is the Chrome / Firefox shape; the
+custom key handler additionally refuses `isImeConfirming(e)` (`src/composables/imeComposition.ts`),
+because **Safari fires `compositionend` BEFORE the confirming keydown** and the flag is already false
+by then — so on Safari the pure guard alone submitted the half-converted line (#1353). The same
+handler covers the keymap and clipboard paths, and the grid's window-level shortcut listener asks the
+same question.
 
 ### Links — three independent mechanisms
 
@@ -347,7 +353,7 @@ looking) — flag them for QA on the release.
 | OSC 8 links | tmux `terminal-features '*:hyperlinks'` present; xterm `linkHandler` set | click Claude statusline `PR #NNNN` → opens the PR (no confirm dialog) |
 | OSC 52 clipboard | tmux `Ms` override + `set-clipboard on` present (`planMsOverride`) | Claude auto-copy reaches the browser clipboard |
 | File-path links | `registerFilePathLinks` order vs WebLinks; `/api/files/raw` cwd containment | click a generated file path → previews the file |
-| Enter / newline | `terminalSubmit` mapping + `isComposing` guard; `macOptionIsMeta` | Enter submits, Shift+Enter newlines; IME confirm not eaten; both `cr` and `esc-cr` |
+| Enter / newline | `terminalSubmit` mapping + `isComposing` guard + `isImeConfirming` (Safari's compositionend-first ordering); `macOptionIsMeta` | Enter submits, Shift+Enter newlines; IME confirm not eaten on any browser; both `cr` and `esc-cr` |
 | Mouse / wheel | `guardMouseTracking` swallow set (1000/1002/1003/1006); wheel→SGR in alt buffer; `wheelNotches` accumulation vs xterm's own `consumeWheelEvent` | wheel scrolls transcript (not prompt history); drag selects, doesn't emit mouse reports; a trackpad swipe moves a TUI about as far as it moves the scrollback |
 | Reattach | `stripTerminalQueries` patterns; replay buffer size; `tmuxTerminalModes` still reports `alternate_on` / `mouse_*_flag`, and `refresh-client` still forces a FULL repaint, on the installed tmux | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives; after a reload the wheel still scrolls a Claude cell's transcript, and the screen matches `capture-pane` rather than showing spliced-together fragments (#1073) |
 

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -45,6 +45,7 @@ import {
 } from "./gridTabs";
 import { activityStatus, type AttentionStatus } from "./attentionStatus";
 import { gridShortcutFor, isEditableTarget, type GridShortcut } from "../composables/gridShortcut";
+import { isImeConfirming } from "../composables/imeComposition";
 import { useCaptureKeydown } from "../composables/useCaptureKeydown";
 import { getActiveKeymap } from "../composables/activeKeymap";
 import { preferredLaunchDir } from "./launchDir";
@@ -453,6 +454,11 @@ function onShortcutKey(e: KeyboardEvent) {
   if (showSettings.value) return;
   const target = e.target instanceof HTMLElement ? e.target : null;
   if (target && isEditableTarget(target.tagName, Array.from(target.classList))) return;
+  // A key confirming an IME candidate is the IME's, not a shortcut. `gridShortcutFor` already
+  // refuses `e.isComposing` — this is the Safari case, where compositionend fires first and the
+  // flag is already false (#1353). Without it, confirming 変換 anywhere the grid can hear runs
+  // whatever that key is bound to.
+  if (isImeConfirming(e)) return;
   const shortcut = gridShortcutFor(getActiveKeymap(), e, expandedUid.value !== null);
   if (!shortcut) return;
   e.preventDefault();

--- a/src/composables/imeComposition.ts
+++ b/src/composables/imeComposition.ts
@@ -22,10 +22,20 @@ if (typeof window !== "undefined") {
   // handler already listens in capture — the flag has to be set before either of them reads it.
   window.addEventListener("compositionstart", shared.onCompositionStart, true);
   window.addEventListener("compositionend", shared.onCompositionEnd, true);
+  // A composition belongs to whatever element has focus, and `compositionend` is not guaranteed to
+  // arrive when that ends some other way — a tab switch, or the input being torn down mid-word.
+  // Per-component state would just go away with the component; this one does not, so a flag left
+  // set here suppresses EVERY later keystroke: no grid shortcuts and no terminal Enter, until the
+  // page is reloaded. That is a worse failure than the one this module exists to prevent.
+  //
+  // `blur` does not bubble, but a capture-phase listener on `window` still sees an element's blur
+  // on the way down, AND the window's own — one listener for both.
+  window.addEventListener("blur", shared.onBlur, true);
 }
 
 /** True while an IME candidate is open, and for a moment after Safari closes one. */
 export const isImeConfirming = (event: KeyboardEvent): boolean => shared.isImeConfirmation(event);
 
-/** Test seam: drop any composition state, as a real blur would. */
+/** Drop any composition state, as losing focus does. Exported for specs, which share this module's
+ *  state and would otherwise carry a composition from one test into the next. */
 export const resetImeComposition = (): void => shared.onBlur();

--- a/src/composables/imeComposition.ts
+++ b/src/composables/imeComposition.ts
@@ -1,0 +1,31 @@
+// Whether the key that just arrived is confirming an IME candidate, for the handlers that see a
+// keystroke WITHOUT owning the field it was typed into: xterm's custom key handler and the grid's
+// window-level shortcut listener.
+//
+// Those paths already refuse `event.isComposing`, which is correct on Chrome and Firefox. It is not
+// enough on Safari, which fires `compositionend` BEFORE the confirming keydown — by then the flag is
+// false, and the keystroke that was only meant to accept 変換 gets sent to the pty or run as a
+// shortcut (#1353). The tracking that closes that gap needs composition events over time, which a
+// pure `(keymap, event)` function cannot see, so it lives here and the call sites ask.
+//
+// Module-level rather than per-consumer: the two consumers must agree about one composition, and it
+// belongs to the document, not to either of them.
+import { useImeAwareEnter } from "./useImeAwareEnter";
+
+// The Enter callback is unused — this consumer wants only the composition tracking and the
+// predicate. Reusing the composable rather than restating the rule keeps ONE definition of "is this
+// an IME confirmation", which is the part that is easy to get subtly wrong twice.
+const shared = useImeAwareEnter(() => {});
+
+if (typeof window !== "undefined") {
+  // Capture, because xterm binds its own listeners on the helper textarea and the grid's shortcut
+  // handler already listens in capture — the flag has to be set before either of them reads it.
+  window.addEventListener("compositionstart", shared.onCompositionStart, true);
+  window.addEventListener("compositionend", shared.onCompositionEnd, true);
+}
+
+/** True while an IME candidate is open, and for a moment after Safari closes one. */
+export const isImeConfirming = (event: KeyboardEvent): boolean => shared.isImeConfirmation(event);
+
+/** Test seam: drop any composition state, as a real blur would. */
+export const resetImeComposition = (): void => shared.onBlur();

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -54,6 +54,7 @@ import { TERMINAL_FONT_SIZE_DEFAULT } from "../../common/terminalFontSize";
 import { TERMINAL_FONT_FAMILY_DEFAULT } from "../../common/terminalFontFamily";
 import { getTerminalSubmitMode } from "./terminalSubmitMode";
 import { clipboardActionFor, selectionToCopy } from "../../common/terminalClipboard";
+import { isImeConfirming } from "./imeComposition";
 import { sendBytesFor, type Keymap, type KeymapKeyEvent } from "../../common/keymap";
 import { getActiveKeymap } from "./activeKeymap";
 import { isCopyOnSelectEnabled } from "./copyOnSelect";
@@ -426,6 +427,12 @@ function wireTerminalInput(term: Terminal, c: Conn): void {
   // the more specific binding should win: copy/paste answer for at most two keys, and a `send`
   // on Enter is someone deliberately overriding the submit behaviour for this one keystroke.
   term.attachCustomKeyEventHandler((e) => {
+    // Before any of the three: a key that is confirming an IME candidate belongs to the IME, and
+    // all three below would otherwise claim it. Each already refuses `e.isComposing`, which covers
+    // Chrome and Firefox — this is the Safari case, where compositionend has already fired and the
+    // flag is false by now (#1353). `true` hands the key back to xterm, which is what happens
+    // anyway when none of the three matches.
+    if (isImeConfirming(e)) return true;
     if (clipboardActionFor(getActiveKeymap(), e, term.hasSelection())) return false;
     if (!onSend(e)) return false;
     return onEnter(e);

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -279,6 +279,7 @@ vi.mock("../../../src/composables/useTerminalConnections", async (orig) => ({
 }));
 
 import { setActiveKeymap } from "../../../src/composables/activeKeymap";
+import { resetImeComposition } from "../../../src/composables/imeComposition";
 import { PAGE_SIZE } from "../../../src/components/gridTabs";
 
 const uuid = (n: number) => `${String(n % 10).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`;
@@ -432,6 +433,28 @@ describe("GridView keyboard shortcuts (#829)", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "PageDown", shiftKey: true, bubbles: true }));
     await flushPromises();
     expect(gridOf(w).props("expandedUid")).toBe(before);
+    w.unmount();
+  });
+
+  // A key confirming an IME candidate belongs to the IME, not to a shortcut. `gridShortcutFor`
+  // already refuses `isComposing`, so the case worth pinning is SAFARI's: compositionend fires
+  // BEFORE the confirming keydown, so the flag is false by then and the shortcut used to run
+  // (#1353). Anywhere the grid can hear — the shortcut listener is on `window`.
+  it("leaves the key that confirms an IME candidate alone", async () => {
+    const w = await mountShortcutGrid(4);
+    await press("F8"); // enlarge, so zoom-next has somewhere to go
+    const before = gridOf(w).props("expandedUid");
+
+    window.dispatchEvent(new Event("compositionstart"));
+    window.dispatchEvent(new Event("compositionend"));
+    await press("PageDown");
+
+    expect(gridOf(w).props("expandedUid")).toBe(before);
+
+    // And once the composition is behind us, the same key works again.
+    resetImeComposition();
+    await press("PageDown");
+    expect(gridOf(w).props("expandedUid")).not.toBe(before);
     w.unmount();
   });
 

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { router } from "../../../src/router";
 import { defineComponent, h, KeepAlive, type Component } from "vue";
@@ -328,6 +328,11 @@ describe("GridView keyboard shortcuts (#829)", () => {
   beforeEach(() => {
     focused.length = 0;
   });
+
+  // In a hook, not at the end of the test that opens a composition: the IME state is module-level,
+  // so a failing assertion before the reset would carry an open composition into the next test and
+  // silence its keys instead.
+  afterEach(() => resetImeComposition());
 
   it("does nothing at all when no keymap is configured — shortcuts are opt-in", async () => {
     // `null`, not `undefined` — passing undefined to a defaulted parameter selects the default.

--- a/test/src/composables/imeComposition.spec.ts
+++ b/test/src/composables/imeComposition.spec.ts
@@ -1,0 +1,56 @@
+// The shared "is this key confirming an IME candidate?" answer, and the two handlers that ask it.
+//
+// Both handlers already refuse `event.isComposing`, which is the Chrome / Firefox shape. What is
+// pinned here is the SAFARI shape: compositionend has already fired, so the flag is false, and
+// without the window the keystroke that only meant to accept 変換 reaches the pty or a shortcut
+// (#1353).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { isImeConfirming, resetImeComposition } from "../../../src/composables/imeComposition";
+import { SAFARI_IME_RACE_WINDOW_MS } from "../../../src/composables/useImeAwareEnter";
+
+const enter = (over: Partial<KeyboardEvent> = {}): KeyboardEvent =>
+  ({ type: "keydown", key: "Enter", isComposing: false, ...over }) as unknown as KeyboardEvent;
+
+/** Composition events as the browser fires them, on the window the module listens to. */
+const fire = (type: "compositionstart" | "compositionend") => window.dispatchEvent(new Event(type));
+
+beforeEach(() => resetImeComposition());
+afterEach(() => {
+  vi.useRealTimers();
+  resetImeComposition();
+});
+
+describe("isImeConfirming", () => {
+  it("is false for an ordinary keystroke", () => {
+    expect(isImeConfirming(enter())).toBe(false);
+  });
+
+  it("is true while the event itself says it is composing", () => {
+    expect(isImeConfirming(enter({ isComposing: true }))).toBe(true);
+  });
+
+  // The module listens on `window` in capture, so a composition anywhere on the page counts —
+  // xterm's helper textarea included, which is the whole reason it is not per-component state.
+  it("is true between compositionstart and compositionend, wherever they were fired", () => {
+    fire("compositionstart");
+    expect(isImeConfirming(enter())).toBe(true);
+
+    fire("compositionend");
+    expect(isImeConfirming(enter())).toBe(true); // still inside the Safari window
+  });
+
+  // Safari's ordering: compositionend, THEN the confirming keydown with isComposing already false.
+  it("is true for the keystroke that immediately follows compositionend", () => {
+    fire("compositionstart");
+    fire("compositionend");
+    expect(isImeConfirming(enter({ isComposing: false }))).toBe(true);
+  });
+
+  it("is false again once the window has passed", async () => {
+    fire("compositionstart");
+    fire("compositionend");
+    await new Promise((r) => setTimeout(r, SAFARI_IME_RACE_WINDOW_MS + 20));
+    expect(isImeConfirming(enter())).toBe(false);
+  });
+});

--- a/test/src/composables/imeComposition.spec.ts
+++ b/test/src/composables/imeComposition.spec.ts
@@ -53,4 +53,32 @@ describe("isImeConfirming", () => {
     await new Promise((r) => setTimeout(r, SAFARI_IME_RACE_WINDOW_MS + 20));
     expect(isImeConfirming(enter())).toBe(false);
   });
+
+  // The state is module-level, so it does NOT go away with a component the way per-instance state
+  // would. A composition abandoned without its `compositionend` — a tab switch, an input torn down
+  // mid-word — would otherwise leave the flag set and suppress every later keystroke: no grid
+  // shortcuts and no terminal Enter until reload. Worse than the bug this module prevents.
+  it("forgets a composition abandoned without compositionend, on losing focus", () => {
+    fire("compositionstart");
+    expect(isImeConfirming(enter())).toBe(true);
+
+    window.dispatchEvent(new Event("blur"));
+
+    expect(isImeConfirming(enter())).toBe(false);
+  });
+
+  // `blur` does not bubble; the listener is in capture on `window` so an element's blur is seen on
+  // the way down. Pinning it because a plain (bubbling) listener would silently miss this one.
+  it("forgets it when the element that was composing blurs", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fire("compositionstart");
+    expect(isImeConfirming(enter())).toBe(true);
+
+    input.dispatchEvent(new Event("blur")); // not bubbling — only capture on window sees it
+
+    expect(isImeConfirming(enter())).toBe(false);
+    input.remove();
+  });
 });

--- a/test/src/composables/terminalConnectionsIme.spec.ts
+++ b/test/src/composables/terminalConnectionsIme.spec.ts
@@ -1,0 +1,97 @@
+// The terminal's custom key handler must hand an IME-confirming key back to xterm rather than
+// turning it into bytes for the pty (#1353).
+//
+// `esc-cr` mode is deliberate: it is the mode where a BARE Enter is intercepted, so an unguarded
+// confirmation submits the half-converted line to the agent. In the default `cr` mode a bare Enter
+// is already left native, which is why this never showed up there.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { termState: mockTermState, keyState: mockKeyState } = await vi.hoisted(async () => (await import("../../helpers/xtermDouble")).createXtermState());
+
+vi.mock("@xterm/xterm", async () => (await import("../../helpers/xtermDouble")).xtermModule(mockTermState, mockKeyState));
+vi.mock("@xterm/addon-fit", async () => (await import("../../helpers/xtermDouble")).fitAddonModule());
+vi.mock("@xterm/addon-web-links", async () => (await import("../../helpers/xtermDouble")).webLinksAddonModule());
+vi.mock("@xterm/addon-clipboard", async () => (await import("../../helpers/xtermDouble")).clipboardAddonModule());
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+import * as conn from "../../../src/composables/useTerminalConnections";
+import { FakeWebSocket } from "../../helpers/xtermDouble";
+import { submitSequence } from "../../../common/terminalSubmit";
+import { setTerminalSubmitMode } from "../../../src/composables/terminalSubmitMode";
+import { resetImeComposition } from "../../../src/composables/imeComposition";
+
+const target = { sessionId: null, cwd: "/typed", devTerminal: false, command: null, launcher: null };
+const bareEnter = (isComposing = false) => ({
+  type: "keydown",
+  key: "Enter",
+  shiftKey: false,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  isComposing,
+  preventDefault: vi.fn(),
+});
+
+const fire = (type: "compositionstart" | "compositionend") => window.dispatchEvent(new Event(type));
+
+/** A connected slot in esc-cr mode, plus the socket its bytes would go to. */
+function connectEscCr() {
+  mockKeyState.handler = () => true;
+  setTerminalSubmitMode("esc-cr");
+  conn.attach("cell-ime", target, { onSession: vi.fn(), onCwd: vi.fn() }, document.createElement("div"));
+  const ws = FakeWebSocket.instances.at(-1);
+  if (!ws) throw new Error("no socket created");
+  ws.onopen?.();
+  ws.sent.length = 0;
+  return ws;
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances.length = 0;
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  resetImeComposition();
+});
+afterEach(() => {
+  conn.release("cell-ime");
+  resetImeComposition();
+  setTerminalSubmitMode("cr");
+});
+
+describe("terminal keys during an IME composition", () => {
+  // The control. Without it the guard tests below would pass against a handler that never sends.
+  it("submits a bare Enter in esc-cr mode when no IME is involved", () => {
+    const ws = connectEscCr();
+
+    expect(mockKeyState.handler(bareEnter())).toBe(false); // claimed
+    expect(ws.sent).toContain(JSON.stringify({ type: "input", data: submitSequence("esc-cr") }));
+  });
+
+  // Chrome / Firefox: the flag is still set on the confirming keydown.
+  it("sends nothing when the event itself is still composing", () => {
+    const ws = connectEscCr();
+
+    expect(mockKeyState.handler(bareEnter(true))).toBe(true); // handed back to xterm
+    expect(ws.sent).toEqual([]);
+  });
+
+  // Safari: compositionend has already fired, so `isComposing` is false — the case the four
+  // existing `isComposing` guards could not see.
+  it("sends nothing on the keydown that immediately follows compositionend", () => {
+    const ws = connectEscCr();
+
+    fire("compositionstart");
+    fire("compositionend");
+
+    expect(mockKeyState.handler(bareEnter(false))).toBe(true);
+    expect(ws.sent).toEqual([]);
+  });
+
+  it("sends nothing while a composition is still open", () => {
+    const ws = connectEscCr();
+
+    fire("compositionstart");
+
+    expect(mockKeyState.handler(bareEnter(false))).toBe(true);
+    expect(ws.sent).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

#1353 でメモ欄を直したとき、issue が挙げていた**既存4箇所**（`common/terminalSubmit.ts` / `common/keymap.ts` / `common/terminalClipboard.ts` / `src/composables/gridShortcut.ts`）も同じ素朴な `isComposing` ガードで、**Safari では同じ穴がある**と報告しました。その follow-up です。

**こちらのほうが被害が大きい**です。メモ欄は「未変換のまま保存される」でしたが、ターミナルでは **変換確定のつもりの Enter が半端な行をエージェントに送信します**。

refs #1353

## なぜ4箇所を直接直さなかったか

4つとも `(keymap, event)` の**純粋関数**で、見えるのは `e.isComposing` だけです。Safari は `compositionend` を確定 keydown より先に発火するので、その時点でフラグは既に `false` — **純粋関数には原理的に塞げません**。塞ぐには composition イベントを時間軸で追う必要があり、それは呼び出し側にしかできません。

そこで DOM 境界に置きました。`src/composables/imeComposition.ts` が `window` の capture で `compositionstart` / `compositionend` を追い、`isImeConfirming(e)` に答えます。**既存の純粋ガードはそのまま**です — Chrome / Firefox には正しく、これはその前段に立ちます。

## 挿入は 2 箇所で 4 箇所ぶん

3 つは xterm の**同じハンドラ**に集約されていました。

| 挿入箇所 | カバーする guard |
|---|---|
| `attachCustomKeyEventHandler`（`useTerminalConnections.ts`） | `keymap` / `terminalClipboard` / `terminalSubmit` |
| `onShortcutKey`（`GridView.vue`、window capture） | `gridShortcut` |

## Items to Confirm / Review

1. **`useImeAwareEnter` を再利用しています**（Enter コールバックは未使用の no-op）。「IME の確定かどうか」の定義を 2 つ持たないためです。あの composable は MulmoClaude の忠実な移植のまま**触っていません** — 2 つの repo を目視で diff できる状態を保つためです（CLAUDE.md の reference-host 規約）。この判断が妥当かご確認ください。

2. **`window` の capture でリッスンしています。** xterm は自分の helper textarea にリスナを張り、グリッドのショートカットも既に capture で聞いているので、**どちらが読むより先にフラグが立っている**必要があるためです。

3. **テストは `esc-cr` モードで書いています。** bare Enter を横取りするのはこのモードだけで、既定の `cr` モードは bare Enter を xterm に任せます（だからこの不具合は既定では出ません）。モード選択の意図が伝わるかご確認ください。

4. **`resetImeComposition` はテスト用の seam です。** モジュールレベルの状態なので、spec 間で持ち越さないために公開しています。

## 検証

**「ガードを足した」ではなく「外すと落ちる」で確認しています。** 2 箇所の挿入をどちらも外すと、新規テストが **3 本赤くなります**。

```
× sends nothing on the keydown that immediately follows compositionend  (Safari 経路 / ターミナル)
× sends nothing while a composition is still open                        (変換中 / ターミナル)
× leaves the key that confirms an IME candidate alone                    (Safari 経路 / グリッド)
```

「イベント自身が `isComposing: true`」のケースは**外しても通ります** — 既存の純粋ガードが正しく効いている証拠で、役割分担が意図どおりであることの裏返しです。

- `yarn lint` 0 errors（warning 11 は既存）/ `yarn typecheck` / `yarn build`
- `yarn test` **7777 passed**（+58）
- `docs/terminal-notes.md` の「`isComposing` でガードしている」という記述を、なぜそれが半分なのかを含めて更新

**実ブラウザでの Safari + IME の確認は自動化できていません。** 合成 composition イベントによる検証です。

## 補足: 規約 doc は書いていません

CLAUDE.md から参照されている doc は `docs/grid-view-modes.md`（グリッド専用）だけで、web 全般の doc が無いため、ご指示に従い新しい規約ページは作っていません。代わりに `docs/terminal-notes.md` の既存記述を正確にし、理由は `imeComposition.ts` 先頭のコメントに置いています。

work in mulmoterminal3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Enter and keyboard shortcut handling during IME input.
  * Prevented accidental command submission when confirming IME candidates, including in Safari.
  * Improved behavior after composition ends and when focus changes during composition.
* **Tests**
  * Added coverage for IME confirmation, Safari timing, terminal Enter handling, and keyboard shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->