### PR TITLE
fix: code scanning の jscpd アラートを、ポーリング処理の共通化で解消する

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -10,7 +10,7 @@ Entries here are folded into the next release's heading when it ships.
 
 ## mulmoterminal@4.3.0 — 2026-08-04
 
-> **Setup guide:** [The workspace is where every GUI tool lives, and an Enter that means 変換](https://receptron.github.io/mulmoterminal/guide/en/v4.3.0.html) — written at release time. ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.3.0.html))
+> **Setup guide:** [The workspace is one place, and an Enter that means 変換](https://receptron.github.io/mulmoterminal/guide/en/v4.3.0.html) — written at release time. ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.3.0.html))
 
 Two things you can see. **The workspace now behaves as one place** rather than four: whichever way
 you start a terminal there — a claude cell, a codex cell, or a launcher chip — it reaches the same

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -2,7 +2,8 @@
 // branch / dirty / ahead·behind. Refreshes on mount, on cwd change, on window
 // focus, and on a light interval (only while the tab is visible). `refresh` is
 // exposed so a caller can force an update right after a turn finishes.
-import { ref, watch, onMounted, onUnmounted, type Ref } from "vue";
+import { ref, watch, type Ref } from "vue";
+import { usePollWhileVisible } from "./usePollWhileVisible";
 import type { GitStatus } from "../../common/gitStatus";
 import { isRecord } from "../../common/isRecord";
 
@@ -33,20 +34,7 @@ export function useGitStatus(cwd: Ref<string | null>) {
     }
   }
 
-  const refreshIfVisible = () => {
-    if (document.visibilityState === "visible") void refresh();
-  };
-
-  let timer: ReturnType<typeof setInterval> | undefined;
-  onMounted(() => {
-    void refresh();
-    window.addEventListener("focus", refreshIfVisible);
-    timer = setInterval(refreshIfVisible, POLL_MS);
-  });
-  onUnmounted(() => {
-    window.removeEventListener("focus", refreshIfVisible);
-    if (timer) clearInterval(timer);
-  });
+  usePollWhileVisible(() => void refresh(), POLL_MS);
   watch(cwd, refresh);
 
   return { status, refresh };

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -1,7 +1,8 @@
 // Polls GET /api/git-status for a terminal's dir so the header can always show
-// branch / dirty / ahead·behind. Refreshes on mount, on cwd change, on window
-// focus, and on a light interval (only while the tab is visible). `refresh` is
-// exposed so a caller can force an update right after a turn finishes.
+// branch / dirty / ahead·behind. Refreshes on mount, on cwd change, and on the
+// shared visible-only poll (window focus, tab visibility, a light interval) —
+// see usePollWhileVisible. `refresh` is exposed so a caller can force an update
+// right after a turn finishes.
 import { ref, watch, type Ref } from "vue";
 import { usePollWhileVisible } from "./usePollWhileVisible";
 import type { GitStatus } from "../../common/gitStatus";

--- a/src/composables/usePollWhileVisible.ts
+++ b/src/composables/usePollWhileVisible.ts
@@ -1,0 +1,32 @@
+// Refresh on mount, whenever the user comes back to this tab, and on a slow tick — but only while
+// the tab is actually visible, so a backgrounded grid of cells is not polling the server per cell.
+//
+// **Both** returning signals are needed, and that is the part worth stating: switching between
+// browser TABS fires `visibilitychange` and not `focus`, while switching between windows or apps
+// fires `focus`. Listening to one leaves the other showing whatever it last fetched until the next
+// tick — which is how a returning tab sat on a stale PR phase for most of a minute (found in review
+// on `useWorkItem`, and `useGitStatus` had the same gap until this was shared).
+//
+// `remoteHostSelfHeal.ts` deliberately does NOT use this: it is not a composable (it returns its own
+// cleanup rather than binding to a component's lifetime), it also heals on `online` and on a socket
+// reconnect, and its tick is unconditional because a heal is a no-op when already connected.
+import { onMounted, onUnmounted } from "vue";
+
+export function usePollWhileVisible(refresh: () => void, intervalMs: number): void {
+  const refreshIfVisible = () => {
+    if (document.visibilityState === "visible") refresh();
+  };
+
+  let timer: ReturnType<typeof setInterval> | undefined;
+  onMounted(() => {
+    refresh();
+    window.addEventListener("focus", refreshIfVisible);
+    document.addEventListener("visibilitychange", refreshIfVisible);
+    timer = setInterval(refreshIfVisible, intervalMs);
+  });
+  onUnmounted(() => {
+    window.removeEventListener("focus", refreshIfVisible);
+    document.removeEventListener("visibilitychange", refreshIfVisible);
+    if (timer) clearInterval(timer);
+  });
+}

--- a/src/composables/useWorkItem.ts
+++ b/src/composables/useWorkItem.ts
@@ -5,7 +5,8 @@
 //
 // The interval is slow on purpose: the server caches each (repo, branch) answer for 30s and the
 // call behind it shells out to `gh`, so polling faster buys nothing but subprocesses.
-import { ref, watch, onMounted, onUnmounted, type Ref } from "vue";
+import { ref, watch, type Ref } from "vue";
+import { usePollWhileVisible } from "./usePollWhileVisible";
 import { EMPTY_WORK_ITEM, isIssueNumber, isPrPhase, type WorkItem } from "../../common/prPhase";
 import { isRecord } from "../../common/isRecord";
 import { isIssueWorkCommentsEnabled } from "./issueWorkComments";
@@ -118,24 +119,7 @@ export function useWorkItem(cwd: Ref<string | null>) {
     }
   }
 
-  const refreshIfVisible = () => {
-    if (document.visibilityState === "visible") void refresh();
-  };
-
-  let timer: ReturnType<typeof setInterval> | undefined;
-  onMounted(() => {
-    void refresh();
-    window.addEventListener("focus", refreshIfVisible);
-    // Switching browser TABS fires this and not `focus`, and at a 30s cadence a returning tab
-    // would otherwise show the previous PR state for most of a minute (CodeRabbit review).
-    document.addEventListener("visibilitychange", refreshIfVisible);
-    timer = setInterval(refreshIfVisible, POLL_MS);
-  });
-  onUnmounted(() => {
-    window.removeEventListener("focus", refreshIfVisible);
-    document.removeEventListener("visibilitychange", refreshIfVisible);
-    if (timer) clearInterval(timer);
-  });
+  usePollWhileVisible(() => void refresh(), POLL_MS);
   watch(cwd, () => void refresh());
 
   return { item, refresh };

--- a/src/composables/useWorkItem.ts
+++ b/src/composables/useWorkItem.ts
@@ -1,7 +1,7 @@
 // What this cell is working on — the branch's PR and the issue behind it — for the header chip.
-// Same shape of poll as useGitStatus (mount, cwd change, window focus, a light interval while
-// visible), because it answers the same question about the same directory and a user who commits
-// or opens a PR expects both chips to catch up together.
+// Literally the same poll as useGitStatus now (usePollWhileVisible, plus a cwd watch), because it
+// answers the same question about the same directory and a user who commits or opens a PR expects
+// both chips to catch up together — which is only true if neither can drift from the other.
 //
 // The interval is slow on purpose: the server caches each (repo, branch) answer for 30s and the
 // call behind it shells out to `gh`, so polling faster buys nothing but subprocesses.

--- a/test/src/composables/usePollWhileVisible.spec.ts
+++ b/test/src/composables/usePollWhileVisible.spec.ts
@@ -1,0 +1,93 @@
+// The polling lifecycle `useGitStatus` and `useWorkItem` share. Extracted because jscpd found them
+// duplicating it (alert #141) — and the two had already drifted: only one of them listened for
+// `visibilitychange`, so the other showed stale data until its next tick after a tab switch.
+//
+// Both returning signals are pinned here, because that drift is exactly what one shared definition
+// is supposed to make impossible.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { defineComponent, h } from "vue";
+import { mount } from "@vue/test-utils";
+
+import { usePollWhileVisible } from "../../../src/composables/usePollWhileVisible";
+
+const INTERVAL_MS = 10_000;
+
+function mountPoller(intervalMs = INTERVAL_MS) {
+  const refresh = vi.fn();
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        usePollWhileVisible(refresh, intervalMs);
+        return () => h("div");
+      },
+    }),
+  );
+  return { wrapper, refresh };
+}
+
+/** jsdom reports "visible" by default; this is how a hidden tab is simulated. */
+const setVisibility = (state: "visible" | "hidden") => Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+
+afterEach(() => {
+  vi.useRealTimers();
+  setVisibility("visible");
+});
+
+describe("usePollWhileVisible", () => {
+  it("refreshes once on mount", () => {
+    const { refresh } = mountPoller();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  // Window / app switching.
+  it("refreshes when the window regains focus", () => {
+    const { refresh } = mountPoller();
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  // BROWSER TAB switching fires this and not `focus` — the signal `useGitStatus` was missing.
+  it("refreshes when the tab becomes visible again", () => {
+    const { refresh } = mountPoller();
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  // A tab going HIDDEN fires visibilitychange too; polling a backgrounded grid per cell is the
+  // cost this guard exists to avoid.
+  it("does not refresh when the tab is going hidden", () => {
+    const { refresh } = mountPoller();
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).toHaveBeenCalledTimes(1); // the mount call only
+  });
+
+  it("refreshes on the interval while visible, and not while hidden", () => {
+    vi.useFakeTimers();
+    const { refresh } = mountPoller();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(INTERVAL_MS);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    setVisibility("hidden");
+    vi.advanceTimersByTime(INTERVAL_MS * 3);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  // A grid unmounts cells constantly. A listener or timer surviving one is a leak that keeps
+  // fetching for a directory nobody is looking at.
+  it("stops listening and ticking when the component unmounts", () => {
+    vi.useFakeTimers();
+    const { wrapper, refresh } = mountPoller();
+    wrapper.unmount();
+    refresh.mockClear();
+
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(INTERVAL_MS * 3);
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

[code scanning](https://github.com/receptron/mulmoterminal/security/code-scanning) の唯一の open アラート **#141**（jscpd / duplicate-code, 59 tokens）を解消します。

`useGitStatus` と `useWorkItem` が、**同じ「可視のときだけポーリングする」ライフサイクル**（mount・window focus・tick とその後始末）を二重に持っていました。抑制ではなく**共通化**で消しています。

refs #141

## Items to Confirm / Review

1. **共通化した副産物として `useGitStatus` の挙動が変わります。** ここが一番見てほしい点です。2 つは既に**ドリフトしていて**、`visibilitychange` を聞いていたのは `useWorkItem` だけでした（レビュー指摘で追加されたもの。**ブラウザのタブ切り替えは `focus` ではなく `visibilitychange` を発火する**ため）。つまり `useGitStatus` は、タブから戻ってきても次の tick まで**古い branch チップを表示**していました。共通化すると `useGitStatus` がこのリスナを得ます。10 秒ポーリングなので最大 10 秒の差でしかありませんが、**黙って変えたことにはしたくない**ので明記します。

2. **`remoteHostSelfHeal.ts` は意図的に共通化していません。** 同じ可視性チェックを持っていますが、(a) composable ではなく自前の cleanup を返す、(b) `online` とソケット再接続でも heal する、(c) tick が可視性で絞られていない（heal は接続済みなら no-op なので）— と形が違います。次に読む人が畳み込まないよう、新ファイルの先頭にその旨を書いています。

3. **計測は CI が pin しているバイナリで行いました。** `npx jscpd` の既定（v4）は**別の集合**を報告します（markup の 2 件を出し、この TypeScript の 1 件を出さない）。CI と同じ **v5.0.12** を取得して実測しています。

## 検証

**「共通化した」ではなく「アラートが消える」で判定しています。** CI と同じ jscpd 5.0.12 で前後を測りました。

```console
$ jscpd . --format "typescript,vue" --ignore "..." --reporters console   # origin/main
Clone found (typescript)
 - src/composables/useGitStatus.ts [30:69 - 43:56] (14 lines, 59 tokens)
Found 1 clones.

$ jscpd . ...                                                            # このブランチ
Found 0 clones.
```

位置もトークン数も**アラート #141 と完全に一致**します（alert: `start_line 30, end_line 43`, `Duplicated code block (59 tokens)`）。SARIF の出力ファイル名も workflow が指定する `jscpd-report.sarif` と一致することを確認済みです。

- 新規 spec 6 本（`usePollWhileVisible.spec.ts`）— mount / focus / visibilitychange / hidden のときは撃たない / interval / unmount 後のリーク無し
- `yarn lint` 0 errors（warning 11 は既存）/ `yarn typecheck` / `yarn build` / `yarn test` **7793 passed**

## 相乗りしている 1 行

`docs/ChangeLog.md` の 4.3.0 の Setup guide リンクの文言が、そのページ自身のタイトルと食い違っていました（4.2.0 以前は一致させる慣例）。リリース直後に気づいたものです。単独 PR にするほどでもないので相乗りさせていますが、**分けたほうがよければ言ってください**。

```diff
-[The workspace is where every GUI tool lives, and an Enter that means 変換]
+[The workspace is one place, and an Enter that means 変換]
```

work in mulmoterminal3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git status and work item updates now refresh reliably when the application is visible, focused, or becomes visible again.
  * Background polling is reduced while the application is hidden.

* **Documentation**
  * Clarified the MulmoTerminal 4.3.0 setup-guide wording.

* **Tests**
  * Added coverage for visibility-aware refreshing, timed updates, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->