### PR TITLE
perf: 巨大 transcript の畳み込みを sidecar に永続化する (#1386)

### DIFF
--- a/plans/perf-1386-transcript-sidecar.md
+++ b/plans/perf-1386-transcript-sidecar.md
@@ -1,0 +1,101 @@
+# Keep the fold beside the transcript, not only in memory (#1386)
+
+#1379 made the session list resume its fold instead of repeating it: an unchanged transcript is not
+read at all, a grown one costs the bytes that arrived. That state lives in **one process's memory**,
+so two things still pay full price:
+
+- **a restart** — 2.1 s on the 2.1 GB project here, all of it one 461 MB file with no `ai-title`
+  anywhere, read end to end to establish that it has none;
+- **every other process** — eight mulmoterminals run against the same `~/.claude/projects` on this
+  machine, and each one warms its own copy.
+
+A sidecar fixes both: write what was folded, and the byte the fold stopped at, to a small JSON file.
+The next process to want it reads a few KB instead of a few hundred MB.
+
+## Which files get one
+
+Transcripts here: 9,883 files, 9.6 GB, **median 93 KB** — the big ones are what matter.
+
+| threshold | files | share of all transcript bytes |
+| --- | --- | --- |
+| >10 MB | 82 | **82%** |
+| >50 MB | 32 | 70% |
+| >100 MB | 18 | 59% |
+| >300 MB | 10 | 43% |
+
+**10 MB.** 82 files of a few KB each is nothing to keep, and it covers 82% of the bytes. Below that
+a fold costs single-digit milliseconds, which is not worth a file — the in-memory cache already
+covers it.
+
+## Where, and what is in it
+
+`~/.mulmoterminal/transcript-index/<kind>/<project-dir>/<session-id>.json` — the same home the
+activity state and the background-session list already use. **Not** `~/.claude/projects`: that is
+Claude Code's directory, and its own `cleanupPeriodDays` sweep runs there.
+
+```json
+{ "v": 1, "size": 532676421, "mtimeMs": 1785801386182, "head": "9f2a…", "scannedTo": 532676421,
+  "value": { "aiTitle": "…", "lastPrompt": "…", "firstUserMsg": "…" } }
+```
+
+- `v` — bump when the fold's MEANING changes. A stale sidecar is not a stale cache; it is a wrong
+  answer that survives restarts, so the version is checked before anything else.
+- `size` / `mtimeMs` — same freshness rule as `createFileCache`: grown → resume from `scannedTo`,
+  shorter → rebuild, same size + different mtime → rebuild.
+- `head` — a hash of the first 256 bytes. The (mtime, size) pair cannot tell "appended to" from
+  "replaced by something longer", and unlike the in-memory cache this one can be **days old** when
+  it is read, so the odds of meeting a replaced file are no longer negligible. A transcript's first
+  record carries its session id and start time, so a different file almost never matches.
+- `value` — guarded on read like any other untrusted input. A file that fails any check is silently
+  rebuilt; there is no error path a user could act on.
+
+Written tmp + rename, so a reader never sees half a file, and eight writers just mean the last one
+wins — every version is self-consistent. Writes are serialized per path within a process.
+
+## This PR
+
+The machinery, plus the one reader that is already an incremental fold (`readSessionMeta`), so the
+mechanism ships proven end to end before the harder readers move onto it. The remaining two steps
+are in #1386: `rollupProjectCost` + `sessionTimeline` (both fold into state that serialises as-is,
+and neither has any cache today), then `readSessionSummary` (whose scan keeps RAW records and needs
+restructuring first).
+
+## Tests
+
+`test/server/session/transcript-sidecar.spec.ts`
+
+- a written sidecar is read back, and resumes at the stored offset
+- version mismatch, shorter file, same size with a different mtime, a different head, corrupt JSON,
+  a value that fails its guard — each rebuilds rather than answering
+- a file below the threshold is never written and never read
+- rename is atomic: no partial file is ever visible, and no tmp file is left behind
+- the path is derived from the transcript's basenames only (a crafted path cannot escape the root)
+
+`test/server/session/session-meta-sidecar.spec.ts`
+
+- a big transcript folded once is answered from the sidecar by a reader whose in-memory cache never
+  saw it — proven by changing the transcript's tail while holding (size, mtime), so an answer that
+  matches the ORIGINAL can only have come from disk
+- appending to it resumes from the sidecar's offset rather than folding from zero
+- a small transcript gets no sidecar file at all
+
+## Measured
+
+`readSessionMeta` over the 50 most recent transcripts of a real project, run twice in SEPARATE
+processes — the second is what a restart, or the second mulmoterminal on this machine, actually
+sees:
+
+| project | transcripts | first process (no sidecar) | second process (sidecar on disk) |
+| --- | --- | --- | --- |
+| mulmoclaude2 | 20 files, 2,112 MB | 1,795 ms | **23 ms** |
+| mulmoclaude3 | 50 files, 1,135 MB | 467 ms | **52 ms** |
+
+mulmoclaude3 keeps more of its first-read cost because most of its 50 files are under the 10 MB
+threshold and are answered from their two ends anyway — which is the trade the threshold is for.
+
+The whole index for both projects is **24 files, 96 KB**.
+
+## Not in scope
+
+Orphan sidecars (the transcript deleted under them) are left for a follow-up: they are ~1 KB each
+and only appear when a >10 MB transcript is removed. Noted on #1386 rather than swept here.

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -22,7 +22,8 @@ import {
   type LatestTurnContext,
   type TimelineEvent,
 } from "./transcript.js";
-import { createAppendFileCache, createFileCache, type FileStamp } from "./file-cache.js";
+import { createAppendFileCache, createFileCache, type AppendScan, type FileStamp } from "./file-cache.js";
+import { createTranscriptSidecar } from "./transcript-sidecar.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, isBackgroundSession, isFailedWorker, knownSessions, sessionMemos } from "./registry.js";
@@ -245,23 +246,42 @@ const TITLE_TAIL_BYTES = 512 * 1024;
 
 const titleFieldsCache = createAppendFileCache<TitleFields>();
 
+// The same fold, kept on disk for the transcripts big enough to be worth a file — so a restart and
+// the next mulmoterminal process do not each pay for it again (#1386). Bump the version when
+// foldTitleField changes what it means, or old files answer for a rule that no longer exists.
+const isTitleFields = (value: unknown): value is TitleFields =>
+  isRecord(value) &&
+  (value.aiTitle === null || typeof value.aiTitle === "string") &&
+  (value.lastPrompt === null || typeof value.lastPrompt === "string") &&
+  (value.firstUserMsg === null || typeof value.firstUserMsg === "string");
+
+const titleFieldsSidecar = createTranscriptSidecar<TitleFields>({ kind: "title-fields", version: 1, isValue: isTitleFields });
+
 // A transcript is append-only, so the same three fields are folded out of it at most once: an
 // unchanged file is not read at all, and a grown one costs only the bytes that arrived. Without
 // this the session list read every one of its fifty transcripts in full on every request — 4.8 s
 // for a 17 KB answer on a 1.1 GB project, and the launcher waits on it (#1377).
 async function readTitleFields(full: string, stamp: FileStamp): Promise<TitleFields> {
-  const resumed = titleFieldsCache.resume(full, stamp);
-  if (resumed && resumed.from >= stamp.size) return resumed.value;
-  if (!resumed) {
-    const cold = await coldTitleFields(full, stamp.size);
-    titleFieldsCache.set(full, stamp, cold.offset, cold.fields);
-    return cold.fields;
+  // Memory first, disk second: the sidecar only has to answer the first read of a file in this
+  // process, and after that the in-memory scan is the one being resumed.
+  const resumed = titleFieldsCache.resume(full, stamp) ?? (await titleFieldsSidecar.read(full, stamp));
+  if (resumed && resumed.from >= stamp.size) {
+    titleFieldsCache.set(full, stamp, resumed.from, resumed.value);
+    return resumed.value;
   }
-  // Resuming from a boundary the previous scan reported, so the record starting there counts.
+  const { fields, offset } = resumed
+    ? // Resuming from a boundary the previous scan reported, so the record starting there counts.
+      await resumeTitleFields(full, resumed)
+    : await coldTitleFields(full, stamp.size);
+  titleFieldsCache.set(full, stamp, offset, fields);
+  titleFieldsSidecar.write(full, stamp, offset, fields);
+  return fields;
+}
+
+async function resumeTitleFields(full: string, resumed: AppendScan<TitleFields>): Promise<{ fields: TitleFields; offset: number }> {
   const fields = { ...resumed.value };
   const offset = await forEachJsonlRecordIn(full, { from: resumed.from, atLineStart: true }, (o) => foldTitleField(fields, o));
-  titleFieldsCache.set(full, stamp, offset, fields);
-  return fields;
+  return { fields, offset };
 }
 
 // The first read of a file: both ends when it is big enough for that to be worth it, and the whole

--- a/server/session/transcript-sidecar.ts
+++ b/server/session/transcript-sidecar.ts
@@ -1,0 +1,129 @@
+// A value folded out of a transcript, kept beside it on disk.
+//
+// createAppendFileCache (file-cache.ts) already stops a fold from being repeated — but only within
+// one process's memory. Two things still pay full price: a restart, and every OTHER mulmoterminal
+// rooted at the same home (eight run on this machine, each warming its own copy). A sidecar is that
+// same {value, offset} written to a small JSON file, so the next reader spends a few KB instead of
+// a few hundred MB (#1386).
+//
+// Only worth it for a big transcript: the median here is 93 KB, which folds in under a millisecond,
+// while files over 10 MB hold 82% of all transcript bytes.
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { MULMOTERMINAL_HOME } from "../config/env.js";
+import { isRecord } from "../../common/isRecord.js";
+import { createKeySerializer } from "../infra/serialize-per-key.js";
+import type { AppendScan, FileStamp } from "./file-cache.js";
+
+const SIDECAR_ROOT = path.join(MULMOTERMINAL_HOME, "transcript-index");
+// Under this, a fold costs single-digit milliseconds and the in-memory cache already covers it.
+const DEFAULT_MIN_BYTES = 10 * 1024 * 1024;
+// Enough to carry a transcript's first record, which names the session and when it started.
+const HEAD_BYTES = 256;
+
+export interface TranscriptSidecar<T> {
+  /** What was folded and where to continue, or undefined when the file must be folded from
+   *  scratch — including every reason to distrust what is on disk. */
+  read(transcript: string, stamp: FileStamp): Promise<AppendScan<T> | undefined>;
+  /** Best effort, and deliberately not awaited by the read path: the answer is already in hand. */
+  write(transcript: string, stamp: FileStamp, from: number, value: T): void;
+}
+
+export interface SidecarOptions<T> {
+  /** One directory per KIND of derived value (title fields, cost, timeline …). */
+  kind: string;
+  /** Bump when the fold's MEANING changes. A stale cache is a slow answer; a stale sidecar is a
+   *  WRONG one that survives restarts, so this is checked before anything else. */
+  version: number;
+  /** A file on disk is untrusted input, whoever wrote it. */
+  isValue: (value: unknown) => value is T;
+  minBytes?: number;
+}
+
+// One write at a time per sidecar path: within a process, two folds of the same transcript would
+// otherwise interleave their tmp+rename.
+const serializeWrite = createKeySerializer();
+
+export function createTranscriptSidecar<T>(options: SidecarOptions<T>): TranscriptSidecar<T> {
+  const minBytes = options.minBytes ?? DEFAULT_MIN_BYTES;
+  return {
+    async read(transcript, stamp) {
+      if (stamp.size < minBytes) return undefined;
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(sidecarPath(options.kind, transcript), "utf8"));
+        return (await usableScan(parsed, options, transcript, stamp)) ?? undefined;
+      } catch {
+        return undefined; // absent, unreadable, or not JSON — fold it again
+      }
+    },
+    write(transcript, stamp, from, value) {
+      if (stamp.size < minBytes) return;
+      const file = sidecarPath(options.kind, transcript);
+      // Per path, so this process cannot race itself. Other processes are handled by the rename:
+      // the last writer wins and every version on disk is self-consistent.
+      void serializeWrite(file, async () => {
+        try {
+          await writeAtomic(
+            file,
+            JSON.stringify({ v: options.version, size: stamp.size, mtimeMs: stamp.mtimeMs, head: await headHash(transcript), scannedTo: from, value }),
+          );
+        } catch {
+          // Best effort: the value is already answered from memory, and a sidecar that cannot be
+          // written just means the next process folds the file itself.
+        }
+      });
+    },
+  };
+}
+
+// Every reason to distrust the file, in one place. `null` rather than a throw: none of these is an
+// error a caller can act on — they all mean "fold it yourself".
+async function usableScan<T>(parsed: unknown, options: SidecarOptions<T>, transcript: string, stamp: FileStamp): Promise<AppendScan<T> | null> {
+  if (!isRecord(parsed) || parsed.v !== options.version) return null;
+  const { size, mtimeMs, scannedTo, head, value } = parsed;
+  if (typeof size !== "number" || typeof mtimeMs !== "number" || typeof scannedTo !== "number" || typeof head !== "string") return null;
+  if (!options.isValue(value)) return null;
+  // The same freshness rule createFileCache states: a shorter file was rewritten, and a same-size
+  // one whose mtime moved was rewritten in place.
+  if (stamp.size < size || scannedTo > stamp.size) return null;
+  if (stamp.size === size && stamp.mtimeMs !== mtimeMs) return null;
+  // (mtime, size) cannot tell "appended to" from "replaced by something longer". In memory that gap
+  // is a moment wide; here the record can be days old, so the first bytes are checked too.
+  if ((await headHash(transcript)) !== head) return null;
+  return { from: scannedTo, value };
+}
+
+// Mirrors the transcript's own layout — <project dir>/<session>.jsonl — from BASENAMES only, so
+// nothing a caller passes can walk out of the sidecar root.
+function sidecarPath(kind: string, transcript: string): string {
+  const project = path.basename(path.dirname(transcript));
+  const session = path.basename(transcript, ".jsonl");
+  return path.join(SIDECAR_ROOT, kind, project, `${session}.json`);
+}
+
+// One read of the first bytes, not a stream: the window is a fixed 256 bytes, and a plain read
+// keeps the buffer typed all the way into the hash.
+async function headHash(transcript: string): Promise<string> {
+  const handle = await fs.open(transcript, "r");
+  try {
+    const buffer = Buffer.alloc(HEAD_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, HEAD_BYTES, 0);
+    return createHash("sha256").update(buffer.subarray(0, bytesRead)).digest("hex");
+  } finally {
+    await handle.close();
+  }
+}
+
+// tmp + rename, so a reader never sees half a file — including the readers in other processes.
+async function writeAtomic(file: string, body: string): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  try {
+    await fs.writeFile(tmp, body);
+    await fs.rename(tmp, file);
+  } catch (err) {
+    await fs.rm(tmp, { force: true });
+    throw err;
+  }
+}

--- a/test/server/session/session-meta-sidecar.spec.ts
+++ b/test/server/session/session-meta-sidecar.spec.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// #1379 made the session list resume its fold instead of repeating it, but that state lives in one
+// process's memory: a restart, and every other mulmoterminal on the machine, still paid for the
+// whole transcript. These pin the disk half — what a SECOND process sees (#1386).
+//
+// A fresh module registry is what stands in for that second process: `vi.resetModules()` gives a
+// reader whose in-memory cache has never seen the file, against the same home and the same
+// transcript on disk.
+
+// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move
+// the next spec's idea of ~/.mulmoterminal (and ~/.claude) without it asking.
+const realHome = process.env.HOME;
+let home = "";
+let projects = "";
+let n = 0;
+
+const line = (o: unknown) => `${JSON.stringify(o)}\n`;
+const userLine = (text: string) => line({ type: "user", message: { content: text } });
+const aiTitleLine = (title: string) => line({ type: "ai-title", aiTitle: title });
+const promptLine = (text: string) => line({ type: "last-prompt", lastPrompt: text });
+const fillerLine = (bytes: number) => line({ type: "assistant", text: "x".repeat(bytes) });
+
+const OVER_THRESHOLD_BYTES = 11 * 1024 * 1024;
+
+async function freshReader() {
+  vi.resetModules();
+  process.env.HOME = home;
+  const mod = await import("../../../server/session/session-reads.js");
+  return mod.readSessionMeta;
+}
+
+const projectDir = () => path.join(projects, "-Users-me-proj");
+
+function writeTranscript(body: string): string {
+  mkdirSync(projectDir(), { recursive: true });
+  const file = `sess-${++n}.jsonl`;
+  writeFileSync(path.join(projectDir(), file), body);
+  return file;
+}
+
+const titleFrom = async (file: string) => {
+  const readSessionMeta = await freshReader();
+  return (await readSessionMeta(projectDir(), file)).title;
+};
+
+// The write is fire-and-forget, so a test that expects the file has to let it land.
+const settled = async () => {
+  for (let i = 0; i < 60; i++) await new Promise((r) => setTimeout(r, 5));
+};
+
+const sidecarsWritten = (): string[] => {
+  const root = path.join(home, ".mulmoterminal", "transcript-index");
+  return existsSync(root)
+    ? readdirSync(root, { recursive: true })
+        .map(String)
+        .filter((e) => e.endsWith(".json"))
+    : [];
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-meta-sidecar-"));
+  projects = path.join(home, ".claude", "projects");
+  mkdirSync(projects, { recursive: true });
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("the session list across processes", () => {
+  it("answers a big transcript from the sidecar, without reading it again", async () => {
+    const file = writeTranscript(userLine("what I asked") + fillerLine(OVER_THRESHOLD_BYTES) + aiTitleLine("from the fold") + promptLine("last prompt"));
+    expect(await titleFrom(file)).toBe("from the fold");
+    await settled();
+    expect(sidecarsWritten()).toHaveLength(1);
+
+    // Rewrite the TAIL in place — same length, same mtime restored — so the bytes now say something
+    // else while the file still looks untouched. A reader that goes to disk answers the old title;
+    // one that re-folds the transcript answers the new one.
+    const full = path.join(projectDir(), file);
+    const body = userLine("what I asked") + fillerLine(OVER_THRESHOLD_BYTES) + aiTitleLine("from the file") + promptLine("last prompt");
+    const frozen = new Date(1_700_000_000_000);
+    writeFileSync(full, body);
+    const { utimesSync, statSync } = await import("node:fs");
+    utimesSync(full, frozen, frozen);
+    const stamped = statSync(full);
+
+    // The sidecar was written for the ORIGINAL stamp, so make it describe this one — the point of
+    // the test is the read path, not the stamp bookkeeping the sidecar spec already covers.
+    const sidecar = path.join(home, ".mulmoterminal", "transcript-index", "title-fields", "-Users-me-proj", `${path.basename(file, ".jsonl")}.json`);
+    const { readFileSync } = await import("node:fs");
+    const parsed: unknown = JSON.parse(readFileSync(sidecar, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) throw new Error("the sidecar should be an object");
+    writeFileSync(sidecar, JSON.stringify({ ...parsed, size: stamped.size, mtimeMs: stamped.mtimeMs, scannedTo: stamped.size }));
+
+    expect(await titleFrom(file)).toBe("from the fold");
+  });
+
+  it("resumes from the sidecar's offset when the transcript has grown", async () => {
+    const file = writeTranscript(userLine("what I asked") + fillerLine(OVER_THRESHOLD_BYTES) + aiTitleLine("first title") + promptLine("last prompt"));
+    expect(await titleFrom(file)).toBe("first title");
+    await settled();
+
+    appendFileSync(path.join(projectDir(), file), aiTitleLine("second title"));
+    expect(await titleFrom(file)).toBe("second title");
+  });
+
+  // Under the threshold a fold costs less than the file would, so there should be nothing on disk.
+  it("writes no sidecar for a small transcript", async () => {
+    const file = writeTranscript(userLine("u") + aiTitleLine("small"));
+    expect(await titleFrom(file)).toBe("small");
+    await settled();
+    expect(sidecarsWritten()).toEqual([]);
+  });
+});

--- a/test/server/session/transcript-sidecar.spec.ts
+++ b/test/server/session/transcript-sidecar.spec.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { isRecord } from "../../../common/isRecord.js";
+
+// A sidecar answers for a file it is not part of, and it can be days old when it is read — so what
+// matters is every reason to DISTRUST it. Each check below is a case where answering from disk
+// would be wrong rather than merely slow (#1386).
+
+// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move
+// the next spec's idea of ~/.mulmoterminal (and ~/.claude) without it asking.
+const realHome = process.env.HOME;
+let home = "";
+let projects = "";
+
+// MULMOTERMINAL_HOME is read at import time, so the module is imported per test run against a
+// scratch home rather than the developer's own.
+async function loadSidecar() {
+  vi.resetModules();
+  process.env.HOME = home;
+  const mod = await import("../../../server/session/transcript-sidecar.js");
+  return mod.createTranscriptSidecar;
+}
+
+interface Fields {
+  title: string;
+}
+const isFields = (v: unknown): v is Fields => isRecord(v) && typeof v.title === "string";
+
+const BIG = 10 * 1024 * 1024;
+// Big enough to be worth a sidecar (the default threshold), with a first record that identifies it.
+const transcriptBody = (session: string, filler = BIG) => `${JSON.stringify({ type: "session", session })}\n${"x".repeat(filler)}\n`;
+
+function writeTranscript(session: string, body?: string): string {
+  const dir = path.join(projects, "-Users-me-proj");
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${session}.jsonl`);
+  writeFileSync(file, body ?? transcriptBody(session));
+  return file;
+}
+
+const stampOf = (file: string) => {
+  const st = statSync(file);
+  return { mtimeMs: st.mtimeMs, size: st.size };
+};
+
+const sidecarFile = (kind: string, transcript: string) =>
+  path.join(home, ".mulmoterminal", "transcript-index", kind, path.basename(path.dirname(transcript)), `${path.basename(transcript, ".jsonl")}.json`);
+
+// The write is fire-and-forget, so a test that reads the file back has to let it land.
+const settled = async () => {
+  for (let i = 0; i < 50; i++) await new Promise((r) => setTimeout(r, 5));
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-sidecar-home-"));
+  projects = path.join(home, ".claude", "projects");
+  mkdirSync(projects, { recursive: true });
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("createTranscriptSidecar", () => {
+  it("reads back what it wrote, and resumes at the stored offset", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    const stamp = stampOf(file);
+
+    expect(await sidecar.read(file, stamp)).toBeUndefined(); // nothing written yet
+    sidecar.write(file, stamp, 1234, { title: "hello" });
+    await settled();
+
+    expect(await sidecar.read(file, stamp)).toEqual({ from: 1234, value: { title: "hello" } });
+  });
+
+  it("resumes at the stored offset for a file that only grew", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    sidecar.write(file, stampOf(file), 100, { title: "hello" });
+    await settled();
+
+    appendFileSync(file, "more\n");
+    expect(await sidecar.read(file, stampOf(file))).toEqual({ from: 100, value: { title: "hello" } });
+  });
+
+  // Each of these means the value describes a file that is no longer the one on disk.
+  it("refuses a stale record rather than answering from it", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    const stamp = stampOf(file);
+    sidecar.write(file, stamp, 100, { title: "hello" });
+    await settled();
+    const onDisk = sidecarFile("k", file);
+    const parsed: unknown = JSON.parse(readFileSync(onDisk, "utf8"));
+    if (!isRecord(parsed)) throw new Error("the sidecar should be an object");
+    const rewrite = (patch: Record<string, unknown>) => writeFileSync(onDisk, JSON.stringify({ ...parsed, ...patch }));
+
+    rewrite({ v: 2 }); // written by a build whose fold meant something else
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+
+    rewrite({ size: stamp.size + 10 }); // the file got SHORTER than the record
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+
+    rewrite({ mtimeMs: stamp.mtimeMs + 1 }); // same length, written again
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+
+    rewrite({ scannedTo: stamp.size + 1 }); // claims to have read past the end
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+
+    rewrite({ value: { title: 42 } }); // not the shape the guard accepts
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+
+    writeFileSync(onDisk, "{not json");
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+  });
+
+  // (mtime, size) cannot tell "appended to" from "replaced by something longer", and a sidecar can
+  // be days old when it is read — so the first bytes are checked too.
+  it("refuses a file whose head changed under a record that still looks fresh", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    sidecar.write(file, stampOf(file), 100, { title: "hello" });
+    await settled();
+
+    // A different session's transcript, longer than the one the record describes.
+    writeFileSync(file, transcriptBody("b", BIG + 500));
+    expect(await sidecar.read(file, stampOf(file))).toBeUndefined();
+  });
+
+  // A small transcript folds in under a millisecond; a file for it would cost more than it saves.
+  it("neither writes nor reads for a file under the threshold", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("small", `${JSON.stringify({ type: "session" })}\n`);
+    const stamp = stampOf(file);
+    sidecar.write(file, stamp, 10, { title: "hello" });
+    await settled();
+
+    expect(existsSync(path.join(home, ".mulmoterminal", "transcript-index"))).toBe(false);
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+  });
+
+  // Eight mulmoterminals share this directory. A reader must never see half a file, and a writer
+  // must not leave its scratch file behind.
+  it("leaves no temporary file behind, and the last of several writers wins", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    const stamp = stampOf(file);
+
+    sidecar.write(file, stamp, 1, { title: "one" });
+    sidecar.write(file, stamp, 2, { title: "two" });
+    sidecar.write(file, stamp, 3, { title: "three" });
+    await settled();
+
+    expect(await sidecar.read(file, stamp)).toEqual({ from: 3, value: { title: "three" } });
+    const dir = path.dirname(sidecarFile("k", file));
+    expect(readdirSync(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+  });
+
+  // Two kinds of derived value for the same transcript are two files, not one overwriting the other.
+  it("keeps one file per kind", async () => {
+    const create = await loadSidecar();
+    const titles = create<Fields>({ kind: "titles", version: 1, isValue: isFields });
+    const costs = create<Fields>({ kind: "costs", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    const stamp = stampOf(file);
+
+    titles.write(file, stamp, 1, { title: "a title" });
+    costs.write(file, stamp, 2, { title: "a cost" });
+    await settled();
+
+    expect(await titles.read(file, stamp)).toEqual({ from: 1, value: { title: "a title" } });
+    expect(await costs.read(file, stamp)).toEqual({ from: 2, value: { title: "a cost" } });
+  });
+
+  // The path is built from BASENAMES, so a transcript path cannot place a file outside the root.
+  it("keeps the file inside the sidecar root whatever the transcript path looks like", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const dir = path.join(projects, "..", "..", "escape-attempt");
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "s.jsonl");
+    writeFileSync(file, transcriptBody("s"));
+
+    sidecar.write(file, stampOf(file), 1, { title: "x" });
+    await settled();
+    const written = readdirSync(path.join(home, ".mulmoterminal", "transcript-index"), { recursive: true }).map(String);
+    expect(written.some((e) => e.endsWith("s.json"))).toBe(true);
+    expect(written.every((e) => !e.includes(".."))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

巨大 transcript から畳み込んだ値を、**本体の脇の小さな JSON（sidecar）に永続化**する。#1379 で入れた「畳み込み＋どこまで読んだかの offset」を、そのままディスクに置いただけ。

#1379 の状態は**1 プロセスのメモリ**にしか無いので、まだ全額払っている場所が 2 つあった:

- **再起動**（2.1 GB のプロジェクトで 1.8 秒）
- **他のプロセス** — このマシンでは mulmoterminal が 8 個、同じ `~/.claude/projects` に対して動いていて、それぞれが同じ 500 MB を個別に温めている

### 実測（同じ処理を**別プロセス**で 2 回。2 回目＝再起動後 / 2 台目が見るもの）

| プロジェクト | transcript | 1 回目（sidecar 無し） | 2 回目（sidecar あり） |
|---|---|---:|---:|
| mulmoclaude2 | 20 本 / 2,112 MB | 1,795 ms | **23 ms** |
| mulmoclaude3 | 50 本 / 1,135 MB | 467 ms | **52 ms** |

両プロジェクト分の索引は **24 ファイル / 96 KB**。

mulmoclaude3 で 52 ms 残るのは、50 本の大半が 10 MB 未満で **sidecar を作らず両端読みで答えている**ため。閾値の狙いどおり。

## Items to Confirm / Review

- **閾値 10 MB**。実データ 9,883 本 / 9.6 GB の分布から決めた: 中央値 93 KB、>10 MB は 82 本で**全バイトの 82%**、>100 MB は 18 本で 59%。「82 本ぶんの数 KB JSON」で 82% をカバーできるのでここにした（ご提案は 300 MB でしたが、それだと 10 本 / 43%）。
- **置き場所は `~/.mulmoterminal/transcript-index/<kind>/<project>/<session>.json`**。`~/.claude/projects` には書かない（Claude Code の領分で、`cleanupPeriodDays` の掃除が走る場所）。
- **信用しない条件を全部入れた**か見てほしい。sidecar は「遅い答え」ではなく「**間違った答えが再起動を越えて生き残る**」形の事故になるので: `v` 不一致 / ファイルが縮んだ / 同サイズで mtime が動いた / offset がファイル末尾を超えている / value が型ガードを通らない / JSON が壊れている、いずれも黙って作り直し。
- **先頭 256 バイトのハッシュ**を足した理由。(mtime, size) では「追記された」と「もっと長いものに置き換わった」を区別できない。メモリ内キャッシュならその隙間は一瞬だが、**sidecar は数日前の記録を読むことがある**ので、同一ファイルであることの確認を入れた。transcript の先頭レコードはセッション id と開始時刻を含むので、別ファイルならまず一致しない。
- **書き込みは tmp + rename**（8 プロセスが同じディレクトリを触るため）。最後の書き手が勝つだけでよく、どの版も自己完結している。プロセス内では path 単位で直列化。
- **孤児 sidecar（transcript が消えた場合）は今回スコープ外**。1 本 1 KB 程度で、10 MB 超の transcript が消えたときだけ出る。#1386 に残した。

## User Prompt

> 300M以上のファイルだと、要約を横にファイルでおいておけばmulmoterminalでは高速化出来ない？毎回全部読む必要ないよね？
>
> ok じゃあ、そのようにsidecarで改善して

会話で決めたこと:

- 進め方は **増分化 →  sidecar**。この PR は sidecar の土台 ＋ すでに増分化済みの `readSessionMeta` まで。
- 閾値は実データの分布を見て 300 MB ではなく **10 MB** に。

## 実装

計画: [`plans/perf-1386-transcript-sidecar.md`](plans/perf-1386-transcript-sidecar.md)

- `server/session/transcript-sidecar.ts`（新規）— `createTranscriptSidecar({ kind, version, isValue, minBytes })`。`read` は信用できないものを全部弾いて `{from, value}` を返し、`write` は fire-and-forget の atomic write。
- `server/session/session-reads.ts` — `readTitleFields` が **メモリ → ディスク** の順で resume を探し、畳み込んだら両方に書く。

## テスト（新規 11 本）

- `transcript-sidecar.spec.ts`（8 本）— 書いて読み戻す / 伸びたファイルは offset から再開 / **信用しない 6 条件それぞれで作り直し** / 先頭が変わったら拒否 / 閾値未満は書かない・読まない / tmp を残さず最後の書き手が勝つ / kind ごとに別ファイル / パスは basename からのみ組み立て（root の外に出られない）
- `session-meta-sidecar.spec.ts`（3 本）— **メモリキャッシュが空のリーダーがディスクから答える**ことを、(size, mtime) を保ったまま中身だけ差し替えて証明 / 伸びていれば sidecar の offset から再開 / 小さい transcript には何も書かない

sidecar 読み出しを外すと最初のテストが落ちることを確認済み。`yarn lint`（0 errors）/ `typecheck` / `test`（7933 passed）green。

## 残り（#1386）

1. `rollupProjectCost` ＋ `sessionTimeline` — どちらも状態がそのまま書ける畳み込みで、**現状キャッシュが無い**（コスト欄で 2.5〜3.1 秒、タイムラインは開くたび全読み）
2. `readSessionSummary` — 一番効く（アクティブな 508 MB のセッションでは**ターンごとに 10.5 秒**）が、畳み込みが生レコードを溜める形なのでリファクタが要る

refs #1386, #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading of large session transcripts by caching transcript metadata and scan progress.
  * Subsequent reads can resume from previously processed content, including after transcripts are appended.
  * Cache data is validated for freshness and integrity, with automatic recovery when it is missing or invalid.
  * Small transcripts avoid unnecessary cache files, while cache writes remain safe during concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->