### PR TITLE
feat: open a MulmoScript in the Canvas from the Files pane (#1374)

### DIFF
--- a/plans/feat-1374-canvas-mulmoscript.md
+++ b/plans/feat-1374-canvas-mulmoscript.md
@@ -1,0 +1,85 @@
+# feat: MulmoScript を Canvas に開く (#1374) — 第2段
+
+issue #1374 の**実装順 2**。第1段（`presentDocument` + `presentHtml`、#1380）で入った
+Files ペインの Canvas ボタンに `presentMulmoScript` を足す。
+
+## 第1段と決定的に違う 2 点
+
+第1段の md / html は「パスだけ載せた合成カードを書けば View が自己 fetch する」で済んだ。
+mulmoScript は**どちらも成り立たない**。
+
+### 1. 絶対パスが使えない
+
+`normalizeStoryPath`（`@mulmoclaude/mulmoscript-plugin`）は **絶対パスとバックスラッシュを拒否**する。
+受けるのは `stories/foo.json` / `foo.json` / `artifacts/stories/foo.json` の 3 つだけ。
+
+第1段は「ペインはセルの cwd、プラグインはワークスペース」の食い違いを**絶対パスに結合して**
+解決した（md / html のガードは絶対パスを受ける）。mulmoScript ではその手が使えないので、
+**ワークスペース相対の `stories/<name>.json` を組み立てる**しかない。
+
+つまりゲートは「拡張子が合うか」ではなく **「このファイルはワークスペースの
+`artifacts/stories/` の中にあるか」** になる。プロジェクトセルが自分の `artifacts/stories/` を
+持っていても、それはプラグインが開くファイルではないので**出してはいけない**。
+
+ワークスペースは UI 側に既にある — `defaultCwd`（CLAUDE_CWD、`/api/config` 由来。
+`launchChips` が WORKSPACE チップに使っているのと同じ値）。
+
+比較は `common/dirPathKey.ts` の `dirPathKey` に載せる。セパレータ両方を畳み、`.` / `..` を
+解決し、Windows のドライブルート / UNC を落とさない。**`..` が畳まれる結果、traversal は
+プレフィックス照合に失敗して自然に落ちる**。
+
+なおこの照合は**字句的**（ブラウザに symlink は解決できない）。第1段と同じく、
+**間違ってもフェイルセーフ**である点が効く — 下の reopen がサーバ側で `normalizeStoryPath` と
+realpath ガードを通すので、UI が通してもカードは書かれない。
+
+### 2. カードにスクリプト本体が要る
+
+`MulmoScriptData` は `{ script: MulmoScript; filePath: string }`。md の `docPath` や html の
+`filePath` と違い、**`script` を欠いたカードは描けない**。
+
+自前で読んで検証するのは、プラグインのロジックを二重化することになる（第1段で「判定は
+プラグイン自身に委ねる」と決めた理由と同じ）。**既にある reopen 経路を呼ぶ**:
+
+```
+POST /api/plugin/presentMulmoScript  { filePath: "stories/x.json" }
+  → 200 { data: { script, filePath }, message, instructions }   … 開ける
+  → 200 { message: "... not found" }（data 無し）              … 開けない
+```
+
+失敗が **HTTP status ではなく 200 のフィールド**で返るのは、このルートの既存契約
+（`server/backends/mulmoscript.spec.ts` が固定している）。`data` の有無で判断する。
+
+`data.filePath` は正規化後の `stories/<name>.json` で、これは**エージェント自身のカードと
+同じ値**。よって `filePathIdentity`（`src/utils/canvasIdentity.ts`）が両者を同じ artifact と
+見なし、`collapseByIdentity` が畳む — 第1段と同じ挙動。
+
+## API の形
+
+`canvasCardForFile` は純粋関数のままでは足りない（reopen が要る）。分ける:
+
+| 関数 | 役割 |
+| --- | --- |
+| `canOpenInCanvas(absPath, workspace)` | 純粋。ボタンの表示可否。3 ツール全部 |
+| `buildCanvasCard(absPath, workspace)` | async。md / html は同期的に組み立て、mulmoScript だけ reopen する |
+| `storyWirePath(absPath, workspace)` | 純粋。`stories/<rest>` か null |
+
+`FilesPane` は `workspace` prop を受ける（grid が `defaultCwd` を渡す）。**ボタンとカードは
+必ず同じ引数で同じ関数を呼ぶ** — 第1段でここが割れて「押しても何も起きないボタン」になった。
+
+## 実装
+
+| ファイル | 内容 |
+| --- | --- |
+| `src/composables/canvasOpenFile.ts` | `storyWirePath` / `reopenStory` を足し、`canOpenInCanvas` と `buildCanvasCard` に workspace を通す |
+| `src/components/FilesPane.vue` | `workspace` prop、ゲートに渡す |
+| `src/components/TerminalGrid.vue` | `:workspace="defaultCwd"`、`buildCanvasCard` を await |
+
+## 検証
+
+- `storyWirePath`: ワークスペース内 / プロジェクトセルの同名パス / traversal / `.json` 以外 /
+  Windows セパレータ / ワークスペース未設定
+- reopen: `data` あり → カード、`data` 無し（not found）→ null かつ POST しない
+- ボタン: story ファイルで出る、ワークスペース外の同名パスでは出ない
+- **各テストは対応する修正を外して落ちることを確認する**（第1段で無効なテストを 2 本作った）
+- `yarn format` / `lint` / `typecheck` / `build` / `test`
+- 実ブラウザで story を 1 つ開く

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -45,7 +45,13 @@ export interface FilesPaneState {
   expanded: string[];
 }
 
-const props = defineProps<{ cwd: string | null; requestedPath?: string | null; initialState?: FilesPaneState | null; canvasTarget?: boolean }>();
+const props = defineProps<{
+  cwd: string | null;
+  requestedPath?: string | null;
+  initialState?: FilesPaneState | null;
+  canvasTarget?: boolean;
+  workspace?: string | null;
+}>();
 const emit = defineEmits<{ close: []; dirty: [boolean]; "open-in-canvas": [path: string] }>();
 
 const roots = ref<Node[]>([]);
@@ -67,7 +73,7 @@ const isMarkdown = computed(() => langKindForFilename(openName.value) === "markd
 // Gated on the path the CARD will carry, not the row's relative one: a cell whose directory has a
 // dot segment (`~/.config/proj`) makes `p.html` pass here and the joined path fail the plugin's
 // own guard, which is a button that does nothing when pressed.
-const canvasOpenable = computed(() => canOpenInCanvas(openPath.value ? absoluteUnder(props.cwd, openPath.value) : null));
+const canvasOpenable = computed(() => canOpenInCanvas(openPath.value ? absoluteUnder(props.cwd, openPath.value) : null, props.workspace ?? null));
 
 const editorHost = ref<HTMLDivElement>();
 let editor: CmEditor | null = null;

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -43,7 +43,7 @@ import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 import type { TerminalAgent } from "../../common/sessionAgent";
-import { canvasCardForFile, seedCanvasCard, hasStoredCard, absoluteUnder } from "../composables/canvasOpenFile";
+import { buildCanvasCard, seedCanvasCard, hasStoredCard, absoluteUnder } from "../composables/canvasOpenFile";
 import { jsonBody } from "../jsonBody";
 import { isUnknownArray } from "../../common/isUnknownArray";
 
@@ -298,7 +298,7 @@ async function openFileInCanvas(path: string): Promise<void> {
   const sessionId = expandedSessionId.value;
   if (uid === null || !sessionId) return;
   // The pane's rows are relative to the CELL's cwd; the plugins resolve against the workspace.
-  const card = canvasCardForFile(absoluteUnder(paneCwd.value, path));
+  const card = await buildCanvasCard(absoluteUnder(paneCwd.value, path), props.defaultCwd);
   if (!card) return; // the button is only shown for files that have one; a stale click is a no-op
   if (!(await seedCanvasCard(sessionId, card))) return;
   // Re-asked after the await, like every other late reply here. openCanvasFor already refuses to
@@ -1010,6 +1010,7 @@ watch(
           :cwd="paneCwd"
           :initial-state="paneState"
           :canvas-target="expandedUid !== null"
+          :workspace="defaultCwd"
           :style="{ flex: `0 0 ${paneWidth}px` }"
           class="border-l border-border bg-deep"
           @close="setFilesOpen(false)"

--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -1,23 +1,35 @@
 // Open a file the user picked in the Canvas, without asking the agent for it (#1374).
 //
 // The Canvas renders a session's TOOL RESULTS, so the way in is to write one: a synthetic result
-// carrying nothing but the path, which the plugin's View then self-fetches from. `presentCollection`
-// has done exactly this since #1768 — see seedCollectionCanvas.ts, which this mirrors, including
-// POSTing to the same route so the card survives a reload and the agent's own card supersedes it.
+// standing in for the tool call nobody made. `presentCollection` has done exactly this since #1768
+// — see seedCollectionCanvas.ts, which this mirrors, including POSTing to the same route so the
+// card survives a reload and the agent's own card supersedes it.
 //
-// Which files qualify is decided by each PLUGIN's own gate rather than by an extension test here.
-// They are lexical guards their executors already run (`isDocumentPath` refuses a prefixed
-// traversal; `isPresentableHtmlPath` refuses a dotfile the iframe mount would deny), so a second
-// opinion in this file could only be a weaker one that reports success for a page that never
-// renders.
+// Which files qualify is decided by each PLUGIN rather than by an extension test here. A second
+// opinion in this file could only be a weaker one that reports success for a file that never
+// renders. How that decision is reached differs per tool, and the difference is the shape of this
+// module:
+//
+//   markdown, html   a lexical guard their executors already run (`isDocumentPath` refuses a
+//                    prefixed traversal; `isPresentableHtmlPath` refuses a dotfile the iframe
+//                    mount would deny). The card carries a path and the View self-fetches.
+//   mulmoScript      no absolute path is accepted at all, and the card needs the parsed script
+//                    rather than a path — so the question is WHERE the file is, and the card
+//                    comes from the plugin's own reopen. See storyWirePath / reopenStory.
 import { TOOL_NAME as DOCUMENT_TOOL, isDocumentPath } from "@mulmoclaude/markdown-plugin/vue";
 import { TOOL_NAME as HTML_TOOL, isPresentableHtmlPath, isHtmlArtifactPath, htmlArtifactPreviewUrl, htmlFileUrl } from "@mulmoclaude/html-plugin";
+import { TOOL_NAME as STORY_TOOL } from "@mulmoclaude/mulmoscript-plugin";
+import { dirPathKey } from "../../common/dirPathKey";
 import { isRecord } from "../../common/isRecord";
 
 export interface CanvasCard {
   toolName: string;
   data: Record<string, unknown>;
 }
+
+/** Where mulmoScript keeps its stories, under the workspace. Both halves are fixed by the plugin:
+ *  the artifacts area is its only file capability, and `stories/` is its wire prefix. */
+const STORY_DIR = "artifacts/stories";
 
 /**
  * The Canvas card that renders `path`, or null when no plugin here can show it.
@@ -62,8 +74,84 @@ export function absoluteUnder(cwd: string | null, relative: string): string {
   return `${base}/${relative}`;
 }
 
-/** Whether the Canvas can show `path` at all — what the Files pane's button is shown on. */
-export const canOpenInCanvas = (path: string | null): boolean => (path ? canvasCardForFile(path) !== null : false);
+/**
+ * The wire path a mulmoScript card carries for `absolutePath`, or null when it is not a story.
+ *
+ * mulmoScript is the one tool here that cannot be handed an absolute path: `normalizeStoryPath`
+ * refuses those (and backslashes) outright, taking only `stories/x.json` and its two historical
+ * spellings. So where markdown and html are asked "can you render this file", this asks the
+ * narrower question the plugin can actually act on — is this file in the WORKSPACE's story
+ * directory — and answers with the path it wants.
+ *
+ * That distinction is the point rather than a technicality: a project cell may well have an
+ * `artifacts/stories/` of its own, and those stories are not the ones the plugin would open.
+ *
+ * Lexical, on the same key the workspace chip compares with: a browser cannot resolve a symlink,
+ * and `..` folds away here, so a traversal simply fails to match the prefix. Nothing rests on it —
+ * the reopen below runs the plugin's own guard and a realpath check server-side, so a path this
+ * lets through still yields no card.
+ */
+export function storyWirePath(absolutePath: string, workspace: string | null): string | null {
+  if (!workspace) return null;
+  const root = dirPathKey(`${workspace}/${STORY_DIR}`);
+  const key = dirPathKey(absolutePath);
+  if (!root || !key.startsWith(`${root}/`)) return null;
+  const relative = key.slice(root.length + 1);
+  return relative.endsWith(".json") ? `stories/${relative}` : null;
+}
+
+/**
+ * Whether the Canvas can show `path` at all — what the Files pane's button is shown on.
+ *
+ * `workspace` is only consulted for stories; markdown and html are judged wherever they live.
+ */
+export const canOpenInCanvas = (path: string | null, workspace: string | null = null): boolean =>
+  path !== null && (canvasCardForFile(path) !== null || storyWirePath(path, workspace) !== null);
+
+/**
+ * The mulmoScript card for `wirePath`, built by the plugin's own reopen rather than here.
+ *
+ * `MulmoScriptData` requires the parsed `script`, not just a path — unlike markdown and html,
+ * whose Views self-fetch — and reading and validating it in the browser would be a second copy of
+ * logic this route already runs. What comes back is what the agent's own tool call produces,
+ * including the normalized `filePath` that `filePathIdentity` collapses the two cards on.
+ *
+ * The route narrates a missing or refused file as a 200 with no `data` (its spec pins this), so
+ * absence of `data` — not the status — is what "cannot open this" looks like.
+ */
+async function reopenStory(wirePath: string): Promise<CanvasCard | null> {
+  try {
+    const res = await fetch("/api/plugin/presentMulmoScript", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ filePath: wirePath }),
+    });
+    if (!res.ok) {
+      console.error(`[canvasOpenFile] reopen HTTP ${res.status}`);
+      return null;
+    }
+    const body: unknown = await res.json();
+    if (!isRecord(body) || !isRecord(body.data)) return null;
+    return { toolName: STORY_TOOL, data: body.data };
+  } catch (err) {
+    console.error("[canvasOpenFile] reopen failed", err);
+    return null;
+  }
+}
+
+/**
+ * The card to seed for `absolutePath`, or null when nothing here can show it.
+ *
+ * The async half of {@link canvasCardForFile}: markdown and html are decided in memory, and only a
+ * story needs the round trip. Callers use THIS and {@link canOpenInCanvas} with the same arguments
+ * — a button gated on one path while the card is built from another is a button that does nothing.
+ */
+export async function buildCanvasCard(absolutePath: string, workspace: string | null): Promise<CanvasCard | null> {
+  const direct = canvasCardForFile(absolutePath);
+  if (direct) return direct;
+  const wirePath = storyWirePath(absolutePath, workspace);
+  return wirePath ? await reopenStory(wirePath) : null;
+}
 
 /**
  * Write `card` into `sessionId`'s Canvas feed.

--- a/test/src/components/FilesPane.spec.ts
+++ b/test/src/components/FilesPane.spec.ts
@@ -532,9 +532,9 @@ describe("the Canvas button", () => {
     }) as unknown as typeof fetch;
   };
 
-  const openRow = async (name: string, cwd: string | null, canvasTarget = true) => {
+  const openRow = async (name: string, cwd: string | null, canvasTarget = true, workspace: string | null = null) => {
     withEntry(name);
-    const w = mount(FilesPane, { props: { cwd, canvasTarget } });
+    const w = mount(FilesPane, { props: { cwd, canvasTarget, workspace } });
     await flushPromises();
     await w.findAll('[data-testid="files-row"]')[0].trigger("click");
     await flushPromises();
@@ -559,6 +559,14 @@ describe("the Canvas button", () => {
   // beside — so the button must not appear even for a file that would render.
   it("is not offered without a cell to open it beside", async () => {
     expect(btn(await openRow("design.md", "/work/proj", false)).exists()).toBe(false);
+  });
+
+  // A story is the one file judged by WHERE it is rather than what it is called: the plugin only
+  // takes a workspace-relative `stories/…`, so a project cell's own artifacts/stories holds files
+  // it would not open. Same name, same shape, two different answers.
+  it("is offered for a story in the workspace and withheld for one outside it", async () => {
+    expect(btn(await openRow("tale.json", "/work/ws/artifacts/stories", true, "/work/ws")).exists()).toBe(true);
+    expect(btn(await openRow("tale.json", "/work/other/artifacts/stories", true, "/work/ws")).exists()).toBe(false);
   });
 
   // The gate runs on the JOINED path, not the row's. `p.html` passes on its own and fails under a

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -858,12 +858,17 @@ describe("open-in-canvas", () => {
     return w;
   };
 
-  const pickFile = (w: ReturnType<typeof mount>) => w.findComponent({ name: "FilesPane" }).vm.$emit("open-in-canvas", "design.md");
+  // Awaited: the card is built before the write is even issued, so releasing the write any earlier
+  // releases nothing and the test proves whatever the timing happened to be.
+  const pickFile = async (w: ReturnType<typeof mount>) => {
+    w.findComponent({ name: "FilesPane" }).vm.$emit("open-in-canvas", "design.md");
+    await flushPromises();
+  };
 
   it("shows the Canvas beside the cell the file was picked in", async () => {
     const release = deferredWrite();
     const w = await gridWithPaneOpen();
-    pickFile(w);
+    await pickFile(w);
     release();
     await flushPromises();
     expect(w.find(".stub-gui-panel").exists()).toBe(true);
@@ -875,7 +880,7 @@ describe("open-in-canvas", () => {
   it("does not enable the Canvas button on the cell the zoom moved to", async () => {
     const release = deferredWrite();
     const w = await gridWithPaneOpen();
-    pickFile(w);
+    await pickFile(w);
     await w.setProps({ expandedUid: 2 });
     await flushPromises();
     release();

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -4,9 +4,9 @@
 // here is that this module actually defers to them rather than re-deciding with a weaker extension
 // test — the traversal and dotfile cases below are the ones a hand-rolled `.endsWith(".md")` would
 // wave through.
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
-import { canvasCardForFile, canOpenInCanvas, absoluteUnder } from "../../../src/composables/canvasOpenFile";
+import { canvasCardForFile, canOpenInCanvas, absoluteUnder, storyWirePath, buildCanvasCard } from "../../../src/composables/canvasOpenFile";
 
 describe("canvasCardForFile", () => {
   it("renders a markdown document through presentDocument, keyed by its path", () => {
@@ -102,5 +102,106 @@ describe("the button's gate and the card's gate agree on the same path", () => {
     const joined = absoluteUnder("/home/me/proj", "p.html");
     expect(canOpenInCanvas(joined)).toBe(true);
     expect(canvasCardForFile(joined)?.toolName).toBe("presentHtml");
+  });
+});
+
+// mulmoScript, the one tool here that cannot be handed an absolute path — `normalizeStoryPath`
+// refuses those outright. So the question is not "does the extension match" but "is this file in
+// the WORKSPACE's story directory", and the answer is the wire path the plugin wants.
+describe("storyWirePath", () => {
+  const WS = "/work/ws";
+
+  it("turns a story under the workspace into the plugin's wire path", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/tale.json`, WS)).toBe("stories/tale.json");
+  });
+
+  it("keeps a story's own subdirectory", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/drafts/tale.json`, WS)).toBe("stories/drafts/tale.json");
+  });
+
+  // The reason this is rooted at the workspace rather than matched on shape: a project cell may
+  // have an artifacts/stories of its own, and those stories are not the ones the plugin opens.
+  it("refuses an identically-shaped path under another directory", () => {
+    expect(storyWirePath("/work/other/artifacts/stories/tale.json", WS)).toBeNull();
+  });
+
+  it("refuses a file in the story directory that is not a script", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/notes.md`, WS)).toBeNull();
+    expect(storyWirePath(`${WS}/artifacts/stories/tale.json.bak`, WS)).toBeNull();
+  });
+
+  // `..` folds away in the key, so a traversal stops matching the prefix rather than being
+  // spotted as a traversal — the same reason the workspace chip can compare paths at all.
+  it("refuses a path that climbs out of the story directory", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/../../../etc/passwd`, WS)).toBeNull();
+    expect(storyWirePath(`${WS}/artifacts/stories/../secrets.json`, WS)).toBeNull();
+  });
+
+  it("refuses the story directory itself, which is not a file", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories`, WS)).toBeNull();
+  });
+
+  it("has no workspace to root against before the config lands", () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/tale.json`, null)).toBeNull();
+  });
+
+  // Both separators fold, so the mixed path `absoluteUnder` produces on Windows still matches.
+  it("matches a Windows workspace against a mixed-separator path", () => {
+    const joined = absoluteUnder("C:\\Users\\me\\ws", "artifacts/stories/tale.json");
+    expect(storyWirePath(joined, "C:\\Users\\me\\ws")).toBe("stories/tale.json");
+  });
+
+  it("is what canOpenInCanvas answers on for a story", () => {
+    expect(canOpenInCanvas(`${WS}/artifacts/stories/tale.json`, WS)).toBe(true);
+    // Without the workspace a story is unrecognisable; markdown and html are judged anywhere.
+    expect(canOpenInCanvas(`${WS}/artifacts/stories/tale.json`, null)).toBe(false);
+    expect(canOpenInCanvas(`${WS}/notes.md`, null)).toBe(true);
+  });
+});
+
+// The card for a story comes from the plugin's own reopen: `MulmoScriptData` needs the parsed
+// script, and reading it here would be a second copy of what that route already does.
+describe("buildCanvasCard", () => {
+  const WS = "/work/ws";
+  afterEach(() => vi.unstubAllGlobals());
+
+  const mockReopen = (body: unknown, ok = true) => {
+    const fetchMock = vi.fn(async () => ({ ok, json: async () => body }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  };
+
+  it("builds a markdown card without asking the server anything", async () => {
+    const fetchMock = mockReopen({});
+    expect(await buildCanvasCard(`${WS}/docs/design.md`, WS)).toEqual({ toolName: "presentDocument", data: { markdown: "", docPath: `${WS}/docs/design.md` } });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reopens a story through the plugin route and carries back what it returned", async () => {
+    const data = { script: { title: "Tale" }, filePath: "stories/tale.json" };
+    const fetchMock = mockReopen({ data, message: "Reopened" });
+    expect(await buildCanvasCard(`${WS}/artifacts/stories/tale.json`, WS)).toEqual({ toolName: "presentMulmoScript", data });
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/api/plugin/presentMulmoScript");
+    // The wire path, not the absolute one the pane is holding — that spelling is refused.
+    expect(JSON.parse(String(init.body))).toEqual({ filePath: "stories/tale.json" });
+  });
+
+  // The route narrates a missing or refused file as a 200 with no `data`, so absence of `data`
+  // — not the status — is what "cannot open this" looks like.
+  it("has no card when the route narrates the file as missing", async () => {
+    mockReopen({ message: "Story not found" });
+    expect(await buildCanvasCard(`${WS}/artifacts/stories/gone.json`, WS)).toBeNull();
+  });
+
+  it("has no card when the route errors outright", async () => {
+    mockReopen({}, false);
+    expect(await buildCanvasCard(`${WS}/artifacts/stories/tale.json`, WS)).toBeNull();
+  });
+
+  it("does not reach the server for a file no plugin renders", async () => {
+    const fetchMock = mockReopen({});
+    expect(await buildCanvasCard(`${WS}/notes.txt`, WS)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

The Canvas button added in #1380 now also opens **MulmoScript stories**. Pick `artifacts/stories/<name>.json` in the Files pane, press Canvas, and the storyboard opens — no agent, no tool call.

This is **step 2 of #1374**; step 1 (`presentDocument` + `presentHtml`) shipped in #1380. The issue stays open until the whole thing has shipped.

mulmoScript breaks **both** assumptions the first two tools were built on, and that is most of this diff:

|  | markdown / html (#1380) | mulmoScript (here) |
| --- | --- | --- |
| Path the plugin takes | absolute is fine | **absolute is refused** — only `stories/x.json` |
| What the card carries | a path; the View self-fetches | **the parsed script** |
| So the gate asks | "can you render this file?" | **"is this file in the workspace's story directory?"** |

## Items to Confirm / Review

1. **The gate is rooted at the workspace, deliberately.** A project cell may have an `artifacts/stories/` of its own; those stories are not the ones the plugin opens. Matching on shape alone would offer a button that opens the wrong file or nothing at all. Please sanity-check that this is the intended rule and not too strict — a story genuinely outside the workspace currently has no way in, which I believe is correct because the plugin has no way to address it.
2. **The card comes from the plugin's reopen route, not from reading the file here.** `POST /api/plugin/presentMulmoScript { filePath }` — the same call the agent's tool makes. It costs a round trip before the Canvas opens. The alternative was parsing and validating the script in the browser, which duplicates the route's logic (and its schema defaults — the route fills in `canvasSize`, `speechParams` and friends, which a hand-built card would not have).
3. **`canOpenInCanvas` gained a second parameter with a default of `null`.** A caller that forgets it silently loses stories while markdown and html keep working. It defaults rather than being required because the FilesOverlay mount has no workspace to pass. Worth a second opinion.
4. **Failure is a field, not a status.** The route narrates a missing or refused file as a **200 with no `data`**, pinned by `server/backends/mulmoscript.spec.ts`. This reads `data`, not `res.status`.
5. **One flaky test, not from this change.** `test/server/session/tool-store.spec.ts > drops a placeholder the agent's real card has already beaten` failed once in a full run, then passed in 3 further full runs on this branch and 2 on clean `main`. This diff contains no server code, and that spec's fixture uses a per-test `mkdtemp`. Reporting rather than diagnosing — I did not chase it further.

## User Prompt

> 次いこう!!

Following the plan agreed on #1374 and recorded when #1380 merged: step 1 was `presentDocument` + `presentHtml`, step 2 is `presentMulmoScript`.

## Implementation

`plans/feat-1374-canvas-mulmoscript.md` has the design record. Three additions to `src/composables/canvasOpenFile.ts`:

- **`storyWirePath(absolutePath, workspace)`** — pure. Is this file under `<workspace>/artifacts/stories/` and a `.json`? Answers with `stories/<rest>`.

  Built on `dirPathKey` (`common/dirPathKey.ts`), the key the workspace chip already compares with: both separators fold, so the mixed path `absoluteUnder` produces on Windows still matches; `..` folds away, so a traversal stops matching the prefix rather than needing to be spotted; drive and UNC roots survive. Lexical, and **nothing rests on it** — a browser cannot resolve a symlink, and the reopen re-runs the plugin's own guard plus a realpath check server-side, so a path this lets through still yields no card.

- **`reopenStory(wirePath)`** — the round trip. Returns the card, or null when the route reports no `data`.

- **`buildCanvasCard(absolutePath, workspace)`** — the async entry point. markdown and html are still decided in memory; only a story costs a request.

`FilesPane` takes a `workspace` prop and `TerminalGrid` passes `defaultCwd` (CLAUDE_CWD, what `launchChips` labels WORKSPACE). **The button and the card builder are called with the same arguments** — #1380 shipped with those two disagreeing, and the symptom was a button that did nothing when pressed.

### On MulmoClaude

Per CLAUDE.md I checked the reference host first. MulmoClaude has **no counterpart** — nothing there opens a file into the canvas without the agent; its `src/utils/collections/presentSeed.ts` seeds a *client-only* placeholder and reconciles it away, where mulmoterminal deliberately persists (that divergence predates this PR, from #1768). Its route namespace also differs (`/api/mulmoScript/save` vs. this repo's `/api/plugin/presentMulmoScript`), which likewise predates this PR; I used the route this repo already mounts and tests.

## Verification

**Real browser, real server** (throwaway `HOME`, so no personal directories appear):

- A workspace story opens and renders in full — title, both beats, Movie / PDF, Edit Script Source — **on a shell cell whose Canvas button read "No render MCP for this directory"**. That is the case the feature exists for.
- An identically-shaped `artifacts/stories/tale.json` under a **non-workspace** directory offers **no button**.
- Zero console errors in both.
- The route itself checked directly: `{"filePath":"stories/tale.json"}` returns `data` with the schema-completed script; `stories/nope.json` returns `{"message":"File not found: …"}` with no `data`.

**Tests** — 16 new. Every one was re-run against the code with its own fix removed, and five mutations were each caught by the intended test:

| mutation | caught by |
| --- | --- |
| root at any directory, not the workspace | the wire-path and Windows tests |
| match the story shape anywhere | "refuses an identically-shaped path under another directory" |
| send the absolute path to the route | "reopens a story … and carries back what it returned" |
| drop the `.json` requirement | "refuses a file in the story directory that is not a script" |
| treat any 200 as a card | "has no card when the route narrates the file as missing" |

`yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` (7937 passed).

refs #1374

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening eligible MulmoScript story files in Canvas.
  * Story files are recognized only within the workspace’s designated stories directory.
  * Canvas cards are generated from reopened story data while retaining existing Markdown and HTML support.
  * Added safeguards against invalid paths, traversal attempts, unsupported extensions, and project artifact conflicts.

* **Bug Fixes**
  * Improved Canvas file handling for missing or unsuccessful story responses.

* **Tests**
  * Added coverage for workspace scoping, path validation, Windows separators, asynchronous loading, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->