### PR TITLE
fix: badge the workspace cell WORKSPACE, not its folder name

### DIFF
--- a/src/components/CellShell.vue
+++ b/src/components/CellShell.vue
@@ -16,6 +16,7 @@ import CellChromeButtons from "./CellChromeButtons.vue";
 import { cellChromeBinding, type CellChromeSource } from "./cellChromeBinding";
 import { useCellChrome } from "../composables/useCellChrome";
 import { formatCwd } from "./cwdDisplay";
+import { isSameDirPath } from "../../common/dirPathKey";
 import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { textTip } from "./tipContent";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
@@ -42,6 +43,10 @@ const props = defineProps<
   CellChromeSource & {
     home: string | null;
     cwd: string | null;
+    // The server's workspace dir, so the badge can say WORKSPACE rather than the folder's own name
+    // — the same thing TerminalCell does with the prop of the same name. A command or launcher cell
+    // running in the workspace is as much "the workspace" as an agent cell is.
+    defaultCwd?: string | null | undefined;
     // Whether the process has ended. Drives the dot only — what "ended" MEANS differs (a command
     // finishes, a launcher exits), which is why the word is the caller's.
     finished: boolean;
@@ -68,6 +73,8 @@ const { chromeProps, chromeEvents } = cellChromeBinding(props, emit);
 const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(toRef(() => props.cwd));
 
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
+
+const isWorkspace = computed(() => isSameDirPath(props.cwd, props.defaultCwd));
 
 // The header shows the path shortened to fit; the tip is the full one. Anchored on the dir span
 // only — the running/idle dot beside it keeps its `title`, since a two-word state does not need a
@@ -101,7 +108,7 @@ function onHeaderClick(event: MouseEvent) {
           @focusout="hideDirTip"
           ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
         >
-        <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+        <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" :workspace="isWorkspace" />
         <span class="cell-cmd" :class="CELL_CMD"
           ><span class="material-symbols-outlined" aria-hidden="true">{{ icon }}</span> {{ label }}</span
         >

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -142,6 +142,7 @@ function copyPrompt() {
     :canvas-available="canvasAvailable"
     :home="home"
     :cwd="command.cwd"
+    :default-cwd="defaultCwd"
     :finished="finished"
     idle-title="Finished"
     icon="play_arrow"

--- a/src/components/DirBadge.vue
+++ b/src/components/DirBadge.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { badgeStyleFor } from "./dirBadge";
+import { WORKSPACE_LABEL } from "./presets";
 import { textTip } from "./tipContent";
 
 // The directory's `name` from .mulmoterminal.json, as the coloured chip in a GRID cell's header.
@@ -9,22 +10,41 @@ import { textTip } from "./tipContent";
 //
 // The single view's badge (Terminal.vue) is deliberately NOT this component: its header has more
 // room and uses a wider cap and looser leading, and unifying them would change how it looks.
-const props = defineProps<{ name: string | null | undefined; color: string | null | undefined }>();
+//
+// `workspace` says this cell is running in THE workspace, and it wins over `name`: the badge then
+// reads WORKSPACE with the same `workspaces` glyph the launcher chip uses, because the two are the
+// same directory seen a second apart. Launching from the chip labelled WORKSPACE and landing in a
+// cell badged `mulmoclaude` reads as two different places, and the folder's own name is the less
+// useful of the two — its ROLE is why every GUI tool is reachable there (see WORKSPACE_LABEL).
+//
+// The colours are NOT overridden: `badgeColor` is still the directory's, so the workspace keeps the
+// palette its `.mulmoterminal.json` gives it and only the wording is role-based. And the configured
+// name is not lost — it is the hover tip, the same place a too-long name has always been readable.
+const props = defineProps<{
+  name: string | null | undefined;
+  color: string | null | undefined;
+  workspace?: boolean | undefined;
+}>();
 
-// The badge truncates at 14ch, so the tip is the only place a longer project name is readable.
+// The badge truncates at 14ch, so the tip is the only place a longer project name is readable —
+// and, in workspace mode, the only place the directory's own name is shown at all.
 const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => textTip(props.name));
 </script>
 
 <template>
   <span
-    v-if="name"
-    class="max-w-[14ch] flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
+    v-if="workspace || name"
+    :data-testid="workspace ? 'dir-badge-workspace' : undefined"
+    class="flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
+    :class="workspace ? 'max-w-none' : 'max-w-[14ch]'"
     :style="badgeStyleFor(color)"
     :aria-describedby="described ? HOVER_TIP_ID : undefined"
     @pointerenter="showTip"
     @pointerleave="hideTip"
     @focusin="showTip"
     @focusout="hideTip"
-    >{{ name }}</span
+    ><template v-if="workspace"
+      ><span class="material-symbols-outlined mr-[3px] align-middle text-[12px]" aria-hidden="true">workspaces</span>{{ WORKSPACE_LABEL }}</template
+    ><template v-else>{{ name }}</template></span
   >
 </template>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -63,6 +63,7 @@ function relaunch() {
     :canvas-available="canvasAvailable"
     :home="home"
     :cwd="cwd"
+    :default-cwd="defaultCwd"
     :finished="finished"
     idle-title="Exited"
     icon="rocket_launch"

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -7,6 +7,7 @@ import { useCellChrome } from "../composables/useCellChrome";
 import { useGitStatus } from "../composables/useGitStatus";
 import { useWorkItem } from "../composables/useWorkItem";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
+import { isSameDirPath } from "../../common/dirPathKey";
 import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
@@ -147,6 +148,9 @@ const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 // Per-directory overrides (<cwd>/.mulmoterminal.json): pins this cell's terminal
 // palette and shows a project badge. Re-fetched when the effective cwd changes.
 const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(cwd);
+// Whether this cell IS the workspace, for the header badge. Same lexical comparison the launcher
+// chip makes (`launchChips`), so a cell launched from the WORKSPACE chip is badged WORKSPACE.
+const isWorkspace = computed(() => isSameDirPath(cwd.value, props.defaultCwd));
 // What this cell is working on (PR + issue), for the `work` chip. Same directory, same kind of
 // poll as the git status below.
 const { item: workItem, refresh: refreshWorkItem } = useWorkItem(cwd);
@@ -1080,7 +1084,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
                thumbnail, leaving only dir + what it's doing + a zoom button. -->
             <template v-if="!filmstrip">
-              <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+              <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" :workspace="isWorkspace" />
               <!-- Unread Canvas output. Same chip vocabulary as the branch / context / token
                    chips beside it, deliberately: this is one more thing to triage at a glance,
                    not a new kind of alert. Clicking expands the cell with the pane open. -->

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -461,6 +461,10 @@ const gridCellProps = (cell: Cell) => ({
   canvasAvailable: canvasOpenable.value,
   zoomed: zoomed.value,
   home: props.home,
+  // Grid-wide, so it is bound here rather than per cell type: every cell compares its own cwd
+  // against it to know whether IT is the workspace, and a cell type left out of that comparison is
+  // one that badges the workspace with the folder's name while its neighbour says WORKSPACE.
+  defaultCwd: props.defaultCwd,
   reorderable: props.reorderable ?? false,
 });
 const gridCellEvents = (cell: Cell) => ({
@@ -1088,7 +1092,6 @@ watch(
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
           :initial-agent="cell.agent"
-          :default-cwd="defaultCwd"
           :presets="presets"
           :launchers="launchers"
           :open-session-ids="openSessionIds"

--- a/src/components/gridCell.ts
+++ b/src/components/gridCell.ts
@@ -32,6 +32,13 @@ export interface GridCellProps {
   // there to ask about.
   canvasAvailable?: boolean;
   home: string | null;
+  // The server's workspace directory. Grid state, not the cell's: a cell compares its OWN cwd
+  // against it to know whether it is the workspace, and then says so in its header badge — the
+  // same role-based name the launcher chip uses (WORKSPACE_LABEL in presets.ts).
+  //
+  // Optional here because only TerminalCell needs it non-null (it also prefills the launch form
+  // from it, and re-declares it as required for that); the other two only compare it.
+  defaultCwd?: string | null;
 }
 
 export interface GridCellEmits {

--- a/src/components/presets.ts
+++ b/src/components/presets.ts
@@ -24,7 +24,7 @@ export interface LaunchChip extends CwdPreset {
 }
 
 /**
- * What the workspace chip is CALLED, rather than what its directory is called.
+ * What the workspace is CALLED, rather than what its directory is called.
  *
  * Every other chip is a place — the basename of somewhere you launched. This one is a ROLE: the
  * directory a session works from, where every GUI tool is reachable and the shared wiki /
@@ -34,8 +34,13 @@ export interface LaunchChip extends CwdPreset {
  * Capitals because it is not a directory name and should not read as one — every neighbour is a
  * lowercase basename. The real path has not gone anywhere: it is the chip's hover, which is where
  * the other chips keep theirs too.
+ *
+ * Used by the launcher chip AND by a cell header's DirBadge, which is why it is not called
+ * CHIP_LABEL any more: the two used to disagree, so launching from a chip labelled WORKSPACE gave
+ * you a cell badged with whatever `name` that folder's `.mulmoterminal.json` happened to carry —
+ * one directory wearing two names across a single click.
  */
-export const WORKSPACE_CHIP_LABEL = "WORKSPACE";
+export const WORKSPACE_LABEL = "WORKSPACE";
 
 /**
  * The chips to render: the workspace FIRST and always, then the recent directories.
@@ -50,7 +55,7 @@ export const WORKSPACE_CHIP_LABEL = "WORKSPACE";
  * Pinned ahead of the priority ordering on purpose. `orderByDirPriority` ranks the directories a
  * user configured against each other; the workspace is not competing in that ranking.
  *
- * It is labelled by its ROLE, not by its directory name — see WORKSPACE_CHIP_LABEL. Matched with
+ * It is labelled by its ROLE, not by its directory name — see WORKSPACE_LABEL. Matched with
  * `isSameDirPath`, the same lexical comparison the worktree rows use: the browser cannot resolve a
  * symlink, so this folds only the spellings a person types (a trailing slash, a `..`). Getting it
  * wrong shows the directory twice — the server still decides what the workspace really is, with a
@@ -59,5 +64,5 @@ export const WORKSPACE_CHIP_LABEL = "WORKSPACE";
 export function launchChips(orderedPresets: readonly CwdPreset[], defaultCwd: string | null | undefined): LaunchChip[] {
   const rest = orderedPresets.filter((p) => !defaultCwd || !isSameDirPath(p.path, defaultCwd)).map((p) => ({ ...p, isWorkspace: false }));
   if (!defaultCwd) return rest;
-  return [{ label: WORKSPACE_CHIP_LABEL, path: defaultCwd, isWorkspace: true }, ...rest];
+  return [{ label: WORKSPACE_LABEL, path: defaultCwd, isWorkspace: true }, ...rest];
 }

--- a/test/src/components/cellChromeColors.spec.ts
+++ b/test/src/components/cellChromeColors.spec.ts
@@ -57,7 +57,10 @@ async function mountClaudeCell(cwd: string) {
       zoomed: false,
       initialSessionId: "11111111-1111-1111-1111-111111111111",
       initialCwd: cwd,
-      defaultCwd: cwd,
+      // Deliberately NOT `cwd`: a cell whose dir IS the workspace is badged WORKSPACE rather than
+      // with the directory's `name` (see dirBadgeCells.spec.ts), and the badge assertion below is
+      // about the name. The colours are the directory's either way.
+      defaultCwd: "/home/me/workspace",
       presets: [],
       home: "/home/me",
       cancellable: false,

--- a/test/src/components/dirBadgeCells.spec.ts
+++ b/test/src/components/dirBadgeCells.spec.ts
@@ -4,6 +4,7 @@ import DirBadge from "../../../src/components/DirBadge.vue";
 import LauncherCell from "../../../src/components/LauncherCell.vue";
 import CommandCell from "../../../src/components/CommandCell.vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
+import { WORKSPACE_LABEL } from "../../../src/components/presets.js";
 
 // `dirBadge.spec.ts` next to this one covers badgeStyleFor (the contrast maths). This file covers
 // the COMPONENT and, more importantly, that all three grid cells actually render it.
@@ -92,7 +93,9 @@ describe("every grid cell shows the directory's badge", () => {
         zoomed: false,
         initialSessionId: "11111111-1111-1111-1111-111111111111",
         initialCwd: "/proj/badge-terminal",
-        defaultCwd: "/proj/badge-terminal",
+        // NOT this cell's dir: a cell running in the workspace is badged WORKSPACE instead (below),
+        // so pinning the two apart is what keeps this case about the directory's own name.
+        defaultCwd: "/home/me/workspace",
         presets: [],
         home: "/home/me",
         cancellable: false,
@@ -102,6 +105,92 @@ describe("every grid cell shows the directory's badge", () => {
     });
     await flushPromises();
     expect(w.findComponent(DirBadge).text()).toBe("PROD");
+    w.unmount();
+  });
+});
+
+// The workspace was reachable from the launcher as a chip labelled WORKSPACE, and one click later
+// the cell it opened was badged `mulmoclaude` — the folder's `name` from its .mulmoterminal.json.
+// One directory, two names, a second apart. The role is what makes that directory special (every
+// GUI tool is reachable there), so the role is what both ends now say.
+describe("the workspace cell is badged by its role", () => {
+  const DIR = { name: "mulmoclaude (home)", badgeColor: "#3fbfd0" };
+  const WS = "/home/me/mulmoclaude";
+
+  it("DirBadge shows WORKSPACE over the configured name, keeping the directory's colour", () => {
+    const w = mount(DirBadge, { props: { name: "mulmoclaude (home)", color: "#190a23", workspace: true } });
+    expect(w.text()).toContain(WORKSPACE_LABEL);
+    expect(w.text()).not.toContain("mulmoclaude");
+    // Marked with the same glyph the launcher chip uses, so the two read as one thing.
+    expect(w.find(".material-symbols-outlined").text()).toBe("workspaces");
+    expect(w.attributes("style")).toContain("background: rgb(25, 10, 35)");
+  });
+
+  // An unnamed workspace still gets the badge: the role does not come from the config, so the one
+  // cell that most needs identifying must not be the one with no badge at all.
+  it("DirBadge renders even when the directory has no name", () => {
+    expect(mount(DirBadge, { props: { name: null, color: null, workspace: true } }).text()).toContain(WORKSPACE_LABEL);
+  });
+
+  it("TerminalCell in the workspace", async () => {
+    serveDirConfig(DIR);
+    const w = mount(TerminalCell, {
+      props: {
+        uid: 4,
+        expanded: false,
+        zoomed: false,
+        initialSessionId: "22222222-2222-2222-2222-222222222222",
+        // Spelled differently from defaultCwd on purpose: the comparison is isSameDirPath, the same
+        // lexical fold the launcher chip makes, not string equality.
+        initialCwd: `${WS}/`,
+        defaultCwd: WS,
+        presets: [],
+        home: "/home/me",
+        cancellable: false,
+        openSessionIds: [],
+        openCwds: [],
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toContain(WORKSPACE_LABEL);
+    w.unmount();
+  });
+
+  // Via CellShell, which the launcher and command cells share: a shell running in the workspace is
+  // in the workspace too, and #914's lesson was that one cell type quietly differing is the bug.
+  it("LauncherCell in the workspace", async () => {
+    serveDirConfig(DIR);
+    const w = mount(LauncherCell, {
+      props: {
+        uid: 5,
+        expanded: false,
+        zoomed: false,
+        launcher: { shell: true, label: "Shell" },
+        session: null,
+        cwd: WS,
+        defaultCwd: WS,
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toContain(WORKSPACE_LABEL);
+    w.unmount();
+  });
+
+  it("CommandCell in the workspace", async () => {
+    serveDirConfig(DIR);
+    const w = mount(CommandCell, {
+      props: {
+        uid: 6,
+        expanded: false,
+        zoomed: false,
+        command: { source: "script" as const, index: 0, label: "build", cwd: WS },
+        defaultCwd: WS,
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toContain(WORKSPACE_LABEL);
     w.unmount();
   });
 });

--- a/test/src/components/presets.spec.ts
+++ b/test/src/components/presets.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { presetLabel, launchChips, WORKSPACE_CHIP_LABEL } from "../../../src/components/presets.js";
+import { presetLabel, launchChips, WORKSPACE_LABEL } from "../../../src/components/presets.js";
 
 describe("presetLabel", () => {
   it("uses the trailing path segment (basename)", () => {
@@ -23,12 +23,12 @@ describe("launchChips", () => {
   const preset = (path: string) => ({ label: presetLabel(path), path });
 
   it("offers the workspace even when nothing has been recorded", () => {
-    expect(launchChips([], "/home/me/mulmoclaude")).toEqual([{ label: WORKSPACE_CHIP_LABEL, path: "/home/me/mulmoclaude", isWorkspace: true }]);
+    expect(launchChips([], "/home/me/mulmoclaude")).toEqual([{ label: WORKSPACE_LABEL, path: "/home/me/mulmoclaude", isWorkspace: true }]);
   });
 
   it("puts it first, ahead of the priority ordering the rest arrive in", () => {
     const chips = launchChips([preset("/a/one"), preset("/b/two")], "/home/me/ws");
-    expect(chips.map((c) => c.label)).toEqual([WORKSPACE_CHIP_LABEL, "one", "two"]);
+    expect(chips.map((c) => c.label)).toEqual([WORKSPACE_LABEL, "one", "two"]);
     expect(chips.filter((c) => c.isWorkspace)).toHaveLength(1);
   });
 


### PR DESCRIPTION
## What

Starting a session in the workspace gave a cell badged `🩵 mulmoclaude (home)` — the `name` from that folder's `.mulmoterminal.json`. The launcher's chip for the *same* directory says **WORKSPACE**, so one directory wore two names across a single click.

The badge now says WORKSPACE, with the same `workspaces` glyph the chip uses.

## Why the folder's name is the wrong one

`WORKSPACE_LABEL`'s existing comment already argues this for the chip: every other chip is a *place* (a basename you launched in); this one is a **role** — the directory where every GUI tool is reachable and the shared wiki / collections / accounting live. Naming it `mulmoclaude` says the least interesting true thing about it and reads as one project among the others. The header badge is the same directory, so it gets the same answer.

Nothing is lost: the configured name moves to the badge's hover tip, which is where a too-long name has always been readable.

## How

- `WORKSPACE_CHIP_LABEL` → `WORKSPACE_LABEL`. The chip is no longer its only caller, and the old name would have read as "the chip's" while the header used it too.
- `DirBadge` takes `workspace?: boolean`. It wins over `name`, renders the glyph + label, and **keeps the directory's colours** — `badgeColor` is still the folder's, so only the wording is role-based. It also renders when the directory has no `name` at all: the role does not come from the config, so the one cell that most needs identifying must not be the one with no badge.
- `defaultCwd` joins `GridCellProps` and is bound once in `gridCellProps()`. Each cell compares its own cwd against it with `isSameDirPath` — the same lexical fold `launchChips` makes, so a trailing slash still matches.

Threading it per cell type is the design that produced #902 (theme/font), #914 (the name badge) and #1006 (the six chrome colours): the same omission three times, because "remember to pass it" was the design. So the launcher and command cells get it too — a shell running in the workspace is in the workspace.

Out of scope: the cockpit roster row shows a truncated **path**, not a name, so it is not misleading; `Terminal.vue`'s single-view badge is left alone.

## Test

- New `describe` in `dirBadgeCells.spec.ts`: the label wins over the name, the glyph is the chip's, the directory's colour survives, an unnamed workspace still gets a badge, and all three cell types show it — the TerminalCell case spells its cwd with a trailing slash so the assertion is on `isSameDirPath`, not string equality.
- Two existing specs passed `defaultCwd: cwd`, i.e. every cell under test was the workspace. Both now pin the two apart, with a comment saying why.
- `yarn format` / `lint` (0 errors) / `typecheck` / `test` (7927 passing) / `build` all green locally.

## Screenshot

Not attached — capturing one means running against a real server with a scratch `HOME`, per CLAUDE.md. Say the word and I'll do it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace directories are now identified with a dedicated workspace icon and “WORKSPACE” label.
  - Workspace badges display consistently across terminal, launcher, and command cells.
  - Directory badges retain names, colors, truncation, and hover details for non-workspace directories.
- **Bug Fixes**
  - Workspace badges now appear correctly even when no directory name is configured.
  - Directory matching is normalized for more reliable workspace detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->