### PR TITLE
fix: 壊れた sidecar の offset でセッションが一覧から消えるのを防ぐ (#1387 のレビュー指摘)

### DIFF
--- a/server/session/transcript-sidecar.ts
+++ b/server/session/transcript-sidecar.ts
@@ -82,7 +82,7 @@ export function createTranscriptSidecar<T>(options: SidecarOptions<T>): Transcri
 async function usableScan<T>(parsed: unknown, options: SidecarOptions<T>, transcript: string, stamp: FileStamp): Promise<AppendScan<T> | null> {
   if (!isRecord(parsed) || parsed.v !== options.version) return null;
   const { size, mtimeMs, scannedTo, head, value } = parsed;
-  if (typeof size !== "number" || typeof mtimeMs !== "number" || typeof scannedTo !== "number" || typeof head !== "string") return null;
+  if (!isByteCount(size) || !isByteCount(scannedTo) || typeof mtimeMs !== "number" || !Number.isFinite(mtimeMs) || typeof head !== "string") return null;
   if (!options.isValue(value)) return null;
   // The same freshness rule createFileCache states: a shorter file was rewritten, and a same-size
   // one whose mtime moved was rewritten in place.
@@ -93,6 +93,13 @@ async function usableScan<T>(parsed: unknown, options: SidecarOptions<T>, transc
   if ((await headHash(transcript)) !== head) return null;
   return { from: scannedTo, value };
 }
+
+// A position in a file, as read back off disk. "typeof number" is not enough: a negative or
+// fractional one reaches createReadStream as `start`, which throws ERR_OUT_OF_RANGE — and the
+// session list turns a throw into a row that silently vanishes, from a sidecar that keeps being
+// read. A number that cannot be an offset means the record is corrupt, i.e. rebuild it
+// (CodeRabbit on #1387).
+const isByteCount = (value: unknown): value is number => typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 
 // Mirrors the transcript's own layout — <project dir>/<session>.jsonl — from BASENAMES only, so
 // nothing a caller passes can walk out of the sidecar root.

--- a/test/server/session/transcript-sidecar.spec.ts
+++ b/test/server/session/transcript-sidecar.spec.ts
@@ -122,6 +122,31 @@ describe("createTranscriptSidecar", () => {
     expect(await sidecar.read(file, stamp)).toBeUndefined();
   });
 
+  // A number that cannot be a file offset is not a smaller answer, it is a THROW: createReadStream
+  // rejects a negative or fractional `start`, and the session list turns that into a row that
+  // silently disappears — from a record it will keep reading (CodeRabbit).
+  it("refuses an offset that could not be a position in a file", async () => {
+    const create = await loadSidecar();
+    const sidecar = create<Fields>({ kind: "k", version: 1, isValue: isFields });
+    const file = writeTranscript("a");
+    const stamp = stampOf(file);
+    sidecar.write(file, stamp, 100, { title: "hello" });
+    await settled();
+    const onDisk = sidecarFile("k", file);
+    const parsed: unknown = JSON.parse(readFileSync(onDisk, "utf8"));
+    if (!isRecord(parsed)) throw new Error("the sidecar should be an object");
+    const rewrite = (patch: Record<string, unknown>) => writeFileSync(onDisk, JSON.stringify({ ...parsed, ...patch }));
+
+    for (const scannedTo of [-1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 2]) {
+      rewrite({ scannedTo });
+      expect(await sidecar.read(file, stamp)).toBeUndefined();
+    }
+    rewrite({ size: -1 });
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+    rewrite({ mtimeMs: Number.NaN });
+    expect(await sidecar.read(file, stamp)).toBeUndefined();
+  });
+
   // (mtime, size) cannot tell "appended to" from "replaced by something longer", and a sidecar can
   // be days old when it is read — so the first bytes are checked too.
   it("refuses a file whose head changed under a record that still looks fresh", async () => {


### PR DESCRIPTION
## Summary

#1387（sidecar）に CodeRabbit が付けた Major 指摘の修正。**#1387 はレビュー対応が入る前にマージされた**ので、フォローアップとして単独 PR にした。

sidecar の `scannedTo` はディスク上の**信用できない JSON**なのに、検証が `typeof === "number"` だけだった。負の値も小数も通る。

この値はそのまま**ファイルオフセット**になる:

- `createReadStream(file, { start: -1 })` → `ERR_OUT_OF_RANGE`（実際に投げることを確認済み）
- セッション一覧はその throw を `readSessionMeta(...).catch(() => null)` で受けて**その行を落とす**
- しかも sidecar は読まれ続けるので、**そのセッションは一覧から消えたまま戻らない**（作り直されない）

つまり「壊れた sidecar が、遅い読み込みではなく**セッションの消失**になる」。

## 修正

`size` と `scannedTo` は**非負の safe integer**、`mtimeMs` は**有限**であることを要求する。ファイル内の位置になり得ない数値は「記録が壊れている」＝作り直し、というこのファイルの他の判定と同じ扱いにした。

CodeRabbit の提案は 11 行の条件式だったが、名前付きの述語（`isByteCount`）に畳んでいる。何を弾いているかが読めるほうがよいので。

## Items to Confirm / Review

- **なぜ「ただの防御」ではないか**: 失敗の形が「遅い」ではなく「セッションが一覧から消える」であること。実際に `ERR_OUT_OF_RANGE` が出ることと、`session-routes.ts` の `.catch(() => null)` が行を落とすことの両方を確認した。
- **`forEachJsonlRecordIn` 側でも防御すべきか**は入れていない。信用境界はディスク上の JSON であって、そこで弾くのが筋だと判断した（メモリ内キャッシュから来る offset は自分の scan の出力なので信用できる）。異論あれば入れる。
- テストは負 / 小数 / NaN / safe integer 超え、および `size` 負・`mtimeMs` NaN。ガードを元に戻すと落ちることを確認済み。

## User Prompt

（`/gh-review-loop` による bot レビュー対応。#1387 のレビューで CodeRabbit が指摘したもの）

## 検証

`yarn lint`（0 errors）/ `typecheck` / `test`（7949 passed）green。

refs #1386, #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4
