### PR TITLE
fix: bound every request in canvasOpenFile, and pin the plugin ordering

### DIFF
--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -109,6 +109,26 @@ export const canOpenInCanvas = (path: string | null, workspace: string | null = 
   path !== null && (canvasCardForFile(path) !== null || storyWirePath(path, workspace) !== null);
 
 /**
+ * Every request here bounded, per the repo's other API callers (useCost, useHandoff, …).
+ *
+ * Not a formality on this path: the reopen BLOCKS the Canvas from opening, so a server that never
+ * answers leaves the button pressed and nothing happening, with no way for the user to tell that
+ * from "this file cannot be shown". A rejection at least reaches the caller, which gives up
+ * visibly.
+ */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+async function fetchBounded(url: string, init?: RequestInit): Promise<Response> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: abort.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * The mulmoScript card for `wirePath`, built by the plugin's own reopen rather than here.
  *
  * `MulmoScriptData` requires the parsed `script`, not just a path — unlike markdown and html,
@@ -121,7 +141,7 @@ export const canOpenInCanvas = (path: string | null, workspace: string | null = 
  */
 async function reopenStory(wirePath: string): Promise<CanvasCard | null> {
   try {
-    const res = await fetch("/api/plugin/presentMulmoScript", {
+    const res = await fetchBounded("/api/plugin/presentMulmoScript", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ filePath: wirePath }),
@@ -163,7 +183,7 @@ export async function buildCanvasCard(absolutePath: string, workspace: string | 
  */
 export async function seedCanvasCard(sessionId: string, card: CanvasCard): Promise<boolean> {
   try {
-    const res = await fetch("/api/agent/toolResult", {
+    const res = await fetchBounded("/api/agent/toolResult", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ uuid: crypto.randomUUID(), ...card, sessionId }),
@@ -186,7 +206,7 @@ export async function seedCanvasCard(sessionId: string, card: CanvasCard): Promi
  */
 export async function hasStoredCard(sessionId: string): Promise<boolean> {
   try {
-    const res = await fetch(`/api/agent/toolResults/${encodeURIComponent(sessionId)}`);
+    const res = await fetchBounded(`/api/agent/toolResults/${encodeURIComponent(sessionId)}`);
     if (!res.ok) return false;
     const body: unknown = await res.json();
     return isRecord(body) && Array.isArray(body.toolResults) && body.toolResults.length > 0;

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -6,7 +6,15 @@
 // wave through.
 import { describe, it, expect, vi, afterEach } from "vitest";
 
-import { canvasCardForFile, canOpenInCanvas, absoluteUnder, storyWirePath, buildCanvasCard } from "../../../src/composables/canvasOpenFile";
+import {
+  canvasCardForFile,
+  canOpenInCanvas,
+  absoluteUnder,
+  storyWirePath,
+  buildCanvasCard,
+  seedCanvasCard,
+  hasStoredCard,
+} from "../../../src/composables/canvasOpenFile";
 
 describe("canvasCardForFile", () => {
   it("renders a markdown document through presentDocument, keyed by its path", () => {
@@ -203,5 +211,74 @@ describe("buildCanvasCard", () => {
     const fetchMock = mockReopen({});
     expect(await buildCanvasCard(`${WS}/notes.txt`, WS)).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// The ordering inside buildCanvasCard is load-bearing and silent: markdown and html are asked
+// first, so if either ever started accepting `.json`, every story in the workspace would quietly
+// open as that other thing instead. Pinned against the plugins themselves, not against our own
+// reasoning about them — a package upgrade is exactly how this would change.
+describe("the three plugins do not claim each other's files", () => {
+  const WS = "/work/ws";
+
+  it("leaves a story's .json to the story branch", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ data: { script: {}, filePath: "stories/tale.json" } }) }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    expect(canvasCardForFile(`${WS}/artifacts/stories/tale.json`)).toBeNull(); // no other plugin takes it
+    expect((await buildCanvasCard(`${WS}/artifacts/stories/tale.json`, WS))?.toolName).toBe("presentMulmoScript");
+    vi.unstubAllGlobals();
+  });
+
+  // The converse: a document that happens to live in the story directory is a document. It is not
+  // a story, and storyWirePath's `.json` requirement is what keeps it from being treated as one.
+  it("leaves a document in the story directory to the markdown branch", async () => {
+    expect(storyWirePath(`${WS}/artifacts/stories/notes.md`, WS)).toBeNull();
+    expect(canvasCardForFile(`${WS}/artifacts/stories/notes.md`)?.toolName).toBe("presentDocument");
+  });
+});
+
+// Bounded like the repo's other API callers. The reopen blocks the Canvas from opening, so a
+// server that never answers would otherwise leave the button pressed and nothing happening.
+describe("a request that never answers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const hangUntilAborted = () => {
+    const started: AbortSignal[] = [];
+    vi.stubGlobal("fetch", (_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (signal) started.push(signal);
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      });
+    });
+    return started;
+  };
+
+  it("gives up on the reopen instead of hanging forever", async () => {
+    vi.useFakeTimers();
+    const started = hangUntilAborted();
+    const pending = buildCanvasCard("/work/ws/artifacts/stories/tale.json", "/work/ws");
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await pending).toBeNull();
+    expect(started[0]?.aborted).toBe(true);
+  });
+
+  it("gives up on the seed, so the Canvas is not revealed over a card that never landed", async () => {
+    vi.useFakeTimers();
+    hangUntilAborted();
+    const pending = seedCanvasCard("s-1", { toolName: "presentDocument", data: {} });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await pending).toBe(false);
+  });
+
+  it("gives up on the stored-card check, answering no", async () => {
+    vi.useFakeTimers();
+    hangUntilAborted();
+    const pending = hasStoredCard("s-1");
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await pending).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two findings from reviewing #1388 that **missed the merge**. #1388 was merged at its first commit while the review loop was still running, so this carries the loop's result forward. No behaviour from #1388 changes.

## Items to Confirm / Review

1. **The timeout value.** 10s, matching the shape of the repo's other bounded callers. The reopen can legitimately take a moment on a large script — if 10s is too tight for a real story, say so and I will raise it.
2. **Three call sites, one helper.** `seedCanvasCard` and `hasStoredCard` shipped unbounded in #1380; they are fixed here too rather than left inconsistent beside the new one. Tell me if you would rather keep this PR to the reopen alone.

## 1. No request here was bounded

CLAUDE.md requires `AbortController` timeouts on network requests, and this repo already does it in nine places with a named constant (`useCost`, `useHandoff`, `useLaunchOptions`, …). None of the three fetches in `canvasOpenFile.ts` had one.

It matters most on the **reopen**, because that call blocks the Canvas from opening: a server that never answers leaves the button pressed and nothing happening, which a user cannot tell apart from "this file cannot be shown". The seed and the stored-card read have the same shape, so all three go through one `fetchBounded` rather than three copies.

## 2. The ordering in `buildCanvasCard` was load-bearing and unpinned

markdown and html are asked before the story branch. If either ever accepted `.json`, **every story in the workspace would quietly open as that other thing** — no error anywhere.

Pinned against the plugins themselves rather than against my reading of them, since a package upgrade is exactly how it would change. The converse is pinned too: a `.md` inside `artifacts/stories/` is still a document, not a story.

## Verification

Each new test was re-run against the code with its own fix removed:

| mutation | result |
| --- | --- |
| `fetchBounded` → plain `fetch` | all three timeout tests hang to the 15s test timeout |
| drop `storyWirePath`'s `.json` requirement | the ordering test fails |

`yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` (7959 passed) on top of current `main`.

refs #1374

work in mulmoterminal3
