### PR TITLE
perf: cost と timeline も transcript を毎回全部読むのをやめる (#1386)

### DIFF
--- a/plans/perf-1386-fold-cost-timeline.md
+++ b/plans/perf-1386-fold-cost-timeline.md
@@ -1,0 +1,89 @@
+# The other two readers that fold a transcript every time (#1386)
+
+`readSessionMeta` stopped re-reading its transcripts in #1379, and #1387 put that fold beside the
+file. Two readers were left doing the whole thing on every request, with **no cache at all**:
+
+- **`/api/cost`** reads up to 200 of a project's transcripts to total them — 2.4 s on this machine's
+  1.1 GB project, every time the cost panel is opened.
+- **the timeline overlay** reads a whole transcript to keep the newest 300 events — 2.2 s on a
+  508 MB session, every time it is opened.
+
+Both are plain folds over records, and both fold into state that serialises as it stands. They are
+the two cheapest wins left on #1386, and they come before `readSessionSummary`, whose scan keeps RAW
+records and needs restructuring first.
+
+## The third copy is where the helper goes
+
+Wiring a reader up means: resume from memory, else from the sidecar, else fold; then write both
+back. Written once it is a paragraph, written three times it is a paragraph that can drift — and
+the duplication scan would say so.
+
+**`server/session/transcript-fold.ts`** — `createTranscriptFold({ kind, version, isValue, empty,
+fold, copy, cold? })`, returning `read(transcript, stamp)`. `readSessionMeta` moves onto it with no
+behaviour change (its head+tail first read becomes the optional `cold` hook, which answers `null`
+when it cannot answer exactly).
+
+`copy` is **required rather than defaulted to a spread**. A value holding a collection needs that
+collection copied too: the timeline's accumulator owns an array that a resumed fold pushes into,
+and the value it was copied from has already been handed to a caller. A default would have made
+that the quiet case rather than the decided one.
+
+## What each one folds
+
+| reader | state | version |
+| --- | --- | --- |
+| title fields | three strings | `title-fields` v1 |
+| cost | `{ usd, unpricedTurns }` | `cost` v1 |
+| timeline | the newest 300 events + how many there have been | `timeline` v1 |
+
+`total` in the timeline's state is not the length of `events` — it counts every event the transcript
+ever had, which is the only thing that can still answer "was this truncated?" after the window has
+dropped the rest.
+
+The cost fold moves out of `createCostScan`'s closure into `foldCost(into, record)`, which the scan
+then uses: a resumed read folds into a total it did not start, so both paths have to add a turn the
+same way or a resumed cost drifts from a fresh one. `sessionCost(cwd, id)` is now exported, so the
+route stops building the transcript path itself and the fold underneath it is testable without an
+HTTP request.
+
+`rollupProjectCost` already stats every file to bucket it by day; it now carries the size along and
+hands the stamp down, rather than making the fold stat 200 files a second time.
+
+## Measured
+
+Against the real 1.1 GB project (its biggest session is 508 MB), before and after:
+
+| | before, every call | after, first call | after, later calls |
+| --- | --- | --- | --- |
+| timeline overlay | 2,247 ms | 2,202 ms | **0 ms** |
+| `/api/cost` | 2,449 ms | 2,323 ms | **1 ms** |
+
+And in a SECOND process, with the sidecars already on disk — a restart, or the next mulmoterminal:
+
+| | first call |
+| --- | --- |
+| timeline overlay | **13 ms** |
+| `/api/cost` | **3 ms** |
+
+The first call is not faster on its own, and should not be: unlike the title fields, neither of
+these can be answered from part of a transcript — a total has to see every turn, and the newest 300
+events are only known once the file has been read. What changes is that it is paid **once**.
+
+## Tests
+
+`test/server/session/transcript-fold.spec.ts` — the shared machinery, which no caller can see: a
+resumed fold equals one uninterrupted pass, an already-returned value is not mutated by the next
+read, a shorter file folds from scratch, and the `cold` hook is used when it answers / fallen back
+on when it returns null.
+
+`test/server/session/timeline-fold.spec.ts` — the window still means the newest 300 with `truncated`
+counting all of them; a resumed fold past the cap equals one pass; an unchanged transcript is not
+read twice (proven by changing its bytes under a held (size, mtime)).
+
+`test/server/session/cost.spec.ts` — an append adds to the total already held; a resumed total
+equals a one-pass total; a missing transcript costs nothing.
+
+## Not in scope
+
+`readSessionSummary` — the one that hurts most (10.5 s per turn on an active 508 MB session), and
+the one that cannot move onto this helper until its scan stops keeping raw records. Left on #1386.

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -104,10 +104,10 @@ export function costFromJsonl(raw: string): JsonlCost {
   return scan.total();
 }
 
-/** One record's contribution, folded into a running total. The rule lives here rather than inside
- *  the scan below because a RESUMED read folds into a total it did not start (#1386): both paths
- *  have to add a turn the same way or a resumed cost drifts from a fresh one. */
-export function foldCost(into: JsonlCost, record: Record<string, unknown>): void {
+// One record's contribution, folded into a running total. The rule lives here rather than inside
+// the scan below because a RESUMED read folds into a total it did not start (#1386): both paths
+// have to add a turn the same way or a resumed cost drifts from a fresh one.
+function foldCost(into: JsonlCost, record: Record<string, unknown>): void {
   const turn = assistantUsageTurn(record);
   if (!turn) return;
   const priced = costForUsage(turn.usage, turn.model);
@@ -115,7 +115,8 @@ export function foldCost(into: JsonlCost, record: Record<string, unknown>): void
   else into.unpricedTurns += 1;
 }
 
-export const EMPTY_COST: JsonlCost = { usd: 0, unpricedTurns: 0 };
+// A template to copy, never a target to fold into — foldCost MUTATES what it is given.
+const EMPTY_COST: JsonlCost = { usd: 0, unpricedTurns: 0 };
 
 /** The same accumulation, fed one record at a time — for a caller streaming a transcript too
  *  large to hold as a string (#998). The pricing rule stays in costForUsage either way. */

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -5,8 +5,9 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import type { Express, Response } from "express";
-import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { parseJsonl } from "./transcript.js";
+import { createTranscriptFold } from "./transcript-fold.js";
+import type { FileStamp } from "./file-cache.js";
 import { isRecord } from "../../common/isRecord.js";
 import { projectSessionsDir } from "./project-dir.js";
 
@@ -103,22 +104,45 @@ export function costFromJsonl(raw: string): JsonlCost {
   return scan.total();
 }
 
+/** One record's contribution, folded into a running total. The rule lives here rather than inside
+ *  the scan below because a RESUMED read folds into a total it did not start (#1386): both paths
+ *  have to add a turn the same way or a resumed cost drifts from a fresh one. */
+export function foldCost(into: JsonlCost, record: Record<string, unknown>): void {
+  const turn = assistantUsageTurn(record);
+  if (!turn) return;
+  const priced = costForUsage(turn.usage, turn.model);
+  if (priced.priced) into.usd += priced.usd;
+  else into.unpricedTurns += 1;
+}
+
+export const EMPTY_COST: JsonlCost = { usd: 0, unpricedTurns: 0 };
+
 /** The same accumulation, fed one record at a time — for a caller streaming a transcript too
  *  large to hold as a string (#998). The pricing rule stays in costForUsage either way. */
 export function createCostScan() {
-  let usd = 0;
-  let unpricedTurns = 0;
+  const total: JsonlCost = { ...EMPTY_COST };
   return {
     add(record: Record<string, unknown>) {
-      const turn = assistantUsageTurn(record);
-      if (!turn) return;
-      const priced = costForUsage(turn.usage, turn.model);
-      if (priced.priced) usd += priced.usd;
-      else unpricedTurns += 1;
+      foldCost(total, record);
     },
-    total: (): JsonlCost => ({ usd, unpricedTurns }),
+    total: (): JsonlCost => ({ ...total }),
   };
 }
+
+// A transcript's cost, folded once: an unchanged file is not read again, a grown one costs only the
+// bytes that arrived, and a big one keeps its total beside it. /api/cost reads up to 200 files per
+// request and had no cache at all — 2.5-3.1 s every time the cost panel was opened on a 1.1 GB
+// project (#1386).
+const isJsonlCost = (value: unknown): value is JsonlCost => isRecord(value) && typeof value.usd === "number" && typeof value.unpricedTurns === "number";
+
+const costFold = createTranscriptFold<JsonlCost>({
+  kind: "cost",
+  version: 1,
+  isValue: isJsonlCost,
+  empty: () => ({ ...EMPTY_COST }),
+  fold: foldCost,
+  copy: (cost) => ({ ...cost }),
+});
 
 // ── project-scoped aggregation (today / month) ─────────────────────────────────
 
@@ -133,6 +157,8 @@ const startOfMonth_ms = (now: Date): number => new Date(now.getFullYear(), now.g
 interface FileStat {
   file: string;
   mtime_ms: number;
+  /** Carried alongside the mtime because the fold needs the same stat, not a second one. */
+  size: number;
 }
 
 // Cheap stat-only pass: every *.jsonl's mtime, so files can be bucketed by day
@@ -143,7 +169,7 @@ async function statJsonlFiles(dir: string): Promise<FileStat[]> {
     names.map(async (file): Promise<FileStat | null> => {
       try {
         const st = await fs.stat(path.join(dir, file));
-        return { file, mtime_ms: st.mtimeMs };
+        return { file, mtime_ms: st.mtimeMs, size: st.size };
       } catch {
         return null;
       }
@@ -152,14 +178,26 @@ async function statJsonlFiles(dir: string): Promise<FileStat[]> {
   return stats.filter((s): s is FileStat => s !== null);
 }
 
-async function readFileCost(dir: string, file: string): Promise<JsonlCost> {
+async function readFileCost(dir: string, file: string, stamp?: FileStamp): Promise<JsonlCost> {
+  const full = path.join(dir, file);
   try {
-    const scan = createCostScan();
-    await forEachJsonlRecord(path.join(dir, file), (record) => scan.add(record));
-    return scan.total();
+    // The roll-up has already stat'ed every file to bucket it by day, so it hands its stamp down
+    // rather than making this stat 200 files a second time.
+    return await costFold.read(full, stamp ?? (await fileStamp(full)));
   } catch {
-    return { usd: 0, unpricedTurns: 0 };
+    return { ...EMPTY_COST };
   }
+}
+
+/** One session's cost. Exported so the route does not build the transcript path itself — and so the
+ *  fold underneath it can be tested without an HTTP request. */
+export async function sessionCost(cwd: string, id: string): Promise<JsonlCost> {
+  return readFileCost(projectSessionsDir(cwd), `${id}.jsonl`);
+}
+
+async function fileStamp(full: string): Promise<FileStamp> {
+  const st = await fs.stat(full);
+  return { mtimeMs: st.mtimeMs, size: st.size };
 }
 
 export interface CostRollup {
@@ -183,7 +221,9 @@ async function rollupProjectCost(cwd: string): Promise<CostRollup> {
   if (inMonth.length > capped.length) {
     console.log(`[api] /api/cost: capped at ${MAX_COST_FILES} of ${inMonth.length} session files for ${dir}`);
   }
-  const perFile = await Promise.all(capped.map(async (s) => ({ mtime_ms: s.mtime_ms, cost: await readFileCost(dir, s.file) })));
+  const perFile = await Promise.all(
+    capped.map(async (s) => ({ mtime_ms: s.mtime_ms, cost: await readFileCost(dir, s.file, { mtimeMs: s.mtime_ms, size: s.size }) })),
+  );
   return perFile.reduce<CostRollup>(
     (acc, f) => ({
       today: acc.today + (f.mtime_ms >= todayStart_ms ? f.cost.usd : 0),
@@ -208,10 +248,10 @@ export function mountCostRoute(app: Express, deps: { resolveCwd: (cwd: unknown, 
     const sessionParam = typeof req.query.session === "string" ? req.query.session : null;
     try {
       const rollup = await rollupProjectCost(cwd);
-      const sessionCost = sessionParam && SESSION_ID_RE.test(sessionParam) ? await readFileCost(projectSessionsDir(cwd), `${sessionParam}.jsonl`) : null;
+      const thisSession = sessionParam && SESSION_ID_RE.test(sessionParam) ? await sessionCost(cwd, sessionParam) : null;
       res.json({
-        session: sessionCost?.usd,
-        sessionUnpricedTurns: sessionCost?.unpricedTurns ?? 0,
+        session: thisSession?.usd,
+        sessionUnpricedTurns: thisSession?.unpricedTurns ?? 0,
         today: rollup.today,
         month: rollup.month,
         currency: "USD",

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -22,8 +22,8 @@ import {
   type LatestTurnContext,
   type TimelineEvent,
 } from "./transcript.js";
-import { createAppendFileCache, createFileCache, type AppendScan, type FileStamp } from "./file-cache.js";
-import { createTranscriptSidecar } from "./transcript-sidecar.js";
+import { createFileCache, type FileStamp } from "./file-cache.js";
+import { createTranscriptFold, type FoldedAt } from "./transcript-fold.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, isBackgroundSession, isFailedWorker, knownSessions, sessionMemos } from "./registry.js";
@@ -160,23 +160,52 @@ export async function readSessionSummary(cwd: string, id: string): Promise<Sessi
 // The tool-activity timeline for a session, capped to the most recent events so the
 // payload stays bounded on a long session. A missing transcript is an empty list.
 const TIMELINE_MAX_EVENTS = 300;
+
+// `total` is not the length of `events` — it counts every event the transcript ever had, which is
+// the only thing that can answer "was this truncated?" once the window has dropped the rest.
+interface TimelineScan {
+  events: TimelineEvent[];
+  total: number;
+}
+
+const isTimelineEvent = (value: unknown): value is TimelineEvent =>
+  isRecord(value) && typeof value.ts === "string" && typeof value.tool === "string" && typeof value.summary === "string";
+
+const isTimelineScan = (value: unknown): value is TimelineScan =>
+  isRecord(value) && typeof value.total === "number" && Array.isArray(value.events) && value.events.every(isTimelineEvent);
+
+function foldTimeline(into: TimelineScan, record: Record<string, unknown>): void {
+  for (const event of timelineEventsIn(record)) {
+    into.total += 1;
+    into.events.push(event);
+    if (into.events.length > TIMELINE_MAX_EVENTS) into.events.shift();
+  }
+}
+
+// Streamed since #998, and folded once since #1386: the payload was already capped, so reading the
+// whole transcript to throw most of it away was the expensive part — and doing that again on every
+// open of the overlay was the rest of it. The window is not a shortcut here: every record is still
+// folded, the newest 300 are simply the only ones kept.
+const timelineFold = createTranscriptFold<TimelineScan>({
+  kind: "timeline",
+  version: 1,
+  isValue: isTimelineScan,
+  empty: () => ({ events: [], total: 0 }),
+  fold: foldTimeline,
+  // The events ARRAY too, not just the record around it: a resumed fold pushes into it, and the
+  // value it copied from has already been handed to a caller.
+  copy: (scan) => ({ events: [...scan.events], total: scan.total }),
+});
+
 export async function sessionTimeline(cwd: string, id: string): Promise<{ events: TimelineEvent[]; truncated: boolean }> {
-  // Streamed, and only the newest TIMELINE_MAX_EVENTS are kept — the payload was already capped,
-  // so holding the whole transcript to then throw most of it away was the expensive part (#998).
-  const events: TimelineEvent[] = [];
-  let total = 0;
+  const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
   try {
-    await forEachJsonlRecord(path.join(projectSessionsDir(cwd), `${id}.jsonl`), (record) => {
-      for (const event of timelineEventsIn(record)) {
-        total += 1;
-        events.push(event);
-        if (events.length > TIMELINE_MAX_EVENTS) events.shift();
-      }
-    });
+    const st = await fs.stat(file);
+    const scan = await timelineFold.read(file, { mtimeMs: st.mtimeMs, size: st.size });
+    return { events: scan.events, truncated: scan.total > TIMELINE_MAX_EVENTS };
   } catch {
     return { events: [], truncated: false };
   }
-  return { events, truncated: total > TIMELINE_MAX_EVENTS };
 }
 
 // A session's last COMPLETED exchange, read from whichever log its agent keeps: Claude's
@@ -240,49 +269,29 @@ function foldTitleField(into: TitleFields, o: Record<string, unknown>): void {
 // Windows for the cold read, measured over the 60 largest transcripts on a working machine (5 MB to
 // 508 MB, each read end to end): the first `user` record sat at most 26.6 KB in, and the last
 // ai-title / last-prompt at most 52.8 KB from EOF. Both windows are ~10x that, and a file whose
-// fields fall outside them is not guessed at — it is read whole (see readTitleFields).
+// fields fall outside them is not guessed at — the fold reads the whole file instead.
 const TITLE_HEAD_BYTES = 256 * 1024;
 const TITLE_TAIL_BYTES = 512 * 1024;
 
-const titleFieldsCache = createAppendFileCache<TitleFields>();
-
-// The same fold, kept on disk for the transcripts big enough to be worth a file — so a restart and
-// the next mulmoterminal process do not each pay for it again (#1386). Bump the version when
-// foldTitleField changes what it means, or old files answer for a rule that no longer exists.
+// The same three fields, folded once per file: an unchanged transcript is not read at all, a grown
+// one costs only the bytes that arrived, and the answer is kept beside a big file so a restart and
+// the next process do not pay for it again (#1377, #1386). Bump the version when foldTitleField
+// changes what it means, or old sidecars answer for a rule that no longer exists.
 const isTitleFields = (value: unknown): value is TitleFields =>
   isRecord(value) &&
   (value.aiTitle === null || typeof value.aiTitle === "string") &&
   (value.lastPrompt === null || typeof value.lastPrompt === "string") &&
   (value.firstUserMsg === null || typeof value.firstUserMsg === "string");
 
-const titleFieldsSidecar = createTranscriptSidecar<TitleFields>({ kind: "title-fields", version: 1, isValue: isTitleFields });
-
-// A transcript is append-only, so the same three fields are folded out of it at most once: an
-// unchanged file is not read at all, and a grown one costs only the bytes that arrived. Without
-// this the session list read every one of its fifty transcripts in full on every request — 4.8 s
-// for a 17 KB answer on a 1.1 GB project, and the launcher waits on it (#1377).
-async function readTitleFields(full: string, stamp: FileStamp): Promise<TitleFields> {
-  // Memory first, disk second: the sidecar only has to answer the first read of a file in this
-  // process, and after that the in-memory scan is the one being resumed.
-  const resumed = titleFieldsCache.resume(full, stamp) ?? (await titleFieldsSidecar.read(full, stamp));
-  if (resumed && resumed.from >= stamp.size) {
-    titleFieldsCache.set(full, stamp, resumed.from, resumed.value);
-    return resumed.value;
-  }
-  const { fields, offset } = resumed
-    ? // Resuming from a boundary the previous scan reported, so the record starting there counts.
-      await resumeTitleFields(full, resumed)
-    : await coldTitleFields(full, stamp.size);
-  titleFieldsCache.set(full, stamp, offset, fields);
-  titleFieldsSidecar.write(full, stamp, offset, fields);
-  return fields;
-}
-
-async function resumeTitleFields(full: string, resumed: AppendScan<TitleFields>): Promise<{ fields: TitleFields; offset: number }> {
-  const fields = { ...resumed.value };
-  const offset = await forEachJsonlRecordIn(full, { from: resumed.from, atLineStart: true }, (o) => foldTitleField(fields, o));
-  return { fields, offset };
-}
+const titleFieldsFold = createTranscriptFold<TitleFields>({
+  kind: "title-fields",
+  version: 1,
+  isValue: isTitleFields,
+  empty: () => ({ ...NO_TITLE_FIELDS }),
+  fold: foldTitleField,
+  copy: (fields) => ({ ...fields }),
+  cold: coldTitleFields,
+});
 
 // The first read of a file: both ends when it is big enough for that to be worth it, and the whole
 // file when it is not — or when the ends did not answer. A field missing from a window is
@@ -293,25 +302,23 @@ async function resumeTitleFields(full: string, resumed: AppendScan<TitleFields>)
 // The offset comes back with the fields, and it is the end of the last COMPLETE line rather than
 // the file's size: a transcript caught mid-append ends in half a record, and resuming past it would
 // start the next scan inside a line — losing the record that half line becomes.
-async function coldTitleFields(full: string, size: number): Promise<{ fields: TitleFields; offset: number }> {
+async function coldTitleFields(full: string, size: number): Promise<FoldedAt<TitleFields> | null> {
   if (size > TITLE_HEAD_BYTES + TITLE_TAIL_BYTES) {
     const head: TitleFields = { ...NO_TITLE_FIELDS };
     const tail: TitleFields = { ...NO_TITLE_FIELDS };
     await forEachJsonlRecordIn(full, { to: TITLE_HEAD_BYTES }, (o) => foldTitleField(head, o));
     const offset = await forEachJsonlRecordIn(full, { from: size - TITLE_TAIL_BYTES }, (o) => foldTitleField(tail, o));
     if (head.firstUserMsg !== null && tail.aiTitle !== null && tail.lastPrompt !== null) {
-      return { fields: { aiTitle: tail.aiTitle, lastPrompt: tail.lastPrompt, firstUserMsg: head.firstUserMsg }, offset };
+      return { value: { aiTitle: tail.aiTitle, lastPrompt: tail.lastPrompt, firstUserMsg: head.firstUserMsg }, offset };
     }
   }
-  const whole: TitleFields = { ...NO_TITLE_FIELDS };
-  const offset = await forEachJsonlRecordIn(full, {}, (o) => foldTitleField(whole, o));
-  return { fields: whole, offset };
+  return null; // the ends did not answer — the caller folds the whole file
 }
 
 export async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> {
   const full = path.join(dir, file);
   const stat = await fs.stat(full);
-  const { aiTitle, lastPrompt, firstUserMsg } = await readTitleFields(full, { mtimeMs: stat.mtimeMs, size: stat.size });
+  const { aiTitle, lastPrompt, firstUserMsg } = await titleFieldsFold.read(full, { mtimeMs: stat.mtimeMs, size: stat.size });
 
   const id = path.basename(file, ".jsonl");
   const title = sessionListTitle({ memo: sessionMemos.get(id), liveAiTitle: aiTitles.get(id), diskAiTitle: aiTitle, diskLastPrompt: lastPrompt, firstUserMsg });

--- a/server/session/transcript-fold.ts
+++ b/server/session/transcript-fold.ts
@@ -1,0 +1,89 @@
+// Folding a value out of a transcript, once.
+//
+// A transcript is append-only, so anything derived from it by folding over its records can be kept
+// up to date by folding only what arrived since — and that state can be kept beside the file so a
+// restart, and the next mulmoterminal process, do not pay for it again. Three readers want exactly
+// that (the session list's title fields, a session's cost, its tool timeline), and the wiring is
+// the same every time: memory first, disk second, fold the delta, write both back.
+//
+// Written once here rather than three times, because the interesting part is not the plumbing but
+// what each caller has to decide: what a fresh accumulator is, how to fold a record into it, how to
+// COPY it (a shared array would be mutated behind the value already handed out), and whether a
+// first read of a big file can be answered from less than the whole thing. #1377 / #1386.
+import { forEachJsonlRecordIn } from "../infra/jsonl-file.js";
+import { createAppendFileCache, type AppendScan, type FileStamp } from "./file-cache.js";
+import { createTranscriptSidecar } from "./transcript-sidecar.js";
+
+export interface FoldedAt<T> {
+  value: T;
+  /** End of the last COMPLETE line — where a later scan resumes. */
+  offset: number;
+}
+
+export interface TranscriptFoldOptions<T> {
+  /** Names the sidecar directory: one per kind of derived value. */
+  kind: string;
+  /** Bump when `fold` changes what it MEANS — a sidecar written by the old rule outlives a
+   *  restart, so it would answer for a rule that no longer exists. */
+  version: number;
+  /** A sidecar is untrusted input, whoever wrote it. */
+  isValue: (value: unknown) => value is T;
+  empty: () => T;
+  fold: (into: T, record: Record<string, unknown>) => void;
+  /** Required, not defaulted to a spread: a value that holds a collection needs that collection
+   *  copied too, and getting it wrong mutates a value already handed to a caller. */
+  copy: (value: T) => T;
+  /** An optional cheaper FIRST read for a big file — the two ends of it, say. Answers null when it
+   *  cannot answer exactly, and the whole file is folded instead. */
+  cold?: (transcript: string, size: number) => Promise<FoldedAt<T> | null>;
+  minBytes?: number;
+}
+
+export interface TranscriptFold<T> {
+  /** The folded value as of this stamp, paying only for what has not been folded yet. */
+  read(transcript: string, stamp: FileStamp): Promise<T>;
+}
+
+export function createTranscriptFold<T>(options: TranscriptFoldOptions<T>): TranscriptFold<T> {
+  const cache = createAppendFileCache<T>();
+  // Spread rather than passed as `minBytes: options.minBytes`: under exactOptionalPropertyTypes an
+  // explicit `undefined` is not the same as "not given", and the sidecar's own default is the point.
+  const sidecar = createTranscriptSidecar<T>({
+    kind: options.kind,
+    version: options.version,
+    isValue: options.isValue,
+    ...(options.minBytes === undefined ? {} : { minBytes: options.minBytes }),
+  });
+
+  return {
+    async read(transcript, stamp) {
+      // Memory first, disk second: the sidecar only has to answer the first read of a file in this
+      // process, and after that it is the in-memory scan being resumed.
+      const resumed = cache.resume(transcript, stamp) ?? (await sidecar.read(transcript, stamp));
+      if (resumed && resumed.from >= stamp.size) {
+        cache.set(transcript, stamp, resumed.from, resumed.value);
+        return resumed.value;
+      }
+      const folded = resumed ? await resume(options, transcript, resumed) : await first(options, transcript, stamp.size);
+      cache.set(transcript, stamp, folded.offset, folded.value);
+      sidecar.write(transcript, stamp, folded.offset, folded.value);
+      return folded.value;
+    },
+  };
+}
+
+// The offset came from a previous scan, so it sits on a line boundary and the record starting there
+// counts — the one case where a mid-file start must NOT drop its first line.
+async function resume<T>(options: TranscriptFoldOptions<T>, transcript: string, from: AppendScan<T>): Promise<FoldedAt<T>> {
+  const value = options.copy(from.value);
+  const offset = await forEachJsonlRecordIn(transcript, { from: from.from, atLineStart: true }, (record) => options.fold(value, record));
+  return { value, offset };
+}
+
+async function first<T>(options: TranscriptFoldOptions<T>, transcript: string, size: number): Promise<FoldedAt<T>> {
+  const shortcut = await options.cold?.(transcript, size);
+  if (shortcut) return shortcut;
+  const value = options.empty();
+  const offset = await forEachJsonlRecordIn(transcript, {}, (record) => options.fold(value, record));
+  return { value, offset };
+}

--- a/test/server/session/cost.spec.ts
+++ b/test/server/session/cost.spec.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { rateForModel, costForUsage, costFromJsonl } from "../../../server/session/cost.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -104,5 +107,73 @@ describe("costFromJsonl", () => {
   it("returns zeros for empty or malformed input", () => {
     expect(costFromJsonl("")).toEqual({ usd: 0, unpricedTurns: 0 });
     expect(costFromJsonl("not json\n{broken")).toEqual({ usd: 0, unpricedTurns: 0 });
+  });
+});
+
+// /api/cost read every one of a project's transcripts in full, on every request and with no cache
+// at all — 2.5-3.1 s on a 1.1 GB project, every time the cost panel was opened (#1386). It now
+// folds each file once and resumes on what was appended, so what is pinned here is that a resumed
+// total is the same total.
+describe("a transcript's cost, folded across reads", () => {
+  const realHome = process.env.HOME;
+  let home = "";
+  let n = 0;
+  const CWD = "/Users/me/proj";
+
+  const transcriptPath = (id: string): string => {
+    const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+    mkdirSync(dir, { recursive: true });
+    return path.join(dir, `${id}.jsonl`);
+  };
+
+  const priced = (outputTokens: number) => `${assistant("claude-sonnet-5", { input_tokens: 0, output_tokens: outputTokens })}\n`;
+  const unpriced = () => `${assistant("some-unknown-model", { input_tokens: 10, output_tokens: 10 })}\n`;
+
+  async function freshCost() {
+    vi.resetModules();
+    process.env.HOME = home;
+    const mod = await import("../../../server/session/cost.js");
+    return mod.sessionCost;
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(tmpdir(), "mt-cost-fold-"));
+  });
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME;
+    else process.env.HOME = realHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("adds what was appended to the total it already had", async () => {
+    const sessionCost = await freshCost();
+    const id = `sess-${++n}`;
+    writeFileSync(transcriptPath(id), priced(1_000_000) + unpriced());
+    const first = await sessionCost(CWD, id);
+    expect(first.usd).toBeGreaterThan(0);
+    expect(first.unpricedTurns).toBe(1);
+
+    appendFileSync(transcriptPath(id), priced(1_000_000));
+    const grown = await sessionCost(CWD, id);
+    expect(grown.usd).toBeCloseTo(first.usd * 2, 10);
+    expect(grown.unpricedTurns).toBe(1);
+  });
+
+  // The equivalence: a total built in two goes is the total one pass would produce.
+  it("matches a reader that folded the grown file in one pass", async () => {
+    const id = `sess-${++n}`;
+    const sessionCost = await freshCost();
+    writeFileSync(transcriptPath(id), priced(500_000));
+    await sessionCost(CWD, id);
+    appendFileSync(transcriptPath(id), priced(250_000) + unpriced());
+    const resumed = await sessionCost(CWD, id);
+
+    const oneShot = await (await freshCost())(CWD, id);
+    expect(resumed).toEqual(oneShot);
+  });
+
+  it("costs nothing for a transcript that is not there", async () => {
+    const sessionCost = await freshCost();
+    expect(await sessionCost(CWD, "never-existed")).toEqual({ usd: 0, unpricedTurns: 0 });
   });
 });

--- a/test/server/session/timeline-fold.spec.ts
+++ b/test/server/session/timeline-fold.spec.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, statSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// The timeline overlay read the whole transcript every time it was opened — a payload capped at 300
+// events, paid for in hundreds of megabytes (#1386). It now folds once and resumes, so what matters
+// is that the window still means the same thing: the NEWEST 300, and `truncated` counting every
+// event the file ever had rather than the ones that survived the window.
+
+// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
+// next spec's idea of ~/.claude without it asking.
+const realHome = process.env.HOME;
+let home = "";
+let n = 0;
+
+const CWD = "/Users/me/proj";
+
+async function freshTimeline() {
+  vi.resetModules();
+  process.env.HOME = home;
+  const mod = await import("../../../server/session/session-reads.js");
+  return mod.sessionTimeline;
+}
+
+const toolUse = (name: string, ts: string) =>
+  `${JSON.stringify({ type: "assistant", timestamp: ts, message: { content: [{ type: "tool_use", name, input: {} }] } })}\n`;
+const noise = () => `${JSON.stringify({ type: "user", message: { content: "hello" } })}\n`;
+
+function transcriptPath(id: string): string {
+  const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${id}.jsonl`);
+}
+
+function writeTranscript(body: string): string {
+  const id = `sess-${++n}`;
+  writeFileSync(transcriptPath(id), body);
+  return id;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-timeline-"));
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("sessionTimeline", () => {
+  it("lists the tool uses in order, and says nothing was dropped", async () => {
+    const sessionTimeline = await freshTimeline();
+    const id = writeTranscript(toolUse("Read", "t1") + noise() + toolUse("Edit", "t2"));
+    expect(await sessionTimeline(CWD, id)).toEqual({
+      events: [
+        { ts: "t1", tool: "Read", summary: "" },
+        { ts: "t2", tool: "Edit", summary: "" },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("keeps the newest 300 and reports the rest as truncated", async () => {
+    const sessionTimeline = await freshTimeline();
+    const id = writeTranscript(Array.from({ length: 305 }, (_, i) => toolUse(`Tool${i}`, `t${i}`)).join(""));
+    const timeline = await sessionTimeline(CWD, id);
+    expect(timeline.events).toHaveLength(300);
+    expect(timeline.events[0]).toMatchObject({ tool: "Tool5" });
+    expect(timeline.events.at(-1)).toMatchObject({ tool: "Tool304" });
+    expect(timeline.truncated).toBe(true);
+  });
+
+  // The window is a fold, so continuing one has to land where one uninterrupted pass would —
+  // including which events fell out of the front of it.
+  it("answers what one pass would after the transcript grows past the cap", async () => {
+    const sessionTimeline = await freshTimeline();
+    const id = writeTranscript(Array.from({ length: 290 }, (_, i) => toolUse(`Tool${i}`, `t${i}`)).join(""));
+    await sessionTimeline(CWD, id);
+    appendFileSync(transcriptPath(id), Array.from({ length: 20 }, (_, i) => toolUse(`Late${i}`, `l${i}`)).join(""));
+    const resumed = await sessionTimeline(CWD, id);
+
+    const oneShot = await (await freshTimeline())(CWD, id);
+    expect(resumed).toEqual(oneShot);
+    expect(resumed.events).toHaveLength(300);
+    expect(resumed.events.at(-1)).toMatchObject({ tool: "Late19" });
+    expect(resumed.truncated).toBe(true);
+  });
+
+  // Proven the same way as the session list: change the bytes while holding (size, mtime), and an
+  // answer that still matches the ORIGINAL cannot have re-read the file.
+  it("does not read an unchanged transcript twice", async () => {
+    const sessionTimeline = await freshTimeline();
+    const id = writeTranscript(toolUse("Read", "t1"));
+    const file = transcriptPath(id);
+    const frozen = new Date(1_700_000_000_000);
+    utimesSync(file, frozen, frozen);
+    expect((await sessionTimeline(CWD, id)).events).toEqual([{ ts: "t1", tool: "Read", summary: "" }]);
+
+    const before = statSync(file);
+    writeFileSync(file, toolUse("Edit", "t1")); // same length, different tool
+    utimesSync(file, frozen, frozen);
+    expect(statSync(file)).toMatchObject({ size: before.size, mtimeMs: before.mtimeMs });
+
+    expect((await sessionTimeline(CWD, id)).events).toEqual([{ ts: "t1", tool: "Read", summary: "" }]);
+  });
+
+  it("has no events for a transcript that is not there", async () => {
+    const sessionTimeline = await freshTimeline();
+    expect(await sessionTimeline(CWD, "never-existed")).toEqual({ events: [], truncated: false });
+  });
+});

--- a/test/server/session/transcript-fold.spec.ts
+++ b/test/server/session/transcript-fold.spec.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { isRecord } from "../../../common/isRecord.js";
+
+// The machinery three readers share (title fields, cost, timeline): fold a transcript once, resume
+// on what was appended, and keep the answer beside a big file (#1377 / #1386). What is pinned here
+// is the part every caller depends on and none of them can see — that a resumed fold produces what
+// one uninterrupted pass would, and that it does not reach back into the value already handed out.
+
+// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
+// next spec's idea of ~/.mulmoterminal without it asking.
+const realHome = process.env.HOME;
+let home = "";
+let projects = "";
+let n = 0;
+
+interface Counted {
+  tools: string[];
+  total: number;
+}
+
+const isCounted = (v: unknown): v is Counted =>
+  isRecord(v) && typeof v.total === "number" && Array.isArray(v.tools) && v.tools.every((t) => typeof t === "string");
+
+const COUNTED = {
+  isValue: isCounted,
+  empty: (): Counted => ({ tools: [], total: 0 }),
+  fold: (into: Counted, record: Record<string, unknown>) => {
+    if (typeof record.tool !== "string") return;
+    into.total += 1;
+    into.tools.push(record.tool);
+  },
+  copy: (v: Counted): Counted => ({ tools: [...v.tools], total: v.total }),
+};
+
+async function loadFold() {
+  vi.resetModules();
+  process.env.HOME = home;
+  const mod = await import("../../../server/session/transcript-fold.js");
+  return mod.createTranscriptFold;
+}
+
+const toolLine = (tool: string) => `${JSON.stringify({ tool })}\n`;
+
+function writeTranscript(body: string): string {
+  const dir = path.join(projects, "-Users-me-proj");
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `s-${++n}.jsonl`);
+  writeFileSync(file, body);
+  return file;
+}
+
+const stampOf = (file: string) => {
+  const st = statSync(file);
+  return { mtimeMs: st.mtimeMs, size: st.size };
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-fold-"));
+  projects = path.join(home, ".claude", "projects");
+  mkdirSync(projects, { recursive: true });
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("createTranscriptFold", () => {
+  it("folds a transcript, and folds only the append the second time", async () => {
+    const create = await loadFold();
+    const fold = create<Counted>({ kind: "counted", version: 1, ...COUNTED });
+    const file = writeTranscript(toolLine("Read") + toolLine("Edit"));
+    expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["Read", "Edit"], total: 2 });
+
+    appendFileSync(file, toolLine("Bash"));
+    expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["Read", "Edit", "Bash"], total: 3 });
+  });
+
+  // The equivalence the whole design rests on: stopping and continuing must not change the answer.
+  it("answers what one uninterrupted pass would", async () => {
+    const create = await loadFold();
+    const resumed = create<Counted>({ kind: "a", version: 1, ...COUNTED });
+    const oneShot = create<Counted>({ kind: "b", version: 1, ...COUNTED });
+
+    const file = writeTranscript(toolLine("Read"));
+    await resumed.read(file, stampOf(file));
+    appendFileSync(file, toolLine("Edit") + toolLine("Bash"));
+    await resumed.read(file, stampOf(file));
+    appendFileSync(file, toolLine("Write"));
+
+    expect(await resumed.read(file, stampOf(file))).toEqual(await oneShot.read(file, stampOf(file)));
+  });
+
+  // `copy` exists for this: the resumed fold pushes into the accumulator, and the caller is still
+  // holding the value it was given last time.
+  it("does not mutate a value it has already handed out", async () => {
+    const create = await loadFold();
+    const fold = create<Counted>({ kind: "counted", version: 1, ...COUNTED });
+    const file = writeTranscript(toolLine("Read"));
+    const first = await fold.read(file, stampOf(file));
+
+    appendFileSync(file, toolLine("Edit"));
+    await fold.read(file, stampOf(file));
+
+    expect(first).toEqual({ tools: ["Read"], total: 1 });
+  });
+
+  it("re-folds from the start when the transcript got shorter", async () => {
+    const create = await loadFold();
+    const fold = create<Counted>({ kind: "counted", version: 1, ...COUNTED });
+    const file = writeTranscript(toolLine("Read") + toolLine("Edit"));
+    await fold.read(file, stampOf(file));
+
+    writeFileSync(file, toolLine("Bash"));
+    expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["Bash"], total: 1 });
+  });
+
+  describe("the optional cheaper first read", () => {
+    it("is used when it answers, and its offset is where the next fold resumes", async () => {
+      const create = await loadFold();
+      const file = writeTranscript(toolLine("Read") + toolLine("Edit"));
+      const size = statSync(file).size;
+      const fold = create<Counted>({
+        kind: "counted",
+        version: 1,
+        ...COUNTED,
+        cold: async () => ({ value: { tools: ["from-the-shortcut"], total: 1 }, offset: size }),
+      });
+
+      expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["from-the-shortcut"], total: 1 });
+      appendFileSync(file, toolLine("Bash"));
+      expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["from-the-shortcut", "Bash"], total: 2 });
+    });
+
+    // A shortcut that cannot answer exactly must cost nothing but the attempt — the whole file is
+    // folded, rather than a half-answer being kept.
+    it("falls back to the whole file when it answers null", async () => {
+      const create = await loadFold();
+      const fold = create<Counted>({ kind: "counted", version: 1, ...COUNTED, cold: async () => null });
+      const file = writeTranscript(toolLine("Read") + toolLine("Edit"));
+      expect(await fold.read(file, stampOf(file))).toEqual({ tools: ["Read", "Edit"], total: 2 });
+    });
+  });
+
+  it("rejects for a transcript that is not there", async () => {
+    const create = await loadFold();
+    const fold = create<Counted>({ kind: "counted", version: 1, ...COUNTED });
+    await expect(fold.read(path.join(projects, "gone.jsonl"), { mtimeMs: 1, size: 10 })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

#1386 のステップ 2。**キャッシュが 1 つも無いまま毎回 transcript を全部読んでいた 2 か所**を、#1379/#1387 と同じ「畳み込みを再開する／sidecar に置く」経路に載せた。

- **`/api/cost`** — プロジェクトの transcript を最大 200 本読んで合計する。1.1 GB のプロジェクトで**コスト欄を開くたび 2.4 秒**。
- **timeline オーバーレイ** — 直近 300 events のために transcript を全部読む。508 MB のセッションで**開くたび 2.2 秒**。

### 実測（実データ: mulmoclaude3 / 最大セッション 508 MB）

| | before（毎回） | after 初回 | after 2 回目以降 |
|---|---:|---:|---:|
| timeline | 2,247 ms | 2,202 ms | **0 ms** |
| `/api/cost` | 2,449 ms | 2,323 ms | **1 ms** |

sidecar がディスクにある**別プロセス**（＝再起動後 / 2 台目）:

| | 初回 |
|---|---:|
| timeline | **13 ms** |
| `/api/cost` | **3 ms** |

**初回が速くならないのは仕様**です。title fields と違い、この 2 つは transcript の一部からは答えられない（合計は全ターンを見る必要があり、直近 300 events も全部読んで初めて確定する）。変わったのは「毎回」が「1 回」になったこと。

## Items to Confirm / Review

- **3 回目のコピーになる直前に共通化した**。`server/session/transcript-fold.ts` に「メモリ → sidecar → 差分だけ畳む → 両方に書く」を 1 か所化し、`readSessionMeta` も**挙動を変えずに**そこへ載せ替え（両端読みは任意の `cold` フックに。正確に答えられないときは `null` を返して全読みへ）。
- **`copy` を必須にした**（spread のデフォルトにしていない）。timeline の畳み込み状態は**配列を持つ**ので、再開時に浅いコピーだと**すでに呼び出し元へ返した値**を後から書き換えてしまう。デフォルトにすると「気づかない側」が既定になるため、各呼び出し元に書かせた。テストで固定してある。
- **`total` は `events.length` ではない**（timeline）。窓から溢れた分を含む総数で、`truncated` を答えられる唯一の情報。
- **`foldCost` を `createCostScan` のクロージャから出した**。再開した読み取りは「自分が始めていない合計」に足し込むので、両経路が同じ足し方をしないと**再開した合計がずれる**。`createCostScan` は `foldCost` を使う形に変えて API は維持。
- **`sessionCost(cwd, id)` を export**。ルート側が transcript のパスを組み立てるのをやめ、畳み込みを HTTP 抜きでテストできるようにした。
- **`rollupProjectCost` の stat を 1 回に**。もともと mtime でバケツ分けするために全ファイルを stat しているので、そこに size を持たせて stamp として渡す（200 ファイルを 2 度 stat しない）。

## User Prompt

> ok じゃあ、そのようにsidecarで改善して
>
> はい。続けて。

会話で決めた進め方（#1386）: ①sidecar の土台 ＋ `readSessionMeta`（#1387、マージ済）→ **②cost ＋ timeline（この PR）** → ③`readSessionSummary`。

## テスト（新規 15 本）

- `transcript-fold.spec.ts`（7 本）— 共通機構そのもの。**再開した畳み込み ＝ 一気に畳んだ結果**／**すでに返した値を後から書き換えない**（`copy` の存在理由）／縮んだら最初から／`cold` フックは答えれば使い、`null` なら全読みに落ちる
- `timeline-fold.spec.ts`（5 本）— 窓は今も「新しい方から 300」で `truncated` は総数基準／**窓を超えて伸びた後も一気読みと一致**／未変更なら読み直さない（(size, mtime) を保ったまま中身を差し替えて証明）／無いファイルは空
- `cost.spec.ts`（+3 本）— 追記分が既存の合計に足される／**再開した合計 ＝ 一気読みの合計**／無いファイルは 0

`yarn lint`（0 errors）/ `typecheck` / `test`（7969 passed）green。

## 残り（#1386）

`readSessionSummary` — 一番効く（アクティブな 508 MB のセッションで**ターンごとに 10.5 秒**）が、畳み込み状態が**生のレコード配列**を溜める形なので、まずそれを解決済みの値に持ち替えるリファクタと等価テストが要る。

refs #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4
