### PR TITLE
perf: セッション要約をターンごとに全読みするのをやめる (#1377 の最後の 1 か所)

### DIFF
--- a/plans/perf-1377-summary-fold.md
+++ b/plans/perf-1377-summary-fold.md
@@ -1,0 +1,90 @@
+# The summary re-read the whole transcript on every turn (#1377)
+
+`/api/session/:id` is hit by every grid cell as its turn finishes. Its reader, `readSessionSummary`,
+had a `(mtime, size)` memo — which can only skip an **unchanged** transcript, and the session being
+written to is never that. So the session you are actively working in, the one most likely to be
+huge, paid a full read per turn: **2.15 s on a 508 MB transcript**, with the event loop stopped and
+every terminal in the app frozen for it.
+
+The other three readers moved onto a resumed fold in #1379/#1387/#1392. This one could not follow,
+because its scan keeps **raw records**:
+
+- every `user` record ever seen (13,664 in one transcript here), kept so the latest MEANINGFUL
+  prompt could be picked out of them at the end;
+- the last `assistant` record, kept so the model and context tokens could be read off it as a unit.
+
+Neither can be written to a sidecar, and holding them across requests is its own problem.
+
+## Resolve as they arrive, without restating the rule
+
+Both are answered by rules that are themselves folds, so the fix is to move the rule — not to
+re-derive its answer somewhere else. #998's lesson applies exactly: a second copy of a rule is how
+the two answers drift.
+
+**`latestMeaningfulUserPromptFromParsed`** picks the last non-trivial prompt, falling back to the
+last prompt at all, then to a `last-prompt` record. Each of those is a *last X*, so the whole rule
+needs three strings — not every record:
+
+```
+PromptTrail { meaningful, latest, record }   // transcript.ts
+foldPromptTrail(trail, record)               // one rule
+meaningfulPromptOf(trail)                    // one choice
+```
+
+The array helpers (`latestMeaningfulUserPromptFromParsed`, `latestUserPromptFromParsed`) now fold the
+same function over their records, so there is one implementation and the streaming caller cannot
+answer differently. The 54 existing `transcript.spec.ts` cases pass unchanged — that is what says the
+refactor kept the rule.
+
+**The context** (model + context tokens) is resolved per assistant record by the same
+`latestTurnContextFromParsed` one-record window that used to be applied at the end. Unconditional
+replacement, matching what keeping the last record did, so a turn naming no model still reports null
+rather than an earlier turn's model.
+
+`createCurrentTurnToolScan` becomes `foldTurnToolNames(names, record)` for the same reason — the
+scan is now a thin wrapper over it.
+
+## Shape
+
+`summary-scan.ts` exposes the fold instead of a closure over it: `emptySummaryState`,
+`foldSummary(state, record)`, `copySummaryState`, `summaryPartsOf(state, max)`. `createSummaryScan()`
+stays for the array callers, built from those. The state is JSON: four usage numbers, a count, two
+strings, the prompt trail, the resolved context, and the current turn's tool names.
+
+`readSessionSummary` then drops its own memo and reads through `createTranscriptFold` (kind
+`summary`), which brings the in-memory resume AND the sidecar with it.
+
+## Measured
+
+`readSessionSummary` against the biggest real transcript here (508 MB), on a copy so the real one is
+never touched:
+
+| | before | after |
+| --- | --- | --- |
+| first read | 2,176 ms | 2,162 ms |
+| unchanged file | 0 ms | 1 ms |
+| **after a turn is appended** | **2,154 ms** | **3 ms** |
+| after another turn | 2,158 ms | 0 ms |
+
+The first read is unchanged and should be: a summary counts every turn, so nothing less than the
+whole file can answer it the first time. What changed is the row that a working session actually
+hits — every turn, in every cell.
+
+## Tests
+
+`test/server/session/summary-scan.spec.ts` — the existing cases already assert the scan against the
+original `*FromParsed` functions on the same records, so they pin the refactor. Added: folding cut at
+**every** position equals one uninterrupted pass; the state a resume continues from is left
+untouched; and the state survives a round trip through JSON (which is what a sidecar is).
+
+`test/server/session/session-summary-fold.spec.ts` — through `readSessionSummary`: a continued fold
+across a turn equals a one-pass read, an unchanged transcript is not read twice (bytes changed under
+a held stamp), and a big session's summary is written beside it and continued **in a fresh process**.
+
+`test/server/session/transcript.spec.ts` — unchanged, and passing, which is the point.
+
+## Not in scope
+
+The `lastAssistantText` in the state is the full reply, sliced to 400 chars only when the summary is
+built. For a sidecar that is a few KB of the value; capping it at fold time would tie the state to
+one caller's `responseMax`, which is not a trade worth making for the size.

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -20,17 +20,17 @@ import {
   timelineEventsIn,
   type SessionUsage,
   type LatestTurnContext,
+  type PromptTrail,
   type TimelineEvent,
 } from "./transcript.js";
-import { createFileCache, type FileStamp } from "./file-cache.js";
 import { createTranscriptFold, type FoldedAt } from "./transcript-fold.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, isBackgroundSession, isFailedWorker, knownSessions, sessionMemos } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
-import { forEachJsonlRecord, forEachJsonlRecordIn, readTailRecords } from "../infra/jsonl-file.js";
-import { createSummaryScan } from "./summary-scan.js";
+import { forEachJsonlRecordIn, readTailRecords } from "../infra/jsonl-file.js";
+import { copySummaryState, emptySummaryState, foldSummary, summaryPartsOf, type SummaryState } from "./summary-scan.js";
 import { partitionPending } from "./partitionPending.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
@@ -119,42 +119,59 @@ export const EMPTY_SUMMARY: SessionSummary = {
 
 // Transcripts are append-only and can be hundreds of MB; /api/session/:id is hit on every
 // window focus and by each grid cell as turns finish, so re-reading + re-parsing the whole
-// .jsonl each time blocked the event loop and janked the terminals. Memoize by (mtime,size):
-// an unchanged transcript returns instantly, and a changed one is read + parsed ONCE (the six
-// derived values share one parse pass, vs. one parse per helper before).
-const sessionSummaryCache = createFileCache<SessionSummary>();
+// .jsonl each time blocked the event loop and janked the terminals. A (mtime,size) memo fixed the
+// UNCHANGED case (#948) and left the one that hurts: a transcript being written to is changed on
+// every turn, so an active 508 MB session paid a 10.5 s full read per turn. The fold is resumed
+// instead, and kept beside a big file so a restart and the next process inherit it (#1377/#1386).
+const isSessionUsage = (value: unknown): value is SessionUsage =>
+  isRecord(value) &&
+  typeof value.inputTokens === "number" &&
+  typeof value.outputTokens === "number" &&
+  typeof value.cacheReadTokens === "number" &&
+  typeof value.cacheCreationTokens === "number";
+
+const isPromptTrail = (value: unknown): value is PromptTrail =>
+  isRecord(value) && [value.meaningful, value.latest, value.record].every((v) => v === null || typeof v === "string");
+
+const isSummaryState = (value: unknown): value is SummaryState =>
+  isRecord(value) &&
+  isSessionUsage(value.usage) &&
+  typeof value.userTurns === "number" &&
+  (value.aiTitle === null || typeof value.aiTitle === "string") &&
+  isPromptTrail(value.prompts) &&
+  (value.lastAssistantText === null || typeof value.lastAssistantText === "string") &&
+  isRecord(value.context) &&
+  (value.context.model === null || typeof value.context.model === "string") &&
+  typeof value.context.contextTokens === "number" &&
+  Array.isArray(value.turnTools) &&
+  value.turnTools.every((tool) => typeof tool === "string");
+
+const summaryFold = createTranscriptFold<SummaryState>({
+  kind: "summary",
+  version: 1,
+  isValue: isSummaryState,
+  empty: emptySummaryState,
+  fold: foldSummary,
+  copy: copySummaryState,
+});
 
 export async function readSessionSummary(cwd: string, id: string): Promise<SessionSummary> {
   const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
-  let stamp: FileStamp;
   try {
     const st = await fs.stat(file);
-    stamp = { mtimeMs: st.mtimeMs, size: st.size };
+    const parts = summaryPartsOf(await summaryFold.read(file, { mtimeMs: st.mtimeMs, size: st.size }), LAST_RESPONSE_MAX);
+    return {
+      lastPrompt: parts.lastPrompt,
+      aiTitle: parts.aiTitle,
+      lastResponse: parts.lastResponse,
+      userTurns: parts.userTurns,
+      usage: parts.usage,
+      context: parts.context,
+      workPhase: classifyWorkPhase(parts.toolNames),
+    };
   } catch {
-    return EMPTY_SUMMARY; // no transcript on disk yet
+    return EMPTY_SUMMARY; // no transcript on disk yet, or it could not be read
   }
-  const cached = sessionSummaryCache.get(file, stamp);
-  if (cached) return cached;
-  // Streamed, never held: the transcript reaches 585 MB here, which is past what one string can
-  // be — and reading it whole is what emptied the longest sessions (#998).
-  const scan = createSummaryScan();
-  try {
-    await forEachJsonlRecord(file, (record) => scan.add(record));
-  } catch {
-    return EMPTY_SUMMARY;
-  }
-  const parts = scan.finish(LAST_RESPONSE_MAX);
-  const summary: SessionSummary = {
-    lastPrompt: parts.lastPrompt,
-    aiTitle: parts.aiTitle,
-    lastResponse: parts.lastResponse,
-    userTurns: parts.userTurns,
-    usage: parts.usage,
-    context: parts.context,
-    workPhase: classifyWorkPhase(parts.toolNames),
-  };
-  sessionSummaryCache.set(file, stamp, summary);
-  return summary;
 }
 
 // The tool-activity timeline for a session, capped to the most recent events so the

--- a/server/session/summary-scan.ts
+++ b/server/session/summary-scan.ts
@@ -15,19 +15,26 @@
 //   - "the newest X"    → the last X seen, replaced as it arrives
 //   - the current turn  → reset on each user prompt (the rule already works that way)
 //
-// The per-record memory is a handful of strings and one array that empties every turn, so a
-// 585 MB transcript costs the same as a small one.
+// The state holds **no raw records**, which is what lets this fold be paused and RESUMED — kept
+// beside the transcript and continued on what was appended rather than run again from the start
+// (#1377 / #1386). It used to keep every user record, to pick the latest meaningful prompt out of
+// them at the end, and the last assistant record, to read the model and context off it. Both are
+// now resolved as they arrive, by the same functions that resolved them before — and both were
+// unbounded: a transcript here holds 13,664 user records, and one of them can be megabytes.
 //
 // Every rule still lives in its `…FromParsed` function: each is fed a one-record or few-record
 // window rather than reimplemented here.
 import {
   aiTitleFromParsed,
   countUserTurnsFromParsed,
-  createCurrentTurnToolScan,
+  emptyPromptTrail,
+  foldPromptTrail,
+  foldTurnToolNames,
   latestAssistantTextFromParsed,
-  latestMeaningfulUserPromptFromParsed,
   latestTurnContextFromParsed,
+  meaningfulPromptOf,
   sessionUsageFromParsed,
+  type PromptTrail,
 } from "./transcript.js";
 import type { LatestTurnContext, SessionUsage } from "./transcript.js";
 import { isRecord } from "../../common/isRecord.js";
@@ -42,52 +49,80 @@ export interface SummaryParts {
   toolNames: string[];
 }
 
-export function createSummaryScan() {
-  const usage: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
-  let userTurns = 0;
-  let aiTitle: string | null = null;
-  const toolScan = createCurrentTurnToolScan();
-  // The records the prompt rule reads: `user` lines, and the `last-prompt` record it falls back to
-  // when a transcript has none (a hook writes that one). Keeping user records alone dropped the
-  // fallback and reported null — Codex caught it. Still far fewer than the transcript.
-  const promptRecords: Record<string, unknown>[] = [];
-  // Whatever produced these most recently, so a long run of tool calls afterwards cannot bury them.
-  let lastAssistantText: string | null = null;
-  // The last assistant MESSAGE, not the last context that named a model: the rule reads model and
-  // tokens off the same final turn as a unit, so a turn naming no model reports null rather than
-  // an earlier turn's model (Codex).
-  let lastAssistantRecord: Record<string, unknown> | null = null;
+/** Everything the summary needs to remember, and nothing that cannot be written down. */
+export interface SummaryState {
+  usage: SessionUsage;
+  userTurns: number;
+  aiTitle: string | null;
+  prompts: PromptTrail;
+  /** Whatever produced text most recently, so a long run of tool calls afterwards cannot bury it. */
+  lastAssistantText: string | null;
+  /** Model and context tokens off the last assistant MESSAGE, read as a unit — so a turn naming no
+   *  model reports null rather than an earlier turn's model (Codex). */
+  context: LatestTurnContext;
+  /** Tool names in the current turn, emptied by each new user prompt. */
+  turnTools: string[];
+}
 
+export const emptySummaryState = (): SummaryState => ({
+  usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  userTurns: 0,
+  aiTitle: null,
+  prompts: emptyPromptTrail(),
+  lastAssistantText: null,
+  context: { model: null, contextTokens: 0 },
+  turnTools: [],
+});
+
+/** Every part of it, including the ones holding a collection: a resumed fold pushes into
+ *  `turnTools` and adds into `usage`, and the state it continues from has already been read. */
+export const copySummaryState = (state: SummaryState): SummaryState => ({
+  usage: { ...state.usage },
+  userTurns: state.userTurns,
+  aiTitle: state.aiTitle,
+  prompts: { ...state.prompts },
+  lastAssistantText: state.lastAssistantText,
+  context: { ...state.context },
+  turnTools: [...state.turnTools],
+});
+
+export function foldSummary(into: SummaryState, record: Record<string, unknown>): void {
+  // One-record windows: each rule still decides for itself what counts, so "what is a user
+  // turn" or "which usage fields exist" lives in one place, not two.
+  const one = [record];
+  into.userTurns += countUserTurnsFromParsed(one);
+  const perRecord = sessionUsageFromParsed(one);
+  into.usage.inputTokens += perRecord.inputTokens;
+  into.usage.outputTokens += perRecord.outputTokens;
+  into.usage.cacheReadTokens += perRecord.cacheReadTokens;
+  into.usage.cacheCreationTokens += perRecord.cacheCreationTokens;
+  into.aiTitle = aiTitleFromParsed(one) ?? into.aiTitle;
+  foldTurnToolNames(into.turnTools, record);
+  foldPromptTrail(into.prompts, record);
+  // `?? previous` rather than an unconditional assign: an assistant record carrying only a
+  // tool_use has no text, and must not blank out the reply the user is looking at.
+  into.lastAssistantText = latestAssistantTextFromParsed(one) ?? into.lastAssistantText;
+  // Resolved as it arrives rather than by keeping the record: the same one-record window, and its
+  // ANSWER is two small fields where the record it came from can be megabytes.
+  if (record.type === "assistant" && isRecord(record.message)) into.context = latestTurnContextFromParsed(one);
+}
+
+export const summaryPartsOf = (state: SummaryState, responseMax: number): SummaryParts => ({
+  lastPrompt: meaningfulPromptOf(state.prompts),
+  aiTitle: state.aiTitle,
+  lastResponse: state.lastAssistantText?.slice(0, responseMax) ?? null,
+  userTurns: state.userTurns,
+  usage: state.usage,
+  context: state.context,
+  toolNames: state.turnTools,
+});
+
+export function createSummaryScan() {
+  const state = emptySummaryState();
   return {
     add(record: Record<string, unknown>) {
-      // One-record windows: each rule still decides for itself what counts, so "what is a user
-      // turn" or "which usage fields exist" lives in one place, not two.
-      const one = [record];
-      userTurns += countUserTurnsFromParsed(one);
-      const perRecord = sessionUsageFromParsed(one);
-      usage.inputTokens += perRecord.inputTokens;
-      usage.outputTokens += perRecord.outputTokens;
-      usage.cacheReadTokens += perRecord.cacheReadTokens;
-      usage.cacheCreationTokens += perRecord.cacheCreationTokens;
-      aiTitle = aiTitleFromParsed(one) ?? aiTitle;
-      toolScan.add(record);
-      if (record.type === "user" || record.type === "last-prompt") promptRecords.push(record);
-      // `?? previous` rather than an unconditional assign: an assistant record carrying only a
-      // tool_use has no text, and must not blank out the reply the user is looking at.
-      lastAssistantText = latestAssistantTextFromParsed(one) ?? lastAssistantText;
-      if (record.type === "assistant" && isRecord(record.message)) lastAssistantRecord = record;
+      foldSummary(state, record);
     },
-
-    finish(responseMax: number): SummaryParts {
-      return {
-        lastPrompt: latestMeaningfulUserPromptFromParsed(promptRecords),
-        aiTitle,
-        lastResponse: lastAssistantText?.slice(0, responseMax) ?? null,
-        userTurns,
-        usage,
-        context: latestTurnContextFromParsed(lastAssistantRecord ? [lastAssistantRecord] : []),
-        toolNames: toolScan.names(),
-      };
-    },
+    finish: (responseMax: number): SummaryParts => summaryPartsOf(state, responseMax),
   };
 }

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -40,26 +40,43 @@ export function parseJsonl(raw: string): Record<string, unknown>[] {
 // several of them (readSessionSummary) parses the .jsonl ONCE. The `*FromJsonl` wrappers
 // (parse-then-derive) stay for one-off callers and existing tests.
 
-// Ordered user-typed prompts in a transcript + the "last-prompt" fallback record.
-function collectPrompts(records: Record<string, unknown>[]): { prompts: string[]; lastPromptRecord: string | null } {
-  const prompts: string[] = [];
-  let lastPromptRecord: string | null = null;
-  for (const o of records) {
-    if (o.type === "user") {
-      const prompt = userPromptText(isRecord(o.message) ? o.message.content : undefined);
-      if (prompt) prompts.push(prompt);
-    } else if (o.type === "last-prompt" && o.lastPrompt) {
-      lastPromptRecord = readString(o.lastPrompt);
-    }
-  }
-  return { prompts, lastPromptRecord };
+// What the two "latest prompt" rules actually need to remember. Both are a choice between the same
+// three things, and each is a LAST — which is why a streaming caller can keep three strings instead
+// of every user record it has ever seen (#1377). The rule itself stays in one place: the array
+// helpers below fold the same function over the same records.
+export interface PromptTrail {
+  /** The last prompt that was not a trivial ack. */
+  meaningful: string | null;
+  /** The last prompt of any kind, trivial or not. */
+  latest: string | null;
+  /** The `last-prompt` record a hook writes, for a transcript with no user lines at all. */
+  record: string | null;
 }
+
+export const emptyPromptTrail = (): PromptTrail => ({ meaningful: null, latest: null, record: null });
+
+export function foldPromptTrail(into: PromptTrail, o: Record<string, unknown>): void {
+  if (o.type === "user") {
+    const prompt = userPromptText(isRecord(o.message) ? o.message.content : undefined);
+    if (!prompt) return;
+    into.latest = prompt;
+    if (!isTrivialPrompt(prompt)) into.meaningful = prompt;
+  } else if (o.type === "last-prompt" && o.lastPrompt) {
+    into.record = readString(o.lastPrompt);
+  }
+}
+
+const promptTrailOf = (records: Record<string, unknown>[]): PromptTrail => {
+  const trail = emptyPromptTrail();
+  for (const o of records) foldPromptTrail(trail, o);
+  return trail;
+};
 
 // The most recent user-typed prompt in a transcript: the last "user" line with real
 // text, falling back to a "last-prompt" record if there are no user lines.
 export function latestUserPromptFromParsed(records: Record<string, unknown>[]): string | null {
-  const { prompts, lastPromptRecord } = collectPrompts(records);
-  return prompts[prompts.length - 1] ?? lastPromptRecord;
+  const trail = promptTrailOf(records);
+  return trail.latest ?? trail.record;
 }
 export const latestUserPromptFromJsonl = (raw: string): string | null => latestUserPromptFromParsed(parseJsonl(raw));
 
@@ -232,13 +249,12 @@ export function preferredHeaderPrompt(current: string | null, incoming: string):
 // one-word follow-up. Falls back to the latest prompt (then the record) if every
 // prompt is trivial.
 export function latestMeaningfulUserPromptFromParsed(records: Record<string, unknown>[]): string | null {
-  const { prompts, lastPromptRecord } = collectPrompts(records);
-  for (let i = prompts.length - 1; i >= 0; i--) {
-    const prompt = prompts[i];
-    if (prompt !== undefined && !isTrivialPrompt(prompt)) return prompt;
-  }
-  return prompts[prompts.length - 1] ?? lastPromptRecord;
+  return meaningfulPromptOf(promptTrailOf(records));
 }
+
+/** The rule itself: the last substantial prompt, else the last prompt at all, else the record a
+ *  hook left. One function, so a streaming caller and an array caller cannot answer differently. */
+export const meaningfulPromptOf = (trail: PromptTrail): string | null => trail.meaningful ?? trail.latest ?? trail.record;
 export const latestMeaningfulUserPromptFromJsonl = (raw: string): string | null => latestMeaningfulUserPromptFromParsed(parseJsonl(raw));
 
 // Cumulative token usage for a session — summed across every assistant turn's
@@ -357,19 +373,21 @@ export function currentTurnToolNamesFromParsed(records: Record<string, unknown>[
  *  them with a window. That matters: measured across the eight largest transcripts here, the
  *  longest single turn spans 3,615 records, so ANY fixed window would drop a turn's early edits and
  *  report `planning` for a turn that has already been implementing. */
+export function foldTurnToolNames(names: string[], o: Record<string, unknown>): void {
+  if (o.type === "user" && userPromptText(isRecord(o.message) ? o.message.content : undefined) !== null) {
+    names.length = 0; // a fresh user prompt starts a new turn
+    return;
+  }
+  if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) return;
+  for (const block of o.message.content) {
+    if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") names.push(block.name);
+  }
+}
+
 export function createCurrentTurnToolScan() {
-  let names: string[] = [];
+  const names: string[] = [];
   return {
-    add(o: Record<string, unknown>) {
-      if (o.type === "user" && userPromptText(isRecord(o.message) ? o.message.content : undefined) !== null) {
-        names = []; // a fresh user prompt starts a new turn
-        return;
-      }
-      if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) return;
-      for (const block of o.message.content) {
-        if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") names.push(block.name);
-      }
-    },
+    add: (o: Record<string, unknown>) => foldTurnToolNames(names, o),
     names: (): string[] => names,
   };
 }

--- a/test/server/session/session-summary-fold.spec.ts
+++ b/test/server/session/session-summary-fold.spec.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// `/api/session/:id` is hit by every grid cell as its turn finishes, and a memo keyed on
+// (mtime, size) could only skip an UNCHANGED transcript — which the session being written to never
+// is. An active 508 MB session therefore paid a full 10.5 s read per turn (#1386). These pin what
+// changed: the summary is folded once and continued, and a big one is kept beside the file.
+
+// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
+// next spec's idea of ~/.claude without it asking.
+const realHome = process.env.HOME;
+let home = "";
+let n = 0;
+
+const CWD = "/Users/me/proj";
+
+async function freshSummary() {
+  vi.resetModules();
+  process.env.HOME = home;
+  const mod = await import("../../../server/session/session-reads.js");
+  return mod.readSessionSummary;
+}
+
+const line = (o: unknown) => `${JSON.stringify(o)}\n`;
+const user = (text: string) => line({ type: "user", message: { role: "user", content: [{ type: "text", text }] } });
+const assistant = (text: string, over: Record<string, unknown> = {}) =>
+  line({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      model: "claude-opus-5",
+      content: [{ type: "text", text }],
+      usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 2, cache_creation_input_tokens: 1 },
+      ...over,
+    },
+  });
+const toolUse = (name: string) =>
+  line({ type: "assistant", message: { role: "assistant", model: "claude-opus-5", content: [{ type: "tool_use", name, input: {} }] } });
+const filler = (bytes: number) => line({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "x".repeat(bytes) }] } });
+
+const OVER_THRESHOLD_BYTES = 11 * 1024 * 1024;
+
+function transcriptPath(id: string): string {
+  const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${id}.jsonl`);
+}
+
+function writeTranscript(body: string): string {
+  const id = `sess-${++n}`;
+  writeFileSync(transcriptPath(id), body);
+  return id;
+}
+
+const settled = async () => {
+  for (let i = 0; i < 60; i++) await new Promise((r) => setTimeout(r, 5));
+};
+
+const summarySidecars = (): string[] => {
+  const root = path.join(home, ".mulmoterminal", "transcript-index", "summary");
+  return existsSync(root)
+    ? readdirSync(root, { recursive: true })
+        .map(String)
+        .filter((e) => e.endsWith(".json"))
+    : [];
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-summary-"));
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("readSessionSummary", () => {
+  it("reports the prompt, reply, turns, usage and phase of a session", async () => {
+    const readSessionSummary = await freshSummary();
+    const id = writeTranscript(user("build the parser") + toolUse("Edit") + assistant("done"));
+    const summary = await readSessionSummary(CWD, id);
+    expect(summary.lastPrompt).toBe("build the parser");
+    expect(summary.lastResponse).toBe("done");
+    expect(summary.userTurns).toBe(1);
+    expect(summary.usage.outputTokens).toBe(5);
+    expect(summary.context.model).toBe("claude-opus-5");
+    expect(summary.workPhase).not.toBeNull();
+  });
+
+  // The case the old memo could not help with: the file changed, so it re-read all of it. Now the
+  // append is all that is folded — and the answer has to be the one a full read would give.
+  it("continues the fold across a turn, landing where one pass would", async () => {
+    const readSessionSummary = await freshSummary();
+    const id = writeTranscript(user("build the parser") + assistant("first reply"));
+    await readSessionSummary(CWD, id);
+
+    appendFileSync(transcriptPath(id), user("now the tests") + toolUse("Bash") + assistant("second reply"));
+    const resumed = await readSessionSummary(CWD, id);
+
+    const oneShot = await (await freshSummary())(CWD, id);
+    expect(resumed).toEqual(oneShot);
+    expect(resumed.lastPrompt).toBe("now the tests");
+    expect(resumed.lastResponse).toBe("second reply");
+    expect(resumed.userTurns).toBe(2);
+  });
+
+  // Proven by changing the bytes under a held (size, mtime): an answer that still matches the
+  // ORIGINAL cannot have re-read the transcript.
+  it("does not read an unchanged transcript twice", async () => {
+    const readSessionSummary = await freshSummary();
+    const id = writeTranscript(user("build the parser") + assistant("first reply"));
+    const file = transcriptPath(id);
+    const frozen = new Date(1_700_000_000_000);
+    utimesSync(file, frozen, frozen);
+    expect((await readSessionSummary(CWD, id)).lastResponse).toBe("first reply");
+
+    const before = statSync(file);
+    writeFileSync(file, user("build the parser") + assistant("SECOND repl")); // same length
+    utimesSync(file, frozen, frozen);
+    expect(statSync(file)).toMatchObject({ size: before.size, mtimeMs: before.mtimeMs });
+
+    expect((await readSessionSummary(CWD, id)).lastResponse).toBe("first reply");
+  });
+
+  // A big session is where the 10.5 s went, so that is the one worth keeping on disk — and a second
+  // process (a restart, the next mulmoterminal) has to be able to continue from it.
+  it("keeps a big session's summary beside it, and resumes from that in a fresh process", async () => {
+    const readSessionSummary = await freshSummary();
+    const id = writeTranscript(user("build the parser") + filler(OVER_THRESHOLD_BYTES) + assistant("first reply"));
+    expect((await readSessionSummary(CWD, id)).lastResponse).toBe("first reply");
+    await settled();
+    expect(summarySidecars()).toHaveLength(1);
+
+    appendFileSync(transcriptPath(id), user("now the tests") + assistant("second reply"));
+    const inAnotherProcess = await (await freshSummary())(CWD, id);
+    expect(inAnotherProcess.lastPrompt).toBe("now the tests");
+    expect(inAnotherProcess.lastResponse).toBe("second reply");
+    expect(inAnotherProcess.userTurns).toBe(2);
+  });
+
+  it("is empty for a transcript that is not there", async () => {
+    const readSessionSummary = await freshSummary();
+    const summary = await readSessionSummary(CWD, "never-existed");
+    expect(summary.lastPrompt).toBeNull();
+    expect(summary.userTurns).toBe(0);
+  });
+});

--- a/test/server/session/summary-scan.spec.ts
+++ b/test/server/session/summary-scan.spec.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { createSummaryScan } from "../../../server/session/summary-scan.js";
+import {
+  copySummaryState,
+  createSummaryScan,
+  emptySummaryState,
+  foldSummary,
+  summaryPartsOf,
+  type SummaryState,
+} from "../../../server/session/summary-scan.js";
 import {
   aiTitleFromParsed,
   countUserTurnsFromParsed,
@@ -139,3 +146,74 @@ describe("createSummaryScan agrees with the whole-array fold", () => {
     expect(scanned([user("q"), assistant(long)]).lastResponse).toHaveLength(RESPONSE_MAX);
   });
 });
+
+// The state holds no raw records, which is what lets the fold be PAUSED and continued — beside the
+// transcript, and across processes (#1386). What has to hold is that continuing it lands where one
+// uninterrupted pass would, including for the fields that are "the last X" and the one that resets
+// on every user prompt.
+describe("a summary folded in two goes", () => {
+  const foldAll = (records: Record<string, unknown>[]): SummaryState => {
+    const state = emptySummaryState();
+    records.forEach((r) => foldSummary(state, r));
+    return state;
+  };
+
+  const resumeFrom = (state: SummaryState, records: Record<string, unknown>[]): SummaryState => {
+    const next = copySummaryState(state);
+    records.forEach((r) => foldSummary(next, r));
+    return next;
+  };
+
+  const transcript = [
+    user("build the parser"),
+    assistant("on it", { content: [{ type: "tool_use", name: "Read" }] }),
+    assistant("here you go"),
+    user("ok"),
+    assistant("anything else?", { content: [{ type: "tool_use", name: "Edit" }] }),
+  ];
+
+  it("equals one uninterrupted pass, wherever it is cut", () => {
+    const whole = summaryPartsOf(foldAll(transcript), RESPONSE_MAX);
+    for (let cut = 0; cut <= transcript.length; cut++) {
+      const resumed = summaryPartsOf(resumeFrom(foldAll(transcript.slice(0, cut)), transcript.slice(cut)), RESPONSE_MAX);
+      expect(resumed, `cut after ${cut} records`).toEqual(whole);
+    }
+  });
+
+  // The reason `copy` exists: the resumed fold pushes into turnTools and adds into usage, and the
+  // state it continued from has already been read by a caller.
+  it("leaves the state it continued from untouched", () => {
+    const first = foldAll(transcript.slice(0, 3));
+    const before = summaryPartsOf(first, RESPONSE_MAX);
+    const beforeTools = [...before.toolNames];
+    const beforeUsage = { ...before.usage };
+
+    resumeFrom(first, transcript.slice(3));
+
+    expect(summaryPartsOf(first, RESPONSE_MAX).toolNames).toEqual(beforeTools);
+    expect(summaryPartsOf(first, RESPONSE_MAX).usage).toEqual(beforeUsage);
+  });
+
+  // A resumed fold has to survive the round trip through a sidecar, which is JSON.
+  it("survives being written down and read back", () => {
+    const half = foldAll(transcript.slice(0, 3));
+    const parsed: unknown = JSON.parse(JSON.stringify(half));
+    if (!isSummaryStateShape(parsed)) throw new Error("a folded summary should round-trip through JSON");
+    expect(summaryPartsOf(resumeFrom(parsed, transcript.slice(3)), RESPONSE_MAX)).toEqual(summaryPartsOf(foldAll(transcript), RESPONSE_MAX));
+  });
+});
+
+// The same shape check readSessionSummary applies to a sidecar, kept here so the round-trip test
+// above fails loudly rather than casting its way past a state JSON could not carry.
+function isSummaryStateShape(value: unknown): value is SummaryState {
+  if (typeof value !== "object" || value === null) return false;
+  const state: Partial<SummaryState> = value;
+  return (
+    typeof state.userTurns === "number" &&
+    typeof state.usage?.inputTokens === "number" &&
+    Array.isArray(state.turnTools) &&
+    typeof state.prompts === "object" &&
+    state.prompts !== null &&
+    typeof state.context?.contextTokens === "number"
+  );
+}


### PR DESCRIPTION
## Summary

#1377 の最後の 1 か所。**`/api/session/:id` は各グリッドセルがターン終了ごとに叩く**のに、`readSessionSummary` のキャッシュは (mtime, size) キーで「**変わっていないファイル**」しかスキップできなかった。書き込み中のセッションは決してそれに当たらないので、**いま作業しているセッション**（＝一番大きくなりがちなもの）が**ターンごとに全読み**していた。508 MB の transcript で 2.15 秒、その間イベントループは止まり、アプリ内の全ターミナルが固まる。

### 実測（実データ 508 MB の transcript。コピーに対して実行、実物は無傷）

| | before | after |
|---|---:|---:|
| 初回 | 2,176 ms | 2,162 ms |
| 未変更 | 0 ms | 1 ms |
| **1 ターン追記された後** | **2,154 ms** | **3 ms** |
| さらに 1 ターン後 | 2,158 ms | 0 ms |

初回が変わらないのは仕様です（合計と件数は全ターンを見ないと出ない）。変わったのは**実際に毎ターン踏む行**です。

## なぜ今まで共通経路に載せられなかったか

この畳み込みだけ**状態に生レコードを溜めていた**ため:

- **すべての `user` レコード**（このマシンの transcript で 13,664 件）— 最後に「最も意味のあるプロンプト」を選び出すため
- **最後の `assistant` レコード** — model と context を「同じターンの組」として読むため

どちらも sidecar に書けないし、リクエストをまたいでメモリに抱えるのも重い。

## 解き方: 答えを別の場所で再導出せず、**規則そのものを移した**

`latestMeaningfulUserPromptFromParsed` は「最後の非自明プロンプト → 最後のプロンプト → `last-prompt` レコード」の選択で、**どれも「最後の X」**。つまり必要なのは全レコードではなく**文字列 3 つ**です。

```
PromptTrail { meaningful, latest, record }   // transcript.ts
foldPromptTrail(trail, record)               // 規則は 1 つ
meaningfulPromptOf(trail)                    // 選択も 1 つ
```

配列版のヘルパー（`latestMeaningfulUserPromptFromParsed` / `latestUserPromptFromParsed`）も**同じ関数を畳む**形に書き換えたので、実装は 1 つだけ。ストリーミング側と配列側が別々の答えを出しようがありません。**既存の `transcript.spec.ts` 54 本がそのまま通る**ことが、規則が変わっていない証拠です。

context（model + context tokens）も、これまで最後にレコードへ適用していた `latestTurnContextFromParsed` の 1 レコード窓を、そのまま到着時に適用する形にしました（無条件置換 = 「最後のレコードを覚える」と同義。model を名乗らないターンは、前のターンの model ではなく null のまま）。

## Items to Confirm / Review

- **規則の移動が本当に等価か**。ここが唯一の risk です。根拠は ①既存 54 本が無修正で通る ②`summary-scan.spec.ts` は元々**元の関数と突き合わせて**検証している ③新規で「**どの位置で切っても**一気読みと一致」を全カット位置について確認（ループ）。
- **`createCurrentTurnToolScan` → `foldTurnToolNames`**。リセットが `names = []`（再代入）から `names.length = 0`（破壊的）に変わりました。`names()` が返す参照が同じままになりますが、呼び出し側は最後に一度読むだけなので挙動は同じです。
- **state が JSON になった**ので summary も sidecar に載ります（10 MB 超のセッションのみ）。round-trip テストあり。
- **`lastAssistantText` は全文のまま**（400 字への切り詰めは組み立て時）。sidecar には数 KB 載りますが、fold 時に切ると state が特定の呼び出し側の `responseMax` に縛られるので、そのトレードは取っていません。plan に明記。

## User Prompt

> はい、残りもやって。

（#1377 に残っていた `readSessionSummary` の増分化。#1379 → #1387 → #1390 → #1392 の続き）

## テスト

- `summary-scan.spec.ts`（+3 本、計 19）— **全カット位置で一気読みと一致** / 再開元の state を壊さない / **JSON を往復しても同じ**（＝sidecar に載る形か）
- `session-summary-fold.spec.ts`（新規 5 本）— `readSessionSummary` 経由で: ターンをまたいだ再開が一気読みと一致 / 未変更なら読み直さない（stamp を保ったままバイトを差し替えて証明）/ **大きいセッションは sidecar に書かれ、別プロセスがそこから続きを畳む** / 無いファイルは空
- `transcript.spec.ts` — **無修正で 54 本通過**

`yarn lint`（0 errors）/ `typecheck` / `knip`（新規の未使用 export なし）/ `test`（7977 passed）green。

**flaky について**: フルスイートを 3 回回したうち 1 回、無関係な `pr-phase-route.spec.ts` が落ちました。単体では 5 回連続で通り、以前確認したとおり **main でも起きる並列負荷由来の既存 flakiness** です（毎回違うスペックが落ちる）。この変更とは無関係。

これで #1377 に挙がっていた 4 か所すべてが完了します。

refs #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved session summary generation for large transcripts by processing only newly added content.
  * Added resumable persistence to support faster recovery and repeated access.

* **Bug Fixes**
  * Session summaries now gracefully handle missing or unreadable transcripts.
  * Preserved accurate prompts, responses, usage, models, phases, turns, and tool details.

* **Tests**
  * Added coverage for incremental updates, persistence, recovery, serialization, and empty sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->