### PR TITLE
feat(grid): give each cell its own right pane

### DIFF
--- a/plans/feat-1378-per-cell-right-pane.md
+++ b/plans/feat-1378-per-cell-right-pane.md
@@ -1,0 +1,81 @@
+# feat(grid): 右ペインの開閉をセルごとに持つ (#1378)
+
+## 何を変えるか
+
+グリッドの右ペインについて、**「開いているか」と「何が開いているか」をセルごとに持つ**。
+セルを切り替えると、そのセルの状態に切り替わる。
+
+いまグリッド全体で 1 値なのは、この 2 つだけ（`TerminalGrid.vue:155,186`）。
+「何を映すか」は既にセル単位になっている:
+
+| 何 | 今の紐づけ | この変更後 |
+| --- | --- | --- |
+| 開いているか / どのペインか | **グリッドで 1 値**（localStorage `files_pane_open`） | **セルごと** |
+| files が開いていたファイル・展開ツリー | セル(uid) ごと + cwd ごと（#958） | 変更なし |
+| files の編集バッファ | 保持しない（出る前にディスク保存、無理なら backup） | 変更なし |
+| canvas の中身 | セッションごと・サーバ（`/api/agent/toolResults/:id`） | 変更なし |
+| 幅 / 全画面 | グリッドで 1 値 / 記憶しない | 変更なし |
+
+## 決めたこと
+
+| 論点 | 決定 |
+| --- | --- |
+| まだ開いたことのないセル | **閉じた状態で始める**。自分で開いたセルだけが開く |
+| リロード後 | **sessionId をキーに localStorage から復元**（uid はリロードで変わるため） |
+| 幅 `paneWidth` / 全画面 `paneExpanded` | **共有のまま**（`paneExpanded` は「記憶しない」が既存の設計判断） |
+| セル移動時に files の保存が失敗したら | **既存の「ペインがズームに追従せず前のセルに留まる」挙動をそのまま使う**。新しい概念を足さない |
+
+## 踏んではいけない罠
+
+**ズームを閉じてもペインは unmount していない。** `zoom-row` は `hidden` になるだけ
+（`TerminalGrid.vue:983`）で、FilesPane は mount されたまま — だからいまはズームを閉じて開き直しても
+編集中のバッファごと残る。
+
+ここで「表示するペイン = `props.expandedUid` のセルの状態」と素直に書くと、**ズームを閉じた瞬間に
+uid が null → ペインが閉じる → FilesPane が unmount → 毎回 flush** になり、今より悪くなる。
+
+逃げ道は既にある。**`paneUid`（`:532`）が「ペインが今どのセルに乗っているか」**という意味の ref で、
+ズームに追従しつつ、ズームを閉じている間は最後のセルに留まる。これを files 専用から
+**ペイン全体の identity に一般化**する。新しい ref を増やさない。
+
+## 実装
+
+### `TerminalGrid.vue`（実質このファイルだけ。`rightPane` の参照は 24 箇所、代入は 1 箇所）
+
+1. `rightPane` を ref から **computed** にする。実体はセル別 Map:
+
+   ```ts
+   const paneByCell = ref(new Map<number, RightPane>()); // 不在 = 閉じている
+   const rightPane = computed(() => (paneUid.value === null ? null : (paneByCell.value.get(paneUid.value) ?? null)));
+   ```
+
+2. `setRightPane(pane, uid)` が Map を書く。`openCanvasFor` は uid を明示して呼ぶ
+   （`emit("toggle-expand")` の直後は `props.expandedUid` がまだ更新されていない）。
+
+3. `paneUid` を一般化する:
+   - 「files を離れるとき null にする」（`:240`）を **やめる** — ペインの identity になったので消さない。
+     `paneCwd` / `paneState` のリセットは今のまま
+   - 再ルート watcher（`:538`）を **files が開いているときだけ動く**から **どのペインでも動く**へ。
+     files 固有の処理（flush / snapshot / reload）は、files が絡むときだけ実行する
+
+4. リロード復元: `localStorage` に `Map<sessionId, RightPane>` を持つ。セルが初めて表示されたとき、
+   メモリに無ければ sessionId で引く。files の cwd 別レイヤ（#958）と同じ発想。
+   旧キー `files_pane_open` は**捨てる**（新規セルは閉じ、が決定なので移行先が無い）。
+
+5. `gridCellProps` の `rightPane` / `filesOpen` を**そのセルの値**にする。
+   各セルのヘッダのボタンが、自分の状態を示すようになる。
+
+### テスト
+
+- ズーム A→B でペイン種別が入れ替わる / A に戻ると A の状態
+- **ズームを閉じて開き直してもペインが閉じない**（罠の回帰テスト。FilesPane が unmount しないこと）
+- 初めてのセルは閉じている
+- リロード相当（新しい uid + 同じ sessionId）で復元される
+- files が dirty で flush 失敗のとき、ペインが前のセルに留まる
+- 既存の canvas 自動オープン（ズーム中セルのみ）が壊れていないこと
+
+## 関連
+
+- #1237 — 単セルでズームが拒否され Canvas に到達できない（`openCanvasFor` を共有）
+- #1374 / #1388 — present 系をエージェント抜きで開く
+- #958 / #910 — files ペインの per-cell / 復元の前例

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -42,6 +42,7 @@ import { isDrawnResult } from "../utils/drawnResult";
 import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
+import { isRecord } from "../../common/isRecord";
 import type { TerminalAgent } from "../../common/sessionAgent";
 import { buildCanvasCard, seedCanvasCard, hasStoredCard, absoluteUnder } from "../composables/canvasOpenFile";
 import { jsonBody } from "../jsonBody";
@@ -150,9 +151,14 @@ onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
 
 // The file pane beside the enlarged cell. ONE pane, not one per cell: it re-roots to whichever
-// cell is enlarged, so walking the zoom doesn't accumulate editors. Open-state and width are
-// per-browser (localStorage), like the single view's splitter and the terminal font size.
-const PANE_OPEN_KEY = "files_pane_open";
+// cell is enlarged, so walking the zoom doesn't accumulate editors. WHICH pane a cell has open is
+// that cell's own (#1378, see paneByCell); the width is per-browser (localStorage), like the
+// single view's splitter and the terminal font size.
+//
+// Keyed by SESSION rather than by uid, which is the number the map below uses: a uid is not the
+// same number after a reload, and a session is what a cell still is (#958 does the same for the
+// files pane's contents, keyed by directory).
+const PANE_OPEN_KEY = "pane_open_by_session";
 const PANE_WIDTH_KEY = "files_pane_width";
 // What each directory had open, so a reload lands back on the file rather than the tree root (#958).
 const PANE_STATE_KEY = "files_pane_state";
@@ -176,15 +182,68 @@ const remember = (key: string, value: string): void => {
 //   files  — the file tree/editor (the original occupant).
 //   canvas — what the agent DREW: the GUI plugin views for this cell's session.
 //   tools  — which GUI tools this session actually has, read-only.
-const isRightPane = (value: string | null): value is RightPane => value === "files" || value === "canvas" || value === "tools";
-// The key used to hold a boolean, where "1" meant the files pane was open — so an existing
-// browser is migrated rather than silently starting closed.
-function restoredPane(value: string | null): RightPane | null {
-  if (isRightPane(value)) return value;
-  return value === "1" ? "files" : null;
+const isRightPane = (value: unknown): value is RightPane => value === "files" || value === "canvas" || value === "tools";
+
+// Which cell the pane is on — the identity everything else hangs off. The UID rather than the
+// directory: two terminals in the same repository is the ordinary case here, and keying on the
+// directory would leave the pane bound to the cell it started on while the zoom moved to its
+// neighbour. It TRAILS the enlarged cell rather than mirroring it: with nothing enlarged the row
+// is merely hidden (see the template) and the pane keeps the cell it was on, and it also stays
+// behind when a re-root could not be saved out of — so a snapshot is filed under the cell the
+// pane is on rather than the one it failed to reach.
+const paneUid = ref<number | null>(null);
+
+// Which pane each cell has open (#1378). ABSENT means never asked, which is where a cell starts
+// and what lets a reload restore one; an explicit `null` is a cell whose pane the user closed,
+// which has to stay closed. The pane itself is still ONE, because one cell is enlarged at a time
+// — what is per-cell is whether there is one and which.
+const paneByCell = ref(new Map<number, RightPane | null>());
+// The same, by session, so a reload lands each cell back on its own pane rather than on one value
+// for the whole grid. Written on every change, read once per cell.
+const paneBySession = new Map<string, RightPane>(readPaneBySession(stored(PANE_OPEN_KEY)));
+function readPaneBySession(raw: string | null): [string, RightPane][] {
+  try {
+    const parsed: unknown = raw === null ? null : JSON.parse(raw);
+    if (!isRecord(parsed)) return [];
+    return Object.entries(parsed).filter((entry): entry is [string, RightPane] => isRightPane(entry[1]));
+  } catch {
+    return []; // an older or hand-edited value: start closed rather than throw on mount
+  }
 }
-const rightPane = ref<RightPane | null>(restoredPane(stored(PANE_OPEN_KEY)));
+
+// What the pane is showing. Derived from the cell it is ON rather than from the enlarged one:
+// collapsing the zoom only HIDES the row (see the template), so the pane stays mounted with its
+// editor and buffer intact — reading the enlarged cell here would close it on every collapse.
+const rightPane = computed<RightPane | null>(() => (paneUid.value === null ? null : (paneByCell.value.get(paneUid.value) ?? null)));
 const filesOpen = computed(() => rightPane.value === "files");
+/** What a given cell has open, for its own header buttons. */
+const paneOf = (uid: number): RightPane | null => paneByCell.value.get(uid) ?? null;
+
+const sessionOf = (uid: number): string | null => props.cells.find((cell) => cell.uid === uid)?.session ?? null;
+
+// Sessions kept, newest last. A browser-wide cap for the same reason the files pane's store has
+// one: without it this grows for as long as the user starts terminals, and localStorage answers a
+// quota error by failing the whole write.
+const MAX_REMEMBERED_SESSIONS = 40;
+
+function persistPane(uid: number, pane: RightPane | null): void {
+  const session = sessionOf(uid);
+  if (!session) return; // a launcher or a cell still starting: nothing stable to file it under
+  paneBySession.delete(session); // re-inserted so the cap drops the least recently used
+  if (pane) paneBySession.set(session, pane);
+  const kept = [...paneBySession.entries()].slice(-MAX_REMEMBERED_SESSIONS);
+  remember(PANE_OPEN_KEY, JSON.stringify(Object.fromEntries(kept)));
+}
+
+// A cell shown for the first time takes the pane its SESSION had before the reload. Only when the
+// cell has no answer of its own: a pane the user closed is an answer, which is why the map holds
+// an explicit null rather than dropping the entry.
+function restoreSessionPane(uid: number): void {
+  if (paneByCell.value.has(uid)) return;
+  const session = sessionOf(uid);
+  const pane = session === null ? undefined : paneBySession.get(session);
+  if (pane) paneByCell.value = new Map(paneByCell.value).set(uid, pane);
+}
 // A pane taken full-width: it covers the enlarged terminal, NOT the roster — a document the agent
 // drew is read, and 480px of a split row is not a reading width. Canvas and Tools can ask for it;
 // the files pane is edited beside the terminal and does not.
@@ -220,33 +279,45 @@ const rowWidthNow = ref(0);
 const paneMax = computed(() => Math.max(0, rowWidthNow.value - MIN_TERMINAL));
 const paneMin = computed(() => Math.min(MIN_GUI, paneMax.value));
 
+// The pane's OWN close button, and the terminal-click entrance. Both act on the pane that is on
+// screen, which is `paneUid` — normally the enlarged cell, but not while the pane trails a re-root
+// it could not save out of.
 function setFilesOpen(open: boolean): void {
-  setRightPane(open ? "files" : null);
+  setRightPane(open ? "files" : null, paneUid.value ?? props.expandedUid);
 }
 
 // Switching panes is the same event as closing the files one, because the files pane unmounts
 // either way — so its buffer has to be saved on both paths, not just on close.
-function setRightPane(pane: RightPane | null): void {
-  const leavingFiles = filesOpen.value && pane !== "files";
+//
+// `uid` is which cell is being answered. It defaults to the enlarged one, and is passed
+// explicitly by the path that has just ASKED for an enlargement: the parent owns `expandedUid`,
+// so it is still the previous cell when openCanvasFor reaches here.
+function setRightPane(pane: RightPane | null, uid: number | null): void {
+  if (uid === null) return; // no cell to answer for: nothing is enlarged and the pane is on none
+  const leavingFiles = filesOpen.value && paneUid.value === uid && pane !== "files";
   if (leavingFiles) rememberPaneState(paneUid.value);
-  rightPane.value = pane;
+  // The pane moves to this cell only if it is the one on screen. A button pressed on a TILED cell
+  // records what that cell wants and nothing more: moving the pane there would unmount an editor
+  // that is merely hidden behind the grid, with a buffer nobody asked to close. The zoom watcher
+  // moves it — and flushes — when that cell is actually enlarged.
+  if (uid === props.expandedUid || paneUid.value === null) paneUid.value = uid;
+  paneByCell.value = new Map(paneByCell.value).set(uid, pane);
+  persistPane(uid, pane);
   // Every arrival at a pane is a split row. See paneExpanded: the takeover is asked for, never
   // inherited — including by the same pane reopened later.
   paneExpanded.value = false;
-  // Leaving files drops the cell it was on, so coming back lands on whichever cell is enlarged
-  // THEN rather than resuming a directory the user has since walked away from.
-  if (leavingFiles) {
-    paneCwd.value = null;
-    paneUid.value = null;
-  }
-  remember(PANE_OPEN_KEY, pane ?? "");
+  // Leaving files drops the directory it was on, so coming back re-roots to whichever cell is
+  // enlarged THEN rather than resuming a directory the user has since walked away from.
+  if (leavingFiles) paneCwd.value = null;
 }
 
-// The header toggle. Closing unmounts the pane, buffer and all, so the buffer is saved on the
-// way out — the pane's OWN close button has already flushed by the time it emits, which is why
-// that path stays separate rather than routing through here.
-async function toggleFiles(): Promise<void> {
-  await toggleRightPane("files");
+// A cell's header toggle, for the cell it was pressed on — which is not always the enlarged one:
+// pressed on a tiled cell it says what that terminal should have open when it IS enlarged (#1378).
+// Closing unmounts the pane, buffer and all, so the buffer is saved on the way out — the pane's
+// OWN close button has already flushed by the time it emits, which is why that path stays separate
+// rather than routing through here.
+async function toggleFiles(uid: number | null): Promise<void> {
+  await toggleRightPane("files", uid);
 }
 
 // The unread-canvas chip on a tiled cell: enlarge that cell AND put the pane beside it, in one
@@ -285,7 +356,9 @@ async function openCanvasFor(uid: number, enlarge = true, stillWanted?: () => bo
     if (!enlarge) return;
     emit("toggle-expand", uid);
   }
-  setRightPane("canvas");
+  // Named rather than left to default: the enlargement above is the PARENT's to apply, so
+  // `expandedUid` is still the previous cell when this runs.
+  setRightPane("canvas", uid);
 }
 
 // Show a file the user picked in the Canvas, without the agent having presented it (#1374). The
@@ -317,13 +390,18 @@ async function openFileInCanvas(path: string): Promise<void> {
 // beside them — so this is the seam rather than another prop to watch.
 defineExpose({ openCanvasFor });
 
-// A pane button: opens its pane, or closes it when it is already the one showing.
-async function toggleRightPane(pane: RightPane): Promise<void> {
+// A pane button: opens its pane on that cell, or closes it when it is already the one that cell
+// has. `uid` is the cell whose button was pressed.
+async function toggleRightPane(pane: RightPane, uid: number | null = props.expandedUid): Promise<void> {
+  if (uid === null) return;
   // Leaving files unmounts the buffer with the pane, so a buffer that could be neither saved
   // nor backed up keeps it open — the error is visible in it. Checked whichever pane was asked
   // for: files unmounts when another pane takes the slot exactly as it does when closed.
-  if (filesOpen.value && (await filesPane.value?.flush()) === false) return;
-  setRightPane(rightPane.value === pane ? null : pane);
+  //
+  // Only for the cell the pane is ON: a button pressed on a tiled cell changes that cell's answer
+  // and unmounts nothing, so there is no buffer in play.
+  if (filesOpen.value && paneUid.value === uid && (await filesPane.value?.flush()) === false) return;
+  setRightPane(paneOf(uid) === pane ? null : pane, uid);
 }
 
 // The enlarged cell's project dir — what the pane browses. A cell that hasn't reported one yet
@@ -456,8 +534,10 @@ const gridCellProps = (cell: Cell) => ({
   "data-uid": cell.uid,
   class: cellClass(cell.uid),
   expanded: cell.uid === props.expandedUid,
-  filesOpen: filesOpen.value,
-  rightPane: rightPane.value,
+  // THIS cell's pane, not the one on screen: the header buttons say what this terminal has open,
+  // and after #1378 two cells can disagree.
+  filesOpen: paneOf(cell.uid) === "files",
+  rightPane: paneOf(cell.uid),
   canvasAvailable: canvasOpenable.value,
   zoomed: zoomed.value,
   home: props.home,
@@ -465,10 +545,12 @@ const gridCellProps = (cell: Cell) => ({
 });
 const gridCellEvents = (cell: Cell) => ({
   "toggle-expand": () => emit("toggle-expand", cell.uid),
-  "toggle-files": toggleFiles,
-  "toggle-canvas": () => toggleRightPane("canvas"),
+  // Each carries the cell it was pressed on: a header button answers for ITS terminal, tiled or
+  // enlarged, and after #1378 two cells can want different panes.
+  "toggle-files": () => toggleFiles(cell.uid),
+  "toggle-canvas": () => toggleRightPane("canvas", cell.uid),
   "open-canvas": () => openCanvasFor(cell.uid),
-  "toggle-tools": () => toggleRightPane("tools"),
+  "toggle-tools": () => toggleRightPane("tools", cell.uid),
   close: () => emit("close", cell.uid),
   move: (dir: -1 | 1) => emit("move", cell.uid, dir),
   status: (value: AttentionStatus) => emit("status", cell.uid, value),
@@ -524,37 +606,42 @@ const paneState = ref<FilesPaneState | null>(null);
 // is declined over unsaved edits — and it, not `expandedCwd`, is what the pane is handed, so a
 // file opened from a tree that stayed put still resolves against the directory it came from.
 const paneCwd = ref<string | null>(null);
-// Which cell the pane is showing — the identity everything else hangs off. The UID rather than
-// the directory: two terminals in the same repository is the ordinary case here, and keying on
-// the directory would leave the pane bound to the cell it started on while the zoom moved to
-// its neighbour. It also trails `expandedUid` when a re-root could not be saved out of, so a
-// snapshot is filed under the cell the pane is on rather than the one it failed to reach.
-const paneUid = ref<number | null>(null);
 
-// Walking the zoom to another terminal has to re-root the pane: the pane deliberately ignores
-// its `cwd` prop (see its defineExpose contract), so nothing else would move it. The buffer is
-// saved first rather than asked about — the zoom moves from keys and filmstrip clicks, and a
-// dialog on each of those would interrupt the very flow the pane is meant to sit beside.
+// Walking the zoom to another terminal moves the pane to that cell: which pane it shows is that
+// cell's (paneByCell), and a files pane additionally re-roots — it deliberately ignores its `cwd`
+// prop (see its defineExpose contract), so nothing else would move it. The buffer is saved first
+// rather than asked about — the zoom moves from keys and filmstrip clicks, and a dialog on each of
+// those would interrupt the very flow the pane is meant to sit beside.
+//
+// `zoomed` is a GUARD, not an input: collapsing the zoom only hides the row, and the pane keeps
+// the cell it is on, buffer and all. Reading `expandedUid` here instead would close the pane on
+// every collapse — flushing an editor the user is coming straight back to.
+// `rightPane` is a dependency too, not just an input: reopening a files pane on the cell it was
+// closed on changes nothing else, and without it the pane would mount with no root and no
+// remembered tree.
 watch(
-  [filesOpen, zoomed, () => props.expandedUid, expandedCwd],
-  async ([open, isZoomed, uid]) => {
-    if (!open || !isZoomed) return;
+  [zoomed, () => props.expandedUid, expandedCwd, rightPane],
+  async ([isZoomed, uid]) => {
+    if (!isZoomed || uid === null) return;
+    const sameCell = paneUid.value === uid;
     // Nothing moved: same cell, and it still reports the same directory.
-    if (paneUid.value === uid && paneCwd.value === expandedCwd.value) return;
-    // First showing: the pane is about to mount against this cell, so there is nothing to re-read.
-    if (paneUid.value === null) {
-      paneUid.value = uid;
-      paneCwd.value = expandedCwd.value;
-      paneState.value = claimPaneState(uid, expandedCwd.value);
-      return;
-    }
-    // Re-rooting re-reads the tree and drops the buffer with it. Nothing to fall back on means
-    // staying put: the pane keeps the cell and root it is on, which its header names.
-    if ((await filesPane.value?.flush()) === false) return;
-    rememberPaneState(paneUid.value);
+    if (sameCell && paneCwd.value === expandedCwd.value) return;
+    // A pane with no root yet is about to mount against this cell: it reads the root and its
+    // `initial-state` on its own, and there is no buffer behind it to save.
+    const firstShowing = paneCwd.value === null;
+    // Leaving a files pane unmounts its editor whether the next cell shows another pane or none,
+    // so it is flushed on every path — the same rule as switching panes by hand. Nothing to fall
+    // back on means staying put: the pane keeps the cell and root it is on, which its header names.
+    const wasFiles = filesOpen.value && !firstShowing;
+    if (wasFiles && (await filesPane.value?.flush()) === false) return;
+    if (!sameCell) rememberPaneState(paneUid.value);
     paneUid.value = uid;
+    restoreSessionPane(uid);
     paneCwd.value = expandedCwd.value;
     paneState.value = claimPaneState(uid, expandedCwd.value);
+    // Only when the files pane STAYS the pane. Arriving at one mounts it fresh, which reads the
+    // new root and `initial-state` on its own; leaving one has nothing left to reload.
+    if (!wasFiles || !filesOpen.value) return;
     await nextTick(); // the pane reads its `cwd` prop when reloading, so let the new one land
     filesPane.value?.reload();
   },
@@ -1034,7 +1121,7 @@ watch(
           :expanded="paneFull"
           :style="{ flex: paneFull ? '1 1 0%' : `0 0 ${paneWidth}px` }"
           @toggle-expand="togglePaneExpanded"
-          @close="setRightPane(null)"
+          @close="setRightPane(null, paneUid)"
         />
         <!-- `width: auto` only while full: the pane sets its own w-[340px], and a fixed width
              beside `flex: 1` is the one combination where the class outlives the layout. -->
@@ -1045,7 +1132,7 @@ watch(
           :style="paneFull ? { flex: '1 1 0%', width: 'auto' } : { flex: `0 0 ${paneWidth}px` }"
           class="border-l border-border"
           @toggle-expand="togglePaneExpanded"
-          @close="setRightPane(null)"
+          @close="setRightPane(null, paneUid)"
         />
       </template>
     </div>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -305,7 +305,11 @@ function setRightPane(pane: RightPane | null, uid: number | null): void {
   persistPane(uid, pane);
   // Every arrival at a pane is a split row. See paneExpanded: the takeover is asked for, never
   // inherited — including by the same pane reopened later.
-  paneExpanded.value = false;
+  //
+  // Only when this is the pane on screen: a button pressed on a tiled cell has not changed what
+  // the user is looking at, and collapsing THAT pane out of full width would be a second cell's
+  // button rearranging the one in front of them.
+  if (paneUid.value === uid) paneExpanded.value = false;
   // Leaving files drops the directory it was on, so coming back re-roots to whichever cell is
   // enlarged THEN rather than resuming a directory the user has since walked away from.
   if (leavingFiles) paneCwd.value = null;

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -638,7 +638,10 @@ watch(
     // back on means staying put: the pane keeps the cell and root it is on, which its header names.
     const wasFiles = filesOpen.value && !firstShowing;
     if (wasFiles && (await filesPane.value?.flush()) === false) return;
-    if (!sameCell) rememberPaneState(paneUid.value);
+    // On EVERY re-root, not only a move to another cell: a terminal that changed directory is
+    // leaving that tree behind too, and the snapshot is what the directory layer restores from
+    // when anything comes back to it (Codex review). A pane with no root yet has nothing to file.
+    if (!firstShowing) rememberPaneState(paneUid.value);
     paneUid.value = uid;
     restoreSessionPane(uid);
     paneCwd.value = expandedCwd.value;

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -458,6 +458,13 @@ describe("file pane beside the enlarged cell", () => {
     await w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
     await nextTick();
   };
+  // The same for a cell that is NOT the enlarged one. Since #1378 each cell has its own answer,
+  // so a test that walks the zoom has to say what the cell it walks TO has open — otherwise the
+  // pane closes on arrival, which is the feature rather than a broken fixture.
+  const openPaneOnCell = async (w: ReturnType<typeof mount>, index: number) => {
+    await w.findAllComponents({ name: "TerminalCell" })[index].vm.$emit("toggle-files");
+    await nextTick();
+  };
 
   // The zoom FLIP asks for prefers-reduced-motion, which jsdom omits; these tests move the
   // enlargement, so they trip over it where the older ones never did.
@@ -518,6 +525,7 @@ describe("file pane beside the enlarged cell", () => {
     const cells = [cell(1, "s1", "/one"), cell(2, "s2", "/two")];
     const w = mountCockpit(cells, 1, []);
     await openPane(w);
+    await openPaneOnCell(w, 1); // cell 2 wants one too, or arriving there would close it
     expect(w.findAllComponents({ name: "FilesPane" })).toHaveLength(1);
     expect(paneOf(w).props("cwd")).toBe("/one");
     expect(paneStub.reload).not.toHaveBeenCalled(); // it mounted on /one; nothing to re-read
@@ -535,6 +543,7 @@ describe("file pane beside the enlarged cell", () => {
   it("saves the buffer before re-rooting, without asking", async () => {
     const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
     await openPane(w);
+    await openPaneOnCell(w, 1);
     const confirmSpy = vi.spyOn(window, "confirm");
 
     await w.setProps({ expandedUid: 2 });
@@ -602,6 +611,7 @@ describe("file pane beside the enlarged cell", () => {
     const cells = [cell(1, "s1", "/one"), cell(2, "s2", "/two")];
     const w = mountCockpit(cells, 1, []);
     await openPane(w);
+    await openPaneOnCell(w, 1);
     expect(paneOf(w).props("initialState")).toBeNull(); // never visited
 
     paneStub.snapshot.mockReturnValueOnce({ openPath: "notes.md", expanded: ["docs"] });
@@ -620,6 +630,7 @@ describe("file pane beside the enlarged cell", () => {
   it("re-roots and re-binds between two cells sharing a directory", async () => {
     const w = mountCockpit([cell(1, "s1", "/same"), cell(2, "s2", "/same")], 1, []);
     await openPane(w);
+    await openPaneOnCell(w, 1);
     paneStub.snapshot.mockReturnValue({ openPath: "from-one.md", expanded: [] });
 
     await w.setProps({ expandedUid: 2 });
@@ -656,6 +667,7 @@ describe("file pane beside the enlarged cell", () => {
       seed("/same", { openPath: "notes.md", expanded: [] });
       const w = mountCockpit([cell(1, "s1", "/same"), cell(2, "s2", "/same")], 1, []);
       await openPane(w);
+      await openPaneOnCell(w, 1);
       expect(paneOf(w).props("initialState")).toEqual({ openPath: "notes.md", expanded: [] });
 
       paneStub.snapshot.mockReturnValue({ openPath: "from-one.md", expanded: [] });
@@ -702,6 +714,7 @@ describe("file pane beside the enlarged cell", () => {
   it("files a snapshot under the cell the pane is actually on", async () => {
     const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
     await openPane(w);
+    await openPaneOnCell(w, 1);
 
     paneStub.flush.mockResolvedValueOnce(false as unknown as undefined);
     paneStub.snapshot.mockReturnValue({ openPath: "from-one.md", expanded: [] });
@@ -723,28 +736,84 @@ describe("file pane beside the enlarged cell", () => {
     expect(paneOf(w).props("initialState")).toEqual({ openPath: "from-one.md", expanded: [] });
   });
 
+  // What survives a reload is keyed by SESSION (#1378): a uid is a different number next time,
+  // and the pane is now that cell's rather than the grid's.
   it("remembers being open across a remount, and the pane's own close puts it away", async () => {
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await openPane(w);
-    // The key now names WHICH pane holds the slot, not just whether the files one is open.
-    expect(localStorage.getItem("files_pane_open")).toBe("files");
+    expect(JSON.parse(localStorage.getItem("pane_open_by_session") ?? "{}")).toEqual({ s1: "files" });
 
-    const reopened = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    // A reload: the same session, a uid it will not have again.
+    const reopened = mountCockpit([cell(7, "s1", "/proj"), cell(8)], 7, []);
+    await flushPromises();
     expect(paneOf(reopened).exists()).toBe(true);
 
     await paneOf(reopened).vm.$emit("close");
     await nextTick();
     expect(paneOf(reopened).exists()).toBe(false);
-    expect(localStorage.getItem("files_pane_open")).toBe("");
+    expect(JSON.parse(localStorage.getItem("pane_open_by_session") ?? "{}")).toEqual({});
   });
 
-  // The key held "1" before the slot could hold anything but files, so an existing browser
-  // would otherwise come back with the pane closed for no reason it could explain.
-  it("migrates the old boolean value", async () => {
-    localStorage.setItem("files_pane_open", "1");
-    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
-    await flushPromises();
-    expect(paneOf(w).exists()).toBe(true);
+  // The whole point of #1378: two cells, two answers, and walking the zoom shows each cell what
+  // IT has open rather than carrying one pane across the grid.
+  describe("one answer per cell", () => {
+    it("starts closed on a cell that has never asked for a pane", async () => {
+      const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
+      await openPane(w);
+      expect(paneOf(w).exists()).toBe(true);
+
+      await w.setProps({ expandedUid: 2 });
+      await flushPromises();
+      expect(paneOf(w).exists()).toBe(false); // cell 2 never asked
+    });
+
+    it("gives each cell back what it had, walking the zoom between them", async () => {
+      const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
+      await openPane(w); // cell 1: files
+      await w.findAllComponents({ name: "TerminalCell" })[1].vm.$emit("toggle-canvas"); // cell 2: canvas
+      await flushPromises();
+      expect(paneOf(w).exists()).toBe(true); // still cell 1's, which is the one enlarged
+
+      await w.setProps({ expandedUid: 2 });
+      await flushPromises();
+      expect(paneOf(w).exists()).toBe(false);
+      expect(w.findComponent({ name: "GuiPanel" }).exists()).toBe(true);
+
+      await w.setProps({ expandedUid: 1 });
+      await flushPromises();
+      expect(paneOf(w).exists()).toBe(true);
+      expect(w.findComponent({ name: "GuiPanel" }).exists()).toBe(false);
+    });
+
+    // A pane asked for while the grid is tiled is that cell's answer for when it IS enlarged —
+    // which is the case the issue opens with (#1378): the canvas cannot open with nothing zoomed.
+    it("opens on enlarging a cell whose pane was asked for while tiled", async () => {
+      const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
+      await openPane(w);
+      await w.setProps({ expandedUid: null });
+      await flushPromises();
+
+      await w.findAllComponents({ name: "TerminalCell" })[1].vm.$emit("toggle-canvas");
+      await flushPromises();
+      expect(paneOf(w).exists()).toBe(true); // the tiled press moved nothing: cell 1's pane stays
+
+      await w.setProps({ expandedUid: 2 });
+      await flushPromises();
+      expect(w.findComponent({ name: "GuiPanel" }).exists()).toBe(true);
+    });
+
+    // Closing is an answer, not the absence of one — a reload must not hand the cell back a pane
+    // it was told to put away.
+    it("keeps a cell closed after the user closes it", async () => {
+      const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+      await openPane(w);
+      await w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+      await flushPromises();
+
+      const reopened = mountCockpit([cell(9, "s1", "/proj"), cell(10)], 9, []);
+      await flushPromises();
+      expect(paneOf(reopened).exists()).toBe(false);
+    });
   });
 });
 
@@ -779,7 +848,7 @@ describe("file pane width restored from storage", () => {
   });
 
   it("clamps to the terminal's floor as soon as the pane is on screen", async () => {
-    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("pane_open_by_session", JSON.stringify({ s1: "files" }));
     localStorage.setItem("files_pane_width", "900");
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await flushPromises();
@@ -791,7 +860,7 @@ describe("file pane width restored from storage", () => {
   // The single view's splitter announces its range; a screen-reader user resizing this one gets
   // nothing without the same three attributes.
   it("announces its value and range on the separator", async () => {
-    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("pane_open_by_session", JSON.stringify({ s1: "files" }));
     localStorage.setItem("files_pane_width", "400");
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await flushPromises();
@@ -802,7 +871,7 @@ describe("file pane width restored from storage", () => {
   });
 
   it("leaves a width that already fits alone", async () => {
-    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("pane_open_by_session", JSON.stringify({ s1: "files" }));
     localStorage.setItem("files_pane_width", "400");
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await flushPromises();

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -676,6 +676,21 @@ describe("file pane beside the enlarged cell", () => {
       expect(paneOf(w).props("initialState")).toBeNull();
     });
 
+    // A terminal that changed directory is leaving that tree behind exactly as a zoom to another
+    // cell does, so the snapshot has to be filed under the directory it is leaving — or coming
+    // back to it restores whatever was there before, which is the wrong tree or none (Codex review).
+    it("files the tree under the directory a cell is leaving when it cds", async () => {
+      const cells = [cell(1, "s1", "/one"), cell(2)];
+      const w = mountCockpit(cells, 1, []);
+      await openPane(w);
+      paneStub.snapshot.mockReturnValue({ openPath: "one.md", expanded: ["src"] });
+
+      await w.setProps({ cells: [cell(1, "s1", "/two"), cell(2)] });
+      await flushPromises();
+      expect(paneOf(w).props("cwd")).toBe("/two");
+      expect(JSON.parse(localStorage.getItem("files_pane_state") ?? "[]")).toEqual([{ cwd: "/one", state: { openPath: "one.md", expanded: ["src"] } }]);
+    });
+
     it("ignores a directory it has nothing stored for", async () => {
       seed("/elsewhere", { openPath: "notes.md", expanded: [] });
       const w = mountCockpit([cell(1, "s1", "/one"), cell(2)], 1, []);

--- a/test/src/components/paneExpand.spec.ts
+++ b/test/src/components/paneExpand.spec.ts
@@ -249,6 +249,21 @@ describe("the takeover is not remembered", () => {
     expect(pane(w).props("expanded")).toBe(false);
   });
 
+  // A button on a TILED cell answers for that cell and changes nothing on screen (#1378). Ending
+  // the takeover of the pane the user is reading would be a second cell's button rearranging the
+  // one in front of them.
+  it("survives a pane asked for on another, tiled cell", async () => {
+    const w = mountGrid();
+    await open(w);
+    await clickExpand(w);
+    expect(pane(w).props("expanded")).toBe(true);
+
+    w.findAllComponents({ name: "TerminalCell" })[1].vm.$emit("toggle-files");
+    await flushPromises();
+    expect(pane(w).props("expanded")).toBe(true);
+    expect(w.find(".zoom-row").classes()).toContain("pane-full");
+  });
+
   // The other way out: collapsing the zoom hides the row without unmounting the pane, so nothing
   // in setRightPane runs. Zooming back in — on this cell or another — must still be a split row.
   //

--- a/test/src/components/paneExpand.spec.ts
+++ b/test/src/components/paneExpand.spec.ts
@@ -251,13 +251,20 @@ describe("the takeover is not remembered", () => {
 
   // The other way out: collapsing the zoom hides the row without unmounting the pane, so nothing
   // in setRightPane runs. Zooming back in — on this cell or another — must still be a split row.
+  //
+  // Both cells are given a pane of their own, because since #1378 that is what decides whether
+  // there is one to come back to: a cell that never asked for one arrives with nothing, and this
+  // is about the takeover rather than about which cell has a pane.
   it("does not survive collapsing the zoom", async () => {
     const w = mountGrid();
     await open(w);
+    w.findAllComponents({ name: "TerminalCell" })[1].vm.$emit("toggle-canvas");
+    await flushPromises();
     await clickExpand(w);
 
     await w.setProps({ expandedUid: null });
     await w.setProps({ expandedUid: 2 });
+    await flushPromises();
     expect(pane(w).props("expanded")).toBe(false);
     expect(w.find(".zoom-row").classes()).not.toContain("pane-full");
   });


### PR DESCRIPTION
## Summary

The right pane already knew everything about a cell except whether to be there. Which file the
tree had open and which directories were expanded were **per-cell** (#958, #910); the canvas is
read **per session**; but *"is a pane open, and which"* was **one value for the whole grid**. So
opening the canvas on one terminal opened it on the next, and closing it there closed it on the
first.

Each cell now answers for itself.

- Walking the zoom shows **that cell's** pane — files, canvas, tools or nothing.
- A cell that never asked for one **arrives with none**. Closing is an answer too, so it stays closed.
- A reload restores by **session** (a uid is a different number next time), capped at 40, LRU.
- A pane can be asked for on a **tiled** cell — which is where #1378 starts, since the canvas cannot
  open with nothing enlarged. The press records what that terminal should have; enlarging it opens it.
- Each cell's header buttons now show **its own** state.
- Width and the full-width takeover stay shared, as the issue proposed.

`Closes #1378`. One file of source (`TerminalGrid.vue`) plus specs.

## Items to Confirm / Review

Three traps, none of them visible from the feature itself, and each one a regression I hit while
building it:

1. **Collapsing the zoom only HIDES the row** — the pane stays mounted with its editor and buffer.
   Deriving the shown pane from `expandedUid` would close it on every collapse and flush an editor
   the user is coming straight back to. It derives from `paneUid`, which already trailed the zoom
   for exactly this reason. Pinned by the existing "keeps the pane and its buffer mounted while the
   zoom is collapsed" spec.
2. **A button pressed on a TILED cell must not move the pane there** — that would unmount an editor
   merely hidden behind the grid, with a buffer nobody asked to close. The press records; the zoom
   watcher moves it, flush and all, when that cell is actually enlarged.
3. **Reopening files on the cell it was closed on** changes nothing the old watcher looked at, so
   its remembered tree never came back. `rightPane` is a watcher dependency now — please check that
   this cannot loop (it re-enters once and early-returns on `paneCwd === expandedCwd`).

Also worth a look:

4. **`paneByCell` distinguishes absent from null.** Absent means "never asked" and is what lets a
   reload restore from the session store; an explicit `null` is "the user closed it" and must
   survive. A `Map<number, RightPane | null>` carries both, which is easy to flatten by accident.
5. **The old `files_pane_open` key is dropped, not migrated.** Since a cell that has never asked
   starts closed, there is nothing for a single grid-wide value to migrate INTO. An existing browser
   comes back with every cell closed once, then remembers per cell from then on.
6. **The decisions came from the issue's own list (a–d).** Key = uid in memory / session across
   reloads (a); new storage key (b); untouched cells start closed (c); width and `paneExpanded` stay
   shared (d).

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1378 これってできる？右ペインで mcp の present 系と
> ファイルエクスプローラーがある。それぞれが状態を持つ必要あるからね。編集中とかの切り替え、今どうなって
> いるんだ？まずはできるか検討して。
>
> あーー、良く読んだらセルごとに開閉をもっていて、zoom を閉じて開いても状態を持ってほしいし、grid で開く、、
> では開かないから grid で開くになったときに expand すると開いてほしい、、、なのでセルごとに右の開いている
> 状態＋何が開いているかを持っておきたいってことだね。それなら、やっぱりセルごとに presentHTML なのか
> ファイルエクスプローラーなのかまで含めて持っておいて、セル切り替えると変化してほしいよね。そのときに
> ファイル開いている状態も持って。

The investigation that preceded this is in [`plans/feat-1378-per-cell-right-pane.md`](plans/feat-1378-per-cell-right-pane.md),
including the state table (what was already per-cell) and what happens to an unsaved buffer on
every switch path.

## What was already there

Worth stating so the diff is not read as doing more than it does: the **file the pane had open and
its expanded tree** were already per-cell and already restored across reloads, and the **canvas
contents** were already per-session and served by the API. This change adds the open/close half
only — which is why it is one file.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` — **7951 passed**, from a clean
`--frozen-lockfile` tree.

Five new specs pin the behaviour: walking the zoom between two cells with different panes, a cell
that never asked starting closed, a pane asked for while tiled opening on enlarge, a closed cell
staying closed across a reload, and restore-by-session.

**Not done: a live click-through.** This is a UI state machine and the specs mock the panes, so a
real two-cell walk in a browser would be worth doing before merge.

work in mulmoterminal2
