### PR TITLE
fix: stop the GUI MCP from cutting a session off from its own MCP (#1338, #1385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ today — **Claude Code** (the default), **Codex**, and **Antigravity** (`agy`).
   file exists, and injects activity hooks per spawn (see
   [Claude hook injection](#claude-hook-injection)) plus the
   [closing summary](#closing-summary) instruction.
-  The **whole** GUI MCP (`--mcp-config` + `--strict-mcp-config`) goes only to a session that is not a grid cell, or to a grid cell whose cwd IS the workspace — `carriesFullGuiMcp` in `server/session/spawn-claude.ts`, which is what gives a workspace cell the tools the single view had before 4.0.0 removed it. That equivalence is about what the session *carries*: a workspace cell is still a grid cell in every other respect. A cell in a project directory attaches neither flag, so Claude Code loads MCP servers the ordinary way — the directory's own local scope, any `.mcp.json` up the tree, and your global ones — including whichever [Canvas switches](#wiki-collections--the-gui-panel) are registered for it.
+  The **whole** GUI MCP (`--mcp-config`, on one all-tools URL) goes only to a session that is not a grid cell, or to a grid cell whose cwd IS the workspace — `claimFullGuiMcp` in `server/session/registry.ts`, which is what gives a workspace cell the tools the single view had before 4.0.0 removed it. That equivalence is about what the session *carries*: a workspace cell is still a grid cell in every other respect. A cell in a project directory attaches none of ours, so its GUI tools come from whichever [Canvas switches](#wiki-collections--the-gui-panel) are registered for it. **Either way, Claude Code loads your own MCP servers normally** — the directory's local scope, any `.mcp.json` up the tree, your global ones and your claude.ai connectors. It did not always: `--strict-mcp-config` used to ride along with `--mcp-config`, which hid all of that from the very sessions meant to be the most capable ([#1338](https://github.com/receptron/mulmoterminal/issues/1338), [#1385](https://github.com/receptron/mulmoterminal/issues/1385)).
 - **Codex** — spawned as `codex` (override with `CODEX_BIN`; `CODEX_MODEL` sets
   `--model`). Codex runs on its own WebSocket (`/ws/codex`) and its sessions appear in the
   cockpit roster next to Claude's. Because Codex only mints its rollout id **after** the first
@@ -781,8 +781,8 @@ points) says the least interesting true thing about it; the real path is on its 
 
 **The launcher is shorter in the workspace**, because two of its choices do not apply
 there. The per-directory **Canvas switches** are replaced by a line saying every GUI tool
-is already available — a session there is handed the whole GUI MCP at spawn, so switches
-would write a registration that `--strict-mcp-config` then ignores. And the **worktree**
+is already available — a session there is handed the whole GUI MCP at spawn, so a switch
+would register a group URL that then has nothing left to serve. And the **worktree**
 section is hidden: a worktree isolates work on one codebase onto a branch, while the
 workspace is what a session works *from* (the shared wiki, collections and accounting
 live there), which is precisely what a detached branch would cut it off from. Both come
@@ -1118,11 +1118,11 @@ A chip is a command line the user wrote, so the injection is a **rewrite of thei
 deliberately narrow: only a bare `claude` or `codex` is recognised, and anything else — a wrapper
 script, `FOO=1 claude` — is passed through unchanged.
 
-A `claude` chip in the workspace is given `--strict-mcp-config`, same as the cell. That makes the
-generated config the only source — but it already contains your Settings `userMcpServers`, so
-**those still load and are still pre-approved**. What stops contributing is a project directory's
-per-folder `.mcp.json`, which in the workspace is the intent: that file is where the per-group URLs
-live, and the chip is being handed the all-tools URL instead.
+A `claude` chip in the workspace is handed the all-tools URL, same as the cell, and like the cell it
+**does not** isolate the session: your own MCP servers and claude.ai connectors load as usual. Where
+a directory also registered per-group URLs in its `.mcp.json`, those groups stand down for that
+session rather than serving a second copy of the same tools — the session already reaches all of
+them under `mt`.
 
 **The asymmetry is deliberate.** `mt` is ours to name: nothing on disk holds it, it is
 regenerated on every spawn, so it was shortened to stop paying 17 characters per tool name. The

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -10,6 +10,48 @@ Entries here are folded into the next release's heading when it ships.
 
 ### Fixed
 
+- **Your claude.ai connectors, and your own MCP servers, now work in the workspace cell and the single view** ([#1338](https://github.com/receptron/mulmoterminal/issues/1338), [#1385](https://github.com/receptron/mulmoterminal/issues/1385)).
+  Gmail, Calendar, Drive, Slack, Notion — anything authorised on your claude.ai account — were
+  invisible to exactly the two kinds of session meant to be the most capable, along with
+  `~/.claude.json`, your plugin MCP servers and the directory's own `.mcp.json`. A cell in any other
+  directory had them all. `claude mcp list` said "Connected" the whole time, because that is the CLI
+  running its own health check rather than reporting what a running session can see.
+
+  Two flags were being pushed on one line. `--mcp-config` **adds** our GUI broker; `--strict-mcp-config`
+  makes it the **only** source. So "give this session the GUI panel" also meant "cut it off from
+  everything you configured" — for the single view since the beginning, and for the workspace cell
+  since 4.0.0 gave it the same treatment. The two reports were filed separately, one as a regression
+  and one as by-design; they are one line.
+
+  The isolating flag is gone (deleted, not made an option — a one-valued flag is the same weld
+  waiting to be re-made). What put it there was a worry that merging config layers would silently
+  drop our own broker; measured on CLI 2.1.221, `--mcp-config` alone yields the broker **and** the
+  connectors, while adding the strict flag yields the broker alone. MulmoClaude, which drives the
+  same workspace, reached that conclusion at CLI 2.1.163 and has run without it since.
+
+  A launcher chip running `claude` drops it on the same commit: parity with the cell beside it was
+  why the chip carried the flag, so it is why the chip loses it.
+
+  The rate-limit probe keeps its own `--strict-mcp-config`. That is a hidden session asking one
+  question that needs no tools, where isolation buys 8.0 s to first window instead of 9–15 s.
+
+### Changed
+
+- **A directory's Canvas tool groups stand down for a session that already has every tool.**
+  Fallout from the fix above, handled rather than left: with the isolating flag gone, a directory
+  that registered per-group MCP URLs could hand a workspace session a second copy of tools it
+  already reaches — `mcp__mt__presentChart` and `mcp__mulmoterminal-render__presentChart` for one
+  action. The session is now recorded as carrying the full GUI MCP **at spawn**, and the group URLs
+  serve it nothing. Deciding it at spawn is what makes it independent of which URL the agent's MCP
+  client happens to dial first.
+
+  The obvious alternative — withhold our GUI MCP when the directory registered groups — would have
+  re-broken [#1188](https://github.com/receptron/mulmoterminal/pull/1188): the groups do not cover
+  the tools that belong to no group, `spawnBackgroundChat` among them.
+
+- **Workspace cells and the single view start slower if you have several MCP servers configured**,
+  because they now load them. The same trade MulmoClaude already makes on the same workspace.
+
 - **A finished background task replaced the cell's task line with the harness's XML** ([#1384](https://github.com/receptron/mulmoterminal/issues/1384)).
   A session running a Monitor or a subagent showed `<task-notification> <task-id>…` on row 1 from the
   moment that task reported, and the AI title was then generated from it. "A harness-injected block

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -49,6 +49,14 @@ Entries here are folded into the next release's heading when it ships.
   re-broken [#1188](https://github.com/receptron/mulmoterminal/pull/1188): the groups do not cover
   the tools that belong to no group, `spawnBackgroundChat` among them.
 
+  The record is also **released** when a session is respawned without the all-tools URL, which the
+  log it lives in could not express before — it was append-only on the stated grounds that "nothing
+  removes one". That stopped being true the moment a stale yes could stand a cell's groups down with
+  nothing to serve them: a session id outlives its process, and one opened in the single view can be
+  respawned as a project-directory cell. It now takes the same shape the tool-group log already uses
+  for the same reason — an append log with a release marker, replayed in order, and a bare id still
+  reads as a claim so existing files keep working.
+
 - **Workspace cells and the single view start slower if you have several MCP servers configured**,
   because they now load them. The same trade MulmoClaude already makes on the same workspace.
 

--- a/docs/codex-vs-claude.md
+++ b/docs/codex-vs-claude.md
@@ -26,7 +26,7 @@ PTY persistence, reattach, grid, pubsub, MCP broker, and GUI panel are all share
 | **Resume** | `--resume <id>` | `resume <id>` **subcommand** (global flags must precede it) | `buildCodexArgs` places `resume` after the flags |
 | **Transcript on disk** | `~/.claude/projects/**/<id>.jsonl` | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | watch for the session's whole lifetime, and attribute only unambiguously |
 | **When the transcript appears** | written as the turn runs | **only after the first user turn** — can be minutes | never assume a rollout exists right after spawn |
-| **MCP delivery** | `--mcp-config <json>` + `--strict-mcp-config` | TOML config | inline `-c mcp_servers.mt.url="…"` — see below |
+| **MCP delivery** | `--mcp-config <json>` (additive — the user's own servers still load) | TOML config | inline `-c mcp_servers.mt.url="…"` — see below |
 | **Tool permission** | per-tool `--allowedTools` | per-server only (coarse) | `default_tools_approval_mode="approve"` on the one GUI server |
 | **System prompt** | `--system-prompt <str>` | **none** — it must be prepended to the user message (or live in AGENTS.md) | collection *actions* are self-contained natural language, so they carry their own instructions |
 | **Draft-ready TUI marker** | `shift+tab to cycle` (stable) | **no stable marker** — the input placeholder rotates | claude sets `draftReadyMarker`; codex omits it, so editable-draft injection is claude-only |

--- a/docs/spawn-architecture.md
+++ b/docs/spawn-architecture.md
@@ -22,7 +22,6 @@ pty.spawn(CLAUDE_BIN, [
   "--permission-mode", CLAUDE_PERMISSION_MODE,
   "--append-system-prompt", "<closing-summary instruction>",
   "--mcp-config",      "<gui mcp json>",
-  "--strict-mcp-config",
   "--allowedTools",    "<gui tool names>",
   // optional (spawnBackgroundChat only):
   "--", "<initial prompt>",
@@ -47,7 +46,7 @@ pty.spawn(CLAUDE_BIN, [
 | 7 | `--permission-mode <mode>` | `CLAUDE_PERMISSION_MODE` (env, default `auto`) | How claude handles tool approval | `auto`/`bypassPermissions` = hands-off; tightening makes it prompt more (in the terminal) |
 | 8 | `--append-system-prompt <text>` | `SESSION_SUMMARY_PROMPT` (`server/agents/session-summary-prompt.ts`) | Asks the agent to end a reply with a **closing summary** — the conversation's standing request, what was achieved, what was not — when it hands control back. Not on every turn (#942) | Remove → returning to a cell means scrolling back to learn what was asked. Passed inline, not `--append-system-prompt-file`: the sandbox spawn cannot read a host path |
 | 9 | `--mcp-config <gui mcp json>` | `mcpConfigJson()` → `{ type: "http", url: /mcp/<sessionId> }` | Registers the **GUI MCP** server that backs the panel plugins (`presentDocument`, `presentForm`, `generateImage`, …) | Remove → the GUI panel plugins stop working |
-| 10 | `--strict-mcp-config` | always | **Load ONLY** the MCP from `--mcp-config`; ignore the user's (`~/.claude.json`) and the project's (`.mcp.json`) MCP servers | Keeps the session minimal/predictable, **but disables all of the user's & workspace MCP servers** (see the decision below) |
+| 10 | ~~`--strict-mcp-config`~~ | **removed 2026-08-04** (#1338, #1385) | Used to make `--mcp-config` the ONLY source | It also hid the user's claude.ai connectors, `~/.claude.json`, their plugin servers and the directory's own `.mcp.json` — see the decision below. `rate-limit-probe.ts` still passes it, for startup speed on a hidden session that needs no tools |
 | 11 | `--allowedTools <gui tool names>` | `allowedToolNames()` | Auto-allow the GUI MCP tools so they don't trip a permission prompt | Remove → each GUI tool call prompts for approval |
 | 12 | `-- <initial prompt>` | `spawnBackgroundChat` only | First message for a headless-spawned session. `--` ends option parsing so a prompt starting with `-` can't be read as a flag | — |
 | 13 | `cols` / `rows` | `120` / `30` | Initial PTY size; the client sends a `resize` on connect | Cosmetic initial value only |
@@ -63,27 +62,53 @@ per-workspace behaviour:
   workspace's skills are active **only for that workspace's sessions** — no
   cross-project mixing. This is automatic, and the directory-switch feature
   preserves it (each session keeps its own `cwd`).
-- **MCP** — claude would normally also load user MCP (`~/.claude.json`) and
-  project MCP (`.mcp.json`, relative to `cwd`). **But `--strict-mcp-config`
-  disables all of that** — today **only the GUI MCP runs**. So "workspace-assuming
-  MCP servers" don't run at all right now.
+- **MCP** — claude loads user MCP (`~/.claude.json`) and project MCP (`.mcp.json`,
+  relative to `cwd`), **plus** the GUI MCP we add with `--mcp-config`. Because we
+  spawn with `cwd = the workspace`, a workspace's MCP servers are active only for
+  that workspace's sessions, exactly as its skills are.
 
-## Decision: MCP scoping
+## Decision: MCP scoping — settled on B, 2026-08-04
 
-| | A. Keep `--strict-mcp-config` (current) | B. Drop `--strict-mcp-config` (like mulmoclaude) |
+| | A. Keep `--strict-mcp-config` | **B. Drop it (like mulmoclaude) — TAKEN** |
 |---|---|---|
 | MCP loaded | GUI MCP only | GUI MCP **+** user (`~/.claude.json`) **+** project (`.mcp.json`), all `cwd`-scoped |
 | Workspace MCP | ❌ not available | ✅ works, naturally **per-workspace** (same isolation as skills) |
 | Predictability | ✅ minimal, fixed surface | ⚠️ depends on each project's `.mcp.json` |
 | Trust prompts | none | project `.mcp.json` triggers a "trust this server?" prompt (handled in the interactive terminal) |
-| GUI MCP coexistence | n/a | must verify GUI + user/project MCP coexist (mulmoclaude confirmed on recent CLI) |
+| GUI MCP coexistence | n/a | verified — see the spike below |
 | Resources | one MCP (HTTP, in-process) | + one process per project MCP server, per session |
-| Permission interaction | simple | verify behaviour with `--permission-mode auto`/`bypass` |
+| Permission interaction | simple | unchanged: `--allowedTools` is an additive allowlist, not "only these" |
 
-**Recommendation:** for the "open any directory" direction, **B** is the
-consistent choice — a workspace then means *its skills **and** its MCP*. Before
-committing, **spike B** locally to confirm GUI + project MCP coexistence, the
-trust-prompt flow, and the interaction with `--permission-mode`.
+A was not merely less consistent — it was **the bug** in #1338 and #1385. Attaching
+the GUI panel also cut the session off from the user's claude.ai connectors
+(Gmail / Calendar / Drive / Slack), `~/.claude.json`, their plugin MCP servers and
+the directory's own `.mcp.json`, because the two flags were pushed on one line.
+
+**The spike this section asked for**, run in `~/mulmoclaude` on **CLI 2.1.221**,
+reading `mcp_servers` off the `system`/`init` event:
+
+| spawn | `init.mcp_servers` |
+|---|---|
+| `--mcp-config` alone | **3** — our broker + `claude.ai Superhuman Docs` + `claude.ai Gmail` |
+| `--mcp-config --strict-mcp-config` | **1** — our broker alone |
+
+So the GUI MCP and the user's own servers coexist; the #1043 worry that a merge
+silently drops our broker does not reproduce. MulmoClaude reached the same
+conclusion at CLI 2.1.163 and has run without the flag since.
+
+**What B costs, accepted with it:**
+
+- **Startup.** A workspace cell now loads the user's MCP servers. The
+  `rate-limit-probe.ts` measurement is the same effect in reverse: 8.0 s to first
+  window with no servers, 9–15 s with one unauthenticated one.
+- **Overlapping tool names**, for a directory that registered tool groups in its own
+  `.mcp.json` — the group URLs are no longer shut out, so the same tool could arrive
+  as both `mcp__mt__presentChart` and `mcp__mulmoterminal-render__presentChart`.
+  Resolved on our side, not by a flag: a session handed the all-tools URL is recorded
+  at spawn (`claimFullGuiMcp`), and the group URLs then offer it nothing
+  (`mcp/tool-gate.ts`). Doing it the obvious way instead — withholding the GUI MCP
+  when groups are registered — would re-break #1188, because groups do not cover the
+  ungrouped tools.
 
 ## Interaction with the directory-switch feature
 

--- a/plans/fix-1338-1385-unweld-strict-mcp.md
+++ b/plans/fix-1338-1385-unweld-strict-mcp.md
@@ -1,0 +1,138 @@
+# Two flags, one gesture: `--strict-mcp-config` rides along with the GUI MCP (#1338, #1385)
+
+Two issues, filed separately and triaged as unrelated — one a regression, one "by design" — are the
+same line of code.
+
+`server/agents/claude-args.ts:52`
+
+```ts
+guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config");
+```
+
+These answer different questions:
+
+| flag | meaning | who needs it |
+| --- | --- | --- |
+| `--mcp-config` | **also** load our broker (additive) | every GUI session |
+| `--strict-mcp-config` | load **only** this (subtractive) | nothing, except the rate-limit probe |
+
+Because they are pushed together, "give this session the GUI panel" silently also means "cut it off
+from the user's own MCP" — the claude.ai connectors, `~/.claude.json`, plugin servers, and the
+directory's own `.mcp.json`.
+
+`carriesFullGuiMcp(attachGuiMcp, cwd) = attachGuiMcp || isWorkspaceCwd(cwd)` routes both reporters
+into that line:
+
+- **#1385** — single view: `attachGuiMcp = true`.
+- **#1338** — grid cell in the workspace: `isWorkspaceCwd(cwd) = true` (added by #1187).
+- a project-directory cell: neither, so no flags — which is exactly why connectors work there and
+  nowhere else.
+
+## The reason the flag was there is gone
+
+Measured on **CLI 2.1.221** in `~/mulmoclaude`, reading `mcp_servers` off the `system`/`init` event:
+
+| spawn | `init.mcp_servers` |
+| --- | --- |
+| `--mcp-config` alone | **3** — our broker + `claude.ai Superhuman Docs` + `claude.ai Gmail` |
+| `--mcp-config --strict-mcp-config` | **1** — our broker alone |
+
+Dropping strict keeps the broker **and** restores the connectors. The #1043 concern that a merge
+silently drops our broker does not reproduce. MulmoClaude reached the same conclusion at CLI 2.1.163
+and has run without strict since; `docs/spawn-architecture.md` already recommends option **B** (drop
+it) and asks for a spike to confirm coexistence first — the table above is that spike.
+
+Under CLAUDE.md's "MulmoClaude is the reference host", two hosts driving the same `~/mulmoclaude`
+must not present opposite MCP surfaces with nothing saying the divergence is deliberate.
+
+## Delete the flag rather than parameterise it
+
+The tempting shape is a second input to `buildClaudeArgs` — `attachGuiMcp` and `isolateMcp` as
+independent decisions. This plan does not do that: no caller would ever pass `isolateMcp: true`, and
+a parameter with one value is the weld waiting to be re-made. Removing the flag is what makes the
+pairing impossible.
+
+The probe keeps its own `--strict-mcp-config` because its reason is a *different* one, stated and
+measured at `rate-limit-probe.ts:140`: it asks one question that needs no tools, and loading the
+user's MCP costs 8.0s → 9–15s of startup for nothing. Isolation for speed on a hidden session is not
+isolation for scoping on a visible one.
+
+### Three sites, not two
+
+The investigation on #1338 counted two occurrences in source. There are now three — the launcher
+chip arrived afterwards:
+
+| site | action |
+| --- | --- |
+| `agents/claude-args.ts:52` | drop the flag |
+| `session/launcher-gui-mcp.ts:71` | drop the flag — CLAUDE.md requires a chip and the cell beside it to be indistinguishable, and fixing only the cell re-creates that drift |
+| `agents/rate-limit-probe.ts:151` | **keep**, with its measurement |
+
+## What removing it costs
+
+**Startup time.** Workspace cells and the single view now load the user's MCP servers — the probe's
+own numbers, in reverse. Accepted (owner's call, 2026-08-04): MulmoClaude already pays it on the same
+workspace, so this is parity rather than a new risk, but cells will be slower for anyone with several
+servers configured.
+
+**Duplicate tool names**, for a directory that registered tool groups in its own `.mcp.json`. The
+session would then see both `mcp__mt__presentChart` (ours, via `--mcp-config`) and
+`mcp__mulmoterminal-render__presentChart` (the group URL, now no longer shut out) — two names for one
+action, and a coin flip over which the model calls.
+
+Not reproducible on this machine — `~/mulmoclaude/.mcp.json` is absent, and of 182 projects in
+`~/.claude.json` exactly two register anything (both `playwright`), neither of them the workspace. So
+it lands only on someone who opted in, which is why it needs fixing by construction rather than by
+observation.
+
+## Phase 2 — make the duplicate impossible, not unlikely
+
+The obvious fix — "don't attach the GUI MCP when the directory registered groups" — is **wrong**.
+Groups do not cover every tool (`common/toolGroups.ts`: an unclassified tool belongs to no group and
+is reachable only through the all-tools URL), and #1188 exists because `spawnBackgroundChat` went
+missing exactly that way.
+
+Put the resolution on **our** side of the wire instead. Both URLs are ours:
+
+1. A session that holds the all-tools URL is **recorded at spawn**. `markAllToolsSession` /
+   `hasAllGuiTools` already exist (`registry.ts:323`) but learn on first request, so today the answer
+   depends on which URL the client happens to connect to first. `carriesFullGuiMcp` is what knows,
+   and it knows before the process starts.
+2. The group URL then **offers nothing** to such a session, and refuses a tool named anyway — the
+   same two-layer shape `mcp/tool-gate.ts` already applies to the worker and group gates.
+
+The group server still connects and still reports itself; it simply has no tools, so the agent has
+exactly one name per action. Serving 404 instead would surface as "server failed to connect", which
+is a worse lie than "connected, nothing here".
+
+To keep the decision and the record from separating, the three spawn paths call one function that
+does both:
+
+```ts
+export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined): boolean
+```
+
+`carriesFullGuiMcp` stays pure and exported for the specs and for readers; `claimFullGuiMcp` is what
+a spawn path asks. Sites: `spawn-claude.ts`, `spawn-codex.ts`, `ws-routes.ts` (launcher chip).
+
+Codex needs it even though `codexGuiMcpServers` already returns the all-tools server *instead of* the
+groups when full — the user's own codex config can still register a group, and the marking is what
+the group URL reads.
+
+## Tests
+
+- `claude-args.spec.ts` / `full-gui-mcp.spec.ts` pin the flag today; they invert to pin its absence,
+  and gain a case that `--mcp-config` is still passed (the failure this must not become is "the
+  panel stopped working").
+- `tool-gate.spec.ts` — a group offer is empty for an all-tools session, and a named tool is refused
+  with a message that says where the tool actually lives.
+- A spec that all three spawn paths record the session, so a fourth path that forgets is visible.
+- The duplicate cannot be reproduced from this machine's config, so the group-registration case is
+  built in a temp directory rather than asserted from the real one.
+
+## Docs
+
+`docs/spawn-architecture.md` carries the A/B decision table and the settings row for the flag — both
+record that B was taken, with the measurement and the date. Also the comments that explain the old
+behaviour: `claude-args.ts`, `mcp-config.ts` (`fullGuiAllowedTools`), `spawn-claude.ts`,
+`ws-routes.ts`, `issue-spawn-options.ts`, `launcher-gui-mcp.ts`.

--- a/plans/fix-1338-1385-unweld-strict-mcp.md
+++ b/plans/fix-1338-1385-unweld-strict-mcp.md
@@ -105,6 +105,15 @@ The group server still connects and still reports itself; it simply has no tools
 exactly one name per action. Serving 404 instead would surface as "server failed to connect", which
 is a worse lie than "connected, nothing here".
 
+The record must also be **released**, which is the part the log could not express: it was append-only
+because "nothing removes one", and that stopped being true here. A session id outlives its process —
+one opened in the single view (full GUI MCP whatever its cwd) can be respawned as a
+project-directory cell — and a stale claim would stand that cell's groups down with no all-tools url
+to serve them instead. Worse than the duplicate. `all-tools-log.ts` gives the file a release marker
+replayed in order, the shape `session-tool-groups.ts` already uses; a bare id still reads as a claim,
+so existing files keep working. The release fires exactly where the tool-group reset already does,
+so a tmux reattach — same process, same url — keeps its claim.
+
 To keep the decision and the record from separating, the three spawn paths call one function that
 does both:
 

--- a/server/agents/claude-args.ts
+++ b/server/agents/claude-args.ts
@@ -1,6 +1,11 @@
 // Pure builder for the `claude` CLI argv. Kept separate so the exact flag set —
-// especially the GUI-MCP / --strict-mcp-config switch — is unit-testable without
-// spawning a PTY.
+// especially the GUI-MCP switch — is unit-testable without spawning a PTY.
+//
+// It passes NO `--strict-mcp-config`. The flag was welded to `--mcp-config` here, which is how
+// attaching the GUI panel came to also hide the user's claude.ai connectors, `~/.claude.json`,
+// their plugin servers and the directory's own `.mcp.json` (#1338, #1385). Deleted rather than
+// made a parameter: no caller would set it, and a one-valued flag is the weld waiting to be
+// re-made. `rate-limit-probe.ts` still passes it, for a different and measured reason.
 
 export interface ClaudeArgsInput {
   sessionId: string;
@@ -10,18 +15,19 @@ export interface ClaudeArgsInput {
   canResume: boolean;
   settings: string; // hook settings JSON (--settings)
   permissionMode: string; // --permission-mode
-  // true  (single view): attach the in-process GUI MCP, auto-allow its tools, and
-  //        isolate to it with --strict-mcp-config (main's classic behavior).
-  // false (grid dev terminal): no GUI MCP and no --strict-mcp-config, so the user's
-  //        + project's MCP servers load normally — INCLUDING a GUI tool group the
-  //        directory registered itself (see common/toolGroups.ts).
+  // true  (single view, workspace cell): attach the in-process GUI MCP on one url carrying every
+  //        tool, and auto-allow its tools.
+  // false (project-directory cell): no GUI MCP of ours — the directory's own config is where its
+  //        GUI tool groups come from (see common/toolGroups.ts).
+  // Either way the user's + project's MCP servers load: the difference is what WE add, not what
+  // they lose.
   attachGuiMcp: boolean;
   mcpConfig: string; // GUI MCP config JSON (--mcp-config), used only when attachGuiMcp
   // Comma-joined fully-qualified tool names for --allowedTools. Passed in BOTH modes: a grid
   // cell gets no --mcp-config, but still needs its render-group tools pre-approved so they
-  // don't stop at a permission prompt on every call. Verified that --allowedTools alone (no
-  // --mcp-config, no --strict-mcp-config) pre-approves without restricting anything else —
-  // it is an additive allowlist, not "only these".
+  // don't stop at a permission prompt on every call. Verified that --allowedTools alone
+  // pre-approves without restricting anything else — it is an additive allowlist, not "only
+  // these".
   allowedTools: string;
   // What this session runs (#579): an alias (sonnet/opus/haiku) or a backend's own model
   // name. Null leaves the choice to Claude Code. `--model` outranks both the settings
@@ -48,12 +54,15 @@ export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
   // is nowhere near the tmux arg limit that forced the seed prompt out of the argv (#942).
   if (input.appendedPrompt) guiArgs.push("--append-system-prompt", input.appendedPrompt);
   if (input.model) guiArgs.push("--model", input.model);
+  // --mcp-config ADDS our broker; it does not replace anything. `--strict-mcp-config` used to
+  // ride along on this same line, and that is what made "give this session the GUI panel" also
+  // mean "cut it off from the user's own MCP" (#1338, #1385).
   if (input.attachGuiMcp) {
-    guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config");
+    guiArgs.push("--mcp-config", input.mcpConfig);
   }
-  // Outside the block: --strict-mcp-config is what makes --mcp-config the ONLY source, and a
-  // grid cell wants neither — but it does want its render-group tools auto-allowed, and those
-  // reach it through the user's own MCP config. Empty means nothing to pre-approve.
+  // Outside the block: a grid cell gets no --mcp-config but still wants its render-group tools
+  // auto-allowed, and those reach it through the user's own MCP config. Empty means nothing to
+  // pre-approve.
   if (input.allowedTools) guiArgs.push("--allowedTools", input.allowedTools);
   // LAST, and one flag for the whole list: `--add-dir` is variadic (`<directories...>`), so a
   // flag placed after it would be fine but a VALUE would be swallowed. Keeping it at the end

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -85,9 +85,12 @@ const SUBMIT_TRANSLATION_TOOL = {
 export function buildGuiMcpServer(
   sessionId: string,
   baseUrl: string,
-  opts: { submitTranslationTool?: boolean; group?: ToolGroup | null; history?: GuiCallRecorder | null } = {},
+  opts: { submitTranslationTool?: boolean; group?: ToolGroup | null; history?: GuiCallRecorder | null; carriesAllTools?: boolean } = {},
 ): Server {
   const group = opts.group ?? null;
+  // Whether this session already reaches every tool on the all-tools url, in which case a group
+  // url of ours has nothing left to add and stands down (see tool-gate.ts).
+  const carriesAllTools = !!opts.carriesAllTools;
   // The advertised server name follows the id a group is expected to be registered under, so
   // what a user sees in `claude mcp list` matches what they wrote in their own config.
   const serverName = group === null ? GUI_SERVER_ID : toolGroupServerId(group);
@@ -97,13 +100,13 @@ export function buildGuiMcpServer(
   // offer is filtered here, and anything outside it that gets named anyway is refused below.
   const isWorker = !!opts.submitTranslationTool;
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: offeredTools(isWorker, toolDefinitions, SUBMIT_TRANSLATION_TOOL, group),
+    tools: offeredTools(isWorker, toolDefinitions, SUBMIT_TRANSLATION_TOOL, group, carriesAllTools),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    const route = routeToolCall(name, isWorker, group);
+    const route = routeToolCall(name, isWorker, group, carriesAllTools);
 
     // Worker-only result tool: deliver the structured translations back to the
     // waiting request (keyed by session id), bypassing the plugin dispatch path.

--- a/server/mcp/tool-gate.ts
+++ b/server/mcp/tool-gate.ts
@@ -47,13 +47,26 @@ export const describeTool = (def: PluginToolDefinition): string => [def.descript
 // `group` null means the all-tools surface (the single view's URL, unchanged). A group filters
 // the offer down to the tools classified into it — and an UNCLASSIFIED tool is in no group, so
 // it never reaches a group URL (see common/toolGroups.ts for why that direction is deliberate).
+//
+// `carriesAllTools` is the THIRD gate, and the only one that can empty a group entirely. A session
+// handed the all-tools url can already call every one of these under `mcp__mt__*`; serving them
+// again under `mcp__mulmoterminal-<group>__*` gives the model two names for one action and a coin
+// flip over which to use. Until #1338 nothing had to decide this, because `--strict-mcp-config` shut
+// the directory's own config out — at the cost of the user's connectors along with it. Removing that
+// flag is what makes the overlap reachable, so the resolution moves here, where BOTH urls are ours.
+//
+// Standing down is not the same as not existing: the group server still connects and still reports
+// itself, with no tools. A 404 would surface in the client as "server failed to connect", which is a
+// worse account of the situation than "connected, nothing here".
 export function offeredTools(
   isTranslationWorker: boolean,
   plugins: readonly PluginToolDefinition[],
   workerTool: OfferedTool,
   group: ToolGroup | null = null,
+  carriesAllTools = false,
 ): OfferedTool[] {
   if (isTranslationWorker) return [workerTool];
+  if (group !== null && carriesAllTools) return [];
   const offered = group === null ? plugins : plugins.filter((def) => groupOfTool(def.name) === group);
   return offered.map((def) => ({ name: def.name, description: describeTool(def), inputSchema: def.parameters ?? NO_PARAMETERS }));
 }
@@ -64,7 +77,7 @@ export type ToolRoute =
   // Hand off to the plugin dispatch route.
   | { kind: "dispatch" };
 
-export function routeToolCall(name: string, isTranslationWorker: boolean, group: ToolGroup | null = null): ToolRoute {
+export function routeToolCall(name: string, isTranslationWorker: boolean, group: ToolGroup | null = null, carriesAllTools = false): ToolRoute {
   const isWorkerTool = name === SUBMIT_TRANSLATION_TOOL_NAME;
   if (isTranslationWorker) {
     if (isWorkerTool) return { kind: "submit-translation" };
@@ -75,6 +88,12 @@ export function routeToolCall(name: string, isTranslationWorker: boolean, group:
   // translation pending, which is a 404 from another module rather than a decision made here
   // — and the layer above already assumes a model can name a tool it was never shown.
   if (isWorkerTool) return { kind: "refused", message: `Tool "${name}" is not available.` };
+  // Second layer of the stood-down group. Named before the group filter below so the message can
+  // say where the tool actually IS — refusing it as "not in this group" would be true and useless,
+  // since the session can call it right now under the all-tools server.
+  if (group !== null && carriesAllTools) {
+    return { kind: "refused", message: `Tool "${name}" is served on this session's all-tools MCP server, not on the "${group}" group.` };
+  }
   // Second layer of the group gate. Refused, not dispatched: the dispatch route would happily
   // run any registered plugin, so "we never offered it" is not a control.
   if (group !== null && groupOfTool(name) !== group) {

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -13,7 +13,7 @@ import type { Express, Request, Response } from "express";
 import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
 import type { GuiCallRecorder } from "../mcp/gui-call-history.js";
-import { translationWorkerIds, markSessionToolGroup, sessionToolGroups, markAllToolsSession } from "../session/registry.js";
+import { translationWorkerIds, markSessionToolGroup, sessionToolGroups, markAllToolsSession, hasAllGuiTools } from "../session/registry.js";
 import { isToolGroup, TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
@@ -86,7 +86,7 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
   // We run in STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
   // request, no session header and no initialize handshake required across requests. The SDK
   // forbids reusing a stateless transport, so it is never cached.
-  async function handleMcpRequest(req: Request, res: Response, sessionId: string, group: ToolGroup | null) {
+  async function handleMcpRequest(req: Request, res: Response, sessionId: string, group: ToolGroup | null, carriesAllTools = false) {
     if (!SESSION_ID_RE.test(sessionId)) {
       return res.status(400).json({ error: "invalid sessionId" });
     }
@@ -101,6 +101,7 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`, {
       submitTranslationTool: isWorker,
       group,
+      carriesAllTools,
       history: isWorker ? null : deps.guiCallHistory(sessionId),
     });
     // No sessionIdGenerator at all is the SDK's stateless mode. Spelling it `undefined` says
@@ -161,9 +162,15 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     if (!isToolGroup(group)) return res.status(404).json({ error: `unknown tool group: ${group}` });
     // Reaching us here IS the evidence that this session has the group — nothing else tells
     // us, since the registration lives in the user's own MCP config. Marked before the request
-    // is served so a panel asking right after the first ListTools already sees it.
+    // is served so a panel asking right after the first ListTools already sees it. Still recorded
+    // when the group stands down below: the directory really did register it, and the Canvas gate
+    // reads that fact.
     learnToolGroups(sessionId, [group]);
-    return handleMcpRequest(req, res, sessionId, group);
+    // A session already holding the all-tools url reaches every one of these tools under a name of
+    // its own, so this url serves none of them (#1338). Answerable on the FIRST request only
+    // because the spawn recorded it — learning it from whichever url connected first would make
+    // the answer depend on connection order.
+    return handleMcpRequest(req, res, sessionId, group, hasAllGuiTools(sessionId));
   });
   app.get("/api/mcp/:group/:sessionId", rejectNonPost);
   app.delete("/api/mcp/:group/:sessionId", rejectNonPost);

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -550,7 +550,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // Gated on `launcherTakesGuiMcp` BEFORE the claim is recorded: a chip running `zsh`, `yarn dev`
   // or `agy` has no rewriter, so it is handed no MCP — and recording it as carrying every GUI tool
   // would misreport it to /api/tools (Codex review on #1399).
-  const fullGui = !live && launcherTakesGuiMcp(command) && claimFullGuiMcp(sessionId, false, cwd);
+  const fullGui = !live && launcherTakesGuiMcp(command) && claimFullGuiMcp(sessionId, false, cwd, false);
   const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
   const codexGui = live ? [] : codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: fullGui });
   // The config file is written ONLY once the command is known to be claude. Writing it up front

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -32,7 +32,13 @@ import {
 } from "../session/registry.js";
 import { SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
-import { launcherCommandWithGuiMcp, launcherCommandWithClaudeGuiMcp, launcherProgram, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
+import {
+  launcherCommandWithGuiMcp,
+  launcherCommandWithClaudeGuiMcp,
+  launcherProgram,
+  launcherRunsAgent,
+  launcherTakesGuiMcp,
+} from "../session/launcher-gui-mcp.js";
 import { codexGuiMcpServers, fullGuiAllowedTools } from "../session/mcp-config.js";
 import { mcpConfigFileArgument, withSettingsCleanup } from "../session/session-settings.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
@@ -540,7 +546,11 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // exactly as it was, on the groups its directory registered.
   //
   // Nothing at all on a tmux REATTACH: it picks the running program up and ignores `command`.
-  const fullGui = !live && claimFullGuiMcp(sessionId, false, cwd);
+  //
+  // Gated on `launcherTakesGuiMcp` BEFORE the claim is recorded: a chip running `zsh`, `yarn dev`
+  // or `agy` has no rewriter, so it is handed no MCP — and recording it as carrying every GUI tool
+  // would misreport it to /api/tools (Codex review on #1399).
+  const fullGui = !live && launcherTakesGuiMcp(command) && claimFullGuiMcp(sessionId, false, cwd);
   const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
   const codexGui = live ? [] : codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: fullGui });
   // The config file is written ONLY once the command is known to be claude. Writing it up front

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -24,6 +24,7 @@ import { codexRolloutExists } from "../agents/codex-sessions.js";
 import {
   antigravityConversations,
   antigravityConversationsHydrated,
+  claimFullGuiMcp,
   codexRolloutIds,
   markDevTerminalSession,
   markAttachedSessionPlaced,
@@ -32,7 +33,7 @@ import {
 import { SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
 import { launcherCommandWithGuiMcp, launcherCommandWithClaudeGuiMcp, launcherProgram, launcherRunsAgent } from "../session/launcher-gui-mcp.js";
-import { codexGuiMcpServers, carriesFullGuiMcp, fullGuiAllowedTools } from "../session/mcp-config.js";
+import { codexGuiMcpServers, fullGuiAllowedTools } from "../session/mcp-config.js";
 import { mcpConfigFileArgument, withSettingsCleanup } from "../session/session-settings.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
@@ -385,9 +386,10 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   const rawSession = url.searchParams.get("session");
   if (rawSession && !requested) console.warn(`[ws] ignoring non-UUID session id: ${JSON.stringify(rawSession)} — starting fresh`);
 
-  // ?gui=0 (the grid's dev terminals) spawns claude WITHOUT the GUI plugin MCP /
-  // --strict-mcp-config, so the user's + project's MCP servers load normally. Absent
-  // (the single view) keeps main's behavior: GUI MCP attached + strict.
+  // ?gui=0 (the grid's dev terminals) spawns claude WITHOUT the GUI plugin MCP, so its GUI tools
+  // come from whatever the directory registered. Absent (the single view) attaches ours on the
+  // all-tools url. Either way the user's + project's MCP servers load — that is not what this
+  // switch decides, and welding it to one was #1338 / #1385.
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   // ?provider=/?model= — what the launch form picked for THIS session (#584). It replaces
@@ -533,12 +535,12 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // lights up for one and never for the other reads as a broken feature. The chip has no argv, only
   // the command line the user wrote, so each agent's MCP arrives as an insertion into that text.
   //
-  // `carriesFullGuiMcp` with `false`, for BOTH: a chip is never the single view, so the cwd is the
+  // `claimFullGuiMcp` with `false`, for BOTH: a chip is never the single view, so the cwd is the
   // only thing that can earn the full GUI MCP here — which keeps a chip in a project directory
   // exactly as it was, on the groups its directory registered.
   //
   // Nothing at all on a tmux REATTACH: it picks the running program up and ignores `command`.
-  const fullGui = !live && carriesFullGuiMcp(false, cwd);
+  const fullGui = !live && claimFullGuiMcp(sessionId, false, cwd);
   const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
   const codexGui = live ? [] : codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: fullGui });
   // The config file is written ONLY once the command is known to be claude. Writing it up front

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -30,7 +30,7 @@ import {
   markAttachedSessionPlaced,
   ptys,
 } from "../session/registry.js";
-import { SpawnRefusedError } from "../session/pty-spawn.js";
+import { SpawnRefusedError, ptyWouldReattach } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
 import {
   launcherCommandWithGuiMcp,
@@ -550,7 +550,12 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // Gated on `launcherTakesGuiMcp` BEFORE the claim is recorded: a chip running `zsh`, `yarn dev`
   // or `agy` has no rewriter, so it is handed no MCP — and recording it as carrying every GUI tool
   // would misreport it to /api/tools (Codex review on #1399).
-  const fullGui = !live && launcherTakesGuiMcp(command) && claimFullGuiMcp(sessionId, false, cwd, false);
+  //
+  // The reattach answer is asked for rather than assumed from `live`: that is only "this process
+  // holds a pty", while a tmux session surviving a server RESTART reattaches with no pty here at
+  // all. Handing the claim a literal `false` would have told it "definitely a new process" in the
+  // one case where the command line is ignored entirely.
+  const fullGui = !live && launcherTakesGuiMcp(command) && claimFullGuiMcp(sessionId, false, cwd, ptyWouldReattach(sessionId, true));
   const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
   const codexGui = live ? [] : codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: fullGui });
   // The config file is written ONLY once the command is known to be claude. Writing it up front

--- a/server/session/all-tools-log.ts
+++ b/server/session/all-tools-log.ts
@@ -1,0 +1,54 @@
+// Which sessions carry the WHOLE GUI MCP, as it is read from and written back to disk.
+//
+// A plain id log (session-id-log.ts) would do, except for one thing its own header rules out:
+// "an id is the only thing ever added (nothing removes one)". This fact can go away. A session id
+// is reused across spawns, and the next process gets whatever it is given at THAT moment — a
+// session that was the single view yesterday can be a project-directory grid cell today, with no
+// all-tools url at all.
+//
+// That was survivable while the answer only widened a pane's tool list. It is not now: a group url
+// serves nothing to a session that carries every tool (mcp/tool-gate.ts), so a stale yes would
+// leave a cell with its groups stood down and nothing to stand in for them — no GUI tools at all.
+//
+// So it takes the shape session-tool-groups.ts already uses for the same reason: an APPEND log with
+// a RELEASE marker, replayed in order. Appending needs no read, which is what keeps it safe without
+// a lock while MULMOTERMINAL_HOME is shared between server instances. A bare id still reads as a
+// claim, so a file written before the marker existed keeps working.
+
+/** A session's RELEASE marker: the id no longer carries the whole GUI MCP. */
+export const ALL_TOOLS_RELEASE = "-";
+
+type Entry = { sessionId: string; carries: boolean };
+
+function entryFromLine(line: string, isValidId: (id: string) => boolean): Entry[] {
+  const [sessionId, marker, ...rest] = line.trim().split(/\s+/);
+  // More than the two fields it should have means a truncated append or a hand-edit. Dropped
+  // rather than guessed at, exactly as the tool-group parser does.
+  if (rest.length > 0 || !sessionId || !isValidId(sessionId)) return [];
+  if (marker === undefined) return [{ sessionId, carries: true }];
+  return marker === ALL_TOOLS_RELEASE ? [{ sessionId, carries: false }] : [];
+}
+
+/**
+ * The ids the file says currently carry the whole GUI MCP, replayed IN ORDER so a release drops a
+ * claim that came before it — the ordering is the whole reason this is not a set union.
+ */
+export function parseAllToolsLog(contents: string, isValidId: (id: string) => boolean): string[] {
+  const carrying = new Set<string>();
+  for (const line of contents.split("\n")) {
+    for (const { sessionId, carries } of entryFromLine(line, isValidId)) {
+      if (carries) carrying.add(sessionId);
+      else carrying.delete(sessionId);
+    }
+  }
+  return [...carrying];
+}
+
+/**
+ * What to append. The newline LEADS rather than trails, for the reason session-id-log.ts spells
+ * out: whatever the file ended with, an appended entry starts its own line, so a write cut off
+ * mid-flight costs one entry rather than welding two together.
+ */
+export function allToolsLogLine(sessionId: string, carries: boolean): string {
+  return carries ? `\n${sessionId}` : `\n${sessionId} ${ALL_TOOLS_RELEASE}`;
+}

--- a/server/session/issue-spawn-options.ts
+++ b/server/session/issue-spawn-options.ts
@@ -12,8 +12,8 @@ import type { SpawnClaudeOptions } from "./spawn-claude.js";
 export function issueSpawnOptions(cwd: string, seed: string, run: boolean): SpawnClaudeOptions {
   return {
     cwd,
-    // A working session in a repository, the same shape as a grid dev terminal, so the project's
-    // own MCP servers load instead of being replaced by the GUI one under --strict-mcp-config.
+    // A working session in a repository, the same shape as a grid dev terminal: it takes its GUI
+    // tools from the project's own MCP config rather than from an all-tools url of ours.
     attachGuiMcp: false,
     ...(run ? { initialPrompt: seed } : { draft: seed }),
   };

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -45,16 +45,14 @@ export function launcherAgent(command: string): SessionAgent {
 
 /**
  * A launcher chip that runs CLAUDE, which reaches the GUI MCP through flags
- * rather than `-c` overrides: `--mcp-config <path> --strict-mcp-config --allowedTools <list>`, the
- * three a claude cell in the workspace is spawned with.
+ * rather than `-c` overrides: `--mcp-config <path> --allowedTools <list>`, the same two a claude
+ * cell in the workspace is spawned with.
  *
- * `--strict-mcp-config` is in on purpose, and what it actually shuts out is narrower than it looks:
- * the generated config is then the ONLY source, but that config already CONTAINS the user's
- * Settings servers (mcpConfigJson merges them), so those still load and are still pre-approved. It
- * is the per-folder `.mcp.json` of a project directory that stops contributing — which in the
- * workspace is the point, since that is the config the group URLs live in and the chip is being
- * given the all-tools URL instead. Same three flags as the cell, same result (owner's call,
- * 2026-08-03); the flag was included because parity is the goal, not despite it.
+ * It used to pass `--strict-mcp-config` as well, for parity with the cell — and that was right
+ * about parity and wrong about the flag: both were hiding the user's claude.ai connectors and
+ * their own MCP servers (#1338, #1385). Parity is still the goal, so this drops the flag on the
+ * same commit the cell does. What keeps the chip from seeing a tool twice is not the flag; it is
+ * that the group urls stand down for a session holding the all-tools url (mcp/tool-gate.ts).
  *
  * The config is a PATH, never inline JSON — see mcpConfigFileArgument.
  *
@@ -68,7 +66,7 @@ export function launcherCommandWithClaudeGuiMcp(
 ): string {
   if (gui === null || launcherProgram(command) !== "claude") return command;
   const quote = shellQuoteFor(platform);
-  const flags = ["--mcp-config", quote(gui.mcpConfigPath), "--strict-mcp-config"];
+  const flags = ["--mcp-config", quote(gui.mcpConfigPath)];
   if (gui.allowedTools) flags.push("--allowedTools", quote(gui.allowedTools));
   return insertAfterProgram(command, flags);
 }

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -44,6 +44,23 @@ export function launcherAgent(command: string): SessionAgent {
 }
 
 /**
+ * Whether a chip's command line will actually be HANDED the GUI MCP — that is, whether one of the
+ * two rewriters below will fire on it.
+ *
+ * Not `launcherRunsAgent`: that also answers yes for antigravity, which has no rewriter here. The
+ * difference matters to anything that records a consequence of the injection rather than performing
+ * it — a chip running `zsh`, `yarn dev` or `agy` is handed no MCP at all, and marking it as carrying
+ * every GUI tool misreports it to `/api/tools` (Codex review on #1399). The same mistake the config
+ * FILE made before #1358, made again for the record instead of the file.
+ *
+ * A spec pins this against what the rewriters actually do, so the two cannot drift apart.
+ */
+export const launcherTakesGuiMcp = (command: string): boolean => {
+  const program = launcherProgram(command);
+  return program === "claude" || program === "codex";
+};
+
+/**
  * A launcher chip that runs CLAUDE, which reaches the GUI MCP through flags
  * rather than `-c` overrides: `--mcp-config <path> --allowedTools <list>`, the same two a claude
  * cell in the workspace is spawned with.

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -120,11 +120,15 @@ export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpSer
 /**
  * What a full-GUI-MCP session pre-approves: our own tools, plus the user's Settings servers by id.
  *
- * Both halves matter, and the second is the one that surprises. `--strict-mcp-config` makes the
- * generated `--mcp-config` the ONLY source — but that payload INCLUDES `userMcpServers` (above), so
- * those servers still load; what strict shuts out is the per-folder `.mcp.json` a project directory
- * would otherwise contribute. Pre-approving them here is what stops each of their tools raising a
- * permission prompt, which is the behaviour the single view has always had.
+ * Both halves matter, and the second is the one that surprises. The generated `--mcp-config`
+ * INCLUDES `userMcpServers` (above), so those servers arrive through our payload rather than
+ * through the user's own config — and pre-approving them here is what stops each of their tools
+ * raising a permission prompt, which is the behaviour the single view has always had.
+ *
+ * Only what WE hand over is pre-approved. The servers Claude Code loads on its own — the
+ * directory's `.mcp.json`, the claude.ai connectors, `~/.claude.json` — prompt as they do in any
+ * other cell; they became reachable here when `--strict-mcp-config` was dropped (#1338, #1385),
+ * and that is a scoping fix, not a licence to auto-allow someone else's tools.
  *
  * Shared rather than spelled out at each spawn because the two callers — a claude cell and a
  * launcher chip running claude — are supposed to be indistinguishable, and this PR exists because

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -28,6 +28,7 @@ import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { devTerminalCwdLine, hydrateCwdsInto } from "./dev-terminal-cwds.js";
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
+import { carriesFullGuiMcp } from "./mcp-config.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
 // Per-session "working" state, driven by Claude hooks (see /api/hook):
@@ -308,10 +309,13 @@ export function isPhoneListableSession(id: string): boolean {
   return devTerminalSessions.has(id) || (unplacedSessions.has(id) && !placedSessions.has(id));
 }
 
-// Sessions that connected on the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url is handed
-// out by --mcp-config and by nothing else, so reaching it is proof the session carries the whole
-// GUI MCP — including the tools that belong to no group and are therefore unreachable through a
-// group url (spawnBackgroundChat).
+// Sessions handed the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url comes from --mcp-config
+// and from nothing else, so it means the session carries the whole GUI MCP — including the tools
+// that belong to no group and are therefore unreachable through a group url (spawnBackgroundChat).
+//
+// Written at TWO moments, and the earlier one is what a decision can rely on. Connecting proves it
+// (below), but a group url may be the first to connect, and it has to know the answer already to
+// stand down (#1338) — so `claimFullGuiMcp` records it at spawn, before either client dials.
 //
 // Recorded as its own fact rather than inferred from "has all four groups", which is a different
 // statement: a directory that registered every group url really does have all four groups and
@@ -336,6 +340,21 @@ export function markAllToolsSession(id: string): void {
 /** Does this session carry the whole GUI MCP, rather than the subset its directory registered? */
 export function hasAllGuiTools(id: string): boolean {
   return allToolsSessions.has(id);
+}
+
+/**
+ * Decide whether a spawn carries the full GUI MCP AND record the answer, in one call.
+ *
+ * Every spawn path asks `carriesFullGuiMcp` — claude's argv, codex's `-c` overrides, the launcher
+ * chip — and each of them then hands out the all-tools url. Keeping the question and the record
+ * apart is how a fourth path would come to hand out the url without anyone knowing, which is the
+ * shape of the drift CLAUDE.md warns about around this predicate. So spawn paths call THIS; the
+ * pure predicate stays exported for the specs and for readers reasoning about the rule.
+ */
+export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined): boolean {
+  const full = carriesFullGuiMcp(attachGuiMcp, cwd);
+  if (full) markAllToolsSession(sessionId);
+  return full;
 }
 
 // Sessions the SCHEDULER started — a user's own configured task, as opposed to a collection

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -27,6 +27,7 @@ import { normalizeMemo } from "../../common/sessionMemo.js";
 import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { devTerminalCwdLine, hydrateCwdsInto } from "./dev-terminal-cwds.js";
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
+import { allToolsLogLine, parseAllToolsLog } from "./all-tools-log.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
 import { carriesFullGuiMcp } from "./mcp-config.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
@@ -326,15 +327,43 @@ export function isPhoneListableSession(id: string): boolean {
 // the ListTools that would teach us again.
 const allToolsSessions = new Set<string>();
 const ALL_TOOLS_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "all-tools-sessions.json");
-export const allToolsSessionsHydrated = hydrateIdLog(ALL_TOOLS_SESSIONS_FILE, allToolsSessions);
-const appendAllToolsSession = idLogAppender(ALL_TOOLS_SESSIONS_FILE, "all-tools-sessions");
+export const allToolsSessionsHydrated = (async () => {
+  try {
+    for (const id of parseAllToolsLog(await fs.readFile(ALL_TOOLS_SESSIONS_FILE, "utf8"), isValidSessionId)) allToolsSessions.add(id);
+  } catch {
+    // absent on first run / unreadable => nothing remembered
+  }
+})();
+let allToolsPersist: Promise<void> = Promise.resolve();
+function appendAllToolsEntry(id: string, carries: boolean): void {
+  allToolsPersist = allToolsPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(ALL_TOOLS_SESSIONS_FILE, allToolsLogLine(id, carries)))
+    .catch((e) => console.error(`[all-tools-sessions] failed to persist: ${messageOf(e)}`));
+}
+export const whenAllToolsPersisted = (): Promise<void> => allToolsPersist;
 
 /** Note that a session reached us on the all-tools url. A no-op once known — one server is built
  *  per MCP request, so this is asked on every tool call. */
 export function markAllToolsSession(id: string): void {
   if (!isValidSessionId(id) || allToolsSessions.has(id)) return;
   allToolsSessions.add(id);
-  appendAllToolsSession(id);
+  appendAllToolsEntry(id, true);
+}
+
+/**
+ * The opposite, and the reason this log needed a release marker at all: a session id outlives the
+ * process that earned the claim. A new process given no all-tools url must stop answering yes, or
+ * its group urls stand down (mcp/tool-gate.ts) with nothing left to serve the tools — a cell with
+ * no GUI tools at all, which is worse than the duplicate the standing-down prevents.
+ *
+ * Called only where a genuinely NEW process is starting, never on a tmux reattach: there the
+ * original process is still running with whatever url it was given.
+ */
+export function releaseAllToolsSession(id: string): void {
+  if (!isValidSessionId(id) || !allToolsSessions.has(id)) return;
+  allToolsSessions.delete(id);
+  appendAllToolsEntry(id, false);
 }
 
 /** Does this session carry the whole GUI MCP, rather than the subset its directory registered? */

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -372,17 +372,28 @@ export function hasAllGuiTools(id: string): boolean {
 }
 
 /**
- * Decide whether a spawn carries the full GUI MCP AND record the answer, in one call.
+ * Decide whether a spawn carries the full GUI MCP AND bring the record in line, in one call.
  *
  * Every spawn path asks `carriesFullGuiMcp` — claude's argv, codex's `-c` overrides, the launcher
- * chip — and each of them then hands out the all-tools url. Keeping the question and the record
- * apart is how a fourth path would come to hand out the url without anyone knowing, which is the
- * shape of the drift CLAUDE.md warns about around this predicate. So spawn paths call THIS; the
- * pure predicate stays exported for the specs and for readers reasoning about the rule.
+ * chip — and each then hands out the all-tools url, or does not. Keeping the question and the record
+ * apart is how one of them comes to answer differently from what it handed over, which is the drift
+ * CLAUDE.md warns about around this predicate and is what happened twice in review on #1399: a chip
+ * running `zsh` claimed without being handed anything, and codex claimed without ever releasing.
+ * So spawn paths call THIS; the pure predicate stays exported for the specs and for readers.
+ *
+ * The two directions are NOT symmetric, and the asymmetry is the safety:
+ *
+ * - **Release unconditionally.** Releasing one that should have been kept only brings the duplicate
+ *   tool names back — cosmetic, and the next spawn corrects it. Keeping a stale claim leaves a cell
+ *   with its group urls stood down and no all-tools url to serve them: no GUI tools at all.
+ * - **Claim only for a genuinely new process.** A tmux reattach runs whatever the ORIGINAL spawn was
+ *   given, which may be no all-tools url — claiming on top of that is exactly the stale-claim
+ *   failure, arrived at from the other side.
  */
-export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined): boolean {
+export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined, wouldReattach: boolean): boolean {
   const full = carriesFullGuiMcp(attachGuiMcp, cwd);
-  if (full) markAllToolsSession(sessionId);
+  if (!full) releaseAllToolsSession(sessionId);
+  else if (!wouldReattach) markAllToolsSession(sessionId);
   return full;
 }
 

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -3,13 +3,13 @@
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
-import { guiMcpEnv, fullGuiAllowedTools } from "./mcp-config.js";
+import { guiMcpEnv, carriesFullGuiMcp, fullGuiAllowedTools } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter, getAppendSystemPrompt, getTerminalSubmit } from "../config/config-routes.js";
 import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
 import { claudeAdapter } from "../agents/claude.js";
 import { appendedSystemPrompt } from "../agents/appended-prompt.js";
-import { claimFullGuiMcp, hookedSessions, knownSessions, launchChoices, ptys, releaseAllToolsSession, resetSessionToolGroups } from "./registry.js";
+import { claimFullGuiMcp, hookedSessions, knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyExitLine, ptyStartLine } from "./pty-exit-log.js";
 import { attachDraftInjection } from "./draft-injection.js";
@@ -112,7 +112,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
   // reattaches.
   function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, options: SpawnClaudeOptions = {}): PtyEntry {
     const { initialPrompt, cwd = CLAUDE_CWD, attachGuiMcp = true, draft, launch } = options;
-    const fullGuiMcp = claimFullGuiMcp(sessionId, attachGuiMcp, cwd);
+    const fullGuiMcp = carriesFullGuiMcp(attachGuiMcp, cwd);
     // fullGuiMcp picks the MCP mode (see buildClaudeArgs, and its own doc for who earns it): our
     // broker on one all-tools url; a project-directory cell gets none of ours and loads the GUI
     // tools its own directory registered. Either way the user's own MCP servers load.
@@ -180,18 +180,17 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // survives it is an over-reported group on a session that lost it — the next genuinely new
     // process clears that, whereas the reverse mistake could not be undone at all.
     //
-    // The all-tools claim is released on the same condition and for the same reason: a session id
-    // outlives its process, so one spawned as the single view and respawned as a project-directory
-    // cell would otherwise keep answering that it carries every tool — and its group urls would
-    // stand down for a process that has no all-tools url to fall back on.
-    function resetToolGroupsUnlessReattaching(): void {
-      if (ptyWouldReattach(sessionId, true)) return;
-      resetSessionToolGroups(sessionId);
-      if (!fullGuiMcp) releaseAllToolsSession(sessionId);
+    // The all-tools claim rides the SAME probe rather than taking its own: asking twice would widen
+    // exactly the window this is placed here to keep narrow. It is passed the answer instead of
+    // asking, and decides for itself what a reattach means for each direction (see claimFullGuiMcp).
+    function recordCapabilitiesForThisSpawn(): void {
+      const reattaching = ptyWouldReattach(sessionId, true);
+      if (!reattaching) resetSessionToolGroups(sessionId);
+      claimFullGuiMcp(sessionId, attachGuiMcp, cwd, reattaching);
     }
 
     function spawnEntry(): PtyEntry {
-      resetToolGroupsUnlessReattaching();
+      recordCapabilitiesForThisSpawn();
       const spawnEnv = { unset: resolved.unset, env: guiMcpEnv(sessionId, PORT), binEnvVar: claudeAdapter.binEnvVar };
       const { term, tmux, reattached } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, spawnEnv);
       console.log(ptyStartLine({ agent: "claude", pid: term.pid, cwd, tmux, reattached, sessionId, note: canResume ? `resume ${resume}` : null }));

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -9,7 +9,7 @@ import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
 import { claudeAdapter } from "../agents/claude.js";
 import { appendedSystemPrompt } from "../agents/appended-prompt.js";
-import { claimFullGuiMcp, hookedSessions, knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
+import { claimFullGuiMcp, hookedSessions, knownSessions, launchChoices, ptys, releaseAllToolsSession, resetSessionToolGroups } from "./registry.js";
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyExitLine, ptyStartLine } from "./pty-exit-log.js";
 import { attachDraftInjection } from "./draft-injection.js";
@@ -179,8 +179,15 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // remaining window is irreducible without tmux reporting which branch `-A` took, and what
     // survives it is an over-reported group on a session that lost it — the next genuinely new
     // process clears that, whereas the reverse mistake could not be undone at all.
+    //
+    // The all-tools claim is released on the same condition and for the same reason: a session id
+    // outlives its process, so one spawned as the single view and respawned as a project-directory
+    // cell would otherwise keep answering that it carries every tool — and its group urls would
+    // stand down for a process that has no all-tools url to fall back on.
     function resetToolGroupsUnlessReattaching(): void {
-      if (!ptyWouldReattach(sessionId, true)) resetSessionToolGroups(sessionId);
+      if (ptyWouldReattach(sessionId, true)) return;
+      resetSessionToolGroups(sessionId);
+      if (!fullGuiMcp) releaseAllToolsSession(sessionId);
     }
 
     function spawnEntry(): PtyEntry {

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -3,13 +3,13 @@
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
-import { guiMcpEnv, carriesFullGuiMcp, fullGuiAllowedTools } from "./mcp-config.js";
+import { guiMcpEnv, fullGuiAllowedTools } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter, getAppendSystemPrompt, getTerminalSubmit } from "../config/config-routes.js";
 import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
 import { claudeAdapter } from "../agents/claude.js";
 import { appendedSystemPrompt } from "../agents/appended-prompt.js";
-import { hookedSessions, knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
+import { claimFullGuiMcp, hookedSessions, knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyExitLine, ptyStartLine } from "./pty-exit-log.js";
 import { attachDraftInjection } from "./draft-injection.js";
@@ -112,9 +112,10 @@ export function createClaudeSpawner(deps: SpawnDeps) {
   // reattaches.
   function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, options: SpawnClaudeOptions = {}): PtyEntry {
     const { initialPrompt, cwd = CLAUDE_CWD, attachGuiMcp = true, draft, launch } = options;
-    const fullGuiMcp = carriesFullGuiMcp(attachGuiMcp, cwd);
-    // fullGuiMcp picks the MCP mode (see buildClaudeArgs, and its own doc for who earns it): the
-    // GUI MCP + --strict-mcp-config; a project-directory cell attaches neither, so its own load.
+    const fullGuiMcp = claimFullGuiMcp(sessionId, attachGuiMcp, cwd);
+    // fullGuiMcp picks the MCP mode (see buildClaudeArgs, and its own doc for who earns it): our
+    // broker on one all-tools url; a project-directory cell gets none of ours and loads the GUI
+    // tools its own directory registered. Either way the user's own MCP servers load.
     // Only --resume when the session has an on-disk transcript — claude doesn't write
     // a session's .jsonl until its first prompt, so a started-but-unused session can't
     // be resumed; we restart fresh (reusing the id via --session-id) instead.

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -6,11 +6,11 @@ import { PORT } from "../config/env.js";
 import { buildCodexArgs } from "../agents/codex-args.js";
 import { codexAdapter } from "../agents/codex.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
-import { codexGuiMcpServers, carriesFullGuiMcp } from "./mcp-config.js";
+import { codexGuiMcpServers } from "./mcp-config.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
-import { claimedCodexRollouts, codexRolloutIds, ptys } from "./registry.js";
+import { claimedCodexRollouts, claimFullGuiMcp, codexRolloutIds, ptys } from "./registry.js";
 import { ptySpawn } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
@@ -83,7 +83,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
     // spawnBackgroundChat, which belongs to no group and is therefore reachable ONLY this way. All
     // of it was already auto-allowed for claude in the same cell, which is the asymmetry this
     // closes; it is still the widest thing this flag does, and the reason it is spelled out here.
-    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: carriesFullGuiMcp(attachGuiMcp, cwd) });
+    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: claimFullGuiMcp(sessionId, attachGuiMcp, cwd) });
     const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.codexBin, args, cwd, true, { binEnvVar: codexAdapter.binEnvVar });
     const spawnedAtMs = Date.now();

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -11,7 +11,7 @@ import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../ag
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
 import { claimedCodexRollouts, claimFullGuiMcp, codexRolloutIds, ptys } from "./registry.js";
-import { ptySpawn } from "./pty-spawn.js";
+import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { attachCodexAutoRun } from "./draft-injection.js";
@@ -83,7 +83,12 @@ export function createCodexSpawner(deps: SpawnDeps) {
     // spawnBackgroundChat, which belongs to no group and is therefore reachable ONLY this way. All
     // of it was already auto-allowed for claude in the same cell, which is the asymmetry this
     // closes; it is still the widest thing this flag does, and the reason it is spelled out here.
-    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: claimFullGuiMcp(sessionId, attachGuiMcp, cwd) });
+    // The claim is RELEASED here as well as made — a codex session resumed into a project directory
+    // reuses the id, and a stale claim would stand its group urls down with nothing left to serve
+    // them (Codex review on #1399). claimFullGuiMcp owns both directions so neither spawn path can
+    // apply half the rule.
+    const allTools = claimFullGuiMcp(sessionId, attachGuiMcp, cwd, ptyWouldReattach(sessionId, true));
+    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools });
     const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.codexBin, args, cwd, true, { binEnvVar: codexAdapter.binEnvVar });
     const spawnedAtMs = Date.now();

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -318,8 +318,8 @@ const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed
 
 // The workspace has no per-directory choice to offer: a session started there is handed the WHOLE
 // GUI MCP on one URL, whatever agent runs it (`carriesFullGuiMcp`, server/session/mcp-config.ts).
-// The four switches are not merely redundant there — they write a per-folder registration that
-// `--strict-mcp-config` then ignores, so they would be controls that visibly do nothing.
+// The four switches are not merely redundant there — a group URL serves nothing to a session that
+// already carries every tool (server/mcp/tool-gate.ts), so they would visibly do nothing.
 //
 // Asked of the directory the launch will USE, not of the field: an empty field means the workspace
 // (see dirFor), which is exactly the case a comparison against the raw input would miss.
@@ -546,8 +546,8 @@ async function removeWorktree(w: Worktree): Promise<void> {
          media both draw but differ in what a call costs, and data and external do not draw at
          all — the split is exactly what the grouping exists for (common/toolGroups.ts). -->
     <template v-if="mcpGroupDir && launchesAgent">
-      <!-- The workspace gets every tool automatically, so it is TOLD, not asked. Switches here
-           would write a registration --strict-mcp-config ignores: controls that do nothing. -->
+      <!-- The workspace gets every tool automatically, so it is TOLD, not asked. A switch here
+           would register a group URL with nothing left to serve: a control that does nothing. -->
       <div v-if="inWorkspace" data-testid="cell-mcp-all" class="flex w-full max-w-[360px] flex-col gap-0.5">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
         <span class="font-sans text-[11px] leading-snug text-secondary">

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -30,10 +30,10 @@ import type { LaunchChoice } from "./wsUrl";
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
 // session (or starting another fresh one) still forces a reconnect.
-// `devTerminal` runs claude as a plain dev terminal (the grid): NO GUI plugin MCP
-// and NO --strict-mcp-config, so the user's (~/.claude.json) + project's (.mcp.json)
-// MCP servers load normally. Default (false, the single view) keeps main's behavior:
-// the in-process GUI MCP attached and isolated with --strict-mcp-config.
+// `devTerminal` runs claude as a plain dev terminal (the grid): no GUI plugin MCP of
+// ours, so its GUI tools come from whatever the directory registered. Default (false,
+// the single view) attaches the in-process GUI MCP on one all-tools url. The user's
+// (~/.claude.json) + project's (.mcp.json) MCP servers load in both.
 // `command` switches the terminal to a plain shell command (the grid's Run menu):
 // it connects to /ws/run with the script index instead of resuming a Claude
 // session, and never auto-reconnects (the ephemeral process can't be resumed).

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -20,7 +20,7 @@ const base: ClaudeArgsInput = {
 const cfg = (over: Partial<ClaudeArgsInput> = {}): ClaudeArgsInput => ({ ...base, ...over });
 
 describe("buildClaudeArgs", () => {
-  it("single view (attachGuiMcp): attaches GUI MCP + --strict-mcp-config + --allowedTools", () => {
+  it("single view (attachGuiMcp): attaches GUI MCP + --allowedTools, and nothing that isolates", () => {
     const args = buildClaudeArgs(base);
     expect(args).toEqual([
       "--session-id",
@@ -33,16 +33,15 @@ describe("buildClaudeArgs", () => {
       SESSION_SUMMARY_PROMPT,
       "--mcp-config",
       "{gui-mcp}",
-      "--strict-mcp-config",
       "--allowedTools",
       "mcp__gui__a,mcp__gui__b",
     ]);
   });
 
-  // A grid cell's GUI tools arrive through the USER's own per-folder MCP config, so it must
-  // get neither --mcp-config nor --strict-mcp-config (which would ignore that config) — but it
-  // still pre-approves the render group, or every draw stops at a permission prompt.
-  it("grid dev terminal (attachGuiMcp=false): no GUI MCP, no --strict-mcp-config, but keeps --allowedTools", () => {
+  // A grid cell's GUI tools arrive through the USER's own per-folder MCP config, so it gets no
+  // --mcp-config of ours — but it still pre-approves the render group, or every draw stops at a
+  // permission prompt.
+  it("grid dev terminal (attachGuiMcp=false): no GUI MCP, but keeps --allowedTools", () => {
     const args = buildClaudeArgs({ ...base, attachGuiMcp: false });
     expect(args).toEqual([
       "--session-id",
@@ -58,6 +57,21 @@ describe("buildClaudeArgs", () => {
     ]);
     expect(args).not.toContain("--mcp-config");
     expect(args).not.toContain("--strict-mcp-config");
+  });
+
+  // The regression #1338 / #1385 are: attaching our broker must ADD to what the session can reach,
+  // never replace it. `--strict-mcp-config` made --mcp-config the only source, which took the user's
+  // claude.ai connectors, ~/.claude.json and the directory's .mcp.json with it. Asserted for the
+  // mode that HAS the GUI MCP — the other two cases below only ever lacked the flag because they
+  // lack --mcp-config, so they could not have caught this.
+  it.each([[true], [false]])("never isolates the session, attachGuiMcp=%s", (attachGuiMcp) => {
+    expect(buildClaudeArgs({ ...base, attachGuiMcp })).not.toContain("--strict-mcp-config");
+  });
+
+  // The other half of that regression, and the one a careless fix would cause: dropping the flag
+  // must not drop the broker with it, or the GUI panel silently stops working.
+  it("still attaches the GUI MCP when it has one", () => {
+    expect(buildClaudeArgs(base)).toContain("--mcp-config");
   });
 
   it("omits --allowedTools entirely when there is nothing to pre-approve", () => {

--- a/test/server/mcp/tool-gate.spec.ts
+++ b/test/server/mcp/tool-gate.spec.ts
@@ -197,3 +197,38 @@ describe("the tool-group gate", () => {
     });
   });
 });
+
+// Removing `--strict-mcp-config` (#1338, #1385) is what lets a directory's own group registration
+// and our all-tools url reach the same session. Both urls are ours, so the overlap is settled here
+// rather than by a CLI flag: the group stands down, and the session keeps ONE name per action.
+describe("a group URL on a session that already carries every tool", () => {
+  it("offers nothing, so the same tool cannot arrive under two names", () => {
+    expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, "render", true))).toEqual([]);
+    expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, "data", true))).toEqual([]);
+  });
+
+  // The half that would break the feature instead of the duplicate: standing down is a property of
+  // the GROUP url, and the all-tools url is where those tools now live.
+  it("leaves the all-tools url offering everything", () => {
+    expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, null, true))).toEqual(["manageCollection", "presentHtml", "spawnBackgroundChat"]);
+  });
+
+  // Second layer, same reason as every other gate here: not offering a tool is not a control.
+  it("refuses a tool named anyway, and says where it actually is", () => {
+    const route = routeToolCall("presentHtml", false, "render", true);
+    expect(route.kind).toBe("refused");
+    // The message has to be actionable — "not in this group" would be true and useless, since the
+    // session can call this very tool right now on its other server.
+    expect(route.kind === "refused" && route.message).toContain("all-tools");
+  });
+
+  it("still dispatches on the all-tools url", () => {
+    expect(routeToolCall("presentHtml", false, null, true)).toEqual({ kind: "dispatch" });
+  });
+
+  // The worker gate stays the narrowest one: it is a security boundary, and this is a tidiness one.
+  it("does not disturb a translation worker", () => {
+    expect(names(offeredTools(true, PLUGINS, WORKER_TOOL, "render", true))).toEqual([SUBMIT_TRANSLATION_TOOL_NAME]);
+    expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, true, "render", true)).toEqual({ kind: "submit-translation" });
+  });
+});

--- a/test/server/session/all-tools-log.spec.ts
+++ b/test/server/session/all-tools-log.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+// The log that says which sessions carry the whole GUI MCP. It needs a release marker for the
+// reason session-tool-groups.ts needs one: a session id outlives the process that earned the
+// claim, and a stale yes now stands a cell's group urls down with nothing to replace them.
+import { describe, it, expect } from "vitest";
+
+import { parseAllToolsLog, allToolsLogLine, ALL_TOOLS_RELEASE } from "../../../server/session/all-tools-log.js";
+
+const A = "11111111-1111-4111-8111-111111111111";
+const B = "22222222-2222-4222-8222-222222222222";
+const isValidId = (id: string) => /^[0-9a-f-]{36}$/.test(id);
+
+describe("parseAllToolsLog", () => {
+  it("reads a bare id as a claim, so a file written before the marker existed still works", () => {
+    expect(parseAllToolsLog(`${A}\n${B}`, isValidId).sort()).toEqual([A, B].sort());
+  });
+
+  it("drops a claim that a later release cancels", () => {
+    expect(parseAllToolsLog(`${A}\n${A} ${ALL_TOOLS_RELEASE}`, isValidId)).toEqual([]);
+  });
+
+  // The ordering is the whole reason this is not a set union: a session released and then given
+  // the url again is carrying it.
+  it("takes the LAST word for a session", () => {
+    expect(parseAllToolsLog(`${A}\n${A} ${ALL_TOOLS_RELEASE}\n${A}`, isValidId)).toEqual([A]);
+    expect(parseAllToolsLog(`${A} ${ALL_TOOLS_RELEASE}\n${A}\n${A} ${ALL_TOOLS_RELEASE}`, isValidId)).toEqual([]);
+  });
+
+  it("releases one session without touching another", () => {
+    expect(parseAllToolsLog(`${A}\n${B}\n${A} ${ALL_TOOLS_RELEASE}`, isValidId)).toEqual([B]);
+  });
+
+  it("releases a session that was never claimed, harmlessly", () => {
+    expect(parseAllToolsLog(`${A} ${ALL_TOOLS_RELEASE}`, isValidId)).toEqual([]);
+  });
+
+  // Dropped rather than guessed at — the same rule the tool-group parser follows, and these end up
+  // compared against real session ids.
+  it.each([["not-a-uuid"], [`${A} ${ALL_TOOLS_RELEASE} extra`], [`${A} nonsense`], [""], ["   "]])("drops the unusable line %j", (line) => {
+    expect(parseAllToolsLog(line, isValidId)).toEqual([]);
+  });
+
+  it("tolerates blank lines and surrounding whitespace", () => {
+    expect(parseAllToolsLog(`\n  ${A}  \n\n`, isValidId)).toEqual([A]);
+  });
+});
+
+describe("allToolsLogLine", () => {
+  // Leading newline, for the reason session-id-log.ts spells out: an appended entry must start its
+  // own line whatever the file ended with, or a cut-off write welds two entries together.
+  it("leads with a newline in both directions", () => {
+    expect(allToolsLogLine(A, true)).toBe(`\n${A}`);
+    expect(allToolsLogLine(A, false)).toBe(`\n${A} ${ALL_TOOLS_RELEASE}`);
+  });
+
+  // The round trip is what the two halves have to agree on, and where a format change would show.
+  it("round-trips through the parser", () => {
+    const file = [allToolsLogLine(A, true), allToolsLogLine(B, true), allToolsLogLine(A, false)].join("");
+    expect(parseAllToolsLog(file, isValidId)).toEqual([B]);
+  });
+});

--- a/test/server/session/full-gui-claim.spec.ts
+++ b/test/server/session/full-gui-claim.spec.ts
@@ -19,7 +19,7 @@ const HOME = makeTempDir("mt-full-gui-claim-");
 const REAL_HOME = process.env.HOME;
 process.env.HOME = HOME;
 const { mountMcpRoutes } = await import("../../../server/routes/mcp-routes.js");
-const { claimFullGuiMcp, hasAllGuiTools, whenToolGroupsPersisted } = await import("../../../server/session/registry.js");
+const { claimFullGuiMcp, hasAllGuiTools, releaseAllToolsSession, whenToolGroupsPersisted } = await import("../../../server/session/registry.js");
 const { carriesFullGuiMcp } = await import("../../../server/session/mcp-config.js");
 const { CLAUDE_CWD } = await import("../../../server/config/env.js");
 
@@ -75,6 +75,34 @@ describe("claimFullGuiMcp", () => {
 // Nothing here asserts the id reaches disk. `markAllToolsSession` already persisted before this
 // change and its append queue is private to the appender; what moved is only WHEN the mark is
 // made, which the group-url cases below are what actually prove.
+
+// A session id outlives the process that earned the claim: one opened in the single view (which
+// takes the whole GUI MCP whatever its cwd) can be respawned as a project-directory grid cell. If
+// the claim survived that, the new process would have its group urls stood down AND no all-tools
+// url to fall back on — a cell with no GUI tools at all, which is worse than the duplicate the
+// standing-down exists to prevent. spawn-claude releases it wherever it resets the tool groups.
+describe("releaseAllToolsSession", () => {
+  it("takes the claim back", () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, "/some/project");
+    releaseAllToolsSession(id);
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+
+  it("hands the group its tools back", async () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, "/some/project");
+    expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
+    releaseAllToolsSession(id);
+    expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text).length).toBeGreaterThan(0);
+  });
+
+  it("is harmless on a session that never claimed", () => {
+    const id = randomUUID();
+    releaseAllToolsSession(id);
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+});
 
 describe("a group url once the session is claimed", () => {
   it("offers nothing, however early the group url connects", async () => {

--- a/test/server/session/full-gui-claim.spec.ts
+++ b/test/server/session/full-gui-claim.spec.ts
@@ -53,14 +53,14 @@ describe("claimFullGuiMcp", () => {
       [true, CLAUDE_CWD],
       [false, CLAUDE_CWD],
     ] as const) {
-      expect(claimFullGuiMcp(randomUUID(), attach, cwd)).toBe(carriesFullGuiMcp(attach, cwd));
+      expect(claimFullGuiMcp(randomUUID(), attach, cwd, false)).toBe(carriesFullGuiMcp(attach, cwd));
     }
   });
 
   it("records the session when it carries the full GUI MCP", () => {
     const id = randomUUID();
     expect(hasAllGuiTools(id)).toBe(false);
-    claimFullGuiMcp(id, true, "/some/project");
+    claimFullGuiMcp(id, true, "/some/project", false);
     expect(hasAllGuiTools(id)).toBe(true);
   });
 
@@ -68,8 +68,42 @@ describe("claimFullGuiMcp", () => {
   // registered — marking it would switch exactly those off.
   it("records nothing for a cell that carries no GUI MCP of ours", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, false, "/some/project");
+    claimFullGuiMcp(id, false, "/some/project", false);
     expect(hasAllGuiTools(id)).toBe(false);
+  });
+
+  // The half Codex found missing on the codex spawn path: a session id is reused across spawns, so
+  // deciding "no" has to TAKE THE CLAIM BACK, not merely decline to add one.
+  it("releases a claim the session no longer earns", () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
+    expect(hasAllGuiTools(id)).toBe(true);
+    claimFullGuiMcp(id, false, "/some/project", false);
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+
+  // The two directions are deliberately not symmetric. A tmux reattach runs whatever the ORIGINAL
+  // spawn was given, so claiming on top of it would assert a url this process may never have had —
+  // the same stale-claim failure, reached from the other side.
+  it("does not claim on a reattach", () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, CLAUDE_CWD, true);
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+
+  // Releasing is unconditional, because the two mistakes do not cost the same: an over-release only
+  // brings the duplicate tool names back and the next spawn corrects it, while a stale claim leaves
+  // a cell with no GUI tools at all.
+  it("releases even on a reattach", () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
+    claimFullGuiMcp(id, false, "/some/project", true);
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+
+  it("still answers the pure predicate on a reattach, whatever it records", () => {
+    expect(claimFullGuiMcp(randomUUID(), true, CLAUDE_CWD, true)).toBe(true);
+    expect(claimFullGuiMcp(randomUUID(), false, "/some/project", true)).toBe(false);
   });
 });
 // Nothing here asserts the id reaches disk. `markAllToolsSession` already persisted before this
@@ -84,14 +118,14 @@ describe("claimFullGuiMcp", () => {
 describe("releaseAllToolsSession", () => {
   it("takes the claim back", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, "/some/project");
+    claimFullGuiMcp(id, true, "/some/project", false);
     releaseAllToolsSession(id);
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
   it("hands the group its tools back", async () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, "/some/project");
+    claimFullGuiMcp(id, true, "/some/project", false);
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
     releaseAllToolsSession(id);
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text).length).toBeGreaterThan(0);
@@ -110,7 +144,7 @@ describe("a group url once the session is claimed", () => {
     // The order this spec exists for: the GROUP url is the first thing to reach us. Before the
     // claim moved to spawn, "does it have all tools" was learned from whichever url connected
     // first, so this call would have been served the full render group.
-    claimFullGuiMcp(id, true, CLAUDE_CWD);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
   });
 
@@ -123,7 +157,7 @@ describe("a group url once the session is claimed", () => {
   // the group down is only correct because the all-tools url carries the same tools and more.
   it("leaves the all-tools url serving everything", async () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, CLAUDE_CWD);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
     const all = toolNamesFrom((await listTools(`/api/mcp/${id}`)).text);
     const group = toolNamesFrom((await listTools(`/api/mcp/render/${randomUUID()}`)).text);
     expect(all.length).toBeGreaterThan(group.length);

--- a/test/server/session/full-gui-claim.spec.ts
+++ b/test/server/session/full-gui-claim.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+// Who is recorded as carrying the whole GUI MCP, and what the group urls do about it.
+//
+// Removing `--strict-mcp-config` (#1338, #1385) is what lets a directory's own group registration
+// and our all-tools url land on the SAME session. Both urls are ours, so the overlap is resolved on
+// our side rather than by a CLI flag — but only if the answer is known before either client dials,
+// which is why the claim happens at spawn rather than on first contact.
+import { describe, it, expect, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import express from "express";
+import request from "supertest";
+import { makeTempDir } from "../../support/tempDir";
+
+// Same reason as mcp-announce.spec.ts: the registry derives MULMOTERMINAL_HOME from the home
+// directory at import time and PERSISTS what it learns, so HOME is pointed somewhere disposable
+// before importing and put back afterwards (a worker is reused across spec files).
+const HOME = makeTempDir("mt-full-gui-claim-");
+const REAL_HOME = process.env.HOME;
+process.env.HOME = HOME;
+const { mountMcpRoutes } = await import("../../../server/routes/mcp-routes.js");
+const { claimFullGuiMcp, hasAllGuiTools, whenToolGroupsPersisted } = await import("../../../server/session/registry.js");
+const { carriesFullGuiMcp } = await import("../../../server/session/mcp-config.js");
+const { CLAUDE_CWD } = await import("../../../server/config/env.js");
+
+afterAll(async () => {
+  await whenToolGroupsPersisted();
+  if (REAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = REAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+const app = express();
+app.use(express.json());
+mountMcpRoutes(app, { publish: () => {}, guiCallHistory: () => null });
+
+const listTools = (route: string) =>
+  request(app).post(route).set("accept", "application/json, text/event-stream").send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+// The route answers as SSE, so the JSON-RPC body arrives on a `data:` line.
+function toolNamesFrom(text: string): string[] {
+  const line = text.split("\n").find((l) => l.startsWith("data:"));
+  const payload: unknown = JSON.parse((line ?? "").replace(/^data:\s*/, ""));
+  const tools = (payload as { result?: { tools?: { name: string }[] } }).result?.tools ?? [];
+  return tools.map((t) => t.name);
+}
+
+describe("claimFullGuiMcp", () => {
+  it("answers exactly what the pure predicate answers", () => {
+    for (const [attach, cwd] of [
+      [true, "/some/project"],
+      [false, "/some/project"],
+      [true, CLAUDE_CWD],
+      [false, CLAUDE_CWD],
+    ] as const) {
+      expect(claimFullGuiMcp(randomUUID(), attach, cwd)).toBe(carriesFullGuiMcp(attach, cwd));
+    }
+  });
+
+  it("records the session when it carries the full GUI MCP", () => {
+    const id = randomUUID();
+    expect(hasAllGuiTools(id)).toBe(false);
+    claimFullGuiMcp(id, true, "/some/project");
+    expect(hasAllGuiTools(id)).toBe(true);
+  });
+
+  // A project-directory cell reaches its GUI tools through the group urls its own directory
+  // registered — marking it would switch exactly those off.
+  it("records nothing for a cell that carries no GUI MCP of ours", () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, false, "/some/project");
+    expect(hasAllGuiTools(id)).toBe(false);
+  });
+});
+// Nothing here asserts the id reaches disk. `markAllToolsSession` already persisted before this
+// change and its append queue is private to the appender; what moved is only WHEN the mark is
+// made, which the group-url cases below are what actually prove.
+
+describe("a group url once the session is claimed", () => {
+  it("offers nothing, however early the group url connects", async () => {
+    const id = randomUUID();
+    // The order this spec exists for: the GROUP url is the first thing to reach us. Before the
+    // claim moved to spawn, "does it have all tools" was learned from whichever url connected
+    // first, so this call would have been served the full render group.
+    claimFullGuiMcp(id, true, CLAUDE_CWD);
+    expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
+  });
+
+  it("still serves the group to a session that was never claimed", async () => {
+    const id = randomUUID();
+    expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text).length).toBeGreaterThan(0);
+  });
+
+  // The failure a careless version of this would cause: the tools have to be somewhere. Standing
+  // the group down is only correct because the all-tools url carries the same tools and more.
+  it("leaves the all-tools url serving everything", async () => {
+    const id = randomUUID();
+    claimFullGuiMcp(id, true, CLAUDE_CWD);
+    const all = toolNamesFrom((await listTools(`/api/mcp/${id}`)).text);
+    const group = toolNamesFrom((await listTools(`/api/mcp/render/${randomUUID()}`)).text);
+    expect(all.length).toBeGreaterThan(group.length);
+    for (const name of group) expect(all).toContain(name);
+  });
+});

--- a/test/server/session/full-gui-mcp.spec.ts
+++ b/test/server/session/full-gui-mcp.spec.ts
@@ -21,7 +21,7 @@ process.env.CLAUDE_CWD = WORKSPACE;
 
 const { carriesFullGuiMcp } = await import("../../../server/session/mcp-config.js");
 const { buildClaudeArgs } = await import("../../../server/agents/claude-args.js");
-const { launcherCommandWithClaudeGuiMcp } = await import("../../../server/session/launcher-gui-mcp.js");
+const { launcherCommandWithClaudeGuiMcp, launcherCommandWithGuiMcp, launcherTakesGuiMcp } = await import("../../../server/session/launcher-gui-mcp.js");
 
 afterAll(() => {
   if (REAL_CLAUDE_CWD === undefined) delete process.env.CLAUDE_CWD;
@@ -141,5 +141,41 @@ describe("the command line a launcher chip ends up with", () => {
   // this edits text the user wrote, so an unrecognised shape means leave it alone.
   it.each([["codex"], ["zsh"], ["yarn dev"], ["FOO=1 claude"], [""], ["   "]])("leaves %s alone", (command) => {
     expect(rewrite(command)).toBe(command);
+  });
+});
+
+// `launcherTakesGuiMcp` answers a question the two rewriters below answer by ACTING, and anything
+// that records a consequence of the injection has to agree with them — a chip marked as carrying
+// every GUI tool while being handed none misreports itself to /api/tools (Codex on #1399). So the
+// predicate is pinned against what the rewriters actually do, rather than restated.
+describe("which chips are handed the GUI MCP at all", () => {
+  const CLAUDE_GUI = { mcpConfigPath: "/home/u/.mulmoterminal/settings/s-mcp.json", allowedTools: "mcp__mt__presentChart" };
+  const CODEX_GUI = [{ id: "mt", url: "http://127.0.0.1:1/api/mcp/s", autoApprove: true }];
+  // Either rewriter firing means the command line came back changed; both see every command and
+  // each recognises only its own program, so at most one can fire.
+  const rewritten = (command: string) =>
+    launcherCommandWithClaudeGuiMcp(command, CLAUDE_GUI, "darwin") !== command || launcherCommandWithGuiMcp(command, CODEX_GUI, "darwin") !== command;
+
+  it.each([
+    ["claude"],
+    ["codex"],
+    ["claude --model opus"],
+    ["codex resume"],
+    ["zsh"],
+    ["yarn dev"],
+    ["agy"],
+    ["antigravity"],
+    ["lazygit"],
+    ["FOO=1 claude"],
+    [""],
+    ["   "],
+  ])("agrees with the rewriters on %j", (command) => {
+    expect(launcherTakesGuiMcp(command)).toBe(rewritten(command));
+  });
+
+  // The one this exists for. `launcherRunsAgent` says yes here (antigravity IS an agent), and using
+  // that as the gate is what over-marked the session.
+  it("says no to an agent with no rewriter", () => {
+    expect(launcherTakesGuiMcp("antigravity")).toBe(false);
   });
 });

--- a/test/server/session/full-gui-mcp.spec.ts
+++ b/test/server/session/full-gui-mcp.spec.ts
@@ -87,18 +87,19 @@ describe("the argv each kind of session gets", () => {
       appendedPrompt: null,
     });
 
-  it("carries --mcp-config and --strict-mcp-config when it has the full GUI MCP", () => {
+  it("carries --mcp-config when it has the full GUI MCP, and nothing that isolates", () => {
     const argv = args(true);
     expect(argv).toContain("--mcp-config");
     expect(argv[argv.indexOf("--mcp-config") + 1]).toBe("MCP_CONFIG");
-    expect(argv).toContain("--strict-mcp-config");
     expect(argv).toContain("GUI_TOOLS");
+    // #1338 / #1385: our broker is ADDED to what the session reaches. Isolating to it took the
+    // user's claude.ai connectors and their own MCP servers away with the directory's .mcp.json.
+    expect(argv).not.toContain("--strict-mcp-config");
   });
 
-  it("carries NEITHER for a project-directory cell, so its own MCP config still loads", () => {
-    // --strict-mcp-config is what makes ours the only source. Withholding both is precisely how a
-    // grid cell keeps reaching the servers its directory registered — the mechanism the Canvas
-    // depends on there.
+  it("carries no --mcp-config for a project-directory cell, so its own MCP config supplies the tools", () => {
+    // Withholding ours is how a grid cell keeps reaching the servers its directory registered —
+    // the mechanism the Canvas depends on there.
     const argv = args(false);
     expect(argv).not.toContain("--mcp-config");
     expect(argv).not.toContain("--strict-mcp-config");
@@ -106,24 +107,28 @@ describe("the argv each kind of session gets", () => {
   });
 });
 
-// The third shape: a launcher CHIP, where the same three flags have to be inserted into a command
-// line rather than appended to an argv. A chip running plain `claude` in the workspace had no
-// Canvas at all while the cell beside it had every tool — that gap is what this closes.
+// The third shape: a launcher CHIP, where the same flags have to be inserted into a command line
+// rather than appended to an argv. A chip running plain `claude` in the workspace had no Canvas at
+// all while the cell beside it had every tool — that gap is what this closes.
 describe("the command line a launcher chip ends up with", () => {
   const GUI = { mcpConfigPath: "/home/u/.mulmoterminal/settings/s-mcp.json", allowedTools: "mcp__mt__presentChart" };
   const rewrite = (command: string, gui: typeof GUI | null = GUI) => launcherCommandWithClaudeGuiMcp(command, gui, "darwin");
 
-  it("gives a claude chip the same three flags a claude cell is spawned with", () => {
-    expect(rewrite("claude")).toBe(
-      `claude --mcp-config '/home/u/.mulmoterminal/settings/s-mcp.json' --strict-mcp-config --allowedTools 'mcp__mt__presentChart'`,
-    );
+  it("gives a claude chip the same flags a claude cell is spawned with", () => {
+    expect(rewrite("claude")).toBe(`claude --mcp-config '/home/u/.mulmoterminal/settings/s-mcp.json' --allowedTools 'mcp__mt__presentChart'`);
+  });
+
+  // The chip drops --strict-mcp-config on the same commit the cell does. Parity is the reason it
+  // carried the flag at all, so parity is the reason it stops (#1338).
+  it("does not isolate the chip's claude from the user's own MCP either", () => {
+    expect(rewrite("claude")).not.toContain("--strict-mcp-config");
   });
 
   // Directly after the program, never appended: claude's own trailing `--add-dir` is variadic, so
   // a flag placed after it would be swallowed as one more directory.
   it("inserts after the program and puts the user's own text back byte for byte", () => {
     expect(rewrite("claude --model opus  --resume x")).toContain("claude --mcp-config");
-    expect(rewrite("claude --model opus  --resume x")).toMatch(/--strict-mcp-config --allowedTools '\S+' --model opus {2}--resume x$/);
+    expect(rewrite("claude --model opus  --resume x")).toMatch(/--allowedTools '\S+' --model opus {2}--resume x$/);
   });
 
   // null is how a PROJECT-directory chip arrives — the route passes nothing there, so its claude

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -41,9 +41,12 @@ vi.mock("../../../server/session/registry.js", () => ({
   // to decide it must NOT record them a second time — see mcp/gui-call-history.ts).
   hookedSessions: new Set(),
   resetSessionToolGroups: (id: string) => resetSessionToolGroups(id),
-  // Answered, not exercised: this spec is about the tool-group reset. What the claim itself does is
-  // pinned in full-gui-mcp.spec.ts, which checks every spawn path records the session.
+  // Answered, not exercised: this spec is about the tool-group reset. What the claim and its
+  // release actually do is pinned in full-gui-claim.spec.ts. The release is stubbed even though a
+  // claim of `true` never reaches it — otherwise flipping this stub to explore the other branch
+  // fails on a missing export rather than on the behaviour being explored.
   claimFullGuiMcp: () => true,
+  releaseAllToolsSession: () => {},
 }));
 
 // The transcript check decides --resume; irrelevant here and it would touch the real disk.

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -41,6 +41,9 @@ vi.mock("../../../server/session/registry.js", () => ({
   // to decide it must NOT record them a second time — see mcp/gui-call-history.ts).
   hookedSessions: new Set(),
   resetSessionToolGroups: (id: string) => resetSessionToolGroups(id),
+  // Answered, not exercised: this spec is about the tool-group reset. What the claim itself does is
+  // pinned in full-gui-mcp.spec.ts, which checks every spawn path records the session.
+  claimFullGuiMcp: () => true,
 }));
 
 // The transcript check decides --resume; irrelevant here and it would touch the real disk.

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -41,12 +41,11 @@ vi.mock("../../../server/session/registry.js", () => ({
   // to decide it must NOT record them a second time — see mcp/gui-call-history.ts).
   hookedSessions: new Set(),
   resetSessionToolGroups: (id: string) => resetSessionToolGroups(id),
-  // Answered, not exercised: this spec is about the tool-group reset. What the claim and its
-  // release actually do is pinned in full-gui-claim.spec.ts. The release is stubbed even though a
-  // claim of `true` never reaches it — otherwise flipping this stub to explore the other branch
-  // fails on a missing export rather than on the behaviour being explored.
+  // Answered, not exercised: this spec is about the reattach PROBE and its ordering. What the claim
+  // records is pinned in full-gui-claim.spec.ts. It shares this function's single probe rather than
+  // taking its own — which is the invariant the ordering test below exists for, and which a second
+  // `ptyWouldReattach` call inside the claim would break.
   claimFullGuiMcp: () => true,
-  releaseAllToolsSession: () => {},
 }));
 
 // The transcript check decides --resume; irrelevant here and it would touch the real disk.

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -326,7 +326,7 @@ describe("the workspace chip", () => {
 
 // The workspace is handed the WHOLE GUI MCP at spawn whatever agent runs there
 // (carriesFullGuiMcp), so there is no per-directory choice to offer. Four switches there would be
-// worse than redundant: they write a per-folder registration that --strict-mcp-config then
+// worse than redundant: they write a per-folder registration that a claimed session then
 // ignores, i.e. controls that visibly do nothing.
 describe("the GUI tool groups in the workspace", () => {
   const guiMcpFetch = () => {


### PR DESCRIPTION
## Summary

Fixes **#1338** and **#1385**. They were filed separately — one as a regression, one as "by design" —
and they are the same line of code.

```ts
// server/agents/claude-args.ts, before
guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config");
```

`--mcp-config` **adds** our GUI broker. `--strict-mcp-config` makes it the **only** source. Pushed
together, "give this session the GUI panel" also meant "cut it off from your claude.ai connectors,
`~/.claude.json`, your plugin MCP servers and the directory's own `.mcp.json`".

`carriesFullGuiMcp(attachGuiMcp, cwd) = attachGuiMcp || isWorkspaceCwd(cwd)` is what routes both
reporters into it — #1385 through `attachGuiMcp` (single view), #1338 through `isWorkspaceCwd`
(workspace grid cell, since #1187). A project-directory cell matches neither, which is exactly why
connectors worked there and nowhere else.

The flag is **deleted**, not made a parameter: no caller would ask to isolate, and a one-valued flag
is the same weld waiting to be re-made.

## Items to Confirm / Review

1. **Sessions get slower, and that is the accepted trade.** Workspace cells and the single view now
   load the user's MCP servers. The size of it is in `rate-limit-probe.ts`'s own measurement, in
   reverse: 8.0 s to first window with none, 9–15 s with one unauthenticated server. Confirmed as
   acceptable (parity with MulmoClaude on the same workspace) before implementing — flagging it
   here because it is the one thing a user will feel.
2. **The probe keeps `--strict-mcp-config`, deliberately.** Its reason is different and measured: a
   hidden session asking one question that needs no tools. If you would rather have zero occurrences
   of the flag in the tree, say so — but it costs 1–7 s per probe.
3. **Phase 2 suppresses group tools for a claimed session.** A session that already carries every
   tool gets an empty tool list from `/api/mcp/:group/:id`. The group server still connects and
   reports itself with no tools; I chose that over 404, which would surface as "server failed to
   connect". Worth a second opinion on which reads better in the client.
4. **`claimFullGuiMcp` lives in `registry.ts`, not `mcp-config.ts`.** The pure predicate stays where
   it was; the recording variant went next to `markAllToolsSession` because `mcp-config.ts` documents
   itself as pure. Three spawn paths call it. If you would rather it sat with the predicate, it is a
   one-file move.
5. **I found and fixed a hole this PR would have opened, not one it inherited** (commit
   `da6735c0`, flagged by nobody). A session id outlives its process: the single view takes the whole
   GUI MCP whatever its cwd, so opening a project directory there claims the id — and the same
   session later opened as a grid cell (`?gui=0`) in that directory respawns without the URL. With
   the claim persisted and never released, that cell's group URLs would stand down and it would have
   **no GUI tools at all**. Worth checking my reading of the reachability, since it is the one case
   here that turns a tidiness feature into a broken cell.
6. **The duplicate this guards against is not reproducible on this machine** — `~/mulmoclaude/.mcp.json`
   is absent and 2 of 182 projects in `~/.claude.json` register anything (both `playwright`, neither
   the workspace). So Phase 2 is verified by spec and by driving the route directly, not by
   reproducing the original overlap.

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1385 と https://github.com/receptron/mulmoterminal/issues/1338 について、どう思うか。**根本的に直せたらよい**。
- （調査結果を受けて）Phase 1 + Phase 2 を1つの PR で進めること。起動が遅くなる点は MulmoClaude と同じなので受け入れる。

## The measurement that made this possible

The flag was there because of a worry (#1043) that merging config layers silently drops our own
broker. Run in `~/mulmoclaude` on **CLI 2.1.221**, reading `mcp_servers` off the `system`/`init`
event:

| spawn | `init.mcp_servers` |
| --- | --- |
| `--mcp-config` alone | **3** — our broker + `claude.ai Superhuman Docs` + `claude.ai Gmail` |
| `--mcp-config --strict-mcp-config` | **1** — our broker alone |

Dropping the flag keeps the broker **and** restores the connectors. MulmoClaude — the reference host
for this workspace per CLAUDE.md — concluded the same at CLI 2.1.163 and has run without it since.
`docs/spawn-architecture.md` already recommended option B and asked for exactly this spike first.

## Three sites, not two

The investigation on #1338 counted two occurrences in source. There are three now — the launcher chip
arrived after that comment was written, and changing only the cell would re-create the very drift
CLAUDE.md's "a chip and the cell beside it must be indistinguishable" rule exists to stop.

| site | action |
| --- | --- |
| `agents/claude-args.ts` | flag removed |
| `session/launcher-gui-mcp.ts` | flag removed |
| `agents/rate-limit-probe.ts` | **kept**, with its measurement |

## Phase 2 — the duplicate, made impossible rather than unlikely

Without the flag, a directory's own group registration and our all-tools URL can reach one session,
so the same tool could arrive as both `mcp__mt__presentChart` and
`mcp__mulmoterminal-render__presentChart`.

The obvious fix — withhold the GUI MCP when the directory registered groups — is **wrong** and would
re-break [#1188](https://github.com/receptron/mulmoterminal/pull/1188): groups do not cover the tools
that belong to no group (`spawnBackgroundChat`).

Both URLs are ours, so it is settled on our side:

- `claimFullGuiMcp(sessionId, attachGuiMcp, cwd)` **decides and records in one call**, at spawn.
  `markAllToolsSession` already existed but learned on first contact, which made the answer depend on
  which URL the MCP client happened to dial first. All three spawn paths (`spawn-claude`,
  `spawn-codex`, the launcher chip in `ws-routes`) call it; `carriesFullGuiMcp` stays pure for the
  specs and for readers.
- `mcp/tool-gate.ts` then offers a claimed session nothing on a group URL, and refuses a tool named
  anyway with a message that says where the tool actually is — the same two-layer shape the worker
  and group gates already use.
- The claim is **released** when a session is respawned without the all-tools URL. Its log could not
  express that: it was append-only on the stated grounds that "an id is the only thing ever added
  (nothing removes one)". Fine while a stale yes only widened a pane's tool list — **not** fine once
  it stands a cell's groups down with nothing to serve them. `all-tools-log.ts` gives the file a
  release marker replayed in order, the shape `session-tool-groups.ts` already uses; a bare id still
  reads as a claim, so existing files keep working. The release fires exactly where the tool-group
  reset already does, so a tmux reattach — same process, same URL — keeps its claim.

## Verification

**The CLI** — the table above, run against the real binary rather than reasoned about.

**The route, against a running server** (`PORT=39851 node --import tsx server/index.ts`), driving
`tools/list` over real HTTP:

| session | result |
| --- | --- |
| only ever uses group URLs | `render` = 4 tools, `data` = 3 — a project cell is untouched |
| all-tools URL first, then `render` | all = 11, `render` = **0** |
| `render` first, then all-tools, then `render` again | 4 → 11 → **0** |

The third row is the ordering `claimFullGuiMcp` exists for: driven over HTTP there is no spawn to
claim it, so the first group request is served. `full-gui-claim.spec.ts` claims the session first and
pins that the same request then returns nothing.

**Specs** — `all-tools-log.spec.ts` pins the release marker's ordered replay (a bare id still reads
as a claim; last word wins; unusable lines dropped). `tool-gate.spec.ts` gains the stand-down cases including the two that would break the
feature instead of the duplicate (the all-tools URL still offers everything; the translation worker's
narrower gate still wins). `claude-args.spec.ts` and `full-gui-mcp.spec.ts` invert from pinning the
flag to pinning its absence, and gain a case that `--mcp-config` is **still** passed — the failure
this must not become is "the GUI panel stopped working".

`yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` / `yarn test` —
**552 files, 8,053 tests passed**, after merging `origin/main`.

## Docs

`docs/spawn-architecture.md`'s A/B decision table records that **B was taken**, with the measurement
and the date, and its settings row for the flag is struck through rather than deleted. Plus README
(three passages), `docs/codex-vs-claude.md`, the changelog, and the comments in `claude-args.ts`,
`mcp-config.ts`, `spawn-claude.ts`, `ws-routes.ts`, `issue-spawn-options.ts`, `launcher-gui-mcp.ts`,
`Terminal.vue` and `CellLaunchForm.vue` that explained the old behaviour.

Dated setup guides (`docs/guide/*/v4.1.1.md`, `v4.3.0.md`) mention the flag and are **left alone** —
they are snapshots of their release, and `v4.1.1`'s reference is to the probe, which still passes it.

Design notes in `plans/fix-1338-1385-unweld-strict-mcp.md`.

Closes #1338
Closes #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
