### PR TITLE
fix: Windows daily CI の失敗を直す（HOME だけの差し替えと、パス規則の写し）

### DIFF
--- a/test/server/routes/mcp-announce.spec.ts
+++ b/test/server/routes/mcp-announce.spec.ts
@@ -7,10 +7,9 @@
 // every group for the all-tools one it can only have been given by --mcp-config.
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { randomUUID } from "node:crypto";
-import { rmSync } from "node:fs";
 import express from "express";
 import request from "supertest";
-import { makeTempDir } from "../../support/tempDir";
+import { takeScratchHome } from "../../support/scratchHome.js";
 
 // The group route PERSISTS what it learned, under a MULMOTERMINAL_HOME derived from the home
 // directory at import time — so point HOME somewhere disposable BEFORE importing, or this spec
@@ -21,9 +20,7 @@ import { makeTempDir } from "../../support/tempDir";
 // Leaving HOME pointed at a directory this file then deletes would hand the next file in the same
 // worker a home that does not exist, so it is put back — the module registry is per file, so the
 // next file's imports read the restored value.
-const HOME = makeTempDir("mt-mcp-announce-");
-const REAL_HOME = process.env.HOME;
-process.env.HOME = HOME;
+const scratchHome = takeScratchHome("mt-mcp-announce-");
 const { mountMcpRoutes, TOOL_GROUPS_CHANNEL } = await import("../../../server/routes/mcp-routes.js");
 const { TOOL_GROUPS } = await import("../../../common/toolGroups.js");
 const { hasAllGuiTools, whenToolGroupsPersisted } = await import("../../../server/session/registry.js");
@@ -35,9 +32,7 @@ const { hasAllGuiTools, whenToolGroupsPersisted } = await import("../../../serve
 // on its own, not only under the full suite (#1345).
 afterAll(async () => {
   await whenToolGroupsPersisted();
-  if (REAL_HOME === undefined) delete process.env.HOME;
-  else process.env.HOME = REAL_HOME;
-  rmSync(HOME, { recursive: true, force: true });
+  scratchHome.release();
 });
 
 const published: { channel: string; data: Record<string, unknown> }[] = [];

--- a/test/server/session/cost.spec.ts
+++ b/test/server/session/cost.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
+import { projectSessionsDir } from "../../../server/session/project-dir.js";
 import { rateForModel, costForUsage, costFromJsonl } from "../../../server/session/cost.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -116,12 +117,13 @@ describe("costFromJsonl", () => {
 // total is the same total.
 describe("a transcript's cost, folded across reads", () => {
   let scratch: ScratchHome;
-  let home = "";
   let n = 0;
   const CWD = "/Users/me/proj";
 
+  // projectSessionsDir, not a second copy of its rule — it resolves the cwd for the host platform,
+  // so the encoded directory differs on Windows (#1396).
   const transcriptPath = (id: string): string => {
-    const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+    const dir = projectSessionsDir(CWD);
     mkdirSync(dir, { recursive: true });
     return path.join(dir, `${id}.jsonl`);
   };
@@ -137,7 +139,6 @@ describe("a transcript's cost, folded across reads", () => {
 
   beforeEach(() => {
     scratch = takeScratchHome("mt-cost-fold-");
-    home = scratch.path;
   });
   afterEach(() => scratch.release());
 

--- a/test/server/session/cost.spec.ts
+++ b/test/server/session/cost.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 import { rateForModel, costForUsage, costFromJsonl } from "../../../server/session/cost.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -115,7 +115,7 @@ describe("costFromJsonl", () => {
 // folds each file once and resumes on what was appended, so what is pinned here is that a resumed
 // total is the same total.
 describe("a transcript's cost, folded across reads", () => {
-  const realHome = process.env.HOME;
+  let scratch: ScratchHome;
   let home = "";
   let n = 0;
   const CWD = "/Users/me/proj";
@@ -130,20 +130,16 @@ describe("a transcript's cost, folded across reads", () => {
   const unpriced = () => `${assistant("some-unknown-model", { input_tokens: 10, output_tokens: 10 })}\n`;
 
   async function freshCost() {
-    vi.resetModules();
-    process.env.HOME = home;
+    vi.resetModules(); // the scratch home is already in place; the module reads it at import
     const mod = await import("../../../server/session/cost.js");
     return mod.sessionCost;
   }
 
   beforeEach(() => {
-    home = mkdtempSync(path.join(tmpdir(), "mt-cost-fold-"));
+    scratch = takeScratchHome("mt-cost-fold-");
+    home = scratch.path;
   });
-  afterEach(() => {
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
-    rmSync(home, { recursive: true, force: true });
-  });
+  afterEach(() => scratch.release());
 
   it("adds what was appended to the total it already had", async () => {
     const sessionCost = await freshCost();

--- a/test/server/session/session-meta-sidecar.spec.ts
+++ b/test/server/session/session-meta-sidecar.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 
 // #1379 made the session list resume its fold instead of repeating it, but that state lives in one
 // process's memory: a restart, and every other mulmoterminal on the machine, still paid for the
@@ -12,9 +12,7 @@ import path from "node:path";
 // reader whose in-memory cache has never seen the file, against the same home and the same
 // transcript on disk.
 
-// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move
-// the next spec's idea of ~/.mulmoterminal (and ~/.claude) without it asking.
-const realHome = process.env.HOME;
+let scratch: ScratchHome;
 let home = "";
 let projects = "";
 let n = 0;
@@ -28,8 +26,7 @@ const fillerLine = (bytes: number) => line({ type: "assistant", text: "x".repeat
 const OVER_THRESHOLD_BYTES = 11 * 1024 * 1024;
 
 async function freshReader() {
-  vi.resetModules();
-  process.env.HOME = home;
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
   const mod = await import("../../../server/session/session-reads.js");
   return mod.readSessionMeta;
 }
@@ -63,15 +60,12 @@ const sidecarsWritten = (): string[] => {
 };
 
 beforeEach(() => {
-  home = mkdtempSync(path.join(tmpdir(), "mt-meta-sidecar-"));
+  scratch = takeScratchHome("mt-meta-sidecar-");
+  home = scratch.path;
   projects = path.join(home, ".claude", "projects");
   mkdirSync(projects, { recursive: true });
 });
-afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
-  rmSync(home, { recursive: true, force: true });
-});
+afterEach(() => scratch.release());
 
 describe("the session list across processes", () => {
   it("answers a big transcript from the sidecar, without reading it again", async () => {

--- a/test/server/session/session-summary-fold.spec.ts
+++ b/test/server/session/session-summary-fold.spec.ts
@@ -1,25 +1,22 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 
 // `/api/session/:id` is hit by every grid cell as its turn finishes, and a memo keyed on
 // (mtime, size) could only skip an UNCHANGED transcript — which the session being written to never
 // is. An active 508 MB session therefore paid a full 10.5 s read per turn (#1386). These pin what
 // changed: the summary is folded once and continued, and a big one is kept beside the file.
 
-// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
-// next spec's idea of ~/.claude without it asking.
-const realHome = process.env.HOME;
+let scratch: ScratchHome;
 let home = "";
 let n = 0;
 
 const CWD = "/Users/me/proj";
 
 async function freshSummary() {
-  vi.resetModules();
-  process.env.HOME = home;
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
   const mod = await import("../../../server/session/session-reads.js");
   return mod.readSessionSummary;
 }
@@ -69,13 +66,10 @@ const summarySidecars = (): string[] => {
 };
 
 beforeEach(() => {
-  home = mkdtempSync(path.join(tmpdir(), "mt-summary-"));
+  scratch = takeScratchHome("mt-summary-");
+  home = scratch.path;
 });
-afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
-  rmSync(home, { recursive: true, force: true });
-});
+afterEach(() => scratch.release());
 
 describe("readSessionSummary", () => {
   it("reports the prompt, reply, turns, usage and phase of a session", async () => {

--- a/test/server/session/session-summary-fold.spec.ts
+++ b/test/server/session/session-summary-fold.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
+import { projectSessionsDir } from "../../../server/session/project-dir.js";
 
 // `/api/session/:id` is hit by every grid cell as its turn finishes, and a memo keyed on
 // (mtime, size) could only skip an UNCHANGED transcript — which the session being written to never
@@ -40,8 +41,12 @@ const filler = (bytes: number) => line({ type: "assistant", message: { role: "as
 
 const OVER_THRESHOLD_BYTES = 11 * 1024 * 1024;
 
+// projectSessionsDir, not a second copy of its rule: it resolves the cwd for the host platform and
+// folds EVERY non-alphanumeric character to "-", so "/Users/me/proj" is `-Users-me-proj` on macOS
+// and `D--Users-me-proj` on Windows. A spec that spelled the macOS answer wrote its transcript
+// where the reader would never look (#1396).
 function transcriptPath(id: string): string {
-  const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+  const dir = projectSessionsDir(CWD);
   mkdirSync(dir, { recursive: true });
   return path.join(dir, `${id}.jsonl`);
 }

--- a/test/server/session/timeline-fold.spec.ts
+++ b/test/server/session/timeline-fold.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { appendFileSync, mkdirSync, writeFileSync, statSync, utimesSync } from "node:fs";
 import path from "node:path";
 import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
+import { projectSessionsDir } from "../../../server/session/project-dir.js";
 
 // The timeline overlay read the whole transcript every time it was opened — a payload capped at 300
 // events, paid for in hundreds of megabytes (#1386). It now folds once and resumes, so what matters
@@ -10,7 +11,6 @@ import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js"
 // event the file ever had rather than the ones that survived the window.
 
 let scratch: ScratchHome;
-let home = "";
 let n = 0;
 
 const CWD = "/Users/me/proj";
@@ -25,8 +25,12 @@ const toolUse = (name: string, ts: string) =>
   `${JSON.stringify({ type: "assistant", timestamp: ts, message: { content: [{ type: "tool_use", name, input: {} }] } })}\n`;
 const noise = () => `${JSON.stringify({ type: "user", message: { content: "hello" } })}\n`;
 
+// projectSessionsDir, not a second copy of its rule: it resolves the cwd for the host platform and
+// folds EVERY non-alphanumeric character to "-", so "/Users/me/proj" is `-Users-me-proj` on macOS
+// and `D--Users-me-proj` on Windows. A spec that spelled the macOS answer wrote its transcript
+// where the reader would never look (#1396).
 function transcriptPath(id: string): string {
-  const dir = path.join(home, ".claude", "projects", CWD.replace(/\//g, "-"));
+  const dir = projectSessionsDir(CWD);
   mkdirSync(dir, { recursive: true });
   return path.join(dir, `${id}.jsonl`);
 }
@@ -39,7 +43,6 @@ function writeTranscript(body: string): string {
 
 beforeEach(() => {
   scratch = takeScratchHome("mt-timeline-");
-  home = scratch.path;
 });
 afterEach(() => scratch.release());
 

--- a/test/server/session/timeline-fold.spec.ts
+++ b/test/server/session/timeline-fold.spec.ts
@@ -1,25 +1,22 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, statSync, utimesSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, mkdirSync, writeFileSync, statSync, utimesSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 
 // The timeline overlay read the whole transcript every time it was opened — a payload capped at 300
 // events, paid for in hundreds of megabytes (#1386). It now folds once and resumes, so what matters
 // is that the window still means the same thing: the NEWEST 300, and `truncated` counting every
 // event the file ever had rather than the ones that survived the window.
 
-// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
-// next spec's idea of ~/.claude without it asking.
-const realHome = process.env.HOME;
+let scratch: ScratchHome;
 let home = "";
 let n = 0;
 
 const CWD = "/Users/me/proj";
 
 async function freshTimeline() {
-  vi.resetModules();
-  process.env.HOME = home;
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
   const mod = await import("../../../server/session/session-reads.js");
   return mod.sessionTimeline;
 }
@@ -41,13 +38,10 @@ function writeTranscript(body: string): string {
 }
 
 beforeEach(() => {
-  home = mkdtempSync(path.join(tmpdir(), "mt-timeline-"));
+  scratch = takeScratchHome("mt-timeline-");
+  home = scratch.path;
 });
-afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
-  rmSync(home, { recursive: true, force: true });
-});
+afterEach(() => scratch.release());
 
 describe("sessionTimeline", () => {
   it("lists the tool uses in order, and says nothing was dropped", async () => {

--- a/test/server/session/transcript-fold.spec.ts
+++ b/test/server/session/transcript-fold.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 import { isRecord } from "../../../common/isRecord.js";
 
 // The machinery three readers share (title fields, cost, timeline): fold a transcript once, resume
@@ -10,9 +10,7 @@ import { isRecord } from "../../../common/isRecord.js";
 // is the part every caller depends on and none of them can see — that a resumed fold produces what
 // one uninterrupted pass would, and that it does not reach back into the value already handed out.
 
-// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move the
-// next spec's idea of ~/.mulmoterminal without it asking.
-const realHome = process.env.HOME;
+let scratch: ScratchHome;
 let home = "";
 let projects = "";
 let n = 0;
@@ -37,8 +35,7 @@ const COUNTED = {
 };
 
 async function loadFold() {
-  vi.resetModules();
-  process.env.HOME = home;
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
   const mod = await import("../../../server/session/transcript-fold.js");
   return mod.createTranscriptFold;
 }
@@ -59,15 +56,12 @@ const stampOf = (file: string) => {
 };
 
 beforeEach(() => {
-  home = mkdtempSync(path.join(tmpdir(), "mt-fold-"));
+  scratch = takeScratchHome("mt-fold-");
+  home = scratch.path;
   projects = path.join(home, ".claude", "projects");
   mkdirSync(projects, { recursive: true });
 });
-afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
-  rmSync(home, { recursive: true, force: true });
-});
+afterEach(() => scratch.release());
 
 describe("createTranscriptFold", () => {
   it("folds a transcript, and folds only the append the second time", async () => {

--- a/test/server/session/transcript-sidecar.spec.ts
+++ b/test/server/session/transcript-sidecar.spec.ts
@@ -1,25 +1,22 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync, appendFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, existsSync, readdirSync, readFileSync, statSync, writeFileSync, appendFileSync } from "node:fs";
 import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
 import { isRecord } from "../../../common/isRecord.js";
 
 // A sidecar answers for a file it is not part of, and it can be days old when it is read — so what
 // matters is every reason to DISTRUST it. Each check below is a case where answering from disk
 // would be wrong rather than merely slow (#1386).
 
-// Restored after every test: vitest reuses a worker across FILES, and a leaked HOME would move
-// the next spec's idea of ~/.mulmoterminal (and ~/.claude) without it asking.
-const realHome = process.env.HOME;
+let scratch: ScratchHome;
 let home = "";
 let projects = "";
 
 // MULMOTERMINAL_HOME is read at import time, so the module is imported per test run against a
 // scratch home rather than the developer's own.
 async function loadSidecar() {
-  vi.resetModules();
-  process.env.HOME = home;
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
   const mod = await import("../../../server/session/transcript-sidecar.js");
   return mod.createTranscriptSidecar;
 }
@@ -55,15 +52,12 @@ const settled = async () => {
 };
 
 beforeEach(() => {
-  home = mkdtempSync(path.join(tmpdir(), "mt-sidecar-home-"));
+  scratch = takeScratchHome("mt-sidecar-home-");
+  home = scratch.path;
   projects = path.join(home, ".claude", "projects");
   mkdirSync(projects, { recursive: true });
 });
-afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
-  rmSync(home, { recursive: true, force: true });
-});
+afterEach(() => scratch.release());
 
 describe("createTranscriptSidecar", () => {
   it("reads back what it wrote, and resumes at the stored offset", async () => {

--- a/test/support/scratchHome.spec.ts
+++ b/test/support/scratchHome.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import { takeScratchHome } from "./scratchHome.js";
+
+// This helper exists because `os.homedir()` reads USERPROFILE on Windows and HOME everywhere else,
+// and a spec that stubs only one of them silently tests a directory the code never touched (#1396).
+// So the thing worth asserting is the one that platform-specific: that os.homedir() actually moved
+// — which on the Windows runner is a real check of the USERPROFILE half.
+
+describe("takeScratchHome", () => {
+  it("moves os.homedir() to a fresh directory and puts it back", () => {
+    const before = os.homedir();
+    const scratch = takeScratchHome("mt-scratch-home-test-");
+    try {
+      expect(os.homedir()).toBe(scratch.path);
+      expect(scratch.path).not.toBe(before);
+      expect(existsSync(scratch.path)).toBe(true);
+    } finally {
+      scratch.release();
+    }
+    expect(os.homedir()).toBe(before);
+  });
+
+  it("removes the directory it made", () => {
+    const scratch = takeScratchHome("mt-scratch-home-test-");
+    const { path } = scratch;
+    scratch.release();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("hands each caller its own directory", () => {
+    const first = takeScratchHome("mt-scratch-home-test-");
+    const second = takeScratchHome("mt-scratch-home-test-");
+    try {
+      expect(second.path).not.toBe(first.path);
+    } finally {
+      second.release();
+      first.release();
+    }
+  });
+});

--- a/test/support/scratchHome.ts
+++ b/test/support/scratchHome.ts
@@ -38,8 +38,9 @@ export function takeScratchHome(prefix: string): ScratchHome {
     else process.env.USERPROFILE = previousUserProfile;
   };
 
-  // macOS resolves /var/folders/… through a symlink, so compare what os.homedir() reports against
-  // what it reports for the same path rather than against the raw string.
+  // Asked, not assumed: the whole point is that "which variable moves os.homedir()" is
+  // platform-specific, so the answer is checked on the platform actually running. A raw string
+  // comparison is right here — os.homedir() hands back the variable verbatim, whichever one it read.
   if (os.homedir() !== home) {
     restore();
     rmSync(home, { recursive: true, force: true });

--- a/test/support/scratchHome.ts
+++ b/test/support/scratchHome.ts
@@ -1,0 +1,56 @@
+// A temporary directory that `os.homedir()` answers with, for a spec that exercises code reading
+// ~/.claude or ~/.mulmoterminal without touching the developer's own home.
+//
+// BOTH variables are set, because **os.homedir() reads USERPROFILE on Windows and HOME everywhere
+// else**. Stubbing only HOME leaves a Windows run pointed at the runner's real home: the code
+// writes there while the spec asserts against the scratch directory, so a path-checking test fails
+// and — worse — a test that only reads the module's own answers PASSES while quietly polluting the
+// real home. That is exactly how four specs went green on macOS and red on Windows (#1396), and
+// #1079 was the same trap in test/bin/instances.spec.ts.
+//
+// Written once here rather than copied into each spec, and it VERIFIES rather than assumes: if
+// os.homedir() does not answer the scratch directory, the spec fails at the call with the reason,
+// instead of later with an empty directory that reads like a missing feature.
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface ScratchHome {
+  /** The directory `os.homedir()` now answers with. */
+  readonly path: string;
+  /** Put the environment back and delete the directory. */
+  release(): void;
+}
+
+export function takeScratchHome(prefix: string): ScratchHome {
+  const home = mkdtempSync(path.join(os.tmpdir(), prefix));
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+
+  // Written out rather than looped over the two names: a computed `delete process.env[name]` is
+  // what the lint rule is about, and there are exactly two.
+  const restore = (): void => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+  };
+
+  // macOS resolves /var/folders/… through a symlink, so compare what os.homedir() reports against
+  // what it reports for the same path rather than against the raw string.
+  if (os.homedir() !== home) {
+    restore();
+    rmSync(home, { recursive: true, force: true });
+    throw new Error(`os.homedir() still answers ${os.homedir()} after HOME/USERPROFILE were pointed at ${home}`);
+  }
+
+  return {
+    path: home,
+    release() {
+      restore();
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

**Windows daily CI が main で赤くなっていた**のを直します（[run 30880832925](https://github.com/receptron/mulmoterminal/actions/runs/30880832925)、10 failed / 4 files）。落ちていたのは #1387 / #1392 / #1395 で私が追加した sidecar・fold 系スペックだけで、**2 つの別々の原因**が重なっていました。どちらも「規則を写した」ことが原因です。

### 原因 1: `os.homedir()` は Windows で `USERPROFILE` を読む

これらのスペックは `process.env.HOME` を一時ディレクトリに差し替えて `~/.claude` と `~/.mulmoterminal` を読み書きさせていました。Windows では `HOME` は見られないので:

- 実装は**ランナーの本物のホーム**に書き、スペックは一時ディレクトリを検証 → パスを見るテストが失敗
- **パスを見ないテストは「通ってしまう」**。`transcript-fold.spec.ts` は Windows で green のまま**本物のホームを汚染**し続けていた ← こちらの方が悪い

このリポジトリは #1079 で同じ罠を踏んでおり、既存 2 スペックには理由付きの対処が入っていました。無かったのは「1 か所で正しくやる場所」で、だから 4 つ目のコピーが間違えました。

→ `test/support/scratchHome.ts` に集約。両方の変数を設定したうえで **`os.homedir()` が実際にその一時ディレクトリを返すことをヘルパー自身が検証**します。片方だけ差し替えた状態は、後で「空のディレクトリ」として現れるのではなく、**その場で理由付きで落ちます**。

### 原因 2: transcript の置き場所の規則を、スペックが自前で書いていた

3 ファイルは `CWD.replace(/\//g, "-")` でディレクトリ名を組み立てていました。`projectSessionsDir` は `path.resolve(cwd)` してから**英数字以外を全部 `-` に**畳むので、`/Users/me/proj` は macOS で `-Users-me-proj`、**Windows では `D--Users-me-proj`**。スペックは読み手が見ない場所に transcript を書き、返ってきた「空」を検証していました。

→ `projectSessionsDir` を呼ぶ形に変更（規則の写しではなく規則そのもの）。

## 実機で検証しました

`workflow_dispatch` でこのブランチに対して Windows workflow を 2 回実行:

| commit | 結果 |
|---|---|
| `1df51efa`（原因 1 のみ修正） | 10 → **7 failed**（sidecar 系 4 件が解消） |
| `44355ad5`（原因 2 も修正） | **success（22.x / 24.x とも）** ← [run 30884000710](https://github.com/receptron/mulmoterminal/actions/runs/30884000710) |

1 回目が「まだ落ちている」ことで**原因が 2 つあると分かった**ので、実機で回した価値がありました。

## Items to Confirm / Review

- **掃引の範囲**: `HOME` を差し替えている**全スペック**を調べ、今回の 6 本に加えて `mcp-announce.spec.ts`（失敗はしていないが同じ潜在的汚染）も直しました。`cleared-transcripts.spec.ts` と `session-title.spec.ts` は **`vi.spyOn(os, "homedir")` で直接モック**していて別ルートで正しいので触っていません。
- **ヘルパーが検証まですること**をどう思うか。`os.homedir()` が期待どおりでなければ即座に throw します。今回のように「片方だけ差し替えて、macOS では通り Windows で意味を失う」類を、次はその場で落とすためです。
- **`test/support/scratchHome.spec.ts`** はヘルパー自身のテスト（移動する・元に戻す・毎回別ディレクトリ）。Windows ランナー上では **USERPROFILE 側の実チェック**になります。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30880832925

（main で赤くなっていた Windows daily CI の run URL）

## 検証

ローカル: `yarn lint`（0 errors）/ `typecheck` / `test`（8020 passed）green。
Windows: 上記のとおり実機で success。

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal4
