### PR TITLE
perf: decision scan を増分フォールドに載せる (#1402)

### DIFF
--- a/plans/perf-1402-decision-fold.md
+++ b/plans/perf-1402-decision-fold.md
@@ -114,7 +114,29 @@ const decisionFold = createTranscriptFold<DecisionScanState>({
 - 新規: `decisionsForCwd` 経由で、ターンが追記されたあとの再開が一気読みと一致する／
   未変更なら読み直さない／大きいセッションは sidecar に書かれ、別プロセスがそこから続きを畳む
 
-## 実測での確認
+## 実測での確認（実施済み）
 
-484 MB の実 transcript のコピーに対して、cold / 未変更 / 1 ターン追記後 / 別プロセスの 4 点を測る
-（#1377 のクローズ時と同じ手順。scratch `HOME` を使い、実ファイルには触らない）。
+484 MB の実 transcript のコピー（scratch `HOME`、実ファイルは無傷）:
+
+| | before | after |
+|---|---:|---:|
+| 初回 | 2,164 ms | 2,096 ms |
+| 未変更 | 1 ms | 0.6 ms |
+| **1 ターン追記後** | **2,164 ms** | **1.3 ms** |
+| さらに 1 ターン後 | 2,164 ms | 0.5 ms |
+| 別プロセスの初回（sidecar から再開） | 2,164 ms | **4.5 ms** |
+
+プロジェクト全体（65 transcripts / 2.4 GB、実ディレクトリを symlink して read-only で走査）:
+
+| | before | after |
+|---|---:|---:|
+| cold（sidecar 無し） | 5,547 ms | 5,599 ms |
+| **cold（sidecar 有り = 2 回目のプロセス）** | 5,547 ms | **66 ms** |
+| warm | 1 ms | 2 ms |
+
+**初回が悪化していない**ことが、案B（全行 parse）の判断が正しかったことの実測での裏付け。
+
+### 正しさ: 実データで main と突き合わせ
+
+`decisionsForCwd` の出力（65 transcripts / 77 decisions / 110,812 bytes の JSON）を main の worktree と
+このブランチで dump して diff → **完全一致**。合成テストではなく実データでの等価確認。

--- a/plans/perf-1402-decision-fold.md
+++ b/plans/perf-1402-decision-fold.md
@@ -1,0 +1,120 @@
+# perf: decision scan を増分フォールドに載せる (#1402)
+
+## 問題
+
+`#1377` / `#1386` で transcript の導出値 4 種（title fields / summary / timeline / cost）は
+`createTranscriptFold` に載り、「変わった分だけ畳む」＋ sidecar でプロセスをまたいで再開できる。
+
+`decisionsForCwd`（`server/session/decision-scan.ts`）だけが `createFileCache`（(mtime, size) キー）
+のままで、**変わったファイルは毎回まるごと読み直す**。書き込み中のセッション＝いま作業している一番
+大きいファイルは決してキャッシュに当たらない。
+
+実測（2026-08-04, read-only, mulmoclaude3 = 2.4 GB / 65 transcripts）:
+
+| | 実測 |
+|---|---:|
+| `decisionsForCwd` cold | 5,547 ms |
+| 同 warm（無変更） | 1 ms |
+| 出力 | 77 decisions / JSON 63 KB |
+| 484 MB の transcript 1 本だけ | 2,164 ms → 1 decision (1.2 KB) |
+
+呼ばれるのは `GET /api/decisions`（`mulmoterminal-decisions` skill）と 6 時間ごとの digest tick
+（`server/index.ts` の `refreshDecisionDigests`）だけなので、#1377 のような毎ターン経路ではない。
+それでも cold の 5.5 秒はイベントループを止め、その間ターミナルが固まる。
+
+## 設計判断: イシューの前提（案A）は実測で覆った
+
+イシューには「`addLine` は substring テストで JSON.parse を避けているので、レコード単位の fold に
+載せると避けていたコストを払い直す。fold に行レベルの入口を足す（案A）か、parse コストを実測して
+決める（案B）」と書いた。**実測したら案B のコストは無視できる**（484 MB の transcript, 3 回計測で安定）:
+
+| | 実測 |
+|---|---:|
+| I/O だけ（行を読むが何もしない） | 1,419 ms |
+| 案A: 行 + `addLine`（substring 先） | 2,125 ms |
+| 案B: 全行 JSON.parse（何もしない） | 2,109 ms |
+
+substring テスト 706 ms に対し、全行 parse は 690 ms。**同じ**である。
+
+さらにコードを読むと、raw line を使っているのは**事前フィルタ 2 つだけ**だった:
+
+```ts
+const isAsk = line.includes(ASK_TOOL);
+const isAnswer = awaiting.size > 0 && mentionsPendingAsk(line, awaiting);
+if (!isAsk && !isAnswer) return;
+const o = parseLine(line);
+if (isAsk) collectAsks(o, asks, awaiting);      // ← 規則そのものは parse 済みレコードで動く
+if (isAnswer) collectAnswer(o, awaiting);       // ←
+```
+
+`collectAsks` は `o.type !== "assistant"` とブロックの type/name を、`collectAnswer` は
+`block.type === "tool_result"` と `awaiting.get(block.tool_use_id)` を自分で見ている。
+つまり substring テストは**その先の関数が必ず落とす行しか落とせない**純粋な最適化で、規則の一部ではない。
+（`AskUserQuestion` という名前も tool_use_id も、その行の JSON に必ず文字列として現れる。）
+
+**よって案B を採る。** 新しい fold の入口も新しい jsonl プリミティブも要らず、他の 4 か所とまったく
+同じ `fold: (into, record) => void` に乗る。案A は fold フレームワークと `jsonl-file.ts` に
+分岐をもう 1 本増やすが、それで買えるものが無い。
+
+## 実装
+
+### 1. `server/session/decisions.ts` — 状態を JSON にする
+
+いまの状態は `asks: Ask[]` と `awaiting: Map<string, Ask>`（値は `asks` の要素と同一参照で、
+`ask.resultText` をその場で書き換える）。Map は JSON にならないので置き換える:
+
+```ts
+export interface DecisionScanState {
+  asks: Ask[];
+  /** まだ tool_result が来ていない toolUseId。古い順。 */
+  pending: string[];
+}
+```
+
+- `emptyDecisionState()` / `foldDecision(into, record)` / `copyDecisionState(state)` /
+  `decisionsOf(state, fallbackSessionId)` を export（`summary-scan.ts` の
+  `emptySummaryState` / `foldSummary` / `copySummaryState` / `summaryPartsOf` と同じ並び）
+- `awaiting.get(id)` は `asks.findLast(a => a.toolUseId === id)` に置き換える。`find` ではなく
+  `findLast` なのは、同じ id が 2 度現れたとき Map が保持していたのは**後**の ask だから
+  （実際には起きないが、規則を変えないため）。この探索が走るのは tool_result ブロックを持つ行だけ。
+- `foldDecision` の中は **`collectAnswer` → `collectAsks` の順**。いまの `isAnswer` は行を parse する
+  **前**に評価されるので、答えは常に「それより前のレコードで出た ask」しか解決できない。順序を逆に
+  することで、事前フィルタが持っていたこの意味をそのまま保つ（`addLine` の doc コメントが言っている
+  "an answer always trails its question" そのもの）。
+- `createDecisionScan()` と `mentionsPendingAsk` は削除。`decisionsFromJsonl` は同じ fold の上に
+  組み直す（規則は 1 つだけ）。`decisions.spec.ts` の 30 本近い assertion がそのまま通ることが、
+  規則が変わっていない証拠になる。
+
+### 2. `server/session/decision-scan.ts` — fold に載せ替え
+
+```ts
+const decisionFold = createTranscriptFold<DecisionScanState>({
+  kind: "decisions", version: 1, isValue: isDecisionState,
+  empty: emptyDecisionState, fold: foldDecision, copy: copyDecisionState,
+});
+```
+
+`isDecisionState` は sidecar（誰が書いたか分からない入力）用の型ガード。`Ask.input` は
+`AskUserQuestion` の入力そのもので任意の JSON なので、ガードは他のフィールドだけ見る。
+
+`cold` は付けない。決定は transcript のどこにでもあり、質問と答えは別の行なので、両端の窓では
+答えられない（#998 の「窓が元の規則を言い換える」）。
+
+### 3. `createFileCache` の削除
+
+これが最後の利用者なので、残すと knip（CI の dead-code-scan）が落ちる。`createFileCache` と
+`FileCache` を `file-cache.ts` から削除し、モジュール冒頭のコメントを 1 つのメモの説明に直す。
+`createAppendFileCache` は `transcript-fold.ts` が使い続ける。
+
+## 等価性の担保
+
+- `decisions.spec.ts` を**無修正で**通す（規則が動いていない証拠）
+- 新規: **全カット位置**で「一気読み == 途中で切って再開」が一致する（#1395 と同じ形）
+- 新規: state を JSON で往復しても同じ（＝ sidecar に載る形か）
+- 新規: `decisionsForCwd` 経由で、ターンが追記されたあとの再開が一気読みと一致する／
+  未変更なら読み直さない／大きいセッションは sidecar に書かれ、別プロセスがそこから続きを畳む
+
+## 実測での確認
+
+484 MB の実 transcript のコピーに対して、cold / 未変更 / 1 ターン追記後 / 別プロセスの 4 点を測る
+（#1377 のクローズ時と同じ手順。scratch `HOME` を使い、実ファイルには触らない）。

--- a/server/session/decision-scan.ts
+++ b/server/session/decision-scan.ts
@@ -3,9 +3,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { DecisionRecord, DecisionsResponse } from "../../common/decisionLog.js";
-import { forEachJsonlLine } from "../infra/jsonl-file.js";
-import { byNewest, createDecisionScan } from "./decisions.js";
-import { createFileCache, type FileStamp } from "./file-cache.js";
+import { isRecord } from "../../common/isRecord.js";
+import { byNewest, copyDecisionState, decisionsOf, emptyDecisionState, foldDecision, type Ask, type DecisionScanState } from "./decisions.js";
+import type { FileStamp } from "./file-cache.js";
+import { createTranscriptFold } from "./transcript-fold.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { safeReaddir } from "./session-reads.js";
 
@@ -14,9 +15,39 @@ import { safeReaddir } from "./session-reads.js";
 // response says how many were actually read, so a truncated scan is visible rather than implied.
 const MAX_TRANSCRIPTS = 200;
 
-// Parsing a transcript is the expensive part and the file is append-only, so the extraction is
-// memoised on (mtime, size) exactly like the session summary it sits next to.
-const cache = createFileCache<DecisionRecord[]>();
+// A sidecar is untrusted input whoever wrote it. `input` is the AskUserQuestion call's own argument
+// object and may be any JSON at all, so it is the one field with nothing to check.
+const isAsk = (value: unknown): value is Ask =>
+  isRecord(value) &&
+  typeof value.toolUseId === "string" &&
+  typeof value.ts === "string" &&
+  typeof value.sessionId === "string" &&
+  (value.cwd === null || typeof value.cwd === "string") &&
+  (value.resultText === null || typeof value.resultText === "string");
+
+const isDecisionState = (value: unknown): value is DecisionScanState =>
+  isRecord(value) &&
+  Array.isArray(value.asks) &&
+  value.asks.every(isAsk) &&
+  Array.isArray(value.pending) &&
+  value.pending.every((id) => typeof id === "string");
+
+// Reading a transcript is the expensive part and the file is append-only, so the scan is resumed
+// from where the last one stopped and kept beside a big file — the same fold the session list, the
+// summary, the timeline and the cost roll-up are on (#1377, #1386, #1402). A (mtime, size) memo was
+// not enough on its own: the session being written to never matches one, so the project's LARGEST
+// transcript was re-read in full every time the digest or the skill asked (2.2 s for 484 MB).
+//
+// No `cold` shortcut: a decision can sit anywhere in the file, and a question and its answer are
+// different records, so neither end of the file can answer for the middle.
+const decisionFold = createTranscriptFold<DecisionScanState>({
+  kind: "decisions",
+  version: 1,
+  isValue: isDecisionState,
+  empty: emptyDecisionState,
+  fold: foldDecision,
+  copy: copyDecisionState,
+});
 
 interface Transcript {
   file: string;
@@ -43,23 +74,11 @@ async function transcriptsNewestFirst(dir: string): Promise<Transcript[]> {
     .slice(0, MAX_TRANSCRIPTS);
 }
 
-// Line by line, never as one string: a transcript on this machine is 585 MB, which is past what
-// a JS string can hold, and reading it whole would drop exactly the longest sessions (#998).
-async function scanTranscript(transcript: Transcript): Promise<DecisionRecord[]> {
-  const scan = createDecisionScan();
-  await forEachJsonlLine(transcript.file, (line) => scan.addLine(line));
-  return scan.finish(transcript.sessionId);
-}
-
 // A transcript that could not be read is reported, not silently treated as one with no decisions:
 // the caller cannot otherwise tell a quiet project from a partial answer.
 async function decisionsIn(transcript: Transcript): Promise<DecisionRecord[] | null> {
-  const hit = cache.get(transcript.file, transcript.stamp);
-  if (hit) return hit;
   try {
-    const found = await scanTranscript(transcript);
-    cache.set(transcript.file, transcript.stamp, found);
-    return found;
+    return decisionsOf(await decisionFold.read(transcript.file, transcript.stamp), transcript.sessionId);
   } catch {
     return null;
   }

--- a/server/session/decisions.ts
+++ b/server/session/decisions.ts
@@ -1,10 +1,14 @@
 // Reading past decisions back out of a Claude transcript (#997, step 1 of #991).
 //
-// Fed one line at a time rather than a parsed file, for two reasons measured on real transcripts:
+// Fed one record at a time rather than a whole file, for two reasons measured on real transcripts:
 // this machine has a 585 MB one, which `readFileSync(..., "utf8")` cannot even represent
 // (`ERR_STRING_TOO_LONG` above ~512 MB), and holding every tool result to look for an answer
-// costs more memory than the answers are worth. A streaming scan keeps both bounded, and the
-// lines that matter are a rounding error in the file.
+// costs more memory than the answers are worth. A streaming fold keeps both bounded, and the
+// records that matter are a rounding error in the file.
+//
+// The state it folds into is plain JSON, which is what lets the same fold be RESUMED from where a
+// previous one stopped and kept beside the file (#1402) — a transcript only ever grows, so a scan
+// that has to start over is paying for bytes it already read.
 import type { DecisionAnswerKind, DecisionOption, DecisionQuestion, DecisionRecord } from "../../common/decisionLog.js";
 import { isRecord } from "../../common/isRecord.js";
 import { splitLines } from "../infra/split-lines.js";
@@ -167,7 +171,7 @@ function questionsOf(input: unknown, text: string | null): DecisionQuestion[] {
   });
 }
 
-interface Ask {
+export interface Ask {
   toolUseId: string;
   ts: string;
   cwd: string | null;
@@ -175,6 +179,23 @@ interface Ask {
   input: unknown;
   resultText: string | null;
 }
+
+/** Everything the scan knows so far. Plain JSON on purpose: the same value is written beside a big
+ *  transcript so the next process resumes instead of re-reading it (#1402), and a Map would not
+ *  survive that trip. `pending` holds the ids of asks still waiting for their tool_result. */
+export interface DecisionScanState {
+  asks: Ask[];
+  pending: string[];
+}
+
+export const emptyDecisionState = (): DecisionScanState => ({ asks: [], pending: [] });
+
+/** A resumed fold mutates what it was handed (an answer is written onto the ask it belongs to), and
+ *  the value it resumes from has already been given to a caller — so each ask is copied too. */
+export const copyDecisionState = (state: DecisionScanState): DecisionScanState => ({
+  asks: state.asks.map((ask) => ({ ...ask })),
+  pending: [...state.pending],
+});
 
 function parseLine(line: string): Record<string, unknown> | null {
   try {
@@ -190,7 +211,7 @@ const contentBlocks = (o: Record<string, unknown>): Record<string, unknown>[] =>
   return Array.isArray(content) ? content.filter(isRecord) : [];
 };
 
-function collectAsks(o: Record<string, unknown>, asks: Ask[], awaiting: Map<string, Ask>): void {
+function collectAsks(state: DecisionScanState, o: Record<string, unknown>): void {
   if (o.type !== "assistant") return;
   for (const block of contentBlocks(o)) {
     if (block.type !== "tool_use" || block.name !== ASK_TOOL) continue;
@@ -202,76 +223,56 @@ function collectAsks(o: Record<string, unknown>, asks: Ask[], awaiting: Map<stri
       input: block.input,
       resultText: null,
     };
-    asks.push(ask);
-    if (ask.toolUseId) awaiting.set(ask.toolUseId, ask);
+    state.asks.push(ask);
+    // Each id at most once, as the Map this replaced held it: a second ask claiming an id already
+    // waiting does not earn that id a second answer.
+    if (ask.toolUseId && !state.pending.includes(ask.toolUseId)) state.pending.push(ask.toolUseId);
   }
 }
 
-function collectAnswer(o: Record<string, unknown>, awaiting: Map<string, Ask>): void {
+function collectAnswer(state: DecisionScanState, o: Record<string, unknown>): void {
   for (const block of contentBlocks(o)) {
     if (block.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
-    const ask = awaiting.get(block.tool_use_id);
+    const at = state.pending.indexOf(block.tool_use_id);
+    if (at < 0) continue;
+    // findLast, not find: an id repeated in one transcript answers to the LAST ask that claimed it,
+    // which is what the Map this replaced held.
+    const ask = state.asks.findLast((a) => a.toolUseId === block.tool_use_id);
     if (!ask) continue;
     ask.resultText = resultText(block.content);
-    awaiting.delete(block.tool_use_id);
+    state.pending.splice(at, 1);
   }
 }
 
-export interface DecisionScan {
-  /** Feed one JSONL line, in file order — an answer always trails its question. */
-  addLine(line: string): void;
-  /** The decisions found so far, oldest first. `fallbackSessionId` covers a line that carries none. */
-  finish(fallbackSessionId: string): DecisionRecord[];
+/** One record into the scan, in file order. Answers first: a tool_result can only belong to an ask
+ *  from an EARLIER record, and running it first is what keeps that true within a record too. */
+export function foldDecision(state: DecisionScanState, record: Record<string, unknown>): void {
+  collectAnswer(state, record);
+  collectAsks(state, record);
 }
 
-const mentionsPendingAsk = (line: string, awaiting: Map<string, Ask>): boolean => {
-  for (const id of awaiting.keys()) {
-    if (line.includes(id)) return true;
-  }
-  return false;
-};
-
-export function createDecisionScan(): DecisionScan {
-  const asks: Ask[] = [];
-  const awaiting = new Map<string, Ask>();
-  return {
-    addLine(line) {
-      // Substring tests before JSON.parse. Only a handful of lines in a transcript are a question
-      // or its answer, and parsing the rest is what makes scanning a large session expensive; a
-      // false positive here costs one parse and is then rejected on structure.
-      //
-      // BOTH tests run on every candidate line, and neither short-circuits the other: a line can
-      // carry the word AskUserQuestion and still be somebody's answer — "AskUserQuestion って
-      // 何？" typed as a free-text answer is the case both reviewers caught, and it would have
-      // recorded a question the user did answer as unanswered.
-      const isAsk = line.includes(ASK_TOOL);
-      const isAnswer = awaiting.size > 0 && mentionsPendingAsk(line, awaiting);
-      if (!isAsk && !isAnswer) return;
-      const o = parseLine(line);
-      if (!o) return;
-      if (isAsk) collectAsks(o, asks, awaiting);
-      if (isAnswer) collectAnswer(o, awaiting);
-    },
-    finish(fallbackSessionId) {
-      return asks
-        .map((a) => ({
-          sessionId: a.sessionId || fallbackSessionId,
-          cwd: a.cwd,
-          ts: a.ts,
-          toolUseId: a.toolUseId,
-          questions: questionsOf(a.input, a.resultText),
-        }))
-        .filter((d) => d.questions.length > 0);
-    },
-  };
+/** The decisions the state holds, oldest first. `fallbackSessionId` covers a record that names none. */
+export function decisionsOf(state: DecisionScanState, fallbackSessionId: string): DecisionRecord[] {
+  return state.asks
+    .map((a) => ({
+      sessionId: a.sessionId || fallbackSessionId,
+      cwd: a.cwd,
+      ts: a.ts,
+      toolUseId: a.toolUseId,
+      questions: questionsOf(a.input, a.resultText),
+    }))
+    .filter((d) => d.questions.length > 0);
 }
 
-/** Whole-file convenience for callers that already hold the text (and for tests). Streaming
- *  callers feed `createDecisionScan()` directly — see server/routes/decision-routes.ts. */
+/** Whole-string convenience for callers that already hold the text (and for tests). A file is folded
+ *  record by record instead — see decision-scan.ts — through the same `foldDecision`. */
 export function decisionsFromJsonl(raw: string, fallbackSessionId: string): DecisionRecord[] {
-  const scan = createDecisionScan();
-  for (const line of splitLines(raw)) scan.addLine(line);
-  return scan.finish(fallbackSessionId);
+  const state = emptyDecisionState();
+  for (const line of splitLines(raw)) {
+    const record = parseLine(line);
+    if (record) foldDecision(state, record);
+  }
+  return decisionsOf(state, fallbackSessionId);
 }
 
 /** Newest first. A record with no timestamp sorts last rather than jumping to the top. */

--- a/server/session/file-cache.ts
+++ b/server/session/file-cache.ts
@@ -1,10 +1,8 @@
-// Two memos keyed by a file's (mtime, size). `createFileCache` reuses a derived value while the
-// file is unchanged and recomputes when it is written; `createAppendFileCache` goes further for an
-// append-only input, remembering where the last scan stopped so a file that GREW costs only the
-// bytes that were added. Purpose-built for session transcripts, whose `.jsonl` is append-only and
-// can be hundreds of MB — re-reading and re-parsing one on every window focus / grid-cell refresh
-// stalls the event loop, and re-reading FIFTY of them is what made the session list take 5 s
-// (#1377).
+// A memo keyed by a file's (mtime, size), for a value folded out of an append-only input:
+// it remembers where the last scan stopped, so a file that GREW costs only the bytes that were
+// added. Purpose-built for session transcripts, whose `.jsonl` is append-only and can be hundreds
+// of MB — re-reading and re-parsing one on every window focus / grid-cell refresh stalls the event
+// loop, and re-reading FIFTY of them is what made the session list take 5 s (#1377).
 //
 // `size` guards the sub-millisecond case where a file is rewritten within the same mtime
 // tick; together (mtime, size) is a cheap, good-enough freshness stamp (a full content hash
@@ -15,29 +13,6 @@ export interface FileStamp {
   size: number;
 }
 
-const sameStamp = (a: FileStamp, b: FileStamp): boolean => a.mtimeMs === b.mtimeMs && a.size === b.size;
-
-export interface FileCache<T> {
-  get(key: string, stamp: FileStamp): T | undefined;
-  set(key: string, stamp: FileStamp, value: T): void;
-}
-
-// Bounded by `max` entries with rough-LRU eviction (a hit/refresh moves the key to the end,
-// so the oldest untouched key is evicted first), so a machine that has opened thousands of
-// sessions doesn't retain every summary forever.
-export function createFileCache<T>(max = 500): FileCache<T> {
-  const entries = createLruStore<{ stamp: FileStamp; value: T }>(max);
-  return {
-    get(key, stamp) {
-      const hit = entries.get(key);
-      return hit && sameStamp(hit.stamp, stamp) ? hit.value : undefined;
-    },
-    set(key, stamp, value) {
-      entries.set(key, { stamp, value });
-    },
-  };
-}
-
 /** What a partially-folded, append-only file left behind: everything folded so far, and the byte
  *  the next scan resumes at. */
 export interface AppendScan<T> {
@@ -45,15 +20,15 @@ export interface AppendScan<T> {
   value: T;
 }
 
-/** The same memo for a value folded out of an APPEND-ONLY file, where an unchanged file is not the
- *  only cheap case: a file that merely GREW can be caught up by folding the new bytes, instead of
- *  being read from the start (#1377 — the session list was re-reading gigabytes it had read).
+/** An unchanged file is not the only cheap case: a file that merely GREW can be caught up by folding
+ *  the new bytes, instead of being read from the start (#1377 — the session list was re-reading
+ *  gigabytes it had read).
  *
  *  Nothing is resumable when the file got SHORTER (truncated, or replaced by a shorter one), nor
  *  when it stayed the same length but was written again — a same-size rewrite is the case mtime
- *  catches here, mirroring how size catches a same-mtime rewrite above. A file rewritten wholesale
- *  into something LONGER still reads as an append; that is the same (mtime, size) approximation
- *  `createFileCache` already makes, and a transcript is only ever appended to. */
+ *  catches here, mirroring how size catches a same-mtime rewrite. A file rewritten wholesale into
+ *  something LONGER still reads as an append; that is the (mtime, size) approximation this stamp
+ *  is, and a transcript is only ever appended to. */
 export interface AppendFileCache<T> {
   resume(key: string, stamp: FileStamp): AppendScan<T> | undefined;
   set(key: string, stamp: FileStamp, from: number, value: T): void;

--- a/server/session/transcript-sidecar.ts
+++ b/server/session/transcript-sidecar.ts
@@ -84,8 +84,8 @@ async function usableScan<T>(parsed: unknown, options: SidecarOptions<T>, transc
   const { size, mtimeMs, scannedTo, head, value } = parsed;
   if (!isByteCount(size) || !isByteCount(scannedTo) || typeof mtimeMs !== "number" || !Number.isFinite(mtimeMs) || typeof head !== "string") return null;
   if (!options.isValue(value)) return null;
-  // The same freshness rule createFileCache states: a shorter file was rewritten, and a same-size
-  // one whose mtime moved was rewritten in place.
+  // The same freshness rule the in-memory cache states: a shorter file was rewritten, and a
+  // same-size one whose mtime moved was rewritten in place.
   if (stamp.size < size || scannedTo > stamp.size) return null;
   if (stamp.size === size && stamp.mtimeMs !== mtimeMs) return null;
   // (mtime, size) cannot tell "appended to" from "replaced by something longer". In memory that gap

--- a/test/server/session/decision-fold.spec.ts
+++ b/test/server/session/decision-fold.spec.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  copyDecisionState,
+  decisionsFromJsonl,
+  decisionsOf,
+  emptyDecisionState,
+  foldDecision,
+  type DecisionScanState,
+} from "../../../server/session/decisions.js";
+
+// The scan used to keep its state in a Map and be fed raw lines, which is why it could not be paused
+// and continued the way the session list, summary, timeline and cost folds are (#1402). What has to
+// hold now is that continuing it lands exactly where one uninterrupted pass would — the answers
+// themselves are pinned by decisions.spec.ts, which this change left untouched.
+
+const SESSION = "sess-1";
+
+const ask = (id: string, question: string, over: Record<string, unknown> = {}) => ({
+  type: "assistant",
+  timestamp: "2026-08-04T00:00:00.000Z",
+  cwd: "/Users/me/proj",
+  sessionId: SESSION,
+  message: {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id,
+        name: "AskUserQuestion",
+        input: { questions: [{ question, header: "H", multiSelect: false, options: [{ label: "yes", description: "d" }] }] },
+      },
+    ],
+  },
+  ...over,
+});
+
+const answer = (id: string, question: string, text: string) => ({
+  type: "user",
+  message: {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: id, content: `Your questions have been answered: "${question}"="${text}". You can now continue` }],
+  },
+});
+
+const chatter = (text: string) => ({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text }] } });
+
+const transcript: Record<string, unknown>[] = [
+  chatter("thinking"),
+  ask("t1", "ship it?"),
+  chatter("waiting"),
+  answer("t1", "ship it?", "yes"),
+  chatter("working"),
+  ask("t2", "release now?"),
+  answer("t2", "release now?", "not yet"),
+  ask("t3", "unanswered?"),
+];
+
+const foldAll = (records: Record<string, unknown>[]): DecisionScanState => {
+  const state = emptyDecisionState();
+  records.forEach((r) => foldDecision(state, r));
+  return state;
+};
+
+const resumeFrom = (state: DecisionScanState, records: Record<string, unknown>[]): DecisionScanState => {
+  const next = copyDecisionState(state);
+  records.forEach((r) => foldDecision(next, r));
+  return next;
+};
+
+describe("a decision scan folded in two goes", () => {
+  it("equals one uninterrupted pass, wherever it is cut", () => {
+    const whole = decisionsOf(foldAll(transcript), SESSION);
+    for (let cut = 0; cut <= transcript.length; cut++) {
+      const resumed = decisionsOf(resumeFrom(foldAll(transcript.slice(0, cut)), transcript.slice(cut)), SESSION);
+      expect(resumed, `cut after ${cut} records`).toEqual(whole);
+    }
+  });
+
+  // The cut that matters most: an answer resumed into a state whose question came from the previous
+  // pass. That is the one an in-memory-only scan never had to survive.
+  it("attaches an answer to a question folded before the pause", () => {
+    const resumed = resumeFrom(foldAll(transcript.slice(0, 3)), transcript.slice(3));
+    expect(decisionsOf(resumed, SESSION)[0]?.questions[0]?.answer).toBe("yes");
+  });
+
+  // The reason `copy` exists: a resumed fold writes the answer ONTO the ask object, and the state it
+  // continued from has already been handed to a caller.
+  it("leaves the state it continued from untouched", () => {
+    const first = foldAll(transcript.slice(0, 3));
+    const before = decisionsOf(first, SESSION);
+    resumeFrom(first, transcript.slice(3));
+    expect(decisionsOf(first, SESSION)).toEqual(before);
+  });
+
+  // A resumed fold has to survive the round trip through a sidecar, which is JSON.
+  it("survives being written down and read back", () => {
+    const half: unknown = JSON.parse(JSON.stringify(foldAll(transcript.slice(0, 3))));
+    if (!isDecisionStateShape(half)) throw new Error("a folded decision scan should round-trip through JSON");
+    expect(decisionsOf(resumeFrom(half, transcript.slice(3)), SESSION)).toEqual(decisionsOf(foldAll(transcript), SESSION));
+  });
+
+  // `pending` stands in for a Map keyed by tool_use_id, and the two only agree if an id is
+  // remembered once and forgotten when it is answered. No real transcript repeats an id — this pins
+  // the state against drifting from what it replaced, not a case anyone will see.
+  it("gives a repeated tool-use id exactly one answer", () => {
+    const state = foldAll([ask("dup", "first?"), ask("dup", "second?"), answer("dup", "second?", "yes"), answer("dup", "second?", "no")]);
+    expect(state.pending).toEqual([]);
+    expect(decisionsOf(state, SESSION).map((d) => d.questions[0]?.answer)).toEqual([null, "yes"]);
+  });
+
+  // The whole-string helper and the record fold are the same rule, so they cannot answer differently.
+  it("agrees with decisionsFromJsonl on the same records", () => {
+    const raw = transcript.map((r) => JSON.stringify(r)).join("\n");
+    expect(decisionsFromJsonl(raw, SESSION)).toEqual(decisionsOf(foldAll(transcript), SESSION));
+  });
+});
+
+// The same shape check decision-scan.ts applies to a sidecar, kept here so the round-trip test above
+// fails loudly rather than casting its way past a state JSON could not carry.
+function isDecisionStateShape(value: unknown): value is DecisionScanState {
+  if (typeof value !== "object" || value === null) return false;
+  const state: Partial<DecisionScanState> = value;
+  return Array.isArray(state.asks) && Array.isArray(state.pending);
+}

--- a/test/server/session/decision-scan-fold.spec.ts
+++ b/test/server/session/decision-scan-fold.spec.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome.js";
+import { projectSessionsDir } from "../../../server/session/project-dir.js";
+
+// The decision scan was the last transcript reader on a plain (mtime, size) memo, which can only
+// skip an UNCHANGED file — and the session being written to never is one. The project's largest
+// transcript was therefore re-read in full every time the digest tick or the skill asked (#1402).
+// These pin what changed: the scan is continued rather than restarted, and a big one is kept beside
+// the file so the next process continues it too.
+
+let scratch: ScratchHome;
+let home = "";
+let n = 0;
+
+const CWD = "/Users/me/proj";
+const DECISION_LIMIT = 50;
+
+async function freshDecisions() {
+  vi.resetModules(); // the scratch home is already in place; the module reads it at import
+  const mod = await import("../../../server/session/decision-scan.js");
+  return mod.decisionsForCwd;
+}
+
+const line = (o: unknown) => `${JSON.stringify(o)}\n`;
+
+const ask = (id: string, question: string) =>
+  line({
+    type: "assistant",
+    timestamp: `2026-08-04T00:00:0${id.length}.000Z`,
+    cwd: CWD,
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id,
+          name: "AskUserQuestion",
+          input: { questions: [{ question, header: "H", multiSelect: false, options: [{ label: "yes", description: "d" }] }] },
+        },
+      ],
+    },
+  });
+
+const answer = (id: string, question: string, text: string) =>
+  line({
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: id, content: `Your questions have been answered: "${question}"="${text}". You can now continue` }],
+    },
+  });
+
+const filler = (bytes: number) => line({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "x".repeat(bytes) }] } });
+
+const OVER_THRESHOLD_BYTES = 11 * 1024 * 1024;
+
+// projectSessionsDir, not a second copy of its rule: it folds every non-alphanumeric character to
+// "-", so the same cwd names a different directory on Windows (#1396).
+function transcriptPath(id: string): string {
+  const dir = projectSessionsDir(CWD);
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${id}.jsonl`);
+}
+
+function writeTranscript(body: string): string {
+  const id = `sess-${++n}`;
+  writeFileSync(transcriptPath(id), body);
+  return id;
+}
+
+const settled = async () => {
+  for (let i = 0; i < 60; i++) await new Promise((r) => setTimeout(r, 5));
+};
+
+const decisionSidecars = (): string[] => {
+  const root = path.join(home, ".mulmoterminal", "transcript-index", "decisions");
+  return existsSync(root)
+    ? readdirSync(root, { recursive: true })
+        .map(String)
+        .filter((e) => e.endsWith(".json"))
+    : [];
+};
+
+const answersOf = (found: { decisions: { questions: { answer: string | null }[] }[] }): (string | null)[] =>
+  found.decisions.flatMap((d) => d.questions.map((q) => q.answer));
+
+beforeEach(() => {
+  scratch = takeScratchHome("mt-decisions-");
+  home = scratch.path;
+});
+afterEach(() => scratch.release());
+
+describe("decisionsForCwd", () => {
+  it("reports a question and the answer it was given", async () => {
+    const decisionsForCwd = await freshDecisions();
+    writeTranscript(ask("t1", "ship it?") + answer("t1", "ship it?", "yes"));
+    const found = await decisionsForCwd(CWD, DECISION_LIMIT);
+    expect(found.scanned).toBe(1);
+    expect(found.decisions).toHaveLength(1);
+    expect(answersOf(found)).toEqual(["yes"]);
+  });
+
+  // The case the old memo could not help with: the file changed, so it re-read all of it. Now only
+  // the append is folded — and the answer has to be the one a full read would give, including when
+  // the answer arrives for a question folded during the PREVIOUS pass.
+  it("continues the scan across a turn, landing where one pass would", async () => {
+    const decisionsForCwd = await freshDecisions();
+    const id = writeTranscript(ask("t1", "ship it?"));
+    expect(answersOf(await decisionsForCwd(CWD, DECISION_LIMIT))).toEqual([null]);
+
+    appendFileSync(transcriptPath(id), answer("t1", "ship it?", "yes") + ask("t2", "release now?") + answer("t2", "release now?", "not yet"));
+    const resumed = await decisionsForCwd(CWD, DECISION_LIMIT);
+
+    const oneShot = await (await freshDecisions())(CWD, DECISION_LIMIT);
+    expect(resumed).toEqual(oneShot);
+    expect(answersOf(resumed).sort()).toEqual(["not yet", "yes"]);
+  });
+
+  // The claim the whole change rests on, and the one an equal-answers test cannot make: a GROWN
+  // transcript costs only the bytes that arrived. Proven by rewriting the already-scanned prefix to
+  // a same-length lie before appending — a scan that started over would report the lie.
+  it("folds only the bytes that arrived", async () => {
+    const decisionsForCwd = await freshDecisions();
+    const id = writeTranscript(ask("t1", "ship it?"));
+    const file = transcriptPath(id);
+    expect(await decisionsForCwd(CWD, DECISION_LIMIT)).toMatchObject({ decisions: [{ questions: [{ question: "ship it?" }] }] });
+
+    const rewritten = ask("t1", "REWROTE!"); // same length as the question it replaces
+    expect(rewritten).toHaveLength(ask("t1", "ship it?").length);
+    writeFileSync(file, rewritten);
+    appendFileSync(file, answer("t1", "ship it?", "yes"));
+
+    const resumed = await decisionsForCwd(CWD, DECISION_LIMIT);
+    expect(resumed.decisions[0]?.questions[0]?.question).toBe("ship it?");
+    expect(answersOf(resumed)).toEqual(["yes"]);
+  });
+
+  // Proven by changing the bytes under a held (size, mtime): an answer that still matches the
+  // ORIGINAL cannot have re-read the transcript.
+  it("does not read an unchanged transcript twice", async () => {
+    const decisionsForCwd = await freshDecisions();
+    const id = writeTranscript(ask("t1", "ship it?") + answer("t1", "ship it?", "yes"));
+    const file = transcriptPath(id);
+    const frozen = new Date(1_700_000_000_000);
+    utimesSync(file, frozen, frozen);
+    expect(answersOf(await decisionsForCwd(CWD, DECISION_LIMIT))).toEqual(["yes"]);
+
+    const before = statSync(file);
+    writeFileSync(file, ask("t1", "ship it?") + answer("t1", "ship it?", "no!")); // same length
+    utimesSync(file, frozen, frozen);
+    expect(statSync(file)).toMatchObject({ size: before.size, mtimeMs: before.mtimeMs });
+
+    expect(answersOf(await decisionsForCwd(CWD, DECISION_LIMIT))).toEqual(["yes"]);
+  });
+
+  // A big session is where the seconds went, so that is the one worth keeping on disk — and a second
+  // process (a restart, the next mulmoterminal, the digest tick) has to continue from it.
+  it("keeps a big session's scan beside it, and resumes from that in a fresh process", async () => {
+    const decisionsForCwd = await freshDecisions();
+    const id = writeTranscript(ask("t1", "ship it?") + filler(OVER_THRESHOLD_BYTES));
+    expect(answersOf(await decisionsForCwd(CWD, DECISION_LIMIT))).toEqual([null]);
+    await settled();
+    expect(decisionSidecars()).toHaveLength(1);
+
+    appendFileSync(transcriptPath(id), answer("t1", "ship it?", "yes"));
+    const inAnotherProcess = await (await freshDecisions())(CWD, DECISION_LIMIT);
+    expect(answersOf(inAnotherProcess)).toEqual(["yes"]);
+  });
+
+  it("reports nothing for a project with no transcripts", async () => {
+    const decisionsForCwd = await freshDecisions();
+    const found = await decisionsForCwd(CWD, DECISION_LIMIT);
+    expect(found).toEqual({ decisions: [], scanned: 0, unreadable: 0 });
+  });
+});

--- a/test/server/session/file-cache.spec.ts
+++ b/test/server/session/file-cache.spec.ts
@@ -1,56 +1,12 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { createAppendFileCache, createFileCache } from "../../../server/session/file-cache.js";
+import { createAppendFileCache } from "../../../server/session/file-cache.js";
 
 const stamp = (mtimeMs: number, size: number) => ({ mtimeMs, size });
 
-describe("createFileCache", () => {
-  it("returns undefined on a cold key", () => {
-    const c = createFileCache<number>();
-    expect(c.get("a", stamp(1, 10))).toBeUndefined();
-  });
-
-  it("returns the cached value while (mtime, size) is unchanged", () => {
-    const c = createFileCache<string>();
-    c.set("a", stamp(1, 10), "v1");
-    expect(c.get("a", stamp(1, 10))).toBe("v1");
-  });
-
-  it("misses when mtime changes", () => {
-    const c = createFileCache<string>();
-    c.set("a", stamp(1, 10), "v1");
-    expect(c.get("a", stamp(2, 10))).toBeUndefined();
-  });
-
-  it("misses when size changes at the same mtime (sub-tick rewrite)", () => {
-    const c = createFileCache<string>();
-    c.set("a", stamp(1, 10), "v1");
-    expect(c.get("a", stamp(1, 11))).toBeUndefined();
-  });
-
-  it("overwrites a key's value+stamp on re-set", () => {
-    const c = createFileCache<string>();
-    c.set("a", stamp(1, 10), "v1");
-    c.set("a", stamp(2, 20), "v2");
-    expect(c.get("a", stamp(2, 20))).toBe("v2");
-    expect(c.get("a", stamp(1, 10))).toBeUndefined();
-  });
-
-  it("evicts the least-recently-used key past the cap", () => {
-    const c = createFileCache<string>(2);
-    c.set("a", stamp(1, 1), "va");
-    c.set("b", stamp(1, 1), "vb");
-    c.get("a", stamp(1, 1)); // touch a → b is now LRU
-    c.set("c", stamp(1, 1), "vc"); // over cap → evict b
-    expect(c.get("a", stamp(1, 1))).toBe("va");
-    expect(c.get("c", stamp(1, 1))).toBe("vc");
-    expect(c.get("b", stamp(1, 1))).toBeUndefined();
-  });
-});
-
-// The append-only variant (#1377): an unchanged file is not the only cheap case — a file that GREW
-// can be caught up from where the last scan stopped, which is what stops the session list from
-// re-reading gigabytes it has already read.
+// #1377: an unchanged file is not the only cheap case — a file that GREW can be caught up from
+// where the last scan stopped, which is what stops the session list from re-reading gigabytes it
+// has already read.
 describe("createAppendFileCache", () => {
   it("resumes nothing for a cold key", () => {
     const c = createAppendFileCache<string>();


### PR DESCRIPTION
## Summary

`decisionsForCwd` は transcript を読む最後の 1 か所で、`createFileCache`（(mtime, size) キー）のままでした。このキャッシュが飛ばせるのは**変わっていないファイル**だけで、**書き込み中のセッション＝プロジェクトで一番大きいファイル**は決してそれに当たりません。結果、`/api/decisions`（`mulmoterminal-decisions` skill）と 6 時間ごとの digest tick のたびに、そのファイルを丸ごと読み直していました（484 MB で 2.2 秒、その間イベントループは止まります）。

`#1377` / `#1386` で作った `createTranscriptFold`（メモリ → sidecar → 差分だけ畳む）に載せ替えます。

### 実測

484 MB の実 transcript のコピー（scratch `HOME`、実ファイルは無傷）:

| | before | after |
|---|---:|---:|
| 初回 | 2,164 ms | 2,096 ms |
| 未変更 | 1 ms | 0.6 ms |
| **1 ターン追記後** | **2,164 ms** | **1.3 ms** |
| さらに 1 ターン後 | 2,164 ms | 0.5 ms |
| **別プロセスの初回**（sidecar から再開） | 2,164 ms | **4.5 ms** |

プロジェクト全体（65 transcripts / 2.4 GB、実ディレクトリを symlink して read-only で走査）:

| | before | after |
|---|---:|---:|
| cold（sidecar 無し） | 5,547 ms | 5,599 ms |
| **cold（sidecar 有り = 2 回目のプロセス）** | 5,547 ms | **66 ms** |
| warm | 1 ms | 2 ms |

## Items to Confirm / Review

- **規則が動いていないか。** ここが唯一の risk です。根拠は 3 つ:
  1. `decisions.spec.ts`（29 本、answer 境界の際どいケースを含む）を**無修正で**通す
  2. **実データで main と突き合わせ**: 65 transcripts / 77 decisions / 110,812 bytes の JSON が main の worktree と**完全一致**（合成データではなく実際のプロジェクト）
  3. 新規テストで**全カット位置**の再開が一気読みと一致
- **`collectAnswer` → `collectAsks` の順序**（従来は Asks → Answer）。従来の `isAnswer` は**行を parse する前**に評価されるので、答えは常に「それより前のレコードで出た ask」しか解決できませんでした。順序を逆にすることでその意味をそのまま保っています（同一レコード内に ask とその tool_result が両方あるケースが唯一の差で、実際の transcript では起きません）。
- **`awaiting: Map` → `pending: string[]`**。Map は JSON にならないため。`asks.findLast(...)` と「同じ id は 1 度だけ push」で Map の意味（後勝ち・answer 済みは忘れる）を保っており、そこだけテストで固定しています。
- **`createFileCache` を削除**しました。これが最後の利用者で、残すと knip（CI の dead-code-scan）が落ちます。`createAppendFileCache` は `transcript-fold.ts` が使い続けます。テストも該当 describe だけ削除。
- **sidecar は 10 MB 超のセッションだけ**（既定の `minBytes`）。それ未満は従来どおりプロセス内メモリのみ。

## イシューの前提（案A）は実測で覆した

#1402 には「`addLine` は substring テストで JSON.parse を避けているので、レコード単位の fold に載せると避けていたコストを払い直す。fold に行レベルの入口を足す（案A）か、parse コストを実測して決める（案B）」と書きました。**実測したら差がありませんでした**（484 MB、3 回計測で安定）:

| | 実測 |
|---|---:|
| I/O だけ（行を読むが何もしない） | 1,419 ms |
| 案A: 行 + `addLine`（substring 先） | 2,125 ms |
| 案B: 全行 JSON.parse（何もしない） | 2,109 ms |

substring テスト 706 ms に対し全行 parse は 690 ms で、**同じ**です。

さらにコードを読むと、raw line を使っていたのは**事前フィルタ 2 つだけ**でした。`collectAsks` は `o.type !== "assistant"` とブロックの type/name を、`collectAnswer` は `block.type === "tool_result"` と `awaiting.get(block.tool_use_id)` を自分で見ています。つまり substring テストは**その先の関数が必ず落とす行しか落とせない**純粋な最適化で、規則の一部ではありません（`AskUserQuestion` という名前も tool_use_id も、その行の JSON に必ず文字列として現れます）。

**よって案B を採りました。** fold フレームワークにも `jsonl-file.ts` にも分岐を増やさず、他の 4 か所とまったく同じ `fold: (into, record) => void` に乗ります。上の表の「初回 2,164 → 2,096 ms」が、この判断が実測どおりだったことの裏付けです。

## テスト

- `decision-fold.spec.ts`（新規 6 本）— **全カット位置**で一気読みと一致 / 中断をまたいで答えが質問に付く / 再開元の state を壊さない / **JSON を往復しても同じ**（＝sidecar に載る形か）/ 重複 id の扱いが Map と同じ / `decisionsFromJsonl` と同じ答え
- `decision-scan-fold.spec.ts`（新規 6 本）— `decisionsForCwd` 経由で: **到着したバイトしか畳まない**（走査済みの前半を同じ長さの別内容に書き換えてから追記し、書き換えが結果に出ないことで証明）/ ターンをまたいだ再開が一気読みと一致 / 未変更なら読み直さない / **大きいセッションは sidecar に書かれ、別プロセスがそこから続きを畳む** / 空のプロジェクト
- `decisions.spec.ts` — **無修正で 29 本通過**

新規テストが**空振りでないこと**も確認しました。`transcript-fold.ts` の resume を一時的に無効化すると「到着したバイトしか畳まない」「未変更なら読み直さない」が期待どおり落ち、重複 id のガードを外すと該当テストが落ちます。

`yarn format` / `lint`（0 errors）/ `typecheck` / `build` / `knip`（新規の未使用 export なし。既存の 2 件は main でも同じ）/ `test`（**8,079 passed**）green。

## User Prompt

> 残課題すすめられる？？
> https://github.com/receptron/mulmoterminal/issues/1377
>
> （#1377 の残りは実測の結果すでに完了していたため close。同じ病気で残っていた decision scan を #1402 として切り出し）
>
> 1402すすめる

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
