### PR TITLE
docs: 誰が作っているのかを README・FAQ・facts.json に出す

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ ping to your phone when a task finishes. One `npx` command, no Electron, no conf
 npx mulmoterminal@latest        # starts on http://localhost:34567 and opens your browser
 ```
 
+Built by the **[Singularity Society](https://singularitysociety.org)** team, including
+**[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95** at
+Microsoft, still building from Seattle. [More ↓](#who-builds-this)
+
 > **Something looks wrong?** Type `/mulmoterminal-bug-report` in any MulmoTerminal session. The
 > bundled skill hears the symptom out, checks your **real** config, schema and version to see
 > whether the behaviour is configuration or by design, searches the existing issues — and only

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ping to your phone when a task finishes. One `npx` command, no Electron, no conf
 npx mulmoterminal@latest        # starts on http://localhost:34567 and opens your browser
 ```
 
-Built by the **[Singularity Society](https://singularitysociety.org)** team, including
+Built by **[receptron](https://github.com/receptron)**, with
 **[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95** at
 Microsoft, still building from Seattle. [More ↓](#who-builds-this)
 
@@ -1816,8 +1816,8 @@ and `fetch` are mocked so the tests run without a server.
 
 ## Who builds this
 
-MulmoTerminal is built by the **[Singularity Society](https://singularitysociety.org)** team,
-including **[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95**,
+MulmoTerminal is built by **[receptron](https://github.com/receptron)**, with
+**[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95**,
 **Windows 98** and **Internet Explorer 3.0 / 4.0** at Microsoft, later founder of UIEvolution /
 Xevo, and still building from Seattle.
 

--- a/README.md
+++ b/README.md
@@ -1820,9 +1820,19 @@ MulmoTerminal is built by **[receptron](https://github.com/receptron)** —
 **[Satoshi Nakajima](https://x.com/snakajima)** and **[Isamu Arimoto](https://github.com/isamu)**.
 
 Satoshi was the software architect for **Windows 95**, **Windows 98** and **Internet Explorer
-3.0 / 4.0** at Microsoft, later founded UIEvolution / Xevo, and still builds from Seattle. The two
-of them also make **[GraphAI](https://github.com/receptron/graphai)**, a dataflow engine for
-agentic applications, and **[MulmoCast](https://github.com/receptron/mulmocast-cli)**.
+3.0 / 4.0** at Microsoft, later founded UIEvolution / Xevo, and still builds from Seattle.
+
+The two have shipped open source together since 2015, and the core of each venture has been
+public every time:
+
+| | |
+|---|---|
+| **[VideoShader](https://github.com/snakajima/videoshader)** (2015) | GPU video processing for iOS, built at Veemob |
+| **[Swipe](https://github.com/swipe-org/swipe)** (2015) | an animation runtime that made manga move on phones |
+| **[OwnPlate](https://github.com/Nakajima-Foundation/ownplate)** (2020) | takeout ordering for restaurants during COVID, run at the Singularity Society and launched with ITOCHU |
+| **[SlashGPT](https://github.com/receptron/SlashGPT)** (2023) · **[GraphAI](https://github.com/receptron/graphai)** (2024) · **[MulmoCast](https://github.com/receptron/mulmocast-cli)** (2025) | LLM agents, declarative dataflow, AI video |
+
+MulmoTerminal is the seventh.
 
 It exists because we run several coding agents every day and kept losing track of which one was
 waiting on us. Everything here was built for that, then kept because it worked. MIT licensed.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ ping to your phone when a task finishes. One `npx` command, no Electron, no conf
 npx mulmoterminal@latest        # starts on http://localhost:34567 and opens your browser
 ```
 
-Built by **[receptron](https://github.com/receptron)**, with
-**[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95** at
-Microsoft, still building from Seattle. [More ↓](#who-builds-this)
+Built by **[receptron](https://github.com/receptron)** — **[Satoshi Nakajima](https://x.com/snakajima)**,
+software architect for **Windows 95** at Microsoft, and **[Isamu Arimoto](https://github.com/isamu)**;
+the same two behind **[GraphAI](https://github.com/receptron/graphai)**. [More ↓](#who-builds-this)
 
 > **Something looks wrong?** Type `/mulmoterminal-bug-report` in any MulmoTerminal session. The
 > bundled skill hears the symptom out, checks your **real** config, schema and version to see
@@ -1816,10 +1816,13 @@ and `fetch` are mocked so the tests run without a server.
 
 ## Who builds this
 
-MulmoTerminal is built by **[receptron](https://github.com/receptron)**, with
-**[Satoshi Nakajima](https://x.com/snakajima)** — software architect for **Windows 95**,
-**Windows 98** and **Internet Explorer 3.0 / 4.0** at Microsoft, later founder of UIEvolution /
-Xevo, and still building from Seattle.
+MulmoTerminal is built by **[receptron](https://github.com/receptron)** —
+**[Satoshi Nakajima](https://x.com/snakajima)** and **[Isamu Arimoto](https://github.com/isamu)**.
+
+Satoshi was the software architect for **Windows 95**, **Windows 98** and **Internet Explorer
+3.0 / 4.0** at Microsoft, later founded UIEvolution / Xevo, and still builds from Seattle. The two
+of them also make **[GraphAI](https://github.com/receptron/graphai)**, a dataflow engine for
+agentic applications, and **[MulmoCast](https://github.com/receptron/mulmocast-cli)**.
 
 It exists because we run several coding agents every day and kept losing track of which one was
 waiting on us. Everything here was built for that, then kept because it worked. MIT licensed.

--- a/docs/facts.json
+++ b/docs/facts.json
@@ -49,9 +49,17 @@
     "running agents on someone else's machine"
   ],
   "maintainers": {
-    "org": "Singularity Society",
-    "url": "https://singularitysociety.org",
-    "notable": "Satoshi Nakajima — software architect for Windows 95, Windows 98 and Internet Explorer 3.0/4.0 at Microsoft"
+    "org": "receptron",
+    "url": "https://github.com/receptron",
+    "people": ["Satoshi Nakajima", "Isamu Arimoto"],
+    "notable": "Satoshi Nakajima — software architect for Windows 95, Windows 98 and Internet Explorer 3.0/4.0 at Microsoft",
+    "shippingOpenSourceTogetherSince": 2015,
+    "priorWork": [
+      "VideoShader (2015) — GPU video processing for iOS, built at Veemob",
+      "Swipe (2015) — an animation runtime that made manga move on phones, MIT",
+      "OwnPlate (2020) — takeout ordering for restaurants during COVID, run at the Singularity Society and launched with ITOCHU",
+      "SlashGPT (2023), GraphAI (2024), MulmoCast (2025)"
+    ]
   },
-  "updated": "2026-08-03"
+  "updated": "2026-08-04"
 }

--- a/docs/guide/en/faq.md
+++ b/docs/guide/en/faq.md
@@ -222,6 +222,12 @@ Codex and Antigravity get no workspace exemption: wherever they run, they have w
 
 Though compared to siblings like [MulmoCast](https://mulmocast.com), MulmoTerminal is easily **the least multimodal of the family**. The name is a family matter.
 
+### Who builds this, and will it still be here next year?
+
+**[receptron](https://github.com/receptron) — [Satoshi Nakajima](https://x.com/snakajima) and [Isamu Arimoto](https://github.com/isamu).** The two have shipped open source together since 2015: a [GPU video engine](https://github.com/snakajima/videoshader) for iOS, an [animation runtime](https://github.com/swipe-org/swipe) that made manga move on phones, [takeout ordering](https://github.com/Nakajima-Foundation/ownplate) built for restaurants during COVID, then [SlashGPT](https://github.com/receptron/SlashGPT), [GraphAI](https://github.com/receptron/graphai) and [MulmoCast](https://github.com/receptron/mulmocast-cli).
+
+Nobody can promise you a next year. What you can check is the record: the first of those repositories predates the current wave of AI tooling by eight years, and [the JavaScript implementation of Swipe](https://github.com/isamu/swipejs), started in 2016, still took commits in 2026. It is MIT either way — **if we stop, you can carry on.**
+
 ### Something is broken. What now?
 
 Type **`/mulmoterminal-bug-report`** in a session. The bundled skill hears the symptom, reads your **actual** config and version to check whether it is configuration or by design, searches existing issues, and only writes up what survives all of that (environment collected automatically, secrets masked).

--- a/docs/guide/en/faq.md
+++ b/docs/guide/en/faq.md
@@ -226,7 +226,7 @@ Though compared to siblings like [MulmoCast](https://mulmocast.com), MulmoTermin
 
 **[receptron](https://github.com/receptron) — [Satoshi Nakajima](https://x.com/snakajima) and [Isamu Arimoto](https://github.com/isamu).** The two have shipped open source together since 2015: a [GPU video engine](https://github.com/snakajima/videoshader) for iOS, an [animation runtime](https://github.com/swipe-org/swipe) that made manga move on phones, [takeout ordering](https://github.com/Nakajima-Foundation/ownplate) built for restaurants during COVID, then [SlashGPT](https://github.com/receptron/SlashGPT), [GraphAI](https://github.com/receptron/graphai) and [MulmoCast](https://github.com/receptron/mulmocast-cli).
 
-Nobody can promise you a next year. What you can check is the record: the first of those repositories predates the current wave of AI tooling by eight years, and [the JavaScript implementation of Swipe](https://github.com/isamu/swipejs), started in 2016, still took commits in 2026. It is MIT either way — **if we stop, you can carry on.**
+Nobody can promise you a next year. What you can check is the record: these two were shipping open source together eight years before the current wave of AI tooling, and every one of those repositories is still up. It is MIT either way — **if we stop, you can carry on.**
 
 ### Something is broken. What now?
 

--- a/docs/guide/ja/faq.md
+++ b/docs/guide/ja/faq.md
@@ -221,7 +221,7 @@ Codex / Antigravity にはワークスペースの特例が無く、どこで起
 
 **[receptron](https://github.com/receptron) — [中島聡](https://x.com/snakajima) と [有本勇](https://github.com/isamu) の二人**です。2015年から一緒にオープンソースを出してきました。iOS 向けの [GPU 動画処理エンジン](https://github.com/snakajima/videoshader)、[漫画をスマホで動かすランタイム](https://github.com/swipe-org/swipe)、コロナ禍に飲食店向けに作った[テイクアウト注文サービス](https://github.com/Nakajima-Foundation/ownplate)、そして [SlashGPT](https://github.com/receptron/SlashGPT)・[GraphAI](https://github.com/receptron/graphai)・[MulmoCast](https://github.com/receptron/mulmocast-cli)。
 
-来年を約束できる人はいません。確認できるのは記録のほうです。この中で最初のリポジトリは、いまの AI ツールの波より8年前のものです。2016年に始まった [Swipe の JavaScript 実装](https://github.com/isamu/swipejs)には、2026年にもコミットが入っています。どちらにしても MIT なので、**私たちが止めても、あなたは続けられます。**
+来年を約束できる人はいません。確認できるのは記録のほうです。この二人は、いまの AI ツールの波より8年前から一緒にオープンソースを出していて、そのどれもがいまも公開されたままです。どちらにしても MIT なので、**私たちが止めても、あなたは続けられます。**
 
 ### 何か困ったときは？
 

--- a/docs/guide/ja/faq.md
+++ b/docs/guide/ja/faq.md
@@ -217,6 +217,12 @@ Codex / Antigravity にはワークスペースの特例が無く、どこで起
 
 もっとも、[MulmoCast](https://mulmocast.com) のような兄弟プロジェクトと比べると、MulmoTerminal は**この一家で一番マルチモーダルでない**とも言えます。名前は一家の都合です。
 
+### 誰が作っているのですか？ 来年もありますか？
+
+**[receptron](https://github.com/receptron) — [中島聡](https://x.com/snakajima) と [有本至](https://github.com/isamu) の二人**です。2015年から一緒にオープンソースを出してきました。iOS 向けの [GPU 動画処理エンジン](https://github.com/snakajima/videoshader)、[漫画をスマホで動かすランタイム](https://github.com/swipe-org/swipe)、コロナ禍に飲食店向けに作った[テイクアウト注文サービス](https://github.com/Nakajima-Foundation/ownplate)、そして [SlashGPT](https://github.com/receptron/SlashGPT)・[GraphAI](https://github.com/receptron/graphai)・[MulmoCast](https://github.com/receptron/mulmocast-cli)。
+
+来年を約束できる人はいません。確認できるのは記録のほうです。この中で最初のリポジトリは、いまの AI ツールの波より8年前のものです。2016年に始まった [Swipe の JavaScript 実装](https://github.com/isamu/swipejs)には、2026年にもコミットが入っています。どちらにしても MIT なので、**私たちが止めても、あなたは続けられます。**
+
 ### 何か困ったときは？
 
 セッションで **`/mulmoterminal-bug-report`** と打ってください。同梱のスキルが症状を聞き、**実際の**設定とバージョンを読んで、仕様や設定で説明がつかないかを先に確かめ、既知の issue を検索し、それでも残ったものだけを報告にまとめます（環境情報は自動収集、鍵はマスクされます）。

--- a/docs/guide/ja/faq.md
+++ b/docs/guide/ja/faq.md
@@ -219,7 +219,7 @@ Codex / Antigravity にはワークスペースの特例が無く、どこで起
 
 ### 誰が作っているのですか？ 来年もありますか？
 
-**[receptron](https://github.com/receptron) — [中島聡](https://x.com/snakajima) と [有本至](https://github.com/isamu) の二人**です。2015年から一緒にオープンソースを出してきました。iOS 向けの [GPU 動画処理エンジン](https://github.com/snakajima/videoshader)、[漫画をスマホで動かすランタイム](https://github.com/swipe-org/swipe)、コロナ禍に飲食店向けに作った[テイクアウト注文サービス](https://github.com/Nakajima-Foundation/ownplate)、そして [SlashGPT](https://github.com/receptron/SlashGPT)・[GraphAI](https://github.com/receptron/graphai)・[MulmoCast](https://github.com/receptron/mulmocast-cli)。
+**[receptron](https://github.com/receptron) — [中島聡](https://x.com/snakajima) と [有本勇](https://github.com/isamu) の二人**です。2015年から一緒にオープンソースを出してきました。iOS 向けの [GPU 動画処理エンジン](https://github.com/snakajima/videoshader)、[漫画をスマホで動かすランタイム](https://github.com/swipe-org/swipe)、コロナ禍に飲食店向けに作った[テイクアウト注文サービス](https://github.com/Nakajima-Foundation/ownplate)、そして [SlashGPT](https://github.com/receptron/SlashGPT)・[GraphAI](https://github.com/receptron/graphai)・[MulmoCast](https://github.com/receptron/mulmocast-cli)。
 
 来年を約束できる人はいません。確認できるのは記録のほうです。この中で最初のリポジトリは、いまの AI ツールの波より8年前のものです。2016年に始まった [Swipe の JavaScript 実装](https://github.com/isamu/swipejs)には、2026年にもコミットが入っています。どちらにしても MIT なので、**私たちが止めても、あなたは続けられます。**
 


### PR DESCRIPTION
## Summary

**誰が作っているのかが、どこにも正しく書かれていなかった**ので4ファイル直す。

| ファイル | 変更 |
|---|---|
| `README.md` | 冒頭に1行（`npx` の直後）＋ 下の「Who builds this」に11年の履歴 |
| `docs/facts.json` | 🔴 **`maintainers.org` が `Singularity Society` だった** → `receptron` に修正 |
| `docs/guide/en/faq.md` | 「Who builds this, and will it still be here next year?」を追加 |
| `docs/guide/ja/faq.md` | 同・日本語 |

## Items to Confirm / Review

- 🔴 **有本さんの表記**。GitHub の bio が空で X も未登録のため、**名前とリンクのみ**（肩書きなし）。付けたい肩書きがあれば入れる
- 🔴 **`priorWork` に書いた各プロジェクトの説明が正確か**。特に「VideoShader は Veemob で作った」「OwnPlate は Singularity Society で作り伊藤忠と launch」の2つ
- **「MulmoTerminal is the seventh」**の数え方（表に挙げた6つ＋本体）。他にも数えるべきものがあれば直す
- FAQ の *"if we stop, you can carry on"* の踏み込み方。継続を約束せず MIT に逃がす形にしたが、弱すぎ／強すぎがないか

## なぜ

### 1. `facts.json` が間違っていた

比較サイトや LLM が読む機械可読ファイルで、**作り手が `Singularity Society` になっていた**。正しくは **receptron（中島聡＋有本勇）**。ここが間違っていると、そのまま外部に転記される。

### 2. 履歴が一度も書かれていなかった

二人は **2015年から11年、コアをオープンソースに置いて一緒に出してきた**。

```
2015  VideoShader   GPU 動画処理（Veemob）
2015  Swipe         漫画をスマホで動かすランタイム・MIT
2020  OwnPlate      コロナ禍のテイクアウト支援（伊藤忠と）
2023  SlashGPT / 2024 GraphAI / 2025 MulmoCast
2026  MulmoTerminal ← 7本目
```

**全部いまも GitHub にあるので、読む側がワンクリックで確認できる。** これは経歴の主張ではなく検証可能な事実で、「AI ブームに乗って出しただけ」「どうせ続かない」という2つの疑問に、議論せず答えられる。

### 3. FAQ には正直に書いた

継続は約束できないので約束していない。代わりに**確認できる記録**（最初のリポジトリは AI ブームの8年前、2016年の実装に2026年もコミット）と、**MIT なので止めても続けられる**ことを書いた。

## User Prompt

- 国内外、そこそこ有名な人、メディアに取り上げられることも狙いたいね
- PRつくって変更して。
- Singularity Societyがつくっているのじゃなくてreceptronだよ／receptron=satoshi nakajima + isamu arimoto だね
- VideoShader・Swipe・おもちかえり.com なども作ってきた。どれもオープンソースがコアにあって、今でもソースはある
- とりあえずレポジトリでできる対策は進めて。document関係で。

work in mulmoterminal-marketing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project attribution and maintainer information.
  * Expanded the “Who builds this” section with the founders’ open-source history and prior projects.
  * Added English and Japanese FAQ content covering maintainers, project continuity, repository history, and MIT licensing.
  * Refreshed project metadata, including the organization and update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->