### PR TITLE
fix: address coderabbitai review comments (#1413 のマージに入り損ねた分)

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -118,7 +118,9 @@ most expected and least available.
   items, and the same three sit below the separator in the path menu, with the same destinations and
   the same `githubUrl` gate: **Repository**, **Issues**, **Pull requests**. Worth stating outright,
   because the first person to go looking for that icon and conclude the feature had been deleted was
-  the maintainer. Nothing about it is configurable and nothing needs restoring — the
+  the maintainer. **The path menu itself is fixed** — its contents are not configurable, and nothing
+  needs restoring to get those three back. A `gh` button in your own `buttons` list still works
+  exactly as before if you want one as a permanent icon; you then have it in both places. The
   [setup guide](https://receptron.github.io/mulmoterminal/guide/en/v4.4.0.html#header-icons) now
   shows the open menu ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.4.0.html#header-icons)).
 


### PR DESCRIPTION
## Summary

**#1413 のマージが取りこぼした 1 コミットの再投入。** docs のみ、1 ファイル 3 行。

#1413 で CodeRabbit の指摘を修正して `7e69b9ed` を push したが、その直後に発行した
`gh pr merge` が **push より前の SHA (`1ba17e5e`) を使ってマージ**したため、修正が main に
入らなかった。マージコミット `6cc8ebcf` に含まれるのは `1ba17e5e` のみ。

`7e69b9ed` はブランチ `docs/4.4.0-path-menu` に残っていたので、それを cherry-pick している
（内容は同一）。

## 何を直すか

changelog の 4.4.0 エントリにある **「Nothing about it is configurable」が誤り**。

固定なのは**パスメニュー自体**（中身は設定で変えられない）であって、GitHub の操作そのものは
configurable — 自分の `buttons` に `gh` を書けば従来どおり常設ボタンとして動く。

**この誤りには実地の証拠がある。** #1413 に至るやりとりの中で、実際に `gh` ボタンを
`~/.mulmoterminal/config.json` に追加し、アプリの `sanitizeButtons` / `resolveHeader` に通して
動作することまで確認している（探していた 3 項目メニューの代わりにはならないと分かって revert した）。
つまり「configurable でない」は、その場で反証されていた記述だった。

## Items to Confirm / Review

- **マージの取りこぼしは私の手順の問題。** push 直後に merge を発行したのが原因で、
  push が GitHub 側に反映される前の SHA でマージされた。今後は merge 前に
  リモートの HEAD が push した SHA と一致することを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal