### PR TITLE
fix(launcher): ワークスペースの「全ツール」判定にエージェントを含める (#1423)

### DIFF
--- a/common/guiMcpAgents.ts
+++ b/common/guiMcpAgents.ts
@@ -1,0 +1,38 @@
+// Which agents are handed the WHOLE GUI MCP — every tool on one generated `mt` URL — when their
+// session runs in the workspace, and which reach GUI tools only through what their directory
+// registered.
+//
+// In `common/` because BOTH sides decide from it and neither can derive it: the server decides it
+// by which spawn path consults `carriesFullGuiMcp`, and the launcher form decides from it whether
+// to state "All of them, automatically" or to offer the four per-group toggles. While the agent
+// dimension lived only in the server — implicit in which file called what — the form could not ask,
+// so it asked the DIRECTORY alone and told an Antigravity session in the workspace that it had
+// every tool while hiding the only control that could have given it any (#1423).
+//
+// Antigravity is out for a structural reason, not an oversight: it reaches MCP through a config
+// FILE it reads for itself (`syncAntigravityMcpConfig` writes the registered group servers into the
+// directory), so there is no per-spawn `--mcp-config` to hand it a session-scoped URL. Claude takes
+// that URL in its argv and codex in its `-c` overrides; agy has nowhere to receive one.
+import { type SessionAgent } from "./sessionAgent.js";
+import { isLaunchAgent } from "./launchAgent.js";
+import { customAgentFor, type AgentPick, type CustomAgent } from "./customAgents.js";
+
+export const FULL_GUI_MCP_AGENTS = ["claude", "codex"] as const;
+
+export type FullGuiMcpAgent = (typeof FULL_GUI_MCP_AGENTS)[number];
+
+export const agentCarriesFullGuiMcp = (agent: SessionAgent): agent is FullGuiMcpAgent => FULL_GUI_MCP_AGENTS.some((candidate) => candidate === agent);
+
+/** The same question asked of an Agent Picker choice, which may name one of the user's own entries.
+ *
+ *  A custom agent IS the CLI its entry declares: the user's command is a wrapper and Claude Code's
+ *  whole argv — `--mcp-config` included — is appended to it, so it receives what that CLI receives.
+ *  Reading `entry.agent` rather than the command text is the point; nothing here parses a command.
+ *
+ *  A `custom:` pick whose entry is gone (a cell outliving its config) answers false: its CLI is no
+ *  longer knowable, and offering the per-group toggles is the harmless way to be wrong. */
+export const pickCarriesFullGuiMcp = (pick: AgentPick, customAgents: readonly CustomAgent[]): boolean => {
+  const custom = customAgentFor(pick, customAgents);
+  if (custom) return agentCarriesFullGuiMcp(custom.agent);
+  return isLaunchAgent(pick) && agentCarriesFullGuiMcp(pick);
+};

--- a/plans/fix-1423-antigravity-workspace-gui-tools.md
+++ b/plans/fix-1423-antigravity-workspace-gui-tools.md
@@ -1,0 +1,86 @@
+# fix #1423 — Antigravity in the workspace is told it has every GUI tool, and loses the way to get any
+
+## What is wrong
+
+`CellLaunchForm.vue` decides two things from one value:
+
+```ts
+const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
+```
+
+- `v-if="inWorkspace"` → show **"All of them, automatically"**
+- its `v-else` → show the four MCP group toggles
+
+The value asks the **directory** and never the **agent**. Pick Antigravity, point at the
+workspace, and the form states something untrue and simultaneously removes the only control that
+could have made it true.
+
+The comment above that line states the premise out loud, and the premise is what is wrong:
+
+> a session started there is handed the WHOLE GUI MCP on one URL, **whatever agent runs it**
+
+Only two of the three spawn paths consult that predicate:
+
+| spawn | full GUI MCP | how |
+|---|---|---|
+| `spawn-claude.ts:202` | yes | `carriesFullGuiMcp(attachGuiMcp, cwd)` |
+| `spawn-codex.ts:90` | yes | `claimFullGuiMcp(...)` |
+| `spawn-antigravity.ts:52` | **no** | `syncAntigravityMcpConfig(cwd, mcpGroups)` only |
+
+`spawn-antigravity.ts` contains no reference to `carriesFullGuiMcp`, `claimFullGuiMcp` or
+`isWorkspaceCwd`. Antigravity reads a per-directory config file that names the registered group
+servers; being in the workspace changes nothing about it.
+
+And there is no other way out: `applyMcpGroup` / `mcpGroupEnabled` exist in exactly one component
+in `src/`, so hiding those toggles removes the capability from the app, not just from the form.
+
+## Which side is wrong
+
+**The UI.** Antigravity being directory-scoped is the intended, documented behaviour — the guide
+merged in #1408 says "Antigravity is the exception: wherever it runs, it gets what its directory
+registered". Confirmed with the maintainer before implementing. So the form must show the toggles
+for Antigravity, in the workspace like anywhere else.
+
+## Why the fix is not just an `&&` in the template
+
+"Which agents are handed the whole GUI MCP in the workspace" is decided by the **server** (by which
+spawn calls the predicate) and needed by the **UI** (to choose panel vs toggles). Today the UI
+cannot ask — the fact is implicit in which file calls what. That is the exact shape CLAUDE.md sends
+to `common/`:
+
+> a value or wire type that BOTH sides decide from … belongs here — never mirrored into `server/`
+> and `src/` with a "keep the two copies in sync" comment
+
+So the agent dimension becomes an exported predicate in `common/`, the UI reads it, and
+`carriesFullGuiMcp` reads it too — so a fourth agent added later cannot be full-GUI on the server
+and toggles-only in the form, or the reverse.
+
+## Plan
+
+1. **`common/guiMcpAgents.ts`** (new)
+   - `FULL_GUI_MCP_AGENTS = ["claude", "codex"]` — the agents whose spawn hands over every GUI tool
+     when the session runs in the workspace.
+   - `agentCarriesFullGuiMcp(agent)` — the predicate both sides call.
+   - The comment carries the *reason* Antigravity is out: it reaches MCP through a per-directory
+     config file it reads itself, so there is no per-spawn URL to hand it.
+
+2. **`server/session/mcp-config.ts`** — `carriesFullGuiMcp` takes the agent and consults the
+   predicate, so the server enforces the same list rather than encoding it by omission.
+   Call sites in `spawn-claude.ts` / `spawn-codex.ts` pass their own agent.
+
+3. **`src/components/CellLaunchForm.vue`** — the panel/toggles branch asks
+   `inWorkspace && agentCarriesFullGuiMcp(props.agent)`. `inWorkspace` keeps its own meaning
+   (used by the worktree row at `:636`), so the agent test goes in a separate named computed
+   rather than being folded into it — the worktree row is about the directory, not the agent.
+
+4. **Tests**
+   - `common/` spec pinning the membership, including that Antigravity is absent **and why**.
+   - Component spec: Antigravity + workspace shows `cell-mcp-toggle-*` and NOT `cell-mcp-all`;
+     claude + workspace still shows `cell-mcp-all`; Antigravity in a project directory unchanged.
+   - Server spec: `carriesFullGuiMcp` is false for antigravity in the workspace.
+   - Each new test re-run with its own fix reverted, to confirm it actually fails.
+
+## Out of scope
+
+Whether Antigravity *should* get every tool in the workspace. That is a feature change, it
+contradicts documentation merged hours ago, and the maintainer chose the other direction.

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -9,6 +9,8 @@
 import type { UserMcpServer } from "../config/config-schema.js";
 import { toolGroupServerId, GUI_SERVER_ID, type ToolGroup } from "../../common/toolGroups.js";
 import { isWorkspaceCwd } from "../config/env.js";
+import { agentCarriesFullGuiMcp } from "../../common/guiMcpAgents.js";
+import type { SessionAgent } from "../../common/sessionAgent.js";
 import type { GuiMcpServer } from "../agents/codex-args.js";
 
 export interface McpConfigInput {
@@ -37,9 +39,16 @@ const DEFAULT_HOST = "127.0.0.1";
  * before any of this. Named and exported rather than left inline because that last sentence is the
  * invariant the whole design is written around, and an invariant nothing can assert is just a hope.
  *
- * It lives HERE, next to the two payload builders, because all three agents now ask it — claude's
- * argv, codex's `-c` overrides, and the launcher chip's rewritten command line. It was a local
- * detail of spawn-claude.ts while claude was the only caller.
+ * It lives HERE, next to the two payload builders, because both agents that can receive a
+ * per-spawn config ask it — claude's argv and codex's `-c` overrides. It was a local detail of
+ * spawn-claude.ts while claude was the only caller.
+ *
+ * The AGENT is the third fact, and leaving it implicit is what #1423 was: antigravity reaches MCP
+ * through a config file it reads itself, so it never had a URL to be handed and never called this
+ * — but the launcher form, which could not see which spawn calls what, asked the cwd alone and
+ * promised an antigravity session in the workspace every tool while hiding the toggles that were
+ * its only real way to get one. The membership now lives in common/guiMcpAgents.ts so the form and
+ * this predicate cannot disagree about a fourth agent later.
  *
  * This is also WHY THE TOOL NAMES DIFFER between cells, which looks like a bug until you know it:
  * true carries every tool under one generated server id (`mt`), so the agent sees
@@ -47,7 +56,11 @@ const DEFAULT_HOST = "127.0.0.1";
  * group ids, so the SAME tool is `mcp__mulmoterminal-render__presentChart`. Neither name is stale.
  * See common/toolGroups.ts for why the two ids are not unified, and README's "MCP server ids".
  */
-export const carriesFullGuiMcp = (attachGuiMcp: boolean, cwd: string | undefined): boolean => attachGuiMcp || isWorkspaceCwd(cwd);
+// `agent` is REQUIRED, deliberately undefaulted: a default would be one agent's answer handed to a
+// caller that never considered the question, which is the shape that produced #1423 in the first
+// place.
+export const carriesFullGuiMcp = (attachGuiMcp: boolean, cwd: string | undefined, agent: SessionAgent): boolean =>
+  agentCarriesFullGuiMcp(agent) && (attachGuiMcp || isWorkspaceCwd(cwd));
 
 // The counterpart for GRID cells, which are handed no --mcp-config at all: their GUI tools
 // come from the user's OWN per-folder MCP config (`claude mcp add -s local`, `.mcp.json`),

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -11,7 +11,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
-import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent.js";
+import { asTerminalAgent, type SessionAgent, type TerminalAgent } from "../../common/sessionAgent.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { parseSessionIdLog, sessionIdLogLine } from "./session-id-log.js";
@@ -402,8 +402,8 @@ export function hasAllGuiTools(id: string): boolean {
  *   given, which may be no all-tools url — claiming on top of that is exactly the stale-claim
  *   failure, arrived at from the other side.
  */
-export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined, wouldReattach: boolean): boolean {
-  const full = carriesFullGuiMcp(attachGuiMcp, cwd);
+export function claimFullGuiMcp(sessionId: string, attachGuiMcp: boolean, cwd: string | undefined, wouldReattach: boolean, agent: SessionAgent): boolean {
+  const full = carriesFullGuiMcp(attachGuiMcp, cwd, agent);
   if (!full) releaseAllToolsSession(sessionId);
   else if (!wouldReattach) markAllToolsSession(sessionId);
   return full;

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -199,7 +199,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
   // reattaches.
   function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, options: SpawnClaudeOptions = {}): PtyEntry {
     const { initialPrompt, cwd = CLAUDE_CWD, attachGuiMcp = true, draft, launch, customAgentId } = options;
-    const fullGuiMcp = carriesFullGuiMcp(attachGuiMcp, cwd);
+    const fullGuiMcp = carriesFullGuiMcp(attachGuiMcp, cwd, "claude");
     // fullGuiMcp picks the MCP mode (see buildClaudeArgs, and its own doc for who earns it): our
     // broker on one all-tools url; a project-directory cell gets none of ours and loads the GUI
     // tools its own directory registered. Either way the user's own MCP servers load.
@@ -272,7 +272,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     function recordCapabilitiesForThisSpawn(): void {
       const reattaching = ptyWouldReattach(sessionId, true);
       if (!reattaching) resetSessionToolGroups(sessionId);
-      claimFullGuiMcp(sessionId, attachGuiMcp, cwd, reattaching);
+      claimFullGuiMcp(sessionId, attachGuiMcp, cwd, reattaching, "claude");
     }
 
     function spawnEntry(): PtyEntry {

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -87,7 +87,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
     // reuses the id, and a stale claim would stand its group urls down with nothing left to serve
     // them (Codex review on #1399). claimFullGuiMcp owns both directions so neither spawn path can
     // apply half the rule.
-    const allTools = claimFullGuiMcp(sessionId, attachGuiMcp, cwd, ptyWouldReattach(sessionId, true));
+    const allTools = claimFullGuiMcp(sessionId, attachGuiMcp, cwd, ptyWouldReattach(sessionId, true), "codex");
     const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools });
     const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.codexBin, args, cwd, true, { binEnvVar: codexAdapter.binEnvVar });

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -11,6 +11,7 @@ import { worktreeAction, worktreeLimitReason } from "../../common/worktreeSessio
 import { isSameDirPath } from "../../common/dirPathKey";
 import { TOOL_GROUPS, TOOL_GROUP_HEADINGS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
 import { customAgentIdOf, type AgentPick, type CustomAgent } from "../../common/customAgents";
+import { pickCarriesFullGuiMcp } from "../../common/guiMcpAgents";
 import type { TerminalAgent } from "../../common/sessionAgent";
 import { launchChips, type CwdPreset, type LaunchChip } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
@@ -341,6 +342,15 @@ const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed
 // (see dirFor), which is exactly the case a comparison against the raw input would miss.
 const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
 
+// The workspace answers "every tool automatically" only for an agent that can RECEIVE a per-spawn
+// config — the directory alone is not enough. Antigravity reads a per-directory file instead, so it
+// gets what that directory registered wherever it runs, and telling it otherwise here both stated
+// something untrue and hid the toggles that were its only way to register anything (#1423).
+//
+// Kept apart from `inWorkspace` rather than folded into it: the worktree row below asks the
+// directory question and only that, and the two would have drifted the moment either changed.
+const workspaceGivesEveryTool = computed(() => inWorkspace.value && pickCarriesFullGuiMcp(props.agent, props.customAgents ?? []));
+
 // What "all of them" covers, named so the statement is checkable rather than a claim. Derived from
 // the headings and de-duplicated — render and media both read "Canvas" — so adding a group needs no
 // second edit here, the same rule mcpGroupTitle follows.
@@ -577,8 +587,10 @@ async function removeWorktree(w: Worktree): Promise<void> {
          all — the split is exactly what the grouping exists for (common/toolGroups.ts). -->
     <template v-if="mcpGroupDir && launchesAgent">
       <!-- The workspace gets every tool automatically, so it is TOLD, not asked. A switch here
-           would register a group URL with nothing left to serve: a control that does nothing. -->
-      <div v-if="inWorkspace" data-testid="cell-mcp-all" class="flex w-full max-w-[360px] flex-col gap-0.5">
+           would register a group URL with nothing left to serve: a control that does nothing.
+           Asked of the AGENT as well as the directory — Antigravity in the workspace takes the
+           `v-else` and gets the switches, because that is genuinely how it reaches any tool. -->
+      <div v-if="workspaceGivesEveryTool" data-testid="cell-mcp-all" class="flex w-full max-w-[360px] flex-col gap-0.5">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
         <span class="font-sans text-[11px] leading-snug text-secondary">
           <span class="material-symbols-outlined mr-[3px] align-middle text-[13px]" aria-hidden="true">workspaces</span>

--- a/test/common/guiMcpAgents.spec.ts
+++ b/test/common/guiMcpAgents.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { FULL_GUI_MCP_AGENTS, agentCarriesFullGuiMcp, pickCarriesFullGuiMcp } from "../../common/guiMcpAgents";
+import { SESSION_AGENTS } from "../../common/sessionAgent";
+import type { CustomAgent } from "../../common/customAgents";
+
+// Which agents are handed every GUI tool in the workspace. This lives in common/ because the server
+// decides it (by which spawn calls carriesFullGuiMcp) and the launcher form decides FROM it — while
+// it was implicit in the server the form could not ask, so it asked the directory alone and told an
+// antigravity session it had every tool while hiding the switches (#1423).
+describe("agentCarriesFullGuiMcp", () => {
+  it("covers claude and codex", () => {
+    expect(agentCarriesFullGuiMcp("claude")).toBe(true);
+    expect(agentCarriesFullGuiMcp("codex")).toBe(true);
+  });
+
+  // The asymmetry this module exists to make explicit, with the REASON in the test so a later
+  // reader can judge whether it still holds: antigravity reads a per-directory MCP config file it
+  // is pointed at, so there is no per-spawn URL to hand it. Adding it here would make the form
+  // promise tools no spawn path delivers.
+  it("excludes antigravity, which reaches MCP through a per-directory file instead", () => {
+    expect(agentCarriesFullGuiMcp("antigravity")).toBe(false);
+  });
+
+  it("excludes shell, which is not an agent session at all", () => {
+    expect(agentCarriesFullGuiMcp("shell")).toBe(false);
+  });
+
+  // Every session kind must have an answer here, so adding a fourth agent cannot silently inherit
+  // one side's default: this fails the moment SESSION_AGENTS grows without a decision being made.
+  it("answers for every session agent", () => {
+    for (const agent of SESSION_AGENTS) expect(typeof agentCarriesFullGuiMcp(agent)).toBe("boolean");
+    expect([...FULL_GUI_MCP_AGENTS].every((agent) => SESSION_AGENTS.some((known) => known === agent))).toBe(true);
+  });
+});
+
+describe("pickCarriesFullGuiMcp", () => {
+  const nemotron: CustomAgent = { id: "nemotron", label: "Nemotron", agent: "claude", command: "ollama launch claude --" };
+
+  it("reads a custom agent's declared CLI, not its command text", () => {
+    expect(pickCarriesFullGuiMcp("custom:nemotron", [nemotron])).toBe(true);
+  });
+
+  // The command names `claude`, but the entry is what decides — and here it declares nothing this
+  // list covers. Nothing in this repo parses a command line to infer an agent.
+  it("does not infer the agent from the command line", () => {
+    const codexish: CustomAgent = { id: "x", label: "X", agent: "claude", command: "wrapper codex --" };
+    expect(pickCarriesFullGuiMcp("custom:x", [codexish])).toBe(true);
+  });
+
+  it("answers false for a custom pick whose entry is gone", () => {
+    expect(pickCarriesFullGuiMcp("custom:deleted", [])).toBe(false);
+  });
+
+  it("passes the built-ins straight through", () => {
+    expect(pickCarriesFullGuiMcp("claude", [])).toBe(true);
+    expect(pickCarriesFullGuiMcp("codex", [])).toBe(true);
+    expect(pickCarriesFullGuiMcp("antigravity", [])).toBe(false);
+    expect(pickCarriesFullGuiMcp("shell", [])).toBe(false);
+  });
+});

--- a/test/server/session/full-gui-claim.spec.ts
+++ b/test/server/session/full-gui-claim.spec.ts
@@ -53,14 +53,14 @@ describe("claimFullGuiMcp", () => {
       [true, CLAUDE_CWD],
       [false, CLAUDE_CWD],
     ] as const) {
-      expect(claimFullGuiMcp(randomUUID(), attach, cwd, false)).toBe(carriesFullGuiMcp(attach, cwd));
+      expect(claimFullGuiMcp(randomUUID(), attach, cwd, false, "claude")).toBe(carriesFullGuiMcp(attach, cwd, "claude"));
     }
   });
 
   it("records the session when it carries the full GUI MCP", () => {
     const id = randomUUID();
     expect(hasAllGuiTools(id)).toBe(false);
-    claimFullGuiMcp(id, true, "/some/project", false);
+    claimFullGuiMcp(id, true, "/some/project", false, "claude");
     expect(hasAllGuiTools(id)).toBe(true);
   });
 
@@ -68,7 +68,7 @@ describe("claimFullGuiMcp", () => {
   // registered — marking it would switch exactly those off.
   it("records nothing for a cell that carries no GUI MCP of ours", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, false, "/some/project", false);
+    claimFullGuiMcp(id, false, "/some/project", false, "claude");
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
@@ -76,9 +76,9 @@ describe("claimFullGuiMcp", () => {
   // deciding "no" has to TAKE THE CLAIM BACK, not merely decline to add one.
   it("releases a claim the session no longer earns", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false, "claude");
     expect(hasAllGuiTools(id)).toBe(true);
-    claimFullGuiMcp(id, false, "/some/project", false);
+    claimFullGuiMcp(id, false, "/some/project", false, "claude");
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
@@ -87,7 +87,7 @@ describe("claimFullGuiMcp", () => {
   // the same stale-claim failure, reached from the other side.
   it("does not claim on a reattach", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, CLAUDE_CWD, true);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, true, "claude");
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
@@ -96,14 +96,14 @@ describe("claimFullGuiMcp", () => {
   // a cell with no GUI tools at all.
   it("releases even on a reattach", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
-    claimFullGuiMcp(id, false, "/some/project", true);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false, "claude");
+    claimFullGuiMcp(id, false, "/some/project", true, "claude");
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
   it("still answers the pure predicate on a reattach, whatever it records", () => {
-    expect(claimFullGuiMcp(randomUUID(), true, CLAUDE_CWD, true)).toBe(true);
-    expect(claimFullGuiMcp(randomUUID(), false, "/some/project", true)).toBe(false);
+    expect(claimFullGuiMcp(randomUUID(), true, CLAUDE_CWD, true, "claude")).toBe(true);
+    expect(claimFullGuiMcp(randomUUID(), false, "/some/project", true, "claude")).toBe(false);
   });
 });
 // Nothing here asserts the id reaches disk. `markAllToolsSession` already persisted before this
@@ -118,14 +118,14 @@ describe("claimFullGuiMcp", () => {
 describe("releaseAllToolsSession", () => {
   it("takes the claim back", () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, "/some/project", false);
+    claimFullGuiMcp(id, true, "/some/project", false, "claude");
     releaseAllToolsSession(id);
     expect(hasAllGuiTools(id)).toBe(false);
   });
 
   it("hands the group its tools back", async () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, "/some/project", false);
+    claimFullGuiMcp(id, true, "/some/project", false, "claude");
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
     releaseAllToolsSession(id);
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text).length).toBeGreaterThan(0);
@@ -144,7 +144,7 @@ describe("a group url once the session is claimed", () => {
     // The order this spec exists for: the GROUP url is the first thing to reach us. Before the
     // claim moved to spawn, "does it have all tools" was learned from whichever url connected
     // first, so this call would have been served the full render group.
-    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false, "claude");
     expect(toolNamesFrom((await listTools(`/api/mcp/render/${id}`)).text)).toEqual([]);
   });
 
@@ -157,7 +157,7 @@ describe("a group url once the session is claimed", () => {
   // the group down is only correct because the all-tools url carries the same tools and more.
   it("leaves the all-tools url serving everything", async () => {
     const id = randomUUID();
-    claimFullGuiMcp(id, true, CLAUDE_CWD, false);
+    claimFullGuiMcp(id, true, CLAUDE_CWD, false, "claude");
     const all = toolNamesFrom((await listTools(`/api/mcp/${id}`)).text);
     const group = toolNamesFrom((await listTools(`/api/mcp/render/${randomUUID()}`)).text);
     expect(all.length).toBeGreaterThan(group.length);

--- a/test/server/session/full-gui-mcp.spec.ts
+++ b/test/server/session/full-gui-mcp.spec.ts
@@ -39,35 +39,46 @@ describe("carriesFullGuiMcp", () => {
   it("does NOT give it to a grid cell in a project directory", () => {
     // The invariant. If this ever flips, every ordinary cell in the grid silently changes what
     // tools it has and where they come from.
-    expect(carriesFullGuiMcp(GRID_CELL, PROJECT)).toBe(false);
+    expect(carriesFullGuiMcp(GRID_CELL, PROJECT, "claude")).toBe(false);
   });
 
   it("gives it to a grid cell running in the workspace", () => {
-    expect(carriesFullGuiMcp(GRID_CELL, WORKSPACE)).toBe(true);
+    expect(carriesFullGuiMcp(GRID_CELL, WORKSPACE, "claude")).toBe(true);
   });
 
   it("gives it to a grid cell that named no directory — that IS the workspace", () => {
-    expect(carriesFullGuiMcp(GRID_CELL, undefined)).toBe(true);
-  });
-
-  // A LAUNCHER chip has no wire flag — it is never the single view — so the cwd is the only thing
-  // that can earn it, which is what the route passes `false` for. Same predicate, so a chip and the
-  // cell beside it agree about which directory is special.
-  it("answers for a launcher chip on the cwd alone", () => {
-    expect(carriesFullGuiMcp(false, WORKSPACE)).toBe(true);
-    expect(carriesFullGuiMcp(false, PROJECT)).toBe(false);
+    expect(carriesFullGuiMcp(GRID_CELL, undefined, "claude")).toBe(true);
   });
 
   it("still gives it to everything that is not a grid cell, whatever the directory", () => {
     // The single view, and every chat spawned without a cell of its own (spawnBackgroundChat,
     // the translation worker, issue work). Unchanged: the wire flag alone decides these.
-    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, PROJECT)).toBe(true);
-    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, WORKSPACE)).toBe(true);
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, PROJECT, "claude")).toBe(true);
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, WORKSPACE, "claude")).toBe(true);
   });
 
   it("does NOT give it to a cell in a subdirectory of the workspace", () => {
     // Equality, not prefix — `{workspace}/foo` is an ordinary project.
-    expect(carriesFullGuiMcp(GRID_CELL, path.join(WORKSPACE, "foo"))).toBe(false);
+    expect(carriesFullGuiMcp(GRID_CELL, path.join(WORKSPACE, "foo"), "claude")).toBe(false);
+  });
+
+  // #1423. The agent is the third fact, and it used to be encoded only by which spawn file called
+  // this — antigravity simply never did. That left the launcher form unable to ask, so it asked the
+  // directory alone and promised an antigravity session in the workspace every tool.
+  it("does NOT give it to antigravity, in the workspace or anywhere else", () => {
+    expect(carriesFullGuiMcp(GRID_CELL, WORKSPACE, "antigravity")).toBe(false);
+    expect(carriesFullGuiMcp(GRID_CELL, PROJECT, "antigravity")).toBe(false);
+    // Not even as a non-grid-cell: agy has no per-spawn config to receive one on.
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, WORKSPACE, "antigravity")).toBe(false);
+  });
+
+  it("gives it to codex on the same terms as claude", () => {
+    expect(carriesFullGuiMcp(GRID_CELL, WORKSPACE, "codex")).toBe(true);
+    expect(carriesFullGuiMcp(GRID_CELL, PROJECT, "codex")).toBe(false);
+  });
+
+  it("does NOT give it to a shell, which is not an agent session", () => {
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, WORKSPACE, "shell")).toBe(false);
   });
 });
 

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -324,10 +324,14 @@ describe("the workspace chip", () => {
   });
 });
 
-// The workspace is handed the WHOLE GUI MCP at spawn whatever agent runs there
-// (carriesFullGuiMcp), so there is no per-directory choice to offer. Four switches there would be
-// worse than redundant: they write a per-folder registration that a claimed session then
+// A claude or codex session in the workspace is handed the WHOLE GUI MCP at spawn
+// (carriesFullGuiMcp), so there is no per-directory choice to offer it. Four switches there would
+// be worse than redundant: they write a per-folder registration that a claimed session then
 // ignores, i.e. controls that visibly do nothing.
+//
+// "Whatever agent runs there" is NOT true and was the bug (#1423): antigravity reaches MCP through
+// a per-directory file, never through a per-spawn config, so in the workspace it must still be
+// asked. The cases below pin both halves.
 describe("the GUI tool groups in the workspace", () => {
   const guiMcpFetch = () => {
     globalThis.fetch = vi.fn(async (url: string) => {
@@ -376,6 +380,47 @@ describe("the GUI tool groups in the workspace", () => {
     expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(false);
     expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
     expect(w.find('[data-testid="cell-mcp-toggle-external"]').exists()).toBe(true);
+  });
+
+  // #1423. Both halves of the bug in one assertion: the claim was untrue for antigravity, AND the
+  // same branch hid the switches — which is the only place in src/ that registers a group at all,
+  // so the form promised every tool while removing the way to obtain any.
+  it("asks antigravity in the workspace, rather than telling it that everything is available", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws", agent: "antigravity" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(false);
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-mcp-toggle-external"]').exists()).toBe(true);
+  });
+
+  it("still tells codex in the workspace that everything is available", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws", agent: "codex" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(false);
+  });
+
+  // A custom agent IS the CLI its entry declares, with the user's command wrapped around it — the
+  // appended argv carries the same --mcp-config a plain claude cell gets. Read from `entry.agent`,
+  // never from the command text.
+  it("treats a custom agent as the CLI its entry declares", async () => {
+    guiMcpFetch();
+    const nemotron: CustomAgent = { id: "nemotron", label: "Nemotron", agent: "claude", command: "ollama launch claude --" };
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws", agent: "custom:nemotron", customAgents: [nemotron] });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(true);
+  });
+
+  // A cell can outlive the config entry it was launched from. Its CLI is then unknowable, so the
+  // form offers the switches: being wrong in the direction that still leaves a way out.
+  it("offers the switches for a custom agent whose entry is gone", async () => {
+    guiMcpFetch();
+    const w = mountForm([], { dir: "/home/me/ws", defaultCwd: "/home/me/ws", agent: "custom:deleted", customAgents: [] });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-all"]').exists()).toBe(false);
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

**Antigravity をワークスペースで起動しようとすると、フォームが事実と違うことを言い、しかも直す手段を隠していた。**

- 表示: `GUI tools — All of them, automatically — Canvas, Workspace data, External accounts.`
- 実際: そのディレクトリに**登録済みのグループだけ**
- おまけに同じ `v-if` が 4 つの MCP トグルを隠すので、その場で登録もできない

UI を実装に合わせる（Antigravity はディレクトリ登録ベースのまま）。**セッションの挙動は変えていない。**

`Closes #1423`

## Items to Confirm / Review

1. **`carriesFullGuiMcp` の第3引数 `agent` を必須にした（既定値なし）。** 呼び出し 4 箇所を更新。
   既定値を付けると「問いを考えなかった呼び出し側に一方の答えを配る」ことになり、**それが本件を
   生んだ構造そのもの**なので避けた。#902 / #914 / #1006 と同じ轍でもある。他意見があれば聞きたい。
2. **`common/guiMcpAgents.ts` を新設した。** 「どのエージェントが全 GUI ツールを得るか」は
   サーバー（どの spawn が述語を呼ぶか）が決め、ランチャフォームもそれを必要とする値。
   これまでサーバー側に**暗黙**（呼ばないことで表現）でしか無く、UI から問えなかった。CLAUDE.md の
   `common/` の規則そのものと判断したが、置き場所の妥当性を見てほしい。
3. **カスタムエージェントの扱い。** `custom:` は `entry.agent` を読んで解決している
   （コマンド文字列は読まない）。エントリが消えている `custom:` は **false**＝トグルを出す側に倒した。
   CLI が分からない以上、「全部ある」と言うより登録手段を残すほうが害が小さいという判断。
4. **`inWorkspace` は残してある。** worktree 行（`:645`）はディレクトリだけを問う正当な用途なので、
   エージェント判定は別 computed (`workspaceGivesEveryTool`) にした。

## 原因

`src/components/CellLaunchForm.vue`

```ts
const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
```

ディレクトリしか見ていない。この 1 値が「All of them パネルを出す」と「4 トグルを隠す」の両方を兼ねていた。
すぐ上のコメントが前提を書いているが、その前提が偽だった:

> a session started there is handed the WHOLE GUI MCP on one URL, **whatever agent runs it**

| spawn | 全 GUI MCP | 経路 |
|---|---|---|
| `spawn-claude.ts:202` | ○ | `carriesFullGuiMcp(attachGuiMcp, cwd)` |
| `spawn-codex.ts:90` | ○ | `claimFullGuiMcp(...)` |
| `spawn-antigravity.ts:52` | **×** | `syncAntigravityMcpConfig(cwd, mcpGroups)` のみ |

`spawn-antigravity.ts` に `carriesFullGuiMcp` / `claimFullGuiMcp` / `isWorkspaceCwd` の参照は 1 つも無い。
Antigravity は**設定ファイル経由**で MCP に届くので、渡すべき per-spawn の URL がそもそも存在しない。

## 逃げ道が無かったことの裏付け

`applyMcpGroup` / `mcpGroupEnabled` を持つコンポーネントは `src/` 全体で **`CellLaunchForm.vue` だけ**。
トグルが隠れると、アプリ内に他の登録手段が無い。

## 変更

| ファイル | 内容 |
|---|---|
| `common/guiMcpAgents.ts` | 新設。`FULL_GUI_MCP_AGENTS` / `agentCarriesFullGuiMcp` / `pickCarriesFullGuiMcp` |
| `server/session/mcp-config.ts` | `carriesFullGuiMcp` が agent を必須で取り、共有述語を参照 |
| `server/session/registry.ts` | `claimFullGuiMcp` に agent を通す |
| `spawn-claude.ts` / `spawn-codex.ts` | 自分の agent を渡す |
| `src/components/CellLaunchForm.vue` | 分岐を `workspaceGivesEveryTool` に。`inWorkspace` は worktree 行のため据え置き |

ついでに `mcp-config.ts` の docblock にあった「the launcher chip's rewritten command line」を削除した
（`7db85b14` でチップの書き換えは廃止済み。同種の古い前提が残っていたもの）。

## 検証

**新テストは修正を戻すと落ちることを individually 確認済み:**

| 戻した修正 | 落ちるテスト |
|---|---|
| テンプレートを `v-if="inWorkspace"` に戻す | antigravity 用 / entry が消えた custom 用 の 2 件 |
| `carriesFullGuiMcp` から agent 判定を外す | antigravity 用 / shell 用 の 2 件 |

- `yarn typecheck` / `yarn lint`（0 errors、warning 12 は既存）/ `yarn build` / `yarn test` **8179 passed**
- 計画: [`plans/fix-1423-antigravity-workspace-gui-tools.md`](plans/fix-1423-antigravity-workspace-gui-tools.md)

## User Prompt

> PR 本文で報告されている CellLaunchForm.vue の別件バグの調査と、本当にバグなら対応を。

（#1408 の本文で @ystknsh さんが「別件で見つけた実装の不整合」として報告していたもの。
修正方針は「UI を実装に合わせる / 実装を UI に合わせる」を確認したうえで前者を選択。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace GUI tool access now adapts to the selected agent.
  * Claude and Codex automatically receive full GUI tool access where supported.
  * Other agents can use configurable, directory-scoped GUI tool groups.

* **Bug Fixes**
  * Corrected workspace handling so unsupported agents no longer receive unintended full GUI access.
  * Custom agent selections now inherit GUI tool behavior from their configured agent when available.

* **Tests**
  * Added coverage for built-in, custom, missing, and unsupported agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->