### PR TITLE
chore: bump @mulmoclaude/markdown-plugin to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.0.0",
     "@mulmoclaude/html-plugin": "^2.0.0",
-    "@mulmoclaude/markdown-plugin": "^2.0.0",
+    "@mulmoclaude/markdown-plugin": "^2.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,15 +1932,15 @@
     "@mulmoclaude/common" "^1.1.1"
     "@mulmoclaude/core" "^2.0.0"
 
-"@mulmoclaude/markdown-plugin@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-2.0.0.tgz#9313dd125a5a759d8abe91344f42618701a75e1d"
-  integrity sha512-1EMK8xreshCfq9Opbm5q2NPxWIR4vrs0LAqb183aVv8BL8sNQobOW9zx/gLy3gFleS8tiK62qi+PEXcDRcGTmg==
+"@mulmoclaude/markdown-plugin@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-2.1.0.tgz#d8faf0e92df0726fc2df6956486416fd81162fd0"
+  integrity sha512-b0+Pn7kGzao9yGbxGrzz+jh3JU3UCD71zTKMf1ryEZ091/K+LUD90BnxwtbuDpOCm1GYOEMXZdfRpnePngZTCQ==
   dependencies:
     "@marp-team/marp-core" "^4.4.0"
-    "@mulmoclaude/common" "^1.1.1"
-    "@mulmoclaude/core" "^2.0.0"
-    "@mulmoclaude/markdown-utils" "^1.3.4"
+    "@mulmoclaude/common" "^1.1.2"
+    "@mulmoclaude/core" "^2.0.1"
+    "@mulmoclaude/markdown-utils" "^1.3.5"
     js-yaml "^5.2.3"
     marked "^18.0.7"
     mermaid "^11.16.0"
@@ -1952,6 +1952,15 @@
   dependencies:
     "@mulmoclaude/common" "^1.1.1"
     js-yaml "^5.2.2"
+    marked "^18.0.7"
+
+"@mulmoclaude/markdown-utils@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-utils/-/markdown-utils-1.3.5.tgz#a62ef488cb8dfe4f199eec7448dc6130506c54de"
+  integrity sha512-AXOhiyMtUFtvOb49Z3dCYntN858HPcSQRfoXjSGZepVevuIPwSrioXBnpeg0bPFgyuSxIFFEUy47wJWDdxP08w==
+  dependencies:
+    "@mulmoclaude/common" "^1.1.2"
+    js-yaml "^5.2.3"
     marked "^18.0.7"
 
 "@mulmoclaude/mulmoscript-plugin@^2.0.0":


### PR DESCRIPTION
Dependency bump only.

`@mulmoclaude/markdown-plugin` 2.0.0 -> 2.1.0, which raises its own floors to `@mulmoclaude/markdown-utils` ^1.3.5, `@mulmoclaude/common` ^1.1.2 and `@mulmoclaude/core` ^2.0.1. `yarn.lock` adds markdown-utils 1.3.5 alongside the existing entry; nothing else moves.

No host binding changed. The plugin peer-requires `@mulmoclaude/core` ^2.0.1, `gui-chat-protocol` ^2.0.0 and `vue` ^3.5.0, all of which this repo already depends on at those ranges, so `presentDocument` wiring is untouched.

Verified locally: `yarn typecheck`, `yarn lint` (0 errors, pre-existing max-lines warnings only), `yarn build`, `yarn test` (573 files, 8291 tests passing).

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown plugin to the latest compatible minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->