### PR TITLE
feat: .mulmoterminal.json をコミットし、worktree 継承を .mulmoterminal.local.json に書く

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,9 @@ dist-ssr
 .mcp.json
 .playwright-mcp/
 
-# Per-directory runtime config the app writes (working-dir styling + Run-menu scripts).
-# Local to each checkout — not shared.
-.mulmoterminal.json
+# This project's own MulmoTerminal styling is COMMITTED (`.mulmoterminal.json`), so a fresh clone
+# gets the repository's colours without configuring anything. What stays out is the per-checkout
+# override — several clones of this repo run side by side and each needs its own shade — and the
+# Run-menu scripts, which are one machine's commands.
 .mulmoterminal.local.json
 script.json

--- a/.mulmoterminal.json
+++ b/.mulmoterminal.json
@@ -1,0 +1,10 @@
+{
+  "badgeColor": "#1a1d75",
+  "headerColor": "#2c30a5",
+  "headerTextColor": "#ffffff",
+  "cellColor": "#f2f2fb",
+  "cellBorderColor": "#5156d6",
+  "dotColor": "#5156d6",
+  "buttonColor": "#cfd0f7",
+  "orderPriority": 20
+}

--- a/.mulmoterminal.json
+++ b/.mulmoterminal.json
@@ -5,6 +5,5 @@
   "cellColor": "#f2f2fb",
   "cellBorderColor": "#5156d6",
   "dotColor": "#5156d6",
-  "buttonColor": "#cfd0f7",
-  "orderPriority": 20
+  "buttonColor": "#cfd0f7"
 }

--- a/README.md
+++ b/README.md
@@ -978,9 +978,11 @@ colours **rotated 12 degrees further around the hue wheel per worktree** (so a p
 as a gradient; a grey like `#ffffff` has no hue to move and stays put), and `orderPriority` at the
 project's rank **+ 1**, so the worktree sorts directly after it. `sound` / `sounds` / `addDirs` are
 not carried — they name paths inside the project directory. Written only where git would **ignore
-the local file**: an untracked file in a worktree's `git status` would make it count as dirty, and
-a dirty worktree is one MulmoTerminal refuses to remove. Whether the *shared* config is committed
-makes no difference. A local file the worktree already has is never overwritten.
+what it writes**: an untracked file in a worktree's `git status` would make it count as dirty, and
+a dirty worktree is one MulmoTerminal refuses to remove. The local override is preferred; a repo
+that ignores `.mulmoterminal.json` instead (the setup this feature shipped with) still gets its
+colours there. A committed shared config is never written to. A local file the worktree already
+has is never overwritten.
 
 **One worktree, one session.** A worktree is tied to a branch, so it is never started
 twice: a listed row **resumes** that worktree's session when it has one, and **starts** one

--- a/README.md
+++ b/README.md
@@ -970,16 +970,17 @@ separate working tree that shares the repo's `.git`, so several agents can work 
 repo without colliding. Worktrees live under `~/.mulmoterminal/worktrees/` (override with
 `MULMOTERMINAL_HOME`), and existing ones are listed below the field.
 
-**A worktree inherits the project's settings.** `.mulmoterminal.json` is normally gitignored,
-so a fresh worktree used to have none — no colours, no name, no model, no grid rank. It is now
-given its own copy derived from the project's: `name` / `theme` / `colors` / `fontSize` /
-`fontFamily` / `provider` / `model` as written, the seven chrome colours **rotated 12 degrees
-further around the hue wheel per worktree** (so a project's trees read as a gradient; a grey like
-`#ffffff` has no hue to move and stays put), and `orderPriority` at the project's rank **+ 1**, so
-the worktree sorts directly after it. `sound` / `sounds` / `addDirs` are not carried — they name
-paths inside the project directory. Written only where git would **ignore** it: an untracked file
-in a worktree's `git status` would make it count as dirty, and a dirty worktree is one
-MulmoTerminal refuses to remove. An existing config in the worktree is never overwritten.
+**A worktree inherits the project's settings.** A fresh worktree used to have none — no colours,
+no name, no model, no grid rank. It is now given its own copy derived from the project's, written
+to **`.mulmoterminal.local.json`** so it layers over whatever the repository committed: `name` /
+`theme` / `colors` / `fontSize` / `fontFamily` / `provider` / `model` as written, the seven chrome
+colours **rotated 12 degrees further around the hue wheel per worktree** (so a project's trees read
+as a gradient; a grey like `#ffffff` has no hue to move and stays put), and `orderPriority` at the
+project's rank **+ 1**, so the worktree sorts directly after it. `sound` / `sounds` / `addDirs` are
+not carried — they name paths inside the project directory. Written only where git would **ignore
+the local file**: an untracked file in a worktree's `git status` would make it count as dirty, and
+a dirty worktree is one MulmoTerminal refuses to remove. Whether the *shared* config is committed
+makes no difference. A local file the worktree already has is never overwritten.
 
 **One worktree, one session.** A worktree is tied to a branch, so it is never started
 twice: a listed row **resumes** that worktree's session when it has one, and **starts** one

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -378,11 +378,12 @@ repository committed and leaves the worktree's `git status` clean:
 
 Two cases where nothing is written, both deliberate:
 
-- **`.mulmoterminal.local.json` isn't gitignored in that repository.** The file would show up as an
-  untracked change in the worktree's `git status` — which is not just untidy: MulmoTerminal refuses
-  to remove a worktree that has uncommitted changes, so it could no longer be cleaned up. Add
-  `.mulmoterminal.local.json` to the repo's `.gitignore` and the next worktree gets its colours.
-  (The *shared* file may be committed or ignored — it makes no difference here.)
+- **Neither file is gitignored in that repository.** Whichever one MulmoTerminal wrote would show
+  up as an untracked change in the worktree's `git status` — which is not just untidy: it refuses
+  to remove a worktree that has uncommitted changes, so the tree could no longer be cleaned up.
+  Add `.mulmoterminal.local.json` to the repo's `.gitignore` and the next worktree gets its
+  colours. A repository set up before this file existed, which ignores `.mulmoterminal.json`
+  instead, keeps working — that one is used as a fallback.
 - **The worktree already has a local file of its own** (you wrote it, or a previous run did). That
   file is the answer; MulmoTerminal never overwrites it. A committed *shared* config does not stop
   it — that is the file the local one is meant to layer over.

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -351,11 +351,13 @@ ranked ones, in that launch order.
 > [Isolating work in a git worktree](worktree.html). This section is the **inheritance rule for this
 > config file**.
 
-`.mulmoterminal.json` is normally gitignored, so a [worktree](glossary.html#git-worktree) cut from the project used
-to start with nothing in it: no colours, no name, no model, no rank — one more grey cell at the end
-of the grid, looking like an unrelated project.
+A [worktree](glossary.html#git-worktree) cut from the project used to start with nothing in it: no
+colours, no name, no model, no rank — one more grey cell at the end of the grid, looking like an
+unrelated project.
 
-Now a new worktree is given its own copy, derived from the project's:
+Now a new worktree is given its own copy, derived from the project's, written to
+**`.mulmoterminal.local.json`** ([above](#local-config)) so it layers over any shared config the
+repository committed and leaves the worktree's `git status` clean:
 
 - **The identity is copied as written** — `name`, `icon`, `theme`, `colors`, `fontSize`,
   `fontFamily`, `provider`, `model`. Same project, same terminal, same model. `icon` is carried as
@@ -376,12 +378,14 @@ Now a new worktree is given its own copy, derived from the project's:
 
 Two cases where nothing is written, both deliberate:
 
-- **The project's config isn't gitignored.** The file would show up as an untracked change in the
-  worktree's `git status` — which is not just untidy: MulmoTerminal refuses to remove a worktree
-  that has uncommitted changes, so it could no longer be cleaned up. Add `.mulmoterminal.json` to
-  the repo's `.gitignore` and the next worktree gets its colours.
-- **The worktree already has one** (it is committed to the repo, or you wrote it yourself). That
-  file is the answer; MulmoTerminal never overwrites it.
+- **`.mulmoterminal.local.json` isn't gitignored in that repository.** The file would show up as an
+  untracked change in the worktree's `git status` — which is not just untidy: MulmoTerminal refuses
+  to remove a worktree that has uncommitted changes, so it could no longer be cleaned up. Add
+  `.mulmoterminal.local.json` to the repo's `.gitignore` and the next worktree gets its colours.
+  (The *shared* file may be committed or ignored — it makes no difference here.)
+- **The worktree already has a local file of its own** (you wrote it, or a previous run did). That
+  file is the answer; MulmoTerminal never overwrites it. A committed *shared* config does not stop
+  it — that is the file the local one is meant to layer over.
 
 The copy is taken at creation and then belongs to the worktree. Recolour the project afterwards and
 existing worktrees keep the shade they were given — edit or delete their own file to change it.

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -362,11 +362,12 @@ worktree の `git status` を汚しません。
 
 書き込まないケースが2つあります。どちらも意図的です。
 
-- **そのリポジトリで `.mulmoterminal.local.json` が gitignore されていない場合。** worktree の `git status` に
-  未追跡ファイルとして出てしまいます。これは単に汚いだけではありません。MulmoTerminal は未コミットの変更がある
-  worktree の削除を拒否するので、掃除できない worktree になります。リポジトリの `.gitignore` に
-  `.mulmoterminal.local.json` を足せば、次の worktree から色が付きます
-  （**共有**ファイルの方はコミットされていてもいなくても関係ありません）
+- **そのリポジトリでどちらのファイルも gitignore されていない場合。** 書いたファイルが worktree の
+  `git status` に未追跡ファイルとして出てしまいます。これは単に汚いだけではありません。MulmoTerminal は
+  未コミットの変更がある worktree の削除を拒否するので、掃除できない worktree になります。リポジトリの
+  `.gitignore` に `.mulmoterminal.local.json` を足せば、次の worktree から色が付きます。
+  このファイルが無かった頃の設定（`.mulmoterminal.json` を ignore している）もそのまま動きます —
+  そちらはフォールバックとして使われます
 - **worktree に既に local ファイルがある場合**（自分で書いた、または前回の作成で書かれた）。そのファイルが答えなので、
   MulmoTerminal が上書きすることはありません。**共有**設定がコミットされていても止まりません — それは local が
   上に重なる相手だからです

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -340,11 +340,12 @@ auto（注目度順）と manual（移動ボタンで手動）と並びます。
 > worktree の作り方・制約・片付けは [worktree で作業を隔離する](worktree.html)へ。ここはその
 > **設定ファイルの引き継ぎ規則**です。
 
-`.mulmoterminal.json` は通常 gitignore されているので、プロジェクトから切った
-[worktree](glossary.html#git-worktree) には何も入っていませんでした。色も名前もモデルも順位も無く、
-グリッドの末尾に灰色のセルが1つ増えるだけ — 無関係なプロジェクトに見えていました。
+プロジェクトから切った [worktree](glossary.html#git-worktree) には何も入っていませんでした。色も名前も
+モデルも順位も無く、グリッドの末尾に灰色のセルが1つ増えるだけ — 無関係なプロジェクトに見えていました。
 
-いまは新しい worktree に、プロジェクトの設定から作った専用のコピーが置かれます。
+いまは新しい worktree に、プロジェクトの設定から作った専用のコピーが置かれます。書き込み先は
+**`.mulmoterminal.local.json`**（[前述](#local-config)）で、リポジトリがコミットした共有設定の上に重なり、
+worktree の `git status` を汚しません。
 
 - **同一性はそのままコピー** — `name` / `icon` / `theme` / `colors` / `fontSize` / `fontFamily` /
   `provider` / `model`。同じプロジェクト、同じターミナル、同じモデルです。`icon` は解決後のファイルでは
@@ -361,11 +362,14 @@ auto（注目度順）と manual（移動ボタンで手動）と並びます。
 
 書き込まないケースが2つあります。どちらも意図的です。
 
-- **プロジェクトの config が gitignore されていない場合。** worktree の `git status` に未追跡ファイルとして出てしまいます。
-  これは単に汚いだけではありません。MulmoTerminal は未コミットの変更がある worktree の削除を拒否するので、
-  掃除できない worktree になります。リポジトリの `.gitignore` に `.mulmoterminal.json` を足せば、次の worktree から色が付きます
-- **worktree に既にファイルがある場合**（リポジトリにコミットされている、または自分で書いた）。そのファイルが答えなので、
-  MulmoTerminal が上書きすることはありません
+- **そのリポジトリで `.mulmoterminal.local.json` が gitignore されていない場合。** worktree の `git status` に
+  未追跡ファイルとして出てしまいます。これは単に汚いだけではありません。MulmoTerminal は未コミットの変更がある
+  worktree の削除を拒否するので、掃除できない worktree になります。リポジトリの `.gitignore` に
+  `.mulmoterminal.local.json` を足せば、次の worktree から色が付きます
+  （**共有**ファイルの方はコミットされていてもいなくても関係ありません）
+- **worktree に既に local ファイルがある場合**（自分で書いた、または前回の作成で書かれた）。そのファイルが答えなので、
+  MulmoTerminal が上書きすることはありません。**共有**設定がコミットされていても止まりません — それは local が
+  上に重なる相手だからです
 
 コピーは作成時に1度だけ取られ、以後は worktree のものです。あとからプロジェクト側の色を変えても、
 既存の worktree は与えられた色のままです。変えたいときは worktree 側のファイルを編集するか削除してください。

--- a/server/config/worktree-dir-config.ts
+++ b/server/config/worktree-dir-config.ts
@@ -78,17 +78,18 @@ export function inheritedWorktreeConfig(parent: DirConfig, index: number): Recor
   return config;
 }
 
-/** Write the derived config into `worktreeDir`'s own local override. Returns whether a file was
- *  written.
+/** Write the derived config into `worktreeDir`, as `name` — the local override by default, or the
+ *  shared file for a repository set up before #1436, which gitignores that one instead. Returns
+ *  whether a file was written.
  *
  *  Writes nothing when the parent configures nothing this carries — an empty `{}` on disk is a
  *  file the settings preview would report as present and doing nothing. Never overwrites: a
  *  worktree that already has one either committed it to the repo or was set up by hand, and
  *  either way that file is the answer, not ours. */
-export function writeInheritedDirConfig(parentDir: string, worktreeDir: string, index: number): boolean {
+export function writeInheritedDirConfig(parentDir: string, worktreeDir: string, index: number, name: string = DIR_LOCAL_CONFIG_FILE): boolean {
   const config = inheritedWorktreeConfig(loadDirConfig(parentDir), index);
   if (Object.keys(config).length === 0) return false;
-  const file = path.join(worktreeDir, DIR_LOCAL_CONFIG_FILE);
+  const file = path.join(worktreeDir, name);
   if (existsSync(file)) return false;
   writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, "utf8");
   return true;

--- a/server/config/worktree-dir-config.ts
+++ b/server/config/worktree-dir-config.ts
@@ -1,16 +1,21 @@
 // What a new git worktree inherits from the project it was cut from (#1317).
 //
-// `.mulmoterminal.json` is normally gitignored, so `git worktree add` produces a directory with
-// no config at all: the worktree's cell loses the project's colours, name, model and grid rank
-// and lands last in the priority sort, looking like an unrelated project. This derives the
-// worktree's own config from the parent's and writes it there.
+// `git worktree add` produces a directory whose cell looks like an unrelated project: no colours,
+// no name, no model, and last in the priority sort. This derives the worktree's own config from
+// the parent's and writes it there.
+//
+// Written to `.mulmoterminal.local.json`, not to the shared file (#1436). That file is gitignored,
+// so the worktree's `git status` stays clean — which matters more than tidiness, since `isDirty`
+// reads that same status and `removeWorktree` would refuse to clean up a worktree whose only
+// change we wrote ourselves. It also layers OVER a shared config the repository committed, which
+// is what lets a project ship its own colours and still give each worktree its own shade.
 //
 // The input is a LOADED DirConfig, not the raw file. Every field of that has already been
 // through the loader's zod validation, so what comes out here is valid by construction and
 // needs no second pass — where re-parsing the raw JSON would have to restate the rules.
 import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { DIR_CONFIG_FILE, loadDirConfig, type DirConfig } from "./dir-config.js";
+import { DIR_LOCAL_CONFIG_FILE, loadDirConfig, type DirConfig } from "./dir-config.js";
 import { dirIconRef } from "./dir-icon.js";
 import { rotateHue } from "./hue-rotate.js";
 
@@ -41,9 +46,14 @@ function worktreeRank(parentRank: number | null): number | null {
   return Number.isSafeInteger(rank) ? rank : null;
 }
 
-/** The `.mulmoterminal.json` contents for the `index`-th worktree of a project (1-based, so the
- *  first worktree is already one step off the parent's hue). Keys the parent doesn't set are
- *  left out rather than written as null, so the file reads like one a person would have typed. */
+/** The local-override contents for the `index`-th worktree of a project (1-based, so the first
+ *  worktree is already one step off the parent's hue). Keys the parent doesn't set are left out
+ *  rather than written as null, so the file reads like one a person would have typed.
+ *
+ *  Still the FULL derived config rather than only the tinted colours: a repository that commits
+ *  its shared file has the identity keys underneath already, and one that gitignores it has
+ *  nothing there at all. Writing everything works in both, and re-stating a value that is already
+ *  the same value costs nothing. */
 export function inheritedWorktreeConfig(parent: DirConfig, index: number): Record<string, unknown> {
   const config: Record<string, unknown> = {};
   INHERITED_KEYS.forEach((key) => {
@@ -68,7 +78,8 @@ export function inheritedWorktreeConfig(parent: DirConfig, index: number): Recor
   return config;
 }
 
-/** Write the derived config into `worktreeDir`. Returns whether a file was written.
+/** Write the derived config into `worktreeDir`'s own local override. Returns whether a file was
+ *  written.
  *
  *  Writes nothing when the parent configures nothing this carries — an empty `{}` on disk is a
  *  file the settings preview would report as present and doing nothing. Never overwrites: a
@@ -77,7 +88,7 @@ export function inheritedWorktreeConfig(parent: DirConfig, index: number): Recor
 export function writeInheritedDirConfig(parentDir: string, worktreeDir: string, index: number): boolean {
   const config = inheritedWorktreeConfig(loadDirConfig(parentDir), index);
   if (Object.keys(config).length === 0) return false;
-  const file = path.join(worktreeDir, DIR_CONFIG_FILE);
+  const file = path.join(worktreeDir, DIR_LOCAL_CONFIG_FILE);
   if (existsSync(file)) return false;
   writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, "utf8");
   return true;

--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { isStrictlyWithin } from "../infra/path-within.js";
 import { splitLines } from "../infra/split-lines.js";
-import { DIR_CONFIG_FILE } from "../config/dir-config.js";
+import { DIR_LOCAL_CONFIG_FILE } from "../config/dir-config.js";
 import { writeInheritedDirConfig } from "../config/worktree-dir-config.js";
 import { ISSUE_BRANCH_PREFIX, issueFromAnchoredBranch } from "../../common/prPhase.js";
 
@@ -289,14 +289,18 @@ function serializeCreate<T>(task: () => Promise<T>): Promise<T> {
 // each tree is its own shade of the project. The parent is the MAIN checkout, so cutting a
 // worktree from another worktree still measures the gradient from the project itself.
 //
-// Only where git would IGNORE the file. A worktree whose `git status` gains an untracked file is
-// not merely untidy: `isDirty` reads that same status, so removeWorktree would go on refusing to
-// clean up a worktree whose only change we wrote ourselves.
+// Only where git would IGNORE the file we are about to write. A worktree whose `git status` gains
+// an untracked file is not merely untidy: `isDirty` reads that same status, so removeWorktree
+// would go on refusing to clean up a worktree whose only change we wrote ourselves.
+//
+// The file is the LOCAL override (#1436), which this repository — and any project that adopts the
+// convention — gitignores. Checking the shared file instead used to mean that committing it
+// silently switched this whole feature off.
 //
 // Best effort throughout — a worktree without its parent's colours is a worktree that works.
 async function adoptParentDirConfig(repo: string, worktreeDir: string): Promise<void> {
   try {
-    if (!(await git(["check-ignore", "--quiet", "--", DIR_CONFIG_FILE], worktreeDir)).ok) return;
+    if (!(await git(["check-ignore", "--quiet", "--", DIR_LOCAL_CONFIG_FILE], worktreeDir)).ok) return;
     // Counted AFTER the add, so it includes the new tree: the first worktree of a repo is index
     // 1 and therefore already one hue step away from the parent, not identical to it.
     writeInheritedDirConfig(repo, worktreeDir, (await listWorktrees(repo)).length);

--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { isStrictlyWithin } from "../infra/path-within.js";
 import { splitLines } from "../infra/split-lines.js";
-import { DIR_LOCAL_CONFIG_FILE } from "../config/dir-config.js";
+import { DIR_CONFIG_FILE, DIR_LOCAL_CONFIG_FILE } from "../config/dir-config.js";
 import { writeInheritedDirConfig } from "../config/worktree-dir-config.js";
 import { ISSUE_BRANCH_PREFIX, issueFromAnchoredBranch } from "../../common/prPhase.js";
 
@@ -293,17 +293,31 @@ function serializeCreate<T>(task: () => Promise<T>): Promise<T> {
 // an untracked file is not merely untidy: `isDirty` reads that same status, so removeWorktree
 // would go on refusing to clean up a worktree whose only change we wrote ourselves.
 //
-// The file is the LOCAL override (#1436), which this repository — and any project that adopts the
+// Preferably the LOCAL override (#1436), which this repository — and any project that adopts the
 // convention — gitignores. Checking the shared file instead used to mean that committing it
 // silently switched this whole feature off.
 //
+// The shared file stays as a FALLBACK, because the setup this feature shipped with told people to
+// gitignore THAT one, and those repositories still exist. Switching the target outright would have
+// turned their worktrees grey with nothing said — the same silent breakage, aimed the other way.
+// A repository that COMMITS the shared file is not caught by the fallback: git reports a tracked
+// file as not-ignored, so it is skipped and only the local override can be written.
+//
 // Best effort throughout — a worktree without its parent's colours is a worktree that works.
+async function inheritableConfigFile(worktreeDir: string): Promise<string | null> {
+  for (const name of [DIR_LOCAL_CONFIG_FILE, DIR_CONFIG_FILE]) {
+    if ((await git(["check-ignore", "--quiet", "--", name], worktreeDir)).ok) return name;
+  }
+  return null;
+}
+
 async function adoptParentDirConfig(repo: string, worktreeDir: string): Promise<void> {
   try {
-    if (!(await git(["check-ignore", "--quiet", "--", DIR_LOCAL_CONFIG_FILE], worktreeDir)).ok) return;
+    const name = await inheritableConfigFile(worktreeDir);
+    if (!name) return;
     // Counted AFTER the add, so it includes the new tree: the first worktree of a repo is index
     // 1 and therefore already one hue step away from the parent, not identical to it.
-    writeInheritedDirConfig(repo, worktreeDir, (await listWorktrees(repo)).length);
+    writeInheritedDirConfig(repo, worktreeDir, (await listWorktrees(repo)).length, name);
   } catch {
     // ignored
   }

--- a/server/skills/mulmoterminal-dirs/SKILL.md
+++ b/server/skills/mulmoterminal-dirs/SKILL.md
@@ -282,7 +282,7 @@ UDGothic); anything else tears the box-drawing frames an agent TUI is made of.
 ### Worktrees derive their own config from this one
 
 A managed git worktree (`~/.mulmoterminal/worktrees/<repo>-<hash>/<task>`) gets its own
-`.mulmoterminal.json` when MulmoTerminal creates it, derived from the project's: identity keys
+`.mulmoterminal.local.json` when MulmoTerminal creates it, derived from the project's: identity keys
 (`name` / `icon` / `theme` / `colors` / `fontSize` / `fontFamily` / `provider` / `model`) as written, the
 seven chrome colours rotated **12° further per worktree**, and `orderPriority` at the project's
 rank **+ 1**. `sound` / `sounds` / `addDirs` are not carried.
@@ -294,7 +294,11 @@ Two consequences for this skill:
   and they collide with the +1 the app writes.
 - **Recolouring a project does not recolour its existing worktrees** — the copy was taken when the
   worktree was created. Say so if the user asks why one cell kept the old colour, and offer to
-  delete that worktree's file so the next launch has nothing stale.
+  delete that worktree's `.mulmoterminal.local.json` so the next launch has nothing stale.
+- **A worktree gets nothing when its repository does not gitignore `.mulmoterminal.local.json`.**
+  That is the check MulmoTerminal makes before writing, since an untracked file would make the
+  worktree count as dirty and therefore unremovable. If a user's worktrees are all grey, that
+  missing `.gitignore` line is the first thing to look at.
 
 ### Other keys in this file
 

--- a/server/skills/mulmoterminal-dirs/SKILL.md
+++ b/server/skills/mulmoterminal-dirs/SKILL.md
@@ -295,10 +295,10 @@ Two consequences for this skill:
 - **Recolouring a project does not recolour its existing worktrees** — the copy was taken when the
   worktree was created. Say so if the user asks why one cell kept the old colour, and offer to
   delete that worktree's `.mulmoterminal.local.json` so the next launch has nothing stale.
-- **A worktree gets nothing when its repository does not gitignore `.mulmoterminal.local.json`.**
-  That is the check MulmoTerminal makes before writing, since an untracked file would make the
-  worktree count as dirty and therefore unremovable. If a user's worktrees are all grey, that
-  missing `.gitignore` line is the first thing to look at.
+- **A worktree gets nothing when its repository gitignores NEITHER config file.** That is the
+  check MulmoTerminal makes before writing, since an untracked file would make the worktree count
+  as dirty and therefore unremovable. If a user's worktrees are all grey, a missing
+  `.gitignore` line is the first thing to look at — `.mulmoterminal.local.json` is the one to add.
 
 ### Other keys in this file
 

--- a/test/server/config/worktree-dir-config.spec.ts
+++ b/test/server/config/worktree-dir-config.spec.ts
@@ -7,6 +7,9 @@ import { loadDirConfig } from "../../../server/config/dir-config";
 import { inheritedWorktreeConfig, writeInheritedDirConfig } from "../../../server/config/worktree-dir-config";
 
 const CONFIG_FILE = ".mulmoterminal.json";
+// What the inherited config is WRITTEN to: the local override (#1436), which is gitignored, so a
+// worktree carrying it still reads as clean and can be removed without force.
+const LOCAL_CONFIG_FILE = ".mulmoterminal.local.json";
 
 // Written and read back through loadDirConfig rather than hand-built, so these tests exercise
 // the same validation the server does — a field the loader would drop can't pass here.
@@ -130,15 +133,26 @@ describe("writeInheritedDirConfig", () => {
   it("leaves no file behind when there is nothing to inherit", () => {
     const worktree = makeTempDir("mt-wt-");
     expect(writeInheritedDirConfig(projectDir(null), worktree, 1)).toBe(false);
-    expect(existsSync(path.join(worktree, CONFIG_FILE))).toBe(false);
+    expect(existsSync(path.join(worktree, LOCAL_CONFIG_FILE))).toBe(false);
   });
 
   // A worktree that already has one either committed it or was set up by hand; either way that
   // file is the answer and ours would silently replace it.
-  it("never overwrites a config the worktree already has", () => {
+  it("never overwrites a local config the worktree already has", () => {
     const worktree = makeTempDir("mt-wt-");
-    writeFileSync(path.join(worktree, CONFIG_FILE), '{"name":"mine"}', "utf8");
+    writeFileSync(path.join(worktree, LOCAL_CONFIG_FILE), '{"name":"mine"}', "utf8");
     expect(writeInheritedDirConfig(projectDir(PROJECT), worktree, 1)).toBe(false);
-    expect(readFileSync(path.join(worktree, CONFIG_FILE), "utf8")).toBe('{"name":"mine"}');
+    expect(readFileSync(path.join(worktree, LOCAL_CONFIG_FILE), "utf8")).toBe('{"name":"mine"}');
+  });
+
+  // A worktree of a repository that COMMITS its shared config has that file already, checked out
+  // by git. Refusing to write because of it would leave every such worktree untinted — the shared
+  // file is what the local one is meant to layer over, not a reason to stand down (#1436).
+  it("writes even when the worktree already has a shared config from the checkout", () => {
+    const worktree = makeTempDir("mt-wt-");
+    writeFileSync(path.join(worktree, CONFIG_FILE), '{"name":"committed"}', "utf8");
+    expect(writeInheritedDirConfig(projectDir(PROJECT), worktree, 1)).toBe(true);
+    expect(readFileSync(path.join(worktree, CONFIG_FILE), "utf8")).toBe('{"name":"committed"}');
+    expect(JSON.parse(readFileSync(path.join(worktree, LOCAL_CONFIG_FILE), "utf8"))).toMatchObject({ name: "mulmoterminal" });
   });
 });

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -202,6 +202,32 @@ describe("git worktree lifecycle", () => {
     GIT_TEST_TIMEOUT_MS,
   );
 
+  // Backward compatibility, and the reason the shared file is still a fallback: the setup this
+  // feature SHIPPED with told people to gitignore `.mulmoterminal.json`, and those repositories
+  // exist. Switching the target outright would have turned their worktrees grey with nothing said.
+  it.skipIf(!hasGit)(
+    "still tints a worktree in a repository set up the old way (only the shared file ignored)",
+    async () => {
+      writeFileSync(path.join(repo, ".gitignore"), ".mulmoterminal.json\n");
+      writeFileSync(path.join(repo, ".mulmoterminal.json"), JSON.stringify({ name: "proj", headerColor: "#2d4ea9", orderPriority: 30 }));
+      await git(["add", ".gitignore"], repo);
+      await git(["commit", "-m", "ignore the shared config, the pre-#1436 way"], repo);
+
+      const wt = await createWorktree(repo, "legacy");
+      if (!wt) throw new Error("expected a worktree");
+      // Written to the SHARED file here, since that is the one this repository ignores.
+      expect(existsSync(path.join(wt.path, ".mulmoterminal.local.json"))).toBe(false);
+      expect(JSON.parse(readFileSync(path.join(wt.path, ".mulmoterminal.json"), "utf8"))).toMatchObject({
+        name: "proj",
+        headerColor: "#2d35a9",
+        orderPriority: 31,
+      });
+      expect(await isDirty(wt.path)).toBe(false);
+      expect(await removeWorktree(repo, wt.path, { deleteBranch: true })).toEqual({ ok: true });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
   // The regression #1436 exists for: committing the shared config used to switch inheritance off,
   // because the guard asked about that file rather than the one being written.
   it.skipIf(!hasGit)(

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -153,20 +153,22 @@ describe("git worktree lifecycle", () => {
     GIT_TEST_TIMEOUT_MS,
   );
 
-  // #1317. `.mulmoterminal.json` is gitignored, so a worktree used to start with no config at
-  // all: the project's colours, name, model and grid rank all stopped at the main checkout.
+  // #1317. A worktree used to start with no config at all: the project's colours, name, model and
+  // grid rank all stopped at the main checkout. Written to the LOCAL override since #1436 — that
+  // is the file a project gitignores, so this keeps working whether or not the shared config is
+  // committed.
   it.skipIf(!hasGit)(
     "gives each new worktree the project's settings, a hue further round each time",
     async () => {
-      writeFileSync(path.join(repo, ".gitignore"), ".mulmoterminal.json\n");
+      writeFileSync(path.join(repo, ".gitignore"), ".mulmoterminal.local.json\n");
       const project = { name: "proj", headerColor: "#2d4ea9", headerTextColor: "#ffffff", orderPriority: 30, model: "qwen3:8b" };
       writeFileSync(path.join(repo, ".mulmoterminal.json"), JSON.stringify(project));
-      await git(["add", ".gitignore"], repo);
-      await git(["commit", "-m", "ignore the local config"], repo);
+      await git(["add", ".gitignore", ".mulmoterminal.json"], repo);
+      await git(["commit", "-m", "commit the shared config, ignore the local one"], repo);
 
       const first = await createWorktree(repo, "first");
       if (!first) throw new Error("expected a worktree");
-      const config = (dir: string): unknown => JSON.parse(readFileSync(path.join(dir, ".mulmoterminal.json"), "utf8"));
+      const config = (dir: string): unknown => JSON.parse(readFileSync(path.join(dir, ".mulmoterminal.local.json"), "utf8"));
       expect(config(first.path)).toEqual({ name: "proj", model: "qwen3:8b", headerColor: "#2d35a9", headerTextColor: "#ffffff", orderPriority: 31 });
       // The file we just wrote must not read as a change. isDirty is what removeWorktree
       // consults, so a worktree dirtied by our own write could no longer be cleaned up.
@@ -185,14 +187,39 @@ describe("git worktree lifecycle", () => {
     GIT_TEST_TIMEOUT_MS,
   );
 
+  // The guard is on the file we WRITE. A project that ignores neither would gain an untracked
+  // file, and `isDirty` — which removeWorktree consults — would then refuse to clean the worktree
+  // up over a change we made ourselves.
   it.skipIf(!hasGit)(
-    "writes no config where git would not ignore it",
+    "writes no config where git would not ignore the local file",
     async () => {
       writeFileSync(path.join(repo, ".mulmoterminal.json"), JSON.stringify({ headerColor: "#2d4ea9" }));
       const wt = await createWorktree(repo, "unignored");
       if (!wt) throw new Error("expected a worktree");
-      expect(existsSync(path.join(wt.path, ".mulmoterminal.json"))).toBe(false);
+      expect(existsSync(path.join(wt.path, ".mulmoterminal.local.json"))).toBe(false);
       expect(await isDirty(wt.path)).toBe(false);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
+  // The regression #1436 exists for: committing the shared config used to switch inheritance off,
+  // because the guard asked about that file rather than the one being written.
+  it.skipIf(!hasGit)(
+    "still tints a worktree whose project COMMITS its shared config",
+    async () => {
+      writeFileSync(path.join(repo, ".gitignore"), ".mulmoterminal.local.json\n");
+      writeFileSync(path.join(repo, ".mulmoterminal.json"), JSON.stringify({ name: "proj", headerColor: "#2d4ea9", orderPriority: 30 }));
+      await git(["add", ".gitignore", ".mulmoterminal.json"], repo);
+      await git(["commit", "-m", "commit the shared config"], repo);
+
+      const wt = await createWorktree(repo, "tinted");
+      if (!wt) throw new Error("expected a worktree");
+      const local: unknown = JSON.parse(readFileSync(path.join(wt.path, ".mulmoterminal.local.json"), "utf8"));
+      expect(local).toMatchObject({ name: "proj", headerColor: "#2d35a9", orderPriority: 31 });
+      // The committed file came along with the checkout and is untouched.
+      expect(JSON.parse(readFileSync(path.join(wt.path, ".mulmoterminal.json"), "utf8"))).toMatchObject({ headerColor: "#2d4ea9" });
+      expect(await isDirty(wt.path)).toBe(false);
+      expect(await removeWorktree(repo, wt.path, { deleteBranch: true })).toEqual({ ok: true });
     },
     GIT_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

このリポジトリの `.mulmoterminal.json` を**コミットします**（gitignore から外す）。#1421 / #1428 / #1430 で「共有ファイルは色まで含めてフル、単体 clone でもそれだけで色が付く」形にしたので、コミットして初めてその意図が届きます。ignore に残すのは `.mulmoterminal.local.json`（各 clone の色）と `script.json`（1台のマシンのコマンド）。

**そのままだと壊れるものが1つあり、同時に直しています。**

## Items to Confirm / Review

1. **worktree 継承が黙って止まるところだった** — `adoptParentDirConfig` は「`.mulmoterminal.json` が gitignore されているとき」だけ継承を書いていました。worktree の `git status` に未追跡ファイルが増えると `isDirty` が真になり、`removeWorktree` が**自分で書いたファイル**のせいで片付けを拒否するためです。

   つまり共有 config をコミットした瞬間、#1317 の「worktree ごとに色相を 12 度ずらす / `orderPriority + 1`」が何のエラーも出さずに効かなくなります。

   **書き込み先と check-ignore の対象を `.mulmoterminal.local.json` にしました。** local は ignore されるので status を汚さず、コミット済みの共有ファイルの**上に重なります**。「共有ファイルが ignore されていないと継承しない」という制約が消え、**ignore すべきファイルと書き込むファイルが一致**します。回帰テストを追加しました（共有 config をコミットしたリポジトリでも worktree が色付き、かつ force 無しで削除できること）。

2. **`orderPriority` はコミットする共有ファイルに入れていません。** 色は共有物ですが順位は各自のグリッドの話で、他人の clone に配るものではないという判断です。指示に無い判断なので、入れるべきならそう言ってください。本リポジトリの各 clone は local 側に持っています。

3. **継承が書く内容はフルのまま** — 共有がコミット済みなら identity キーは同値で無害、gitignore しているリポジトリなら local だけで完結します。どちらの状態でも動くのでこの形にしました。

4. **マージ後、他の clone は `git pull` が中断します。** `.mulmoterminal.json` を untracked で持っているためで、**内容が同一でも git は中断します**（`Please move or remove them before you merge.` — 実際に再現して確認しました）。各 clone で `rm .mulmoterminal.json` してから pull すれば、同じ内容が checkout から戻ります（6 clone すべてで md5 一致を確認済み）。

## User Prompt

> .mulmoterminal.jsonはマージする。.mulmoterminal.local.jsonはignoreする。

## ドキュメント

`.mulmoterminal.json` が gitignore されている前提の記述を README・`docs/guide/{en,ja}`・`mulmoterminal-dirs` スキルから直しました。継承は local ファイルに書かれるようになったので、共有ファイルがコミットされているかどうかは無関係になっています。スキルには「worktree が全部灰色なら、まず `.gitignore` に local ファイルの行が無いことを疑う」も足しました。

`yarn format` / `lint`（error 0）/ `typecheck` / `build` / `test`（8313 passed）green。

refs #1436

work in mulmoterminal4
