### PR TITLE
docs: Antigravity は workspace でも Canvas 登録が要る — 書き足しと、逆を言っていた3箇所の訂正

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,10 @@ today — **Claude Code** (the default), **Codex**, **Antigravity** (`agy`), and
   `~/.mulmoterminal/antigravity-conversations.jsonl`, so a conversation is still resumable after
   the server restarts — the same log Codex keeps, in the same format.
 
-  Its **GUI tools work differently**, because `agy` takes no MCP flag: it reads its servers from
-  `.agents/mcp_config.json` in the working directory. MulmoTerminal writes that file from the
+  Its **GUI tools work differently — in the workspace too**, because `agy` takes no MCP flag: it
+  reads its servers from `.agents/mcp_config.json` in the working directory. So it never gets the
+  workspace's "every tool automatically"; register what it needs with the Canvas switches, wherever
+  it runs (see [MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)). MulmoTerminal writes that file from the
   directory's [Canvas switches](#wiki-collections--the-gui-panel) — the same switches Claude's cells read — so
   one switch serves every agent, and rewrites it whenever a switch flips or an agy session starts.
   Servers in it that MulmoTerminal did not write are left alone, the file is removed once no group
@@ -436,9 +438,11 @@ today — **Claude Code** (the default), **Codex**, **Antigravity** (`agy`), and
   via `GROK_HOME`) after the first turn, and re-using a `--session-id` that already exists is a hard
   error, which is why the two flags are never sent together.
 
-  Its **GUI tools work like Antigravity's** and for the same reason: `grok` takes no MCP flag, so
+  Its **GUI tools work like Antigravity's — in the workspace too** and for the same reason: `grok`
+  takes no MCP flag, so it never gets the workspace's "every tool automatically" either, and
   MulmoTerminal registers the bridge in `.grok/config.toml` (grok's project-scope config) from the
-  directory's [Canvas switches](#wiki-collections--the-gui-panel). That file is TOML and yours, so —
+  directory's [Canvas switches](#wiki-collections--the-gui-panel), wherever it runs (see
+  [MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)). That file is TOML and yours, so —
   unlike agy's JSON — MulmoTerminal never rewrites it directly: it drives `grok mcp add -s project` /
   `grok mcp remove -s project`, and only for the server ids it wrote itself. Nothing else in the file
   is touched, a directory already in the right state runs no command at all, and the file is added to
@@ -765,7 +769,7 @@ Settings → Directory settings names both files and lists which keys the local 
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
 | `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
 | `fontSize`   | Terminal font size in px for this directory (8–32), overriding the Settings value. A size outside the range is clamped; a non-number is ignored. Changing it re-fits the terminal, so the PTY learns the new width — unlike browser zoom, which leaves the two disagreeing. |
-| `orderPriority` | This directory's rank in the grid's **priority** ordering — the third mode on the toolbar's ordering button, next to auto (attention-first) and manual (the move buttons). Any integer, **lowest first**; negatives are allowed. Directories that set nothing sort last, keeping their existing order, so adding the key to one project doesn't shuffle the rest. The grid reads it in **priority** mode only; the launcher's directory chips sort by it, so a project sits in the same place on both. The one exception is the **workspace** chip, which always leads the launcher's row regardless of any rank — it is not one of the directories being ranked against each other, and it is the one place every GUI tool is reachable (see [MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)). |
+| `orderPriority` | This directory's rank in the grid's **priority** ordering — the third mode on the toolbar's ordering button, next to auto (attention-first) and manual (the move buttons). Any integer, **lowest first**; negatives are allowed. Directories that set nothing sort last, keeping their existing order, so adding the key to one project doesn't shuffle the rest. The grid reads it in **priority** mode only; the launcher's directory chips sort by it, so a project sits in the same place on both. The one exception is the **workspace** chip, which always leads the launcher's row regardless of any rank — it is not one of the directories being ranked against each other, and it is the one place a claude or codex session reaches every GUI tool without registering anything (agy and grok get what the directory registered wherever they run — see [MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)). |
 | `fontFamily` | CSS font-family stack for this directory's terminals, overriding the global `fontFamily`. Use the names as your OS lists them (`"'Cica', 'MS Gothic', monospace"`). An unusable stack is ignored whole rather than half-applied; `monospace` is appended if you name no generic family. Prefer fonts whose fullwidth glyphs are exactly twice the Latin width, or box-drawing frames tear. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). The fallback for every kind. |
 | `sounds`     | Per-kind override of `sound`: `{ "command-failed": "preset:gong" }`. Each value is a `preset:<id>` or a directory-relative path, under the same confinement. |
@@ -828,7 +832,9 @@ An empty grid cell's launcher sets the **Working directory** by typing, by a pre
 chip, or with the **📁 folder button** (a native OS folder dialog). The preset chips are
 the directories you have launched in; the **workspace** leads them always, labelled
 **WORKSPACE** and marked with an icon, whether or not you have ever launched there — it is
-the one directory where a session reaches every GUI tool, so it is never a click you can
+the one directory where a claude or codex session reaches every GUI tool (agy and grok get
+what the directory registered, there as anywhere — see
+[MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)), so it is never a click you can
 lose. It has no remove button for the same reason. It is named for its role rather than its
 folder, because the folder name (`~/mulmoclaude` by default, or wherever `CLAUDE_CWD`
 points) says the least interesting true thing about it; the real path is on its hover.
@@ -836,7 +842,12 @@ points) says the least interesting true thing about it; the real path is on its 
 **The launcher is shorter in the workspace**, because two of its choices do not apply
 there. The per-directory **Canvas switches** are replaced by a line saying every GUI tool
 is already available — a session there is handed the whole GUI MCP at spawn, so a switch
-would register a group URL that then has nothing left to serve. And the **worktree**
+would register a group URL that then has nothing left to serve. **With Antigravity or Grok
+picked they stay**, in the workspace as everywhere else: neither is handed anything at spawn
+and both read their servers from the directory's file, so the switches are their only route
+to a GUI tool and hiding them would leave the session with none (see
+[MCP server ids](#mcp-server-ids-why-a-workspace-cell-and-a-project-cell-disagree)).
+And the **worktree**
 section is hidden: a worktree isolates work on one codebase onto a branch, while the
 workspace is what a session works *from* (the shared wiki, collections and accounting
 live there), which is precisely what a detached branch would cut it off from. Both come
@@ -1163,14 +1174,33 @@ Which route a session takes is decided by `carriesFullGuiMcp()` in
 `server/session/mcp-config.ts` — the single view, a cell-less chat, or anything whose cwd **is**
 the workspace take the first; anything in a project directory takes the second.
 
-**The workspace is agent-agnostic.** All three agents ask the same predicate, so two terminals in
-the workspace reach the same tools no matter which agent started them:
+**The workspace is agent-agnostic for the agents that can RECEIVE a per-spawn config** — claude and
+codex ask the same predicate, so two terminals in the workspace reach the same tools no matter which
+of the two started them. **Antigravity and Grok cannot, and that is the exception you will meet
+first:**
 
 | Started as | In the workspace | In a project directory |
 |---|---|---|
 | claude cell (including `?gui=0`) | `mt`, every tool | the directory's registered groups |
 | codex cell | `mt`, every tool | the directory's registered groups |
+| antigravity cell | **the directory's registered groups** — nothing registered means **no GUI tools at all** | the directory's registered groups |
+| grok cell | **the directory's registered groups** — nothing registered means **no GUI tools at all** | the directory's registered groups |
 | any launcher chip | untouched | untouched |
+
+Neither takes an MCP flag: `agy` reads `.agents/mcp_config.json` and `grok` reads `.grok/config.toml`
+in the working directory, and a file shared by every session in a directory cannot be handed to one
+session and not another — so there is nothing for "this cwd is the workspace" to change. The
+membership is `FULL_GUI_MCP_AGENTS` in `common/guiMcpAgents.ts`, in `common/` precisely so the
+launcher form and the spawn cannot disagree about it
+([#1423](https://github.com/receptron/mulmoterminal/issues/1423)).
+
+The consequence is easy to hit and hard to guess: `presentDocument` works in a project you once
+flipped **Canvas** on for, and is missing in the workspace where everything else is automatic. Fix it
+the same way anywhere — pick **Antigravity** or **Grok**, point WORKING DIRECTORY at that directory,
+flip the **Canvas** switch (it stays visible for both), and start a **new** session; the switch
+registers the directory, never a session already running. Full procedure:
+[Antigravity and Grok register everywhere](https://receptron.github.io/mulmoterminal/guide/en/basics.html#antigravity-gui-tools)
+· [日本語](https://receptron.github.io/mulmoterminal/guide/ja/basics.html#antigravity-gui-tools).
 
 **A launcher chip is not an agent session — it is a command.** Whatever the command line names,
 it runs exactly as written: nothing is inserted, and no GUI MCP is attached. A chip running

--- a/docs/guide/en/basics.md
+++ b/docs/guide/en/basics.md
@@ -60,7 +60,7 @@ Empty cells in the grid show a **launcher form**. This is where you choose **wha
 | **Agent Picker** (**Claude / Codex / Antigravity / Grok / Shell**) | Choose what runs in this cell — an **agent**, or **Shell**: your OS default shell (`$SHELL`), with nothing to install and nothing to configure. This is the control that starts a real agent session; the **launch commands** below run your own command line verbatim |
 | **WORKING DIRECTORY** | Enter the working directory (the play button launches it). Frequently used directories are offered as clickable *cwd preset* **chips** that fill the field (the chip's play button launches right away). A **WORKSPACE** chip always leads that row (→ [which directory to launch in](#launch-dir)) |
 | **Model picker** (when Claude is selected) | Pick the backend / model for this session only (→ [providers](providers.html)) |
-| **Canvas / Workspace data / External accounts** toggles (with an agent selected) | Register a GUI tool group (`render` / `data` / `media` / `external`) as an MCP server **for the directory, not for this session**. **They are absent while the workspace is selected** — everything is available there without registering anything |
+| **Canvas / Workspace data / External accounts** toggles (with an agent selected) | Register a GUI tool group (`render` / `data` / `media` / `external`) as an MCP server **for the directory, not for this session**. With **Claude or Codex** picked they are **absent while the workspace is selected** — everything is available there without registering anything. With **Antigravity or Grok** picked they stay, in the workspace too: they are those two agents' only way to get GUI tools anywhere (→ [Antigravity and Grok register everywhere](#antigravity-gui-tools)) |
 | **OR ISOLATE IN A WORKTREE** | In a git repo, enter a task name and hit **New worktree** to create an isolated worktree and launch there. Existing worktrees are listed below it |
 | **OR RESUME HERE** | Sessions that already exist in this directory — click one to continue it |
 | **OR LAUNCH** | Start a configured **launch command** (`codex`, `htop`, anything) as a persistent terminal |
@@ -118,17 +118,45 @@ Claude or Codex, it is the same — pick either in the **Agent Picker** and laun
 **The workspace is one chip away.**
 A **WORKSPACE** chip always sits at the head of the launcher's chip row, apart from the recent directories and named for its role rather than its folder, with an icon of its own.
 Its play button launches there; the chip itself only fills WORKING DIRECTORY.
-While the workspace is selected the MCP toggles are gone, replaced by `GUI TOOLS — All of them, automatically`, because there is nothing left to register.
+While the workspace is selected **with Claude or Codex picked**, the MCP toggles are gone, replaced by `GUI TOOLS — All of them, automatically`, because there is nothing left to register. Pick **Antigravity** or **Grok** and the toggles come back, workspace or not — see below.
 
 ![The launcher's chip row — the workspace leads it](../images/v4.3.1-workspace-chip.png)
-
-**Antigravity and Grok have no such rule.**
-Even in the workspace, their GUI tools are whatever that directory has registered — Antigravity through `.agents/mcp_config.json` (→ [2.8.0 setup guide](v2.8.0.html)), Grok through `.grok/config.toml`.
-Neither CLI takes an MCP flag, so there is no per-session set of tools to hand them; the directory's toggles are the only lever, and the launcher shows you those toggles rather than promising tools it cannot deliver.
 
 **In a project directory, register what you need with the MCP toggles.**
 **Canvas** (`render` / `media`) is the panel beside an enlarged cell, **Workspace data** (`data`) is collections and the books, and **External accounts** (`external`) is Google, X and the like.
 A toggle registers **the directory, not the session**, so it takes effect on the next session started there — it never reaches a session already running.
+
+### Antigravity and Grok register everywhere — the workspace included {#antigravity-gui-tools}
+
+**Antigravity and Grok have no such rule.** Even in the workspace, their GUI tools are whatever
+**that directory** has registered — so an `agy` or `grok` session in the workspace with nothing
+registered has **no GUI tools at all**, while the same session in a project you once flipped Canvas
+on for has them. That is the shape of the surprise: `presentDocument` works in your project and is
+missing in the workspace, which is the one place everything is supposed to work.
+
+The reason is structural, not an oversight. Claude and Codex are handed a **per-session** MCP config
+when the session starts (`--mcp-config`, `-c mcp_servers.…`), so the workspace can simply hand them
+everything. Neither of the other two takes such a flag: each reads its servers from a **file in the
+working directory** — `agy` from `.agents/mcp_config.json`, which MulmoTerminal writes from that
+directory's toggles (→ [2.8.0 setup guide](v2.8.0.html)), and `grok` from `.grok/config.toml`, which
+MulmoTerminal registers through grok's own `grok mcp add -s project` so the rest of your file is left
+as you wrote it. A file per directory cannot be given to one session and not another, so there is
+nothing for "you are in the workspace" to change.
+
+**To give an Antigravity or Grok session GUI tools — in the workspace or anywhere else:**
+
+1. In an empty cell's launcher, pick **Antigravity** or **Grok** in the Agent Picker.
+2. Put the directory in **WORKING DIRECTORY** (the **WORKSPACE** chip, if that is where you want it).
+3. The **Canvas / Workspace data / External accounts** toggles stay visible — they do not disappear
+   for these two the way they do for Claude and Codex. Flip on what you need: **Canvas** (`render`)
+   is the one that carries `presentDocument`, `presentChart`, `presentHtml` and `presentForm`.
+4. **Launch a new session.** A toggle registers the *directory*, so it never reaches a session that
+   is already running — the one you have open keeps whatever it was given at spawn.
+
+You can check it from the outside: `<that directory>/.agents/mcp_config.json` (Antigravity) or
+`<that directory>/.grok/config.toml` (Grok) should now list a `mulmoterminal-render` server. In the
+session, the tool is called `mcp__mulmoterminal-render__presentDocument` — both agents always use the
+per-group server ids, never the `mt` id a workspace Claude session sees.
 
 ## Reading a cell — "what each agent is doing and where"
 

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -23,6 +23,7 @@ description: Configuring MulmoTerminal — the settings modal, per-project colou
 | Two `yarn dev` **fighting over port 3000** | [A port per worktree](#worktree-env) |
 | A **worktree** looks like a different project | [Worktrees inherit this file](#worktree-inherit) |
 | **No Canvas** when you enlarge a cell / no GUI tools | [Which directory to launch in](basics.html#launch-dir) |
+| **Antigravity or Grok** has no GUI tools, even in the workspace | [Antigravity and Grok register everywhere](basics.html#antigravity-gui-tools) |
 | Run on **a model other than Claude** | [Providers](#providers) |
 | Start Claude Code through **your own command** (`ollama launch claude …`) | [Custom agents](#custom-agents) |
 | Add **your own button** to the header | [Customizing the header](#header) |

--- a/docs/guide/en/faq.md
+++ b/docs/guide/en/faq.md
@@ -211,7 +211,7 @@ cells that get colour, a chime and a phone push, because they're the ones that s
 **The repository, when you are working on that project — the workspace, when you want what the single view in 3.x gave you** (the server's default working directory, printed as `Workspace: …` at startup; if you also run MulmoClaude, the workspace you share with it, `~/mulmoclaude` by default).
 
 **A Claude or Codex session launched in the workspace has every GUI tool** — drawing into the Canvas, working with collections, all of it available with nothing to register.
-Claude or Codex, it is the same, and the **WORKSPACE** chip at the head of the WORKING DIRECTORY row is the quick way to get there (Antigravity and Grok are the exceptions: wherever either runs, it gets what its directory registered). A **launch command** is not this — it runs your command line verbatim and carries no GUI tools, `claude` included.
+Claude or Codex, it is the same, and the **WORKSPACE** chip at the head of the WORKING DIRECTORY row is the quick way to get there (Antigravity and Grok are the exceptions: wherever either runs, it gets what its directory registered → [Antigravity and Grok register everywhere](basics.html#antigravity-gui-tools)). A **launch command** is not this — it runs your command line verbatim and carries no GUI tools, `claude` included.
 A cell in a project directory has only the tool groups registered for that directory, so register one with the launcher's MCP toggles when you want GUI tools there (→ [which directory to launch in](basics.html#launch-dir)).
 
 ---

--- a/docs/guide/en/glossary.md
+++ b/docs/guide/en/glossary.md
@@ -90,7 +90,7 @@ The server's **default working directory** (`CLAUDE_CWD`) — settled in the ord
 It is printed as `Workspace: …` at startup.
 Collections, Wiki and Accounting read and write there, and if you also run MulmoClaude it should be **the same directory for both** (`~/mulmoclaude` by default) — not the directory you cloned MulmoClaude into.
 
-It is treated differently from a project directory: **a Claude or Codex session launched here has every GUI tool**, the way the single view in 3.x did — whichever of the two you pick in the Agent Picker. Antigravity and Grok are the exceptions (each gets what its directory registered), and a Shell or a **launch command** carries no GUI tools at all, `claude` as the command line included: a launch command is run verbatim and is never an agent session.
+It is treated differently from a project directory: **a Claude or Codex session launched here has every GUI tool**, the way the single view in 3.x did — whichever of the two you pick in the Agent Picker. Antigravity and Grok are the exceptions (each gets what its directory registered, in the workspace too → [Antigravity and Grok register everywhere](basics.html#antigravity-gui-tools)), and a Shell or a **launch command** carries no GUI tools at all, `claude` as the command line included: a launch command is run verbatim and is never an agent session.
 
 → [Which directory to launch in](basics.html#launch-dir)
 

--- a/docs/guide/ja/basics.md
+++ b/docs/guide/ja/basics.md
@@ -57,7 +57,7 @@ description: グリッドで複数の AI コーディングエージェント（
 | **Agent Picker**（**Claude / Codex / Antigravity / Grok / Shell**） | このセルで動かすものを選ぶ。**エージェント**か、**Shell**（OS 標準シェル `$SHELL`。インストールも設定も不要）。実際のエージェントセッションを起動するのはこのコントロールで、下の **launch commands** はユーザーが書いたコマンドをそのまま実行する |
 | **WORKING DIRECTORY** | 作業ディレクトリを入力（再生ボタンで起動）。よく使うディレクトリは *cwd presets* の**チップ**をクリックして入力（チップの再生ボタンで即起動）。チップ列の先頭には **WORKSPACE** が常にあります（→ [どのディレクトリで起動するか](#launch-dir)） |
 | **モデル選択**（Claude 選択時） | このセッションだけのバックエンド／モデルを選ぶ（→ [プロバイダ](providers.html)） |
-| **Canvas / Workspace data / External accounts** のトグル（エージェント選択時） | GUI ツール群（`render` / `data` / `media` / `external`）の MCP サーバを、**このセッションではなくディレクトリに**登録。**ワークスペースを選んでいる間は出ません**（そこは登録なしで全部使えるため） |
+| **Canvas / Workspace data / External accounts** のトグル（エージェント選択時） | GUI ツール群（`render` / `data` / `media` / `external`）の MCP サーバを、**このセッションではなくディレクトリに**登録。**Claude / Codex** を選んでいるときは、**ワークスペースを選んでいる間は出ません**（そこは登録なしで全部使えるため）。**Antigravity / Grok** を選んでいるときはワークスペースでも出たままです — この 2 つはどこで動いてもこの登録だけが GUI ツールの入手経路だからです（→ [Antigravity と Grok はどこでも登録が要る](#antigravity-gui-tools)） |
 | **OR ISOLATE IN A WORKTREE** | git リポなら、タスク名を入れて **New worktree**。作業を隔離した worktree を作って起動。既存の worktree はその下に一覧表示 |
 | **OR RESUME HERE** | そのディレクトリに既にあるセッション。クリックすると続きから再開 |
 | **OR LAUNCH** | 設定済みの**起動コマンド**（`codex` / `htop` / 任意）を永続端末として起動 |
@@ -116,18 +116,46 @@ Claude でも Codex でも同じです。**Agent Picker** でどちらかを選�
 **ワークスペースはチップ 1 つで選べます。**
 ランチャのチップ列の先頭には、最近使ったディレクトリとは別枠で **WORKSPACE** チップが常に出ています（ディレクトリ名ではなく役割名で、専用アイコン付き）。
 再生ボタンでそのまま起動、チップ本体を押せば WORKING DIRECTORY に入るだけです。
-ワークスペースを選んでいる間は MCP トグルが消え、代わりに `GUI TOOLS — All of them, automatically` と出ます。登録するものが無いからです。
+**Claude / Codex を選んだ状態で**ワークスペースを選んでいる間は MCP トグルが消え、代わりに `GUI TOOLS — All of them, automatically` と出ます。登録するものが無いからです。**Antigravity / Grok** を選ぶとトグルは戻ります（ワークスペースでも）。次項を参照してください。
 
 ![ランチャのチップ列 — 先頭がワークスペース](../images/v4.3.1-workspace-chip.png)
-
-**Antigravity と Grok にこの特例はありません。**
-ワークスペースで起動しても、GUI ツールはそのディレクトリに登録されているぶんだけです（Antigravity は `.agents/mcp_config.json` 経由。→ [2.8.0 セットアップガイド](v2.8.0.html)。Grok は `.grok/config.toml` 経由）。
-どちらの CLI も MCP のフラグを受け取らないので、セッション単位で渡せるツールがそもそもありません。効くのはディレクトリのトグルだけで、ランチャも渡せないツールを約束せずそのトグルを出します。
 
 **プロジェクトのディレクトリで GUI ツールが要るときは、MCP トグルで登録します。**
 どのトグルが何をもたらすかは、**Canvas**（`render` / `media`）が拡大したセルの横のパネル、**Workspace data**（`data`）がコレクションと帳簿、**External accounts**（`external`）が Google や X などの外部アカウントです。
 トグルは**セッションではなくディレクトリ**への登録なので、効くのは次にそこで起動するセッションからです。
 動いているセッションに後から載ることはありません。
+
+### Antigravity と Grok はどこでも登録が要る — ワークスペースでも {#antigravity-gui-tools}
+
+**Antigravity と Grok にこの特例はありません。** ワークスペースで起動しても、GUI ツールは
+**そのディレクトリに**登録されているぶんだけです。つまり、何も登録していないワークスペースで動かした
+`agy` / `grok` セッションは **GUI ツールを 1 つも持ちません**。一方、以前 Canvas を入れたプロジェクト
+では同じセッションが使えます。これが分かりにくさの正体です — 「全部使えるはずの」ワークスペースでだけ
+`presentDocument` が無く、プロジェクトでは動く、という形で出ます。
+
+理由は仕様上の構造で、不具合ではありません。Claude / Codex は起動時に**セッション単位の** MCP 設定を
+渡されます（`--mcp-config`、`-c mcp_servers.…`）。だからワークスペースでは全部渡してしまえます。
+残る 2 つにはその口がなく、どちらも作業ディレクトリの**ファイル**から MCP サーバを読みます。`agy` は
+`.agents/mcp_config.json` で、これはそのディレクトリのトグルから MulmoTerminal が書き出しています
+（→ [2.8.0 セットアップガイド](v2.8.0.html)）。`grok` は `.grok/config.toml` で、こちらは grok 自身の
+`grok mcp add -s project` 経由なので、ファイルの他の記述はそのまま残ります。ディレクトリに 1 つの
+ファイルは特定のセッションにだけ渡す、ということができないので、「ワークスペースにいる」ことで
+変えられるものが無いのです。
+
+**Antigravity / Grok のセッションに GUI ツールを持たせる手順（ワークスペースでも、それ以外でも同じ）:**
+
+1. 空きセルのランチャで、Agent Picker の **Antigravity** または **Grok** を選びます。
+2. **WORKING DIRECTORY** にディレクトリを入れます（ワークスペースなら **WORKSPACE** チップ）。
+3. **Canvas / Workspace data / External accounts** のトグルはそのまま出ています — Claude / Codex の
+   ときのように消えません。必要なものを ON にします。`presentDocument`・`presentChart`・
+   `presentHtml`・`presentForm` を持ってくるのは **Canvas**（`render`）です。
+4. **セッションを起動し直します。** トグルは*ディレクトリ*への登録なので、既に動いているセッションには
+   届きません。開いているセッションは起動時に渡されたものを持ち続けます。
+
+外から確かめるなら、`<そのディレクトリ>/.agents/mcp_config.json`（Antigravity）または
+`<そのディレクトリ>/.grok/config.toml`（Grok）に `mulmoterminal-render` サーバが入っているかを見ます。
+セッション内でのツール名は `mcp__mulmoterminal-render__presentDocument` です。どちらも常にグループごとの
+サーバ id を使い、ワークスペースの Claude セッションが見る `mt` id にはなりません。
 
 ## セルの読み方 — 「どこで何をしているか」
 

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -23,6 +23,7 @@ description: MulmoTerminal の設定方法。設定モーダル、プロジェ�
 | 2つの `yarn dev` が **ポート 3000 を取り合う** | [worktree ごとのポート](#worktree-env) |
 | **worktree だけ別プロジェクトに見える** | [worktree はこのファイルを引き継ぐ](#worktree-inherit) |
 | 拡大しても **Canvas が出ない** / GUI ツールが使えない | [どのディレクトリで起動するか](basics.html#launch-dir) |
+| **Antigravity / Grok** だけ GUI ツールが無い（ワークスペースでも） | [Antigravity と Grok はどこでも登録が要る](basics.html#antigravity-gui-tools) |
 | **Claude 以外のモデル**で動かしたい | [プロバイダ](#providers) |
 | **自分のコマンド**で Claude Code を起動したい（`ollama launch claude …`） | [カスタムエージェント](#custom-agents) |
 | ヘッダーに**自分のボタン**を足したい | [ヘッダーのカスタマイズ](#header) |

--- a/docs/guide/ja/faq.md
+++ b/docs/guide/ja/faq.md
@@ -205,7 +205,7 @@ npx mulmoterminal@latest
 **そのプロジェクトの作業ならそのリポジトリ、3.x までの単一ビューと同じことをしたいならワークスペース**（サーバの既定の作業ディレクトリ。起動時に `Workspace: …` と表示されます。MulmoClaude と併用しているなら、その共有ワークスペース＝既定 `~/mulmoclaude`）**です。**
 
 **ワークスペースで起動した Claude / Codex のセッションは、GUI ツールを全部持ちます** — Canvas に描かせる・コレクションを触らせるといったツールが、何も登録せずに通る状態です。
-Claude でも Codex でも同じで、WORKING DIRECTORY 行の先頭にある **WORKSPACE** チップがそこへの近道です（Antigravity と Grok は例外で、どちらもどこで動かしてもディレクトリに登録されたぶんだけ）。**起動コマンド（launch command）はこれには当たりません** — コマンドラインを逐語的に実行するだけで、`claude` であっても GUI ツールは付きません。
+Claude でも Codex でも同じで、WORKING DIRECTORY 行の先頭にある **WORKSPACE** チップがそこへの近道です（Antigravity と Grok は例外で、どちらもどこで動かしてもディレクトリに登録されたぶんだけ → [Antigravity と Grok はどこでも登録が要る](basics.html#antigravity-gui-tools)）。**起動コマンド（launch command）はこれには当たりません** — コマンドラインを逐語的に実行するだけで、`claude` であっても GUI ツールは付きません。
 プロジェクトのディレクトリで起動したセルは、そのディレクトリに登録されているツールグループだけを持つので、GUI ツールが要るならランチャの MCP トグルで登録します（→ [どのディレクトリで起動するか](basics.html#launch-dir)）。
 
 ---

--- a/docs/guide/ja/glossary.md
+++ b/docs/guide/ja/glossary.md
@@ -92,7 +92,7 @@ MulmoTerminal はこのやり方を**ターミナルで**やるための画面�
 Collections・Wiki・Accounting が読み書きするのはここで、MulmoClaude と併用するなら**両者で同じディレクトリ**（既定 `~/mulmoclaude`）にします。
 MulmoClaude を clone したディレクトリのことではありません。
 
-プロジェクトのディレクトリとは扱いが違い、**ここで起動した Claude / Codex のセッションは GUI ツールを全部持ちます**（3.x までの単一ビューと同じ状態）。Agent Picker でどちらを選んでも同じです。Antigravity と Grok は対象外（それぞれそのディレクトリに登録されたものだけ）で、Shell や**起動コマンド**にはそもそも GUI ツールが付きません — コマンドラインが `claude` であっても同じです。起動コマンドは逐語的に実行されるだけで、エージェントのセッションにはなりません。
+プロジェクトのディレクトリとは扱いが違い、**ここで起動した Claude / Codex のセッションは GUI ツールを全部持ちます**（3.x までの単一ビューと同じ状態）。Agent Picker でどちらを選んでも同じです。Antigravity と Grok は対象外（ワークスペースでも、それぞれそのディレクトリに登録されたものだけ → [Antigravity と Grok はどこでも登録が要る](basics.html#antigravity-gui-tools)）で、Shell や**起動コマンド**にはそもそも GUI ツールが付きません — コマンドラインが `claude` であっても同じです。起動コマンドは逐語的に実行されるだけで、エージェントのセッションにはなりません。
 
 → [どのディレクトリで起動するか](basics.html#launch-dir)
 

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -335,19 +335,20 @@ const mcpGroupTitle = (group: ToolGroup): string =>
 // whether there is one — the alternative asserts in the hover what the branch already decided.
 const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed.value[group] ?? undefined;
 
-// The workspace has no per-directory choice to offer: a session started there is handed the WHOLE
-// GUI MCP on one URL, whatever agent runs it (`carriesFullGuiMcp`, server/session/mcp-config.ts).
-// The four switches are not merely redundant there — a group URL serves nothing to a session that
-// already carries every tool (server/mcp/tool-gate.ts), so they would visibly do nothing.
+// Is the launch pointed at the workspace? On its own this decides only the WORKTREE row below —
+// whether the four MCP switches have anything to offer takes the AGENT as well, which is
+// `workspaceGivesEveryTool` right underneath (an agy or grok session in the workspace is handed
+// nothing at spawn, so the switches are its only route to a GUI tool and must stay).
 //
 // Asked of the directory the launch will USE, not of the field: an empty field means the workspace
 // (see dirFor), which is exactly the case a comparison against the raw input would miss.
 const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
 
 // The workspace answers "every tool automatically" only for an agent that can RECEIVE a per-spawn
-// config — the directory alone is not enough. Antigravity reads a per-directory file instead, so it
-// gets what that directory registered wherever it runs, and telling it otherwise here both stated
-// something untrue and hid the toggles that were its only way to register anything (#1423).
+// config — the directory alone is not enough. Antigravity and grok read a per-directory file
+// instead, so each gets what that directory registered wherever it runs, and telling them otherwise
+// here both stated something untrue and hid the toggles that were their only way to register
+// anything (#1423).
 //
 // Kept apart from `inWorkspace` rather than folded into it: the worktree row below asks the
 // directory question and only that, and the two would have drifted the moment either changed.


### PR DESCRIPTION
## 何が起きたか

Antigravity で workspace のセルを起動すると、GUI ツールが **1 つも付かない**。`../mag2` のような
プロジェクトでは `presentDocument` が使えるのに、「全部使えるはず」の workspace で消える、という
形で出る。**Grok も同じ**（#1441 でマージ、リベースで取り込み済み）。

原因は仕様どおりの経路差で、バグではない。claude / codex は起動時に per-session の MCP 設定を
渡される（`--mcp-config` / `-c mcp_servers.…`）ので workspace で全部渡せるが、`agy` と `grok` には
その口が無く、作業ディレクトリのファイル（`.agents/mcp_config.json` / `.grok/config.toml`）を
自分で読むだけ。ディレクトリ共有のファイルは特定のセッションにだけ渡せないので、「workspace に
いる」ことで変えられるものが無い（`FULL_GUI_MCP_AGENTS`, `common/guiMcpAgents.ts`, #1423）。

問題は、これが**どこにも書かれていなかった**こと。それどころか 3 箇所が逆を断言していた。

## 訂正

| 場所 | 何が書いてあったか |
|---|---|
| `docs/guide/{en,ja}/basics.md` ランチャ表 + WORKSPACE チップ段落 | 「ワークスペースを選んでいる間は MCP トグルは出ません」→ 出ないのは **Claude / Codex のときだけ**。Antigravity / Grok では出たままで、それが唯一の入手経路 |
| `README.md` §MCP server ids | 「**The workspace is agent-agnostic.** All three agents ask the same predicate」→ 判定に入るのは claude と codex だけ。表に antigravity 行と grok 行（登録ゼロなら GUI ツールもゼロ）を追加 |
| `src/components/CellLaunchForm.vue:338` | 「handed the WHOLE GUI MCP … whatever agent runs it」→ 直下の `workspaceGivesEveryTool` と矛盾。**この記述が上記 2 つの誤記の出どころ** |

`README.md` の Antigravity 節と Grok 節にも「in the workspace too」を明示した。

同じ種類の言い過ぎが README に 2 箇所残っていたので、あわせて限定した（codex レビュー指摘）:

- `README.md` `orderPriority` 行 — 「the one place every GUI tool is reachable」
- `README.md` §Scripts — 「the one directory where a session reaches every GUI tool」

どちらも claude / codex に限定し、agy / grok はどこでもディレクトリ登録ぶんだけであることへのリンクを付けた。

## 書き足し

実体は guide の新セクション（両言語）:

- `docs/guide/en/basics.md` — *Antigravity and Grok register everywhere — the workspace included*
- `docs/guide/ja/basics.md` — *Antigravity と Grok はどこでも登録が要る — ワークスペースでも*

構成は 症状 → 構造的理由 → 4 ステップの手順（Agent Picker で Antigravity / Grok → ディレクトリ選択 →
消えない Canvas トグルを ON → **新規セッションで起動**。トグルはディレクトリ登録なので実行中の
セッションには届かない）→ 外からの確認方法（`.agents/mcp_config.json` / `.grok/config.toml` に
`mulmoterminal-render`、ツール名は `mcp__mulmoterminal-render__presentDocument`）。

導線: `config.md`（en/ja）のトラブルシュート表に症状行、`faq.md` と `glossary.md` の既存の一行言及から
新アンカーへリンク。

## 確認したこと

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn test`（8424 passed）— エラーなし（lint の警告は既存の max-lines のみ）
- 新アンカー `#antigravity-gui-tools` は en/ja の basics.md に定義済み、参照 10 箇所すべてが解決
- 実機で再現・解消を確認（workspace に render を登録 → agy から `presentDocument` が使えるようになった）
- main（#1441 grok マージ後）にリベース済み。guide 6 ファイルの衝突は Grok を新セクションに畳み込む形で解消

## 入れていないもの

- ランチャ UI に「Antigravity / Grok はここでも登録が必要」というヒント行を出す変更（コード側の挙動変更に
  なるため別途）
- `docs/ChangeLog.md` への記載（リリース時にまとめる）

work in mulmoterminal
