### PR TITLE
fix: do not rewrite antigravity's shared MCP config on a tmux reattach

### DIFF
--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -9,7 +9,7 @@ import { antigravityAdapter } from "../agents/antigravity.js";
 import { buildAntigravityArgs } from "../agents/antigravity-args.js";
 import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
-import { ptySpawn } from "./pty-spawn.js";
+import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
@@ -49,7 +49,18 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
     },
   ): PtyEntry {
     const { mcpGroups, initialPrompt = null } = options;
-    syncAntigravityMcpConfig(cwd, mcpGroups);
+    // Only for a spawn that will really START agy. After a server restart `ptys` is empty but the
+    // tmux session can still be there, so this function is reached for what turns out to be a
+    // REATTACH — and the agy already running in that pane read `.agents/mcp_config.json` once, at
+    // its own start. Rewriting it now cannot affect that process; it can only speak for the OTHER
+    // sessions in the directory, which is the one thing this file must never do.
+    //
+    // The damaging case is not hypothetical: the caller resolves the groups with
+    // `.catch(() => [])`, so a transient failure reading Claude Code's config would arrive here as
+    // "no groups" and CLEAR the entries every live agy in that directory is using. Skipping the
+    // reattach leaves the file exactly as the running sessions expect it (#1443; grok, which has
+    // the same per-directory shape, was fixed in #1441).
+    if (!ptyWouldReattach(sessionId, true)) syncAntigravityMcpConfig(cwd, mcpGroups);
     const root = antigravityBrainRoot();
     const before = snapshotAntigravitySessions(root);
 

--- a/test/server/session/spawn-antigravity-mcp-sync.spec.ts
+++ b/test/server/session/spawn-antigravity-mcp-sync.spec.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+//
+// agy's MCP registration is written per DIRECTORY (`.agents/mcp_config.json`), so it is shared by
+// every antigravity session running there — and a REATTACH must not touch it.
+//
+// spawnAntigravityPty is reached by both paths: a genuinely new agy, and the one ws-routes comes
+// back through after the server restarts while the tmux session (and its agy) kept running. The agy
+// in that pane read the file once, at its own start; nothing re-reads it. So a rewrite on a
+// reattach cannot affect the process being reattached — it can only speak for the OTHER sessions in
+// the directory.
+//
+// The damaging case is not hypothetical. The caller resolves the groups with `.catch(() => [])`, so
+// a transient failure reading Claude Code's config arrives here as "no groups", and an
+// unconditional sync would then CLEAR the entries every live agy in that directory is using —
+// leaving them with no GUI tools until something else re-registered them. (#1443; the same fix
+// landed for grok in #1441.)
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ID = "sess-antigravity-1";
+const CWD = "/home/me/project";
+
+let reattaching = false;
+const syncAntigravityMcpConfig = vi.fn();
+
+vi.mock("../../../server/session/pty-spawn.js", () => ({
+  ptySpawn: () => ({ term: fakeTerm(), tmux: true, reattached: reattaching }),
+  ptyWouldReattach: () => reattaching,
+}));
+
+vi.mock("../../../server/agents/antigravity-mcp.js", () => ({
+  syncAntigravityMcpConfig: (cwd: string, groups: readonly string[]) => syncAntigravityMcpConfig(cwd, groups),
+}));
+
+// The conversation-id watcher reads the real brain directory and would outlive the test.
+vi.mock("../../../server/agents/antigravity-session.js", () => ({
+  antigravityBrainRoot: () => `${CWD}/.antigravity/brain`,
+  snapshotAntigravitySessions: () => new Set<string>(),
+  watchForAntigravitySession: () => Promise.resolve(null),
+}));
+
+vi.mock("../../../server/session/registry.js", () => ({
+  ptys: new Map(),
+  claimedAntigravityConversations: new Set<string>(),
+  rememberAntigravityConversation: vi.fn(),
+}));
+
+// The relay wires activity/output plumbing this spec is not about, and it would reach the pubsub.
+vi.mock("../../../server/session/pty-relay.js", () => ({ wireAgentPtyRelay: vi.fn() }));
+
+const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
+
+const { createAntigravitySpawner } = await import("../../../server/session/spawn-antigravity.js");
+
+const deps = { antigravityBin: "agy", antigravityModel: null } as unknown as Parameters<typeof createAntigravitySpawner>[0];
+const spawn = (groups: readonly string[]) => createAntigravitySpawner(deps).spawnAntigravityPty(ID, null, null, CWD, { mcpGroups: groups as never });
+
+describe("spawnAntigravityPty and the directory's shared .agents/mcp_config.json", () => {
+  beforeEach(() => {
+    reattaching = false;
+    syncAntigravityMcpConfig.mockClear();
+  });
+
+  it("registers the directory's groups when it really starts agy", () => {
+    spawn(["render"]);
+    expect(syncAntigravityMcpConfig).toHaveBeenCalledWith(CWD, ["render"]);
+  });
+
+  it("does not touch the file when tmux will reattach an already-running agy", () => {
+    reattaching = true;
+    spawn(["render"]);
+    expect(syncAntigravityMcpConfig).not.toHaveBeenCalled();
+  });
+
+  // The specific harm, stated as its own case: an empty group list on a reattach is the shape a
+  // failed config read takes, and it must not reach the file.
+  it("does not clear everything when a reattach arrives with no groups resolved", () => {
+    reattaching = true;
+    spawn([]);
+    expect(syncAntigravityMcpConfig).not.toHaveBeenCalled();
+  });
+});

--- a/test/server/session/spawn-antigravity.spec.ts
+++ b/test/server/session/spawn-antigravity.spec.ts
@@ -13,6 +13,8 @@ vi.mock("../../../server/session/pty-spawn.js", () => ({
     },
     tmux: false,
   })),
+  // This spawn really starts agy, so it is the branch that syncs the directory's MCP config (#1443).
+  ptyWouldReattach: vi.fn(() => false),
 }));
 
 describe("createAntigravitySpawner", () => {


### PR DESCRIPTION
Fixes #1443.

`spawnAntigravityPty` called `syncAntigravityMcpConfig(cwd, mcpGroups)` unconditionally, before `ptySpawn` had decided whether it was starting a fresh `agy` or reattaching to one already running in tmux (the path taken after a server restart, when `ptys` is empty but the tmux session is alive).

`.agents/mcp_config.json` is per directory and shared by every antigravity session there, and the `agy` being reattached read it once at its own start — nothing re-reads it. So the rewrite cannot affect the process being reattached; it can only speak for the *other* sessions in the directory, which is what the function's own doc comment says this path must never do. Since the caller resolves the groups with `.catch(() => [])`, a transient failure reading Claude Code's config arrives as "no groups" and clears every MulmoTerminal entry — every `agy` started in that directory afterwards has no GUI tools, while the launcher toggles still report the groups as on.

## Change

- `server/session/spawn-antigravity.ts` — sync only when `!ptyWouldReattach(sessionId, true)`, the same predicate `spawn-grok.ts` consults (that one was fixed in #1441; antigravity was deliberately left alone under a Grok heading).
- `test/server/session/spawn-antigravity-mcp-sync.spec.ts` — new, mirroring `spawn-grok-mcp-sync.spec.ts`: syncs on a real spawn, does not touch the file on a reattach, and the empty-group reattach case as its own test. Verified against the unfixed source — 2 of the 3 cases fail without the guard.
- `test/server/session/spawn-antigravity.spec.ts` — its `pty-spawn.js` mock needed the new `ptyWouldReattach` export.

No behaviour change for a spawn that really starts `agy`.

## Checks

`yarn format`, `yarn lint` (0 errors; 12 pre-existing max-lines warnings), `yarn typecheck`, `yarn test` — 8427 passed, 45 skipped.

work in mulmoterminal