### PR TITLE
feat: このリポジトリ自身に repo.json と favicon.svg を置く

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'>
+  <rect x='1' y='1' width='30' height='30' rx='7' fill='#1a1a2e'/>
+  <rect x='2.5' y='2.5' width='27' height='27' rx='5.5' fill='none' stroke='#8a8aa0' stroke-width='2'/>
+  <path d='M10 9 L16 16 L10 23' fill='none' stroke='#e8e8f0' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/>
+  <rect x='18' y='20.5' width='8' height='3' rx='1.5' fill='#8a8aa0'/>
+</svg>

--- a/repo.json
+++ b/repo.json
@@ -1,0 +1,6 @@
+{
+  "name": "mulmoterminal",
+  "description": "A browser terminal grid for running several AI coding agents in parallel",
+  "icon": "favicon.svg",
+  "homepage": "https://receptron.github.io/mulmoterminal/"
+}


### PR DESCRIPTION
## Summary

#1442 で `repo.json` を読めるようにしたので、**このリポジトリ自身にも置きます**。規格を作った側が使っていないのは説得力がありません。

```json
{
  "name": "mulmoterminal",
  "description": "A browser terminal grid for running several AI coding agents in parallel",
  "icon": "favicon.svg",
  "homepage": "https://receptron.github.io/mulmoterminal/"
}
```

## Items to Confirm / Review

1. **`favicon.svg` を新規に足しています。** favicon は `index.html` のインライン data: SVG しか無く、ファイルとして存在しませんでした。`repo.json` から参照するには実体が要ります。1タグ1行に整形してあるので、380字の塊ではなく差分が読めます。

2. **`index.html` のインライン版はそのまま残しました。** 読み込み時のリクエストを1つ減らすためのもので、アプリ自身の都合です。結果として**同じ絵が2箇所にあります** — マークを変えるときは両方直す必要があります。`public/` を作って1つにまとめることもできますが、それはこの PR の範囲外と判断しました。

3. **`color` は入れていません。** このリポジトリの 7 色（`.mulmoterminal.json` にコミット済み）は「このユーザーのグリッドでどう見えるか」の選択であって、プロジェクトのブランド色ではありません。前者は `.mulmoterminal.json` の持ち場、というのが `mulmoterminal-dirs` スキルに書いた使い分けです。入れるべきなら足します。

## 動作確認

実ローダーで `source.repo: name, icon` と icon の解決を確認し、実機のセルヘッダーに ❯ のマークが出ることを確認しました。

`.mulmoterminal.local.json`（この checkout の色）が上に乗るので、既存の見た目は変わりません。

work in mulmoterminal4