### PR TITLE
docs: stop the version guides colliding with glossary and claude-ollama

### DIFF
--- a/docs/guide/en/v1.10.0.md
+++ b/docs/guide/en/v1.10.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.10.0
 layout: default
 parent: English
-nav_order: 41
+nav_order: 43
 ---
 
 # 1.10.0: your `.env` is read now

--- a/docs/guide/en/v1.11.0.md
+++ b/docs/guide/en/v1.11.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.11.0
 layout: default
 parent: English
-nav_order: 40
+nav_order: 42
 ---
 
 # 1.11.0: clicking a file path got smarter

--- a/docs/guide/en/v1.11.1.md
+++ b/docs/guide/en/v1.11.1.md
@@ -2,7 +2,7 @@
 title: What 1.11.1 fixed
 layout: default
 parent: English
-nav_order: 39
+nav_order: 41
 ---
 
 # 1.11.1: sessions start on an npm-global Claude Code (Windows)

--- a/docs/guide/en/v1.12.0.md
+++ b/docs/guide/en/v1.12.0.md
@@ -2,7 +2,7 @@
 title: What 1.12.0 fixed
 layout: default
 parent: English
-nav_order: 38
+nav_order: 40
 ---
 
 # What 1.12.0 fixed

--- a/docs/guide/en/v1.7.1.md
+++ b/docs/guide/en/v1.7.1.md
@@ -2,7 +2,7 @@
 title: What 1.7.1 fixed
 layout: default
 parent: English
-nav_order: 47
+nav_order: 49
 ---
 
 # 1.7.1: grid session list and wheel scrolling

--- a/docs/guide/en/v1.7.2.md
+++ b/docs/guide/en/v1.7.2.md
@@ -2,7 +2,7 @@
 title: What 1.7.2 fixed
 layout: default
 parent: English
-nav_order: 46
+nav_order: 48
 ---
 
 # 1.7.2: worktree creation could hang

--- a/docs/guide/en/v1.8.0.md
+++ b/docs/guide/en/v1.8.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.8.0
 layout: default
 parent: English
-nav_order: 45
+nav_order: 47
 ---
 
 # 1.8.0: Enter's behaviour is configurable

--- a/docs/guide/en/v1.9.0.md
+++ b/docs/guide/en/v1.9.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.9.0
 layout: default
 parent: English
-nav_order: 44
+nav_order: 46
 ---
 
 # 1.9.0: the phone gets each session's identity

--- a/docs/guide/en/v1.9.1.md
+++ b/docs/guide/en/v1.9.1.md
@@ -2,7 +2,7 @@
 title: What's new in 1.9.1
 layout: default
 parent: English
-nav_order: 43
+nav_order: 45
 ---
 
 # 1.9.1: Windows sessions start, terminal links work

--- a/docs/guide/en/v1.9.2.md
+++ b/docs/guide/en/v1.9.2.md
@@ -2,7 +2,7 @@
 title: What 1.9.2 fixed
 layout: default
 parent: English
-nav_order: 42
+nav_order: 44
 ---
 
 # 1.9.2: npm-global installs spawn too (Windows)

--- a/docs/guide/en/v2.0.0.md
+++ b/docs/guide/en/v2.0.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.0.0
 layout: default
 parent: English
-nav_order: 37
+nav_order: 39
 ---
 
 # Using what 2.0.0 added

--- a/docs/guide/en/v2.1.0.md
+++ b/docs/guide/en/v2.1.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.1.0
 layout: default
 parent: English
-nav_order: 36
+nav_order: 38
 ---
 
 # Using what 2.1.0 added

--- a/docs/guide/en/v2.1.1.md
+++ b/docs/guide/en/v2.1.1.md
@@ -2,7 +2,7 @@
 title: What's new in 2.1.1
 layout: default
 parent: English
-nav_order: 35
+nav_order: 37
 ---
 
 # What changed in 2.1.1

--- a/docs/guide/en/v2.2.0.md
+++ b/docs/guide/en/v2.2.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.2.0
 layout: default
 parent: English
-nav_order: 34
+nav_order: 36
 ---
 
 # What changed in 2.2.0

--- a/docs/guide/en/v2.3.0.md
+++ b/docs/guide/en/v2.3.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.3.0
 layout: default
 parent: English
-nav_order: 33
+nav_order: 35
 ---
 
 # What changed in 2.3.0

--- a/docs/guide/en/v2.4.0.md
+++ b/docs/guide/en/v2.4.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.4.0
 layout: default
 parent: English
-nav_order: 32
+nav_order: 34
 ---
 
 # What changed in 2.4.0

--- a/docs/guide/en/v2.5.0.md
+++ b/docs/guide/en/v2.5.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.0
 layout: default
 parent: English
-nav_order: 31
+nav_order: 33
 ---
 
 # What changed in 2.5.0

--- a/docs/guide/en/v2.5.1.md
+++ b/docs/guide/en/v2.5.1.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.1
 layout: default
 parent: English
-nav_order: 30
+nav_order: 32
 ---
 
 # What changed in 2.5.1

--- a/docs/guide/en/v2.5.2.md
+++ b/docs/guide/en/v2.5.2.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.2
 layout: default
 parent: English
-nav_order: 29
+nav_order: 31
 ---
 
 # What changed in 2.5.2

--- a/docs/guide/en/v2.5.3.md
+++ b/docs/guide/en/v2.5.3.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.3
 layout: default
 parent: English
-nav_order: 28
+nav_order: 30
 ---
 
 # What changed in 2.5.3

--- a/docs/guide/en/v2.6.0.md
+++ b/docs/guide/en/v2.6.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.6.0
 layout: default
 parent: English
-nav_order: 27
+nav_order: 29
 ---
 
 # What changed in 2.6.0

--- a/docs/guide/en/v2.7.0.md
+++ b/docs/guide/en/v2.7.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.7.0
 layout: default
 parent: English
-nav_order: 26
+nav_order: 28
 ---
 
 # What changed in 2.7.0

--- a/docs/guide/en/v2.8.0.md
+++ b/docs/guide/en/v2.8.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.8.0
 layout: default
 parent: English
-nav_order: 25
+nav_order: 27
 ---
 
 # What changed in 2.8.0

--- a/docs/guide/en/v2.9.0.md
+++ b/docs/guide/en/v2.9.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.9.0
 layout: default
 parent: English
-nav_order: 24
+nav_order: 26
 ---
 
 # What changed in 2.9.0

--- a/docs/guide/en/v2.9.1.md
+++ b/docs/guide/en/v2.9.1.md
@@ -2,7 +2,7 @@
 title: What changed in 2.9.1
 layout: default
 parent: English
-nav_order: 23
+nav_order: 25
 ---
 
 # What changed in 2.9.1

--- a/docs/guide/en/v3.0.0.md
+++ b/docs/guide/en/v3.0.0.md
@@ -2,7 +2,7 @@
 title: 3.0.0 — start from the issue
 layout: default
 parent: English
-nav_order: 22
+nav_order: 24
 description: Setup guide for MulmoTerminal 3.0.0 — press one button on an issue row and get a worktree plus a Claude session with the issue already in its input box.
 ---
 

--- a/docs/guide/en/v4.0.0.md
+++ b/docs/guide/en/v4.0.0.md
@@ -2,7 +2,7 @@
 title: 4.0.0 — the grid is the app
 layout: default
 parent: English
-nav_order: 21
+nav_order: 23
 description: Setup guide for MulmoTerminal 4.0.0 — the single terminal view is removed, the Collections door replaces it, and a worktree now runs exactly one agent session.
 ---
 

--- a/docs/guide/en/v4.1.0.md
+++ b/docs/guide/en/v4.1.0.md
@@ -2,7 +2,7 @@
 title: 4.1.0 — GitLab in the PRs & Issues view
 layout: default
 parent: English
-nav_order: 20
+nav_order: 22
 description: Setup guide for MulmoTerminal 4.1.0 — put a GitLab project in prRepos and its merge requests and issues appear beside your GitHub ones, with the same one-click start.
 ---
 

--- a/docs/guide/en/v4.1.1.md
+++ b/docs/guide/en/v4.1.1.md
@@ -2,7 +2,7 @@
 title: 4.1.1 — Usage that stops saying n/a, and 300 lines of scrollback on the phone
 layout: default
 parent: English
-nav_order: 19
+nav_order: 21
 description: Setup guide for MulmoTerminal 4.1.1 — the header's usage figure stops sticking at n/a on slow machines, the phone's terminal shows 300 lines of history, and GitLab worktrees get the PR pill and the Open PR button.
 ---
 

--- a/docs/guide/en/v4.2.0.md
+++ b/docs/guide/en/v4.2.0.md
@@ -2,7 +2,7 @@
 title: 4.2.0 — Self-hosted GitLab, panes that take the whole terminal, and worktrees that keep their colours
 layout: default
 parent: English
-nav_order: 18
+nav_order: 20
 description: Setup guide for MulmoTerminal 4.2.0 — declaring a self-hosted GitLab in gitlabHosts, expanding the Canvas and Tools panes over the terminal, worktrees that inherit their project's settings, and a terminal that repairs itself as you type.
 ---
 

--- a/docs/guide/en/v4.3.0.md
+++ b/docs/guide/en/v4.3.0.md
@@ -2,7 +2,7 @@
 title: 4.3.0 — The workspace is one place, and an Enter that means 変換
 layout: default
 parent: English
-nav_order: 17
+nav_order: 19
 description: Setup guide for MulmoTerminal 4.3.0 — the workspace reaches the same GUI tools however you start a terminal there, the launcher always offers it, the GUI MCP server id is now mt, and an IME's confirming Enter is no longer eaten.
 ---
 

--- a/docs/guide/en/v4.3.1.md
+++ b/docs/guide/en/v4.3.1.md
@@ -2,7 +2,7 @@
 title: 4.3.1 — The workspace chip says WORKSPACE
 layout: default
 parent: English
-nav_order: 16
+nav_order: 18
 description: Setup guide for MulmoTerminal 4.3.1 — the launcher's workspace chip is labelled by its role rather than its folder name, and the git chip refreshes when you come back to the tab.
 ---
 

--- a/docs/guide/en/v4.4.0.md
+++ b/docs/guide/en/v4.4.0.md
@@ -2,7 +2,7 @@
 title: 4.4.0 — Every cell keeps its own pane, and the Canvas opens a file on its own
 layout: default
 parent: English
-nav_order: 15
+nav_order: 17
 description: Setup guide for MulmoTerminal 4.4.0 — each cell remembers its own right pane, the Files pane can open a document or a story in the Canvas without an agent, your claude.ai connectors work in the workspace again, and the session list stops re-reading whole transcripts.
 ---
 

--- a/docs/guide/en/v4.5.0.md
+++ b/docs/guide/en/v4.5.0.md
@@ -2,7 +2,7 @@
 title: 4.5.0 — repo.json, a port per worktree, Grok, and settings you can reach
 layout: default
 parent: English
-nav_order: 14
+nav_order: 16
 description: Setting up what 4.5.0 shipped — repo.json (a repository's own icon and colour), a dev-server port and database name per git worktree, Grok in the Agent Picker, and the settings that used to need hand-edited JSON. Written 2026-08-05.
 ---
 

--- a/docs/guide/ja/v1.10.0.md
+++ b/docs/guide/ja/v1.10.0.md
@@ -2,7 +2,7 @@
 title: 1.10.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 41
+nav_order: 43
 ---
 
 # 1.10.0：`.env` が読まれるようになりました

--- a/docs/guide/ja/v1.11.0.md
+++ b/docs/guide/ja/v1.11.0.md
@@ -2,7 +2,7 @@
 title: 1.11.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 40
+nav_order: 42
 ---
 
 # 1.11.0：ファイルパスのクリックが賢くなりました

--- a/docs/guide/ja/v1.11.1.md
+++ b/docs/guide/ja/v1.11.1.md
@@ -2,7 +2,7 @@
 title: 1.11.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 39
+nav_order: 41
 ---
 
 # 1.11.1：Windows の npm-global 版で起動するように

--- a/docs/guide/ja/v1.12.0.md
+++ b/docs/guide/ja/v1.12.0.md
@@ -2,7 +2,7 @@
 title: 1.12.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 38
+nav_order: 40
 ---
 
 # 1.12.0 で直ったこと

--- a/docs/guide/ja/v1.7.1.md
+++ b/docs/guide/ja/v1.7.1.md
@@ -2,7 +2,7 @@
 title: 1.7.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 47
+nav_order: 49
 ---
 
 # 1.7.1：グリッドのセッション一覧とホイールスクロールの回帰修正

--- a/docs/guide/ja/v1.7.2.md
+++ b/docs/guide/ja/v1.7.2.md
@@ -2,7 +2,7 @@
 title: 1.7.2 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 46
+nav_order: 48
 ---
 
 # 1.7.2：worktree 作成が固まる問題ほか

--- a/docs/guide/ja/v1.8.0.md
+++ b/docs/guide/ja/v1.8.0.md
@@ -2,7 +2,7 @@
 title: 1.8.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 45
+nav_order: 47
 ---
 
 # 1.8.0：Enter の挙動を設定できるようになりました

--- a/docs/guide/ja/v1.9.0.md
+++ b/docs/guide/ja/v1.9.0.md
@@ -2,7 +2,7 @@
 title: 1.9.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 44
+nav_order: 46
 ---
 
 # 1.9.0：スマホにセッションの素性が届くように

--- a/docs/guide/ja/v1.9.1.md
+++ b/docs/guide/ja/v1.9.1.md
@@ -2,7 +2,7 @@
 title: 1.9.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 43
+nav_order: 45
 ---
 
 # 1.9.1：Windows でセッションが起動、ターミナルのリンクが復活

--- a/docs/guide/ja/v1.9.2.md
+++ b/docs/guide/ja/v1.9.2.md
@@ -2,7 +2,7 @@
 title: 1.9.2 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 42
+nav_order: 44
 ---
 
 # 1.9.2：Windows の npm-global インストールでも起動

--- a/docs/guide/ja/v2.0.0.md
+++ b/docs/guide/ja/v2.0.0.md
@@ -2,7 +2,7 @@
 title: 2.0.0 の新機能ガイド
 layout: default
 parent: 日本語
-nav_order: 37
+nav_order: 39
 ---
 
 # 2.0.0 で入った機能の使い方

--- a/docs/guide/ja/v2.1.0.md
+++ b/docs/guide/ja/v2.1.0.md
@@ -2,7 +2,7 @@
 title: 2.1.0 の新機能ガイド
 layout: default
 parent: 日本語
-nav_order: 36
+nav_order: 38
 ---
 
 # 2.1.0 で入った機能の使い方

--- a/docs/guide/ja/v2.1.1.md
+++ b/docs/guide/ja/v2.1.1.md
@@ -2,7 +2,7 @@
 title: 2.1.1 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 35
+nav_order: 37
 ---
 
 # 2.1.1 で変わったこと

--- a/docs/guide/ja/v2.2.0.md
+++ b/docs/guide/ja/v2.2.0.md
@@ -2,7 +2,7 @@
 title: 2.2.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 34
+nav_order: 36
 ---
 
 # 2.2.0 で変わったこと

--- a/docs/guide/ja/v2.3.0.md
+++ b/docs/guide/ja/v2.3.0.md
@@ -2,7 +2,7 @@
 title: 2.3.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 33
+nav_order: 35
 ---
 
 # 2.3.0 で変わったこと

--- a/docs/guide/ja/v2.4.0.md
+++ b/docs/guide/ja/v2.4.0.md
@@ -2,7 +2,7 @@
 title: 2.4.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 32
+nav_order: 34
 ---
 
 # 2.4.0 で変わったこと

--- a/docs/guide/ja/v2.5.0.md
+++ b/docs/guide/ja/v2.5.0.md
@@ -2,7 +2,7 @@
 title: 2.5.0 の変更点
 layout: default
 parent: 日本語
-nav_order: 31
+nav_order: 33
 ---
 
 # 2.5.0 の変更点

--- a/docs/guide/ja/v2.5.1.md
+++ b/docs/guide/ja/v2.5.1.md
@@ -2,7 +2,7 @@
 title: 2.5.1 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 30
+nav_order: 32
 ---
 
 # 2.5.1 で変わったこと

--- a/docs/guide/ja/v2.5.2.md
+++ b/docs/guide/ja/v2.5.2.md
@@ -2,7 +2,7 @@
 title: 2.5.2 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 29
+nav_order: 31
 ---
 
 # 2.5.2 で変わったこと

--- a/docs/guide/ja/v2.5.3.md
+++ b/docs/guide/ja/v2.5.3.md
@@ -2,7 +2,7 @@
 title: 2.5.3 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 28
+nav_order: 30
 ---
 
 # 2.5.3 で変わったこと

--- a/docs/guide/ja/v2.6.0.md
+++ b/docs/guide/ja/v2.6.0.md
@@ -2,7 +2,7 @@
 title: 2.6.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 27
+nav_order: 29
 ---
 
 # 2.6.0 で変わったこと

--- a/docs/guide/ja/v2.7.0.md
+++ b/docs/guide/ja/v2.7.0.md
@@ -2,7 +2,7 @@
 title: 2.7.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 26
+nav_order: 28
 ---
 
 # 2.7.0 で変わったこと

--- a/docs/guide/ja/v2.8.0.md
+++ b/docs/guide/ja/v2.8.0.md
@@ -2,7 +2,7 @@
 title: 2.8.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 25
+nav_order: 27
 ---
 
 # 2.8.0 で変わったこと

--- a/docs/guide/ja/v2.9.0.md
+++ b/docs/guide/ja/v2.9.0.md
@@ -2,7 +2,7 @@
 title: 2.9.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 24
+nav_order: 26
 ---
 
 # 2.9.0 で変わったこと

--- a/docs/guide/ja/v2.9.1.md
+++ b/docs/guide/ja/v2.9.1.md
@@ -2,7 +2,7 @@
 title: 2.9.1 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 23
+nav_order: 25
 ---
 
 # 2.9.1 で変わったこと

--- a/docs/guide/ja/v3.0.0.md
+++ b/docs/guide/ja/v3.0.0.md
@@ -2,7 +2,7 @@
 title: 3.0.0 — issue から始める
 layout: default
 parent: 日本語
-nav_order: 22
+nav_order: 24
 description: MulmoTerminal 3.0.0 のセットアップガイド。issue の行のボタンを1つ押すと、worktree と、issue が入力欄に入った Claude セッションが立ち上がる。
 ---
 

--- a/docs/guide/ja/v4.0.0.md
+++ b/docs/guide/ja/v4.0.0.md
@@ -2,7 +2,7 @@
 title: 4.0.0 — グリッドがアプリそのものに
 layout: default
 parent: 日本語
-nav_order: 21
+nav_order: 23
 description: MulmoTerminal 4.0.0 のセットアップガイド — 単一ターミナルビューを廃止し、代わりに Collections の入口を用意。worktree は 1 つのエージェントセッションだけを持つようになりました。
 ---
 

--- a/docs/guide/ja/v4.1.0.md
+++ b/docs/guide/ja/v4.1.0.md
@@ -2,7 +2,7 @@
 title: 4.1.0 — PRs & Issues が GitLab を読む
 layout: default
 parent: 日本語
-nav_order: 20
+nav_order: 22
 description: MulmoTerminal 4.1.0 のセットアップガイド。prRepos に GitLab のプロジェクトを書くと、MR と issue が GitHub のものと並んで出て、着手も同じ1クリック。
 ---
 

--- a/docs/guide/ja/v4.1.1.md
+++ b/docs/guide/ja/v4.1.1.md
@@ -2,7 +2,7 @@
 title: 4.1.1 — usage が n/a のままにならない、スマホで300行さかのぼれる
 layout: default
 parent: 日本語
-nav_order: 19
+nav_order: 21
 description: MulmoTerminal 4.1.1 のセットアップガイド — ヘッダーの usage が遅いマシンで n/a に張り付く問題を修正、スマホのターミナルが300行の履歴を返すように、GitLab の worktree でも PR pill と Open PR が動くように。
 ---
 

--- a/docs/guide/ja/v4.2.0.md
+++ b/docs/guide/ja/v4.2.0.md
@@ -2,7 +2,7 @@
 title: 4.2.0 — セルフホストの GitLab、端末いっぱいに広がるペイン、色を引き継ぐ worktree
 layout: default
 parent: 日本語
-nav_order: 18
+nav_order: 20
 description: MulmoTerminal 4.2.0 のセットアップガイド — セルフホストの GitLab を gitlabHosts で宣言する、Canvas と Tools を端末領域いっぱいに広げる、worktree がプロジェクトの設定を引き継ぐ、打鍵で直る端末。
 ---
 

--- a/docs/guide/ja/v4.3.0.md
+++ b/docs/guide/ja/v4.3.0.md
@@ -2,7 +2,7 @@
 title: 4.3.0 — ワークスペースがひとつの場所になり、Enter が変換確定に戻る
 layout: default
 parent: 日本語
-nav_order: 17
+nav_order: 19
 description: MulmoTerminal 4.3.0 のセットアップガイド — ワークスペースならどの起動方法でも同じ GUI ツールに届く、ランチャーが常にワークスペースを出す、GUI MCP のサーバー ID が mt になった、IME の変換確定 Enter が食われなくなった。
 ---
 

--- a/docs/guide/ja/v4.3.1.md
+++ b/docs/guide/ja/v4.3.1.md
@@ -2,7 +2,7 @@
 title: 4.3.1 — ワークスペースのチップが WORKSPACE と名乗る
 layout: default
 parent: 日本語
-nav_order: 16
+nav_order: 18
 description: MulmoTerminal 4.3.1 のセットアップガイド — ランチャーのワークスペースチップがフォルダ名ではなく役割名で名乗るようになり、git チップがタブに戻ったときに更新されるようになった。
 ---
 

--- a/docs/guide/ja/v4.4.0.md
+++ b/docs/guide/ja/v4.4.0.md
@@ -2,7 +2,7 @@
 title: 4.4.0 — セルごとにペインを覚え、Canvas がファイルを自分で開く
 layout: default
 parent: 日本語
-nav_order: 15
+nav_order: 17
 description: MulmoTerminal 4.4.0 のセットアップガイド — 右ペインがセルごとになり、Files ペインからエージェント抜きでドキュメントやストーリーを Canvas に開けるようになり、ワークスペースで claude.ai のコネクタが使えるようになり、セッション一覧が transcript を毎回全部読むのをやめた。
 ---
 

--- a/docs/guide/ja/v4.5.0.md
+++ b/docs/guide/ja/v4.5.0.md
@@ -2,7 +2,7 @@
 title: 4.5.0 — repo.json、worktree ごとのポート、Grok、そして触れるようになった設定
 layout: default
 parent: 日本語
-nav_order: 14
+nav_order: 16
 description: MulmoTerminal 4.5.0 のセットアップガイド — repo.json（リポジトリ自身のアイコンと色）、git worktree ごとの dev サーバのポートと DB 名、Agent Picker に加わった Grok、JSON 手書きでしか触れなかった設定。2026-08-05 のスナップショット。
 ---
 


### PR DESCRIPTION
## Summary

The sidebar read **4.5.0 → 用語集 → 4.4.0**. The cause is a `nav_order` collision, not a sort bug.

The reference pages occupy **1–15** (`claude-ollama` = 14, `glossary` = 15), but the version pages
started at **14**, so:

| nav_order | pages sharing it |
|---|---|
| 14 | `claude-ollama.md` and `v4.5.0.md` |
| 15 | `glossary.md` and `v4.4.0.md` |

just-the-docs breaks a tie by title, which is what interleaved the glossary between two release
pages. This shifts every `docs/guide/*/v*.md` down by 2 so the version block starts at **16**.

After: both languages are **49 pages, 1–49, no duplicates, no gaps** — verified by enumerating the
files rather than from a typed list, per the rule in CLAUDE.md.

```
13  Open-source alternatives / 他の選択肢との比較
14  Local models with claude-ollama
15  Glossary / 用語集
16  4.5.0
17  4.4.0
18  4.3.1
```

## Items to Confirm / Review

- **The next release now takes 16**, and everything below shifts by one — the existing rule, except
  that 14 and 15 were never free to begin with. Nothing enforces this: there is no test over
  `nav_order`, and a collision produces no error, just a quietly wrong sidebar. Happy to add a spec
  pinning uniqueness across the guide if you want it — that would be a code change, so it is not in
  this PR.
- Front matter only; no prose, no links, no images touched.

## User Prompt

> 4.5.0 用語集 4.4.0という順になっている、サイドメニュー。

## Verification

`docs/guide/{en,ja}/*.md` enumerated by glob, filtered to pages carrying `parent: English` /
`parent: 日本語`: 49 each, contiguous 1–49, zero duplicates.

Docs-only diff, so per CLAUDE.md this does not wait on CI or bots.

work in mulmoterminal4