### PR TITLE
docs: give the release guides their own nav_order range (1000+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,10 +203,14 @@ procedure: open this file, paste this, restart what, how to tell it worked, what
 
 - **Both languages**, and `nav_order` must be a **unique** sequence running **newest release
   first** — ordered by release date, not by version number sorted as text, so 1.11.1 sits above
-  1.11.0. A new release takes the lowest free number and everything below shifts down by one.
-  When renumbering, **enumerate `docs/guide/*/v*.md` rather than typing the list out**: a
-  hand-typed list has silently dropped a page, and the check written from the same list agreed
-  with it, so nothing caught the duplicate until review did.
+  1.11.0. **Release pages live in the 1000s** (`1001` is the newest); the reference guide keeps
+  the small numbers and grows into the space between. A new release takes `1001` and every older
+  page shifts down by one. The two ranges are far apart because they used to collide: the guide
+  had reached `claude-ollama` = 14 and `glossary` = 15 while releases started at 14, and
+  just-the-docs breaks a tie by title, so the sidebar quietly read 4.5.0 / glossary / 4.4.0 with
+  nothing erroring. When renumbering, **enumerate `docs/guide/*/v*.md` rather than typing the list
+  out**: a hand-typed list has silently dropped a page, and the check written from the same list
+  agreed with it, so nothing caught the duplicate until review did.
 - **State the date in the first line and call it a snapshot.** These pages *will* go stale — that
   is accepted, and the date is what makes a stale one readable rather than misleading. Never
   edit an old one to match new behaviour; write the next version's page instead.

--- a/docs/guide/en/v1.10.0.md
+++ b/docs/guide/en/v1.10.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.10.0
 layout: default
 parent: English
-nav_order: 43
+nav_order: 1028
 ---
 
 # 1.10.0: your `.env` is read now

--- a/docs/guide/en/v1.11.0.md
+++ b/docs/guide/en/v1.11.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.11.0
 layout: default
 parent: English
-nav_order: 42
+nav_order: 1027
 ---
 
 # 1.11.0: clicking a file path got smarter

--- a/docs/guide/en/v1.11.1.md
+++ b/docs/guide/en/v1.11.1.md
@@ -2,7 +2,7 @@
 title: What 1.11.1 fixed
 layout: default
 parent: English
-nav_order: 41
+nav_order: 1026
 ---
 
 # 1.11.1: sessions start on an npm-global Claude Code (Windows)

--- a/docs/guide/en/v1.12.0.md
+++ b/docs/guide/en/v1.12.0.md
@@ -2,7 +2,7 @@
 title: What 1.12.0 fixed
 layout: default
 parent: English
-nav_order: 40
+nav_order: 1025
 ---
 
 # What 1.12.0 fixed

--- a/docs/guide/en/v1.7.1.md
+++ b/docs/guide/en/v1.7.1.md
@@ -2,7 +2,7 @@
 title: What 1.7.1 fixed
 layout: default
 parent: English
-nav_order: 49
+nav_order: 1034
 ---
 
 # 1.7.1: grid session list and wheel scrolling

--- a/docs/guide/en/v1.7.2.md
+++ b/docs/guide/en/v1.7.2.md
@@ -2,7 +2,7 @@
 title: What 1.7.2 fixed
 layout: default
 parent: English
-nav_order: 48
+nav_order: 1033
 ---
 
 # 1.7.2: worktree creation could hang

--- a/docs/guide/en/v1.8.0.md
+++ b/docs/guide/en/v1.8.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.8.0
 layout: default
 parent: English
-nav_order: 47
+nav_order: 1032
 ---
 
 # 1.8.0: Enter's behaviour is configurable

--- a/docs/guide/en/v1.9.0.md
+++ b/docs/guide/en/v1.9.0.md
@@ -2,7 +2,7 @@
 title: What's new in 1.9.0
 layout: default
 parent: English
-nav_order: 46
+nav_order: 1031
 ---
 
 # 1.9.0: the phone gets each session's identity

--- a/docs/guide/en/v1.9.1.md
+++ b/docs/guide/en/v1.9.1.md
@@ -2,7 +2,7 @@
 title: What's new in 1.9.1
 layout: default
 parent: English
-nav_order: 45
+nav_order: 1030
 ---
 
 # 1.9.1: Windows sessions start, terminal links work

--- a/docs/guide/en/v1.9.2.md
+++ b/docs/guide/en/v1.9.2.md
@@ -2,7 +2,7 @@
 title: What 1.9.2 fixed
 layout: default
 parent: English
-nav_order: 44
+nav_order: 1029
 ---
 
 # 1.9.2: npm-global installs spawn too (Windows)

--- a/docs/guide/en/v2.0.0.md
+++ b/docs/guide/en/v2.0.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.0.0
 layout: default
 parent: English
-nav_order: 39
+nav_order: 1024
 ---
 
 # Using what 2.0.0 added

--- a/docs/guide/en/v2.1.0.md
+++ b/docs/guide/en/v2.1.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.1.0
 layout: default
 parent: English
-nav_order: 38
+nav_order: 1023
 ---
 
 # Using what 2.1.0 added

--- a/docs/guide/en/v2.1.1.md
+++ b/docs/guide/en/v2.1.1.md
@@ -2,7 +2,7 @@
 title: What's new in 2.1.1
 layout: default
 parent: English
-nav_order: 37
+nav_order: 1022
 ---
 
 # What changed in 2.1.1

--- a/docs/guide/en/v2.2.0.md
+++ b/docs/guide/en/v2.2.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.2.0
 layout: default
 parent: English
-nav_order: 36
+nav_order: 1021
 ---
 
 # What changed in 2.2.0

--- a/docs/guide/en/v2.3.0.md
+++ b/docs/guide/en/v2.3.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.3.0
 layout: default
 parent: English
-nav_order: 35
+nav_order: 1020
 ---
 
 # What changed in 2.3.0

--- a/docs/guide/en/v2.4.0.md
+++ b/docs/guide/en/v2.4.0.md
@@ -2,7 +2,7 @@
 title: What's new in 2.4.0
 layout: default
 parent: English
-nav_order: 34
+nav_order: 1019
 ---
 
 # What changed in 2.4.0

--- a/docs/guide/en/v2.5.0.md
+++ b/docs/guide/en/v2.5.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.0
 layout: default
 parent: English
-nav_order: 33
+nav_order: 1018
 ---
 
 # What changed in 2.5.0

--- a/docs/guide/en/v2.5.1.md
+++ b/docs/guide/en/v2.5.1.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.1
 layout: default
 parent: English
-nav_order: 32
+nav_order: 1017
 ---
 
 # What changed in 2.5.1

--- a/docs/guide/en/v2.5.2.md
+++ b/docs/guide/en/v2.5.2.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.2
 layout: default
 parent: English
-nav_order: 31
+nav_order: 1016
 ---
 
 # What changed in 2.5.2

--- a/docs/guide/en/v2.5.3.md
+++ b/docs/guide/en/v2.5.3.md
@@ -2,7 +2,7 @@
 title: What changed in 2.5.3
 layout: default
 parent: English
-nav_order: 30
+nav_order: 1015
 ---
 
 # What changed in 2.5.3

--- a/docs/guide/en/v2.6.0.md
+++ b/docs/guide/en/v2.6.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.6.0
 layout: default
 parent: English
-nav_order: 29
+nav_order: 1014
 ---
 
 # What changed in 2.6.0

--- a/docs/guide/en/v2.7.0.md
+++ b/docs/guide/en/v2.7.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.7.0
 layout: default
 parent: English
-nav_order: 28
+nav_order: 1013
 ---
 
 # What changed in 2.7.0

--- a/docs/guide/en/v2.8.0.md
+++ b/docs/guide/en/v2.8.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.8.0
 layout: default
 parent: English
-nav_order: 27
+nav_order: 1012
 ---
 
 # What changed in 2.8.0

--- a/docs/guide/en/v2.9.0.md
+++ b/docs/guide/en/v2.9.0.md
@@ -2,7 +2,7 @@
 title: What changed in 2.9.0
 layout: default
 parent: English
-nav_order: 26
+nav_order: 1011
 ---
 
 # What changed in 2.9.0

--- a/docs/guide/en/v2.9.1.md
+++ b/docs/guide/en/v2.9.1.md
@@ -2,7 +2,7 @@
 title: What changed in 2.9.1
 layout: default
 parent: English
-nav_order: 25
+nav_order: 1010
 ---
 
 # What changed in 2.9.1

--- a/docs/guide/en/v3.0.0.md
+++ b/docs/guide/en/v3.0.0.md
@@ -2,7 +2,7 @@
 title: 3.0.0 — start from the issue
 layout: default
 parent: English
-nav_order: 24
+nav_order: 1009
 description: Setup guide for MulmoTerminal 3.0.0 — press one button on an issue row and get a worktree plus a Claude session with the issue already in its input box.
 ---
 

--- a/docs/guide/en/v4.0.0.md
+++ b/docs/guide/en/v4.0.0.md
@@ -2,7 +2,7 @@
 title: 4.0.0 — the grid is the app
 layout: default
 parent: English
-nav_order: 23
+nav_order: 1008
 description: Setup guide for MulmoTerminal 4.0.0 — the single terminal view is removed, the Collections door replaces it, and a worktree now runs exactly one agent session.
 ---
 

--- a/docs/guide/en/v4.1.0.md
+++ b/docs/guide/en/v4.1.0.md
@@ -2,7 +2,7 @@
 title: 4.1.0 — GitLab in the PRs & Issues view
 layout: default
 parent: English
-nav_order: 22
+nav_order: 1007
 description: Setup guide for MulmoTerminal 4.1.0 — put a GitLab project in prRepos and its merge requests and issues appear beside your GitHub ones, with the same one-click start.
 ---
 

--- a/docs/guide/en/v4.1.1.md
+++ b/docs/guide/en/v4.1.1.md
@@ -2,7 +2,7 @@
 title: 4.1.1 — Usage that stops saying n/a, and 300 lines of scrollback on the phone
 layout: default
 parent: English
-nav_order: 21
+nav_order: 1006
 description: Setup guide for MulmoTerminal 4.1.1 — the header's usage figure stops sticking at n/a on slow machines, the phone's terminal shows 300 lines of history, and GitLab worktrees get the PR pill and the Open PR button.
 ---
 

--- a/docs/guide/en/v4.2.0.md
+++ b/docs/guide/en/v4.2.0.md
@@ -2,7 +2,7 @@
 title: 4.2.0 — Self-hosted GitLab, panes that take the whole terminal, and worktrees that keep their colours
 layout: default
 parent: English
-nav_order: 20
+nav_order: 1005
 description: Setup guide for MulmoTerminal 4.2.0 — declaring a self-hosted GitLab in gitlabHosts, expanding the Canvas and Tools panes over the terminal, worktrees that inherit their project's settings, and a terminal that repairs itself as you type.
 ---
 

--- a/docs/guide/en/v4.3.0.md
+++ b/docs/guide/en/v4.3.0.md
@@ -2,7 +2,7 @@
 title: 4.3.0 — The workspace is one place, and an Enter that means 変換
 layout: default
 parent: English
-nav_order: 19
+nav_order: 1004
 description: Setup guide for MulmoTerminal 4.3.0 — the workspace reaches the same GUI tools however you start a terminal there, the launcher always offers it, the GUI MCP server id is now mt, and an IME's confirming Enter is no longer eaten.
 ---
 

--- a/docs/guide/en/v4.3.1.md
+++ b/docs/guide/en/v4.3.1.md
@@ -2,7 +2,7 @@
 title: 4.3.1 — The workspace chip says WORKSPACE
 layout: default
 parent: English
-nav_order: 18
+nav_order: 1003
 description: Setup guide for MulmoTerminal 4.3.1 — the launcher's workspace chip is labelled by its role rather than its folder name, and the git chip refreshes when you come back to the tab.
 ---
 

--- a/docs/guide/en/v4.4.0.md
+++ b/docs/guide/en/v4.4.0.md
@@ -2,7 +2,7 @@
 title: 4.4.0 — Every cell keeps its own pane, and the Canvas opens a file on its own
 layout: default
 parent: English
-nav_order: 17
+nav_order: 1002
 description: Setup guide for MulmoTerminal 4.4.0 — each cell remembers its own right pane, the Files pane can open a document or a story in the Canvas without an agent, your claude.ai connectors work in the workspace again, and the session list stops re-reading whole transcripts.
 ---
 

--- a/docs/guide/en/v4.5.0.md
+++ b/docs/guide/en/v4.5.0.md
@@ -2,7 +2,7 @@
 title: 4.5.0 — repo.json, a port per worktree, Grok, and settings you can reach
 layout: default
 parent: English
-nav_order: 16
+nav_order: 1001
 description: Setting up what 4.5.0 shipped — repo.json (a repository's own icon and colour), a dev-server port and database name per git worktree, Grok in the Agent Picker, and the settings that used to need hand-edited JSON. Written 2026-08-05.
 ---
 

--- a/docs/guide/ja/v1.10.0.md
+++ b/docs/guide/ja/v1.10.0.md
@@ -2,7 +2,7 @@
 title: 1.10.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 43
+nav_order: 1028
 ---
 
 # 1.10.0：`.env` が読まれるようになりました

--- a/docs/guide/ja/v1.11.0.md
+++ b/docs/guide/ja/v1.11.0.md
@@ -2,7 +2,7 @@
 title: 1.11.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 42
+nav_order: 1027
 ---
 
 # 1.11.0：ファイルパスのクリックが賢くなりました

--- a/docs/guide/ja/v1.11.1.md
+++ b/docs/guide/ja/v1.11.1.md
@@ -2,7 +2,7 @@
 title: 1.11.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 41
+nav_order: 1026
 ---
 
 # 1.11.1：Windows の npm-global 版で起動するように

--- a/docs/guide/ja/v1.12.0.md
+++ b/docs/guide/ja/v1.12.0.md
@@ -2,7 +2,7 @@
 title: 1.12.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 40
+nav_order: 1025
 ---
 
 # 1.12.0 で直ったこと

--- a/docs/guide/ja/v1.7.1.md
+++ b/docs/guide/ja/v1.7.1.md
@@ -2,7 +2,7 @@
 title: 1.7.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 49
+nav_order: 1034
 ---
 
 # 1.7.1：グリッドのセッション一覧とホイールスクロールの回帰修正

--- a/docs/guide/ja/v1.7.2.md
+++ b/docs/guide/ja/v1.7.2.md
@@ -2,7 +2,7 @@
 title: 1.7.2 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 48
+nav_order: 1033
 ---
 
 # 1.7.2：worktree 作成が固まる問題ほか

--- a/docs/guide/ja/v1.8.0.md
+++ b/docs/guide/ja/v1.8.0.md
@@ -2,7 +2,7 @@
 title: 1.8.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 47
+nav_order: 1032
 ---
 
 # 1.8.0：Enter の挙動を設定できるようになりました

--- a/docs/guide/ja/v1.9.0.md
+++ b/docs/guide/ja/v1.9.0.md
@@ -2,7 +2,7 @@
 title: 1.9.0 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 46
+nav_order: 1031
 ---
 
 # 1.9.0：スマホにセッションの素性が届くように

--- a/docs/guide/ja/v1.9.1.md
+++ b/docs/guide/ja/v1.9.1.md
@@ -2,7 +2,7 @@
 title: 1.9.1 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 45
+nav_order: 1030
 ---
 
 # 1.9.1：Windows でセッションが起動、ターミナルのリンクが復活

--- a/docs/guide/ja/v1.9.2.md
+++ b/docs/guide/ja/v1.9.2.md
@@ -2,7 +2,7 @@
 title: 1.9.2 の更新ガイド
 layout: default
 parent: 日本語
-nav_order: 44
+nav_order: 1029
 ---
 
 # 1.9.2：Windows の npm-global インストールでも起動

--- a/docs/guide/ja/v2.0.0.md
+++ b/docs/guide/ja/v2.0.0.md
@@ -2,7 +2,7 @@
 title: 2.0.0 の新機能ガイド
 layout: default
 parent: 日本語
-nav_order: 39
+nav_order: 1024
 ---
 
 # 2.0.0 で入った機能の使い方

--- a/docs/guide/ja/v2.1.0.md
+++ b/docs/guide/ja/v2.1.0.md
@@ -2,7 +2,7 @@
 title: 2.1.0 の新機能ガイド
 layout: default
 parent: 日本語
-nav_order: 38
+nav_order: 1023
 ---
 
 # 2.1.0 で入った機能の使い方

--- a/docs/guide/ja/v2.1.1.md
+++ b/docs/guide/ja/v2.1.1.md
@@ -2,7 +2,7 @@
 title: 2.1.1 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 37
+nav_order: 1022
 ---
 
 # 2.1.1 で変わったこと

--- a/docs/guide/ja/v2.2.0.md
+++ b/docs/guide/ja/v2.2.0.md
@@ -2,7 +2,7 @@
 title: 2.2.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 36
+nav_order: 1021
 ---
 
 # 2.2.0 で変わったこと

--- a/docs/guide/ja/v2.3.0.md
+++ b/docs/guide/ja/v2.3.0.md
@@ -2,7 +2,7 @@
 title: 2.3.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 35
+nav_order: 1020
 ---
 
 # 2.3.0 で変わったこと

--- a/docs/guide/ja/v2.4.0.md
+++ b/docs/guide/ja/v2.4.0.md
@@ -2,7 +2,7 @@
 title: 2.4.0 の変更ガイド
 layout: default
 parent: 日本語
-nav_order: 34
+nav_order: 1019
 ---
 
 # 2.4.0 で変わったこと

--- a/docs/guide/ja/v2.5.0.md
+++ b/docs/guide/ja/v2.5.0.md
@@ -2,7 +2,7 @@
 title: 2.5.0 の変更点
 layout: default
 parent: 日本語
-nav_order: 33
+nav_order: 1018
 ---
 
 # 2.5.0 の変更点

--- a/docs/guide/ja/v2.5.1.md
+++ b/docs/guide/ja/v2.5.1.md
@@ -2,7 +2,7 @@
 title: 2.5.1 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 32
+nav_order: 1017
 ---
 
 # 2.5.1 で変わったこと

--- a/docs/guide/ja/v2.5.2.md
+++ b/docs/guide/ja/v2.5.2.md
@@ -2,7 +2,7 @@
 title: 2.5.2 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 31
+nav_order: 1016
 ---
 
 # 2.5.2 で変わったこと

--- a/docs/guide/ja/v2.5.3.md
+++ b/docs/guide/ja/v2.5.3.md
@@ -2,7 +2,7 @@
 title: 2.5.3 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 30
+nav_order: 1015
 ---
 
 # 2.5.3 で変わったこと

--- a/docs/guide/ja/v2.6.0.md
+++ b/docs/guide/ja/v2.6.0.md
@@ -2,7 +2,7 @@
 title: 2.6.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 29
+nav_order: 1014
 ---
 
 # 2.6.0 で変わったこと

--- a/docs/guide/ja/v2.7.0.md
+++ b/docs/guide/ja/v2.7.0.md
@@ -2,7 +2,7 @@
 title: 2.7.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 28
+nav_order: 1013
 ---
 
 # 2.7.0 で変わったこと

--- a/docs/guide/ja/v2.8.0.md
+++ b/docs/guide/ja/v2.8.0.md
@@ -2,7 +2,7 @@
 title: 2.8.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 27
+nav_order: 1012
 ---
 
 # 2.8.0 で変わったこと

--- a/docs/guide/ja/v2.9.0.md
+++ b/docs/guide/ja/v2.9.0.md
@@ -2,7 +2,7 @@
 title: 2.9.0 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 26
+nav_order: 1011
 ---
 
 # 2.9.0 で変わったこと

--- a/docs/guide/ja/v2.9.1.md
+++ b/docs/guide/ja/v2.9.1.md
@@ -2,7 +2,7 @@
 title: 2.9.1 で変わったこと
 layout: default
 parent: 日本語
-nav_order: 25
+nav_order: 1010
 ---
 
 # 2.9.1 で変わったこと

--- a/docs/guide/ja/v3.0.0.md
+++ b/docs/guide/ja/v3.0.0.md
@@ -2,7 +2,7 @@
 title: 3.0.0 — issue から始める
 layout: default
 parent: 日本語
-nav_order: 24
+nav_order: 1009
 description: MulmoTerminal 3.0.0 のセットアップガイド。issue の行のボタンを1つ押すと、worktree と、issue が入力欄に入った Claude セッションが立ち上がる。
 ---
 

--- a/docs/guide/ja/v4.0.0.md
+++ b/docs/guide/ja/v4.0.0.md
@@ -2,7 +2,7 @@
 title: 4.0.0 — グリッドがアプリそのものに
 layout: default
 parent: 日本語
-nav_order: 23
+nav_order: 1008
 description: MulmoTerminal 4.0.0 のセットアップガイド — 単一ターミナルビューを廃止し、代わりに Collections の入口を用意。worktree は 1 つのエージェントセッションだけを持つようになりました。
 ---
 

--- a/docs/guide/ja/v4.1.0.md
+++ b/docs/guide/ja/v4.1.0.md
@@ -2,7 +2,7 @@
 title: 4.1.0 — PRs & Issues が GitLab を読む
 layout: default
 parent: 日本語
-nav_order: 22
+nav_order: 1007
 description: MulmoTerminal 4.1.0 のセットアップガイド。prRepos に GitLab のプロジェクトを書くと、MR と issue が GitHub のものと並んで出て、着手も同じ1クリック。
 ---
 

--- a/docs/guide/ja/v4.1.1.md
+++ b/docs/guide/ja/v4.1.1.md
@@ -2,7 +2,7 @@
 title: 4.1.1 — usage が n/a のままにならない、スマホで300行さかのぼれる
 layout: default
 parent: 日本語
-nav_order: 21
+nav_order: 1006
 description: MulmoTerminal 4.1.1 のセットアップガイド — ヘッダーの usage が遅いマシンで n/a に張り付く問題を修正、スマホのターミナルが300行の履歴を返すように、GitLab の worktree でも PR pill と Open PR が動くように。
 ---
 

--- a/docs/guide/ja/v4.2.0.md
+++ b/docs/guide/ja/v4.2.0.md
@@ -2,7 +2,7 @@
 title: 4.2.0 — セルフホストの GitLab、端末いっぱいに広がるペイン、色を引き継ぐ worktree
 layout: default
 parent: 日本語
-nav_order: 20
+nav_order: 1005
 description: MulmoTerminal 4.2.0 のセットアップガイド — セルフホストの GitLab を gitlabHosts で宣言する、Canvas と Tools を端末領域いっぱいに広げる、worktree がプロジェクトの設定を引き継ぐ、打鍵で直る端末。
 ---
 

--- a/docs/guide/ja/v4.3.0.md
+++ b/docs/guide/ja/v4.3.0.md
@@ -2,7 +2,7 @@
 title: 4.3.0 — ワークスペースがひとつの場所になり、Enter が変換確定に戻る
 layout: default
 parent: 日本語
-nav_order: 19
+nav_order: 1004
 description: MulmoTerminal 4.3.0 のセットアップガイド — ワークスペースならどの起動方法でも同じ GUI ツールに届く、ランチャーが常にワークスペースを出す、GUI MCP のサーバー ID が mt になった、IME の変換確定 Enter が食われなくなった。
 ---
 

--- a/docs/guide/ja/v4.3.1.md
+++ b/docs/guide/ja/v4.3.1.md
@@ -2,7 +2,7 @@
 title: 4.3.1 — ワークスペースのチップが WORKSPACE と名乗る
 layout: default
 parent: 日本語
-nav_order: 18
+nav_order: 1003
 description: MulmoTerminal 4.3.1 のセットアップガイド — ランチャーのワークスペースチップがフォルダ名ではなく役割名で名乗るようになり、git チップがタブに戻ったときに更新されるようになった。
 ---
 

--- a/docs/guide/ja/v4.4.0.md
+++ b/docs/guide/ja/v4.4.0.md
@@ -2,7 +2,7 @@
 title: 4.4.0 — セルごとにペインを覚え、Canvas がファイルを自分で開く
 layout: default
 parent: 日本語
-nav_order: 17
+nav_order: 1002
 description: MulmoTerminal 4.4.0 のセットアップガイド — 右ペインがセルごとになり、Files ペインからエージェント抜きでドキュメントやストーリーを Canvas に開けるようになり、ワークスペースで claude.ai のコネクタが使えるようになり、セッション一覧が transcript を毎回全部読むのをやめた。
 ---
 

--- a/docs/guide/ja/v4.5.0.md
+++ b/docs/guide/ja/v4.5.0.md
@@ -2,7 +2,7 @@
 title: 4.5.0 — repo.json、worktree ごとのポート、Grok、そして触れるようになった設定
 layout: default
 parent: 日本語
-nav_order: 16
+nav_order: 1001
 description: MulmoTerminal 4.5.0 のセットアップガイド — repo.json（リポジトリ自身のアイコンと色）、git worktree ごとの dev サーバのポートと DB 名、Agent Picker に加わった Grok、JSON 手書きでしか触れなかった設定。2026-08-05 のスナップショット。
 ---
 


### PR DESCRIPTION
## Summary

#1452 fixed the collision by shifting the release pages down by two — which works until the
reference guide grows two more pages and lands on them again. This separates the two ranges
instead, so they cannot meet.

| block | nav_order |
|---|---|
| reference guide (getting-started … glossary) | **1–15**, free to grow to 999 |
| release pages (newest first) | **1001** (4.5.0) … **1034** (1.7.1) |

A new release now takes `1001` and every older page shifts down by one, with no need to check what
the reference side has claimed.

`CLAUDE.md`'s publishing section is updated to state the new rule and why the ranges are far apart —
the old wording said "the lowest free number", which is exactly the instruction that produced the
collision.

## Items to Confirm / Review

- **Only the release pages moved.** Reference pages are untouched at 1–15.
- **Order within the release block is preserved exactly** — mapped arithmetically from the current
  numbers rather than re-derived from filenames, so no page could be reordered by a version string
  sorting as text.
- Still nothing *enforces* uniqueness; the ranges just make a collision much harder to reach by
  accident. A spec over `nav_order` is still available if you want one — code change, separate PR.

## User Prompt

> nav_order、release系は1000番台からとかしにておけば？

## Verification

Enumerated by glob, filtered to pages carrying `parent: English` / `parent: 日本語`:
**en** 15 reference (1–15) + 34 release (1001–1034), **ja** the same, duplicates none in either.

Docs-only diff, so per CLAUDE.md this does not wait on CI or bots.

work in mulmoterminal4