### PR TITLE
fix: let the new-terminal form use the cell's width

### DIFF
--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -441,7 +441,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
     >
       <span class="material-symbols-outlined" aria-hidden="true">close</span>
     </button>
-    <div v-if="chips.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
+    <div v-if="chips.length" class="flex w-full flex-wrap justify-center gap-1.5">
       <span
         v-for="p in chips"
         :key="p.label + p.path"
@@ -514,7 +514,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
          wrapped row is centred too rather than hanging off the left. -->
     <div
       data-testid="agent-picker"
-      class="inline-flex max-w-[360px] flex-wrap justify-center gap-0.5 rounded-[7px] border border-border bg-deep p-0.5"
+      class="inline-flex max-w-full flex-wrap justify-center gap-0.5 rounded-[7px] border border-border bg-deep p-0.5"
       role="radiogroup"
       aria-label="Agent picker — what this terminal runs"
     >
@@ -533,7 +533,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
         {{ option.label }}
       </button>
     </div>
-    <label class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+    <label class="flex w-full flex-col items-center gap-1.5">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
       <span class="flex w-full items-stretch gap-1.5">
         <input
@@ -593,7 +593,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
            would register a group URL with nothing left to serve: a control that does nothing.
            Asked of the AGENT as well as the directory — Antigravity in the workspace takes the
            `v-else` and gets the switches, because that is genuinely how it reaches any tool. -->
-      <div v-if="workspaceGivesEveryTool" data-testid="cell-mcp-all" class="flex w-full max-w-[360px] flex-col gap-0.5">
+      <div v-if="workspaceGivesEveryTool" data-testid="cell-mcp-all" class="flex w-full flex-col gap-0.5">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
         <span class="font-sans text-[11px] leading-snug text-secondary">
           <span class="material-symbols-outlined mr-[3px] align-middle text-[13px]" aria-hidden="true">workspaces</span>
@@ -605,7 +605,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
            A `template v-else` around the loop rather than `v-else` ON it: v-if and v-for on one
            element is the ambiguity eslint-plugin-vue forbids. -->
       <template v-else>
-        <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full max-w-[360px] items-center justify-between gap-2" :title="mcpGroupTitle(group)">
+        <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full items-center justify-between gap-2" :title="mcpGroupTitle(group)">
           <!-- The group is named, not just the feature: each switch registers ONE MCP server
            (`mulmoterminal-<group>`), so a heading alone would not say which of the four rows
            writes which server — and two of them share the heading "Canvas".
@@ -637,7 +637,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
     <div
       v-if="dirListsLoading"
       data-testid="cell-dir-loading"
-      class="flex w-full max-w-[360px] items-center justify-center gap-1.5 font-sans text-[11px] text-dim"
+      class="flex w-full items-center justify-center gap-1.5 font-sans text-[11px] text-dim"
       role="status"
     >
       <span class="material-symbols-outlined animate-spin text-[14px]" aria-hidden="true">progress_activity</span>
@@ -647,11 +647,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
          ONE codebase onto a branch; the workspace is the hub a session works FROM — the place the
          agent reads and writes shared state (wiki, collections, accounting), which is exactly what
          a detached branch would cut it off from. Offering it there is offering a mistake. -->
-    <div
-      v-if="worktreeList.isGit && launchesAgent && !inWorkspace"
-      data-testid="cell-worktrees"
-      class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5"
-    >
+    <div v-if="worktreeList.isGit && launchesAgent && !inWorkspace" data-testid="cell-worktrees" class="flex w-full flex-col items-stretch gap-1.5">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
       <!-- Said here rather than left to be inferred from a row that behaves differently each time:
            the one-session rule is why a row resumes instead of launching, and why one of them
@@ -710,7 +706,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
     </div>
     <LaunchChipList heading="or run a script" icon="play_arrow" :chips="scriptChips" @pick="runScript" />
     <LaunchChipList heading="or launch" icon="rocket_launch" :chips="launcherChips" @pick="launchProgram" />
-    <div v-if="resumable.sessions.length" data-testid="cell-resume" class="flex min-h-0 w-full max-w-[360px] flex-col items-center gap-1.5">
+    <div v-if="resumable.sessions.length" data-testid="cell-resume" class="flex min-h-0 w-full flex-col items-center gap-1.5">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or resume here</span>
       <div class="flex w-full flex-col gap-1">
         <button

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -507,11 +507,11 @@ async function removeWorktree(w: Worktree): Promise<void> {
         </button>
       </span>
     </div>
-    <!-- The AGENT PICKER. Centred like everything else in this column — the directory field, the
-         model picker and the chips above it all sit on the centre line, so a left-aligned toggle
-         was the one thing off it. Wraps rather than overflowing: four options do not fit one row
-         in a narrow cell, and the one that would fall off the edge is the last, Shell — so the
-         wrapped row is centred too rather than hanging off the left. -->
+    <!-- The AGENT PICKER is the one row that keeps its CONTENT width while the rest of the column
+         spans the cell: it is a segmented control, so stretching it would widen the pill's
+         background and fit nothing more into it. It still wraps rather than overflowing — the
+         options do not fit one row in a narrow cell — and the row that falls to the next line is
+         centred rather than hanging off the left. -->
     <div
       data-testid="agent-picker"
       class="inline-flex max-w-full flex-wrap justify-center gap-0.5 rounded-[7px] border border-border bg-deep p-0.5"

--- a/src/components/LaunchChipList.vue
+++ b/src/components/LaunchChipList.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{ (e: "pick", index: number): void }>();
 </script>
 
 <template>
-  <div v-if="chips.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+  <div v-if="chips.length" class="flex w-full flex-col items-center gap-1.5">
     <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">{{ heading }}</span>
     <div class="flex w-full flex-wrap justify-center gap-1.5">
       <button

--- a/src/components/ModelPicker.vue
+++ b/src/components/ModelPicker.vue
@@ -36,7 +36,7 @@ const selected = computed({
 </script>
 
 <template>
-  <div class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+  <div class="flex w-full flex-col items-center gap-1.5">
     <span class="flex w-full items-center justify-between">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Model</span>
       <button

--- a/test/src/components/launchFormWidth.spec.ts
+++ b/test/src/components/launchFormWidth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import CellLaunchForm from "../../../src/components/CellLaunchForm.vue";
 import LaunchChipList from "../../../src/components/LaunchChipList.vue";
 import ModelPicker from "../../../src/components/ModelPicker.vue";
@@ -16,16 +16,23 @@ const capsIn = (html: string): string[] => html.match(new RegExp(PIXEL_CAP, "g")
 
 describe("the launch form takes the cell's width", () => {
   beforeEach(() => {
+    // A worktree and a session, because their two rows render only once those fetches land — the
+    // form's initial DOM has neither, so asserting on it would quietly cover fewer rows than the
+    // test claims (CodeRabbit on #1455).
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);
-      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
-      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      if (u.includes("/api/worktrees"))
+        return {
+          ok: true,
+          json: async () => ({ isGit: true, base: "main", worktrees: [{ path: "/repo/../wt", branch: "fix-login", task: "fix-login", dirty: false }] }),
+        };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [{ id: "s1", title: "a session", mtime: 1 }] }) };
       return { ok: true, json: async () => ({}) };
     }) as unknown as typeof fetch;
   });
 
-  const mountForm = () =>
-    mount(CellLaunchForm, {
+  const mountForm = async () => {
+    const w = mount(CellLaunchForm, {
       props: {
         dir: "/repo",
         agent: "claude" as AgentPick,
@@ -35,17 +42,25 @@ describe("the launch form takes the cell's width", () => {
         openSessionIds: [],
       },
     });
+    await flushPromises();
+    return w;
+  };
 
-  it("caps no row at a fixed pixel width", () => {
-    const w = mountForm();
+  it("caps no row at a fixed pixel width", async () => {
+    const w = await mountForm();
     expect(capsIn(w.html())).toEqual([]);
   });
 
   // Every direct child spans the form, so the width the form is given is the width they get. The
   // agent picker is the one exception and stays content-sized: it is a segmented control, and
   // stretching it would widen the pill's background rather than fit anything into it.
-  it("gives every row the full width, and leaves the agent picker its own", () => {
-    const w = mountForm();
+  it("gives every row the full width, and leaves the agent picker its own", async () => {
+    const w = await mountForm();
+    // The two rows that arrive with the fetches, named so a fixture that stops producing them
+    // fails here rather than silently shrinking what the loop below walks.
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-resume"]').exists()).toBe(true);
+
     const rows = [...w.get('[data-testid="cell-launch"]').element.children].filter((el) => el.getAttribute("data-testid") !== "cell-launch-cancel");
     const picker = rows.find((el) => el.getAttribute("data-testid") === "agent-picker");
     // classList, not a substring of the class string: "max-w-full" contains "w-full".
@@ -62,7 +77,10 @@ describe("the launch form takes the cell's width", () => {
     expect(w.get("div").classes()).toContain("w-full");
   });
 
-  it("spans the width in the model picker", () => {
+  // The picker's WRAPPER is what this file is about — the row the form stacks. The `<select>` inside
+  // it takes its width from SELECT_CONTROL, which every select in the app shares, so pinning it from
+  // here would tie one launch-form test to a decision made for the whole app.
+  it("spans the width in the model picker's row", () => {
     const w = mount(ModelPicker, { props: { modelValue: null } });
     expect(capsIn(w.html())).toEqual([]);
     expect(w.get("div").classes()).toContain("w-full");

--- a/test/src/components/launchFormWidth.spec.ts
+++ b/test/src/components/launchFormWidth.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CellLaunchForm from "../../../src/components/CellLaunchForm.vue";
+import LaunchChipList from "../../../src/components/LaunchChipList.vue";
+import ModelPicker from "../../../src/components/ModelPicker.vue";
+import type { AgentPick } from "../../../common/customAgents";
+
+// The launch form's rows were each capped at a fixed pixel width, so an enlarged cell drew a narrow
+// centred column and left the rest empty — 25 chips wrapping into 20 rows inside 360px while the
+// cell was 1535px wide. Nothing pinned that cap, so nothing failed when it changed; this is the
+// guard, and it is written against ANY pixel cap rather than the one number that was there, because
+// re-introducing the shape is the regression, not re-introducing 360.
+const PIXEL_CAP = /max-w-\[\d+px\]/;
+
+const capsIn = (html: string): string[] => html.match(new RegExp(PIXEL_CAP, "g")) ?? [];
+
+describe("the launch form takes the cell's width", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  });
+
+  const mountForm = () =>
+    mount(CellLaunchForm, {
+      props: {
+        dir: "/repo",
+        agent: "claude" as AgentPick,
+        choice: null,
+        defaultCwd: "/home/me/ws",
+        presets: [{ label: "repo", path: "/repo" }],
+        openSessionIds: [],
+      },
+    });
+
+  it("caps no row at a fixed pixel width", () => {
+    const w = mountForm();
+    expect(capsIn(w.html())).toEqual([]);
+  });
+
+  // Every direct child spans the form, so the width the form is given is the width they get. The
+  // agent picker is the one exception and stays content-sized: it is a segmented control, and
+  // stretching it would widen the pill's background rather than fit anything into it.
+  it("gives every row the full width, and leaves the agent picker its own", () => {
+    const w = mountForm();
+    const rows = [...w.get('[data-testid="cell-launch"]').element.children].filter((el) => el.getAttribute("data-testid") !== "cell-launch-cancel");
+    const picker = rows.find((el) => el.getAttribute("data-testid") === "agent-picker");
+    // classList, not a substring of the class string: "max-w-full" contains "w-full".
+    expect([...(picker?.classList ?? [])]).toContain("max-w-full");
+    expect([...(picker?.classList ?? [])]).not.toContain("w-full");
+    rows.filter((el) => el !== picker).forEach((el) => expect([...el.classList]).toContain("w-full"));
+  });
+
+  it("spans the width in the chip lists it stacks", () => {
+    const w = mount(LaunchChipList, {
+      props: { heading: "or run a script", icon: "play_arrow", chips: [{ key: 0, label: "build", title: "yarn build" }] },
+    });
+    expect(capsIn(w.html())).toEqual([]);
+    expect(w.get("div").classes()).toContain("w-full");
+  });
+
+  it("spans the width in the model picker", () => {
+    const w = mount(ModelPicker, { props: { modelValue: null } });
+    expect(capsIn(w.html())).toEqual([]);
+    expect(w.get("div").classes()).toContain("w-full");
+  });
+});


### PR DESCRIPTION
## Summary

Every row of `CellLaunchForm` was capped at `max-w-[360px]`, so a wide cell rendered a narrow
centred column with the rest of the width unused. The chips are what actually suffers: **25 chips
wrapped into 20 rows inside 360px while the cell was 1535px wide.**

The cap is removed in the three components that shared it — `CellLaunchForm.vue` (6 rows + the chip
row), `LaunchChipList.vue`, `ModelPicker.vue`. Rows now span the cell and take their margin from the
form's own `p-4`.

One exception: the **agent picker** keeps its content width (`max-w-full` rather than `w-full`). It
is a segmented control, so stretching it would only widen the pill's background — the cap there
existed to decide *where it wraps*, which `max-w-full` still does in a narrow cell.

Measured against a running server at a 1600px viewport: chip row **360px → 1503px**, the same 25
chips fall into **4 rows instead of 20**.

## Items to Confirm / Review

Two controls now read oddly at extreme width, and I'd rather you judge them than pick for you:

- **The MCP toggle rows** are `justify-between`, so at 1535px the checkbox sits ~1500px from the
  label it belongs to. Functional, but a long way for the eye to travel.
- **The model `<select>`** now spans the full width, which is unusual for a dropdown.

If those bother you, the alternative is: chips and chip lists go edge-to-edge as they do here, and
the *input* controls (directory, model, MCP, worktree, resume) take a generous cap instead — much
wider than 360 but not full-bleed. Say the word and I'll push it.

Also worth noting: **no test pinned the 360px cap**, so nothing failed when it changed. The
verification below is a live measurement, not a spec.

## User Prompt

> 新規ターミナルの画面、横幅制限しているのでこんな感じ。paddingくらいだけとるようにして画面幅をもっと使いたい

(with a screenshot of the chips wrapping into a narrow centred column)

## Verification

- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn test` — 8479 passed. One failure
  in `test/server/backends/calendarPush.spec.ts` ("socket hang up"), which **passes on its own** and
  is a server-route spec untouched by this diff.
- Live check against `yarn dev`, on the **Vite** port rather than the Express one — the Express port
  serves a stale `dist/` and showed the old `max-w-[360px]` in the DOM after the source had already
  changed, which is exactly how a UI fix gets called broken.

work in mulmoterminal4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Launch form controls now use the full available width for a more flexible layout.
  * Chip lists and model selection no longer have a narrow fixed-width limit.
  * Agent selection preserves content-sized controls while wrapping as needed.
  * Worktree, resume, MCP, and working-directory sections now expand to fit available space.

* **Tests**
  * Added coverage to verify responsive, full-width launch form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->