### PR TITLE
fix: keep a width on the launch form's controls, not on its chips

### DIFF
--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -20,6 +20,7 @@ import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import LaunchChipList from "./LaunchChipList.vue";
 import ModelPicker from "./ModelPicker.vue";
+import { LAUNCH_ROW } from "./launchFormClasses";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
@@ -533,7 +534,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
         {{ option.label }}
       </button>
     </div>
-    <label class="flex w-full flex-col items-center gap-1.5">
+    <label class="flex flex-col items-center gap-1.5" :class="LAUNCH_ROW">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
       <span class="flex w-full items-stretch gap-1.5">
         <input
@@ -593,7 +594,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
            would register a group URL with nothing left to serve: a control that does nothing.
            Asked of the AGENT as well as the directory — Antigravity in the workspace takes the
            `v-else` and gets the switches, because that is genuinely how it reaches any tool. -->
-      <div v-if="workspaceGivesEveryTool" data-testid="cell-mcp-all" class="flex w-full flex-col gap-0.5">
+      <div v-if="workspaceGivesEveryTool" data-testid="cell-mcp-all" class="flex flex-col gap-0.5" :class="LAUNCH_ROW">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
         <span class="font-sans text-[11px] leading-snug text-secondary">
           <span class="material-symbols-outlined mr-[3px] align-middle text-[13px]" aria-hidden="true">workspaces</span>
@@ -605,7 +606,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
            A `template v-else` around the loop rather than `v-else` ON it: v-if and v-for on one
            element is the ambiguity eslint-plugin-vue forbids. -->
       <template v-else>
-        <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full items-center justify-between gap-2" :title="mcpGroupTitle(group)">
+        <label v-for="group in TOOL_GROUPS" :key="group" class="flex items-center justify-between gap-2" :class="LAUNCH_ROW" :title="mcpGroupTitle(group)">
           <!-- The group is named, not just the feature: each switch registers ONE MCP server
            (`mulmoterminal-<group>`), so a heading alone would not say which of the four rows
            writes which server — and two of them share the heading "Canvas".
@@ -637,7 +638,8 @@ async function removeWorktree(w: Worktree): Promise<void> {
     <div
       v-if="dirListsLoading"
       data-testid="cell-dir-loading"
-      class="flex w-full items-center justify-center gap-1.5 font-sans text-[11px] text-dim"
+      class="flex items-center justify-center gap-1.5 font-sans text-[11px] text-dim"
+      :class="LAUNCH_ROW"
       role="status"
     >
       <span class="material-symbols-outlined animate-spin text-[14px]" aria-hidden="true">progress_activity</span>
@@ -647,7 +649,12 @@ async function removeWorktree(w: Worktree): Promise<void> {
          ONE codebase onto a branch; the workspace is the hub a session works FROM — the place the
          agent reads and writes shared state (wiki, collections, accounting), which is exactly what
          a detached branch would cut it off from. Offering it there is offering a mistake. -->
-    <div v-if="worktreeList.isGit && launchesAgent && !inWorkspace" data-testid="cell-worktrees" class="flex w-full flex-col items-stretch gap-1.5">
+    <div
+      v-if="worktreeList.isGit && launchesAgent && !inWorkspace"
+      data-testid="cell-worktrees"
+      class="flex flex-col items-stretch gap-1.5"
+      :class="LAUNCH_ROW"
+    >
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
       <!-- Said here rather than left to be inferred from a row that behaves differently each time:
            the one-session rule is why a row resumes instead of launching, and why one of them
@@ -706,7 +713,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
     </div>
     <LaunchChipList heading="or run a script" icon="play_arrow" :chips="scriptChips" @pick="runScript" />
     <LaunchChipList heading="or launch" icon="rocket_launch" :chips="launcherChips" @pick="launchProgram" />
-    <div v-if="resumable.sessions.length" data-testid="cell-resume" class="flex min-h-0 w-full flex-col items-center gap-1.5">
+    <div v-if="resumable.sessions.length" data-testid="cell-resume" class="flex min-h-0 flex-col items-center gap-1.5" :class="LAUNCH_ROW">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or resume here</span>
       <div class="flex w-full flex-col gap-1">
         <button

--- a/src/components/LaunchChipList.vue
+++ b/src/components/LaunchChipList.vue
@@ -10,11 +10,13 @@ defineProps<{
   // `title` is the command behind the chip, shown on hover.
   chips: { key: string | number; label: string; title: string }[];
 }>();
+import { LAUNCH_ROW } from "./launchFormClasses";
+
 const emit = defineEmits<{ (e: "pick", index: number): void }>();
 </script>
 
 <template>
-  <div v-if="chips.length" class="flex w-full flex-col items-center gap-1.5">
+  <div v-if="chips.length" class="flex flex-col items-center gap-1.5" :class="LAUNCH_ROW">
     <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">{{ heading }}</span>
     <div class="flex w-full flex-wrap justify-center gap-1.5">
       <button

--- a/src/components/ModelPicker.vue
+++ b/src/components/ModelPicker.vue
@@ -11,6 +11,7 @@ import { useLaunchOptions } from "../composables/useLaunchOptions";
 import { modelOptionLabel, sortedModels } from "./modelOption";
 import { SELECT_CONTROL } from "./selectClasses";
 import ModelSetupHelp from "./ModelSetupHelp.vue";
+import { LAUNCH_ROW } from "./launchFormClasses";
 import type { LaunchChoice } from "./wsUrl";
 
 const props = defineProps<{ modelValue: LaunchChoice | null }>();
@@ -36,7 +37,7 @@ const selected = computed({
 </script>
 
 <template>
-  <div class="flex w-full flex-col items-center gap-1.5">
+  <div class="flex flex-col items-center gap-1.5" :class="LAUNCH_ROW">
     <span class="flex w-full items-center justify-between">
       <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Model</span>
       <button

--- a/src/components/launchFormClasses.ts
+++ b/src/components/launchFormClasses.ts
@@ -1,0 +1,9 @@
+// One width for the launch form's rows, as a Tailwind utility string so the styling travels with
+// the markup (docs/styling.md) instead of becoming a CSS class.
+//
+// The DIRECTORY CHIPS are deliberately outside it and span the cell: they tile, so width buys rows
+// back — 25 of them inside a 360px cap wrapped into 20 rows while the cell was 1535px wide (#1455).
+// Everything else is a control, and a control gains nothing from being 1500px wide: a checkbox
+// ends up an eye-journey from the label it belongs to.
+
+export const LAUNCH_ROW = "w-full max-w-[560px]";

--- a/test/src/components/launchFormWidth.spec.ts
+++ b/test/src/components/launchFormWidth.spec.ts
@@ -10,7 +10,8 @@ import type { AgentPick } from "../../../common/customAgents";
 // invisible from either side alone: the directory chips tile, so 25 of them inside the old 360px cap
 // wrapped into 20 rows while the cell was 1535px wide, while the controls below gain nothing from
 // the width and lose the checkbox to the far edge of the screen (#1455).
-const CAP = LAUNCH_ROW.split(" ").find((c) => c.startsWith("max-w-")) ?? "";
+const PIXEL_CAP = /^max-w-\[\d+px\]$/;
+const capOf = (classes: string[]): string | undefined => classes.find((c) => PIXEL_CAP.test(c));
 
 describe("the launch form takes the cell's width", () => {
   beforeEach(() => {
@@ -44,12 +45,21 @@ describe("the launch form takes the cell's width", () => {
     return w;
   };
 
-  // The one row let out of the cap, and the reason the cap was worth revisiting at all.
+  // Without this the file stops guarding the moment LAUNCH_ROW drops its cap: every assertion below
+  // is derived from that constant, so all four would keep passing over a form with no cap at all
+  // (Codex on #1460).
+  it("keeps a pixel cap in the row class the controls share", () => {
+    expect(capOf(LAUNCH_ROW.split(" "))).toMatch(PIXEL_CAP);
+  });
+
+  // The one row let out of the cap, and the reason the cap was worth revisiting at all. Asked of the
+  // class list directly rather than against LAUNCH_ROW's value, so the chips are pinned as uncapped
+  // whatever the controls settle on.
   it("lets the directory chips span the whole cell", async () => {
     const w = await mountForm();
     const chipRow = w.get('[data-testid="cell-chip"]').element.parentElement;
     expect([...(chipRow?.classList ?? [])]).toContain("w-full");
-    expect([...(chipRow?.classList ?? [])]).not.toContain(CAP);
+    expect(capOf([...(chipRow?.classList ?? [])])).toBeUndefined();
   });
 
   // Every other row shares one width, so the column stays a column. The agent picker is content-

--- a/test/src/components/launchFormWidth.spec.ts
+++ b/test/src/components/launchFormWidth.spec.ts
@@ -3,16 +3,14 @@ import { mount, flushPromises } from "@vue/test-utils";
 import CellLaunchForm from "../../../src/components/CellLaunchForm.vue";
 import LaunchChipList from "../../../src/components/LaunchChipList.vue";
 import ModelPicker from "../../../src/components/ModelPicker.vue";
+import { LAUNCH_ROW } from "../../../src/components/launchFormClasses";
 import type { AgentPick } from "../../../common/customAgents";
 
-// The launch form's rows were each capped at a fixed pixel width, so an enlarged cell drew a narrow
-// centred column and left the rest empty — 25 chips wrapping into 20 rows inside 360px while the
-// cell was 1535px wide. Nothing pinned that cap, so nothing failed when it changed; this is the
-// guard, and it is written against ANY pixel cap rather than the one number that was there, because
-// re-introducing the shape is the regression, not re-introducing 360.
-const PIXEL_CAP = /max-w-\[\d+px\]/;
-
-const capsIn = (html: string): string[] => html.match(new RegExp(PIXEL_CAP, "g")) ?? [];
+// The form is a capped column with ONE row let out of it. That asymmetry is the whole point and is
+// invisible from either side alone: the directory chips tile, so 25 of them inside the old 360px cap
+// wrapped into 20 rows while the cell was 1535px wide, while the controls below gain nothing from
+// the width and lose the checkbox to the far edge of the screen (#1455).
+const CAP = LAUNCH_ROW.split(" ").find((c) => c.startsWith("max-w-")) ?? "";
 
 describe("the launch form takes the cell's width", () => {
   beforeEach(() => {
@@ -46,15 +44,18 @@ describe("the launch form takes the cell's width", () => {
     return w;
   };
 
-  it("caps no row at a fixed pixel width", async () => {
+  // The one row let out of the cap, and the reason the cap was worth revisiting at all.
+  it("lets the directory chips span the whole cell", async () => {
     const w = await mountForm();
-    expect(capsIn(w.html())).toEqual([]);
+    const chipRow = w.get('[data-testid="cell-chip"]').element.parentElement;
+    expect([...(chipRow?.classList ?? [])]).toContain("w-full");
+    expect([...(chipRow?.classList ?? [])]).not.toContain(CAP);
   });
 
-  // Every direct child spans the form, so the width the form is given is the width they get. The
-  // agent picker is the one exception and stays content-sized: it is a segmented control, and
-  // stretching it would widen the pill's background rather than fit anything into it.
-  it("gives every row the full width, and leaves the agent picker its own", async () => {
+  // Every other row shares one width, so the column stays a column. The agent picker is content-
+  // sized on top of that: it is a segmented control, and stretching it would widen the pill's
+  // background rather than fit anything into it.
+  it("holds every control to one width, and leaves the agent picker its own", async () => {
     const w = await mountForm();
     // The two rows that arrive with the fetches, named so a fixture that stops producing them
     // fails here rather than silently shrinking what the loop below walks.
@@ -63,26 +64,30 @@ describe("the launch form takes the cell's width", () => {
 
     const rows = [...w.get('[data-testid="cell-launch"]').element.children].filter((el) => el.getAttribute("data-testid") !== "cell-launch-cancel");
     const picker = rows.find((el) => el.getAttribute("data-testid") === "agent-picker");
+    const chipRow = w.get('[data-testid="cell-chip"]').element.parentElement;
     // classList, not a substring of the class string: "max-w-full" contains "w-full".
     expect([...(picker?.classList ?? [])]).toContain("max-w-full");
     expect([...(picker?.classList ?? [])]).not.toContain("w-full");
-    rows.filter((el) => el !== picker).forEach((el) => expect([...el.classList]).toContain("w-full"));
+
+    // The directory field, the model picker, and the two rows named above. A smaller number means
+    // the fixture stopped rendering something and the loop below is checking less than it reads as.
+    const capped = rows.filter((el) => el !== picker && el !== chipRow);
+    expect(capped.length).toBeGreaterThanOrEqual(4);
+    capped.forEach((el) => LAUNCH_ROW.split(" ").forEach((cls) => expect([...el.classList]).toContain(cls)));
   });
 
-  it("spans the width in the chip lists it stacks", () => {
+  it("holds the chip lists it stacks to the same width", () => {
     const w = mount(LaunchChipList, {
       props: { heading: "or run a script", icon: "play_arrow", chips: [{ key: 0, label: "build", title: "yarn build" }] },
     });
-    expect(capsIn(w.html())).toEqual([]);
-    expect(w.get("div").classes()).toContain("w-full");
+    LAUNCH_ROW.split(" ").forEach((cls) => expect(w.get("div").classes()).toContain(cls));
   });
 
   // The picker's WRAPPER is what this file is about — the row the form stacks. The `<select>` inside
   // it takes its width from SELECT_CONTROL, which every select in the app shares, so pinning it from
   // here would tie one launch-form test to a decision made for the whole app.
-  it("spans the width in the model picker's row", () => {
+  it("holds the model picker's row to the same width", () => {
     const w = mount(ModelPicker, { props: { modelValue: null } });
-    expect(capsIn(w.html())).toEqual([]);
-    expect(w.get("div").classes()).toContain("w-full");
+    LAUNCH_ROW.split(" ").forEach((cls) => expect(w.get("div").classes()).toContain(cls));
   });
 });


### PR DESCRIPTION
## Summary

#1455 removed every width cap from the launch form. That fixed the part that needed it — the
directory chips, 25 of which had been wrapping into 20 rows inside 360px — but it stretched
everything below them: at a 1535px cell a checkbox sat ~1500px from the label it belongs to, and the
model `<select>` ran the width of the screen.

So the cap comes back **for the controls only**:

| | width |
|---|---|
| directory chips | the whole cell — they tile, so width buys rows back |
| everything else | one shared cap, `LAUNCH_ROW` = `w-full max-w-[560px]` |
| agent picker | its own content width (unchanged) |

560 rather than the old 360: wide enough for a long path and a worktree task name beside its button,
narrow enough that a checkbox stays with its label.

The cap lives in `src/components/launchFormClasses.ts` because three components share it —
`CellLaunchForm`, `LaunchChipList`, `ModelPicker` — and it has now been changed twice. Same shape as
the existing `selectClasses.ts`.

## Items to Confirm / Review

- **560 is a judgement call.** It is one constant in one file if it should be wider or narrower.
- **Which rows count as "chips"**: only the *directory* chip row is let out. The "or run a script"
  and "or launch" lists are chips too, but they are short in practice and read as part of the
  control column — say the word if they should span as well.
- The spec now pins the **asymmetry from both sides** — it fails if the chips gain a cap *and* if
  any control loses one. I verified both directions by breaking each in turn, since a guard that
  cannot fail is the failure mode this file exists to avoid.

## User Prompt

> あーー、そうね。reuseのdir一覧的な部分以外は、ある程度横幅制限があってもよいかもね

(following #1455, which removed the cap everywhere)

## Verification

- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` / `yarn test` — 8484 passed.
- Screenshot against a running dev server at a 1600px viewport: chips still span (1503px in a 1535px
  cell, 25 chips in 4 rows), and the controls below sit in a 560px column with each checkbox beside
  its label.

work in mulmoterminal4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved launch form layout consistency across working-directory, MCP, loading, worktree, resume, chip-list, and model-picker sections.
  * Standardized control rows with a responsive full-width layout capped at 560px.
  * Preserved full-width behavior for directory chip rows and independent sizing for the agent picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->