### PR TITLE
fix: never offer a provider with no models in the launch picker (#1432)

### DIFF
--- a/docs/guide/en/providers.md
+++ b/docs/guide/en/providers.md
@@ -129,9 +129,15 @@ In any directory, tell a Claude session `add OpenRouter to my mulmoterminal conf
 `mulmoterminal-config` skill keeps your existing settings and writes a valid entry — **without your
 key in it**.
 
-**Do not list models here.** Registering a provider with this `id` is enough — the
-[27 measured models](#verified) appear in the picker on their own. You only list models to add ones
-that are **not** in that list (→ [Adding models](#add-models)).
+**Under the id `openrouter`, do not list models here.** Registering a provider with this `id` is
+enough — the [27 measured models](#verified) appear in the picker on their own. You only list models
+to add ones that are **not** in that list (→ [Adding models](#add-models)).
+
+**Under any other `id`, `models` is required.** The measured list is OpenRouter's alone, matched by
+that exact id, so a backend registered as `deepseek`, `moonshot` or an in-house gateway starts with
+none — and **a backend with no models is not offered in the picker**, because a session named on a
+provider without a model refuses to start. List the ids you want to run
+(→ [Adding models](#add-models)).
 
 | Key | Meaning |
 |---|---|
@@ -140,7 +146,7 @@ that are **not** in that list (→ [Adding models](#add-models)).
 | `baseUrl` | **no trailing `/v1`** — see below |
 | `tokenEnv` | the **name** of the environment variable holding the key, never the key |
 | `maxOutputTokens` | optional; defaults to 16000 |
-| `models` | optional; only to add models **not** in the built-in list (→ [Adding models](#add-models)) |
+| `models` | **required unless `id` is `openrouter`** — that is the only id with presets. Under `openrouter`, only to add models **not** in the built-in list (→ [Adding models](#add-models)) |
 
 ### Never end `baseUrl` in `/v1`
 {: .no_toc }
@@ -330,7 +336,9 @@ If you are unsure where to start, try **Kimi K2.7 Code** (fast, coding-oriented)
 | `404 No endpoints available …` | that model is excluded by your [privacy settings](https://openrouter.ai/settings/privacy) |
 | Empty replies, looks hung | `maxOutputTokens` too low — keep it at 16000+ |
 | Talks but never uses tools | the model's own limitation — check the table or `model-trials.ts` |
-| No MODEL select in the launch form | no provider is registered (step 2) or its key is missing; "Use another model…" in the form names what's missing |
+| No MODEL select in the launch form | no provider is registered (step 2), its key is missing, or it has no models to pick; the link beside the MODEL label — "Needs attention" / "Use another model…" — names what's missing |
+| A registered backend is missing from the MODEL list | it has no models: presets come with the id `openrouter` and no other, so [list its `models`](#add-models) |
+| `models` is in the config and the picker still offers none | every id in it was refused — a model id is letters, digits and `. _ : / - ~`, so an object like `{"id": "…"}` or a value with a space is dropped. The server's log names what it dropped |
 | No model in the header | `ctx` is not in your `chips` |
 
 ---

--- a/docs/guide/ja/providers.md
+++ b/docs/guide/ja/providers.md
@@ -127,8 +127,15 @@ console.log("added openrouter to " + file);
 どのディレクトリでもいいので、Claude のセッションに `mulmoterminal の設定に OpenRouter を追加して` と
 頼めば、同梱の `mulmoterminal-config` スキルが既存の設定を保ったまま書いてくれます（**鍵は書きません**）。
 
-**モデルは書きません。** この `id` のプロバイダを登録した時点で、[検証済みの 27 モデル](#verified)が
-選択肢に出ます。書くのは、その一覧に**無いモデルを足したいとき**だけです（→ [モデルを足す](#add-models)）。
+**`id` が `openrouter` のときは、モデルを書きません。** この `id` のプロバイダを登録した時点で、
+[検証済みの 27 モデル](#verified)が選択肢に出ます。書くのは、その一覧に**無いモデルを足したいとき**
+だけです（→ [モデルを足す](#add-models)）。
+
+**それ以外の `id` では `models` が必須です。** 検証済み一覧は OpenRouter のもので、`id` がちょうど
+`openrouter` のときだけ付きます。`deepseek`・`moonshot`・社内ゲートウェイなどで登録したプロバイダは
+モデルがゼロの状態から始まり、**モデルが 1 つも無いプロバイダは MODEL の選択肢に出ません**——
+プロバイダだけ指定してモデルを指定しないセッションは起動を拒否されるからです。動かしたいモデル id を
+列挙してください（→ [モデルを足す](#add-models)）。
 
 | キー | 意味 |
 |---|---|
@@ -137,7 +144,7 @@ console.log("added openrouter to " + file);
 | `baseUrl` | **末尾に `/v1` を付けない**（下の注意を参照） |
 | `tokenEnv` | 鍵が入っている環境変数の**名前**。鍵そのものではありません |
 | `maxOutputTokens` | 任意。省略時 16000 |
-| `models` | 任意。組み込み一覧に**無い**モデルを足すときだけ（→ [モデルを足す](#add-models)） |
+| `models` | **`id` が `openrouter` 以外なら必須**（プリセットが付くのはその id だけ）。`openrouter` では、組み込み一覧に**無い**モデルを足すときだけ（→ [モデルを足す](#add-models)） |
 
 ### `baseUrl` に `/v1` を付けてはいけない
 {: .no_toc }
@@ -323,7 +330,9 @@ yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 qwen/qwen3-cod
 | `404 No endpoints available …` | そのモデルが [Privacy 設定](https://openrouter.ai/settings/privacy)で除外されている |
 | 返事が空、固まったように見える | `maxOutputTokens` が小さすぎる。16000 以上に |
 | ツールを使わず、文章だけ返ってくる | そのモデルの限界。上の一覧か `model-trials.ts` で確認を |
-| モデル選択欄が出ない | `providers` が未登録（[2 章](#2-接続先を登録する必須)）か、鍵が無い。フォームの「Use another model…」から不足箇所を確認できます |
+| モデル選択欄が出ない | `providers` が未登録（[2 章](#2-接続先を登録する必須)）か、鍵が無いか、選べるモデルが 1 つも無い。MODEL ラベル横のリンク（「Needs attention」／「Use another model…」）に不足箇所が出ます |
+| 登録したはずの接続先が MODEL の一覧に出ない | モデルがゼロ。プリセットが付くのは `id` が `openrouter` のときだけなので、[`models` を列挙](#add-models)してください |
+| `models` を書いたのに 1 つも選べない | 書いた id が全部弾かれている。モデル id に使えるのは英数と `. _ : / - ~` だけで、`{"id": "…"}` のようなオブジェクトや空白入りの値は捨てられます。捨てた id はサーバのログに出ます |
 | ヘッダーにモデル名が出ない | 設定の `chips` に `ctx` が入っていない |
 
 ---

--- a/plans/fix-1432-model-picker-empty-provider.md
+++ b/plans/fix-1432-model-picker-empty-provider.md
@@ -1,0 +1,81 @@
+# fix #1432 — a custom provider shows in the MODEL dropdown but cannot be picked
+
+## What was reported
+
+A DeepSeek provider registered in `~/.mulmoterminal/config.json` appears in the launch form's
+MODEL dropdown next to "This directory's default", drawn with a highlighted background — and
+neither a click nor the arrow keys will select it. Reproduces every time (4.4.0, Windows, Chrome).
+
+## Root cause
+
+`ModelPicker.vue` renders one `<optgroup>` per ready provider and one `<option>` per model:
+
+```html
+<optgroup v-for="provider in readyProviders" :label="provider.label">
+  <option v-for="model in sortedModels(provider.models)" …/>
+</optgroup>
+```
+
+A provider whose `models` is empty therefore renders `<optgroup label="DeepSeek"></optgroup>` —
+a **group header with no options**. Chrome draws that as a bold, shaded row that is not clickable
+and that arrow keys skip. It looks exactly like a broken option, which is what was filed.
+
+Verified against the real DOM before changing anything:
+
+```
+<option value="">This directory's default</option>
+<optgroup label="DeepSeek"></optgroup>
+```
+
+Two independent paths end in an empty `models`, and **both are silent**:
+
+1. **The built-in presets are OpenRouter-only.** Every entry in `common/modelPresets.ts` carries
+   `provider: "openrouter"`, and `presetsForProvider` matches on that id. A provider registered
+   under any other id (`deepseek`, `moonshot`, an in-house gateway) starts with zero models, so it
+   MUST list `models` — and `server/skills/mulmoterminal-model/SKILL.md` said the opposite:
+   *"Do not write a `models` array … registering the provider is enough"*, which is true only for
+   the id `openrouter`.
+2. **A malformed `models` entry is dropped without a word.** `providerSchema.models` filters
+   anything that is not a usable model-id string and `.catch([])`s a non-array — so
+   `models: [{ "id": "deepseek-chat" }]` or `models: { … }` becomes `[]`, and nothing anywhere
+   says so.
+
+A session cannot start on a provider with no model anyway (`resolveProvider` refuses a named
+provider without a model), so such a provider is not a choice — it is a setup problem.
+
+## The fix
+
+- **`src/components/launchOffer.ts` (new)** — one rule for what the picker offers:
+  `isOfferable = ready && models.length > 0`, and `notOfferedReason()`, the one sentence to show
+  about a provider that is not offered (the server's own refusal, or "has no models to pick").
+- **`ModelPicker.vue`** — offer only offerable providers, so an empty `<optgroup>` can no longer
+  be rendered; show the select only when something is offerable; the help link reads
+  **"Needs attention"** when a configured provider is not offered, so the explanation is findable
+  even while another provider works.
+- **`ModelSetupHelp.vue`** — the "Needs attention" block covers the no-models case too, and the
+  setup copy says presets exist only for the id `openrouter`.
+- **`server/config/app-config.ts`** — warn once, naming the ids, when a provider's `models`
+  entries are dropped. Otherwise the UI says "no models" while the user is looking at a config
+  file that lists some.
+- **Docs / skill** — `mulmoterminal-model` skill, `docs/guide/{en,ja}/providers.md`.
+
+## Tests
+
+- `test/src/components/launchOffer.spec.ts` — the rule and the sentences.
+- `ModelPicker.spec.ts` — a models-less provider is not offered; **no `<optgroup>` is ever empty**
+  (the regression, written against the shape rather than one payload); the select hides when the
+  only provider has no models; the help link says "Needs attention"; the help explains it.
+- `launch-options.spec.ts` — a provider whose id is not `openrouter` gets no presets (the rule
+  that made this reachable), and its option is well-formed.
+- `app-config.spec.ts` — the dropped ids are named in the warning, and a non-array `models` is
+  reported rather than silently emptied.
+
+## Not part of this fix
+
+The two console errors in the report:
+
+- `GET /api/dir-sound?… → 404` is **by design** — the route 404s when the directory has no custom
+  sound, and the client falls back to the global sound, then the built-in chime.
+- `426 Upgrade Required` is not emitted anywhere in this repo: every `WebSocketServer` runs in
+  `noServer` mode (`ws` only sends 426 from its own standalone `port` server). It cannot disable
+  a `<select>` option either. Left for the reporter to confirm with the failing request's URL.

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -464,6 +464,15 @@ const warnOnce = (message: string): void => {
   console.warn(message);
 };
 
+// What a rejected entry is quoted as. A dropped value is whatever the user's JSON held — an
+// object, or a string far past MODEL_ID_MAX_LENGTH, which is one of the reasons it was rejected —
+// so it is quoted to a bound rather than echoed whole into the line.
+const DROPPED_MODEL_QUOTE_MAX = 80;
+const quoteDropped = (model: unknown): string => {
+  const text = JSON.stringify(model) ?? String(model);
+  return text.length > DROPPED_MODEL_QUOTE_MAX ? `${text.slice(0, DROPPED_MODEL_QUOTE_MAX)}…` : text;
+};
+
 // A model id the schema refuses is dropped in silence, and a provider whose whole list was
 // refused looks exactly like one that never listed any: the picker has nothing to offer while the
 // user is reading a config file that lists models (#1432). Compared against what the schema KEPT
@@ -477,7 +486,7 @@ function warnDroppedModels(provider: Provider, raw: unknown): void {
   const kept = new Set(provider.models);
   const dropped = raw.models.filter((model) => typeof model !== "string" || !kept.has(model.trim()));
   if (dropped.length === 0) return;
-  const shown = dropped.map((model) => JSON.stringify(model)).join(", ");
+  const shown = dropped.map(quoteDropped).join(", ");
   warnOnce(`[providers] '${provider.id}': dropped ${dropped.length} unusable model id(s) — ${shown}. A model id is ${MODEL_ID_ALLOWED}.`);
 }
 

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -28,6 +28,7 @@ import { DEFAULT_PUSH_KINDS, PUSH_KINDS, type PushKind } from "../../common/push
 import { DEFAULT_SOUND_KINDS, NOTIFY_KINDS, type NotifyKind } from "../../common/notifyKinds.js";
 import { parsePresetRef } from "../../common/notifySounds.js";
 import { isRecord } from "../../common/isRecord.js";
+import { MODEL_ID_ALLOWED } from "../../common/modelIds.js";
 import { sanitizeKeymap, type Keymap } from "../../common/keymap.js";
 import { sanitizeCockpitLines, DEFAULT_COCKPIT_LINES, type CockpitLines } from "../../common/cockpitLines.js";
 import { normalizeFontFamily } from "../../common/terminalFontFamily.js";
@@ -454,6 +455,32 @@ export const emptyConfig = (): AppConfig => ({
   fontFamily: null,
 });
 
+// Said once per process: this config is re-read on paths that run per session spawn, so an entry
+// the user has not fixed yet would repeat its line at every launch and bury everything else.
+const warnedConfigLines = new Set<string>();
+const warnOnce = (message: string): void => {
+  if (warnedConfigLines.has(message)) return;
+  warnedConfigLines.add(message);
+  console.warn(message);
+};
+
+// A model id the schema refuses is dropped in silence, and a provider whose whole list was
+// refused looks exactly like one that never listed any: the picker has nothing to offer while the
+// user is reading a config file that lists models (#1432). Compared against what the schema KEPT
+// rather than re-testing the rule here, so the two cannot drift apart.
+function warnDroppedModels(provider: Provider, raw: unknown): void {
+  if (!isRecord(raw) || raw.models === undefined) return;
+  if (!Array.isArray(raw.models)) {
+    warnOnce(`[providers] '${provider.id}': "models" must be an array of model ids — the whole value was ignored, so this backend offers nothing.`);
+    return;
+  }
+  const kept = new Set(provider.models);
+  const dropped = raw.models.filter((model) => typeof model !== "string" || !kept.has(model.trim()));
+  if (dropped.length === 0) return;
+  const shown = dropped.map((model) => JSON.stringify(model)).join(", ");
+  warnOnce(`[providers] '${provider.id}': dropped ${dropped.length} unusable model id(s) — ${shown}. A model id is ${MODEL_ID_ALLOWED}.`);
+}
+
 // Drop malformed entries rather than rejecting the whole config: one bad provider must
 // not cost the user their launchers and presets. A bad entry surfaces at spawn time,
 // where resolveProvider names the actual problem.
@@ -461,7 +488,9 @@ export function sanitizeProviders(input: unknown): Provider[] {
   if (!Array.isArray(input)) return [];
   return input.flatMap((entry) => {
     const parsed = providerSchema.safeParse(entry);
-    return parsed.success ? [parsed.data] : [];
+    if (!parsed.success) return [];
+    warnDroppedModels(parsed.data, entry);
+    return [parsed.data];
   });
 }
 

--- a/server/skills/mulmoterminal-model/SKILL.md
+++ b/server/skills/mulmoterminal-model/SKILL.md
@@ -50,9 +50,19 @@ hard to diagnose from inside it:
   them where it goes; do not store it anywhere yourself.
 - **Keep `maxOutputTokens` at 16000 or above.** A thinking model given less spends the whole budget
   thinking and returns empty visible text, which reads as a hung session.
-- **Do not write a `models` array** unless the user names a model outside the built-in list.
-  Registering the provider is enough — every preset for that `id` appears in the picker on its own.
-  `models` exists only to ADD ids nobody has measured.
+- **`models` is REQUIRED under any `id` other than `openrouter`.** Every preset in
+  `common/modelPresets.ts` carries `provider: "openrouter"`, and they are matched by that id — so a
+  backend registered as `deepseek`, `moonshot` or a company gateway starts with **no models at
+  all**, and a provider with no models is not offered in the picker (it cannot start a session
+  either: naming a provider without a model is refused at spawn). Ask which model ids the user
+  wants to run and list them.
+- **Under the id `openrouter`, do not write a `models` array** unless the user names a model outside
+  the built-in list — every preset appears in the picker on its own, with its measured pass rate,
+  and `models` there exists only to ADD ids nobody has measured.
+- **A model id is letters, digits and `. _ : / - ~`.** Anything else in `models` — an object like
+  `{"id": "…"}`, a value with a space, a `models` that is not an array — is dropped when the config
+  loads, leaving a backend that lists models in the file and offers none in the picker. The server
+  log names what it dropped; check it after writing.
 - This is a **partial `POST /api/config` merge** — write only `providers`. Send the array **complete**
   (existing entries included): it replaces rather than appends.
 - The server reads the environment **at startup**: after adding a key, it has to be restarted.
@@ -201,6 +211,8 @@ Work down this list; each maps to one of the rules above.
 | Every request 404s | A trailing `/v1` on `baseUrl` |
 | Session starts, replies are empty | `maxOutputTokens` below 16000 on a thinking model |
 | Session refuses to start | A `provider` id that isn't registered, or `tokenEnv` naming a variable that isn't set in the server's shell |
+| The backend is missing from the MODEL dropdown | It has no models to pick — presets exist only under the id `openrouter`, so list `models`. Open "Needs attention" beside the MODEL label for the sentence naming what is missing |
+| `models` is in the config and the picker still offers none | Every id in it was refused by the shape rule above. The server's log names them |
 | Worked yesterday, not today | The key was in a shell that's gone. The server reads the environment at startup |
 | Model answers but never edits files | Not a config problem — check the model's pass rate in `modelPresets.ts` |
 | A custom agent's button never appears | The entry was dropped on load — most often no `agent: "claude"`, an `id` that is not a lowercase slug, or one clashing with a built-in. Audit `/api/config`, then reload the tab |

--- a/src/components/ModelPicker.vue
+++ b/src/components/ModelPicker.vue
@@ -4,10 +4,11 @@
 //
 // The choice lasts for this session only — the directory's .mulmoterminal.json still holds
 // the default, and leaving this alone is what uses it. The picker only appears when there
-// is something to choose between: with no reachable provider there is no decision to make,
+// is something to choose between: with nothing offerable there is no decision to make,
 // only setup to explain, so it collapses to a link into the help.
 import { computed, ref } from "vue";
 import { useLaunchOptions } from "../composables/useLaunchOptions";
+import { isOfferable, notOfferedReason } from "./launchOffer";
 import { modelOptionLabel, sortedModels } from "./modelOption";
 import { SELECT_CONTROL } from "./selectClasses";
 import ModelSetupHelp from "./ModelSetupHelp.vue";
@@ -19,9 +20,20 @@ const emit = defineEmits<{ (e: "update:modelValue", choice: LaunchChoice | null)
 const { launchOptions } = useLaunchOptions();
 const helpOpen = ref(false);
 
-// A provider is only offerable when this server can actually reach it; an unready one is
-// left to the help, which names the single thing that is missing.
-const readyProviders = computed(() => launchOptions.value.providers.filter((provider) => provider.ready));
+// Only what can actually be picked: reachable, and with models to choose from. A provider
+// missing either is left to the help, which names the single thing that is missing — offering
+// one with no models renders a group header with nothing under it, which a browser draws as a
+// row that cannot be clicked or arrowed to (#1432).
+const offerable = computed(() => launchOptions.value.providers.filter(isOfferable));
+
+// Whether some configured backend is not offered. Said on the help link rather than left to the
+// user to discover, because the picker looks complete when another provider works.
+const anyNeedsAttention = computed(() => launchOptions.value.providers.some((provider) => notOfferedReason(provider) !== null));
+
+const helpLabel = computed(() => {
+  if (anyNeedsAttention.value) return "Needs attention";
+  return launchOptions.value.anyReady ? "How this works" : "Use another model…";
+});
 
 // One flat <select>: "<provider>|<model>", empty string for the directory's own default.
 const SEPARATOR = "|";
@@ -45,19 +57,19 @@ const selected = computed({
         class="cursor-pointer border-none bg-transparent p-0 font-sans text-[11px] text-dim underline hover:text-fg"
         @click="helpOpen = true"
       >
-        {{ launchOptions.anyReady ? "How this works" : "Use another model…" }}
+        {{ helpLabel }}
       </button>
     </span>
 
     <select
-      v-if="launchOptions.anyReady"
+      v-if="offerable.length"
       v-model="selected"
       data-testid="cell-model-select"
       aria-label="Model for this session"
       :class="[SELECT_CONTROL, 'font-mono']"
     >
       <option value="">This directory's default</option>
-      <optgroup v-for="provider in readyProviders" :key="provider.id" :label="provider.label">
+      <optgroup v-for="provider in offerable" :key="provider.id" :label="provider.label">
         <option v-for="model in sortedModels(provider.models)" :key="model.id" :value="`${provider.id}${SEPARATOR}${model.id}`">
           {{ modelOptionLabel(model) }}
         </option>

--- a/src/components/ModelSetupHelp.vue
+++ b/src/components/ModelSetupHelp.vue
@@ -9,12 +9,21 @@
 import { computed, ref } from "vue";
 import { MODAL_FOCUSABLE } from "../utils/focusTrap";
 import { useModalKeyboard } from "../composables/useModalKeyboard";
+import { notOfferedReason } from "./launchOffer";
 import type { LaunchProviderOption } from "../../common/launchOptions";
 
 const props = defineProps<{ providers: LaunchProviderOption[] }>();
 const emit = defineEmits<{ (e: "close"): void }>();
 
-const blocked = computed(() => props.providers.filter((provider) => !provider.ready));
+// Every configured backend the picker does not offer, each with its own sentence — a missing
+// key, an unusable base URL, or nothing to pick. The last one used to be invisible: the picker
+// showed the provider's name over an empty list, and the help said nothing at all (#1432).
+const notOffered = computed(() =>
+  props.providers.flatMap((provider) => {
+    const reason = notOfferedReason(provider);
+    return reason === null ? [] : [{ id: provider.id, reason }];
+  }),
+);
 
 const CONFIG_EXAMPLE = `{
   "providers": [
@@ -63,10 +72,10 @@ useModalKeyboard({ modalEl, onClose: () => emit("close"), trapSelector: MODAL_FO
         <em>server</em> was started with — never from a file it serves.
       </p>
 
-      <!-- The one sentence that matters when something is already configured but unusable. -->
-      <section v-if="blocked.length" class="flex flex-col gap-1.5 rounded-md border border-border bg-elevated p-3">
+      <!-- The one sentence that matters about a backend that is configured and still not offered. -->
+      <section v-if="notOffered.length" class="flex flex-col gap-1.5 rounded-md border border-border bg-elevated p-3">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Needs attention</span>
-        <p v-for="provider in blocked" :key="provider.id" class="m-0 font-mono text-[11px] leading-relaxed text-fg">{{ provider.reason }}</p>
+        <p v-for="provider in notOffered" :key="provider.id" class="m-0 font-mono text-[11px] leading-relaxed text-fg">{{ provider.reason }}</p>
       </section>
 
       <section class="flex flex-col gap-1.5">
@@ -82,6 +91,11 @@ useModalKeyboard({ modalEl, onClose: () => emit("close"), trapSelector: MODAL_FO
         <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
           <code class="font-mono">baseUrl</code> must not end in <code class="font-mono">/v1</code> — Claude Code appends
           <code class="font-mono">/v1/messages</code> itself. <code class="font-mono">tokenEnv</code> is the <em>name</em> of the variable holding the key.
+        </p>
+        <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
+          The measured models below come with the id <code class="font-mono">openrouter</code> and no other. Under any other <code class="font-mono">id</code>,
+          add the ids you want to run — <code class="font-mono">"models": ["deepseek-chat"]</code> — or the picker has nothing to offer. Ids may contain
+          letters, digits and <code class="font-mono">. _ : / - ~</code>; anything else in the list is dropped, and the server's log says which.
         </p>
       </section>
 

--- a/src/components/launchOffer.ts
+++ b/src/components/launchOffer.ts
@@ -1,0 +1,29 @@
+// Which configured backends the launch picker offers, and what to say about the ones it does
+// not (#1432).
+//
+// A provider is a CHOICE only when this server can reach it AND it has at least one model to
+// pick: a session named on a provider with no model is refused at spawn, so a provider with an
+// empty list is a setup problem rather than an option. Rendering it anyway produced the bug this
+// module exists to prevent — an `<optgroup>` with no `<option>` inside, which a browser draws as
+// a shaded row that neither a click nor an arrow key can reach.
+//
+// Shared by the picker and the help so the two cannot disagree about which providers are offered
+// and which are explained.
+import type { LaunchProviderOption } from "../../common/launchOptions";
+
+export const isOfferable = (provider: LaunchProviderOption): boolean => provider.ready && provider.models.length > 0;
+
+// Why this backend is not in the picker, in one sentence — the server's own refusal when a
+// session could not start on it at all, else what is missing. Null when it IS offered.
+//
+// The no-models wording names the config file and the preset rule because both ends of it are
+// invisible from the picker: the built-in list is OpenRouter's alone (every entry in
+// common/modelPresets.ts carries `provider: "openrouter"`), so a backend registered under any
+// other id has nothing until its `models` are listed.
+export function notOfferedReason(provider: LaunchProviderOption): string | null {
+  if (!provider.ready) return provider.reason ?? `provider '${provider.id}' cannot be used as configured`;
+  if (provider.models.length === 0) {
+    return `provider '${provider.id}' has no models to pick — list its model ids under "models" in ~/.mulmoterminal/config.json (only 'openrouter' has built-in presets)`;
+  }
+  return null;
+}

--- a/src/components/settings/ModelsSection.vue
+++ b/src/components/settings/ModelsSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useAppConfig } from "../../composables/useAppConfig";
 import { useLaunchOptions } from "../../composables/useLaunchOptions";
+import { isOfferable, notOfferedReason } from "../launchOffer";
 import SkillLaunchButton from "../SkillLaunchButton.vue";
 import { SECTION_HEADING, SETTINGS_LIST } from "./sectionClasses";
 import type { BundledSkillName } from "../../../common/bundledSkills";
@@ -30,8 +31,12 @@ defineEmits<{ (e: "launch-skill", skill: BundledSkillName): void }>();
       <span class="font-mono text-[12px] text-secondary">{{ p.label }}</span>
       <span class="text-[11px] text-dim">{{ p.models.length }} model{{ p.models.length === 1 ? "" : "s" }} · key in {{ p.tokenEnv }}</span>
       <span class="flex-auto" />
-      <span v-if="p.ready" class="text-[11px] text-dim">ready</span>
-      <span v-else class="text-[11px] text-err-text" :title="p.reason">not ready</span>
+      <span v-if="!p.ready" class="text-[11px] text-err-text" :title="p.reason">not ready</span>
+      <!-- Reachable, and still not a choice: a session cannot be started on a provider without a
+           model, so the launch picker leaves it out. Said here because "ready · 0 models" reads
+           like it works (#1432). -->
+      <span v-else-if="!isOfferable(p)" class="text-[11px] text-err-text" :title="notOfferedReason(p) ?? ''">not in the picker</span>
+      <span v-else class="text-[11px] text-dim">ready</span>
     </li>
   </ul>
   <p v-else class="mb-2 text-[12px] text-dim">None configured — sessions run on the built-in default.</p>

--- a/test/server/config/launch-options.spec.ts
+++ b/test/server/config/launch-options.spec.ts
@@ -160,6 +160,18 @@ describe("what config accepts and what the launch path accepts", () => {
       expect(spy.mock.calls.map((call) => String(call[0])).join("\n")).toContain("not-a-list");
     });
 
+    // The value is whatever the user's JSON held, and "longer than a model id may be" is one of
+    // the reasons it was rejected — so the line quotes it to a bound instead of echoing a
+    // megabyte of it. Observed during review; no bot flagged it.
+    it("quotes a rejected value to a bound rather than echoing it whole", () => {
+      const spy = warn();
+      const huge = `x`.repeat(50_000);
+      sanitizeProviders([{ ...provider("huge-value"), models: [`${huge} not an id`] }]);
+      const line = spy.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(line).toContain("huge-value");
+      expect(line.length).toBeLessThan(400);
+    });
+
     it("stays quiet when every listed model was kept", () => {
       const spy = warn();
       sanitizeProviders([{ ...provider("all-kept"), models: ["z-ai/glm-5.2", " moonshotai/kimi-k3 "] }]);

--- a/test/server/config/launch-options.spec.ts
+++ b/test/server/config/launch-options.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { launchOptions } from "../../../server/config/launch-options.js";
 import { resolveProvider, type ProviderConfig } from "../../../server/session/provider-env.js";
@@ -92,6 +92,29 @@ describe("launchOptions", () => {
     const broken = { ...OPENROUTER, id: "moonshot", label: "Moonshot", tokenEnv: "MOONSHOT_API_KEY" };
     expect(launchOptions([broken, OPENROUTER], WITH_KEY).anyReady).toBe(true);
   });
+
+  // The rule that made #1432 reachable: every preset in modelPresets.ts carries
+  // `provider: "openrouter"`, so a backend registered under any other id starts with nothing and
+  // offers only what its own `models` lists. Pinned because it is invisible from the config file,
+  // and because "register it and the models appear" was written down as advice.
+  it("gives a provider whose id is not openrouter no presets of its own", () => {
+    const deepseek: ProviderConfig = { id: "deepseek", label: "DeepSeek", baseUrl: "https://api.deepseek.com/anthropic", tokenEnv: "DEEPSEEK_API_KEY" };
+    const [option] = launchOptions([deepseek], { DEEPSEEK_API_KEY: "sk-test" } as NodeJS.ProcessEnv).providers;
+    expect(option).toMatchObject({ id: "deepseek", ready: true, models: [] });
+  });
+
+  it("offers exactly the models such a provider lists, and nothing else", () => {
+    const deepseek: ProviderConfig = {
+      id: "deepseek",
+      label: "DeepSeek",
+      baseUrl: "https://api.deepseek.com/anthropic",
+      tokenEnv: "DEEPSEEK_API_KEY",
+      models: ["deepseek-chat", "deepseek-reasoner"],
+    };
+    const [option] = launchOptions([deepseek], { DEEPSEEK_API_KEY: "sk-test" } as NodeJS.ProcessEnv).providers;
+    expect(option.models.map((model) => model.id)).toEqual(["deepseek-chat", "deepseek-reasoner"]);
+    expect(option.models.every((model) => model.provider === "deepseek" && model.trials.status === "unmeasured")).toBe(true);
+  });
 });
 
 // Codex on PR #587: the config schema accepted ids the launch parser then dropped, and a
@@ -111,6 +134,43 @@ describe("what config accepts and what the launch path accepts", () => {
   it("drops only the malformed model, not the provider's whole list", () => {
     const [saved] = sanitizeProviders([{ ...provider("openrouter"), models: ["z-ai/glm-5.2", "bad id", 42] }]);
     expect(saved.models).toEqual(["z-ai/glm-5.2"]);
+  });
+
+  // Dropping them silently is half of #1432: the picker then says the backend has no models
+  // while the user is looking at a config file that lists them. Each case uses its own provider
+  // id — the warning is said once per process, so a repeat of the same sentence stays quiet.
+  describe("and what it says when it drops one", () => {
+    const warn = () => vi.spyOn(console, "warn").mockImplementation(() => {});
+    afterEach(() => vi.restoreAllMocks());
+
+    it("names every model id it refused, and the shape it wanted", () => {
+      const spy = warn();
+      sanitizeProviders([{ ...provider("named-drops"), models: ["z-ai/glm-5.2", "bad id", 42] }]);
+      const line = spy.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(line).toContain("named-drops");
+      expect(line).toContain('"bad id"');
+      expect(line).toContain("42");
+      expect(line).not.toContain("z-ai/glm-5.2");
+    });
+
+    it("says so when `models` is not a list at all, which empties it whole", () => {
+      const spy = warn();
+      const [saved] = sanitizeProviders([{ ...provider("not-a-list"), models: { "deepseek-chat": true } }]);
+      expect(saved.models).toEqual([]);
+      expect(spy.mock.calls.map((call) => String(call[0])).join("\n")).toContain("not-a-list");
+    });
+
+    it("stays quiet when every listed model was kept", () => {
+      const spy = warn();
+      sanitizeProviders([{ ...provider("all-kept"), models: ["z-ai/glm-5.2", " moonshotai/kimi-k3 "] }]);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("stays quiet when the entry lists no models at all", () => {
+      const spy = warn();
+      sanitizeProviders([provider("no-models-listed")]);
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   // The round trip that matters: anything config keeps must survive the ws query.

--- a/test/src/components/ModelPicker.spec.ts
+++ b/test/src/components/ModelPicker.spec.ts
@@ -25,6 +25,10 @@ const MODELS = [
 
 const READY = { providers: [{ id: "openrouter", label: "OpenRouter", ready: true, tokenEnv: "OPENROUTER_API_KEY", models: MODELS }], anyReady: true };
 const UNCONFIGURED = { providers: [], anyReady: false };
+// Reachable — key present, base URL fine — and with nothing to run: the built-in presets are
+// OpenRouter's alone, so any other id offers only what its own `models` lists (#1432).
+const NO_MODELS = { providers: [{ id: "deepseek", label: "DeepSeek", ready: true, tokenEnv: "DEEPSEEK_API_KEY", models: [] }], anyReady: true };
+const READY_AND_NO_MODELS = { providers: [...READY.providers, ...NO_MODELS.providers], anyReady: true };
 const BLOCKED = {
   providers: [
     {
@@ -95,6 +99,67 @@ describe("ModelPicker", () => {
     await select.setValue("openrouter|moonshotai/kimi-k2.7-code");
     await select.setValue("");
     expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([null]);
+  });
+
+  // #1432: a provider with no models rendered as `<optgroup label="DeepSeek"></optgroup>` — Chrome
+  // draws that as a shaded row that a click and the arrow keys both skip, so it read as a broken
+  // option rather than as the setup problem it is. Written against the SHAPE, not against this
+  // payload: an empty group is never right, whatever put it there.
+  it("never renders a group with no options in it", async () => {
+    for (const payload of [READY, NO_MODELS, READY_AND_NO_MODELS]) {
+      await serve(payload);
+      const wrapper = picker();
+      await flushPromises();
+      const groups = wrapper.findAll("optgroup");
+      expect(groups.every((group) => group.findAll("option").length > 0)).toBe(true);
+      wrapper.unmount();
+    }
+  });
+
+  it("does not offer a reachable provider that has no models to pick", async () => {
+    await serve(READY_AND_NO_MODELS);
+    const wrapper = picker();
+    await flushPromises();
+    expect(
+      wrapper
+        .get('[data-testid="cell-model-select"]')
+        .findAll("optgroup")
+        .map((group) => group.attributes("label")),
+    ).toEqual(["OpenRouter"]);
+  });
+
+  // With nothing left to choose between, the select would be one row reading "This directory's
+  // default" — a decision that isn't one. The setup problem is what to show instead.
+  it("hides the select when the only provider has no models", async () => {
+    await serve(NO_MODELS);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="cell-model-select"]').exists()).toBe(false);
+  });
+
+  // The help holds the explanation, so the link to it has to say that there IS one — otherwise a
+  // grid where another provider works looks complete and the broken one is simply gone.
+  it("points at the help when a configured provider is not offered", async () => {
+    await serve(READY_AND_NO_MODELS);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.get('[data-testid="cell-model-help"]').text()).toBe("Needs attention");
+  });
+
+  it("says what to add for a provider with no models, and where", async () => {
+    await serve(NO_MODELS);
+    const wrapper = picker();
+    await flushPromises();
+    await wrapper.get('[data-testid="cell-model-help"]').trigger("click");
+    expect(wrapper.text()).toContain("provider 'deepseek' has no models to pick");
+    expect(wrapper.text()).toContain("~/.mulmoterminal/config.json");
+  });
+
+  it("keeps the plain help link when every configured provider is offered", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.get('[data-testid="cell-model-help"]').text()).toBe("How this works");
   });
 
   it("hides the select when nothing is configured, and offers the help instead", async () => {

--- a/test/src/components/launchOffer.spec.ts
+++ b/test/src/components/launchOffer.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import { isOfferable, notOfferedReason } from "../../../src/components/launchOffer";
+import type { LaunchProviderOption } from "../../../common/launchOptions";
+import type { ModelPreset } from "../../../common/modelPresets";
+
+const MODEL: ModelPreset = {
+  provider: "deepseek",
+  id: "deepseek-chat",
+  label: "deepseek-chat",
+  contextLength: 0,
+  pricePerMTok: { input: 0, output: 0 },
+  trials: { status: "unmeasured" },
+};
+
+const provider = (over: Partial<LaunchProviderOption> = {}): LaunchProviderOption => ({
+  id: "deepseek",
+  label: "DeepSeek",
+  ready: true,
+  tokenEnv: "DEEPSEEK_API_KEY",
+  models: [MODEL],
+  ...over,
+});
+
+describe("what the launch picker offers", () => {
+  it("offers a reachable provider that has a model to pick", () => {
+    expect(isOfferable(provider())).toBe(true);
+    expect(notOfferedReason(provider())).toBeNull();
+  });
+
+  // The bug in #1432: this rendered as a group header with no options under it, which a browser
+  // draws as a row that neither a click nor an arrow key can reach.
+  it("does not offer a reachable provider with no models", () => {
+    expect(isOfferable(provider({ models: [] }))).toBe(false);
+  });
+
+  it("does not offer a provider this server cannot reach, however many models it lists", () => {
+    expect(isOfferable(provider({ ready: false, reason: "needs DEEPSEEK_API_KEY" }))).toBe(false);
+  });
+
+  it("explains an unreachable provider in the server's own words", () => {
+    expect(notOfferedReason(provider({ ready: false, reason: "provider 'deepseek' needs DEEPSEEK_API_KEY in the server's environment" }))).toBe(
+      "provider 'deepseek' needs DEEPSEEK_API_KEY in the server's environment",
+    );
+  });
+
+  // A `reason` is only promised when the server says why. Falling through to `undefined` here
+  // would render an empty line in the help — worse than the bug it explains.
+  it("still says something about an unreachable provider that carries no reason", () => {
+    expect(notOfferedReason(provider({ ready: false }))).toContain("deepseek");
+  });
+
+  // The two halves a user cannot see from the picker: which file to edit, and that the measured
+  // presets belong to one provider id.
+  it("tells a models-less provider what to add and where", () => {
+    const reason = notOfferedReason(provider({ models: [] })) ?? "";
+    expect(reason).toContain("deepseek");
+    expect(reason).toContain('"models"');
+    expect(reason).toContain("~/.mulmoterminal/config.json");
+    expect(reason).toContain("openrouter");
+  });
+});

--- a/test/src/components/settings/globalSettingSections.spec.ts
+++ b/test/src/components/settings/globalSettingSections.spec.ts
@@ -11,6 +11,7 @@ import { setDecisionDigest } from "../../../../src/composables/decisionDigest";
 import { setWorklogEnabled, setWorklogIntervalHours } from "../../../../src/composables/worklog";
 import { setGlobalFontFamily } from "../../../../src/composables/terminalFontFamily";
 import { useAppConfig } from "../../../../src/composables/useAppConfig";
+import { reloadLaunchOptions } from "../../../../src/composables/useLaunchOptions";
 
 // The sections that gave a config.json-only setting a control (#1401). What matters about each is
 // that flipping it POSTs the RIGHT FIELD: every one is a partial update, so a section naming the
@@ -241,5 +242,22 @@ describe("ModelsSection", () => {
     const wrapper = mount(ModelsSection);
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain("None configured");
+  });
+
+  // "ready · 0 models" reads like a working backend, and the launch picker leaves it out — which
+  // is how #1432 was reported as the picker being broken rather than the config being incomplete.
+  it("marks a reachable provider with no models as not being in the picker", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ providers: [{ id: "deepseek", label: "DeepSeek", ready: true, tokenEnv: "DEEPSEEK_API_KEY", models: [] }], anyReady: true }),
+    })) as unknown as typeof fetch;
+    await reloadLaunchOptions();
+    const wrapper = mount(ModelsSection);
+    await flushPromises();
+    // The provider's own row, not the section's prose: "ready" must not be what this line says.
+    const row = wrapper.get("li").text();
+    expect(row).toContain("0 models");
+    expect(row).toContain("not in the picker");
+    expect(row).not.toContain("ready");
   });
 });


### PR DESCRIPTION
## Summary

A custom provider appeared in the launch form's MODEL dropdown and could not be selected by a
click or by the arrow keys (#1432). It was not an option at all: a provider whose `models` is
empty renders as `<optgroup label="DeepSeek"></optgroup>` — a **group header with nothing under
it**, which a browser draws as a shaded row that a click and the arrow keys both skip.

The picker now offers only providers that are reachable **and** have a model to pick, so an empty
group cannot be rendered; the ones it leaves out are explained instead of vanishing.

## Items to Confirm / Review

1. **The help link changes wording** — it now reads **"Needs attention"** whenever a configured
   backend is not offered (previously "How this works" / "Use another model…" only). A provider
   with a missing key used to say "Use another model…"; it now says "Needs attention".
2. **`sanitizeProviders` gained a `console.warn`** naming the model ids the schema dropped. It is
   said **once per process** because this config is re-read on paths that run per session spawn
   (`getAppendSystemPrompt`), which would otherwise repeat the line at every launch. That makes
   the module stateful across calls — deliberate, but worth a look.
3. **Settings now shows "not in the picker"** (in the error colour) for a provider that is
   reachable with zero models. `ready` itself is unchanged and still means "a session CAN run on
   it" — a directory that pins a model of its own launches fine, which is why this is a separate
   state rather than "not ready".
4. **Skill / docs wording reversed for non-OpenRouter ids.** `mulmoterminal-model` said *"Do not
   write a `models` array … registering the provider is enough"*, which is true **only** for the
   id `openrouter`. Under any other id it produced exactly the broken entry in this issue.
5. **Not changed, noticed while here:** `useLaunchOptions`'s wire guard drops a **whole provider**
   when one model row fails `isModelPreset`, while the config schema drops **per model**. Not
   reachable today (the server builds those rows itself), so it is left alone — but the two layers
   disagree on the same principle.
6. **Not reproduced in a real Chrome** — this checkout has no Playwright browser installed. What
   was verified is that the empty `<optgroup>` is no longer in the DOM (see below); the painting of
   an empty group as an unreachable row is the reporter's own observation.

## User Prompt

> 調査、修正、テスト強化できる？？
> https://github.com/receptron/mulmoterminal/issues/1432

## Root cause

`ModelPicker.vue` rendered one `<optgroup>` per **ready** provider and one `<option>` per model.
Ready says only that this server can reach the backend — it says nothing about there being
anything to pick. Two silent paths lead to an empty list, and #1432 hit at least one of them:

1. **The built-in presets are OpenRouter's alone.** Every entry in `common/modelPresets.ts` carries
   `provider: "openrouter"`, and `presetsForProvider` matches on that id — so a backend registered
   as `deepseek`, `moonshot` or a company gateway starts with **no models**, and must list its own.
2. **A malformed `models` entry is dropped without a word.** `providerSchema.models` filters
   anything that is not a usable model-id string and `.catch([])`s a non-array, so
   `models: [{"id": "deepseek-chat"}]` becomes `[]` — the user reads a config file that lists
   models while the UI has none.

A session cannot start on such a provider anyway (`resolveProvider` refuses a named provider
without a model), so it is not a choice — it is a setup problem, and it now reads as one.

## What changed

| File | Change |
|---|---|
| `src/components/launchOffer.ts` (new) | One rule: `isOfferable = ready && models.length > 0`, plus `notOfferedReason()` — the sentence to show about a provider the picker leaves out |
| `src/components/ModelPicker.vue` | Offers only offerable providers (an empty group can no longer be rendered); shows the select only when something is offerable; the help link says "Needs attention" when a backend is not offered |
| `src/components/ModelSetupHelp.vue` | "Needs attention" now covers the no-models case; step 1 says presets come with the id `openrouter` and no other, and what a model id may contain |
| `src/components/settings/ModelsSection.vue` | A reachable provider with no models reads "not in the picker" rather than "ready" |
| `server/config/app-config.ts` | Warns, once per process, naming every model id it dropped (and a `models` that is not an array) |
| `server/skills/mulmoterminal-model/SKILL.md` | `models` is REQUIRED under any id other than `openrouter`; the id shape rule; two new troubleshooting rows |
| `docs/guide/{en,ja}/providers.md` | Same correction, plus troubleshooting rows for "the backend is missing from the MODEL list" |

## Verification

Against a real server, with a scratch `HOME` holding the reported config (`DEEPSEEK_API_KEY` set,
`models` written as objects — one of the two silent paths):

```
[providers] 'deepseek': dropped 1 unusable model id(s) — {"id":"deepseek-chat"}. A model id is letters, digits and . _ : / - ~.

GET /api/launch-options
{"providers":[{"id":"deepseek","label":"DeepSeek","ready":true,"tokenEnv":"DEEPSEEK_API_KEY","models":[]}],"anyReady":true}
```

That is the reporter's exact server state — `ready`, and nothing to pick. With the same config
corrected to `"models": ["deepseek-chat", "deepseek-reasoner"]`, the route answers two unmeasured
models and the log is silent, so the fix does not over-filter.

The DOM before the fix, captured from the mounted component:

```html
<option value="">This directory's default</option>
<optgroup label="DeepSeek"></optgroup>   <!-- the row that could not be clicked -->
```

The four new picker tests were run against the **unfixed** component and all four failed, then
pass with it.

## Tests

- `test/src/components/launchOffer.spec.ts` (new) — the rule, and both sentences
- `ModelPicker.spec.ts` — **no `<optgroup>` is ever empty**, written against the shape rather than
  one payload; a models-less provider is not offered; the select hides when it is the only one;
  the help link and the help text
- `launch-options.spec.ts` — a provider whose id is not `openrouter` gets no presets (the rule that
  made this reachable); it offers exactly what it lists; and four cases pinning what the config
  loader says when it drops a model id
- `globalSettingSections.spec.ts` — the Settings row says "not in the picker", not "ready"

`yarn format` / `lint` (0 errors) / `typecheck` / `test` (8503 passed) / `build` all green.

## The other two console errors in the report

- `GET /api/dir-sound?… → 404` is **by design**: the route 404s when the directory has no custom
  sound, and the client falls back to the global sound, then the built-in chime.
- `426 Upgrade Required` is emitted **nowhere in this repo** — every `WebSocketServer` runs in
  `noServer` mode, and `ws` only sends 426 from its own standalone `port` server. It also cannot
  disable a `<select>` option. Left open, with a request for the failing URL, in the issue.

refs #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3
