### PR TITLE
fix(test): Windows daily の 4 件のパス依存テストを直す

### DIFF
--- a/plans/fix-windows-daily-path-specs.md
+++ b/plans/fix-windows-daily-path-specs.md
@@ -1,0 +1,64 @@
+# fix: Windows (daily) の 4 件のパス依存テスト（#1459）
+
+`Windows (daily)` が main で連続失敗している。lint / typecheck / build は green で、
+落ちるのは `yarn test` の 3 ファイル・4 テストだけ。22.x / 24.x で同一。
+最新の失敗: https://github.com/receptron/mulmoterminal/actions/runs/30984995312
+
+Windows は PR では回らない（`windows-daily.yaml` は `pull_request` に入っていない）ので、
+3 件とも「macOS で書かれ、macOS でしか実行されないまま main に入った」もの。
+
+## 1. `test/server/config/dir-icon-detect.spec.ts` — `ref` の区切り文字
+
+```
+expected 'public/favicon.png' to be 'public\favicon.png'
+```
+
+`detectDirIcon` が返す `ref` は `ICON_CANDIDATES` の定数そのもの（`"public/favicon.png"`）。
+テストだけが `path.join("public", "favicon.png")` を期待していて、Windows では `\` になる。
+
+同じファイルの manifest 側のテストは Windows でも通っていたが、それは**実装が
+`path.join(manifestDir, entry.src)` を使っていて、Windows では `public\big.png` という
+`ref` を作っていたから**。`ref` は「書かれたとおりのパス」として設定ファイルに載る値
+（`dir-icon.ts` の型コメント、`worktree-dir-config.ts` の継承）なので、プラットフォーム依存の
+区切り文字が入るのは筋が悪い。
+
+対応:
+
+- 実装: manifest 分岐を `path.posix.dirname` / `path.posix.join` にし、この関数が返す `ref` を
+  全プラットフォームで `/` 区切りに統一する。`resolveIconFile` の `path.resolve` は Windows でも
+  `/` を受けるので解決結果は変わらない（`../` の脱出も従来どおり `isWithin` で弾かれる）。
+- テスト: `ref` の期待値を `path.join` ではなく素の文字列リテラルにする（9 箇所）。
+
+## 2. `test/server/config/dir-local-config.spec.ts` — drive-less な絶対パス
+
+```
+expected 'D:\work\proj' to be '\work\proj'
+```
+
+テストが `/work/proj/...` を渡している。Windows では `\work\proj` は「絶対だがドライブ無し」
+なので、`writtenFilePath` の `path.resolve` がカレントドライブを足して `D:\work\proj` を返す。
+
+姉妹テスト `dir-config.spec.ts` の `dirConfigWriteTarget` 群は同じ理由で
+`path.resolve("/Users/me/proj")` と書かれている。そちらに合わせる。
+
+## 3. `test/server/config/worktree-env.spec.ts` — 8.3 短縮名
+
+```
+expected {} to deeply equal { PORT: '3000' }
+```
+
+クロスプロセスのレースを再現するため、この spec だけが log ファイルへ直接
+`{ dir: competitor, ... }` を append する。ところが spec の temp dir は `realpathSync`（JS 版）
+で解決していて、production の `canonicalPath` は `realpathSync.native`。Windows の 8.3 短縮名
+（`C:\Users\RUNNER~1\...`）は native でしか展開されないため、書いた `dir` と
+`reservedWorktreeEnv` が引く正規化済みパスが別物になり、読み戻しが空になる。
+
+`test/support/tempDir.ts` の `makeTempDir` がまさにこのために `.native` を使っている（#1052）。
+この spec だけがそれを迂回していたので、`makeTempDir` に寄せる。
+
+## 検証
+
+- macOS: `yarn format` / `lint` / `typecheck` / `build` / `test`（全 592 ファイル）
+- Windows: ブランチに push したうえで `gh workflow run windows-daily.yaml --ref <branch>` を実行し、
+  実機 green を確認してからマージする（macOS だけの green は今回の失敗の原因そのものなので、
+  ground truth は Windows ランナーで取る）

--- a/server/config/dir-icon-detect.ts
+++ b/server/config/dir-icon-detect.ts
@@ -78,9 +78,14 @@ function iconFromManifest(base: string, manifestRef: string): DirIcon | null {
   // `src` is resolved against the MANIFEST's directory, not the project root: in the layout every
   // one of these repositories uses, the manifest sits in `public/` and its `/pwa-192.png` means
   // `public/pwa-192.png` — the web root is that directory, not the checkout.
-  const manifestDir = path.dirname(manifestRef);
+  //
+  // Joined with path.posix so the `ref` this produces is spelled the way the candidate list above
+  // spells one — a `ref` is a config value (dir-icon.ts) and a config file is read on every
+  // platform, so `public\big.png` would be a path only Windows resolves. path.resolve inside
+  // resolveIconFile takes "/" on Windows, so nothing is lost by keeping it.
+  const manifestDir = path.posix.dirname(manifestRef);
   for (const entry of rankedIcons(parsed.icons)) {
-    const icon = resolveIconFile(base, path.join(manifestDir, entry.src));
+    const icon = resolveIconFile(base, path.posix.join(manifestDir, entry.src));
     if (icon) return icon;
   }
   return null;

--- a/test/server/config/dir-icon-detect.spec.ts
+++ b/test/server/config/dir-icon-detect.spec.ts
@@ -19,6 +19,9 @@ const project = (files: Record<string, string>): string => {
   return dir;
 };
 const cleanup = () => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+// A `ref` is a config value, so it is spelled with "/" on every platform — never `path.join`,
+// which would assert `public\favicon.png` on Windows and pass there for a value no config file
+// should ever carry.
 const refOf = (dir: string): string | null => {
   const icon = detectDirIcon(dir);
   return icon?.source === "file" ? icon.ref : null;
@@ -69,7 +72,7 @@ describe("detectDirIcon — which file wins", () => {
     writeFileSync(path.join(parent, "outside.png"), "x");
     symlinkSync(path.join(parent, "outside.png"), path.join(dir, "public", "apple-touch-icon.png"));
     writeFileSync(path.join(dir, "public", "favicon.png"), "x");
-    expect(refOf(dir)).toBe(path.join("public", "favicon.png"));
+    expect(refOf(dir)).toBe("public/favicon.png");
     cleanup();
   });
 
@@ -80,7 +83,7 @@ describe("detectDirIcon — which file wins", () => {
       "public/real.png": "x",
     });
     mkdirSync(path.join(dir, "public", "favicon.ico"));
-    expect(refOf(dir)).toBe(path.join("public", "real.png"));
+    expect(refOf(dir)).toBe("public/real.png");
     cleanup();
   });
 
@@ -115,7 +118,7 @@ describe("detectDirIcon — the web manifest", () => {
       "public/big.png": "x",
       "public/mid.png": "x",
     });
-    expect(refOf(dir)).toBe(path.join("public", "big.png"));
+    expect(refOf(dir)).toBe("public/big.png");
     cleanup();
   });
 
@@ -130,9 +133,9 @@ describe("detectDirIcon — the web manifest", () => {
       "public/mask.png": "x",
       "public/plain.png": "x",
     });
-    expect(refOf(both)).toBe(path.join("public", "plain.png"));
+    expect(refOf(both)).toBe("public/plain.png");
     const only = project({ "public/manifest.json": manifest([{ src: "mask.png", sizes: "512x512", purpose: "maskable" }]), "public/mask.png": "x" });
-    expect(refOf(only)).toBe(path.join("public", "mask.png"));
+    expect(refOf(only)).toBe("public/mask.png");
     cleanup();
   });
 
@@ -145,7 +148,7 @@ describe("detectDirIcon — the web manifest", () => {
       "public/raster.png": "x",
       "public/vector.svg": "<svg xmlns='http://www.w3.org/2000/svg'/>",
     });
-    expect(refOf(dir)).toBe(path.join("public", "vector.svg"));
+    expect(refOf(dir)).toBe("public/vector.svg");
     cleanup();
   });
 
@@ -153,7 +156,7 @@ describe("detectDirIcon — the web manifest", () => {
   // directory. Resolving it against the checkout instead would miss every Vite project.
   it("resolves a root-relative src against the manifest's own directory", () => {
     const dir = project({ "public/site.webmanifest": manifest([{ src: "/pwa-192.png", sizes: "192x192" }]), "public/pwa-192.png": "x" });
-    expect(refOf(dir)).toBe(path.join("public", "pwa-192.png"));
+    expect(refOf(dir)).toBe("public/pwa-192.png");
     cleanup();
   });
 
@@ -168,7 +171,7 @@ describe("detectDirIcon — the web manifest", () => {
       ]),
       "public/local.png": "x",
     });
-    expect(refOf(dir)).toBe(path.join("public", "local.png"));
+    expect(refOf(dir)).toBe("public/local.png");
     cleanup();
   });
 
@@ -211,7 +214,7 @@ describe("detectDirIcon — the web manifest", () => {
       ]),
       "public/here.png": "x",
     });
-    expect(refOf(dir)).toBe(path.join("public", "here.png"));
+    expect(refOf(dir)).toBe("public/here.png");
     cleanup();
   });
 });

--- a/test/server/config/dir-local-config.spec.ts
+++ b/test/server/config/dir-local-config.spec.ts
@@ -82,9 +82,12 @@ describe("the local file layers over the shared one", () => {
 // Writing either file has to recolour the cells. Reloading only on the shared one would leave the
 // file a user edits MOST — their own clone's — not applying until a browser reload.
 describe("live reload", () => {
+  // Resolved, like the sibling cases in dir-config.spec.ts: on Windows "\work\proj" is absolute
+  // but drive-LESS, so the function under test answers "D:\work\proj" and a joined expectation
+  // never matches it.
   it.each([DIR_CONFIG_FILE, DIR_LOCAL_CONFIG_FILE])("fires for a write to %s", (name) => {
-    const file = path.join("/work", "proj", name);
-    expect(dirConfigWriteTarget("Write", { file_path: file })).toBe(path.join("/work", "proj"));
+    const dir = path.resolve("/work/proj");
+    expect(dirConfigWriteTarget("Write", { file_path: path.join(dir, name) })).toBe(dir);
   });
 
   it("does not fire for another file in the same directory", () => {

--- a/test/server/config/worktree-env.spec.ts
+++ b/test/server/config/worktree-env.spec.ts
@@ -1,9 +1,8 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { appendFileSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
-import { realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import path from "node:path";
+import { makeTempDir } from "../../support/tempDir.js";
 import { ensureWorktreeEnv, releaseWorktreeEnv, reservedWorktreeEnv, worktreeEnvLogFile, worktreeEnvValues } from "../../../server/config/worktree-env";
 import { MAX_SLUG_CHARS, MAX_SLUG_SUFFIX, type WorktreeEnvSpec } from "../../../common/worktreeEnv";
 
@@ -17,10 +16,13 @@ const FREE = (): Promise<boolean> => Promise.resolve(true);
 
 beforeEach(() => {
   savedHome = process.env.MULMOTERMINAL_HOME;
-  // realpath: every path this module records goes through canonicalPath, and on macOS the temp
-  // dir is a symlink — so an un-resolved root would contain none of the worktrees under it.
-  home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wtenv-home-")));
-  projects = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wtenv-proj-")));
+  // makeTempDir, for the realpath it does: every path this module records goes through
+  // canonicalPath, so a directory spelled any other way is a directory it never finds. Node's own
+  // realpathSync is not enough — it leaves Windows' 8.3 component (RUNNER~1) alone where
+  // canonicalPath's `.native` expands it, and a spec writing that spelling into the log then reads
+  // back nothing at all.
+  home = makeTempDir("mt-wtenv-home-");
+  projects = makeTempDir("mt-wtenv-proj-");
   process.env.MULMOTERMINAL_HOME = home;
 });
 


### PR DESCRIPTION
## Summary

`Windows (daily)` が main で連続失敗していた（[run 30984995312](https://github.com/receptron/mulmoterminal/actions/runs/30984995312)、22.x / 24.x 両方）。lint / typecheck / build は green で、`yarn test` の **3 ファイル・4 テスト**だけが赤。3 件とも「その OS が実際には生成しないパス表現をテストが期待していた」もので、Windows は `pull_request` で回らない（`windows-daily.yaml` は意図的に除外）ため macOS だけで green のまま main に入っていた。

| ファイル | 失敗内容 | 原因 |
|---|---|---|
| `dir-icon-detect.spec.ts` | `expected 'public/favicon.png' to be 'public\favicon.png'` | `ref` は候補リストの定数（`/` 区切り）なのに、テストが `path.join` を期待 |
| `dir-local-config.spec.ts` (×2) | `expected 'D:\work\proj' to be '\work\proj'` | `/work/proj` は Windows では「絶対だがドライブ無し」→ `path.resolve` がカレントドライブを補う |
| `worktree-env.spec.ts` | `expected {} to deeply equal { PORT: '3000' }` | spec の temp dir が JS 版 `realpathSync`。production の `canonicalPath` は `.native` で、8.3 短縮名 `RUNNER~1` はこちらでしか展開されない |

Closes #1459

## Items to Confirm / Review

- **プロダクトコードの変更は 1 箇所だけ**: `dir-icon-detect.ts` の manifest 分岐を `path.join` → `path.posix.join` に変更。`ref` は「書かれたとおりのパス」として設定ファイルに載る値（`dir-icon.ts` の型コメント、`worktree-dir-config.ts` の継承）なので、Windows でだけ `public\big.png` になるのは筋が悪い、という判断。**候補リスト側の `ref` は元から `/` 区切りだったので、これで両分岐が揃う**。この統一に異論があればここ。
  - 解決結果は変わらないことを確認済み: `path.win32.resolve("C:\\proj", "public/big.png")` → `C:\proj\public\big.png`、`path.win32.isAbsolute("public/big.png")` → `false`、`../` 脱出も従来どおり `isWithin` で弾かれる。
  - 現状 auto-detect の `ref` が設定ファイルへ書かれる経路は無い（`worktree-dir-config.ts` が継承するのは *written* な `icon` のみ）ので、実挙動の差分は無い。
- **残り 2 件はテストのみの修正**。プロダクトの Windows 挙動は壊れていなかった。
- **検証**: macOS で `format` / `lint` / `typecheck` / `build` / `test`（592 ファイル 8484 passed）green。加えて**このブランチで `windows-daily.yaml` を `workflow_dispatch` して実機 green を確認してからマージする**（macOS だけの green は今回の失敗そのものなので、ground truth は Windows ランナーで取る）。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30984995312 直せる？

## 実装の詳細

### 1. `dir-icon-detect` — `ref` の区切り文字を `/` に統一

`detectDirIcon` が返す `ref` は `ICON_CANDIDATES` の定数そのもの（`"public/favicon.png"`）。テストだけが `path.join("public", "favicon.png")` を期待していて Windows で不一致だった。

同ファイルの manifest 系テストが Windows でも通っていたのは、**実装が `path.join(manifestDir, entry.src)` で Windows 専用の `ref` を作っていたから**。実装を `path.posix.dirname` / `path.posix.join` に変え、テストの期待値は素の文字列リテラルにした（9 箇所）。`refOf` ヘルパーに「`ref` は設定値なので `path.join` を使わない」旨のコメントを追加。

### 2. `dir-local-config` — drive-less な絶対パス

`writtenFilePath` は絶対パスを `path.resolve` するので、Windows では `\work\proj\...` にカレントドライブが付く。姉妹テスト `dir-config.spec.ts` の `dirConfigWriteTarget` 群と同じく `path.resolve("/work/proj")` で両辺を組み立てるようにした。

### 3. `worktree-env` — 8.3 短縮名

クロスプロセスのレースを再現するため、この spec だけが log ファイルへ直接 `{ dir: competitor, ... }` を append する。ところが spec の temp dir は JS 版 `realpathSync` で解決していて、production の `canonicalPath` は `realpathSync.native`。Windows の `C:\Users\RUNNER~1\...` は native でしか展開されないため、書いた `dir` と `reservedWorktreeEnv` が引く正規化済みパスが別物になり、読み戻しが `{}` になっていた。

`test/support/tempDir.ts` の `makeTempDir` がまさにこのために `.native` を使っている（#1052 の再発防止）。この spec だけがそれを迂回していたので、`makeTempDir` に寄せた。

設計メモは `plans/fix-windows-daily-path-specs.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal6
