### PR TITLE
fix: ファイルダイアログを zenity 依存から外し、失敗を画面に出す (#1447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Needs **Node ≥ 22.9**, plus these CLIs on your `PATH`:
 | Optional | `codex` | [Codex sessions](#agents-claude--codex) in a cell, alongside Claude | `npm i -g @openai/codex` |
 | Optional | `ffmpeg` | video rendering from the [mulmo-script panel](#wiki-collections--the-gui-panel) (its plugin ships enabled) | `brew install ffmpeg` · `sudo apt install ffmpeg` · `sudo dnf install ffmpeg` |
 | Optional | `ollama` | [`claude-ollama`](https://receptron.github.io/mulmoterminal/guide/en/claude-ollama.html) — Claude Code against a fully local model | [ollama.com/download](https://ollama.com/download) |
+| Linux only | a file dialog | the **Choose a folder / Insert a file path** buttons, which open an OS dialog on the machine the server runs on. macOS and Windows have one built in; **WSL** uses the Windows one over interop and needs nothing installed. A Linux desktop needs one of these — without any, the buttons say so and you type the path instead (#1447) | `sudo apt install zenity` · `sudo dnf install zenity` · `kdialog`, `qarma` and `yad` also work |
 
 The server starts without any of the non-required rows; you just lose that row's feature,
 and the header/panel for it says so. `git` and `gh` are marked required because losing them
@@ -1541,7 +1542,7 @@ same-origin-guarded.
 | `POST /api/transcribe`(`/model`…) | Voice-input transcription (Whisper, macOS). |
 | `POST /api/translation` | Runtime UI-string translation. |
 | `GET /api/remote-host/status` · `POST /api/remote-host/{connect,disconnect}` | Companion phone-client link. Each response carries the command channel's `health` (`online` / `reconnecting` / `offline`, plus the last listener error), so the toolbar shows a dropped channel instead of the last state it happened to fetch. |
-| `POST /api/open-dir` · `POST /api/pick-file` | Reveal a dir in Finder/Explorer; OS file-picker → path (`{ directory: true }` opens the folder picker — used by the launcher's Working-directory 📁 button). |
+| `POST /api/open-dir` · `POST /api/pick-file` | Reveal a dir in Finder/Explorer; OS file-picker → path (`{ directory: true }` opens the folder picker — used by the launcher's Working-directory 📁 button). Both run on the SERVER's machine, and both answer **500 with a reason** when it has nothing to open a dialog with, rather than a silent nothing (#1447). The picker tries every dialog the host might have: macOS `osascript`, Windows PowerShell, **WSL** the Windows dialog over interop (`powershell.exe` + `wslpath`), Linux `zenity` → `kdialog` → `qarma` → `yad`. A user cancel is a 200 with `paths: []`. |
 | `POST /api/session/:id/drop` | A dropped file whose path the browser withheld. **Raw bytes**, not JSON, under the file's own content type (base64 in JSON would cap real files near 18 MB, and a dropped `.json` would be parsed as a document); the original name rides percent-encoded in `x-drop-filename` and is used for its **suffix only**. Answers `{ path }` — absolute, inside the private per-session directory the session was granted at launch. 110 MiB cap; 404 for a session this server isn't running. |
 
 The phone itself uses **none** of these routes — it reaches the host over Firestore command
@@ -1857,7 +1858,8 @@ server/
   git/            git, GitHub (gh) and GitLab (glab) + worktrees: git-status.ts, gitRemote.ts,
                   gh.ts, prs.ts, issues.ts, pr-for-branch.ts, worktrees.ts, worktree-*.ts
   files/          files-browse.ts (contained tree read/write), pick-file.ts,
-                  open-dir.ts, scripts.ts (Run-menu script.json loader)
+                  open-dir.ts, wsl.ts (interop detection + wslpath),
+                  scripts.ts (Run-menu script.json loader)
   infra/          process/transport/misc: tmux.ts, tmux-routes.ts,
                   pubsub.ts (socket.io /ws/pubsub), spa-fallback.ts, host-tools.ts,
                   plugins-registry.ts, web-push.ts, install-bundled-skills.ts, accounting-tool.ts

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -9,6 +9,7 @@ import { execSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
+import { release } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
@@ -106,6 +107,40 @@ const PATH_TOOLS = [
   { cmd: "ollama", versionArg: "--version", required: false, why: "a fully local model via claude-ollama", hint: "https://ollama.com/download" },
 ];
 
+// The variables WSL exports into a login shell, then the kernel that names itself
+// (`…-microsoft-standard-WSL2`, `…-Microsoft` on WSL1) for the processes those variables never
+// reach. Mirrors `isWsl()` in server/files/wsl.ts, which this file cannot import: bin runs as
+// plain JS, the server runs through tsx. Keep the two in step.
+function isWslHost() {
+  if (process.platform !== "linux") return false;
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) || /microsoft/i.test(release());
+}
+
+// The file dialog is the one requirement that differs per host, so it is checked per host rather
+// than listed above: macOS and Windows have one built in and can't be missing it. WSL reaches the
+// Windows dialog over interop, and a Linux desktop has whichever toolkit it was installed with —
+// zenity's absence there is what makes the picker look broken (#1447).
+function fileDialogTool() {
+  if (process.platform === "darwin" || process.platform === "win32") return null;
+  const why = "the file / folder picker";
+  if (isWslHost()) {
+    return {
+      cmd: "powershell.exe",
+      versionArg: "-NoProfile -Command exit",
+      required: false,
+      why: `${why}, using the Windows dialog`,
+      hint: "enable WSL interop (wsl.conf), or: sudo apt install zenity",
+    };
+  }
+  return {
+    cmd: "zenity",
+    versionArg: "--version",
+    required: false,
+    why: `${why} (kdialog / qarma / yad also work)`,
+    hint: "sudo apt install zenity  ·  sudo dnf install zenity",
+  };
+}
+
 function toolCheckLine({ cmd, versionArg, required, why, hint }) {
   if (hasCommand(cmd, versionArg)) return `  ✓ ${cmd} — ${why}`;
   const head = required ? `  ✗ ${cmd} — not found, needed for ${why}` : `  ○ ${cmd} — optional (${why})`;
@@ -139,7 +174,7 @@ async function runInit(initArgs) {
     console.log("      → npm install -g @anthropic-ai/claude-code   (then run `claude` and log in)");
   }
 
-  PATH_TOOLS.forEach((tool) => console.log(toolCheckLine(tool)));
+  [...PATH_TOOLS, fileDialogTool()].filter(Boolean).forEach((tool) => console.log(toolCheckLine(tool)));
 
   // Config half: derive working-dir presets from Claude history + write config.json.
   console.log("");
@@ -188,9 +223,13 @@ function runGoogle(googleArgs) {
   });
 }
 
+// WSL has no Linux browser to open (and often no `xdg-open` either), so the URL goes to the
+// Windows shell — `start` through cmd.exe, which is what opens the user's real browser. It exits
+// 0, unlike `explorer.exe`, so a failure here still means a failure.
 function pickOpenCommand() {
   if (process.platform === "darwin") return "open";
   if (process.platform === "win32") return "start";
+  if (isWslHost()) return 'cmd.exe /c start ""';
   return "xdg-open";
 }
 

--- a/docs/guide/en/getting-started.md
+++ b/docs/guide/en/getting-started.md
@@ -288,7 +288,8 @@ npx mulmoterminal@latest init
 ```
 
 - Reports your Node version and `claude` / `git` / `gh` / `glab` / `tmux` / `codex` /
-  `ffmpeg` / `ollama` as **`✓` (found), `✗` (required, missing), `○` (optional)**
+  `ffmpeg` / `ollama` as **`✓` (found), `✗` (required, missing), `○` (optional)** — plus, on
+  Linux, whatever this host opens a file dialog with
 - Seeds the launcher's **directory presets** from your Claude Code history
 - Writes `~/.mulmoterminal/config.json`, keeping your other settings
 - With `claude` installed, offers to hand off to the `/mulmoterminal-config` skill
@@ -379,6 +380,7 @@ costs you that one feature.
 | Optional | `codex` | [Codex sessions](basics.html#claude-and-codex) in a cell, alongside Claude | `npm i -g @openai/codex` |
 | Optional | `ffmpeg` | video rendering from the [GUI panel](features.html)'s mulmo-script plugin | `brew install ffmpeg` · `sudo apt install ffmpeg` |
 | Optional | `ollama` | [claude-ollama](claude-ollama.html) — Claude Code against a fully local model | [ollama.com/download](https://ollama.com/download) |
+| Linux only | a file dialog | the **Choose a folder** / **Insert a file path** buttons, which open an OS dialog on the machine the server runs on. macOS and Windows have one built in, and **WSL** uses the Windows one — nothing to install. A Linux desktop needs one; without any, the buttons say so and you type the path instead | `sudo apt install zenity` · `sudo dnf install zenity` · `kdialog`, `qarma` and `yad` also work |
 
 [`init`](#init) reports which of these it can find on this machine.
 

--- a/docs/guide/ja/getting-started.md
+++ b/docs/guide/ja/getting-started.md
@@ -292,7 +292,8 @@ npx mulmoterminal@latest init
 ```
 
 - Node のバージョン、`claude` / `git` / `gh` / `glab` / `tmux` / `codex` / `ffmpeg` / `ollama` を
-  **`✓`（あり）・`✗`（必須なのに無い）・`○`（任意）** で表示します
+  **`✓`（あり）・`✗`（必須なのに無い）・`○`（任意）** で表示します。Linux では、このホストが
+  ファイルダイアログを何で開くかも確認します
 - Claude Code の履歴から、**よく使うディレクトリのチップ**を作ります
 - `~/.mulmoterminal/config.json` を書き出します（あなたの他の設定は残します）
 - `claude` があれば、そのまま対話設定（`/mulmoterminal-config` スキル）に入るか聞かれます
@@ -383,6 +384,7 @@ MulmoTerminal は普段の開発ツールを操縦するコックピットなの
 | 任意 | `codex` | セルで [Codex セッション](basics.html#claude-and-codex)を Claude と並べて動かす | `npm i -g @openai/codex` |
 | 任意 | `ffmpeg` | [GUI パネル](features.html)の mulmo-script プラグインからの動画生成 | `brew install ffmpeg` · `sudo apt install ffmpeg` |
 | 任意 | `ollama` | [claude-ollama](claude-ollama.html) — 完全ローカルのモデルで Claude Code を動かす | [ollama.com/download](https://ollama.com/download) |
+| Linux のみ | ファイルダイアログ | **Choose a folder** / **Insert a file path** ボタン。サーバが動いているマシンで OS のダイアログを開きます。macOS と Windows は OS 内蔵、**WSL** は Windows 側のダイアログを使うのでインストール不要です。Linux デスクトップではどれか 1 つ必要で、無ければボタンがその旨を表示します（パスを直接入力すれば使えます） | `sudo apt install zenity` · `sudo dnf install zenity` · `kdialog` / `qarma` / `yad` でも可 |
 
 いま何が足りないかは [`init`](#init) が一覧で出します。
 

--- a/plans/fix-1447-picker-linux-wsl.md
+++ b/plans/fix-1447-picker-linux-wsl.md
@@ -1,0 +1,146 @@
+# fix(#1447): zenity を入れなくても Linux / WSL2 でファイル選択が動くようにする
+
+## 問題
+
+`server/files/pick-file.ts` の `pickFileCommand()` は darwin / win32 以外を **`zenity` 決め打ち**で
+spawn する。zenity が無いホスト（WSL2 の Ubuntu、最小構成の Linux）では ENOENT でルートが 500 を
+返すが、呼び出し側 3 箇所が全部 `if (!res.ok) return;` と `catch {}` でそれを捨てているため、
+ユーザーからは **「押しても何も起きないボタン」** になる。
+
+握りつぶしている 3 箇所:
+
+| 箇所 | ボタン |
+| --- | --- |
+| `src/components/CellLaunchForm.vue` `pickDir()` | New terminal の Working directory 📁 |
+| `src/composables/useHeaderAction.ts` `pickFileInto()` | ヘッダの "Insert a file path" |
+| `src/components/settings/NotificationSoundsSection.vue` `browseSound()` | Settings の通知音の選択 |
+
+## 同じ形のバグ（sweep して見つけた分）
+
+「ホストのコマンドを spawn する / 失敗が UI に出ない / WSL が考慮されていない」で横に並べると:
+
+1. **`server/files/open-dir.ts`** — 非 darwin/win32 は `xdg-open` 決め打ち。しかも spawn 失敗を
+   `console.error` に書くだけで、レスポンスは先に `{ok:true}` を返している（`error` イベントは
+   レスポンスの後に来る）。WSL では `xdg-open` が無い / Linux 側を開いてしまい、**UI 上は成功に見える**。
+2. **`bin/mulmoterminal.js` `pickOpenCommand()`** — 起動時のブラウザ起動が `xdg-open` 決め打ち。
+   こちらは失敗すると `Open your browser: <url>` を出すので沈黙はしないが、WSL では自動で開かない。
+
+音の再生はブラウザ側（AudioContext）なのでホスト依存なし。他の spawn（git / gh / tmux / pty）は
+GUI を開かないので対象外。
+
+## 方針
+
+**追加インストールを要求しない = OS 標準でできるのが好ましい**（ユーザー方針）。
+
+- **WSL2 → Windows 側のダイアログ**。WSL からは interop で `powershell.exe` がそのまま実行できるので、
+  既存の Windows 用スクリプト（COM の Explorer 型フォルダダイアログ / `OpenFileDialog`）を流用する。
+  返り値は Windows パスなので `wslpath -u` で Linux パスへ変換する。**zenity 不要**。
+- **素の Linux → フォールバックチェーン** `zenity` → `kdialog` → `qarma` → `yad`。
+  厳密な "OS 標準" は xdg-desktop-portal の `org.freedesktop.portal.FileChooser` だが、結果が D-Bus の
+  Response シグナルで非同期に返る仕様で `gdbus` 一発では取れず、常駐監視か D-Bus ライブラリ依存が要る。
+  コスト対効果でチェーン方式にする。
+- **全滅したらエラーを UI に出す**。これはプラットフォームを問わず必須。
+
+## 実装
+
+### 1. `server/files/wsl.ts`（新規）
+
+- `isWsl(platform, env, kernelRelease = os.release())` — 純関数。判定は 2 段:
+  1. `WSL_DISTRO_NAME` / `WSL_INTEROP`（WSL が**ログインシェル**に撒く変数。ドキュメント化された正攻法）
+  2. カーネル名（`…-microsoft-standard-WSL2` / WSL1 は `…-Microsoft`）。**systemd 等で起動され変数が
+     届かないプロセス**が「素の Linux」と誤判定されるのを防ぐ。これが漏れると zenity の無い WSL で
+     今回の修正が丸ごと効かない。
+  - **WSL1 と WSL2 は区別しない**。どちらも interop と `wslpath` を持ち、欲しいものが同じ。
+  - 誤検出のコストは設計で下げる: どの呼び出し側も Windows 側コマンドが起動できなければ Linux 側へ
+    フォールバックするので、**誤検出は ENOENT 1 回**、取りこぼしは機能喪失。非対称なので前者に倒す。
+- `toLinuxPath(windowsPath, run?)` / `toWindowsPath(linuxPath, run?)` — `wslpath -u` / `-w`。
+  `run` を差し替え可能にしてテストする。
+
+**判定は端で 1 回だけ**行う。ルートが `isWsl()` を呼び、以下の純関数には `wsl: boolean` という
+**決定済みの事実**を渡す（`pickFileCandidates` / `openDirCommands` / `pickerUnavailableMessage`）。
+env を各所で読み直さないので、判定箇所が 1 つに固定され、テストもホスト非依存になる
+（WSL 上でテストを回しても「Linux はチェーン」を検証できる）。
+
+### 2. `server/files/pick-file.ts`
+
+- `pickFileCommand()` → **`pickFileCandidates(platform, directory, env)`**（候補の配列）に変える。
+  - darwin: `osascript`
+  - win32: `powershell`
+  - WSL: `powershell.exe`（+ `appendWindowsPath=false` 向けに絶対パスの `/mnt/c/...` を 2 番目）→ Linux チェーン
+  - その他 Linux: zenity → kdialog → qarma → yad
+- ルートは候補を順に試し、**「起動できなかった / 起動したが失敗した」候補だけ**次へ送る。
+  判定は純関数 `classifyPickerRun()` に出してテストする:
+  - spawn error（ENOENT 等）→ 失敗
+  - `code !== 0 && stdout 空 && stderr 非空 && ユーザーキャンセルでない` → 失敗
+  - それ以外 → 成功（**キャンセルは成功で `paths: []`**）
+  - macOS のキャンセルは `osascript` が stderr に `User canceled. (-128)` を出して exit 1 になるので、
+    候補ごとに `isUserCancel` を持たせる。ここを間違えると **キャンセルするたびにエラーが出る**。
+- WSL 候補の stdout は Windows パスなので、`path.isAbsolute` フィルタの **前に** `wslpath -u` を通す。
+  （`C:\proj` は posix では絶対パスではないため、順序を間違えると全部落ちて「キャンセル」と同じになる）
+- WSL 候補は `-Command` ではなく **`-EncodedCommand`**（base64 UTF-16LE）でスクリプトを渡す。
+  interop の argv→コマンドライン変換で here-string の引用符・改行が壊れるのを避けるため。
+  win32 の既存経路は**触らない**（実機で動いている挙動を変えない）。
+- 全滅時は 500 + プラットフォーム別の案内文（`pickerUnavailableMessage()`、純関数）。
+
+### 3. `server/files/win-folder-dialog.ts`
+
+初期フォルダを渡せるようにする（`IFileDialog.SetFolder` + `SHCreateItemFromParsingName`）。
+WSL では `wslpath -w $HOME` を渡し、Windows のダイアログが `\\wsl.localhost\<distro>\home\...` から
+開くようにする。これが無いと Windows 側の既定位置から手で UNC を辿ることになり実用にならない。
+**win32 は初期フォルダ無し（＝現行と同じ argv）**。SetFolder は独自の try/catch で囲み、失敗しても
+ダイアログ自体は開く。
+
+### 4. `server/files/open-dir.ts`
+
+- こちらも**候補チェーン** `openDirCommands(platform, wsl)` にする。WSL は
+  `explorer.exe <windows path>`（`wslpath -w` で変換）→ `xdg-open`。1 発勝負にすると WSL 誤検出が
+  「動いていた `xdg-open` を壊す」ことになるため、フォールバックを必ず後ろに置く。
+  `explorer.exe` は成功時も exit 1 を返すことがあるので終了コードでは判定しない。
+- レスポンスを `spawn` イベント（成功）/ `error` イベント（失敗）まで待ってから返し、全滅は 500 にする。
+  UI 側（`TerminalCell.vue` / `useHeaderAction.ts`）でも握りつぶしをやめる。
+
+### 5. UI: 共有ヘルパー `src/composables/pickPaths.ts`（新規）
+
+`pickPaths({directory})` → `{ paths, error }`。3 箇所の fetch + パース + エラー処理を 1 つにまとめる。
+表示先:
+
+- `CellLaunchForm.vue` — Working directory 欄の下（`cell-dir-busy` と同じ amber 行）
+- `NotificationSoundsSection.vue` — サウンド欄の下（`GoogleAccountSection` の `google-warn` と同じ形）
+- ヘッダボタン — `Terminal.vue` の既存の**セル内トースト** `showHint()` を使う。
+  `runHeaderButton()` に `onError` を渡す形にする。
+
+### 6. `bin/mulmoterminal.js`
+
+- `PATH_TOOLS` にファイルダイアログの依存を**プラットフォーム別に**足す
+  （darwin/win32 は不要、WSL は `powershell.exe`、素の Linux は `zenity`）。
+- `pickOpenCommand()` を WSL 対応（`explorer.exe`）。
+
+### 7. ドキュメント
+
+- README の要件表に 1 行（tmux / glab と同じ扱い）と、ファイルダイアログの節に説明。
+- `docs/guide/{en,ja}` は要件表を持たないので、リリース時のガイドページで触れる（本 PR では触らない）。
+
+## テスト
+
+- `test/server/files/wsl.spec.ts`（新規）— 検出とパス変換。
+- `test/server/files/pick-file.spec.ts` — 候補の順序、WSL 分岐、`classifyPickerRun`（**キャンセル 3 種**:
+  zenity exit 1 / osascript -128 / PowerShell exit 0 空 stdout）、変換→絶対パス判定の順序、案内文。
+- `test/server/files/open-dir.spec.ts` — WSL 分岐と失敗時 500。
+- `test/src/composables/pickPaths.spec.ts`（新規）— 500 / 例外 / 正常。
+- 既存の 3 コンポーネント spec にエラー表示のケースを足す。
+
+## macOS 実機で確認できたこと
+
+- `/api/open-dir` → Finder が開き 200。`/api/pick-file` → 実際にダイアログが出る（`osascript`
+  プロセスを確認）、閉じると 200 `{"paths":[]}`。**キャンセルがエラー表示にならない**。
+- この機体でバックグラウンドから出したダイアログは自動キャンセルされ、実出力は
+  `22:63: execution error: ユーザによってキャンセルされました。 (-128)` だった。
+  **文言はロケールで翻訳される**ので、英語文言ではなく `(-128)` で判定しているのが効いている
+  （判定を入れていなければ、ここで 500 が画面に出ていた）。この実出力を spec に固定した。
+
+## 検証できないこと（PR に明記する）
+
+**WSL2 / Windows の実機がない。** `wslpath` の UNC 変換、interop 経由で PowerShell のダイアログが
+実際に開くか、`explorer.exe` の挙動は**未検証**。issue 報告者に確認を依頼済み（#1447 のコメント）。
+コードは「WSL 候補が失敗したら Linux チェーンへ、それも全滅ならエラー表示」と degrade するので、
+最悪でも現状（無反応）より悪くはならないようにする。

--- a/server/files/open-dir.ts
+++ b/server/files/open-dir.ts
@@ -1,15 +1,45 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import { resolveDirRequest } from "./dirRequest.js";
+import { isWsl, toWindowsPath } from "./wsl.js";
 
-// The native file-manager opener for a platform. The command is a fixed
-// allowlist (never built from input); the directory is passed as a separate argv
-// entry, so there's no shell and no injection surface.
-export function openCommand(platform: NodeJS.Platform): string {
-  if (platform === "win32") return "explorer";
-  if (platform === "darwin") return "open";
-  return "xdg-open";
+export interface OpenDirCommand {
+  cmd: string;
+  /** The command is a Windows program, so it wants the Windows form of the path (WSL interop). */
+  windowsPath?: boolean;
 }
+
+// The native file-manager openers for a platform, best first. The commands are a fixed
+// allowlist (never built from input); the directory is passed as a separate argv entry, so
+// there's no shell and no injection surface.
+//
+// WSL is Explorer's job even though the platform is `linux`: the distro has no desktop of its
+// own, and `xdg-open` there either doesn't exist or opens a Linux app nobody can see (#1447).
+// `xdg-open` still follows it, so a host wrongly read as WSL — or a WSL with interop turned off —
+// falls back to what a Linux desktop would have done instead of failing outright.
+export function openDirCommands(platform: NodeJS.Platform, wsl: boolean): OpenDirCommand[] {
+  if (platform === "win32") return [{ cmd: "explorer" }];
+  if (platform === "darwin") return [{ cmd: "open" }];
+  if (wsl) return [{ cmd: "explorer.exe", windowsPath: true }, { cmd: "xdg-open" }];
+  return [{ cmd: "xdg-open" }];
+}
+
+// Resolves null once the child is running, or the reason it could not start. The exit CODE is
+// deliberately not waited for: `explorer.exe` returns 1 on a perfectly successful open, and the
+// user is done with us the moment the window appears.
+function spawnOpener(cmd: string, dir: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, [dir], { detached: true, stdio: "ignore" });
+    child.on("error", (e) => resolve(e.message));
+    child.on("spawn", () => {
+      child.unref();
+      resolve(null);
+    });
+  });
+}
+
+/** The path this opener wants, or null when it cannot be expressed (so the caller skips it). */
+const targetFor = (candidate: OpenDirCommand, dir: string): Promise<string | null> => (candidate.windowsPath ? toWindowsPath(dir) : Promise.resolve(dir));
 
 interface OpenDirOptions {
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
@@ -19,17 +49,25 @@ interface OpenDirOptions {
 // file manager. The server runs locally, so this is how a browser tab (which can't
 // touch the filesystem) opens a folder. Guarded by the same-origin check used for
 // the sockets so a random website can't drive it.
+//
+// It answers only once an opener has actually STARTED. It used to answer `{ok:true}` first and
+// log the failure to a console the user never sees, so a host without `xdg-open` reported success
+// and revealed nothing (#1447).
 export function mountOpenDirRoute(app: Express, { isAllowedOrigin }: OpenDirOptions) {
-  app.post("/api/open-dir", (req: Request, res) => {
+  app.post("/api/open-dir", async (req: Request, res) => {
     const dir = resolveDirRequest(req, res, isAllowedOrigin);
     if (!dir) return;
-    try {
-      const child = spawn(openCommand(process.platform), [dir], { detached: true, stdio: "ignore" });
-      child.on("error", (e) => console.error(`[open-dir] failed to open ${dir}: ${e.message}`));
-      child.unref();
-      res.json({ ok: true });
-    } catch (e) {
-      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    const attempts: string[] = [];
+    for (const candidate of openDirCommands(process.platform, isWsl(process.platform, process.env))) {
+      const target = await targetFor(candidate, dir);
+      if (target === null) {
+        attempts.push(`${candidate.cmd}: wslpath could not translate ${dir}`);
+        continue;
+      }
+      const failure = await spawnOpener(candidate.cmd, target);
+      if (failure === null) return res.json({ ok: true });
+      attempts.push(`${candidate.cmd}: ${failure}`);
     }
+    res.status(500).json({ error: `could not open ${dir} [${attempts.join("; ")}]` });
   });
 }

--- a/server/files/pick-file.ts
+++ b/server/files/pick-file.ts
@@ -162,12 +162,24 @@ export function parsePickerOutput(stdout: string): string[] {
   return pickerLines(stdout).filter((line) => path.isAbsolute(line));
 }
 
+export interface PickOutcome {
+  paths: string[];
+  /** Lines the dialog returned that could not be turned into a path this process can open. */
+  untranslated: number;
+}
+
 // The WSL dialog answers in Windows paths, and `C:\proj` is NOT absolute to posix — so the
 // translation has to happen BEFORE the filter above, or every pick reads as a cancel.
-async function pickedPaths(stdout: string, candidate: PickerCandidate): Promise<string[]> {
-  if (!candidate.windowsPaths) return parsePickerOutput(stdout);
-  const converted = await Promise.all(pickerLines(stdout).map((line) => toLinuxPath(line)));
-  return converted.filter((p): p is string => p !== null && path.isAbsolute(p));
+//
+// `untranslated` exists because that failure mode IS the bug in #1447: a `wslpath` that is missing
+// or refuses a UNC path would otherwise turn a real pick into `paths: []`, which the UI cannot
+// tell from a cancel, so the button silently does nothing all over again.
+export async function pickedPaths(stdout: string, candidate: PickerCandidate, convert = toLinuxPath): Promise<PickOutcome> {
+  if (!candidate.windowsPaths) return { paths: parsePickerOutput(stdout), untranslated: 0 };
+  const lines = pickerLines(stdout);
+  const converted = await Promise.all(lines.map((line) => convert(line)));
+  const paths = converted.filter((p): p is string => p !== null && path.isAbsolute(p));
+  return { paths, untranslated: lines.length - paths.length };
 }
 
 function runPicker(candidate: PickerCandidate): Promise<PickerRun> {
@@ -212,8 +224,18 @@ export function mountPickFileRoute(app: Express, { isAllowedOrigin }: PickFileOp
     const attempts: string[] = [];
     for (const candidate of pickFileCandidates(process.platform, directory, { wsl, startFolder })) {
       const run = await runPicker(candidate);
-      if (!pickerRunFailed(run, candidate.cancelStderr)) return res.json({ paths: await pickedPaths(run.stdout, candidate) });
-      attempts.push(attemptNote(candidate, run));
+      if (pickerRunFailed(run, candidate.cancelStderr)) {
+        attempts.push(attemptNote(candidate, run));
+        continue;
+      }
+      const { paths, untranslated } = await pickedPaths(run.stdout, candidate);
+      // Nothing usable out of something the user DID pick: keep going, and say so, rather than
+      // answering with the empty list that means "cancelled".
+      if (paths.length === 0 && untranslated > 0) {
+        attempts.push(`${candidate.cmd}: wslpath could not translate ${untranslated} chosen path(s)`);
+        continue;
+      }
+      return res.json({ paths });
     }
     res.status(500).json({ error: pickerUnavailableMessage(process.platform, wsl, attempts) });
   });

--- a/server/files/pick-file.ts
+++ b/server/files/pick-file.ts
@@ -1,17 +1,40 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
+import os from "node:os";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import { winFolderDialogScript } from "./win-folder-dialog.js";
 import { PS_UTF8_STDOUT } from "./win-powershell-utf8.js";
+import { psSingleQuoted } from "./ps-quote.js";
+import { isWsl, toLinuxPath, toWindowsPath } from "./wsl.js";
 import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 
 // A native "open file/folder" dialog per platform whose stdout is the selection's
 // absolute path(s), newline-separated. Browsers can't hand the terminal a real
-// filesystem path, but the local server can ask the OS. Fixed command + literal
-// argv (the prompts are constants) — no shell, no input interpolation.
+// filesystem path, but the local server can ask the OS. Fixed commands + literal
+// argv — the prompts are constants, and the one runtime value (the start folder,
+// derived from this process's own home directory) goes through `psSingleQuoted`.
+//
+// There is no single dialog on Linux, so a platform yields a LIST of candidates and the route
+// takes the first that runs: WSL reaches the Windows one over interop, a desktop has whichever
+// toolkit it was installed with. Before #1447 this was `zenity` alone, and a host without it got
+// a button that did nothing at all.
 const FILE_PROMPT = "Select file(s)";
 const DIR_PROMPT = "Select folder";
+
+export interface PickerCandidate {
+  cmd: string;
+  args: string[];
+  /** stdout carries WINDOWS paths — the Windows dialog, reached from WSL over interop. */
+  windowsPaths?: boolean;
+  /** stderr this tool prints when the USER cancels, which must not read as a broken dialog. */
+  cancelStderr?: RegExp;
+}
+
+// macOS says "User canceled. (-128)" on stderr and exits non-zero for a cancel — the one dialog
+// here that reports a cancel as an error. Read as a failure it would put an error on screen every
+// time someone closes the dialog, which is worse than the bug this file is fixing.
+const MAC_USER_CANCELED = /\(-128\)/;
 
 // macOS: `choose file` (multi) vs `choose folder` (single — a working directory is one dir).
 function macArgs(directory: boolean): string[] {
@@ -36,30 +59,138 @@ function macArgs(directory: boolean): string[] {
 
 // The FILE dialog needs nothing special: `OpenFileDialog` has been the Explorer-style one since
 // Vista. Only the FOLDER dialog is stuck on the legacy tree, so only it goes through COM (#1003).
-function winArgs(directory: boolean): string[] {
-  if (directory) return ["-NoProfile", "-STA", "-Command", winFolderDialogScript(DIR_PROMPT)];
-  const dialog = `$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join "\`n" }`;
-  return ["-NoProfile", "-STA", "-Command", `${PS_UTF8_STDOUT}; Add-Type -AssemblyName System.Windows.Forms; ${dialog}`];
+function winPickerScript(directory: boolean, startFolder: string | null): string {
+  if (directory) return winFolderDialogScript(DIR_PROMPT, startFolder);
+  const start = startFolder ? `$d.InitialDirectory = ${psSingleQuoted(startFolder)}; ` : "";
+  const dialog = `$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; ${start}if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join "\`n" }`;
+  return `${PS_UTF8_STDOUT}; Add-Type -AssemblyName System.Windows.Forms; ${dialog}`;
 }
 
-export function pickFileCommand(platform: NodeJS.Platform, directory = false): { cmd: string; args: string[] } {
-  if (platform === "darwin") return { cmd: "osascript", args: macArgs(directory) };
-  if (platform === "win32") return { cmd: "powershell", args: winArgs(directory) };
-  const zenity = directory
-    ? ["--file-selection", "--directory", `--title=${DIR_PROMPT}`]
-    : ["--file-selection", "--multiple", "--separator=\n", `--title=${FILE_PROMPT}`];
-  return { cmd: "zenity", args: zenity };
+// Where WSL looks for the Windows shell. `powershell.exe` alone covers a default install (WSL
+// appends the Windows PATH); the absolute path is for `appendWindowsPath = false` in wsl.conf,
+// where nothing Windows-side is on PATH at all.
+const WSL_POWERSHELL = ["powershell.exe", "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"];
+
+// `-EncodedCommand` (base64 UTF-16LE), not `-Command`, for the WSL candidates only: interop
+// rebuilds our argv into a single Windows command line, and the folder script is a multi-line
+// here-string full of quotes. Windows itself keeps `-Command`, which is what ships and works.
+const encodedCommandArgs = (script: string): string[] => ["-NoProfile", "-STA", "-EncodedCommand", Buffer.from(script, "utf16le").toString("base64")];
+
+// zenity's own options, which qarma (its Qt rebuild) takes verbatim.
+const zenityArgs = (directory: boolean): string[] =>
+  directory ? ["--file-selection", "--directory", `--title=${DIR_PROMPT}`] : ["--file-selection", "--multiple", "--separator=\n", `--title=${FILE_PROMPT}`];
+
+const kdialogArgs = (directory: boolean): string[] =>
+  directory ? ["--title", DIR_PROMPT, "--getexistingdirectory", "."] : ["--title", FILE_PROMPT, "--getopenfilename", ".", "--multiple", "--separate-output"];
+
+// yad forked from zenity before `--file-selection` and spells it `--file`.
+const yadArgs = (directory: boolean): string[] =>
+  directory ? ["--file", "--directory", `--title=${DIR_PROMPT}`] : ["--file", "--multiple", "--separator=\n", `--title=${FILE_PROMPT}`];
+
+/** The Linux desktop dialogs, in the order they are tried: GNOME, KDE, then the two clones. */
+function linuxPickerCandidates(directory: boolean): PickerCandidate[] {
+  return [
+    { cmd: "zenity", args: zenityArgs(directory) },
+    { cmd: "kdialog", args: kdialogArgs(directory) },
+    { cmd: "qarma", args: zenityArgs(directory) },
+    { cmd: "yad", args: yadArgs(directory) },
+  ];
 }
 
-// `trim` is load-bearing beyond whitespace: U+FEFF is ECMAScript WhiteSpace, so it also drops a
-// UTF-8 BOM a console host may print ahead of the first path — and BOM + `C:\proj` is not an
-// absolute path, which would silently turn every pick into a cancel. A spec pins it.
-export function parsePickerOutput(stdout: string): string[] {
-  return stdout
+/** What the host is, decided ONCE by the route. `startFolder` is a WINDOWS path, and WSL-only. */
+export interface PickerHost {
+  wsl?: boolean;
+  startFolder?: string | null;
+}
+
+/** Every dialog worth trying on this host, best first. */
+export function pickFileCandidates(platform: NodeJS.Platform, directory: boolean, host: PickerHost = {}): PickerCandidate[] {
+  if (platform === "darwin") return [{ cmd: "osascript", args: macArgs(directory), cancelStderr: MAC_USER_CANCELED }];
+  if (platform === "win32") return [{ cmd: "powershell", args: ["-NoProfile", "-STA", "-Command", winPickerScript(directory, null)] }];
+  const linux = linuxPickerCandidates(directory);
+  if (!host.wsl) return linux;
+  const args = encodedCommandArgs(winPickerScript(directory, host.startFolder ?? null));
+  // The Windows dialog first: it needs nothing installed. A WSL user who DID install zenity still
+  // gets it, one candidate later, if interop is off — which is also what makes a WRONG guess at
+  // "this is WSL" cost an ENOENT rather than the feature.
+  return [...WSL_POWERSHELL.map((cmd) => ({ cmd, args, windowsPaths: true })), ...linux];
+}
+
+export interface PickerRun {
+  /** null when the command could not be started at all. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: string | null;
+}
+
+// Did this candidate fail to give the user a dialog — as opposed to giving them one they closed?
+// The two look alike from here: a cancel is a non-zero exit with no output, and so is a zenity
+// that could not reach a display. What separates them is that the broken one explains itself on
+// stderr. Guessing wrong in either direction is a real bug — an error toast on every cancel, or
+// the silent nothing from #1447 — so the rule is pinned by specs rather than inlined.
+export function pickerRunFailed(run: PickerRun, cancelStderr?: RegExp): boolean {
+  if (run.spawnError !== null) return true;
+  if (run.code === 0 || run.stdout.trim().length > 0) return false;
+  const stderr = run.stderr.trim();
+  if (stderr.length === 0) return false;
+  return !(cancelStderr?.test(stderr) ?? false);
+}
+
+const INSTALL_A_DIALOG = "install zenity (sudo apt install zenity · sudo dnf install zenity), kdialog, qarma or yad";
+
+/** What the user is told when no candidate could open a dialog — it has to name the way out. */
+export function pickerUnavailableMessage(platform: NodeJS.Platform, wsl: boolean, attempts: string[]): string {
+  const detail = attempts.length > 0 ? ` [${attempts.join("; ")}]` : "";
+  if (wsl)
+    return `No file dialog on this host: WSL could not run the Windows one over interop, and no Linux dialog is installed — ${INSTALL_A_DIALOG}.${detail}`;
+  if (platform === "darwin" || platform === "win32") return `File dialog unavailable.${detail}`;
+  return `No file dialog on this host — ${INSTALL_A_DIALOG}.${detail}`;
+}
+
+/** stdout's non-empty lines. `trim` is load-bearing beyond whitespace: U+FEFF is ECMAScript
+ *  WhiteSpace, so it also drops a UTF-8 BOM a console host may print ahead of the first path. */
+export const pickerLines = (stdout: string): string[] =>
+  stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => line.length > 0 && path.isAbsolute(line));
+    .filter((line) => line.length > 0);
+
+// BOM + `C:\proj` is not an absolute path, which would silently turn every pick into a cancel.
+// A spec pins it.
+export function parsePickerOutput(stdout: string): string[] {
+  return pickerLines(stdout).filter((line) => path.isAbsolute(line));
 }
+
+// The WSL dialog answers in Windows paths, and `C:\proj` is NOT absolute to posix — so the
+// translation has to happen BEFORE the filter above, or every pick reads as a cancel.
+async function pickedPaths(stdout: string, candidate: PickerCandidate): Promise<string[]> {
+  if (!candidate.windowsPaths) return parsePickerOutput(stdout);
+  const converted = await Promise.all(pickerLines(stdout).map((line) => toLinuxPath(line)));
+  return converted.filter((p): p is string => p !== null && path.isAbsolute(p));
+}
+
+function runPicker(candidate: PickerCandidate): Promise<PickerRun> {
+  return new Promise((resolve) => {
+    const child = spawn(candidate.cmd, candidate.args, { stdio: ["ignore", "pipe", "pipe"] });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+    child.on("error", (e) => resolve({ code: null, stdout: "", stderr: "", spawnError: e.message }));
+    child.on("close", (code) => resolve({ code, stdout: Buffer.concat(out).toString(), stderr: Buffer.concat(err).toString(), spawnError: null }));
+  });
+}
+
+/** One line per candidate that failed, for the message the user reads. */
+function attemptNote(candidate: PickerCandidate, run: PickerRun): string {
+  const said = run.spawnError ?? pickerLines(run.stderr)[0] ?? `exit ${run.code}`;
+  return `${candidate.cmd}: ${said}`;
+}
+
+// Where the WSL dialog opens: this user's home INSIDE the distro. Without it the Windows dialog
+// starts on the Windows side, and reaching a project means typing a `\\wsl.localhost\…` UNC path.
+const wslStartFolder = (wsl: boolean): Promise<string | null> => (wsl ? toWindowsPath(os.homedir()) : Promise.resolve(null));
 
 interface PickFileOptions {
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
@@ -68,20 +199,22 @@ interface PickFileOptions {
 // POST /api/pick-file — open the OS file dialog and return the chosen absolute
 // path(s). Body `{ directory: true }` opens a FOLDER picker instead (for the launcher's
 // Working-directory field). A user cancel yields empty stdout, so the response is
-// { paths: [] }. Same-origin guarded like the other local-action routes.
+// { paths: [] }; a host with no dialog at all is a 500 whose message names the fix, and the
+// UI shows it. Same-origin guarded like the other local-action routes.
 export function mountPickFileRoute(app: Express, { isAllowedOrigin }: PickFileOptions) {
-  app.post("/api/pick-file", (req: Request, res) => {
+  app.post("/api/pick-file", async (req: Request, res) => {
     if (!requestOriginAllowed(req, isAllowedOrigin)) return res.status(403).json({ error: "forbidden origin" });
     const directory = isRecord(req.body) && req.body.directory === true;
-    const { cmd, args } = pickFileCommand(process.platform, directory);
-    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
-    const out: Buffer[] = [];
-    child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
-    child.on("error", (e) => {
-      if (!res.headersSent) res.status(500).json({ error: `file dialog unavailable: ${e.message}` });
-    });
-    child.on("close", () => {
-      if (!res.headersSent) res.json({ paths: parsePickerOutput(Buffer.concat(out).toString()) });
-    });
+    // Asked ONCE, here at the edge: everything below takes the answer rather than re-deriving it
+    // from the environment, so there is a single place that decides what this host is.
+    const wsl = isWsl(process.platform, process.env);
+    const startFolder = await wslStartFolder(wsl);
+    const attempts: string[] = [];
+    for (const candidate of pickFileCandidates(process.platform, directory, { wsl, startFolder })) {
+      const run = await runPicker(candidate);
+      if (!pickerRunFailed(run, candidate.cancelStderr)) return res.json({ paths: await pickedPaths(run.stdout, candidate) });
+      attempts.push(attemptNote(candidate, run));
+    }
+    res.status(500).json({ error: pickerUnavailableMessage(process.platform, wsl, attempts) });
   });
 }

--- a/server/files/ps-quote.ts
+++ b/server/files/ps-quote.ts
@@ -1,0 +1,7 @@
+// A value going INTO a PowerShell script literal. The picker scripts used to interpolate nothing
+// but constants; a start folder derived from the host's home directory is the first runtime value,
+// and a single quote in a user name would otherwise end the literal early (#1447).
+//
+// Single-quoted, so PowerShell does no expansion at all — `$`, backtick and `\` stay themselves,
+// and the only escape is a doubled quote.
+export const psSingleQuoted = (value: string): string => `'${value.replace(/'/g, "''")}'`;

--- a/server/files/win-folder-dialog.ts
+++ b/server/files/win-folder-dialog.ts
@@ -1,4 +1,5 @@
 import { PS_UTF8_STDOUT } from "./win-powershell-utf8.js";
+import { psSingleQuoted } from "./ps-quote.js";
 
 // The Windows folder picker, in the dialog Explorer actually uses (#1003).
 //
@@ -69,7 +70,22 @@ namespace MtPicker {
     void SetFilter(IntPtr pFilter);
   }
   public static class Folder {
-    public static string Pick(string title) {
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string path, IntPtr bindCtx, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out IShellItem item);
+
+    // Where the dialog opens. Its own try/catch because a start folder is a convenience: a path the
+    // shell cannot parse must cost the user a starting point, never the dialog.
+    private static void SetStartFolder(IFileDialog dialog, string startFolder) {
+      if (String.IsNullOrEmpty(startFolder)) return;
+      try {
+        Guid riid = new Guid("${IID_ISHELL_ITEM}");
+        IShellItem item;
+        SHCreateItemFromParsingName(startFolder, IntPtr.Zero, ref riid, out item);
+        dialog.SetFolder(item);
+      } catch { }
+    }
+
+    public static string Pick(string title, string startFolder) {
       Type type = Type.GetTypeFromCLSID(new Guid("${CLSID_FILE_OPEN_DIALOG}"));
       IFileDialog dialog = (IFileDialog)Activator.CreateInstance(type);
       try {
@@ -77,6 +93,7 @@ namespace MtPicker {
         dialog.GetOptions(out options);
         dialog.SetOptions(options | ${FOS_FLAGS});
         dialog.SetTitle(title);
+        SetStartFolder(dialog, startFolder);
         if (dialog.Show(IntPtr.Zero) != 0) return null;
         IShellItem item;
         dialog.GetResult(out item);
@@ -94,14 +111,18 @@ namespace MtPicker {
 // NOTE: the `'@` terminator of a PowerShell here-string must start its own line, or the script is
 // a syntax error. A spec pins that, because prettier reflowing this template would not fail
 // anything else.
-export const winFolderDialogScript = (prompt: string): string => `
+//
+// `startFolder` is where the dialog opens, and it is empty on Windows itself — the shell's own
+// "last place you picked" is better than anything this could name. WSL passes one, because there
+// the dialog's default is the Windows side of the machine and the user wants their distro (#1447).
+export const winFolderDialogScript = (prompt: string, startFolder: string | null = null): string => `
 ${PS_UTF8_STDOUT}
 $ErrorActionPreference = 'Stop'
 function Get-MtModernFolder {
   Add-Type -TypeDefinition @'
 ${FOLDER_PICKER_CSHARP}
 '@
-  return [MtPicker.Folder]::Pick('${prompt}')
+  return [MtPicker.Folder]::Pick('${prompt}', ${psSingleQuoted(startFolder ?? "")})
 }
 try {
   $picked = Get-MtModernFolder
@@ -109,7 +130,7 @@ try {
 } catch {
   Add-Type -AssemblyName System.Windows.Forms
   $legacy = New-Object System.Windows.Forms.FolderBrowserDialog
-  $legacy.Description = '${prompt}'
+  $legacy.Description = '${prompt}'${startFolder ? `\n  $legacy.SelectedPath = ${psSingleQuoted(startFolder)}` : ""}
   if ($legacy.ShowDialog() -eq 'OK') { $legacy.SelectedPath }
 }
 `;

--- a/server/files/wsl.ts
+++ b/server/files/wsl.ts
@@ -1,0 +1,46 @@
+// WSL is a Linux `process.platform` with a Windows host one interop call away: `powershell.exe`
+// runs from here, and `wslpath` translates a path between the two filesystems. That matters for
+// anything that opens a GUI — WSL ships no Linux desktop, so the OS dialog a user has is the
+// Windows one (#1447).
+import os from "node:os";
+import { spawnCaptureAsync } from "../infra/spawnCapture.js";
+
+// WSL's own kernel names itself: `6.6.x-microsoft-standard-WSL2`, and `…-Microsoft` on WSL1. The
+// two are NOT told apart on purpose — both have interop and `wslpath`, so a WSL1 user wants
+// exactly what a WSL2 user gets.
+const WSL_KERNEL = /microsoft/i;
+
+// The environment variables WSL exports are the documented signal, but they only reach a process
+// started from a LOGIN SHELL — a server run by systemd inside the distro has neither, and would
+// read as a bare Linux box with no dialog at all. The kernel name has no such hole, so it is the
+// second opinion rather than the first.
+//
+// A false positive is cheap by construction: every caller falls back to the Linux command when
+// the Windows one cannot be started. A false NEGATIVE is what costs the user the dialog.
+export function isWsl(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, kernelRelease: string = os.release()): boolean {
+  if (platform !== "linux") return false;
+  if (env.WSL_DISTRO_NAME ?? env.WSL_INTEROP) return true;
+  return WSL_KERNEL.test(kernelRelease);
+}
+
+/** Runs `wslpath` with the given arguments. Injected so the conversions are testable off WSL. */
+export type WslpathRunner = (args: string[]) => Promise<{ status: number | null; stdout: string }>;
+
+// Short: wslpath is a string translation, so anything slower than this means the interop bridge is
+// not answering, and waiting longer only delays the fallback.
+const WSLPATH_TIMEOUT_MS = 5_000;
+
+const runWslpath: WslpathRunner = (args) => spawnCaptureAsync("wslpath", args, { timeoutMs: WSLPATH_TIMEOUT_MS });
+
+async function convert(flag: string, value: string, run: WslpathRunner): Promise<string | null> {
+  const { status, stdout } = await run([flag, value]);
+  if (status !== 0) return null;
+  const converted = stdout.trim();
+  return converted.length > 0 ? converted : null;
+}
+
+/** `C:\proj` / `\\wsl.localhost\Ubuntu\home\me` → the path this process can open, or null. */
+export const toLinuxPath = (windowsPath: string, run: WslpathRunner = runWslpath): Promise<string | null> => convert("-u", windowsPath, run);
+
+/** `/home/me` → the path a Windows program can open, or null. */
+export const toWindowsPath = (linuxPath: string, run: WslpathRunner = runWslpath): Promise<string | null> => convert("-w", linuxPath, run);

--- a/server/files/wsl.ts
+++ b/server/files/wsl.ts
@@ -17,9 +17,12 @@ const WSL_KERNEL = /microsoft/i;
 //
 // A false positive is cheap by construction: every caller falls back to the Linux command when
 // the Windows one cannot be started. A false NEGATIVE is what costs the user the dialog.
+// `||`, never `??`: an EMPTY `WSL_DISTRO_NAME` is not an answer, and `??` would accept it and
+// never look at `WSL_INTEROP`. It is also what bin/mulmoterminal.js does, and the two must not
+// reach different conclusions about the same machine (Codex review on #1463).
 export function isWsl(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, kernelRelease: string = os.release()): boolean {
   if (platform !== "linux") return false;
-  if (env.WSL_DISTRO_NAME ?? env.WSL_INTEROP) return true;
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return true;
   return WSL_KERNEL.test(kernelRelease);
 }
 

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -20,8 +20,8 @@ import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import LaunchChipList from "./LaunchChipList.vue";
 import ModelPicker from "./ModelPicker.vue";
-import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
+import { pickPaths } from "../composables/pickPaths";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
 
 // What an EMPTY grid cell shows: pick a directory, pick what to run in it, and start — or resume
@@ -236,18 +236,14 @@ function fillDir(path: string): void {
 
 // The folder button: the browser can't open a native folder chooser, so the local server does
 // (POST /api/pick-file { directory: true }). Fill the Working-directory field with the pick.
+// A host with no dialog at all says so under the field — typing the path still works, and that
+// is only discoverable if the button explains itself instead of doing nothing (#1447).
+const pickError = ref<string | null>(null);
 async function pickDir(): Promise<void> {
-  try {
-    // Deliberately unbounded: this route answers when the USER closes the native file dialog,
-    // so any deadline here is a guess at how long they will take to choose.
-    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ directory: true }) });
-    if (!res.ok) return;
-    const data = await jsonBody(res);
-    const dir = isUnknownArray(data.paths) ? data.paths.find((p): p is string => typeof p === "string") : undefined;
-    if (dir) fillDir(dir);
-  } catch {
-    // best-effort — the native dialog is unavailable or the user canceled
-  }
+  const { paths, error } = await pickPaths({ directory: true });
+  pickError.value = error;
+  const dir = paths[0];
+  if (dir) fillDir(dir);
 }
 
 // The chip's launch button: a one-click quick launch — fill the field and jump straight into a
@@ -571,6 +567,7 @@ async function removeWorktree(w: Worktree): Promise<void> {
       <span v-if="takenWorktreeAt(targetDir)" data-testid="cell-dir-busy" class="font-sans text-[11px] leading-snug text-amber">{{
         takenWorktreeAt(targetDir)
       }}</span>
+      <span v-if="pickError" data-testid="cell-dir-pick-error" role="alert" class="font-sans text-[11px] leading-snug text-amber">{{ pickError }}</span>
     </label>
     <!-- Codex has its own model configuration and doesn't read this one. Keyed on the AGENT
          PICKER, not on the agent the cell will run: that reads "claude" while Shell is picked (a

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -171,7 +171,9 @@ const headerButtons = computed(() => (props.command || props.launcher ? [] : res
 // command — it emits the button id + this session's context, and the server re-resolves it (see /ws/run).
 function onHeaderButton(button: HeaderButton): void {
   if (button.run !== "shell") {
-    runHeaderButton(button, slotKey, serverCwd.value);
+    // The banner the drop/paste hints use: a picker or a reveal that could not run says so HERE,
+    // rather than in a console nobody has open (#1447).
+    runHeaderButton(button, slotKey, serverCwd.value, (message) => void showHint(message, "folder_open"));
     return;
   }
   const command: RunCommand = {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -478,15 +478,21 @@ function resumeSession({ id, cwd: dir, agent: resumeAgent }: { id: string; cwd: 
 async function openDir() {
   if (!cwd.value) return;
   try {
-    await fetchWithTimeout("/api/open-dir", {
+    const res = await fetchWithTimeout("/api/open-dir", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ path: cwd.value }),
     });
-  } catch {
-    // best-effort — opening a folder is non-critical
+    // A host with no file manager to call (a bare Linux box, WSL without interop) used to look
+    // exactly like a successful reveal — the route said ok and nothing appeared (#1447).
+    if (!res.ok) showAskMsg(openDirFailureText(await jsonBody(res), res.status));
+  } catch (e) {
+    showAskMsg(`Could not open the folder: ${e instanceof Error ? e.message : String(e)}`);
   }
 }
+
+const openDirFailureText = (body: Record<string, unknown>, status: number): string =>
+  typeof body.error === "string" && body.error.length > 0 ? body.error : `Could not open the folder (HTTP ${status}).`;
 
 // The server reports where the PTY actually runs (it may have rejected the
 // requested dir). Adopt it as the truth — display and persist the effective cwd.

--- a/src/components/settings/NotificationSoundsSection.vue
+++ b/src/components/settings/NotificationSoundsSection.vue
@@ -11,7 +11,7 @@ import { NOTIFY_KINDS, type NotifyKind } from "../../../common/notifyKinds";
 import { presetRef, SOUND_PRESETS } from "../../../common/notifySounds";
 import type { BundledSkillName } from "../../../common/bundledSkills";
 import type { SoundEmits } from "./soundEmits";
-import { isRecord } from "../../../common/isRecord";
+import { pickPaths } from "../../composables/pickPaths";
 
 const props = defineProps<{ soundFile?: string | null | undefined; soundKinds?: NotifyKind[] | undefined; sounds?: SoundMap | undefined }>();
 const emit = defineEmits<SoundEmits & { (e: "launch-skill", skill: BundledSkillName): void }>();
@@ -79,6 +79,9 @@ function testKindSound(kind: NotifyKind) {
 // Custom attention sound, applied immediately (like the theme) — empty => the
 // built-in chime. The text box mirrors the saved value; Browse / typing apply it.
 const soundPath = ref(props.soundFile ?? "");
+// A host with no file dialog installed: the field still takes a typed path, which nobody discovers
+// from a Browse button that does nothing (#1447).
+const pickError = ref<string | null>(null);
 watch(
   () => props.soundFile,
   (f) => (soundPath.value = f ?? ""),
@@ -92,19 +95,12 @@ function clearSound() {
   emit("update-sound", null);
 }
 async function browseSound() {
-  try {
-    // Deliberately unbounded: this route answers when the USER closes the native file dialog,
-    // so any deadline here is a guess at how long they will take to choose.
-    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
-    if (!res.ok) return;
-    const data: unknown = await res.json();
-    const picked = isRecord(data) && Array.isArray(data.paths) && typeof data.paths[0] === "string" ? data.paths[0] : "";
-    if (picked) {
-      soundPath.value = picked;
-      applySound();
-    }
-  } catch {
-    // native dialog unavailable / canceled — leave the field as-is
+  const { paths, error } = await pickPaths();
+  pickError.value = error;
+  const picked = paths[0];
+  if (picked) {
+    soundPath.value = picked;
+    applySound();
   }
 }
 </script>
@@ -169,6 +165,7 @@ async function browseSound() {
     <SettingsButton @click="browseSound">Browse…</SettingsButton>
     <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
   </div>
+  <p v-if="pickError" data-testid="sound-pick-error" class="mt-1.5 text-[12px] text-err-text" role="alert">{{ pickError }}</p>
   <p class="mb-3 mt-3 text-[12px] text-dim">
     These are the sounds for every session. The skill also gives one project its own sound, picks which moments push to your phone, and works out which of them
     is the one waking you up.

--- a/src/composables/pickPaths.ts
+++ b/src/composables/pickPaths.ts
@@ -1,0 +1,37 @@
+// The OS file dialog runs on the SERVER — a browser cannot read a real filesystem path — so every
+// picker button in the app is this one round trip.
+//
+// It is shared because the failure is the point. All three call sites (the launcher's
+// Working-directory button, the header's "Insert a file path", the notification-sound field) had
+// their own copy that dropped a non-200 with `if (!res.ok) return;`, so a host with no dialog
+// installed got three buttons that did nothing at all and said nothing (#1447). The server's
+// message names what to install; a caller's job is to put `error` somewhere the user can read it.
+import { isUnknownArray } from "../../common/isUnknownArray";
+import { jsonBody } from "../jsonBody";
+
+export interface PickResult {
+  paths: string[];
+  /** Why no dialog opened. null covers success AND a plain user cancel (which yields no paths). */
+  error: string | null;
+}
+
+const failureText = (body: Record<string, unknown>, status: number): string =>
+  typeof body.error === "string" && body.error.length > 0 ? body.error : `The file dialog failed (HTTP ${status}).`;
+
+export async function pickPaths(options: { directory?: boolean } = {}): Promise<PickResult> {
+  try {
+    // Deliberately unbounded: this route answers when the USER closes the native file dialog,
+    // so any deadline here is a guess at how long they will take to choose.
+    const res = await fetch("/api/pick-file", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ directory: options.directory === true }),
+    });
+    const body = await jsonBody(res);
+    if (!res.ok) return { paths: [], error: failureText(body, res.status) };
+    const paths = isUnknownArray(body.paths) ? body.paths.filter((p): p is string => typeof p === "string") : [];
+    return { paths, error: null };
+  } catch (e) {
+    return { paths: [], error: `Could not reach the file dialog: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}

--- a/src/composables/useHeaderAction.ts
+++ b/src/composables/useHeaderAction.ts
@@ -11,26 +11,22 @@ import { submitText, insertText } from "./useTerminalConnections";
 import { openTerminalAt } from "./useNewTerminal";
 import { toInsertText } from "../components/dropPaths";
 import type { HeaderButton, OpenTarget } from "./useHeaderButtons";
-import { isRecord } from "../../common/isRecord";
+import { pickPaths } from "./pickPaths";
+import { jsonBody } from "../jsonBody";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 
 const OPEN_URL_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
 
+/** Where a failed action explains itself — the cell's own banner, supplied by Terminal.vue. */
+export type ReportProblem = (message: string) => void;
+
 // Open the OS file dialog (server-side, since the browser can't read a real path) and insert the chosen
 // path(s) at the session's cursor. slotKey identifies which terminal receives the text.
-async function pickFileInto(slotKey: string | null): Promise<void> {
+async function pickFileInto(slotKey: string | null, report: ReportProblem): Promise<void> {
   if (!slotKey) return;
-  try {
-    // Deliberately unbounded: this route answers when the USER closes the native file dialog,
-    // so any deadline here is a guess at how long they will take to choose.
-    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
-    if (!res.ok) return;
-    const data: unknown = await res.json();
-    const paths = isRecord(data) && Array.isArray(data.paths) ? data.paths.filter((p): p is string => typeof p === "string") : [];
-    insertText(slotKey, toInsertText(paths));
-  } catch {
-    // best-effort — the native dialog is unavailable or the user canceled
-  }
+  const { paths, error } = await pickPaths();
+  if (error) return report(error);
+  insertText(slotKey, toInsertText(paths));
 }
 
 function openUrl(url: string): void {
@@ -41,11 +37,24 @@ function openUrl(url: string): void {
   }
 }
 
-function revealDir(dirPath: string): void {
-  fetchWithTimeout("/api/open-dir", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ path: dirPath }) }).catch(
-    () => {},
-  );
+// Reveal a directory in the OS file manager. The route answers only once the opener has actually
+// started, so a host that has none (a bare Linux box with no `xdg-open`) reports it rather than
+// leaving the button looking broken (#1447).
+async function revealDir(dirPath: string, report: ReportProblem): Promise<void> {
+  try {
+    const res = await fetchWithTimeout("/api/open-dir", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: dirPath }),
+    });
+    if (!res.ok) report(revealFailureText(await jsonBody(res), res.status));
+  } catch (e) {
+    report(`Could not open the folder: ${e instanceof Error ? e.message : String(e)}`);
+  }
 }
+
+const revealFailureText = (body: Record<string, unknown>, status: number): string =>
+  typeof body.error === "string" && body.error.length > 0 ? body.error : `Could not open the folder (HTTP ${status}).`;
 
 function openView(view: string, cwd: string | null): void {
   if (view === "prs") prsGotoIndex();
@@ -55,22 +64,24 @@ function openView(view: string, cwd: string | null): void {
   else filesGotoIndex(cwd); // "files" and (until a dedicated route) "diff"
 }
 
-function dispatchOpen(open: OpenTarget, cwd: string | null, slotKey: string | null): void {
+function dispatchOpen(open: OpenTarget, cwd: string | null, slotKey: string | null, report: ReportProblem): void {
   if (open.url) openUrl(open.url);
-  else if (open.reveal) revealDir(open.reveal);
+  else if (open.reveal) void revealDir(open.reveal, report);
   else if (open.files) filesGotoIndex(open.files);
   else if (open.view) openView(open.view, cwd);
   else if (open.terminal) openTerminalAt(open.terminal, slotKey);
-  else if (open.pickFile) void pickFileInto(slotKey);
+  else if (open.pickFile) void pickFileInto(slotKey, report);
 }
 
-export function runHeaderButton(button: HeaderButton, slotKey: string | null, cwd: string | null): void {
+const logProblem: ReportProblem = (message) => console.warn(`[header] ${message}`);
+
+export function runHeaderButton(button: HeaderButton, slotKey: string | null, cwd: string | null, report: ReportProblem = logProblem): void {
   if (button.run === "input" && button.text && slotKey) {
     submitText(slotKey, button.text);
     return;
   }
   if (button.run === "open" && button.open) {
-    dispatchOpen(button.open, cwd, slotKey);
+    dispatchOpen(button.open, cwd, slotKey, report);
     return;
   }
   // run === "shell" is dispatched by Terminal.vue (emits `run` → command cell); reaching here is a bug.

--- a/test/server/files/open-dir.spec.ts
+++ b/test/server/files/open-dir.spec.ts
@@ -1,15 +1,25 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { openCommand } from "../../../server/files/open-dir.js";
+import { openDirCommands } from "../../../server/files/open-dir.js";
 
-describe("openCommand", () => {
+describe("openDirCommands", () => {
   it("uses `open` on macOS", () => {
-    expect(openCommand("darwin")).toBe("open");
+    expect(openDirCommands("darwin", false)).toEqual([{ cmd: "open" }]);
   });
   it("uses `explorer` on Windows", () => {
-    expect(openCommand("win32")).toBe("explorer");
+    expect(openDirCommands("win32", false)).toEqual([{ cmd: "explorer" }]);
   });
   it("falls back to `xdg-open` elsewhere (Linux)", () => {
-    expect(openCommand("linux")).toBe("xdg-open");
+    expect(openDirCommands("linux", false)).toEqual([{ cmd: "xdg-open" }]);
+  });
+  // WSL has no Linux file manager to reveal anything in, so the folder belongs to Windows
+  // Explorer — which needs the path in its own form (#1447).
+  it("uses Windows Explorer, and a Windows path, on WSL", () => {
+    expect(openDirCommands("linux", true)[0]).toEqual({ cmd: "explorer.exe", windowsPath: true });
+  });
+  // Detection is a guess (a kernel name, or environment variables a service may not have), so a
+  // wrong one must cost an ENOENT and a retry — never the feature.
+  it("still tries xdg-open after Explorer, so a wrong WSL guess degrades", () => {
+    expect(openDirCommands("linux", true).map((c) => c.cmd)).toEqual(["explorer.exe", "xdg-open"]);
   });
 });

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   pickFileCandidates,
   parsePickerOutput,
+  pickedPaths,
   pickerRunFailed,
   pickerUnavailableMessage,
   type PickerHost,
@@ -227,5 +228,33 @@ describe("parsePickerOutput", () => {
   // Skipped on Windows, where `path.isAbsolute` reads that path the other way and WSL cannot run.
   it.skipIf(process.platform === "win32")("drops a Windows path, which is why the WSL conversion happens first", () => {
     expect(parsePickerOutput("C:\\proj\\a")).toEqual([]);
+  });
+});
+
+// A WSL pick has to survive the trip back through `wslpath`. If it doesn't, the route must NOT
+// answer with an empty list — that is what a cancel looks like, and the silence it produces is
+// exactly the bug #1447 reported. Observed during review, not flagged by a bot.
+describe("pickedPaths", () => {
+  const wslCandidate = { cmd: "powershell.exe", args: [], windowsPaths: true };
+
+  it("translates the Windows paths a WSL dialog returns", async () => {
+    const convert = (p: string) => Promise.resolve(p.replace("C:\\", "/mnt/c/").replaceAll("\\", "/"));
+    await expect(pickedPaths("C:\\proj\\a\nC:\\proj\\b", wslCandidate, convert)).resolves.toEqual({
+      paths: ["/mnt/c/proj/a", "/mnt/c/proj/b"],
+      untranslated: 0,
+    });
+  });
+
+  it("counts what it could not translate, so the route can tell that from a cancel", async () => {
+    const convert = () => Promise.resolve(null);
+    await expect(pickedPaths("C:\\proj\\a", wslCandidate, convert)).resolves.toEqual({ paths: [], untranslated: 1 });
+  });
+
+  it("reports a real cancel as nothing to translate", async () => {
+    await expect(pickedPaths("", wslCandidate, () => Promise.resolve(null))).resolves.toEqual({ paths: [], untranslated: 0 });
+  });
+
+  it("leaves a Linux dialog's output alone", async () => {
+    await expect(pickedPaths("/a/b\n/c/d", { cmd: "zenity", args: [] })).resolves.toEqual({ paths: ["/a/b", "/c/d"], untranslated: 0 });
   });
 });

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -1,23 +1,67 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { pickFileCommand, parsePickerOutput } from "../../../server/files/pick-file.js";
+import {
+  pickFileCandidates,
+  parsePickerOutput,
+  pickerRunFailed,
+  pickerUnavailableMessage,
+  type PickerHost,
+  type PickerRun,
+} from "../../../server/files/pick-file.js";
 import { PS_UTF8_STDOUT } from "../../../server/files/win-powershell-utf8.js";
 
-describe("pickFileCommand", () => {
+const NO_WSL = { wsl: false };
+const WSL = { wsl: true };
+const commands = (platform: NodeJS.Platform, directory = false, host: PickerHost = NO_WSL) => pickFileCandidates(platform, directory, host).map((c) => c.cmd);
+const first = (platform: NodeJS.Platform, directory = false, host: PickerHost = NO_WSL) => pickFileCandidates(platform, directory, host)[0];
+// The Windows scripts live in the last argv entry of either form (`-Command` / `-EncodedCommand`).
+const winScript = (directory: boolean) => first("win32", directory).args[3];
+
+describe("pickFileCandidates", () => {
   it("uses osascript on macOS", () => {
-    expect(pickFileCommand("darwin").cmd).toBe("osascript");
+    expect(commands("darwin")).toEqual(["osascript"]);
   });
   it("uses powershell on Windows", () => {
-    expect(pickFileCommand("win32").cmd).toBe("powershell");
+    expect(commands("win32")).toEqual(["powershell"]);
   });
-  it("falls back to zenity elsewhere (Linux)", () => {
-    expect(pickFileCommand("linux").cmd).toBe("zenity");
+  // #1447: zenity ALONE was the whole Linux story, so a host without it got a button that did
+  // nothing. Every one of these is a dialog somebody's desktop actually ships.
+  it("tries the desktop dialogs in turn on Linux", () => {
+    expect(commands("linux")).toEqual(["zenity", "kdialog", "qarma", "yad"]);
+  });
+  it("reaches the Windows dialog first on WSL, then the Linux ones", () => {
+    expect(commands("linux", false, WSL)).toEqual([
+      "powershell.exe",
+      "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+      "zenity",
+      "kdialog",
+      "qarma",
+      "yad",
+    ]);
+  });
+  // Only the WSL candidates answer in Windows paths; mislabel a Linux one and every pick it makes
+  // is thrown away by the absolute-path filter.
+  it("marks only the WSL candidates as returning Windows paths", () => {
+    const marked = pickFileCandidates("linux", true, WSL).filter((c) => c.windowsPaths);
+    expect(marked.map((c) => c.cmd)).toEqual(["powershell.exe", "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"]);
+    expect(pickFileCandidates("linux", true, NO_WSL).some((c) => c.windowsPaths)).toBe(false);
+  });
+  // WSL interop rebuilds our argv into one Windows command line, and the folder script is a
+  // multi-line here-string full of quotes. Base64 UTF-16LE has nothing left to mangle.
+  it("hands the WSL candidates the script base64-encoded, not as -Command", () => {
+    const { args } = first("linux", true, WSL);
+    expect(args).toContain("-EncodedCommand");
+    expect(args).not.toContain("-Command");
+    expect(Buffer.from(args[3], "base64").toString("utf16le")).toContain("FolderBrowserDialog");
+  });
+  it("keeps -Command on Windows itself", () => {
+    expect(first("win32", true).args).toContain("-Command");
   });
 });
 
-describe("pickFileCommand (directory mode)", () => {
+describe("pickFileCandidates (directory mode)", () => {
   it("macOS: osascript 'choose folder'", () => {
-    const { cmd, args } = pickFileCommand("darwin", true);
+    const { cmd, args } = first("darwin", true);
     expect(cmd).toBe("osascript");
     expect(args.join(" ")).toContain("choose folder");
   });
@@ -25,7 +69,7 @@ describe("pickFileCommand (directory mode)", () => {
   // keeps the legacy tree only as the catch — so a runtime that cannot compile the interop still
   // lets the user choose a directory.
   it("Windows: the shell's IFileOpenDialog, with the legacy tree as the fallback", () => {
-    const script = pickFileCommand("win32", true).args.join(" ");
+    const script = winScript(true);
     expect(script).toContain("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7"); // CLSID_FileOpenDialog
     expect(script).toContain("0x20"); // FOS_PICKFOLDERS — without it this picks files
     expect(script).toContain("FolderBrowserDialog"); // the fallback, inside `catch`
@@ -36,7 +80,7 @@ describe("pickFileCommand (directory mode)", () => {
   // member calls a different function than the name says. Pinning the two that this depends on
   // catches a "tidy up the unused ones" edit.
   it("Windows: keeps the IFileDialog vtable order the interop depends on", () => {
-    const script = pickFileCommand("win32", true).args.join(" ");
+    const script = winScript(true);
     const order = ["int Show(", "SetFileTypes(", "SetOptions(", "GetOptions(", "GetResult("];
     const positions = order.map((member) => script.indexOf(member));
     expect(positions.every((at) => at > 0)).toBe(true);
@@ -46,15 +90,29 @@ describe("pickFileCommand (directory mode)", () => {
   // A PowerShell here-string ends only at a `'@` that starts its own line. Reflow the template and
   // the whole script becomes a syntax error — which nothing else here would notice.
   it("Windows: closes its here-string at the start of a line", () => {
-    expect(pickFileCommand("win32", true).args[3]).toContain("\n'@");
+    expect(winScript(true)).toContain("\n'@");
   });
   it("Linux: zenity --directory", () => {
-    expect(pickFileCommand("linux", true).args).toContain("--directory");
+    expect(first("linux", true).args).toContain("--directory");
   });
   it("file mode (default) is unchanged", () => {
-    expect(pickFileCommand("darwin").args.join(" ")).toContain("choose file");
-    expect(pickFileCommand("win32").args.join(" ")).toContain("OpenFileDialog");
-    expect(pickFileCommand("linux").args).toContain("--multiple");
+    expect(first("darwin").args.join(" ")).toContain("choose file");
+    expect(winScript(false)).toContain("OpenFileDialog");
+    expect(first("linux").args).toContain("--multiple");
+  });
+});
+
+// The start folder only exists so the WSL dialog opens inside the distro instead of on the
+// Windows side. Windows itself passes none — the shell's own "last place you picked" beats it.
+describe("the dialog's start folder", () => {
+  const withStart = (platform: NodeJS.Platform, host: PickerHost) =>
+    pickFileCandidates(platform, true, { ...host, startFolder: "\\\\wsl.localhost\\Ubuntu\\home\\o'brien" })[0];
+  it("reaches the WSL folder dialog, single-quote-escaped", () => {
+    const script = Buffer.from(withStart("linux", WSL).args[3], "base64").toString("utf16le");
+    expect(script).toContain("'\\\\wsl.localhost\\Ubuntu\\home\\o''brien'");
+  });
+  it("is empty on Windows even when one is offered", () => {
+    expect(withStart("win32", NO_WSL).args[3]).toContain("Pick('Select folder', '')");
   });
 });
 
@@ -63,12 +121,12 @@ describe("pickFileCommand (directory mode)", () => {
 // then quietly replaces with the default workspace. Both dialogs read stdout, so both need this.
 describe("Windows picker output encoding", () => {
   it("forces UTF-8 stdout in the folder picker, before the dialog is shown", () => {
-    const script = pickFileCommand("win32", true).args[3];
+    const script = winScript(true);
     expect(script).toContain(PS_UTF8_STDOUT);
     expect(script.indexOf(PS_UTF8_STDOUT)).toBeLessThan(script.indexOf("Folder]::Pick"));
   });
   it("forces UTF-8 stdout in the file picker too", () => {
-    const script = pickFileCommand("win32", false).args[3];
+    const script = winScript(false);
     expect(script).toContain(PS_UTF8_STDOUT);
     expect(script.indexOf(PS_UTF8_STDOUT)).toBeLessThan(script.indexOf("OpenFileDialog"));
   });
@@ -82,6 +140,58 @@ describe("Windows picker output encoding", () => {
   // a terminating error would cost the user the dialog itself.
   it("cannot kill the script when the console has no code page to set", () => {
     expect(PS_UTF8_STDOUT).toMatch(/^try \{.*\} catch \{ \}$/);
+  });
+});
+
+// A cancel and a broken dialog look almost identical from here — both exit non-zero with no
+// output. Read a cancel as a failure and the app shows an error every time somebody closes the
+// dialog; read a failure as a cancel and you are back to the silent nothing of #1447.
+describe("pickerRunFailed", () => {
+  const run = (over: Partial<PickerRun> = {}): PickerRun => ({ code: 0, stdout: "", stderr: "", spawnError: null, ...over });
+
+  it("fails when the command is not installed", () => {
+    expect(pickerRunFailed(run({ code: null, spawnError: "spawn zenity ENOENT" }))).toBe(true);
+  });
+  it("fails when the dialog ran but explained itself on stderr", () => {
+    expect(pickerRunFailed(run({ code: 1, stderr: "Unable to init server: Could not connect: Connection refused" }))).toBe(true);
+  });
+  it("is not a failure when zenity exits 1 saying nothing (the user cancelled)", () => {
+    expect(pickerRunFailed(run({ code: 1 }))).toBe(false);
+  });
+  it("is not a failure when the Windows dialog exits 0 with no pick", () => {
+    expect(pickerRunFailed(run({ code: 0 }))).toBe(false);
+  });
+  // osascript is the one that reports a CANCEL as an error, so its own pattern spares it.
+  it("is not a failure when macOS reports the user's cancel", () => {
+    const canceled = run({ code: 1, stderr: "osascript: execution error: User canceled. (-128)" });
+    expect(pickerRunFailed(canceled, /\(-128\)/)).toBe(false);
+    expect(pickerRunFailed(canceled)).toBe(true); // ...and it IS a failure without the pattern
+  });
+  // The SENTENCE is localized — this is verbatim from `osascript -e 'error number -128'` on a
+  // Japanese macOS. Matching the code rather than the English wording is what makes the cancel
+  // readable on every locale, so both are pinned here.
+  it("reads a cancel reported in the user's own language", () => {
+    const [pattern] = pickFileCandidates("darwin", true).map((c) => c.cancelStderr);
+    const localized = run({ code: 1, stderr: "0:17: execution error: ユーザによってキャンセルされました。 (-128)" });
+    expect(pickerRunFailed(localized, pattern)).toBe(false);
+  });
+  it("is not a failure when a path came back, whatever the exit code", () => {
+    expect(pickerRunFailed(run({ code: 1, stdout: "/a/b", stderr: "warning: ignoring config" }))).toBe(false);
+  });
+});
+
+describe("pickerUnavailableMessage", () => {
+  it("tells a Linux user what to install", () => {
+    expect(pickerUnavailableMessage("linux", false, ["zenity: spawn zenity ENOENT"])).toContain("sudo apt install zenity");
+  });
+  it("tells a WSL user that interop failed too", () => {
+    expect(pickerUnavailableMessage("linux", true, [])).toContain("interop");
+  });
+  it("carries what each candidate said, so the reason is not lost", () => {
+    expect(pickerUnavailableMessage("linux", false, ["zenity: no display", "yad: ENOENT"])).toContain("[zenity: no display; yad: ENOENT]");
+  });
+  it("says nothing about installing a dialog on macOS", () => {
+    expect(pickerUnavailableMessage("darwin", false, ["osascript: boom"])).not.toContain("zenity");
   });
 });
 
@@ -110,5 +220,12 @@ describe("parsePickerOutput", () => {
   // ECMAScript WhiteSpace. Pinned so a "tidier" line filter cannot turn a pick into a cancel.
   it("tolerates a UTF-8 BOM ahead of the first path", () => {
     expect(parsePickerOutput("\uFEFF/proj/日本語\n/proj/b")).toEqual(["/proj/日本語", "/proj/b"]);
+  });
+  // The WSL dialog answers `C:\proj`, which is NOT absolute to posix — so its output has to be
+  // translated BEFORE this filter, never after. Pinned because getting the order wrong turns
+  // every WSL pick into a silent cancel, which is indistinguishable from the bug being fixed.
+  // Skipped on Windows, where `path.isAbsolute` reads that path the other way and WSL cannot run.
+  it.skipIf(process.platform === "win32")("drops a Windows path, which is why the WSL conversion happens first", () => {
+    expect(parsePickerOutput("C:\\proj\\a")).toEqual([]);
   });
 });

--- a/test/server/files/win-picker-encoding.spec.ts
+++ b/test/server/files/win-picker-encoding.spec.ts
@@ -14,7 +14,7 @@
 // under test is the encoding of its stdout.
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { parsePickerOutput, pickFileCommand } from "../../../server/files/pick-file.js";
+import { parsePickerOutput, pickFileCandidates } from "../../../server/files/pick-file.js";
 import { PS_UTF8_STDOUT } from "../../../server/files/win-powershell-utf8.js";
 
 const isWindows = process.platform === "win32";
@@ -28,7 +28,7 @@ const NON_ASCII_PATHS = ["C:\\proj\\日本語フォルダ", "C:\\proj\\中文目
 
 // The interpreter the route itself spawns, taken from the route, so this exercises the same
 // resolution rather than a second guess at where PowerShell lives.
-const { cmd: POWERSHELL } = pickFileCommand("win32", true);
+const { cmd: POWERSHELL } = pickFileCandidates("win32", true, process.env)[0];
 
 function powershellStdout(script: string, picked: string): Buffer {
   const result = spawnSync(POWERSHELL, ["-NoProfile", "-Command", script], { env: { ...process.env, [PATH_VAR]: picked } });

--- a/test/server/files/wsl.spec.ts
+++ b/test/server/files/wsl.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { isWsl, toLinuxPath, toWindowsPath, type WslpathRunner } from "../../../server/files/wsl.js";
+
+describe("isWsl", () => {
+  it("is true for the variables WSL exports", () => {
+    expect(isWsl("linux", { WSL_DISTRO_NAME: "Ubuntu" })).toBe(true);
+    expect(isWsl("linux", { WSL_INTEROP: "/run/WSL/8_interop" })).toBe(true);
+  });
+  // The kernel is named explicitly, not left to the runner: a maintainer running the suite ON WSL
+  // would otherwise see this fail for being right.
+  it("is false on a plain Linux desktop", () => {
+    expect(isWsl("linux", {}, "6.8.0-45-generic")).toBe(false);
+  });
+  // Windows itself already has the dialog and needs no translation; reading it as WSL would send
+  // every path through a `wslpath` that isn't there.
+  it("is false on macOS and Windows, whatever the environment says", () => {
+    expect(isWsl("darwin", { WSL_DISTRO_NAME: "Ubuntu" })).toBe(false);
+    expect(isWsl("win32", { WSL_INTEROP: "/run/WSL/8_interop" })).toBe(false);
+  });
+});
+
+const answers =
+  (status: number | null, stdout: string): WslpathRunner =>
+  () =>
+    Promise.resolve({ status, stdout });
+
+describe("wslpath conversions", () => {
+  it("returns the translated path", async () => {
+    await expect(toLinuxPath("C:\\proj", answers(0, "/mnt/c/proj\n"))).resolves.toBe("/mnt/c/proj");
+    await expect(toWindowsPath("/home/me", answers(0, "\\\\wsl.localhost\\Ubuntu\\home\\me\n"))).resolves.toBe("\\\\wsl.localhost\\Ubuntu\\home\\me");
+  });
+  it("passes the right flag for each direction", async () => {
+    const seen: string[][] = [];
+    const record: WslpathRunner = (args) => {
+      seen.push(args);
+      return Promise.resolve({ status: 0, stdout: "/x" });
+    };
+    await toLinuxPath("C:\\x", record);
+    await toWindowsPath("/x", record);
+    expect(seen).toEqual([
+      ["-u", "C:\\x"],
+      ["-w", "/x"],
+    ]);
+  });
+  // A null answer is what makes the caller fall back or report, rather than passing a Windows path
+  // on to something that would silently reject it.
+  it("is null when wslpath fails or says nothing", async () => {
+    await expect(toLinuxPath("C:\\proj", answers(1, ""))).resolves.toBeNull();
+    await expect(toLinuxPath("C:\\proj", answers(null, ""))).resolves.toBeNull();
+    await expect(toLinuxPath("C:\\proj", answers(0, "  \n"))).resolves.toBeNull();
+  });
+});
+
+// The environment variables reach a process started from a login shell. A server started by
+// systemd inside the distro has neither — and reading that as "a bare Linux box" is what would
+// cost a WSL user the whole fix, since the fallback there is a zenity they do not have.
+describe("isWsl without the environment variables", () => {
+  it("recognises a WSL2 kernel", () => {
+    expect(isWsl("linux", {}, "6.6.87.2-microsoft-standard-WSL2")).toBe(true);
+  });
+  // WSL1 is deliberately NOT told apart: it has interop and wslpath too, so it wants the same
+  // treatment. Its kernel spells the name with a capital M.
+  it("recognises a WSL1 kernel", () => {
+    expect(isWsl("linux", {}, "4.4.0-19041-Microsoft")).toBe(true);
+  });
+  it("leaves an ordinary Linux kernel alone", () => {
+    expect(isWsl("linux", {}, "6.8.0-45-generic")).toBe(false);
+    expect(isWsl("linux", {}, "5.15.0-1040-azure")).toBe(false);
+  });
+  // The variables still win, so a distro whose kernel was rebuilt under another name is covered.
+  it("trusts the variables whatever the kernel is called", () => {
+    expect(isWsl("linux", { WSL_INTEROP: "/run/WSL/8_interop" }, "6.8.0-45-generic")).toBe(true);
+  });
+});

--- a/test/server/files/wsl.spec.ts
+++ b/test/server/files/wsl.spec.ts
@@ -73,3 +73,14 @@ describe("isWsl without the environment variables", () => {
     expect(isWsl("linux", { WSL_INTEROP: "/run/WSL/8_interop" }, "6.8.0-45-generic")).toBe(true);
   });
 });
+
+// An empty variable is not an answer. `??` accepted it and never looked at the second one, which
+// also made the server disagree with bin/mulmoterminal.js about the same machine (Codex on #1463).
+describe("isWsl with an empty variable", () => {
+  it("falls through an empty WSL_DISTRO_NAME to WSL_INTEROP", () => {
+    expect(isWsl("linux", { WSL_DISTRO_NAME: "", WSL_INTEROP: "/run/WSL/8_interop" }, "6.8.0-45-generic")).toBe(true);
+  });
+  it("is still false when both are empty on an ordinary kernel", () => {
+    expect(isWsl("linux", { WSL_DISTRO_NAME: "", WSL_INTEROP: "" }, "6.8.0-45-generic")).toBe(false);
+  });
+});

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -605,3 +605,40 @@ describe("the Agent Picker's custom agents (#1414)", () => {
     expect(w.find('[data-testid="agent-picker"]').findAll('[role="radio"]')).toHaveLength(TERMINAL_AGENTS.length + 1);
   });
 });
+
+// #1447: the folder button posted to /api/pick-file and dropped a non-200 on the floor, so on a
+// host with no dialog installed it was a button that did nothing and said nothing. The field still
+// accepts a typed path — which nobody discovers unless the button explains itself.
+describe("the folder button when the host has no file dialog", () => {
+  const pickError = (w: ReturnType<typeof mountForm>) => w.find('[data-testid="cell-dir-pick-error"]');
+
+  const mountWithPicker = async (picker: { ok: boolean; body: unknown }) => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/pick-file")) return { ok: picker.ok, status: picker.ok ? 200 : 500, json: async () => picker.body };
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+    }) as unknown as typeof fetch;
+    const w = mountForm();
+    await flushPromises();
+    await w.find('[aria-label="Choose the working directory"]').trigger("click");
+    await flushPromises();
+    return w;
+  };
+
+  it("shows what the server said, under the field", async () => {
+    const w = await mountWithPicker({ ok: false, body: { error: "No file dialog on this host — install zenity" } });
+    expect(pickError(w).text()).toContain("install zenity");
+  });
+
+  it("says nothing when the dialog opened and the user cancelled", async () => {
+    const w = await mountWithPicker({ ok: true, body: { paths: [] } });
+    expect(pickError(w).exists()).toBe(false);
+  });
+
+  it("fills the field, and shows no error, when a folder comes back", async () => {
+    const w = await mountWithPicker({ ok: true, body: { paths: ["/picked/dir"] } });
+    expect(w.emitted("update:dir")?.at(-1)).toEqual(["/picked/dir"]);
+    expect(pickError(w).exists()).toBe(false);
+  });
+});

--- a/test/src/components/SettingsModal.spec.ts
+++ b/test/src/components/SettingsModal.spec.ts
@@ -118,7 +118,7 @@ describe("SettingsModal", () => {
     globalThis.fetch = (async () => ({ ok: true, json: async () => ({ paths: ["/picked/sound.ogg"] }) })) as unknown as typeof fetch;
     const w = mountModal({ soundFile: null });
     await clickBtn(w, (t) => t.includes("Browse"));
-    await Promise.resolve();
+    await flushPromises();
     expect((w.find('[aria-label="Custom notification sound file"]').element as HTMLInputElement).value).toBe("/picked/sound.ogg");
     expect(w.emitted("update-sound")?.at(-1)?.[0]).toBe("/picked/sound.ogg");
   });

--- a/test/src/components/settings/NotificationSoundsSection.spec.ts
+++ b/test/src/components/settings/NotificationSoundsSection.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+vi.mock("../../../../src/composables/useAttentionSound", () => ({ previewNotify: vi.fn() }));
+
+import NotificationSoundsSection from "../../../../src/components/settings/NotificationSoundsSection.vue";
+
+const mountSection = () =>
+  mount(NotificationSoundsSection, { props: { soundFile: null, soundKinds: [], sounds: {} }, global: { stubs: { SkillLaunchButton: true } } });
+
+const browse = async (w: ReturnType<typeof mountSection>) => {
+  const button = w.findAll("button").find((b) => b.text().includes("Browse"));
+  await button?.trigger("click");
+  await flushPromises();
+};
+
+// #1447: the third call site of the OS file dialog. It swallowed the failure like the other two,
+// so on a host without one the Browse button did nothing — with the typed-path field right beside
+// it as the way out, unmentioned.
+describe("the notification sound's Browse button", () => {
+  it("shows why no dialog opened", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ error: "No file dialog on this host — install zenity" }), { status: 500 }))),
+    );
+    const w = mountSection();
+    await browse(w);
+    expect(w.find('[data-testid="sound-pick-error"]').text()).toContain("install zenity");
+    vi.unstubAllGlobals();
+  });
+
+  it("says nothing when the user simply cancels", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ paths: [] }), { status: 200 }))),
+    );
+    const w = mountSection();
+    await browse(w);
+    expect(w.find('[data-testid="sound-pick-error"]').exists()).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it("adopts the chosen file", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ paths: ["/sounds/ping.wav"] }), { status: 200 }))),
+    );
+    const w = mountSection();
+    await browse(w);
+    expect(w.emitted("update-sound")?.at(-1)).toEqual(["/sounds/ping.wav"]);
+    vi.unstubAllGlobals();
+  });
+});

--- a/test/src/composables/pickPaths.spec.ts
+++ b/test/src/composables/pickPaths.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { pickPaths } from "../../../src/composables/pickPaths";
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pickPaths", () => {
+  it("returns the chosen paths", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, { paths: ["/a", "/b"] })));
+    await expect(pickPaths()).resolves.toEqual({ paths: ["/a", "/b"], error: null });
+  });
+
+  it("asks for a folder only when told to", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { paths: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await pickPaths({ directory: true });
+    await pickPaths();
+    expect(fetchMock.mock.calls.map((c) => c[1]?.body)).toEqual(['{"directory":true}', '{"directory":false}']);
+  });
+
+  // A cancel is a 200 with no paths, and must NOT read as something to complain about.
+  it("reports no error when the user cancels", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, { paths: [] })));
+    await expect(pickPaths()).resolves.toEqual({ paths: [], error: null });
+  });
+
+  // #1447: this is the whole bug. The route said what was wrong and every caller dropped it.
+  it("carries the server's explanation for a 500", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(500, { error: "No file dialog on this host — install zenity" })));
+    await expect(pickPaths()).resolves.toEqual({ paths: [], error: "No file dialog on this host — install zenity" });
+  });
+
+  it("still reports something when the failing body has no message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("<html>502</html>", { status: 502 })));
+    const { error } = await pickPaths();
+    expect(error).toContain("502");
+  });
+
+  it("reports a request that never got there", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Failed to fetch")));
+    const { paths, error } = await pickPaths();
+    expect(paths).toEqual([]);
+    expect(error).toContain("Failed to fetch");
+  });
+
+  it("ignores non-string entries in the answer", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, { paths: ["/a", 7, null] })));
+    await expect(pickPaths()).resolves.toEqual({ paths: ["/a"], error: null });
+  });
+});

--- a/test/src/composables/useHeaderAction.spec.ts
+++ b/test/src/composables/useHeaderAction.spec.ts
@@ -78,6 +78,32 @@ describe("runHeaderButton", () => {
     vi.unstubAllGlobals();
   });
 
+  // #1447: a host with no dialog answered 500 and this dropped it, so the button looked broken.
+  // The message goes to the caller's banner, and nothing is typed into the session.
+  it("open pickFile → reports the reason instead of inserting when no dialog opened", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ error: "No file dialog on this host — install zenity" }), { status: 500 }))),
+    );
+    const report = vi.fn();
+    runHeaderButton(btn({ run: "open", open: { pickFile: true } }), "single", null, report);
+    await vi.waitFor(() => expect(report).toHaveBeenCalledWith(expect.stringContaining("install zenity")));
+    expect(m.insertText).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  // The same silence on the reveal button: the route answered ok before the opener had started.
+  it("open reveal → reports a folder that could not be opened", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ error: "could not open /proj with xdg-open: ENOENT" }), { status: 500 }))),
+    );
+    const report = vi.fn();
+    runHeaderButton(btn({ run: "open", open: { reveal: "/proj" } }), "single", null, report);
+    await vi.waitFor(() => expect(report).toHaveBeenCalledWith(expect.stringContaining("xdg-open")));
+    vi.unstubAllGlobals();
+  });
+
   it("open pickFile without a slot key is a no-op (no dialog)", () => {
     const f = vi.fn();
     vi.stubGlobal("fetch", f);


### PR DESCRIPTION
## Summary

`zenity` の無い Linux / WSL2 で New terminal の「Choose a folder…」が**完全に無反応**だった問題
(#1447) を直します。原因は 2 つあり、両方を直したうえで **zenity 無しでも動く**ようにしました。

1. `pickFileCommand()` が darwin/win32 以外を `zenity` 決め打ちで spawn していた → ENOENT で 500。
2. その 500 を、pick-file を呼ぶ **3 箇所すべて**が `if (!res.ok) return;` と `catch {}` で捨てていた。

主な変更:

- **候補チェーン化**。WSL2 は interop で `powershell.exe` を実行し既存の Windows ダイアログを流用
  （**追加インストール不要**）、返る Windows パスを `wslpath -u` で変換。素の Linux は
  `zenity → kdialog → qarma → yad`。
- **失敗理由を UI に表示**。3 箇所の fetch を `src/composables/pickPaths.ts` に集約。
- **同型のバグを `POST /api/open-dir` でも修正**（下記）。
- WSL 判定・doctor・README。

`Closes #1447`

## Items to Confirm / Review

**AI 生成 PR です。とくに以下を人間の目で見てほしいです。**

1. **WSL2 / Windows 実機での動作確認ができていません。** 開発チームに Windows 環境が無いため、
   `wslpath` の UNC 変換、interop 経由で PowerShell のダイアログが実際に開くか、`explorer.exe` の
   挙動は**未検証**です。#1447 の報告者に確認を依頼済み。
   コードは「WSL 候補が失敗 → Linux チェーン → 全滅ならエラー表示」と degrade するので、
   最悪でも現状（無反応）より悪くはならない設計にしています。
2. **キャンセルと「ダイアログが開けなかった」の判別** (`pickerRunFailed`)。ここを間違えると
   「キャンセルのたびにエラーが出る」か「無反応のまま」のどちらかになります。判定規則:
   spawn error / `exit != 0 かつ stdout 空 かつ stderr 非空 かつ ユーザーキャンセルでない` → 失敗。
   macOS だけキャンセルを stderr にエラーとして出すため `(-128)` で除外しています
   （**文言はロケールで翻訳される**ので英語文言では判定できない — 実機で確認済み、下記）。
3. **WSL 判定の 2 段構え**（env 変数 → カーネル名）。カーネル名まで見るのは、systemd 等で起動され
   `WSL_DISTRO_NAME` が届かないプロセスを「素の Linux」と誤判定させないためです。誤検出のコストは
   フォールバックで ENOENT 1 回に抑えています。WSL1 と WSL2 は**意図的に区別していません**
   （どちらも interop と `wslpath` を持つ）。
4. **`win-folder-dialog.ts` の C# に `SHCreateItemFromParsingName` を追加**しました（WSL でダイアログを
   distro 内から開くため）。Windows 本体は初期フォルダを渡さない（＝従来どおり）ようにしていますが、
   COM 周りなので目視レビューをお願いします。SetFolder は独自の try/catch で囲んであり、失敗しても
   ダイアログ自体は開きます。
5. `-EncodedCommand`（base64 UTF-16LE）は **WSL 候補のみ**。Windows 本体は `-Command` のままです
   （実機で動いている経路を変えないため）。エンコード後 11,060 文字で、Windows のコマンドライン上限
   32,767 内に収まることを確認しています。

## User Prompt

> windowsの問題。これって対策できる? fileのランチャーって別のところでなにか対策したよね? OS標準でできるのが好ましい
> https://github.com/receptron/mulmoterminal/issues/1447
>
> wsl2やlinuxもできるだけサポートしてね。外でも似た問題あったら対応してね。
>
> あと報告者には十分なお礼と、開発チームにwindowsのユーザがいないのでwindowsの問題、とくにWSL２関連は
> 助かるので、今後も何かあれば教えてください！！！ありがとう！！と。
>
> WSL2・とかwindowsって判定して出し分けたりしているのかな？

（3 番目は #1447 へのコメントとして実施済み。4 番目を受けて判定の穴を 1 つ塞ぎました — 下記「WSL 判定」）

## 実装

### pick-file: 単一コマンド → 候補チェーン

`pickFileCommand(platform, directory)` を `pickFileCandidates(platform, directory, host)` に変更し、
ルートが先頭から順に試して**最初に起動できたもの**を使います。

| host | 候補（この順に試す） |
| --- | --- |
| macOS | `osascript` |
| Windows | `powershell` (`-Command`) |
| **WSL** | `powershell.exe` → `/mnt/c/.../powershell.exe`(※) → `zenity` → `kdialog` → `qarma` → `yad` |
| Linux | `zenity` → `kdialog` → `qarma` → `yad` |

※ `appendWindowsPath = false` を設定している人向け。

- WSL 候補の stdout は Windows パスなので、**`path.isAbsolute` フィルタの前に** `wslpath -u` を通します
  （`C:\proj` は posix では絶対パスではないため、順序を誤ると全部落ちて「キャンセル」と同じになる）。
  この順序依存は spec で固定しました。
- WSL ではダイアログの初期位置を `wslpath -w $HOME` にして distro 内から開きます
  （`IFileDialog.SetFolder`）。これが無いと Windows 側の既定位置から手で UNC を辿ることになります。

### エラーを握りつぶさない（3 箇所 → 共有ヘルパー 1 つ）

`src/composables/pickPaths.ts` を新設し、`{ paths, error }` を返します。表示先:

- `CellLaunchForm.vue` — Working directory 欄の下（`cell-dir-pick-error`）
- `NotificationSoundsSection.vue` — サウンド欄の下（`sound-pick-error`）
- ヘッダの "Insert a file path" — `Terminal.vue` の既存セル内バナー（`showHint`）を利用。
  `runHeaderButton()` に `report` コールバックを渡す形にしました。

### 同型のバグ: `POST /api/open-dir`

sweep して見つけた分です。非 darwin/win32 は `xdg-open` 決め打ちで、しかも **spawn 失敗を
`console.error` に書くだけでレスポンスは先に `{ok:true}` を返していた**（`error` イベントは
レスポンスの後に来る）ため、UI 上は成功に見えていました。

- `spawn` イベント（起動成功）まで待ってから返し、全滅は 500。
- WSL は `explorer.exe` + Windows パス → `xdg-open` のチェーン。1 発勝負にすると WSL 誤検出が
  「動いていた `xdg-open` を壊す」ことになるため、フォールバックを必ず後ろに置いています。
- `explorer.exe` は成功時も exit 1 を返すことがあるので終了コードでは判定しません。
- UI 側（`TerminalCell.vue` / `useHeaderAction.ts`）の握りつぶしも解除。

### WSL 判定

`server/files/wsl.ts` の `isWsl(platform, env, kernelRelease)` に集約:

1. `WSL_DISTRO_NAME` / `WSL_INTEROP`（WSL がログインシェルに撒く変数）
2. カーネル名に `microsoft`（WSL2 `…-microsoft-standard-WSL2` / WSL1 `…-Microsoft`）

**判定はルートで 1 回だけ**行い、純関数（`pickFileCandidates` / `openDirCommands` /
`pickerUnavailableMessage`）には `wsl: boolean` という決定済みの事実を渡します。env を各所で
読み直さないので、判定箇所が 1 つに固定され、テストもホスト非依存になります
（WSL 上でテストを回しても「Linux はチェーン」を検証できる）。

### CLI (`bin/mulmoterminal.js`)

- `init` の doctor に、プラットフォーム別のダイアログ依存チェックを追加（WSL は `powershell.exe`、
  素の Linux は `zenity`。macOS / Windows は OS 内蔵なので行を出しません）。
- 起動時のブラウザ起動を WSL では `cmd.exe /c start ""` に（`xdg-open` が無い環境が多いため）。
  TS を import できないので `isWsl()` と同等の判定を持たせ、同期させる旨をコメントに明記。

## 検証

**macOS 実機（サーバを起動して確認。build 成功 ≠ 動作する）**

- `/api/open-dir` → Finder が開き 200。
- `/api/pick-file` → 実際にダイアログが出る（`osascript` プロセスを確認）、閉じると 200 `{"paths":[]}`。
  **キャンセルがエラー表示にならない**ことを確認。
- この機体でバックグラウンドから出したダイアログは自動キャンセルされ、実出力は
  `22:63: execution error: ユーザによってキャンセルされました。 (-128)` でした。
  **文言がロケールで翻訳される**ことがここで判明し、`(-128)` で判定している設計が正しいと確認できました
  （英語文言で判定していたら、この機体ではキャンセルのたびに 500 が出ていた）。この実出力を spec に固定。

**自動テスト**: `yarn format` / `lint`（error 0）/ `typecheck` / `build` / `test` **8,530 件 green**。
新規 spec: `wsl.spec.ts`、`pickPaths.spec.ts`、`NotificationSoundsSection.spec.ts`。
既存 spec に候補順・WSL 分岐・キャンセル判定・エラー表示のケースを追加。

**未検証**: WSL2 / Windows 実機（上記 Items to Confirm 1）。

Closes #1447

work in mulmoterminal2
