### PR TITLE
feat: モデル名とトークン使用量のバッジを Codex / Grok / Antigravity でも出す (#1465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,20 @@ Each grid cell's header shows two badges for its session, refreshed when a turn 
 - **Token badge** — `⇡<in> ⇣<out>`: cumulative input (fresh + cache-read + cache-creation)
   and output tokens for the session, k/M-formatted, with a full breakdown in the tooltip.
 
+**Both badges are read from the agent's own log**, so what each agent can show differs by
+what it writes down (`?agent=` on the route picks the reader):
+
+| Agent | Context badge | Token badge |
+|---|---|---|
+| **Claude** | `Opus · ctx 35%` — window from the table above | full |
+| **Codex** | `gpt-5.5 · ctx 21%` — window from codex's own `model_context_window`, so no table to be out of date | full |
+| **Grok** | `grok-4.5` — the model only; grok records no token counts | hidden |
+| **Antigravity** | `antigravity` — a constant; agy records neither a model id nor tokens | hidden |
+
+The token badge hides itself when nothing has been counted, and the context badge shows
+the model alone when the tokens or the window are unknown — a percentage is only ever
+shown when both numbers came from the agent.
+
 The **Settings** modal (⚙) shows an **estimated $ cost** — Session / Today / Month — from
 `GET /api/cost`, using a built-in public per-model price table (cache reads billed at
 0.1×, cache writes at 1.25× input). It's an estimate: real billing differs, **flat-plan

--- a/README.md
+++ b/README.md
@@ -1154,8 +1154,9 @@ what it writes down (`?agent=` on the route picks the reader):
 | **Antigravity** | `antigravity` — a constant; agy records neither a model id nor tokens | hidden |
 
 The token badge hides itself when nothing has been counted, and the context badge shows
-the model alone when the tokens or the window are unknown — a percentage is only ever
-shown when both numbers came from the agent.
+the model alone unless it has **both** a token count from the agent and a context window
+— agent-reported (codex) or resolved from the built-in table above (Claude, provider
+models). Either one missing means a name and no percentage.
 
 The **Settings** modal (⚙) shows an **estimated $ cost** — Session / Today / Month — from
 `GET /api/cost`, using a built-in public per-model price table (cache reads billed at

--- a/common/sessionContext.ts
+++ b/common/sessionContext.ts
@@ -1,0 +1,22 @@
+// Which model a session is running and how full its context is: the `context` object
+// GET /api/session/:id answers with, and the thing the header's model badge renders.
+//
+// In `common/` because BOTH sides decide from it. The server fills it from whichever log the
+// session's agent keeps, and the client decides from `contextWindow` whether to trust the agent's
+// own window or fall back to its per-model table (`src/components/modelBadge.ts`). It was mirrored
+// as `LatestTurnContext` on the server and `CellContext` in the UI; both are now this.
+export interface SessionContextInfo {
+  /** null until a turn has told us — a session that has not answered yet wears no badge. */
+  model: string | null;
+  /** Tokens re-sent as context for the NEXT turn, off the most recent completed turn. */
+  contextTokens: number;
+  /**
+   * The model's context window, when the AGENT ITSELF reports one. codex writes
+   * `model_context_window` into every `token_count` event, which is better than any table we can
+   * keep: the substring list in modelBadge.ts has already claimed a model whose window it had
+   * wrong (#985), and nothing on this side can notice when a provider changes one.
+   *
+   * Absent (or null) means nobody told us, NOT "no window" — the client falls back to its table.
+   */
+  contextWindow?: number | null;
+}

--- a/server/agents/codex-events.ts
+++ b/server/agents/codex-events.ts
@@ -1,0 +1,20 @@
+// Reading one record out of a codex rollout.
+//
+// Everything codex reports about a running session — the turn boundaries, the final reply, the
+// token counts, the rate-limit windows — arrives as an `event_msg` whose real type is on the
+// PAYLOAD, so every reader of a rollout starts by asking the same question. It was written out
+// twice (the last-turn reader and the badge reader) before jscpd said so; a third copy is what
+// this file exists to prevent.
+import { isRecord } from "../../common/isRecord.js";
+
+/**
+ * The payload of an `event_msg` of this type, or null for any other record.
+ *
+ * BOTH halves are checked on purpose: the outer `type` is always `event_msg` and the inner one is
+ * what distinguishes a `task_complete` from a `token_count`, so matching only the inner one would
+ * also match a `response_item` that happens to carry the same field.
+ */
+export const codexEventPayload = (doc: Record<string, unknown>, type: string): Record<string, unknown> | null => {
+  const payload = isRecord(doc.payload) ? doc.payload : null;
+  return doc.type === "event_msg" && payload?.type === type ? payload : null;
+};

--- a/server/agents/codex-usage.spec.ts
+++ b/server/agents/codex-usage.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { codexBadgesFromRolloutDocs } from "./codex-usage";
+
+// The records are real ones, trimmed: a `token_count` event and a `turn_context` as codex 0.146.0
+// writes them. The numbers are what a live rollout on this machine held, which is where the
+// arithmetic below was checked — `total_tokens` is `input_tokens` + `output_tokens`, so the cached
+// and reasoning figures are SUBSETS and adding them again would overstate the session.
+const tokenCount = (total: Record<string, number>, last: Record<string, number>, window: number) => ({
+  timestamp: "2026-08-04T05:25:36.182Z",
+  type: "event_msg",
+  payload: { type: "token_count", info: { total_token_usage: total, last_token_usage: last, model_context_window: window } },
+});
+
+const turnContext = (model: string) => ({ timestamp: "2026-08-04T05:24:19.315Z", type: "turn_context", payload: { turn_id: "t1", model } });
+
+const usage = {
+  input_tokens: 108_611,
+  cached_input_tokens: 21_248,
+  cache_write_input_tokens: 0,
+  output_tokens: 6481,
+  reasoning_output_tokens: 1105,
+  total_tokens: 115_092,
+};
+const lastTurn = {
+  input_tokens: 55_447,
+  cached_input_tokens: 16_768,
+  cache_write_input_tokens: 0,
+  output_tokens: 3215,
+  reasoning_output_tokens: 125,
+  total_tokens: 58_662,
+};
+
+describe("codexBadgesFromRolloutDocs", () => {
+  it("reads the session totals, the current context and the model's own window", () => {
+    const badges = codexBadgesFromRolloutDocs([turnContext("gpt-5.5"), tokenCount(usage, lastTurn, 258_400)]);
+    expect(badges.usage).toEqual({ inputTokens: 108_611, outputTokens: 6481, cacheReadTokens: 0, cacheCreationTokens: 0 });
+    expect(badges.context).toEqual({ model: "gpt-5.5", contextTokens: 55_447, contextWindow: 258_400 });
+  });
+
+  // The cached figure is inside `input_tokens`. Splitting it into `cacheReadTokens` would have the
+  // UI — which sums input + cacheRead + cacheCreation for the ⇡ badge — count it twice, reporting
+  // 129,859 input tokens for a session codex says used 108,611.
+  it("does not double-count the cached input", () => {
+    const { usage: shown } = codexBadgesFromRolloutDocs([tokenCount(usage, lastTurn, 258_400)]);
+    expect(shown.inputTokens + shown.cacheReadTokens + shown.cacheCreationTokens).toBe(usage.input_tokens);
+  });
+
+  it("takes the LAST of each, so /model mid-session and the newest turn win", () => {
+    const badges = codexBadgesFromRolloutDocs([
+      turnContext("gpt-5.5"),
+      tokenCount(usage, lastTurn, 258_400),
+      turnContext("gpt-5.5-codex-mini"),
+      tokenCount({ ...usage, input_tokens: 200_000 }, { ...lastTurn, input_tokens: 90_000 }, 400_000),
+    ]);
+    expect(badges.context).toEqual({ model: "gpt-5.5-codex-mini", contextTokens: 90_000, contextWindow: 400_000 });
+    expect(badges.usage.inputTokens).toBe(200_000);
+  });
+
+  // An interrupted turn writes the event with no `info`. Skipped rather than treated as zeroes,
+  // or the badge would blank out every time a turn was cancelled.
+  it("keeps the last real reading when a later event carries no info", () => {
+    const badges = codexBadgesFromRolloutDocs([
+      turnContext("gpt-5.5"),
+      tokenCount(usage, lastTurn, 258_400),
+      { type: "event_msg", payload: { type: "token_count", info: null } },
+    ]);
+    expect(badges.usage.inputTokens).toBe(108_611);
+    expect(badges.context.contextTokens).toBe(55_447);
+  });
+
+  it("answers nulls and zeroes for a rollout that has not counted anything yet", () => {
+    const badges = codexBadgesFromRolloutDocs([{ type: "session_meta", payload: { id: "019fcb3a-a33c-7e72-8364-57e44926dfed" } }]);
+    expect(badges.context).toEqual({ model: null, contextTokens: 0, contextWindow: null });
+    expect(badges.usage).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+});

--- a/server/agents/codex-usage.ts
+++ b/server/agents/codex-usage.ts
@@ -19,6 +19,7 @@
 // that folded the whole thing. That is what lets the caller use readTailRecords on a rollout of
 // any size.
 import { isRecord } from "../../common/isRecord.js";
+import { codexEventPayload } from "./codex-events.js";
 import type { SessionContextInfo } from "../../common/sessionContext.js";
 import type { SessionUsage } from "../session/transcript.js";
 
@@ -40,11 +41,6 @@ const num = (record: Record<string, unknown>, key: string): number => {
 const positive = (record: Record<string, unknown>, key: string): number | null => {
   const value = num(record, key);
   return value > 0 ? value : null;
-};
-
-const payloadOf = (doc: Record<string, unknown>, type: string): Record<string, unknown> | null => {
-  const payload = isRecord(doc.payload) ? doc.payload : null;
-  return doc.type === "event_msg" && payload?.type === type ? payload : null;
 };
 
 const bucket = (info: Record<string, unknown>, key: string): Record<string, unknown> | null => (isRecord(info[key]) ? info[key] : null);
@@ -70,6 +66,25 @@ function turnContextModel(doc: Record<string, unknown>): string | null {
   return typeof model === "string" && model ? model : null;
 }
 
+/**
+ * The last model named in these records, with none of the token reading.
+ *
+ * For the ONE thing in this file that is not cumulative. Every other field is a running total or
+ * a most-recent value, so the tail answers as well as the whole file — but `turn_context` is
+ * written once, at the START of a turn, and a turn that then writes more than the tail window
+ * leaves its own model row outside it. The reader would pair fresh token numbers with `model:
+ * null`, and the badge hides on exactly the long sessions the bounded read exists to serve.
+ *
+ * So the caller reads the rollout's HEAD with this when the tail named nobody: the first
+ * `turn_context` of the session is a few hundred bytes in. That answers "which model" for every
+ * session that has not used `/model`, at 64 KB rather than an unbounded scan.
+ */
+export function codexModelFromDocs(docs: Record<string, unknown>[]): string | null {
+  let model: string | null = null;
+  for (const doc of docs) model = turnContextModel(doc) ?? model;
+  return model;
+}
+
 export function codexBadgesFromRolloutDocs(docs: Record<string, unknown>[]): CodexBadges {
   let usage = EMPTY_CODEX_BADGES.usage;
   let contextTokens = 0;
@@ -79,7 +94,7 @@ export function codexBadgesFromRolloutDocs(docs: Record<string, unknown>[]): Cod
   for (const doc of docs) {
     model = turnContextModel(doc) ?? model;
 
-    const counted = payloadOf(doc, "token_count");
+    const counted = codexEventPayload(doc, "token_count");
     const info = counted && isRecord(counted.info) ? counted.info : null;
     if (!info) continue; // codex emits a token_count with `info: null` when a turn was interrupted
     const totals = bucket(info, "total_token_usage");

--- a/server/agents/codex-usage.ts
+++ b/server/agents/codex-usage.ts
@@ -1,0 +1,95 @@
+// What a codex rollout says about tokens and the model, for the two header badges Claude
+// sessions have always had (#1465). Pure: fed records, answers the same two objects the Claude
+// transcript reader answers with, so the route needs no branch beyond picking the reader.
+//
+// codex accounts for itself in `event_msg` / `token_count` events, one per turn:
+//
+//   info.total_token_usage    cumulative for the session  -> the ⇡/⇣ badge
+//   info.last_token_usage     the most recent turn        -> how full the context is
+//   info.model_context_window the model's window          -> the % the badge shows
+//
+// The window is why this reads better than Claude's: codex STATES it, where the Claude path
+// infers it from a substring table that has been wrong (#985). It travels on `contextWindow`.
+//
+// The model is not in that event — it is on `turn_context`, written at the start of each turn,
+// and the LAST one wins because `/model` mid-session changes it.
+//
+// **Cumulative, so the tail is enough.** Every field here is either a running total or a
+// most-recent value, so a reader that sees only the end of the file gets the same answer as one
+// that folded the whole thing. That is what lets the caller use readTailRecords on a rollout of
+// any size.
+import { isRecord } from "../../common/isRecord.js";
+import type { SessionContextInfo } from "../../common/sessionContext.js";
+import type { SessionUsage } from "../session/transcript.js";
+
+export interface CodexBadges {
+  usage: SessionUsage;
+  context: SessionContextInfo;
+}
+
+export const EMPTY_CODEX_BADGES: CodexBadges = {
+  usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  context: { model: null, contextTokens: 0, contextWindow: null },
+};
+
+const num = (record: Record<string, unknown>, key: string): number => {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+};
+
+const positive = (record: Record<string, unknown>, key: string): number | null => {
+  const value = num(record, key);
+  return value > 0 ? value : null;
+};
+
+const payloadOf = (doc: Record<string, unknown>, type: string): Record<string, unknown> | null => {
+  const payload = isRecord(doc.payload) ? doc.payload : null;
+  return doc.type === "event_msg" && payload?.type === type ? payload : null;
+};
+
+const bucket = (info: Record<string, unknown>, key: string): Record<string, unknown> | null => (isRecord(info[key]) ? info[key] : null);
+
+// codex's own arithmetic, kept rather than reshaped: `total_tokens` = `input_tokens` +
+// `output_tokens`, with `cached_input_tokens` a SUBSET of the input and
+// `reasoning_output_tokens` a subset of the output. Splitting the cached part out into
+// `cacheReadTokens` would double-count it — the UI adds the three input fields together — so the
+// whole input goes in `inputTokens` and the cache buckets stay 0. The badge shows the two sums,
+// which is exactly what codex reports; what is lost is a breakdown nothing renders.
+const usageFrom = (totals: Record<string, unknown>): SessionUsage => ({
+  inputTokens: num(totals, "input_tokens"),
+  outputTokens: num(totals, "output_tokens"),
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+});
+
+/** The model a `turn_context` names, or null for any other record. Written at the start of every
+ *  turn, so the last one seen is what the session is running now — `/model` changes it. */
+function turnContextModel(doc: Record<string, unknown>): string | null {
+  if (doc.type !== "turn_context" || !isRecord(doc.payload)) return null;
+  const model = doc.payload.model;
+  return typeof model === "string" && model ? model : null;
+}
+
+export function codexBadgesFromRolloutDocs(docs: Record<string, unknown>[]): CodexBadges {
+  let usage = EMPTY_CODEX_BADGES.usage;
+  let contextTokens = 0;
+  let contextWindow: number | null = null;
+  let model: string | null = null;
+
+  for (const doc of docs) {
+    model = turnContextModel(doc) ?? model;
+
+    const counted = payloadOf(doc, "token_count");
+    const info = counted && isRecord(counted.info) ? counted.info : null;
+    if (!info) continue; // codex emits a token_count with `info: null` when a turn was interrupted
+    const totals = bucket(info, "total_token_usage");
+    if (totals) usage = usageFrom(totals);
+    const last = bucket(info, "last_token_usage");
+    // The tokens re-sent as context for the next turn — the turn's INPUT, matching what the Claude
+    // reader counts (fresh input plus cache). The turn's output is excluded there and here.
+    if (last) contextTokens = num(last, "input_tokens");
+    contextWindow = positive(info, "model_context_window") ?? contextWindow;
+  }
+
+  return { usage, context: { model, contextTokens, contextWindow } };
+}

--- a/server/agents/grok-sessions.ts
+++ b/server/agents/grok-sessions.ts
@@ -91,6 +91,19 @@ export function parseGrokSummary(text: string): GrokSummary {
   };
 }
 
+/**
+ * The model a conversation is running, from the same `summary.json`.
+ *
+ * `current_model_id` ("grok-4.5") is the only model grok records that a reader can trust: the
+ * per-turn `model_id` in `events.jsonl` says the same thing but costs a scan of a file whose
+ * phase_changed rows outnumber everything else 100:1. There are no token counts anywhere in a
+ * conversation directory, which is why this answers the model alone (agent-badges.ts).
+ */
+export const grokModelFromSummary = (text: string): string | null => {
+  const doc = parseJsonRecord(text);
+  return doc ? nonEmpty(doc.current_model_id) : null;
+};
+
 async function mtimeOf(target: string): Promise<number | null> {
   try {
     return (await fs.stat(target)).mtimeMs;

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -57,6 +57,7 @@ import { AGENT_SESSION_LIST_PATHS } from "../../common/agentSessionList.js";
 import { TERMINAL_AGENTS, type TerminalAgent } from "../../common/sessionAgent.js";
 import type { SessionMeta } from "../session/types.js";
 import { parseActivityIds, selectSessionRows } from "../session/session-list.js";
+import { agentBadges } from "../session/agent-badges.js";
 import { sessionDetailView } from "../session/session-detail-view.js";
 import { clearedTranscripts } from "../session/cleared-transcripts.js";
 import { requestBody } from "./requestBody.js";
@@ -90,7 +91,12 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
   const cwd = workspaceForRoute(req.query.cwd, res);
   if (cwd === null) return;
   await activityStateHydrated; // a reconnect re-fetch must see the restored working/waiting, not idle
+  // `?agent=` decides where the two header badges are read from — nothing else on this route. It
+  // defaults to Claude, so a client that does not send it (an older build, the single view) gets
+  // exactly what it got before.
+  const agent = normalizeAgent(req.query.agent);
   const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
+  const badges = agent === "claude" ? { usage, context } : await agentBadges(cwd, id, agent);
   // If we haven't titled it yet, kick off a summary; sessionDetailView falls back meanwhile.
   freshenRosterTitle(id, cwd, userTurns);
   await sessionMemosHydrated; // a cell seeding on boot must not be told its memo is gone
@@ -100,7 +106,7 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
     activity.get(id) ?? {},
     clearedTranscripts.has(id),
   );
-  res.json({ id, cwd, ...view, usage, context, workPhase });
+  res.json({ id, cwd, ...view, usage: badges.usage, context: badges.context, workPhase });
 }
 
 // The user's one-line note on a session (#1084). An empty text ERASES it — the same route, so a

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -1,0 +1,96 @@
+// The two header badges — `Opus · ctx 35%` and `⇡12.3k ⇣4.5k` — for a session that is NOT Claude
+// (#1465).
+//
+// They were Claude-only for a reason that was never a decision: both come from `usage` and
+// `context` on GET /api/session/:id, and the only reader behind that route folded Claude's
+// per-project transcript. A codex cell has no file there, so the route answered
+// `{ model: null }` + zeroes and the UI — which is agent-agnostic and always has been — rendered
+// nothing. Nobody chose to hide them.
+//
+// What each agent can actually answer is not the same, and this is the whole of it:
+//
+//   codex        both badges, and a REAL context window (`model_context_window`) rather than the
+//                UI's substring table. See codex-usage.ts.
+//   grok         the model only. `summary.json` names it; a conversation directory holds no token
+//                accounting at all (the only `token` fields in one are `first_token` timings and a
+//                WebFetch tool parameter), so the usage badge stays hidden — it hides itself when
+//                the totals are zero.
+//   antigravity  the NAME only, and a constant one. agy's transcript records neither tokens nor a
+//                model id; the single mention of a model is prose inside the user turn ("The user
+//                changed setting `Model Selection` … to Gemini 3.6 Flash (High)"), written only
+//                when the setting CHANGED, and `settings.json` holds the current global pick which
+//                an old conversation was not run under. Reading either would put a specific,
+//                confident, sometimes-wrong model name on the cell. "antigravity" is what we can
+//                stand behind.
+//
+// A wrong number here is worse than no number: this badge is what a user reads before deciding to
+// /compact, so every field is either what the agent stated or absent.
+import { promises as fs } from "node:fs";
+import type { TerminalAgent } from "../../common/sessionAgent.js";
+import type { SessionContextInfo } from "../../common/sessionContext.js";
+import { codexBadgesFromRolloutDocs, EMPTY_CODEX_BADGES, type CodexBadges } from "../agents/codex-usage.js";
+import { codexSessionsRoot } from "../agents/codex-session.js";
+import { codexRolloutPath } from "../agents/codex-sessions.js";
+import { grokModelFromSummary, grokSummaryPath } from "../agents/grok-sessions.js";
+import { grokSessionsRoot } from "../agents/grok-session.js";
+import { readTailRecords } from "../infra/jsonl-file.js";
+import { codexRollouts, codexRolloutsHydrated } from "./registry.js";
+import type { SessionUsage } from "./transcript.js";
+
+export interface SessionBadges {
+  usage: SessionUsage;
+  context: SessionContextInfo;
+}
+
+const EMPTY_USAGE: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+
+/** What the badge calls an agy session. A constant, for the reason in the header comment. */
+export const ANTIGRAVITY_MODEL_LABEL = "antigravity";
+
+const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE, context: { model, contextTokens: 0 } });
+
+/** Where each agent keeps its sessions. Defaulted from the agent's own module and overridden only
+ *  by the specs, which write a rollout and a conversation into a temp directory — the alternative
+ *  was a test that reassigns `CODEX_HOME` for the whole worker process. */
+export interface BadgeRoots {
+  codexSessions?: string;
+  grokSessions?: string;
+}
+
+async function codexBadges(sessionKey: string, root: string): Promise<CodexBadges> {
+  // The same lookup codexLastTurn makes, and awaited for the same reason: the mapping is read off
+  // disk, so a request served during startup would fall through to the key — a mulmoterminal id,
+  // which names no rollout.
+  await codexRolloutsHydrated;
+  const rolloutId = codexRollouts.get(sessionKey)?.conversationId ?? sessionKey;
+  const file = codexRolloutPath(root, rolloutId);
+  if (!file) return EMPTY_CODEX_BADGES;
+  try {
+    // The tail: every field the reader wants is a running total or a most-recent value, so the end
+    // of the file answers the same as the whole of it — at a bounded cost (#998).
+    return codexBadgesFromRolloutDocs(readTailRecords(file));
+  } catch {
+    return EMPTY_CODEX_BADGES;
+  }
+}
+
+async function grokBadges(cwd: string, id: string, root: string): Promise<SessionBadges> {
+  try {
+    return modelOnly(grokModelFromSummary(await fs.readFile(grokSummaryPath(root, cwd, id), "utf8")));
+  } catch {
+    return modelOnly(null); // no conversation directory yet, or none in this cwd
+  }
+}
+
+/**
+ * The badges for a session, from whichever log its agent keeps.
+ *
+ * Claude is NOT here: its two fields fall out of the summary fold the route already runs, and
+ * re-reading the transcript to answer them again would double the cost of the busiest route in the
+ * app. The caller passes Claude's straight through.
+ */
+export async function agentBadges(cwd: string, id: string, agent: Exclude<TerminalAgent, "claude">, roots: BadgeRoots = {}): Promise<SessionBadges> {
+  if (agent === "codex") return codexBadges(id, roots.codexSessions ?? codexSessionsRoot());
+  if (agent === "grok") return grokBadges(cwd, id, roots.grokSessions ?? grokSessionsRoot());
+  return modelOnly(ANTIGRAVITY_MODEL_LABEL);
+}

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -28,7 +28,8 @@
 import { promises as fs } from "node:fs";
 import type { TerminalAgent } from "../../common/sessionAgent.js";
 import type { SessionContextInfo } from "../../common/sessionContext.js";
-import { codexBadgesFromRolloutDocs, EMPTY_CODEX_BADGES, type CodexBadges } from "../agents/codex-usage.js";
+import { codexBadgesFromRolloutDocs, codexModelFromDocs, EMPTY_CODEX_BADGES, type CodexBadges } from "../agents/codex-usage.js";
+import { parseJsonRecord, readTranscriptHead } from "../agents/transcript-head.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { grokModelFromSummary, grokSummaryPath } from "../agents/grok-sessions.js";
@@ -66,12 +67,40 @@ async function codexBadges(sessionKey: string, root: string): Promise<CodexBadge
   const file = codexRolloutPath(root, rolloutId);
   if (!file) return EMPTY_CODEX_BADGES;
   try {
-    // The tail: every field the reader wants is a running total or a most-recent value, so the end
-    // of the file answers the same as the whole of it — at a bounded cost (#998).
-    return codexBadgesFromRolloutDocs(readTailRecords(file));
+    // The tail: the token fields are running totals and most-recent values, so the end of the file
+    // answers the same as the whole of it — at a bounded cost (#998).
+    const badges = codexBadgesFromRolloutDocs(readTailRecords(file));
+    // The model is the exception, and the reviewers of #1466 caught it: `turn_context` is written
+    // ONCE, at the start of a turn, so a turn that writes more than the tail window leaves its own
+    // model row outside it. Fresh numbers would then arrive with `model: null` and the badge would
+    // hide — on exactly the long sessions the bounded read exists for. The session's first
+    // `turn_context` is a few hundred bytes into the file, so the head answers instead.
+    //
+    // Asked ONLY when the tail named nobody, and only once there is something to label: a rollout
+    // that has not counted a token yet is a session with no badge either way, and this route is
+    // polled per cell.
+    if (badges.context.model !== null || badges.context.contextTokens === 0) return badges;
+    return { ...badges, context: { ...badges.context, model: await rolloutHeadModel(file) } };
   } catch {
     return EMPTY_CODEX_BADGES;
   }
+}
+
+// Enough for the session_meta record and the first turn_context behind it; the same size the
+// rollout listing reads a title from.
+const ROLLOUT_HEAD_BYTES = 64 * 1024;
+
+/** The model the session STARTED on, from the head of its rollout. A fallback, so it is the right
+ *  answer for every session that has not used `/model` and the closest available one when a
+ *  single turn is bigger than the tail window. */
+async function rolloutHeadModel(file: string): Promise<string | null> {
+  const read = await readTranscriptHead(file, ROLLOUT_HEAD_BYTES);
+  if (!read) return null;
+  const docs = read.head
+    .split("\n")
+    .map(parseJsonRecord)
+    .filter((d): d is Record<string, unknown> => d !== null);
+  return codexModelFromDocs(docs);
 }
 
 async function grokBadges(cwd: string, id: string, root: string): Promise<SessionBadges> {

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -5,7 +5,7 @@
 // simply isn't on disk (#254).
 
 import { conversationTurnsFromParsed, parseJsonl } from "./transcript.js";
-import { isRecord } from "../../common/isRecord.js";
+import { codexEventPayload as eventPayload } from "../agents/codex-events.js";
 
 export interface LastTurn {
   prompt: string | null;
@@ -37,12 +37,8 @@ export const lastTurnFromClaudeJsonl = (raw: string): LastTurn => lastTurnFromCl
 // codex tags only its turn BOUNDARIES with a turn_id (task_started / turn_context /
 // task_complete) — the user_message and agent_message rows in between carry none. So a
 // turn is the positional span between a task_started and its matching task_complete,
-// and the id serves to pair those two rather than to group the contents.
-const eventPayload = (doc: Record<string, unknown>, type: string): Record<string, unknown> | null => {
-  const payload = isRecord(doc.payload) ? doc.payload : null;
-  return doc.type === "event_msg" && payload?.type === type ? payload : null;
-};
-
+// and the id serves to pair those two rather than to group the contents. Each of those
+// rows is reached through `eventPayload` above, which is shared with the badge reader.
 const trimmedString = (value: unknown): string | null => (typeof value === "string" && value.trim() ? value.trim() : null);
 
 // Walk back to the task_started that opened this turn, then forward to the first

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -4,6 +4,7 @@
 
 import { isRecord } from "../../common/isRecord.js";
 import { readString } from "../../common/readString.js";
+import type { SessionContextInfo } from "../../common/sessionContext.js";
 
 // Text the HARNESS put in the user channel, rather than something a person typed:
 // slash-command wrappers, bash input, and the notification a finished background task
@@ -307,10 +308,12 @@ export const sessionUsageFromJsonl = (raw: string): SessionUsage => sessionUsage
 // tokens re-sent as context for the next turn. This is NOT the cumulative
 // sessionUsageFromJsonl sum, which counts every turn's re-sent context and so
 // double-counts. `model` is the most recent assistant turn's declared model.
-export interface LatestTurnContext {
-  model: string | null;
-  contextTokens: number;
-}
+//
+// The shape is shared with the UI (common/sessionContext.ts) because it goes on the wire
+// whole; this name is what the Claude readers here have always called it. The Claude
+// transcript reports no context window, so `contextWindow` stays absent on this path — the
+// agents that DO report one fill it in (server/session/agent-badges.ts).
+export type LatestTurnContext = SessionContextInfo;
 
 const contextTokensOf = (u: Record<string, unknown>): number =>
   usageNum(u, "input_tokens") + usageNum(u, "cache_read_input_tokens") + usageNum(u, "cache_creation_input_tokens");

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -10,9 +10,13 @@ const props = defineProps<{
   agent: BadgeAgent;
   model: string | null;
   contextTokens: number;
+  /** The window the agent stated, when it stated one — codex does, Claude does not. `undefined`
+   *  is admitted rather than made optional: it arrives off the wire object, where the field is
+   *  simply absent for every other agent. */
+  contextWindow: number | null | undefined;
 }>();
 
-const badge = computed(() => (props.model ? modelBadge(props.agent, props.model, props.contextTokens) : null));
+const badge = computed(() => (props.model ? modelBadge(props.agent, props.model, props.contextTokens, props.contextWindow) : null));
 
 // The badge shortens the model to `Opus`; the tip is where the full name and the token counts live.
 const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => badgeTip(badge.value?.title ?? ""));

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -150,6 +150,7 @@ const { config: dirConfig } = useDirConfig(dirConfigCwd);
 const { context: sessionContext } = useSessionContext(
   computed(() => props.sessionId),
   serverCwd,
+  computed(() => props.agent ?? "claude"),
 );
 // What GET /api/header resolves for this terminal's directory: the user's configured action buttons
 // (or the built-in defaults), and the per-tree values the directory reserved (#1367).

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -323,8 +323,11 @@ function activityPushOf(d: Record<string, unknown>): ActivityPush {
 
 async function fetchSessionDetail(id: string): Promise<Record<string, unknown> | null> {
   try {
-    const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
-    const res = await fetchWithTimeout(`/api/session/${id}${q}`);
+    // The agent goes along because the two header badges are read from ITS log, not Claude's
+    // (#1465) — and grok's is partitioned by directory, so the cwd is part of that lookup too.
+    const params = new URLSearchParams({ agent: agent.value });
+    if (cwd.value) params.set("cwd", cwd.value);
+    const res = await fetchWithTimeout(`/api/session/${id}?${params}`);
     if (!res.ok) return null;
     const data = await jsonBody(res);
     return id === sessionId.value ? data : null;
@@ -1167,6 +1170,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                   :agent="agent"
                   :model="context.model"
                   :context-tokens="context.contextTokens"
+                  :context-window="context.contextWindow"
                 />
                 <span
                   v-else-if="chip.builtin === 'usage' && showUsage"

--- a/src/components/cellPayload.ts
+++ b/src/components/cellPayload.ts
@@ -1,5 +1,6 @@
 // The two payload shapes a cell believes without asking anyone: the token usage and the
 import { isRecord } from "../../common/isRecord";
+import type { SessionContextInfo } from "../../common/sessionContext";
 // running model/context that back its header badges.
 //
 // They arrive from /api/session/:id and the cost route, and the guards only asked whether a
@@ -17,10 +18,9 @@ export interface CellUsage {
   cacheCreationTokens: number;
 }
 
-export interface CellContext {
-  model: string | null;
-  contextTokens: number;
-}
+// The wire shape itself (common/sessionContext.ts) — the server answers it and this file only
+// says whether what arrived is renderable.
+export type CellContext = SessionContextInfo;
 
 // Rendered as a number, so it has to be one: NaN and Infinity read as a broken badge just as
 // a string would.
@@ -47,5 +47,9 @@ export function isCellContext(value: unknown): value is CellContext {
   // `model` is legitimately null before the first assistant turn — that hides the badge,
   // which is different from the field being the wrong type.
   const modelOk = context.model === null || typeof context.model === "string";
-  return modelOk && isRenderableCount(context.contextTokens);
+  // Optional on the wire: only the agents that state a window send it (codex). Absent and null
+  // both mean "nobody told us" and are fine; a NaN or a string is the broken shape this guard is
+  // for — it would divide into a percentage.
+  const windowOk = context.contextWindow === undefined || context.contextWindow === null || isRenderableCount(context.contextWindow);
+  return modelOk && windowOk && isRenderableCount(context.contextTokens);
 }

--- a/src/components/modelBadge.ts
+++ b/src/components/modelBadge.ts
@@ -49,7 +49,12 @@ export function shortModelLabel(model: string): string {
   return family ? family.label : (model.split("/").pop() ?? model);
 }
 
-function contextWindowTokens(model: string): number | null {
+function contextWindowTokens(model: string, reported: number | null | undefined): number | null {
+  // What the AGENT said, ahead of everything below: codex writes `model_context_window` into its
+  // rollout, and a number the running agent states beats one this file infers from a substring —
+  // which is how a 1M model was read against a 200k window and the badge came out 5x too high
+  // (#985). Absent means nobody told us, so the table still answers for Claude.
+  if (reported && reported > 0) return reported;
   // A preset carries the window its provider publishes, so a session on one shows a real % instead
   // of nothing — the substring list only knows Claude's own families.
   const preset = presetFor(model);
@@ -65,9 +70,12 @@ type ContextReading = { kind: "measured"; windowTokens: number; percent: number 
 // percentage tells us is that CONTEXT_WINDOWS has the wrong window for this model. Reported as
 // unknown rather than clamped — a precise wrong number gets acted on, and a clamp would hide the
 // gap entirely (#985).
-function readContext(model: string, contextTokens: number): ContextReading {
-  const windowTokens = contextWindowTokens(model);
+function readContext(model: string, contextTokens: number, reportedWindow: number | null | undefined): ContextReading {
+  const windowTokens = contextWindowTokens(model, reportedWindow);
   if (windowTokens === null) return { kind: "no-window" };
+  // Nothing measured yet — a grok or antigravity session, which names its model but reports no
+  // tokens. `ctx 0%` would be a reading; there isn't one.
+  if (contextTokens <= 0) return { kind: "no-window" };
   const percent = Math.round((contextTokens / windowTokens) * PERCENT);
   return percent > PERCENT ? { kind: "overflow", windowTokens } : { kind: "measured", windowTokens, percent };
 }
@@ -87,7 +95,8 @@ function badgeTitle(agent: BadgeAgent, model: string, contextTokens: number, rea
 
 export type ModelBadge = { text: string; title: string };
 
-export function modelBadge(agent: BadgeAgent, model: string, contextTokens: number): ModelBadge {
-  const reading = readContext(model, contextTokens);
+// `contextWindow` is the window the agent itself reported, when it reported one (codex does).
+export function modelBadge(agent: BadgeAgent, model: string, contextTokens: number, contextWindow?: number | null): ModelBadge {
+  const reading = readContext(model, contextTokens, contextWindow);
   return { text: badgeText(shortModelLabel(model), reading), title: badgeTitle(agent, model, contextTokens, reading) };
 }

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -2,18 +2,19 @@
 // Used where only the model/context is needed (e.g. header `${model}` substitution). Components that
 // also need live activity/usage (TerminalCell) fetch the same endpoint alongside those concerns.
 import { ref, type Ref } from "vue";
+import type { TerminalAgent } from "../../common/sessionAgent";
+import type { SessionContextInfo } from "../../common/sessionContext";
 import { useAutoRefresh } from "./useAutoRefresh";
 import { jsonBody } from "../jsonBody";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 
-export interface SessionContext {
-  model: string | null;
-  contextTokens: number;
-}
+export type SessionContext = SessionContextInfo;
 
 const isContext = (c: unknown): c is SessionContext => typeof c === "object" && c !== null && "contextTokens" in c;
 
-export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string | null>) {
+// `agent` because the model is read from that agent's own log (#1465); omitted means Claude,
+// which is what the route defaults to.
+export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string | null>, agent?: Ref<TerminalAgent>) {
   const context = ref<SessionContext | null>(null);
   let requestSeq = 0;
   let loadedFor: string | null = null; // the session id `context` currently reflects
@@ -31,10 +32,11 @@ export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string
       context.value = null;
       loadedFor = null;
     }
-    const query = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
+    const params = new URLSearchParams({ agent: agent?.value ?? "claude" });
+    if (cwd.value) params.set("cwd", cwd.value);
     const seq = ++requestSeq;
     try {
-      const res = await fetchWithTimeout(`/api/session/${id}${query}`);
+      const res = await fetchWithTimeout(`/api/session/${id}?${params}`);
       if (seq !== requestSeq || !res.ok) return;
       const data = await jsonBody(res);
       // Guard against a stale response: the terminal may have switched session mid-flight.

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -17,18 +17,23 @@ const isContext = (c: unknown): c is SessionContext => typeof c === "object" && 
 export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string | null>, agent?: Ref<TerminalAgent>) {
   const context = ref<SessionContext | null>(null);
   let requestSeq = 0;
-  let loadedFor: string | null = null; // the session id `context` currently reflects
+  // What `context` currently reflects — the session AND the agent it was read from, because the
+  // two decide the answer together: the same id asked about a different agent is read from a
+  // different log entirely.
+  let loadedFor: string | null = null;
 
   async function refresh(): Promise<void> {
     const id = sessionId.value;
+    const key = `${agent?.value ?? "claude"} ${id ?? ""}`;
     if (!id) {
       context.value = null;
       loadedFor = null;
       return;
     }
-    // Switched to a different session: drop the old model now, so a slow/failed fetch can't keep
-    // showing the previous session's model. A same-session refresh keeps the last value (no flicker).
-    if (loadedFor !== id) {
+    // Switched to a different session — or to another agent on the same one: drop the old model
+    // now, so a slow/failed fetch can't keep showing the previous one. A refresh of the same pair
+    // keeps the last value (no flicker).
+    if (loadedFor !== key) {
       context.value = null;
       loadedFor = null;
     }
@@ -42,14 +47,17 @@ export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string
       // Guard against a stale response: the terminal may have switched session mid-flight.
       if (seq === requestSeq && id === sessionId.value && isContext(data.context)) {
         context.value = data.context;
-        loadedFor = id;
+        loadedFor = key;
       }
     } catch {
       // best-effort — `${model}` just renders empty until a later fetch succeeds
     }
   }
 
-  useAutoRefresh(refresh, [sessionId, cwd]);
+  // `agent` is a dependency, not just a query param: it names the reader on the server, so a cell
+  // relaunched on another agent would otherwise wear the previous agent's badge until the session
+  // or directory happened to change.
+  useAutoRefresh(refresh, agent ? [sessionId, cwd, agent] : [sessionId, cwd]);
 
   return { context, refresh };
 }

--- a/test/server/agents/grok-sessions.spec.ts
+++ b/test/server/agents/grok-sessions.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { listGrokSessions, parseGrokSummary, grokPromptTitles } from "../../../server/agents/grok-sessions.js";
+import { listGrokSessions, parseGrokSummary, grokPromptTitles, grokModelFromSummary } from "../../../server/agents/grok-sessions.js";
 
 // Captured from grok 0.2.118's own `summary.json`, trimmed to the fields the listing reads. The
 // two timestamps disagree on purpose and that disagreement is the point: `updated_at` (and the
@@ -43,6 +43,18 @@ describe("parseGrokSummary", () => {
     expect(parseGrokSummary(JSON.stringify({ created_at: "2026-08-05T05:00:00Z" })).mtime).toBe(Date.parse("2026-08-05T05:00:00Z"));
     expect(parseGrokSummary(JSON.stringify({ last_active_at: "not a date" })).mtime).toBeNull();
     expect(parseGrokSummary("{oops")).toEqual({ title: null, mtime: null });
+  });
+});
+
+describe("grokModelFromSummary", () => {
+  // What the header's model badge shows for a grok cell (#1465). The real file carries it as
+  // `current_model_id`; a conversation that has not recorded one wears no badge rather than a
+  // guess, which is the same rule the Claude path follows before its first turn.
+  it("reads the current model id, and nothing when there is none", () => {
+    expect(grokModelFromSummary(JSON.stringify({ ...JSON.parse(REAL_SUMMARY), current_model_id: "grok-4.5" }))).toBe("grok-4.5");
+    expect(grokModelFromSummary(REAL_SUMMARY)).toBeNull();
+    expect(grokModelFromSummary(JSON.stringify({ current_model_id: "" }))).toBeNull();
+    expect(grokModelFromSummary("{oops")).toBeNull();
   });
 });
 

--- a/test/server/session/agent-badges.spec.ts
+++ b/test/server/session/agent-badges.spec.ts
@@ -61,6 +61,17 @@ describe("agentBadges", () => {
     expect(badges.usage.outputTokens).toBe(6481);
   });
 
+  // The one field that is not cumulative: `turn_context` is written once, at the start of a turn,
+  // so a turn bigger than the tail window leaves its model row outside it. Without the head
+  // fallback the badge disappears on exactly the long sessions the bounded read is for.
+  it("falls back to the head's model when a huge turn pushed turn_context out of the tail", async () => {
+    const filler = JSON.stringify({ type: "response_item", payload: { junk: "x".repeat(200_000) } });
+    writeRollout([turnContextLine, ...Array.from({ length: 30 }, () => filler), tokenCountLine]);
+    const badges = await agentBadges(CWD, ROLLOUT_ID, "codex", roots);
+    expect(badges.context.model).toBe("gpt-5.5"); // read from the head, not the 4 MB tail
+    expect(badges.context.contextTokens).toBe(55_447); // and the numbers still come from the tail
+  });
+
   // Nothing on disk to read is the ordinary state of a session that has just been launched, and it
   // has to be silence rather than zeroes presented as a reading.
   it("answers nothing for a codex session with no rollout", async () => {

--- a/test/server/session/agent-badges.spec.ts
+++ b/test/server/session/agent-badges.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { agentBadges, ANTIGRAVITY_MODEL_LABEL, type BadgeRoots } from "../../../server/session/agent-badges.js";
+
+// The header badges for a session that is not Claude (#1465). Each agent is asked the question the
+// same way and answers as much of it as its own log can: codex both badges, grok the model, agy a
+// constant. What must NOT happen is a number nobody wrote down.
+
+const ROLLOUT_ID = "019fcb3a-a33c-7e72-8364-57e44926dfed";
+const GROK_ID = "150496cf-fb8d-4c35-b19b-e2826a4e7242";
+const CWD = "/Users/x/my proj";
+
+const tokenCountLine = JSON.stringify({
+  timestamp: "2026-08-04T05:26:35.526Z",
+  type: "event_msg",
+  payload: {
+    type: "token_count",
+    info: {
+      total_token_usage: { input_tokens: 108_611, cached_input_tokens: 21_248, output_tokens: 6481, total_tokens: 115_092 },
+      last_token_usage: { input_tokens: 55_447, cached_input_tokens: 16_768, output_tokens: 3215, total_tokens: 58_662 },
+      model_context_window: 258_400,
+    },
+  },
+});
+const turnContextLine = JSON.stringify({ timestamp: "2026-08-04T05:24:19.315Z", type: "turn_context", payload: { turn_id: "t1", model: "gpt-5.5" } });
+
+describe("agentBadges", () => {
+  let home = "";
+  // The roots are injected rather than pointed at by CODEX_HOME / GROK_HOME: those are read by
+  // every other codex and grok reader in the process, and a spec that reassigns them owns the
+  // environment of whatever else its worker runs.
+  let roots: BadgeRoots = {};
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "mt-agent-badges-"));
+    roots = { codexSessions: path.join(home, "codex", "sessions"), grokSessions: path.join(home, "grok", "sessions") };
+  });
+
+  afterEach(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const writeRollout = (lines: string[]) => {
+    const dir = path.join(home, "codex", "sessions", "2026", "08", "04");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `rollout-2026-08-04T05-24-05-${ROLLOUT_ID}.jsonl`), `${lines.join("\n")}\n`);
+  };
+
+  const writeGrokSummary = (summary: unknown) => {
+    const dir = path.join(home, "grok", "sessions", encodeURIComponent(CWD), GROK_ID);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify(summary));
+  };
+
+  it("reads a codex session's totals, context and window out of its rollout", async () => {
+    writeRollout([turnContextLine, tokenCountLine]);
+    const badges = await agentBadges(CWD, ROLLOUT_ID, "codex", roots);
+    expect(badges.context).toEqual({ model: "gpt-5.5", contextTokens: 55_447, contextWindow: 258_400 });
+    expect(badges.usage.inputTokens).toBe(108_611);
+    expect(badges.usage.outputTokens).toBe(6481);
+  });
+
+  // Nothing on disk to read is the ordinary state of a session that has just been launched, and it
+  // has to be silence rather than zeroes presented as a reading.
+  it("answers nothing for a codex session with no rollout", async () => {
+    const badges = await agentBadges(CWD, ROLLOUT_ID, "codex", roots);
+    expect(badges.context.model).toBeNull();
+    expect(badges.usage.inputTokens).toBe(0);
+  });
+
+  it("names grok's model, and reports no tokens because grok records none", async () => {
+    writeGrokSummary({ current_model_id: "grok-4.5", session_summary: "whatever" });
+    const badges = await agentBadges(CWD, GROK_ID, "grok", roots);
+    expect(badges.context.model).toBe("grok-4.5");
+    expect(badges.context.contextTokens).toBe(0);
+    expect(badges.usage).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+
+  // grok partitions by directory, so the cwd is part of the lookup: the same id under another
+  // directory is a different conversation and must not answer for this one.
+  it("does not read a grok conversation from another directory", async () => {
+    writeGrokSummary({ current_model_id: "grok-4.5" });
+    expect((await agentBadges("/Users/x/elsewhere", GROK_ID, "grok", roots)).context.model).toBeNull();
+  });
+
+  // agy records neither a model nor a token count. The constant is deliberate: the only model name
+  // in its transcript is prose in a settings block that is written only when the setting changed.
+  it("labels an antigravity session with the agent's own name", async () => {
+    const badges = await agentBadges(CWD, "any-id", "antigravity", roots);
+    expect(badges.context).toEqual({ model: ANTIGRAVITY_MODEL_LABEL, contextTokens: 0 });
+    expect(badges.usage.inputTokens).toBe(0);
+  });
+});

--- a/test/src/components/ModelContextBadge.spec.ts
+++ b/test/src/components/ModelContextBadge.spec.ts
@@ -4,9 +4,14 @@ import ModelContextBadge from "../../../src/components/ModelContextBadge.vue";
 
 // Wiring only — which window a model has, and what the badge says when we cannot know, is decided
 // in src/components/modelBadge.ts and tested in modelBadge.spec.ts without mounting anything.
-function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; contextTokens?: number }) {
+function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; contextTokens?: number; contextWindow?: number | null }) {
   return mount(ModelContextBadge, {
-    props: { agent: props.agent ?? "claude", model: props.model, contextTokens: props.contextTokens ?? 0 },
+    props: {
+      agent: props.agent ?? "claude",
+      model: props.model,
+      contextTokens: props.contextTokens ?? 0,
+      contextWindow: props.contextWindow ?? null,
+    },
   });
 }
 
@@ -23,5 +28,12 @@ describe("ModelContextBadge", () => {
 
   it("renders nothing when the model is unknown/null (no transcript model yet)", () => {
     expect(mountBadge({ model: null, contextTokens: 1000 }).find("span").exists()).toBe(false);
+  });
+
+  // A codex cell: the window comes from the rollout rather than the substring table, which knows
+  // no OpenAI model at all — without it this would read `gpt-5.5` with no percentage (#1465).
+  it("reads the percentage off the window the agent reported", () => {
+    const badge = mountBadge({ agent: "codex", model: "gpt-5.5", contextTokens: 64_600, contextWindow: 258_400 });
+    expect(badge.find('[data-testid="model-badge"]').text()).toBe("gpt-5.5 · ctx 25%");
   });
 });

--- a/test/src/components/headerChipFont.spec.ts
+++ b/test/src/components/headerChipFont.spec.ts
@@ -26,7 +26,7 @@ const chips = [
   ["dir badge", () => mount(DirBadge, { props: { name: "demo", color: null } }), "span"],
   [
     "model / context",
-    () => mount(ModelContextBadge, { props: { agent: "claude", model: "claude-opus-4-20250514", contextTokens: 1000 } }),
+    () => mount(ModelContextBadge, { props: { agent: "claude", model: "claude-opus-4-20250514", contextTokens: 1000, contextWindow: null } }),
     '[data-testid="model-badge"]',
   ],
 ] as const;

--- a/test/src/components/modelBadge.spec.ts
+++ b/test/src/components/modelBadge.spec.ts
@@ -87,3 +87,33 @@ describe("modelBadge — the tooltip", () => {
     expect(modelBadge("claude", "claude-opus-4-20250514", 70_000).title).toBe("Claude · claude-opus-4-20250514 · context 70,000 / 200,000 (35%) tokens");
   });
 });
+
+// #1465: the badge is no longer Claude-only, and the other agents do not all report the same
+// things. codex states its window, grok and antigravity state nothing but a name.
+describe("modelBadge — a window the agent reported", () => {
+  it("prefers the agent's own window to the table", () => {
+    // gpt-5.5 matches nothing in CONTEXT_WINDOWS, so without codex's number there is no percentage
+    // to show at all.
+    expect(modelBadge("codex", "gpt-5.5", 55_447).text).toBe("gpt-5.5");
+    expect(modelBadge("codex", "gpt-5.5", 55_447, 258_400).text).toBe("gpt-5.5 · ctx 21%");
+  });
+
+  it("overrides a Claude family window rather than being overridden by it", () => {
+    // A model whose window the table thinks it knows: whoever is RUNNING is the better authority,
+    // which is the whole reason #985 could happen to a table nobody could correct from outside.
+    expect(modelBadge("claude", "claude-opus-4", 100_000, 1_000_000).text).toBe("Opus · ctx 10%");
+  });
+
+  it("ignores a window that is absent, null or zero", () => {
+    expect(modelBadge("claude", "claude-opus-4", 100_000, null).text).toBe("Opus · ctx 50%");
+    expect(modelBadge("claude", "claude-opus-4", 100_000, 0).text).toBe("Opus · ctx 50%");
+  });
+
+  it("says only the model when nothing has counted any tokens", () => {
+    // grok names its model and records no usage; `ctx 0%` would read as a measurement of an empty
+    // context rather than the absence of one.
+    expect(modelBadge("grok", "grok-4.5", 0).text).toBe("grok-4.5");
+    expect(modelBadge("antigravity", "antigravity", 0).text).toBe("antigravity");
+    expect(modelBadge("claude", "claude-opus-4", 0).text).toBe("Opus");
+  });
+});

--- a/test/src/composables/useSessionContext.spec.ts
+++ b/test/src/composables/useSessionContext.spec.ts
@@ -44,6 +44,25 @@ describe("useSessionContext", () => {
     unmount();
   });
 
+  // Changing the agent changes which log the server reads, so it has to re-fetch — and clear the
+  // old badge while it does, or a codex cell relaunched as claude keeps wearing `gpt-5.5`.
+  it("re-fetches and drops the old model when the agent changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ context: { model: "gpt-5.5", contextTokens: 1 } }))
+      .mockResolvedValueOnce({ ok: false } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const agent = ref<TerminalAgent>("codex");
+    const { result, unmount } = withSetup(() => useSessionContext(ref<string | null>("sess-1"), ref<string | null>(null), agent));
+    await flushPromises();
+    expect(result.context.value?.model).toBe("gpt-5.5");
+    agent.value = "claude";
+    await flushPromises();
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/session/sess-1?agent=claude");
+    expect(result.context.value).toBeNull(); // no stale codex model on a claude terminal
+    unmount();
+  });
+
   it("does not fetch and stays null when there is no session id", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/test/src/composables/useSessionContext.spec.ts
+++ b/test/src/composables/useSessionContext.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { createApp, defineComponent, ref } from "vue";
 import { flushPromises } from "@vue/test-utils";
 import { useSessionContext } from "../../../src/composables/useSessionContext";
+import type { TerminalAgent } from "../../../common/sessionAgent";
 
 function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
   let result!: T;
@@ -23,8 +24,23 @@ describe("useSessionContext", () => {
     const { result, unmount } = withSetup(() => useSessionContext(ref<string | null>("sess-1"), ref<string | null>("/proj")));
     await flushPromises();
     // #1393: every request carries a deadline now, so the init is no longer absent.
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/session/sess-1?cwd=%2Fproj");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/session/sess-1?agent=claude&cwd=%2Fproj");
     expect(result.context.value?.model).toBe("claude-opus-4-8");
+    unmount();
+  });
+
+  // The badges are read from the agent's OWN log (#1465), so a terminal that is not Claude has to
+  // say which one it is — a request without it is answered from Claude's transcript, where a codex
+  // session has no file and the badge would stay empty.
+  it("names the agent it is asking about", async () => {
+    const fetchMock = vi.fn<(url: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(() =>
+      Promise.resolve(jsonResponse({ context: { model: "gpt-5.5", contextTokens: 42, contextWindow: 258_400 } })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { result, unmount } = withSetup(() => useSessionContext(ref<string | null>("sess-1"), ref<string | null>("/proj"), ref<TerminalAgent>("codex")));
+    await flushPromises();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/session/sess-1?agent=codex&cwd=%2Fproj");
+    expect(result.context.value?.contextWindow).toBe(258_400);
     unmount();
   });
 


### PR DESCRIPTION
Closes #1465

セルヘッダ 1 行目の 2 つのバッジ（`Opus · ctx 35%` と `⇡427k ⇣1.8k`）が Claude Code セッションでしか出ていなかったのを、他の 3 エージェントでも出す。

## なぜ出ていなかったか

UI の問題ではない。`GET /api/session/:id` の `usage` / `context` を作る `readSessionSummary` が `~/.claude/projects/<slug>/<id>.jsonl` — Claude Code の transcript 形式 — しか読まないため、Codex / Grok / Antigravity のセルでは `{ model: null }` とゼロが返り、バッジが自分で非表示になっていた。`modelBadge.ts` は元からエージェント非依存で、隠すという判断は誰もしていない。

## この PR

`?agent=` でリーダーを選ぶ。**Claude の経路は一切変わらない** — パラメータ無し = claude で、その 2 フィールドは今まで通りルートが既に走らせている summary fold から出る。

各エージェントは、自分のログに書いてあることだけを答える:

| Agent | Context バッジ | Token バッジ |
|---|---|---|
| Claude | `Opus · ctx 35%`（窓は従来の表） | 従来通り |
| Codex | `gpt-5.5 · ctx 33%` — 窓は codex 自身の `model_context_window` | あり |
| Grok | `grok-4.5` — モデル名のみ | 非表示（grok はトークンを記録しない） |
| Antigravity | `antigravity` — 固定ラベル | 非表示 |

### Codex

`token_count` イベントの `total_token_usage` / `last_token_usage` / `model_context_window`、モデル名は `turn_context.payload.model`（`/model` で変わるので最後の 1 つが勝つ）。窓は `contextWindow` として wire に載せ、バッジは推測表よりそちらを優先する — 表は OpenAI のモデルを 1 つも知らないし、Claude のモデルで一度間違えている (#985)。

`cached_input_tokens` は `input_tokens` の**部分集合**（`total_tokens` = `input_tokens` + `output_tokens` で検算）なので、`cacheReadTokens` に分けていない。UI は input 系 3 つを足して ⇡ を出すため、分けると二重計上になる。spec で固定した。

### Antigravity

固定ラベルにしたのは、agy がモデル id もトークンも記録していないため。唯一の言及は user turn 内の `<USER_SETTINGS_CHANGE>` の散文で、しかも設定を**変えた時だけ**書かれる。`settings.json` は現在のグローバル設定であって、古い会話がその設定で走ったとは限らない。どちらを読んでも「自信のある間違い」を表示することになる。

### ついでに

トークンが 1 つも数えられていないときは `ctx 0%` ではなくモデル名だけを出す。読み取り値が無いことは、空のコンテキストを測定したことではない。

## 確認

- `yarn format` / `yarn lint`（error 0）/ `yarn typecheck` / `yarn test`（8598 passed）
- 実機のログに対して直接: 実在の rollout が `gpt-5.5` · 84,787/258,400 · ⇡482k ⇣2.7k、実在の grok 会話が `grok-4.5` を返すことを確認
- スクリーンショットは無し（このリポジトリを serve しているインスタンスを再起動する必要があるため）。ブラウザでの目視確認はお願いします

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-specific session badges for Claude, Codex, Grok, and Antigravity.
  * Codex sessions now display token usage, context usage, model, and context-window percentages when available.
  * Grok and Antigravity sessions display model labels without token badges.
  * Session details now load data for the selected agent and working directory.

* **Bug Fixes**
  * Improved handling of missing, invalid, or unavailable usage and context data.

* **Documentation**
  * Updated badge documentation to describe agent-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->