### PR TITLE
feat: Antigravity セッションのモデル名をトランスクリプトから抽出してバッジに表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,7 +1151,7 @@ what it writes down (`?agent=` on the route picks the reader):
 | **Claude** | `Opus · ctx 35%` — window from the table above | full |
 | **Codex** | `gpt-5.5 · ctx 21%` — window from codex's own `model_context_window`, so no table to be out of date | full |
 | **Grok** | `grok-4.5` — the model only; grok records no token counts | hidden |
-| **Antigravity** | `antigravity` — a constant; agy records neither a model id nor tokens | hidden |
+| **Antigravity** | `Gemini 3.6 Flash (High)` — model name from the turn settings metadata (`antigravity` fallback); agy records no token counts | hidden |
 
 The token badge hides itself when nothing has been counted, and the context badge shows
 the model alone unless it has **both** a token count from the agent and a context window

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -15,17 +15,13 @@
 //                accounting at all (the only `token` fields in one are `first_token` timings and a
 //                WebFetch tool parameter), so the usage badge stays hidden — it hides itself when
 //                the totals are zero.
-//   antigravity  the NAME only, and a constant one. agy's transcript records neither tokens nor a
-//                model id; the single mention of a model is prose inside the user turn ("The user
-//                changed setting `Model Selection` … to Gemini 3.6 Flash (High)"), written only
-//                when the setting CHANGED, and `settings.json` holds the current global pick which
-//                an old conversation was not run under. Reading either would put a specific,
-//                confident, sometimes-wrong model name on the cell. "antigravity" is what we can
-//                stand behind.
+//   antigravity  the model name from the user turn's setting block (`<USER_SETTINGS_CHANGE>`), falling
+//                back to "antigravity" if unrecorded; agy records no token usage.
 //
 // A wrong number here is worse than no number: this badge is what a user reads before deciding to
 // /compact, so every field is either what the agent stated or absent.
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import type { TerminalAgent } from "../../common/sessionAgent.js";
 import type { SessionContextInfo } from "../../common/sessionContext.js";
 import { codexBadgesFromRolloutDocs, codexModelFromDocs, EMPTY_CODEX_BADGES, type CodexBadges } from "../agents/codex-usage.js";
@@ -34,8 +30,10 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { grokModelFromSummary, grokSummaryPath } from "../agents/grok-sessions.js";
 import { grokSessionsRoot } from "../agents/grok-session.js";
+import { antigravityBrainRoot, antigravityConversationExists, antigravityHome } from "../agents/antigravity-session.js";
+import { antigravityTranscriptPath } from "../agents/antigravity-sessions.js";
 import { readTailRecords } from "../infra/jsonl-file.js";
-import { codexRollouts, codexRolloutsHydrated } from "./registry.js";
+import { antigravityConversations, antigravityConversationsHydrated, codexRollouts, codexRolloutsHydrated } from "./registry.js";
 import type { SessionUsage } from "./transcript.js";
 
 export interface SessionBadges {
@@ -45,10 +43,35 @@ export interface SessionBadges {
 
 const EMPTY_USAGE: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
 
-/** What the badge calls an agy session. A constant, for the reason in the header comment. */
+/** What the badge calls an agy session as a fallback when unrecorded. */
 export const ANTIGRAVITY_MODEL_LABEL = "antigravity";
 
 const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE, context: { model, contextTokens: 0 } });
+
+const ANTIGRAVITY_MODEL_RE = /Model Selection` from .+? to (.+?)\.(?:\s+(?:No need|If reporting)|$|\n)/;
+
+/** The model name mentioned in an Antigravity transcript step, or null if unrecorded. */
+export function antigravityModelFromDocs(docs: Iterable<Record<string, unknown>>): string | null {
+  let model: string | null = null;
+  for (const d of docs) {
+    if (d.type === "USER_INPUT" && typeof d.content === "string") {
+      const m = ANTIGRAVITY_MODEL_RE.exec(d.content);
+      if (m?.[1]) model = m[1];
+    }
+  }
+  return model;
+}
+
+async function lastConversationForCwd(cwd: string): Promise<string | null> {
+  try {
+    const file = path.join(antigravityHome(), "cache", "last_conversations.json");
+    const content = await fs.readFile(file, "utf8");
+    const json = JSON.parse(content) as Record<string, unknown>;
+    return typeof json[cwd] === "string" ? json[cwd] : null;
+  } catch {
+    return null;
+  }
+}
 
 /** Where each agent keeps its sessions. Defaulted from the agent's own module and overridden only
  *  by the specs, which write a rollout and a conversation into a temp directory — the alternative
@@ -56,6 +79,7 @@ const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE
 export interface BadgeRoots {
   codexSessions?: string;
   grokSessions?: string;
+  antigravityBrain?: string;
 }
 
 async function codexBadges(sessionKey: string, root: string): Promise<CodexBadges> {
@@ -111,6 +135,35 @@ async function grokBadges(cwd: string, id: string, root: string): Promise<Sessio
   }
 }
 
+async function antigravityBadges(cwd: string, sessionKey: string, root: string): Promise<SessionBadges> {
+  await antigravityConversationsHydrated;
+  let conversationId = antigravityConversations.get(sessionKey)?.conversationId ?? sessionKey;
+  if (!antigravityConversationExists(root, conversationId)) {
+    const lastId = await lastConversationForCwd(cwd);
+    if (lastId && antigravityConversationExists(root, lastId)) {
+      conversationId = lastId;
+    }
+  }
+  const file = antigravityTranscriptPath(root, conversationId);
+  try {
+    // Check tail first for recent model setting changes in long sessions, fallback to head
+    let model = antigravityModelFromDocs(readTailRecords(file));
+    if (!model) {
+      const read = await readTranscriptHead(file, ROLLOUT_HEAD_BYTES);
+      if (read) {
+        const docs = read.head
+          .split("\n")
+          .map(parseJsonRecord)
+          .filter((d): d is Record<string, unknown> => d !== null);
+        model = antigravityModelFromDocs(docs);
+      }
+    }
+    return modelOnly(model ?? ANTIGRAVITY_MODEL_LABEL);
+  } catch {
+    return modelOnly(ANTIGRAVITY_MODEL_LABEL);
+  }
+}
+
 /**
  * The badges for a session, from whichever log its agent keeps.
  *
@@ -121,5 +174,5 @@ async function grokBadges(cwd: string, id: string, root: string): Promise<Sessio
 export async function agentBadges(cwd: string, id: string, agent: Exclude<TerminalAgent, "claude">, roots: BadgeRoots = {}): Promise<SessionBadges> {
   if (agent === "codex") return codexBadges(id, roots.codexSessions ?? codexSessionsRoot());
   if (agent === "grok") return grokBadges(cwd, id, roots.grokSessions ?? grokSessionsRoot());
-  return modelOnly(ANTIGRAVITY_MODEL_LABEL);
+  return antigravityBadges(cwd, id, roots.antigravityBrain ?? antigravityBrainRoot());
 }

--- a/test/server/session/agent-badges.spec.ts
+++ b/test/server/session/agent-badges.spec.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { agentBadges, ANTIGRAVITY_MODEL_LABEL, type BadgeRoots } from "../../../server/session/agent-badges.js";
+import { rememberAntigravityConversation } from "../../../server/session/registry.js";
 
 // The header badges for a session that is not Claude (#1465). Each agent is asked the question the
 // same way and answers as much of it as its own log can: codex both badges, grok the model, agy a
@@ -36,7 +37,11 @@ describe("agentBadges", () => {
 
   beforeEach(() => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "mt-agent-badges-"));
-    roots = { codexSessions: path.join(home, "codex", "sessions"), grokSessions: path.join(home, "grok", "sessions") };
+    roots = {
+      codexSessions: path.join(home, "codex", "sessions"),
+      grokSessions: path.join(home, "grok", "sessions"),
+      antigravityBrain: path.join(home, "antigravity", "brain"),
+    };
   });
 
   afterEach(() => fs.rmSync(home, { recursive: true, force: true }));
@@ -51,6 +56,12 @@ describe("agentBadges", () => {
     const dir = path.join(home, "grok", "sessions", encodeURIComponent(CWD), GROK_ID);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify(summary));
+  };
+
+  const writeAntigravityTranscript = (id: string, lines: string[]) => {
+    const dir = path.join(home, "antigravity", "brain", id, ".system_generated", "logs");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "transcript.jsonl"), `${lines.join("\n")}\n`);
   };
 
   it("reads a codex session's totals, context and window out of its rollout", async () => {
@@ -95,10 +106,35 @@ describe("agentBadges", () => {
     expect((await agentBadges("/Users/x/elsewhere", GROK_ID, "grok", roots)).context.model).toBeNull();
   });
 
-  // agy records neither a model nor a token count. The constant is deliberate: the only model name
-  // in its transcript is prose in a settings block that is written only when the setting changed.
-  it("labels an antigravity session with the agent's own name", async () => {
-    const badges = await agentBadges(CWD, "any-id", "antigravity", roots);
+  it("reads an antigravity session model from its user turn settings metadata", async () => {
+    const userInput = JSON.stringify({
+      type: "USER_INPUT",
+      content:
+        "<USER_REQUEST>\nhello\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment on this change if the user doesn't ask about it.\n</USER_SETTINGS_CHANGE>",
+    });
+    writeAntigravityTranscript("agy-123", [userInput]);
+    const badges = await agentBadges(CWD, "agy-123", "antigravity", roots);
+    expect(badges.context).toEqual({ model: "Gemini 3.6 Flash (High)", contextTokens: 0 });
+    expect(badges.usage.inputTokens).toBe(0);
+  });
+
+  it("reads an antigravity session model when session key is mapped to a conversationId", async () => {
+    const userInput = JSON.stringify({
+      type: "USER_INPUT",
+      content:
+        "<USER_REQUEST>\nhello\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment on this change if the user doesn't ask about it.\n</USER_SETTINGS_CHANGE>",
+    });
+    const sessionKey = "a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6";
+    const conversationId = "f6e5d4c3-b2a1-4098-8765-43210fedcba9";
+    rememberAntigravityConversation(sessionKey, conversationId, CWD);
+    writeAntigravityTranscript(conversationId, [userInput]);
+
+    const badges = await agentBadges(CWD, sessionKey, "antigravity", roots);
+    expect(badges.context).toEqual({ model: "Gemini 3.6 Flash (High)", contextTokens: 0 });
+  });
+
+  it("falls back to default label for an antigravity session without model recorded or missing file", async () => {
+    const badges = await agentBadges(CWD, "non-existent-id", "antigravity", roots);
     expect(badges.context).toEqual({ model: ANTIGRAVITY_MODEL_LABEL, contextTokens: 0 });
     expect(badges.usage.inputTokens).toBe(0);
   });


### PR DESCRIPTION
## 概要

PR #1466 の改善として、Antigravity セッションで固定文字列 `antigravity` ではなく、会話トランスクリプトのプロンプト内に記録されるモデル選択設定（`<USER_SETTINGS_CHANGE>`）から実際のモデル名（例: `Gemini 3.6 Flash (High)`）を抽出してヘッダバッジに表示するように変更しました。

## 変更内容

1. **Antigravity モデル名の抽出 ()**:
   - 会話ログ (`.system_generated/logs/transcript.jsonl`) の `USER_INPUT` ステップから `<USER_SETTINGS_CHANGE>` 内の `Model Selection` を正規表現で抽出。
   - `sessionKey` → `conversationId` のマッピング (`antigravityConversations`) を解決。
   - 未キャプチャの新規セッション用フォールバックとして `cache/last_conversations.json` のディレクトリ（`cwd`）ごとの会話IDを参照。
   - トランスクリプト未存在・未記録時はフォールバックとして従来通り `antigravity` を返却。

2. **ユニットテスト追加 (`test/server/session/agent-badges.spec.ts`)**:
   - トランスクリプトからのモデル名抽出テストおよび ID マッピング時の参照テストを追加。

3. **ドキュメント更新 (`README.md`)**:
   - Antigravity のモデルバッジ動作に関する説明を更新。

## 確認
- `yarn format` / `yarn lint` (error 0) / `yarn typecheck` / `yarn test` (すべてのテストをパス)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity session badges now display the model selected in session settings.
  * Added fallback handling when session or transcript details are unavailable.

* **Documentation**
  * Updated the README to identify Antigravity’s current model and fallback label.

* **Tests**
  * Added coverage for model detection, conversation mapping, and default-label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->