### PR TITLE
feat: Antigravity セルのバッジにモデル名・ctx%・トークン使用量を出す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,9 +1154,11 @@ what it writes down (`?agent=` on the route picks the reader):
 | **Antigravity** | `Gemini 3.6 Flash · ctx 78%` — the model from the first step of the conversation's transcript, the reading from agy's own per-generation accounting (a real 256k window, not a table) | full |
 
 The token badge hides itself when nothing has been counted, and the context badge shows
-the model alone unless it has **both** a token count from the agent and a context window
-— agent-reported (codex) or resolved from the built-in table above (Claude, provider
-models). Either one missing means a name and no percentage. The context badge is absent
+the model alone unless it has **both** a *current-context* token count from the agent and a
+context window — agent-reported (codex, Antigravity) or resolved from the built-in table
+above (Claude, provider models). Either one missing means a name and no percentage. The two
+badges are independent: an Antigravity session whose accounting cannot be read still shows
+its model, and one whose cumulative totals are zero still shows a percentage. The context badge is absent
 entirely until an agent has named a model: codex and Antigravity file their logs under an id
 the agent mints *after* the session starts, so a brand-new cell shows no model badge until it
 has been prompted once — a few seconds, not the rest of the session.

--- a/README.md
+++ b/README.md
@@ -1151,12 +1151,15 @@ what it writes down (`?agent=` on the route picks the reader):
 | **Claude** | `Opus · ctx 35%` — window from the table above | full |
 | **Codex** | `gpt-5.5 · ctx 21%` — window from codex's own `model_context_window`, so no table to be out of date | full |
 | **Grok** | `grok-4.5` — the model only; grok records no token counts | hidden |
-| **Antigravity** | `antigravity` — a constant; agy records neither a model id nor tokens | hidden |
+| **Antigravity** | `Gemini 3.6 Flash` — the model agy names in the first step of the conversation's transcript; agy records no token counts | hidden |
 
 The token badge hides itself when nothing has been counted, and the context badge shows
 the model alone unless it has **both** a token count from the agent and a context window
 — agent-reported (codex) or resolved from the built-in table above (Claude, provider
-models). Either one missing means a name and no percentage.
+models). Either one missing means a name and no percentage. The context badge is absent
+entirely until an agent has named a model: codex and Antigravity file their logs under an id
+the agent mints *after* the session starts, so a brand-new cell shows no model badge until it
+has been prompted once — a few seconds, not the rest of the session.
 
 The **Settings** modal (⚙) shows an **estimated $ cost** — Session / Today / Month — from
 `GET /api/cost`, using a built-in public per-model price table (cache reads billed at

--- a/README.md
+++ b/README.md
@@ -1151,7 +1151,7 @@ what it writes down (`?agent=` on the route picks the reader):
 | **Claude** | `Opus · ctx 35%` — window from the table above | full |
 | **Codex** | `gpt-5.5 · ctx 21%` — window from codex's own `model_context_window`, so no table to be out of date | full |
 | **Grok** | `grok-4.5` — the model only; grok records no token counts | hidden |
-| **Antigravity** | `Gemini 3.6 Flash` — the model agy names in the first step of the conversation's transcript; agy records no token counts | hidden |
+| **Antigravity** | `Gemini 3.6 Flash · ctx 78%` — the model from the first step of the conversation's transcript, the reading from agy's own per-generation accounting (a real 256k window, not a table) | full |
 
 The token badge hides itself when nothing has been counted, and the context badge shows
 the model alone unless it has **both** a token count from the agent and a context window
@@ -1160,6 +1160,13 @@ models). Either one missing means a name and no percentage. The context badge is
 entirely until an agent has named a model: codex and Antigravity file their logs under an id
 the agent mints *after* the session starts, so a brand-new cell shows no model badge until it
 has been prompted once — a few seconds, not the rest of the session.
+
+Antigravity's numbers are the one case read from a store with **no published format**: agy keeps
+its per-generation accounting as protobuf in `~/.gemini/antigravity-cli/conversations/<id>.db`,
+with no schema on disk, so the fields are identified by measurement (see
+`server/agents/antigravity-usage.ts`). Every layer of that reader is built to answer *nothing*
+rather than a number it is unsure of, so if a future agy release moves those fields, an
+Antigravity cell falls back to showing its model alone — it will not show a wrong percentage.
 
 The **Settings** modal (⚙) shows an **estimated $ cost** — Session / Today / Month — from
 `GET /api/cost`, using a built-in public per-model price table (cache reads billed at

--- a/plans/feat-antigravity-model-badge.md
+++ b/plans/feat-antigravity-model-badge.md
@@ -77,11 +77,62 @@ Consequence, and it is deliberate: a cell that has not been prompted yet shows *
 rather than a constant. That is what grok already does before its first turn, and it is what lets
 the client tell "unknown" from "known" — which is the whole mechanism above.
 
+## The numbers, from a store with no published format
+
+Follow-up ask: Claude's cell shows `ctx %` and token counts — can agy's? The transcript really has
+none (its record types carry `step_index`, `content`, `tool_calls`, `exit_code` and nothing else).
+They are in a second store the transcript never mentions:
+`~/.gemini/antigravity-cli/conversations/<conversationId>.db`, a SQLite database whose
+`gen_metadata` table holds one **protobuf blob per generation**. There is no `.proto` on disk.
+
+The fields were identified by watching them across a real 519-generation conversation:
+
+```
+idx=  0  ctx   2,522/256,000  prompt 22,812  out 178  cached       0  thoughts  80
+idx=240  ctx 234,987/256,000  prompt  4,901  out 180  cached 227,183  thoughts  94
+idx=300  ctx 146,536/256,000  prompt  3,660  out  84  cached 137,957  thoughts  68  <- compacted
+```
+
+`1.9.10.1` climbs against `1.9.10.4` = 256,000 and drops on compaction; the per-generation counts
+under `1.4` sum to within a few percent of it. That is a context reading and nothing else.
+
+**Everything about the reader is built to answer "nothing" rather than a number it is unsure of**,
+because the badge is what a user compacts by:
+
+- `antigravity-proto.ts` walks only the requested path, skipping other fields by length (a 740 KB
+  row costs a few dozen byte reads), stops at the first byte it cannot account for rather than
+  resynchronising, and never throws;
+- `antigravity-usage.ts` gates every reading — a window outside 1 KB–100 M, a `used` above its own
+  window, a token count above a billion, a missing leaf — and drops the whole answer rather than
+  contributing a zero;
+- the two badges are independent, so unreadable accounting still leaves the model named.
+
+If a future agy renumbers these fields, an agy cell shows its model alone. That is the pre-#1465
+behaviour, reached quietly.
+
+Two things only the real database revealed, both now pinned by tests:
+
+- **`node:sqlite` throws "column index out of range" on `limit ?`.** A named `$limit` binds.
+- **A varint too large to hold must be SKIPPED, not refused.** agy stores an
+  `18446744073709551615` sentinel in the very message that holds the context reading. The first
+  cut treated "cannot represent" as "cannot continue", stopped there, and reported no context at
+  all — with every synthetic fixture passing. Skipping a field never needs its value.
+
+Freshness needed one more piece: with no turn end, the context reading would be frozen at whatever
+it was when the cell first asked. An agy cell re-reads its badges once a minute (one indexed
+sqlite row plus a 64 KB head read), which is the substitute for the activity tracker it does not
+have and should be deleted the day it gets one.
+
 ## Verified
 
-- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn test` (8614 passed)
-- Against the real logs, not only fixtures: three actual conversations under
-  `~/.gemini/antigravity-cli/brain` answer `Gemini 3.6 Flash (High)`, and an unknown id answers
-  `null`.
+- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn test` (8636 passed)
+- Against the real stores, not only fixtures — which is where both bugs above came from:
+
+  ```
+  a4dbbf1e | Gemini 3.6 Flash (High) | ctx 199141/256000 (78%) | in 4258938 out 266486 cache 75671040
+  9ee2d1bb | Gemini 3.6 Flash (High) | ctx 209450/256000 (82%) | in 1789741 out  93143 cache 15236168
+  2658608b | Gemini 3.6 Flash (High) | ctx  82657/256000 (32%) | in  195827 out  12216 cache  1706889
+  unknown  | null                    | ctx 0/null             | in 0 out 0 cache 0
+  ```
 - The specs write nothing into `~/.mulmoterminal/` — the spawner spec stubs `remember` and the
   watcher, which the previous spec did not (it left a fake session in the real log).

--- a/plans/feat-antigravity-model-badge.md
+++ b/plans/feat-antigravity-model-badge.md
@@ -1,0 +1,87 @@
+# feat — name the model on an Antigravity cell's badge
+
+## What it does
+
+An agy cell's header badge said `antigravity`, a constant. It now says the model agy is
+running — `Gemini 3.6 Flash` — read from the conversation's own transcript.
+
+## Why the constant was there, and why it goes now
+
+#1466 refused to read the model, and wrote down why: the only mention of one is prose inside
+the user turn ("The user changed setting `Model Selection` … to Gemini 3.6 Flash (High)"),
+apparently written **only when the setting changed**, so reading it would put a confident,
+sometimes-wrong name on the cell.
+
+That reasoning was from the wording, not from the data. Counted across every conversation on
+the machine this was written on:
+
+```
+transcripts: 50   with a settings block: 50   with more than one block: 0
+first-hit line index histogram: {0: 50}
+```
+
+agy states the selection at the START of a conversation as a change "from None", whether or not
+the user touched the setting. So it is a fact about **this** conversation — which `settings.json`
+is not (global, current, and not what an older conversation ran under), and which the cwd's
+last conversation is not either (see below).
+
+The bound, stated in the code: the block is read from the **head**, so if agy ever begins writing
+a second block mid-conversation, the badge keeps naming the model the conversation STARTED on
+until it is next resumed.
+
+## Shape
+
+- `server/agents/antigravity-sessions.ts` — `antigravityModelFromTranscriptHead`, beside the
+  title parser that already has to strip the same block. The model name is bounded (48 chars) and
+  the sentence terminator is a period **followed by a space or the end of the block**, because
+  `Gemini 3.6` contains one too.
+- `server/session/agent-badges.ts` — resolves our session id to agy's conversation id through
+  `antigravityConversations` (the codex lookup, for the codex reason) and reads 64 KB of the head.
+  No tail read: the block is at the front, and a second read that almost never finds anything
+  would be paid on every cell.
+- `src/components/modelBadge.ts` — drops a trailing bracketed qualifier, so the badge reads
+  `Gemini 3.6 Flash` and not `Gemini 3.6 Flash (High)`. The badge is `whitespace-nowrap flex-none`:
+  it does not truncate, it pushes the rest of the header's chips out. The full name stays in the tip.
+
+## What #1468 got wrong, kept here as the reason not to redo it
+
+That PR fell back to `cache/last_conversations.json` when the session had no mapping yet. That
+file holds only the LAST conversation per cwd and is written at exit (`antigravity-sessions.ts`
+says so at the top), so in exactly the case it was reached for — a fresh session — it names a
+**previous** conversation. A new cell would show the model of the session before it, and two cells
+in one directory would show the same. An unmapped session is answered `null` instead.
+
+## The half that is not parsing: a fresh cell never re-asked
+
+Reported against the first cut: resuming from chat history showed the model, starting a new
+terminal did not. Not a parsing bug —
+
+- a **resumed** session records its mapping at spawn, so the cell's seed fetch already reads the
+  right transcript;
+- a **fresh** one gets its id from a watcher, after agy creates the conversation on the first
+  prompt — so the seed fetch legitimately answers "nobody", and **nothing ever asked again**.
+  `refreshUsage()` runs on `working -> idle`, and nothing calls `setWorking` for an agy session:
+  it has no hooks (claude) and no activity tracker (codex). The badge was frozen at its mount value
+  for the life of the session.
+
+Two changes, one on each side:
+
+- `spawn-antigravity.ts` publishes the session row when the capture lands — the one edge where the
+  answer changed. `publishActivity` joins `SpawnDeps` next to `publishSessionCreated`.
+- `TerminalCell.vue` re-reads its badges on a push **while the model is still unknown**, for a
+  non-claude cell. Self-limiting: once a model is known it stops. Claude is excluded because its
+  badges come from the summary the route already folds, and this is the busiest route in the app.
+  This fixes the same first-turn latency for codex, which mints its rollout id the same way.
+
+Consequence, and it is deliberate: a cell that has not been prompted yet shows **no** model badge
+rather than a constant. That is what grok already does before its first turn, and it is what lets
+the client tell "unknown" from "known" — which is the whole mechanism above.
+
+## Verified
+
+- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn test` (8614 passed)
+- Against the real logs, not only fixtures: three actual conversations under
+  `~/.gemini/antigravity-cli/brain` answer `Gemini 3.6 Flash (High)`, and an unknown id answers
+  `null`.
+- The specs write nothing into `~/.mulmoterminal/` — the spawner spec stubs `remember` and the
+  watcher, which the previous spec did not (it left a fake session in the real log).

--- a/server/agents/antigravity-proto.ts
+++ b/server/agents/antigravity-proto.ts
@@ -1,0 +1,161 @@
+// Reading a few numbers out of a protobuf record whose schema we do not have.
+//
+// agy stores its per-generation accounting as protobuf blobs in a SQLite database
+// (antigravity-usage.ts). There is no .proto anywhere on disk, so a field is addressed by NUMBER
+// and its meaning was established by watching it: `1.9.10.1` climbs to 252,780 against `1.9.10.4`
+// = 256,000 and drops when the conversation compacts, which is a context reading and nothing else.
+//
+// That is a fine way to learn a format and a terrible thing to trust blindly, so this walker is
+// built to fail rather than to guess:
+//
+//   - it NEVER throws — a truncated blob, a wrong wire type, a field that is a string where a
+//     message was expected, all answer `undefined`, and the caller shows no badge;
+//   - it reads only the path it is asked for, skipping every other field by its length, so a
+//     740 KB row costs a few dozen byte reads rather than a full decode;
+//   - it stops at the first byte it cannot account for, rather than resynchronising — a walker
+//     that recovers from garbage is a walker that reports numbers from garbage.
+//
+// The caller is where the numbers are sanity-checked. Nothing here knows what a plausible token
+// count is; it only knows what a varint is.
+
+/** A protobuf varint at `offset`: where the next field starts, and its value — `null` when the
+ *  value is real but too large for a JS number to hold exactly.
+ *
+ *  Those two are deliberately separate answers. agy's rows carry a `18446744073709551615` sentinel
+ *  in the message that also holds the context reading, and a walker that treats "cannot represent
+ *  this" as "cannot continue" stops there and reports no context at all — which is precisely what
+ *  the first cut did against the real database, while every synthetic fixture passed. Skipping a
+ *  field never needs its value. */
+interface Varint {
+  value: number | null;
+  next: number;
+}
+
+// 10 bytes is the most a 64-bit varint can occupy. A longer run means the blob is not what we
+// think it is, which is a stop rather than a number.
+const MAX_VARINT_BYTES = 10;
+// Beyond 2^53 a JS number stops counting exactly. Nothing we read is anywhere near it — a token
+// count or a byte length — so a value that big is a misread field, not a big number.
+const MAX_EXACT = Number.MAX_SAFE_INTEGER;
+
+function readVarint(buf: Buffer, offset: number): Varint | null {
+  let value = 0;
+  let shift = 1;
+  let exact = true;
+  for (let i = 0; i < MAX_VARINT_BYTES; i++) {
+    const at = offset + i;
+    if (at >= buf.length) return null; // truncated: the blob really does end mid-field
+    const byte = buf[at] ?? 0;
+    value += (byte & 0x7f) * shift;
+    if (value > MAX_EXACT) exact = false;
+    if ((byte & 0x80) === 0) return { value: exact ? value : null, next: at + 1 };
+    shift *= 128;
+  }
+  return null; // an eleventh continuation byte: not a varint, so not this format
+}
+
+/** A field key: its number and wire type, or null if the key itself is unreadable. A key is small
+ *  by construction, so one that is not exact is a blob we are not reading. */
+function readKey(buf: Buffer, offset: number): { field: number; wireType: number; next: number } | null {
+  const key = readVarint(buf, offset);
+  if (key?.value === null || key === null) return null;
+  return { field: Math.floor(key.value / 8), wireType: key.value % 8, next: key.next };
+}
+
+/** One field: what it is, what it holds, and where the next one starts. Null means the bytes here
+ *  are not a field, which ends the walk — a group, a wire type that does not exist, or a payload
+ *  claiming to run past the end of the buffer. */
+interface Field {
+  field: number;
+  varint: number | null | undefined;
+  bytes: Buffer | undefined;
+  next: number;
+}
+
+const FIXED64_BYTES = 8;
+const FIXED32_BYTES = 4;
+
+function readField(buf: Buffer, offset: number): Field | null {
+  const key = readKey(buf, offset);
+  if (!key) return null;
+  const skipped = { field: key.field, varint: undefined, bytes: undefined };
+  if (key.wireType === 0) {
+    const value = readVarint(buf, key.next);
+    return value && { field: key.field, varint: value.value, bytes: undefined, next: value.next };
+  }
+  if (key.wireType === 2) {
+    const length = readVarint(buf, key.next);
+    if (length?.value == null) return null;
+    const end = length.next + length.value;
+    if (end > buf.length) return null;
+    return { field: key.field, varint: undefined, bytes: buf.subarray(length.next, end), next: end };
+  }
+  if (key.wireType === 5) return { ...skipped, next: key.next + FIXED32_BYTES };
+  if (key.wireType === 1) return { ...skipped, next: key.next + FIXED64_BYTES };
+  return null;
+}
+
+/**
+ * Walk `buf`'s fields, handing each one to `onField`, until the bytes stop making sense.
+ *
+ * `onField` gets the field number and, for a varint, its value (null when the value is beyond a JS
+ * number — the field is still SKIPPED correctly, which is the whole point). Length-delimited
+ * payloads arrive as a subarray. Everything else is stepped over by its fixed width.
+ */
+function walkFields(buf: Buffer, onField: (field: number, varint: number | null | undefined, bytes: Buffer | undefined) => void): void {
+  let offset = 0;
+  while (offset < buf.length) {
+    const field = readField(buf, offset);
+    if (!field) return;
+    onField(field.field, field.varint, field.bytes);
+    offset = field.next;
+  }
+}
+
+/** The bytes of length-delimited field `field` inside `buf`, or undefined if it holds no such
+ *  field. The LAST one wins, matching protobuf's own rule for a repeated-or-overwritten field. */
+function messageField(buf: Buffer, field: number): Buffer | undefined {
+  let found: Buffer | undefined;
+  walkFields(buf, (at, _varint, bytes) => {
+    if (at === field && bytes) found = bytes;
+  });
+  return found;
+}
+
+/** The varint value of field `field` in `buf`, or undefined — including when the field is there but
+ *  too large to hold exactly, which is not a number we may report. */
+function varintField(buf: Buffer, field: number): number | undefined {
+  let found: number | undefined;
+  walkFields(buf, (at, varint) => {
+    if (at === field && varint !== undefined) found = varint ?? undefined;
+  });
+  return found;
+}
+
+/**
+ * The varint at a path of field numbers — `[1, 9, 10, 1]` for `1.9.10.1`. Every step but the last
+ * must be a length-delimited field holding a message; the last must be a varint. Anything else,
+ * at any depth, is `undefined`.
+ */
+export function protoVarintAt(blob: Buffer, path: readonly number[]): number | undefined {
+  if (path.length === 0) return undefined;
+  let cursor: Buffer | undefined = blob;
+  for (const field of path.slice(0, -1)) {
+    cursor = messageField(cursor, field);
+    if (!cursor) return undefined;
+  }
+  const leaf = path[path.length - 1];
+  return leaf === undefined ? undefined : varintField(cursor, leaf);
+}
+
+/** Several varints under one shared prefix, read in a single descent. `undefined` for any leaf the
+ *  record does not carry — which a caller must treat as "not this shape", not as zero. */
+export function protoVarintsAt(blob: Buffer, prefix: readonly number[], leaves: readonly number[]): (number | undefined)[] {
+  let cursor: Buffer | undefined = blob;
+  for (const field of prefix) {
+    cursor = messageField(cursor, field);
+    if (!cursor) return leaves.map(() => undefined);
+  }
+  const at = cursor;
+  return leaves.map((leaf) => varintField(at, leaf));
+}

--- a/server/agents/antigravity-proto.ts
+++ b/server/agents/antigravity-proto.ts
@@ -75,6 +75,9 @@ interface Field {
 const FIXED64_BYTES = 8;
 const FIXED32_BYTES = 4;
 
+/** A field whose payload fits inside the buffer, or null when it claims to run past the end. */
+const endWithin = (buf: Buffer, field: Omit<Field, "next">, next: number): Field | null => (next <= buf.length ? { ...field, next } : null);
+
 function readField(buf: Buffer, offset: number): Field | null {
   const key = readKey(buf, offset);
   if (!key) return null;
@@ -90,8 +93,12 @@ function readField(buf: Buffer, offset: number): Field | null {
     if (end > buf.length) return null;
     return { field: key.field, varint: undefined, bytes: buf.subarray(length.next, end), next: end };
   }
-  if (key.wireType === 5) return { ...skipped, next: key.next + FIXED32_BYTES };
-  if (key.wireType === 1) return { ...skipped, next: key.next + FIXED64_BYTES };
+  // Bounds-checked like every other width here. It changes no answer today — a fixed-width field
+  // carries neither a varint nor bytes, so the callback records nothing and the walk ends on the
+  // next loop test either way — but "stop at the first byte you cannot account for" has to hold
+  // for every wire type, or the first reader to report a fixed-width value inherits the hole.
+  if (key.wireType === 5) return endWithin(buf, { ...skipped }, key.next + FIXED32_BYTES);
+  if (key.wireType === 1) return endWithin(buf, { ...skipped }, key.next + FIXED64_BYTES);
   return null;
 }
 

--- a/server/agents/antigravity-session.ts
+++ b/server/agents/antigravity-session.ts
@@ -18,8 +18,15 @@ export function antigravityHome(): string {
   return process.env.ANTIGRAVITY_HOME || path.join(os.homedir(), ".gemini", "antigravity-cli");
 }
 
-export function antigravityBrainRoot(): string {
-  return path.join(antigravityHome(), "brain");
+export function antigravityBrainRoot(home: string = antigravityHome()): string {
+  return path.join(home, "brain");
+}
+
+// Where agy keeps a conversation's own database — one file per conversation id, beside the brain
+// directory rather than inside it. The transcript and the accounting live in different trees
+// (antigravity-usage.ts), so a reader needs both roots and neither is derivable from the other.
+export function antigravityConversationsRoot(home: string = antigravityHome()): string {
+  return path.join(home, "conversations");
 }
 
 // One directory per conversation, named by its id. Anything else in there is not a conversation.

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -53,6 +53,42 @@ export function antigravityTitleFromTranscriptHead(head: string): string {
   return cleanTitle(typeof first?.content === "string" ? promptText(first.content) : null, DEFAULT_TITLE);
 }
 
+// The model the conversation is running, out of the same block the title has to strip.
+//
+// It reads as prose written only on a CHANGE ("The user changed setting `Model Selection` from
+// None to Gemini 3.6 Flash (High)."), and that wording is why #1466 refused to read it. The
+// transcripts say otherwise: across all 50 conversations on the machine this was written on, every
+// one carries the block, always in step 0, and none carries a second — agy states the selection at
+// the start of a conversation as a change "from None", whether or not the user touched the setting.
+//
+// So this is a fact about THIS conversation, unlike `settings.json` (global, current, and not what
+// an older conversation ran under). The bound: it is read from the head, so if agy ever starts
+// writing a second block mid-conversation, the badge keeps naming the model the conversation
+// STARTED on until it is next resumed. Wrong in a way the user caused and can see, and cheap —
+// a bounded head read, on a file an agent appends to without limit.
+const SETTINGS_BLOCK_RE = /<USER_SETTINGS_CHANGE>([\s\S]*?)<\/USER_SETTINGS_CHANGE>/g;
+// `.` ends the sentence, but a model name contains one too ("Gemini 3.6"), so the terminator is a
+// period FOLLOWED BY a space or the end of the block — not the first period.
+const MODEL_SELECTION_RE = /`Model Selection` from [\s\S]*? to (.+?)\.(?=\s|$)/;
+// A name, not a paragraph. Anything longer means the wording moved and the capture ran on, and a
+// header badge is the wrong place to find that out — the fallback label is.
+const MODEL_NAME_MAX = 48;
+
+/** The model named in a transcript head, or null if it names none. */
+export function antigravityModelFromTranscriptHead(head: string): string | null {
+  let model: string | null = null;
+  for (const record of head.split("\n").map(parseJsonRecord)) {
+    if (!record || !isUserInput(record) || typeof record.content !== "string") continue;
+    // The LAST block wins: none of the captured transcripts has two, but if one ever does, the
+    // later line is the later change.
+    for (const [, block] of record.content.matchAll(SETTINGS_BLOCK_RE)) {
+      const name = MODEL_SELECTION_RE.exec(block ?? "")?.[1]?.trim();
+      if (name && name.length <= MODEL_NAME_MAX) model = name;
+    }
+  }
+  return model;
+}
+
 async function readTranscriptSummary(file: string): Promise<{ title: string; mtime: number } | null> {
   const read = await readTranscriptHead(file, HEAD_BYTES);
   return read && { title: antigravityTitleFromTranscriptHead(read.head), mtime: read.mtime };

--- a/server/agents/antigravity-usage.ts
+++ b/server/agents/antigravity-usage.ts
@@ -21,7 +21,6 @@
 // answer rather than contributing a zero. If agy moves these fields the badges go quiet, which is
 // where they were before this existed.
 import path from "node:path";
-import { stat } from "node:fs/promises";
 import { protoVarintsAt } from "./antigravity-proto.js";
 import type { SessionContextInfo } from "../../common/sessionContext.js";
 import type { SessionUsage } from "../session/transcript.js";
@@ -58,7 +57,10 @@ const MAX_TOKENS = 1_000_000_000;
 const CONTEXT_SCAN_ROWS = 32;
 /** Summing the whole table is what makes the usage badge cumulative. A conversation this long is
  *  beyond anything measured (the largest here has 519 rows), so it is a runaway guard: the usage
- *  badge is dropped rather than reported from a partial sum. */
+ *  badge is dropped rather than reported from a partial sum.
+ *
+ *  One MORE than this is read, so that a table of exactly this many rows is recognised as complete
+ *  rather than assumed to be the top of a longer one. */
 const MAX_USAGE_ROWS = 50_000;
 
 export function antigravityDbPath(conversationsRoot: string, conversationId: string): string {
@@ -83,7 +85,11 @@ async function readGenRows(file: string, limit: number): Promise<GenRow[] | null
     const { DatabaseSync } = await import("node:sqlite");
     // Read-only, and through a URI so a database agy has open is opened as a reader rather than as
     // something that could take a write lock on the file the agent is working from.
-    db = new DatabaseSync(`file:${encodeURI(file)}?mode=ro`, { readOnly: true });
+    // A PLAIN path, not a `file:…?mode=ro` URI. node:sqlite does not enable SQLite's URI filenames
+    // on every Node this package supports (`>=22.9`), and where it does not, the URI is taken as a
+    // literal filename — the open fails, and every agy badge silently goes quiet on that runtime.
+    // `readOnly` is the option that makes this a reader, and it is honoured everywhere.
+    db = new DatabaseSync(file, { readOnly: true });
     // A NAMED parameter: `limit ?` binds fine in every other sqlite binding and throws
     // "column index out of range" in node:sqlite, which the specs caught and this comment exists
     // so nobody "simplifies" back to.
@@ -163,11 +169,11 @@ function usageOf(rows: readonly GenRow[]): SessionUsage | null {
  */
 export async function antigravityBadgesFromDb(conversationsRoot: string, conversationId: string): Promise<AntigravityBadges | null> {
   const file = antigravityDbPath(conversationsRoot, conversationId);
-  const rows = await readGenRows(file, MAX_USAGE_ROWS);
+  const rows = await readGenRows(file, MAX_USAGE_ROWS + 1);
   if (!rows?.length) return null;
-  // The cap was hit, so the oldest generations are missing and any total would be short. The
+  // A row beyond the cap means older generations are missing and any total would be short. The
   // context reading is still exact — it comes from the newest row — so only the usage is dropped.
-  const complete = rows.length < MAX_USAGE_ROWS;
+  const complete = rows.length <= MAX_USAGE_ROWS;
   const context = contextOf(rows.slice(0, CONTEXT_SCAN_ROWS));
   const usage = complete ? usageOf(rows) : null;
   if (!context && !usage) return null;
@@ -175,13 +181,4 @@ export async function antigravityBadgesFromDb(conversationsRoot: string, convers
     usage: usage ?? { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
     context: context ?? { contextTokens: 0, contextWindow: null },
   };
-}
-
-/** Whether a conversation's database exists at all, for callers that want to skip the read. */
-export async function antigravityDbExists(conversationsRoot: string, conversationId: string): Promise<boolean> {
-  try {
-    return (await stat(antigravityDbPath(conversationsRoot, conversationId))).isFile();
-  } catch {
-    return false;
-  }
 }

--- a/server/agents/antigravity-usage.ts
+++ b/server/agents/antigravity-usage.ts
@@ -1,0 +1,187 @@
+// The token and context numbers for an Antigravity session, out of agy's own accounting.
+//
+// They are NOT in the transcript — `transcript.jsonl` has no token field of any kind, which is why
+// #1465 shipped the model alone. They are in a second store the transcript never mentions:
+// `~/.gemini/antigravity-cli/conversations/<conversationId>.db`, a SQLite database whose
+// `gen_metadata` table holds one protobuf blob per generation. Measured on a real conversation:
+//
+//   idx=  0  ctx 2,522/256,000    prompt 22,812  out   178  cached       0  thoughts  80
+//   idx=240  ctx 234,987/256,000  prompt  4,901  out   180  cached 227,183  thoughts  94
+//   idx=300  ctx 146,536/256,000  prompt  3,660  out    84  cached 137,957  thoughts  68   <- compacted
+//   idx=518  ctx 199,141/256,000  prompt  2,485  out   255  cached 194,633  thoughts 221
+//
+// The context reading climbs, drops when the conversation compacts, and the per-generation counts
+// sum to within a few percent of it. That is what identifies the fields; there is no schema on
+// disk and no name anywhere — see antigravity-proto.ts.
+//
+// **So the whole of this file is written to answer "nothing" rather than a wrong number.** A badge
+// is read before deciding to compact, and a number invented from a renumbered field would be acted
+// on. Every layer can decline: the walker returns undefined for anything unexpected, the gates
+// below reject a reading that is not internally consistent, and one missing leaf drops the whole
+// answer rather than contributing a zero. If agy moves these fields the badges go quiet, which is
+// where they were before this existed.
+import path from "node:path";
+import { stat } from "node:fs/promises";
+import { protoVarintsAt } from "./antigravity-proto.js";
+import type { SessionContextInfo } from "../../common/sessionContext.js";
+import type { SessionUsage } from "../session/transcript.js";
+
+export interface AntigravityBadges {
+  usage: SessionUsage;
+  context: Omit<SessionContextInfo, "model">;
+}
+
+// `1.9.10` — the context reading. `.1` is how much of the window this generation used, `.4` is the
+// window itself.
+const CONTEXT_PREFIX = [1, 9, 10] as const;
+const CONTEXT_USED = 1;
+const CONTEXT_WINDOW = 4;
+
+// `1.4` — the generation's token counts.
+const USAGE_PREFIX = [1, 4] as const;
+const PROMPT_TOKENS = 2; // input that was not served from cache
+const OUTPUT_TOKENS = 3;
+const CACHED_TOKENS = 5; // input served from cache; absent on the first generation, which has none
+const TOOL_PROMPT_TOKENS = 9;
+const THINKING_TOKENS = 10;
+
+// What a reading has to look like to be one. These are deliberately loose — they are here to catch
+// a field that now means something else entirely (a timestamp, an enum, a byte offset), not to
+// second-guess agy about its own limits.
+const MIN_WINDOW = 1024;
+const MAX_WINDOW = 100_000_000;
+const MAX_TOKENS = 1_000_000_000;
+
+/** The most recent rows are scanned newest-first for the context reading, because the last row of
+ *  the table is not always a generation — a conversation can end with a configuration record. Past
+ *  this many the answer is "no reading", not a deeper search. */
+const CONTEXT_SCAN_ROWS = 32;
+/** Summing the whole table is what makes the usage badge cumulative. A conversation this long is
+ *  beyond anything measured (the largest here has 519 rows), so it is a runaway guard: the usage
+ *  badge is dropped rather than reported from a partial sum. */
+const MAX_USAGE_ROWS = 50_000;
+
+export function antigravityDbPath(conversationsRoot: string, conversationId: string): string {
+  return path.join(conversationsRoot, `${conversationId}.db`);
+}
+
+interface GenRow {
+  data: Buffer;
+}
+
+/**
+ * Rows of `gen_metadata`, newest first, or null if the database cannot be read as one.
+ *
+ * `node:sqlite` is imported here rather than at module scope for two reasons: it is flagged
+ * experimental, so importing it prints a warning on a server that may never start an agy session,
+ * and a Node built without it would otherwise take the whole module down at import time instead of
+ * costing one quiet badge.
+ */
+async function readGenRows(file: string, limit: number): Promise<GenRow[] | null> {
+  let db: InstanceType<typeof import("node:sqlite").DatabaseSync> | null = null;
+  try {
+    const { DatabaseSync } = await import("node:sqlite");
+    // Read-only, and through a URI so a database agy has open is opened as a reader rather than as
+    // something that could take a write lock on the file the agent is working from.
+    db = new DatabaseSync(`file:${encodeURI(file)}?mode=ro`, { readOnly: true });
+    // A NAMED parameter: `limit ?` binds fine in every other sqlite binding and throws
+    // "column index out of range" in node:sqlite, which the specs caught and this comment exists
+    // so nobody "simplifies" back to.
+    const rows = db.prepare("select data from gen_metadata order by idx desc limit $limit").all({ limit });
+    return rows.map(genRowOf).filter((row): row is GenRow => row !== null);
+  } catch {
+    return null; // no database yet, a shape we do not know, or no sqlite in this runtime
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // Closing a handle that never opened is not a failure worth reporting.
+    }
+  }
+}
+
+/** One row's blob. node:sqlite hands a BLOB back as a Uint8Array, not a Buffer — wrapped rather
+ *  than copied, since these run to hundreds of kilobytes each. */
+function genRowOf(row: Record<string, unknown> | null): GenRow | null {
+  const data = row?.data;
+  if (Buffer.isBuffer(data)) return { data };
+  if (data instanceof Uint8Array) return { data: Buffer.from(data.buffer, data.byteOffset, data.byteLength) };
+  return null;
+}
+
+const inRange = (value: number | undefined, max: number): value is number => value !== undefined && Number.isInteger(value) && value >= 0 && value <= max;
+
+/** The context reading from the newest generation row that carries one. */
+function contextOf(rows: readonly GenRow[]): { contextTokens: number; contextWindow: number } | null {
+  for (const row of rows) {
+    const [used, window] = protoVarintsAt(row.data, CONTEXT_PREFIX, [CONTEXT_USED, CONTEXT_WINDOW]);
+    if (!inRange(window, MAX_WINDOW) || window < MIN_WINDOW) continue;
+    if (!inRange(used, MAX_TOKENS)) continue;
+    // Over the window is not a reading: it means these two fields are no longer the pair we think
+    // they are. The UI makes the same call for the same reason (#985) — see readContext.
+    if (used > window) return null;
+    return { contextTokens: used, contextWindow: window };
+  }
+  return null;
+}
+
+/** Cumulative usage across every generation, or null if any row that carries counts is not the
+ *  shape we know — a partial sum is a wrong number, not a smaller one. */
+function usageOf(rows: readonly GenRow[]): SessionUsage | null {
+  const total: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+  let counted = 0;
+  for (const row of rows) {
+    const [prompt, output, cached, toolPrompt, thinking] = protoVarintsAt(row.data, USAGE_PREFIX, [
+      PROMPT_TOKENS,
+      OUTPUT_TOKENS,
+      CACHED_TOKENS,
+      TOOL_PROMPT_TOKENS,
+      THINKING_TOKENS,
+    ]);
+    // A row with no prompt count is not a generation (a configuration record sits in this table
+    // too), so it is skipped rather than counted as a turn that cost nothing.
+    if (prompt === undefined) continue;
+    // Everything else is optional and genuinely absent on some rows — the first generation has no
+    // cache read, a turn with no tool call has no tool prompt — but a value that IS there and is
+    // out of range means the shape moved.
+    const parts = [prompt, output, cached, toolPrompt, thinking];
+    if (parts.some((part) => part !== undefined && !inRange(part, MAX_TOKENS))) return null;
+    total.inputTokens += prompt + (toolPrompt ?? 0);
+    total.outputTokens += (output ?? 0) + (thinking ?? 0);
+    total.cacheReadTokens += cached ?? 0;
+    counted++;
+  }
+  return counted > 0 ? total : null;
+}
+
+/**
+ * The token and context badges for an agy conversation, or null when they cannot be read.
+ *
+ * Null is a normal answer, not an error: a conversation agy has not written a generation for yet,
+ * a runtime without `node:sqlite`, a database whose fields no longer mean what they meant. The
+ * caller shows the model alone, exactly as it did before this file existed.
+ */
+export async function antigravityBadgesFromDb(conversationsRoot: string, conversationId: string): Promise<AntigravityBadges | null> {
+  const file = antigravityDbPath(conversationsRoot, conversationId);
+  const rows = await readGenRows(file, MAX_USAGE_ROWS);
+  if (!rows?.length) return null;
+  // The cap was hit, so the oldest generations are missing and any total would be short. The
+  // context reading is still exact — it comes from the newest row — so only the usage is dropped.
+  const complete = rows.length < MAX_USAGE_ROWS;
+  const context = contextOf(rows.slice(0, CONTEXT_SCAN_ROWS));
+  const usage = complete ? usageOf(rows) : null;
+  if (!context && !usage) return null;
+  return {
+    usage: usage ?? { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    context: context ?? { contextTokens: 0, contextWindow: null },
+  };
+}
+
+/** Whether a conversation's database exists at all, for callers that want to skip the read. */
+export async function antigravityDbExists(conversationsRoot: string, conversationId: string): Promise<boolean> {
+  try {
+    return (await stat(antigravityDbPath(conversationsRoot, conversationId))).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -319,6 +319,7 @@ const spawnDeps: SpawnDeps = {
   setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),
   uiPort: String(process.env.CLIENT_PORT || PORT),
   publishSessionCreated: (sessionId) => pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" }),
+  publishActivity: (sessionId) => publishActivity(sessionId),
 };
 const { spawnClaudePty } = createClaudeSpawner(spawnDeps);
 const { spawnCodexPty } = createCodexSpawner(spawnDeps);

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -15,13 +15,12 @@
 //                accounting at all (the only `token` fields in one are `first_token` timings and a
 //                WebFetch tool parameter), so the usage badge stays hidden — it hides itself when
 //                the totals are zero.
-//   antigravity  the NAME only, and a constant one. agy's transcript records neither tokens nor a
-//                model id; the single mention of a model is prose inside the user turn ("The user
-//                changed setting `Model Selection` … to Gemini 3.6 Flash (High)"), written only
-//                when the setting CHANGED, and `settings.json` holds the current global pick which
-//                an old conversation was not run under. Reading either would put a specific,
-//                confident, sometimes-wrong model name on the cell. "antigravity" is what we can
-//                stand behind.
+//   antigravity  the model only, from the `<USER_SETTINGS_CHANGE>` block agy writes into step 0 of
+//                the conversation's own transcript (see antigravityModelFromTranscriptHead, which
+//                has the counts behind trusting it). No tokens: agy's transcript records none, so
+//                the usage badge stays hidden as grok's does. A session with no transcript to read
+//                answers `null` — the badge hides, as grok's does before its first turn — and NOT
+//                the cwd's last conversation, which is a different session's model (#1468).
 //
 // A wrong number here is worse than no number: this badge is what a user reads before deciding to
 // /compact, so every field is either what the agent stated or absent.
@@ -34,8 +33,10 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { grokModelFromSummary, grokSummaryPath } from "../agents/grok-sessions.js";
 import { grokSessionsRoot } from "../agents/grok-session.js";
+import { antigravityBrainRoot } from "../agents/antigravity-session.js";
+import { antigravityModelFromTranscriptHead, antigravityTranscriptPath } from "../agents/antigravity-sessions.js";
 import { readTailRecords } from "../infra/jsonl-file.js";
-import { codexRollouts, codexRolloutsHydrated } from "./registry.js";
+import { antigravityConversations, antigravityConversationsHydrated, codexRollouts, codexRolloutsHydrated } from "./registry.js";
 import type { SessionUsage } from "./transcript.js";
 
 export interface SessionBadges {
@@ -45,9 +46,6 @@ export interface SessionBadges {
 
 const EMPTY_USAGE: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
 
-/** What the badge calls an agy session. A constant, for the reason in the header comment. */
-export const ANTIGRAVITY_MODEL_LABEL = "antigravity";
-
 const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE, context: { model, contextTokens: 0 } });
 
 /** Where each agent keeps its sessions. Defaulted from the agent's own module and overridden only
@@ -56,6 +54,7 @@ const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE
 export interface BadgeRoots {
   codexSessions?: string;
   grokSessions?: string;
+  antigravityBrain?: string;
 }
 
 async function codexBadges(sessionKey: string, root: string): Promise<CodexBadges> {
@@ -111,6 +110,28 @@ async function grokBadges(cwd: string, id: string, root: string): Promise<Sessio
   }
 }
 
+// Step 0 and nothing else is needed, so the head the listing reads a title from answers this too —
+// the same 64 KB, never the file. There is deliberately no tail read behind it: the block sits at
+// the front, and a second read that almost never finds anything is paid on every session a cell
+// renders.
+const ANTIGRAVITY_HEAD_BYTES = 64 * 1024;
+
+async function antigravityBadges(sessionKey: string, root: string): Promise<SessionBadges> {
+  // The codex lookup, for the same reason (see codexBadges): the route is given OUR session id and
+  // agy files its transcript under an id of its own. `?? sessionKey` covers a cell resumed straight
+  // onto a conversation id; anything naming no transcript reads as unknown, not as a neighbour's.
+  //
+  // Unknown is the NORMAL state for the first seconds of a fresh cell — agy creates the
+  // conversation on the first prompt and the id is watched for, so a cell that has not been typed
+  // into yet has nothing to read. It is the spawner's capture that says otherwise, by publishing
+  // (spawn-antigravity.ts): without that the answer here never changes, because nothing sets
+  // working for an agy session and the cell's only other badge refresh is on a finished turn.
+  await antigravityConversationsHydrated;
+  const conversationId = antigravityConversations.get(sessionKey)?.conversationId ?? sessionKey;
+  const read = await readTranscriptHead(antigravityTranscriptPath(root, conversationId), ANTIGRAVITY_HEAD_BYTES);
+  return modelOnly(read && antigravityModelFromTranscriptHead(read.head));
+}
+
 /**
  * The badges for a session, from whichever log its agent keeps.
  *
@@ -121,5 +142,5 @@ async function grokBadges(cwd: string, id: string, root: string): Promise<Sessio
 export async function agentBadges(cwd: string, id: string, agent: Exclude<TerminalAgent, "claude">, roots: BadgeRoots = {}): Promise<SessionBadges> {
   if (agent === "codex") return codexBadges(id, roots.codexSessions ?? codexSessionsRoot());
   if (agent === "grok") return grokBadges(cwd, id, roots.grokSessions ?? grokSessionsRoot());
-  return modelOnly(ANTIGRAVITY_MODEL_LABEL);
+  return antigravityBadges(id, roots.antigravityBrain ?? antigravityBrainRoot());
 }

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -15,12 +15,14 @@
 //                accounting at all (the only `token` fields in one are `first_token` timings and a
 //                WebFetch tool parameter), so the usage badge stays hidden — it hides itself when
 //                the totals are zero.
-//   antigravity  the model only, from the `<USER_SETTINGS_CHANGE>` block agy writes into step 0 of
-//                the conversation's own transcript (see antigravityModelFromTranscriptHead, which
-//                has the counts behind trusting it). No tokens: agy's transcript records none, so
-//                the usage badge stays hidden as grok's does. A session with no transcript to read
-//                answers `null` — the badge hides, as grok's does before its first turn — and NOT
-//                the cwd's last conversation, which is a different session's model (#1468).
+//   antigravity  all three, from TWO stores. The model is prose in the `<USER_SETTINGS_CHANGE>`
+//                block agy writes into step 0 of the transcript (antigravityModelFromTranscriptHead
+//                has the counts behind trusting it). The tokens and the window are not in that file
+//                at all — they are protobuf in a SQLite database beside it, read by
+//                antigravity-usage.ts, which answers nothing at all unless every field is where it
+//                was measured to be. A session with no transcript to read answers `null` — the
+//                badge hides, as grok's does before its first turn — and NOT the cwd's last
+//                conversation, which is a different session's model (#1468).
 //
 // A wrong number here is worse than no number: this badge is what a user reads before deciding to
 // /compact, so every field is either what the agent stated or absent.
@@ -33,8 +35,9 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { grokModelFromSummary, grokSummaryPath } from "../agents/grok-sessions.js";
 import { grokSessionsRoot } from "../agents/grok-session.js";
-import { antigravityBrainRoot } from "../agents/antigravity-session.js";
+import { antigravityBrainRoot, antigravityConversationsRoot, antigravityHome } from "../agents/antigravity-session.js";
 import { antigravityModelFromTranscriptHead, antigravityTranscriptPath } from "../agents/antigravity-sessions.js";
+import { antigravityBadgesFromDb } from "../agents/antigravity-usage.js";
 import { readTailRecords } from "../infra/jsonl-file.js";
 import { antigravityConversations, antigravityConversationsHydrated, codexRollouts, codexRolloutsHydrated } from "./registry.js";
 import type { SessionUsage } from "./transcript.js";
@@ -54,7 +57,10 @@ const modelOnly = (model: string | null): SessionBadges => ({ usage: EMPTY_USAGE
 export interface BadgeRoots {
   codexSessions?: string;
   grokSessions?: string;
-  antigravityBrain?: string;
+  /** agy's HOME, not one of its two stores: the transcript is under `brain/` and the accounting is
+   *  under `conversations/`, and a spec that pointed at one of them would leave the other on the
+   *  developer's real disk. */
+  antigravityHome?: string;
 }
 
 async function codexBadges(sessionKey: string, root: string): Promise<CodexBadges> {
@@ -116,7 +122,7 @@ async function grokBadges(cwd: string, id: string, root: string): Promise<Sessio
 // renders.
 const ANTIGRAVITY_HEAD_BYTES = 64 * 1024;
 
-async function antigravityBadges(sessionKey: string, root: string): Promise<SessionBadges> {
+async function antigravityBadges(sessionKey: string, home: string): Promise<SessionBadges> {
   // The codex lookup, for the same reason (see codexBadges): the route is given OUR session id and
   // agy files its transcript under an id of its own. `?? sessionKey` covers a cell resumed straight
   // onto a conversation id; anything naming no transcript reads as unknown, not as a neighbour's.
@@ -128,8 +134,15 @@ async function antigravityBadges(sessionKey: string, root: string): Promise<Sess
   // working for an agy session and the cell's only other badge refresh is on a finished turn.
   await antigravityConversationsHydrated;
   const conversationId = antigravityConversations.get(sessionKey)?.conversationId ?? sessionKey;
-  const read = await readTranscriptHead(antigravityTranscriptPath(root, conversationId), ANTIGRAVITY_HEAD_BYTES);
-  return modelOnly(read && antigravityModelFromTranscriptHead(read.head));
+  const [read, meters] = await Promise.all([
+    readTranscriptHead(antigravityTranscriptPath(antigravityBrainRoot(home), conversationId), ANTIGRAVITY_HEAD_BYTES),
+    antigravityBadgesFromDb(antigravityConversationsRoot(home), conversationId),
+  ]);
+  const model = (read && antigravityModelFromTranscriptHead(read.head)) ?? null;
+  // The two stores are independent, and so are the two badges: the accounting can be unreadable
+  // while the transcript still names the model (and, before agy's first generation, always is).
+  if (!meters) return modelOnly(model);
+  return { usage: meters.usage, context: { model, ...meters.context } };
 }
 
 /**
@@ -142,5 +155,5 @@ async function antigravityBadges(sessionKey: string, root: string): Promise<Sess
 export async function agentBadges(cwd: string, id: string, agent: Exclude<TerminalAgent, "claude">, roots: BadgeRoots = {}): Promise<SessionBadges> {
   if (agent === "codex") return codexBadges(id, roots.codexSessions ?? codexSessionsRoot());
   if (agent === "grok") return grokBadges(cwd, id, roots.grokSessions ?? grokSessionsRoot());
-  return antigravityBadges(id, roots.antigravityBrain ?? antigravityBrainRoot());
+  return antigravityBadges(id, roots.antigravityHome ?? antigravityHome());
 }

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -23,6 +23,12 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
         if (!id) return;
         claimedAntigravityConversations.add(id);
         rememberAntigravityConversation(sessionId, id, cwd);
+        // The cell is holding a header badge answered before this id existed — agy names its model
+        // in the transcript this mapping points at, and until now there was no transcript to point
+        // at. Nothing else will correct it: an agy session has no hooks and no activity tracker, so
+        // it never goes working -> idle, and that transition is the cell's only other badge
+        // refresh. One push, on the one edge where the answer changed.
+        deps.publishActivity(sessionId);
         console.log(`[pty] captured antigravity conversation ${id} for session ${sessionId}`);
       })
       .catch(() => {});

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -28,4 +28,8 @@ export interface SpawnDeps {
   uiPort: string;
   /** Surface a brand-new session in the sidebar before it is persisted. */
   publishSessionCreated: (sessionId: string) => void;
+  /** Re-publish a session's row when something a cell reads has changed but its activity has not —
+   *  an agent that mints its conversation id asynchronously answers its model badge only once that
+   *  id is known (spawn-antigravity.ts). */
+  publishActivity: (sessionId: string) => void;
 }

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -296,6 +296,14 @@ function applyActivity(d: ActivityPush) {
   // Not while the box is open: the push that lands as another tab saves would otherwise
   // overwrite the sentence being typed here, mid-word.
   if (!memoEditing.value) memo.value = next.memo;
+  // A cell whose model is still unknown asks again on any push. codex and agy file their
+  // transcripts under an id the agent mints AFTER the spawn, so the seed fetch at mount can only
+  // answer "nobody" — and for agy nothing else would ever re-ask, since it has no hooks and no
+  // activity tracker to finish a turn (its spawner publishes precisely to reach this line).
+  // Claude is excluded: its badges come from the summary the route already folds, so a push adds
+  // nothing and this is the busiest route in the app. Self-limiting either way — once a model is
+  // known, this stops.
+  if (agent.value !== "claude" && !context.value?.model) void refreshUsage();
 }
 
 // This session's detail, or nothing to apply. Nothing covers three cases the callers all

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -296,13 +296,19 @@ function applyActivity(d: ActivityPush) {
   // Not while the box is open: the push that lands as another tab saves would otherwise
   // overwrite the sentence being typed here, mid-word.
   if (!memoEditing.value) memo.value = next.memo;
-  // A cell whose model is still unknown asks again on any push. codex and agy file their
-  // transcripts under an id the agent mints AFTER the spawn, so the seed fetch at mount can only
-  // answer "nobody" — and for agy nothing else would ever re-ask, since it has no hooks and no
-  // activity tracker to finish a turn (its spawner publishes precisely to reach this line).
-  // Claude is excluded: its badges come from the summary the route already folds, so a push adds
-  // nothing and this is the busiest route in the app. Self-limiting either way — once a model is
-  // known, this stops.
+}
+
+// A cell whose model is still unknown asks again when a push says something changed. codex and agy
+// file their logs under an id the agent mints AFTER the spawn, so the seed fetch at mount can only
+// answer "nobody" — and for agy nothing else would ever re-ask, since it has no hooks and no
+// activity tracker to finish a turn (its spawner publishes precisely to reach this line). Claude is
+// excluded: its badges come from the summary the route already folds, so a push adds nothing and
+// this is the busiest route in the app. Self-limiting either way — once a model is known, it stops.
+//
+// Called from the PUSH path only, never from a seed: loadInitial applies activity BEFORE badges, so
+// asking there would see `context` still empty and fire a second fetch for the answer already in
+// its hand — on every non-claude cell, every load.
+function refreshBadgesIfModelUnknown() {
   if (agent.value !== "claude" && !context.value?.model) void refreshUsage();
 }
 
@@ -424,7 +430,9 @@ let badgePoll: ReturnType<typeof setInterval> | null = null;
 
 onMounted(() => {
   unsubscribe = subscribe("sessions", (d) => {
-    if (isActivityMsg(d) && d.id === sessionId.value) applyActivity(d);
+    if (!isActivityMsg(d) || d.id !== sessionId.value) return;
+    applyActivity(d);
+    refreshBadgesIfModelUnknown();
   });
   badgePoll = setInterval(() => {
     if (agent.value === "antigravity" && sessionId.value) void refreshUsage();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -413,10 +413,22 @@ watch(
   },
 );
 
+// An agy cell has no turn to end. Claude publishes a Stop hook and codex has an activity tracker,
+// so both re-read their badges the moment a turn settles; nothing calls setWorking for antigravity,
+// so its context reading would be frozen at whatever it was when the cell first asked — `ctx 1%`
+// for the rest of the session, which is worse than no reading at all. This is the substitute, and
+// it is deliberately slow: one indexed sqlite row plus a 64 KB head read, per agy cell, per minute.
+// Delete it the day agy gets an activity tracker.
+const UNTRACKED_BADGE_POLL_MS = 60_000;
+let badgePoll: ReturnType<typeof setInterval> | null = null;
+
 onMounted(() => {
   unsubscribe = subscribe("sessions", (d) => {
     if (isActivityMsg(d) && d.id === sessionId.value) applyActivity(d);
   });
+  badgePoll = setInterval(() => {
+    if (agent.value === "antigravity" && sessionId.value) void refreshUsage();
+  }, UNTRACKED_BADGE_POLL_MS);
   // A dropped socket misses the pushes sent while it was down, and this cell's status is
   // derived state that pub/sub only replays room membership for — not the missed events. So
   // on reconnect re-seed from the authoritative snapshot (guarded by activityGen), or a turn
@@ -433,6 +445,7 @@ onUnmounted(() => {
   unsubscribe?.();
   unsubscribeCanvas?.();
   offReconnect?.();
+  if (badgePoll) clearInterval(badgePoll);
 });
 
 // Set when the user starts a FRESH session from the launcher, so the next server

--- a/src/components/modelBadge.ts
+++ b/src/components/modelBadge.ts
@@ -41,12 +41,25 @@ const PERCENT = 100;
 const AGENT_NAME: Record<TerminalAgent, string> = { claude: "Claude", codex: "Codex", antigravity: "Antigravity", grok: "Grok" };
 export type BadgeAgent = TerminalAgent;
 
+// A trailing qualifier in brackets — agy names a model `Gemini 3.6 Flash (High)`, where `(High)` is
+// the reasoning effort. The badge is `whitespace-nowrap flex-none`, so it does not truncate: it
+// pushes the rest of the header's chips out instead. Dropped here and kept in the tip, which is
+// where this file already puts the full name. Sliced rather than matched: the regex for it
+// backtracks super-linearly, and this runs on every model a cell renders.
+function withoutTrailingQualifier(name: string): string {
+  if (!name.endsWith(")")) return name;
+  const open = name.lastIndexOf("(");
+  if (open <= 0) return name; // no bracket, or a name that is nothing but one
+  return name.slice(0, open).trimEnd() || name;
+}
+
 export function shortModelLabel(model: string): string {
   const preset = presetFor(model);
   if (preset) return preset.label;
   const lower = model.toLowerCase();
   const family = CLAUDE_FAMILIES.find((f) => lower.includes(f.match));
-  return family ? family.label : (model.split("/").pop() ?? model);
+  if (family) return family.label;
+  return withoutTrailingQualifier(model.split("/").pop() ?? model);
 }
 
 function contextWindowTokens(model: string, reported: number | null | undefined): number | null {

--- a/test/server/agents/antigravity-proto.spec.ts
+++ b/test/server/agents/antigravity-proto.spec.ts
@@ -66,6 +66,14 @@ describe("protoVarintAt", () => {
     expect(protoVarintAt(buf([...key(1, 2), ...varint(9999), 1, 2, 3]), [1, 1])).toBeUndefined(); // length past the end
   });
 
+  it("stops at a fixed-width field whose payload runs past the end", () => {
+    // A fixed64 header with only three bytes behind it. What was read BEFORE it still stands; the
+    // walk does not continue past a field the buffer cannot contain.
+    const short = buf([...varintField(1, 7), ...key(2, 1), 0xaa, 0xbb, 0xcc]);
+    expect(protoVarintAt(short, [1])).toBe(7);
+    expect(protoVarintAt(short, [2])).toBeUndefined();
+  });
+
   it("stops at a wire type that does not exist instead of resynchronising", () => {
     // Field 1 is a real varint; field 2 claims wire type 6, which protobuf does not define. What
     // follows must not be read, however much it looks like a field.

--- a/test/server/agents/antigravity-proto.spec.ts
+++ b/test/server/agents/antigravity-proto.spec.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { protoVarintAt, protoVarintsAt } from "../../../server/agents/antigravity-proto.js";
+
+// The walker reads agy's accounting blobs, for which there is no schema (antigravity-usage.ts).
+// Every test here is about the same property: an input that is not exactly the shape we measured
+// answers `undefined`, so the caller shows no badge. Nothing may be inferred, recovered or
+// resynchronised — a number from a misread field would be rendered as fact.
+
+const varint = (value: number): number[] => {
+  const out: number[] = [];
+  let rest = value;
+  while (rest > 0x7f) {
+    out.push((rest & 0x7f) | 0x80);
+    rest = Math.floor(rest / 128);
+  }
+  out.push(rest);
+  return out;
+};
+
+const key = (field: number, wireType: number) => varint(field * 8 + wireType);
+const varintField = (field: number, value: number): number[] => [...key(field, 0), ...varint(value)];
+const bytesField = (field: number, body: number[]): number[] => [...key(field, 2), ...varint(body.length), ...body];
+const stringField = (field: number, text: string): number[] => bytesField(field, [...Buffer.from(text, "utf8")]);
+const buf = (bytes: number[]) => Buffer.from(bytes);
+
+// `1.9.10.{1,4}` and `1.4.{2,3}` — the real paths, in the real nesting, with unrelated fields
+// beside them exactly as agy's rows carry them.
+const realShape = buf(
+  bytesField(1, [
+    ...varintField(3, 1071),
+    ...bytesField(4, [...varintField(2, 5907), ...varintField(3, 484), ...varintField(5, 243_385)]),
+    ...bytesField(9, [...varintField(2, 18_446_744_073), ...bytesField(10, [...varintField(1, 251_378), ...varintField(4, 256_000)])]),
+    ...stringField(19, "gemini-3.6-flash"),
+  ]),
+);
+
+describe("protoVarintAt", () => {
+  it("reads a varint from a nested path", () => {
+    expect(protoVarintAt(realShape, [1, 9, 10, 1])).toBe(251_378);
+    expect(protoVarintAt(realShape, [1, 9, 10, 4])).toBe(256_000);
+    expect(protoVarintAt(realShape, [1, 4, 2])).toBe(5907);
+  });
+
+  it("skips the fields around the one it was asked for, whatever their wire type", () => {
+    expect(protoVarintAt(realShape, [1, 3])).toBe(1071); // past a nested message and a string
+  });
+
+  it("answers undefined for a path the record does not have", () => {
+    expect(protoVarintAt(realShape, [1, 9, 10, 7])).toBeUndefined(); // leaf missing
+    expect(protoVarintAt(realShape, [1, 9, 11, 1])).toBeUndefined(); // branch missing
+    expect(protoVarintAt(realShape, [2, 9, 10, 1])).toBeUndefined(); // root missing
+    expect(protoVarintAt(realShape, [])).toBeUndefined();
+  });
+
+  it("answers undefined when the path runs through the wrong kind of field", () => {
+    expect(protoVarintAt(realShape, [1, 19, 1])).toBeUndefined(); // a string used as a message
+    expect(protoVarintAt(realShape, [1, 9, 10])).toBeUndefined(); // a message read as a varint
+  });
+
+  // The failure that matters: a renumbered or re-typed field must not be reported as a count.
+  it("answers undefined for truncated, empty and non-protobuf input", () => {
+    expect(protoVarintAt(realShape.subarray(0, 12), [1, 9, 10, 1])).toBeUndefined();
+    expect(protoVarintAt(buf([]), [1])).toBeUndefined();
+    expect(protoVarintAt(buf([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), [1])).toBeUndefined();
+    expect(protoVarintAt(buf([...key(1, 2), ...varint(9999), 1, 2, 3]), [1, 1])).toBeUndefined(); // length past the end
+  });
+
+  it("stops at a wire type that does not exist instead of resynchronising", () => {
+    // Field 1 is a real varint; field 2 claims wire type 6, which protobuf does not define. What
+    // follows must not be read, however much it looks like a field.
+    const bad = buf([...varintField(1, 42), ...key(2, 6), ...varintField(3, 999)]);
+    expect(protoVarintAt(bad, [1])).toBe(42);
+    expect(protoVarintAt(bad, [3])).toBeUndefined();
+  });
+
+  it("does not lose exactness on a huge varint", () => {
+    const huge = buf(varintField(1, Number.MAX_SAFE_INTEGER + 10));
+    expect(protoVarintAt(huge, [1])).toBeUndefined();
+  });
+
+  // The bug the real database found and every synthetic fixture missed. agy puts a
+  // `18446744073709551615` sentinel in the very message that holds the context reading. A walker
+  // that stops when it cannot REPRESENT a value never reaches the fields behind it, so the badge
+  // reported no context at all while the specs stayed green. Skipping needs no value.
+  it("walks past a varint too large to represent and reads the fields behind it", () => {
+    const sentinel = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]; // 2^64 - 1
+    const withSentinel = buf(bytesField(1, [...bytesField(9, [...key(2, 0), ...sentinel, ...bytesField(10, varintField(1, 251_378))])]));
+    expect(protoVarintAt(withSentinel, [1, 9, 10, 1])).toBe(251_378);
+    expect(protoVarintAt(withSentinel, [1, 9, 2])).toBeUndefined(); // still not reported as a number
+  });
+});
+
+describe("protoVarintsAt", () => {
+  it("reads several leaves under one prefix in a single descent", () => {
+    expect(protoVarintsAt(realShape, [1, 4], [2, 3, 5, 9])).toEqual([5907, 484, 243_385, undefined]);
+  });
+
+  it("answers all-undefined when the prefix is not there", () => {
+    expect(protoVarintsAt(realShape, [1, 44], [1, 2])).toEqual([undefined, undefined]);
+  });
+});

--- a/test/server/agents/antigravity-sessions.spec.ts
+++ b/test/server/agents/antigravity-sessions.spec.ts
@@ -3,7 +3,12 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { antigravityTitleFromTranscriptHead, antigravityTranscriptPath, listAntigravitySessions } from "../../../server/agents/antigravity-sessions.js";
+import {
+  antigravityModelFromTranscriptHead,
+  antigravityTitleFromTranscriptHead,
+  antigravityTranscriptPath,
+  listAntigravitySessions,
+} from "../../../server/agents/antigravity-sessions.js";
 import type { AgentConversation } from "../../../server/session/agent-conversations.js";
 
 // Captured verbatim from agy 1.1.9 (`agy -p`), so a format change breaks this rather than
@@ -50,6 +55,48 @@ describe("antigravityTitleFromTranscriptHead", () => {
   it("still drops the known blocks if the request wrapper ever goes away", () => {
     const head = userInput("bare prompt\n<ADDITIONAL_METADATA>\nThe current local time is: now.\n</ADDITIONAL_METADATA>");
     expect(antigravityTitleFromTranscriptHead(head)).toBe("bare prompt");
+  });
+});
+
+describe("antigravityModelFromTranscriptHead", () => {
+  const settings = (sentence: string) => userInput(`<USER_REQUEST>\nhi\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\n${sentence}\n</USER_SETTINGS_CHANGE>`);
+  const CHANGED =
+    "The user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment on this change if the user doesn't ask about it.";
+
+  // The same fixture the title tests read, so both sides of the block are pinned to one capture.
+  it("reads the model out of a real agy transcript head", () => {
+    expect(antigravityModelFromTranscriptHead(REAL_TRANSCRIPT_HEAD)).toBe("Gemini 3.6 Flash (High)");
+  });
+
+  it("stops at the sentence's period, not at the one inside the version", () => {
+    expect(antigravityModelFromTranscriptHead(settings(CHANGED))).toBe("Gemini 3.6 Flash (High)");
+  });
+
+  it("does not depend on the wording that follows the name", () => {
+    expect(antigravityModelFromTranscriptHead(settings("The user changed setting `Model Selection` from Gemini 3.6 Pro to Gemini 3.6 Flash."))).toBe(
+      "Gemini 3.6 Flash",
+    );
+  });
+
+  it("takes the last block, so a later change wins", () => {
+    const head = settings(CHANGED) + settings("The user changed setting `Model Selection` from Gemini 3.6 Flash (High) to Gemini 3.6 Pro. No need to comment.");
+    expect(antigravityModelFromTranscriptHead(head)).toBe("Gemini 3.6 Pro");
+  });
+
+  it("ignores a settings change that is not about the model", () => {
+    expect(antigravityModelFromTranscriptHead(settings("The user changed setting `Planning Mode` from None to Always. No need to comment."))).toBeNull();
+  });
+
+  // Every one of these is a session the badge labels `antigravity` instead of pasting prose into
+  // the cell header: a name is short, and anything else means the block moved.
+  it("names nobody when there is no block, no transcript, or a runaway capture", () => {
+    expect(antigravityModelFromTranscriptHead(userInput("<USER_REQUEST>\nno settings block\n</USER_REQUEST>"))).toBeNull();
+    expect(antigravityModelFromTranscriptHead("")).toBeNull();
+    expect(antigravityModelFromTranscriptHead(settings(`The user changed setting \`Model Selection\` from None to ${"x".repeat(60)}. Done.`))).toBeNull();
+  });
+
+  it("skips a corrupt line and a truncated final line", () => {
+    expect(antigravityModelFromTranscriptHead(`not json at all\n${settings(CHANGED)}{"step_index":9,"type":"USER_IN`)).toBe("Gemini 3.6 Flash (High)");
   });
 });
 

--- a/test/server/agents/antigravity-usage.spec.ts
+++ b/test/server/agents/antigravity-usage.spec.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { antigravityBadgesFromDb, antigravityDbPath } from "../../../server/agents/antigravity-usage.js";
+
+// agy's accounting, which lives in a SQLite database of protobuf blobs and NOT in the transcript
+// (see the file's header for the measurements the field numbers come from). Everything here is
+// about the same rule: a database that is not exactly the shape measured must produce no badge at
+// all. Half a reading is a wrong number on a header a user compacts by.
+
+const varint = (value: number): number[] => {
+  const out: number[] = [];
+  let rest = value;
+  while (rest > 0x7f) {
+    out.push((rest & 0x7f) | 0x80);
+    rest = Math.floor(rest / 128);
+  }
+  out.push(rest);
+  return out;
+};
+const key = (field: number, wireType: number) => varint(field * 8 + wireType);
+const v = (field: number, value: number): number[] => [...key(field, 0), ...varint(value)];
+const msg = (field: number, body: number[]): number[] => [...key(field, 2), ...varint(body.length), ...body];
+
+interface Gen {
+  used?: number;
+  window?: number;
+  prompt?: number;
+  output?: number;
+  cached?: number;
+  toolPrompt?: number;
+  thinking?: number;
+}
+
+/** One `gen_metadata` row in agy's real nesting: usage under 1.4, the context reading under
+ *  1.9.10. A field left out of `gen` is left out of the blob, as agy leaves out a cache count on
+ *  the first generation of a conversation. */
+const genRow = (gen: Gen): Buffer => {
+  const usage = [
+    ...(gen.prompt === undefined ? [] : v(2, gen.prompt)),
+    ...(gen.output === undefined ? [] : v(3, gen.output)),
+    ...(gen.cached === undefined ? [] : v(5, gen.cached)),
+    ...(gen.toolPrompt === undefined ? [] : v(9, gen.toolPrompt)),
+    ...(gen.thinking === undefined ? [] : v(10, gen.thinking)),
+  ];
+  const context = [...(gen.used === undefined ? [] : v(1, gen.used)), ...(gen.window === undefined ? [] : v(4, gen.window))];
+  return Buffer.from(msg(1, [...v(3, 1071), ...msg(4, usage), ...msg(9, [...msg(10, context)])]));
+};
+
+const CONVERSATION = "a4dbbf1e-9cba-4879-a84a-d397b47e4f47";
+
+describe("antigravityBadgesFromDb", () => {
+  let root = "";
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "mt-agy-usage-"));
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  /** A real database, written the way agy's is: one blob per generation, oldest first. */
+  const writeDb = (rows: Buffer[], conversation = CONVERSATION) => {
+    const db = new DatabaseSync(antigravityDbPath(root, conversation));
+    db.exec("create table gen_metadata (idx integer primary key, data blob, size integer not null default 0)");
+    const insert = db.prepare("insert into gen_metadata (idx, data, size) values (?, ?, ?)");
+    rows.forEach((data, idx) => insert.run(idx, data, data.length));
+    db.close();
+  };
+
+  // The numbers in this fixture are the ones measured on the real conversation, so a change to the
+  // field constants breaks here rather than on someone's header.
+  it("reads the newest context reading and the cumulative token totals", async () => {
+    writeDb([
+      genRow({ used: 2522, window: 256_000, prompt: 22_812, output: 178, toolPrompt: 98, thinking: 80 }),
+      genRow({ used: 234_987, window: 256_000, prompt: 4901, output: 180, cached: 227_183, toolPrompt: 15, thinking: 94 }),
+    ]);
+    const badges = await antigravityBadgesFromDb(root, CONVERSATION);
+
+    expect(badges?.context).toEqual({ contextTokens: 234_987, contextWindow: 256_000 });
+    expect(badges?.usage).toEqual({
+      inputTokens: 22_812 + 98 + 4901 + 15,
+      outputTokens: 178 + 80 + 180 + 94,
+      cacheReadTokens: 227_183,
+      cacheCreationTokens: 0,
+    });
+  });
+
+  // The last row of the table is not always a generation — a conversation can end with a
+  // configuration record, which is where the real data's last row landed.
+  it("looks past trailing rows that carry no reading", async () => {
+    writeDb([genRow({ used: 199_141, window: 256_000, prompt: 2485, output: 255 }), Buffer.from(msg(3, [...v(13, 1)])), Buffer.from(msg(3, [...v(13, 1)]))]);
+    expect((await antigravityBadgesFromDb(root, CONVERSATION))?.context).toEqual({ contextTokens: 199_141, contextWindow: 256_000 });
+  });
+
+  it("counts a generation with no cache read, and skips a row that is not a generation", async () => {
+    writeDb([genRow({ prompt: 1000, output: 10 }), Buffer.from(msg(3, [...v(13, 1)]))]);
+    const badges = await antigravityBadgesFromDb(root, CONVERSATION);
+    expect(badges?.usage.inputTokens).toBe(1000);
+    expect(badges?.usage.cacheReadTokens).toBe(0);
+  });
+
+  describe("refuses a reading rather than reporting a wrong one", () => {
+    it("when the context value is larger than its own window", async () => {
+      writeDb([genRow({ used: 300_000, window: 256_000, prompt: 100, output: 1 })]);
+      const badges = await antigravityBadgesFromDb(root, CONVERSATION);
+      expect(badges?.context).toEqual({ contextTokens: 0, contextWindow: null }); // usage survives; the reading does not
+      expect(badges?.usage.inputTokens).toBe(100);
+    });
+
+    it("when the window is too small to be one", async () => {
+      writeDb([genRow({ used: 5, window: 24, prompt: 100, output: 1 })]);
+      expect((await antigravityBadgesFromDb(root, CONVERSATION))?.context).toEqual({ contextTokens: 0, contextWindow: null });
+    });
+
+    it("when a token count is impossible", async () => {
+      writeDb([genRow({ used: 1000, window: 256_000, prompt: 100, output: 5_000_000_000 })]);
+      expect((await antigravityBadgesFromDb(root, CONVERSATION))?.usage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      });
+    });
+
+    it("when the fields have moved", async () => {
+      // The same numbers, one level shallower — what a renumbering looks like from here.
+      writeDb([Buffer.from(msg(1, [...msg(4, [...v(7, 4901)]), ...msg(9, [...msg(11, [...v(1, 234_987), ...v(4, 256_000)])])]))]);
+      expect(await antigravityBadgesFromDb(root, CONVERSATION)).toBeNull();
+    });
+  });
+
+  it("answers null for a conversation with no database, an empty one, and a file that is not one", async () => {
+    expect(await antigravityBadgesFromDb(root, CONVERSATION)).toBeNull();
+
+    writeDb([]);
+    expect(await antigravityBadgesFromDb(root, CONVERSATION)).toBeNull();
+
+    const junk = "b2dab7a3-d613-4292-8308-47bef12eeccd";
+    fs.writeFileSync(antigravityDbPath(root, junk), "this is not a database");
+    expect(await antigravityBadgesFromDb(root, junk)).toBeNull();
+  });
+
+  it("answers null for a database without the table it reads", async () => {
+    const db = new DatabaseSync(antigravityDbPath(root, CONVERSATION));
+    db.exec("create table steps (idx integer primary key, data blob)");
+    db.close();
+    expect(await antigravityBadgesFromDb(root, CONVERSATION)).toBeNull();
+  });
+
+  // agy holds this database open for the whole session, and the badge is read while it does.
+  it("reads a database that is open elsewhere, without taking a write lock", async () => {
+    writeDb([genRow({ used: 1234, window: 256_000, prompt: 10, output: 1 })]);
+    const open = new DatabaseSync(antigravityDbPath(root, CONVERSATION));
+    try {
+      expect((await antigravityBadgesFromDb(root, CONVERSATION))?.context.contextTokens).toBe(1234);
+      // Still writable by its owner afterwards: the read must not have left a lock behind.
+      open.exec("insert into gen_metadata (idx, data, size) values (99, x'00', 1)");
+    } finally {
+      open.close();
+    }
+  });
+});

--- a/test/server/session/agent-badges.spec.ts
+++ b/test/server/session/agent-badges.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { DatabaseSync } from "node:sqlite";
 import { agentBadges, type BadgeRoots } from "../../../server/session/agent-badges.js";
 
 // The header badges for a session that is not Claude (#1465). Each agent is asked the question the
@@ -40,7 +41,7 @@ describe("agentBadges", () => {
     roots = {
       codexSessions: path.join(home, "codex", "sessions"),
       grokSessions: path.join(home, "grok", "sessions"),
-      antigravityBrain: path.join(home, "antigravity", "brain"),
+      antigravityHome: path.join(home, "antigravity"),
     };
   });
 
@@ -56,6 +57,35 @@ describe("agentBadges", () => {
     const dir = path.join(home, "grok", "sessions", encodeURIComponent(CWD), GROK_ID);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify(summary));
+  };
+
+  // agy's accounting store, in the nesting antigravity-usage.ts reads (its own spec covers the
+  // shape; this one only has to prove the badge route reaches it).
+  const writeAntigravityDb = (id: string, gen: { used: number; window: number; prompt: number; output: number; cached?: number }) => {
+    const dir = path.join(home, "antigravity", "conversations");
+    fs.mkdirSync(dir, { recursive: true });
+    const varint = (value: number): number[] => {
+      const out: number[] = [];
+      let rest = value;
+      while (rest > 0x7f) {
+        out.push((rest & 0x7f) | 0x80);
+        rest = Math.floor(rest / 128);
+      }
+      out.push(rest);
+      return out;
+    };
+    const v = (field: number, value: number) => [...varint(field * 8), ...varint(value)];
+    const msg = (field: number, body: number[]) => [...varint(field * 8 + 2), ...varint(body.length), ...body];
+    const blob = Buffer.from(
+      msg(1, [
+        ...msg(4, [...v(2, gen.prompt), ...v(3, gen.output), ...(gen.cached === undefined ? [] : v(5, gen.cached))]),
+        ...msg(9, [...msg(10, [...v(1, gen.used), ...v(4, gen.window)])]),
+      ]),
+    );
+    const db = new DatabaseSync(path.join(dir, `${id}.db`));
+    db.exec("create table gen_metadata (idx integer primary key, data blob, size integer not null default 0)");
+    db.prepare("insert into gen_metadata (idx, data, size) values (0, $data, $size)").run({ data: blob, size: blob.length });
+    db.close();
   };
 
   const writeAntigravityTranscript = (id: string, settings: string) => {
@@ -107,11 +137,21 @@ describe("agentBadges", () => {
     expect((await agentBadges("/Users/x/elsewhere", GROK_ID, "grok", roots)).context.model).toBeNull();
   });
 
-  // agy names its model in step 0 of the conversation's transcript and counts no tokens, so the
-  // model badge fills in and the usage badge stays hidden. The id here IS the conversation id: the
-  // session -> conversation mapping is codex's, already covered above, and asking for it in this
-  // spec would append a fake session to the developer's real ~/.mulmoterminal log.
-  it("reads an antigravity session's model from step 0 of its transcript", async () => {
+  // agy answers from TWO stores: the model is prose in the transcript, the numbers are protobuf in
+  // a database beside it. The id here IS the conversation id — the session -> conversation mapping
+  // is codex's, already covered above, and asking for it in this spec would append a fake session
+  // to the developer's real ~/.mulmoterminal log.
+  it("reads an antigravity session's model from its transcript and its numbers from its database", async () => {
+    writeAntigravityTranscript(AGY_ID, "The user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment.");
+    writeAntigravityDb(AGY_ID, { used: 234_987, window: 256_000, prompt: 4901, output: 180, cached: 227_183 });
+    const badges = await agentBadges(CWD, AGY_ID, "antigravity", roots);
+    expect(badges.context).toEqual({ model: "Gemini 3.6 Flash (High)", contextTokens: 234_987, contextWindow: 256_000 });
+    expect(badges.usage).toEqual({ inputTokens: 4901, outputTokens: 180, cacheReadTokens: 227_183, cacheCreationTokens: 0 });
+  });
+
+  // The stores are written at different moments: agy creates the transcript on the first prompt and
+  // the database when the model first answers. Between the two, the model badge must still fill in.
+  it("names the model with no numbers when the database is not there yet", async () => {
     writeAntigravityTranscript(AGY_ID, "The user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment.");
     const badges = await agentBadges(CWD, AGY_ID, "antigravity", roots);
     expect(badges.context).toEqual({ model: "Gemini 3.6 Flash (High)", contextTokens: 0 });

--- a/test/server/session/agent-badges.spec.ts
+++ b/test/server/session/agent-badges.spec.ts
@@ -3,14 +3,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { agentBadges, ANTIGRAVITY_MODEL_LABEL, type BadgeRoots } from "../../../server/session/agent-badges.js";
+import { agentBadges, type BadgeRoots } from "../../../server/session/agent-badges.js";
 
 // The header badges for a session that is not Claude (#1465). Each agent is asked the question the
-// same way and answers as much of it as its own log can: codex both badges, grok the model, agy a
-// constant. What must NOT happen is a number nobody wrote down.
+// same way and answers as much of it as its own log can: codex both badges, grok and agy the model.
+// What must NOT happen is a number nobody wrote down, or a model another session was running.
 
 const ROLLOUT_ID = "019fcb3a-a33c-7e72-8364-57e44926dfed";
 const GROK_ID = "150496cf-fb8d-4c35-b19b-e2826a4e7242";
+const AGY_ID = "a4dbbf1e-9cba-4879-a84a-d397b47e4f47";
 const CWD = "/Users/x/my proj";
 
 const tokenCountLine = JSON.stringify({
@@ -36,7 +37,11 @@ describe("agentBadges", () => {
 
   beforeEach(() => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "mt-agent-badges-"));
-    roots = { codexSessions: path.join(home, "codex", "sessions"), grokSessions: path.join(home, "grok", "sessions") };
+    roots = {
+      codexSessions: path.join(home, "codex", "sessions"),
+      grokSessions: path.join(home, "grok", "sessions"),
+      antigravityBrain: path.join(home, "antigravity", "brain"),
+    };
   });
 
   afterEach(() => fs.rmSync(home, { recursive: true, force: true }));
@@ -51,6 +56,13 @@ describe("agentBadges", () => {
     const dir = path.join(home, "grok", "sessions", encodeURIComponent(CWD), GROK_ID);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify(summary));
+  };
+
+  const writeAntigravityTranscript = (id: string, settings: string) => {
+    const file = path.join(home, "antigravity", "brain", id, ".system_generated", "logs", "transcript.jsonl");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const content = `<USER_REQUEST>\nhi\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\n${settings}\n</USER_SETTINGS_CHANGE>`;
+    fs.writeFileSync(file, `${JSON.stringify({ step_index: 0, source: "USER_EXPLICIT", type: "USER_INPUT", status: "DONE", content })}\n`);
   };
 
   it("reads a codex session's totals, context and window out of its rollout", async () => {
@@ -95,11 +107,24 @@ describe("agentBadges", () => {
     expect((await agentBadges("/Users/x/elsewhere", GROK_ID, "grok", roots)).context.model).toBeNull();
   });
 
-  // agy records neither a model nor a token count. The constant is deliberate: the only model name
-  // in its transcript is prose in a settings block that is written only when the setting changed.
-  it("labels an antigravity session with the agent's own name", async () => {
-    const badges = await agentBadges(CWD, "any-id", "antigravity", roots);
-    expect(badges.context).toEqual({ model: ANTIGRAVITY_MODEL_LABEL, contextTokens: 0 });
+  // agy names its model in step 0 of the conversation's transcript and counts no tokens, so the
+  // model badge fills in and the usage badge stays hidden. The id here IS the conversation id: the
+  // session -> conversation mapping is codex's, already covered above, and asking for it in this
+  // spec would append a fake session to the developer's real ~/.mulmoterminal log.
+  it("reads an antigravity session's model from step 0 of its transcript", async () => {
+    writeAntigravityTranscript(AGY_ID, "The user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment.");
+    const badges = await agentBadges(CWD, AGY_ID, "antigravity", roots);
+    expect(badges.context).toEqual({ model: "Gemini 3.6 Flash (High)", contextTokens: 0 });
+    expect(badges.usage).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+
+  // The session this badge is for has no transcript of its own — a cell that has not been typed
+  // into yet, so agy has not created the conversation. Nobody is the answer, and the badge hides;
+  // the model of whatever else ran in this directory is NOT the answer (#1468).
+  it("names nobody for an antigravity session with no transcript of its own", async () => {
+    writeAntigravityTranscript(AGY_ID, "The user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment.");
+    const badges = await agentBadges(CWD, "8dcd4b0f-6d55-4a02-9f2c-1c4f2a7b9e10", "antigravity", roots);
+    expect(badges.context).toEqual({ model: null, contextTokens: 0 });
     expect(badges.usage.inputTokens).toBe(0);
   });
 });

--- a/test/server/session/spawn-antigravity.spec.ts
+++ b/test/server/session/spawn-antigravity.spec.ts
@@ -17,16 +17,39 @@ vi.mock("../../../server/session/pty-spawn.js", () => ({
   ptyWouldReattach: vi.fn(() => false),
 }));
 
+const CAPTURED_ID = "1c0f5b2e-9d84-4f21-a7c3-6b5e8d9a0f14";
+
+// The watcher polls agy's real brain root for half an hour, and `remember` appends to the real
+// ~/.mulmoterminal log. Both are stubbed: this file is about what the spawner does with a capture,
+// and a unit test must not write a session that never existed into the developer's own state.
+const mocks = vi.hoisted(() => ({ remembered: [] as { sessionId: string; conversationId: string; cwd: string }[] }));
+
+vi.mock("../../../server/agents/antigravity-session.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/antigravity-session.js")>()),
+  watchForAntigravitySession: vi.fn(() => Promise.resolve(CAPTURED_ID)),
+}));
+
+vi.mock("../../../server/session/registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/session/registry.js")>()),
+  rememberAntigravityConversation: vi.fn((sessionId: string, conversationId: string, cwd: string) => {
+    mocks.remembered.push({ sessionId, conversationId, cwd });
+  }),
+}));
+
 describe("createAntigravitySpawner", () => {
+  const publishActivity = vi.fn();
   const dummyDeps = {
     antigravityBin: "agy",
     antigravityModel: null,
     outputBufferLimit: 10000,
     reap: vi.fn(),
+    publishActivity,
   } as unknown as SpawnDeps;
 
   beforeEach(() => {
     ptys.clear();
+    mocks.remembered.length = 0;
+    publishActivity.mockClear();
   });
 
   it("spawns an antigravity PTY entry and registers it in ptys registry", () => {
@@ -36,5 +59,29 @@ describe("createAntigravitySpawner", () => {
     expect(entry.agent).toBe("antigravity");
     expect(entry.cwd).toBe("/test/dir");
     expect(ptys.get("session-1")).toBe(entry);
+  });
+
+  // Without this the cell keeps the header badge it was given before agy had a conversation at all,
+  // for the whole session: an agy session has no hooks and no activity tracker, so it never
+  // finishes a turn, and a finished turn is the cell's only other reason to re-read its badges.
+  it("publishes once the conversation id is captured, so the cell re-reads its model badge", async () => {
+    const { spawnAntigravityPty } = createAntigravitySpawner(dummyDeps);
+    spawnAntigravityPty("session-2", null, null, "/test/dir", { mcpGroups: [] });
+    await vi.waitFor(() => expect(mocks.remembered).toHaveLength(1));
+
+    expect(mocks.remembered[0]).toEqual({ sessionId: "session-2", conversationId: CAPTURED_ID, cwd: "/test/dir" });
+    expect(publishActivity).toHaveBeenCalledWith("session-2");
+  });
+
+  // A resumed session knows its conversation at spawn, so the seed fetch already reads the right
+  // transcript — and the watcher is not run at all, which is what keeps a concurrent conversation
+  // from being mis-attributed to it.
+  it("does not run the watcher for a resumed conversation", async () => {
+    const { spawnAntigravityPty } = createAntigravitySpawner(dummyDeps);
+    spawnAntigravityPty("session-3", null, CAPTURED_ID, "/test/dir", { mcpGroups: [] });
+    await vi.waitFor(() => expect(mocks.remembered).toHaveLength(1));
+
+    expect(mocks.remembered[0]?.conversationId).toBe(CAPTURED_ID);
+    expect(publishActivity).not.toHaveBeenCalled();
   });
 });

--- a/test/server/session/spawn-custom-agent.spec.ts
+++ b/test/server/session/spawn-custom-agent.spec.ts
@@ -80,6 +80,7 @@ const deps = {
   setWaiting: vi.fn(),
   uiPort: "3000",
   publishSessionCreated: vi.fn(),
+  publishActivity: vi.fn(),
 };
 
 // A per-test session id where the test is not ABOUT the memory: the spawn remembers which

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -77,6 +77,7 @@ const deps = {
   setWaiting: vi.fn(),
   uiPort: "3000",
   publishSessionCreated: vi.fn(),
+  publishActivity: vi.fn(),
 };
 
 // `ws` is null throughout: every case here spawns headless, and the socket was only ever passed

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -856,6 +856,9 @@ describe("TerminalCell", () => {
     const w = mountCell(id, { initialAgent: "antigravity" });
     await flushPromises();
     expect(w.find('[data-testid="model-badge"]').exists()).toBe(false); // agy has not created the conversation yet
+    // The seed applies activity BEFORE badges, so a re-ask hung off that path would fire here for
+    // the answer it already has — on every non-claude cell, every load.
+    expect(detailReads).toBe(1);
 
     model = "Gemini 3.6 Flash (High)"; // the capture landed, so the transcript now names it
     captured?.({ id, working: false, waiting: false });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -42,6 +42,10 @@ vi.mock("../../../src/components/Terminal.vue", () => ({
   },
 }));
 
+// GET /api/session/:id itself — NOT its sub-routes (/memo, /terminate) and not the other polls a
+// cell runs, which a "everything else" counter would fold in and make a refresh test read high.
+const SESSION_DETAIL_RE = /\/api\/session\/[^/?]+(\?|$)/;
+
 const promptText = (w: ReturnType<typeof mount>) => w.find('[data-testid="cell-prompt"]').text();
 const dotClass = (w: ReturnType<typeof mount>) => w.find(".cell-dot").classes();
 
@@ -845,7 +849,7 @@ describe("TerminalCell", () => {
       const u = String(url);
       if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
       if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
-      detailReads++;
+      if (SESSION_DETAIL_RE.test(u)) detailReads++;
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model, contextTokens: 0 } }) };
     }) as unknown as typeof fetch;
 
@@ -866,6 +870,47 @@ describe("TerminalCell", () => {
     expect(detailReads).toBe(settled);
   });
 
+  // agy's context reading moves every turn, and agy has no turn end to hang a refresh on — so
+  // without this the percentage is frozen at whatever it was when the cell first asked.
+  it("re-reads an antigravity cell's badges on a timer, and no other agent's", async () => {
+    vi.useFakeTimers();
+    try {
+      const id = "55555555-5555-5555-5555-555555555555";
+      let detailReads = 0;
+      globalThis.fetch = vi.fn(async (url: string) => {
+        const u = String(url);
+        if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+        if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+        if (SESSION_DETAIL_RE.test(u)) detailReads++;
+        return {
+          ok: true,
+          json: async () => ({
+            working: false,
+            waiting: false,
+            lastPrompt: null,
+            context: { model: "Gemini 3.6 Flash", contextTokens: 1000, contextWindow: 256_000 },
+          }),
+        };
+      }) as unknown as typeof fetch;
+
+      const agy = mountCell(id, { initialAgent: "antigravity" });
+      await vi.advanceTimersByTimeAsync(1);
+      const afterMount = detailReads;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(detailReads).toBeGreaterThan(afterMount);
+      agy.unmount();
+
+      const claude = mountCell(id);
+      await vi.advanceTimersByTimeAsync(1);
+      const claudeSettled = detailReads;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(detailReads).toBe(claudeSettled);
+      claude.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Claude's badges ride along with the summary the route already folds, and this is the busiest
   // route in the app — a push must not turn every claude cell into a poller.
   it("does not re-read the badges on a push for a claude cell", async () => {
@@ -875,7 +920,7 @@ describe("TerminalCell", () => {
       const u = String(url);
       if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
       if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
-      detailReads++;
+      if (SESSION_DETAIL_RE.test(u)) detailReads++;
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model: null, contextTokens: 0 } }) };
     }) as unknown as typeof fetch;
 

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -84,11 +84,13 @@ function mountCell(
     expanded?: boolean;
     zoomed?: boolean;
     reorderable?: boolean;
+    initialAgent?: "claude" | "codex" | "antigravity" | "grok";
   } = {},
 ) {
   return mount(TerminalCell, {
     props: {
       uid: 1,
+      ...(opts.initialAgent ? { initialAgent: opts.initialAgent } : {}),
       expanded: opts.expanded ?? false,
       zoomed: opts.zoomed ?? false,
       reorderable: opts.reorderable ?? false,
@@ -829,6 +831,61 @@ describe("TerminalCell", () => {
     const badge = w.find('[data-testid="model-badge"]');
     expect(badge.exists()).toBe(true);
     expect(badge.text()).toBe("Opus · ctx 35%"); // 70k / 200k
+  });
+
+  // An agy cell is the case that has no other way back: agy mints its conversation id after the
+  // spawn, so the seed fetch can only answer "no model" — and with no hooks and no activity
+  // tracker it never finishes a turn, which is the cell's only other badge refresh. The server
+  // publishes when it captures the id (spawn-antigravity.ts); this is the other half.
+  it("re-reads the badges on a push while the model is still unknown", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    let model: string | null = null;
+    let detailReads = 0;
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      detailReads++;
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model, contextTokens: 0 } }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id, { initialAgent: "antigravity" });
+    await flushPromises();
+    expect(w.find('[data-testid="model-badge"]').exists()).toBe(false); // agy has not created the conversation yet
+
+    model = "Gemini 3.6 Flash (High)"; // the capture landed, so the transcript now names it
+    captured?.({ id, working: false, waiting: false });
+    await flushPromises();
+    await nextTick();
+    expect(w.find('[data-testid="model-badge"]').text()).toBe("Gemini 3.6 Flash");
+
+    // And it stops: a known model is not asked for again on the next push.
+    const settled = detailReads;
+    captured?.({ id, working: false, waiting: false });
+    await flushPromises();
+    expect(detailReads).toBe(settled);
+  });
+
+  // Claude's badges ride along with the summary the route already folds, and this is the busiest
+  // route in the app — a push must not turn every claude cell into a poller.
+  it("does not re-read the badges on a push for a claude cell", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    let detailReads = 0;
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      detailReads++;
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model: null, contextTokens: 0 } }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id);
+    await flushPromises();
+    const settled = detailReads;
+    captured?.({ id, working: true, waiting: false });
+    await flushPromises();
+    expect(detailReads).toBe(settled);
+    expect(w.find('[data-testid="model-badge"]').exists()).toBe(false);
   });
 
   it("renders configured chips: hides an omitted built-in, keeps a listed one, and shows custom text", async () => {

--- a/test/src/components/modelBadge.spec.ts
+++ b/test/src/components/modelBadge.spec.ts
@@ -16,6 +16,17 @@ describe("shortModelLabel", () => {
     expect(shortModelLabel("openai/o3-pro")).toBe("o3-pro");
   });
 
+  // agy names a model `Gemini 3.6 Flash (High)`. The badge does not truncate — it pushes the rest
+  // of the header out — and the full name is still in the tip.
+  it("drops a trailing bracketed qualifier", () => {
+    expect(shortModelLabel("Gemini 3.6 Flash (High)")).toBe("Gemini 3.6 Flash");
+    expect(modelBadge("antigravity", "Gemini 3.6 Flash (High)", 0).title).toContain("Gemini 3.6 Flash (High)");
+  });
+
+  it("keeps a name that is nothing but a bracketed part", () => {
+    expect(shortModelLabel("(High)")).toBe("(High)");
+  });
+
   it("prefers a preset's own label when the id is one we launch with", () => {
     expect(shortModelLabel("qwen/qwen3-235b-a22b-2507")).toBe("Qwen3 235B A22B");
   });


### PR DESCRIPTION
## 概要

Antigravity セルのヘッダバッジを、固定文字列 `antigravity` から実際の情報に置き換える。

- **モデル名**: `Gemini 3.6 Flash`（会話のトランスクリプト step 0 から）
- **ctx%**: `ctx 78%`（agy 自身の世代ごとの記録から。実測 256,000 の窓）
- **トークン使用量**: Claude と同じ `⇡入力 ⇣出力` バッジ

閉じた #1468 の作り直し。前回の指摘（別セッションのモデルを表示しうる `last_conversations.json` フォールバック、実 home を汚すテスト）は入れていない。

## 1. モデル名 — #1466 の前提はデータと違った

#1466 は「モデル名は設定を**変えたときだけ**書かれる散文なので読まない」と判断した。文面からの推測で、実データはこうだった:

```
transcripts: 50   with a settings block: 50   with more than one block: 0
first-hit line index histogram: {0: 50}
```

agy は会話開始時に必ず「from None to ...」として選択中のモデルを書く。つまり**その会話についての事実**であって、`settings.json`（グローバルかつ現在値）とも、cwd の最後の会話とも違う。

- 読むのは head 64KB のみ（step 0 にあるため）。tail 読みは追加しない。
- モデル名が読めない会話は `null` を返してバッジを隠す（grok と同じ）。定数は返さない。
- バッジ表示は `Gemini 3.6 Flash`（末尾の `(High)` は落とす。バッジは truncate せず他のチップを押し出すため）。フルネームは tooltip に残る。

## 2. 新規セルでバッジが更新されない問題

「履歴から resume すると出るが、新しくセルを立てると出ない」という報告への修正。パースの問題ではなかった:

- resume は spawn 時に conversation id を記録するので初回 fetch で読める
- 新規は watcher が id を捕捉するまで読めず、しかも**二度と再取得されない**。セルがバッジを読み直すのは `working -> idle` のときだけで、agy には hook も activity tracker も無いため working が立たない

そこで、capture 時に publish し（`publishActivity` を `SpawnDeps` に追加）、モデル未確定の非 claude セルは push でバッジを読み直す。claude は除外（バッジはルートが既に畳んでいる summary から来るため、最も忙しいルートを叩く意味が無い）。codex の初回ターンの遅延も同時に直る。

## 3. ctx% とトークン — スキーマの無いストアから

トークン情報は `transcript.jsonl` には**無い**（レコードは `step_index` / `content` / `tool_calls` / `exit_code` などのみ）。実体は `~/.gemini/antigravity-cli/conversations/<id>.db`（SQLite）の `gen_metadata` テーブルにある、世代ごとの **protobuf blob**。`.proto` はディスク上のどこにも無い。

実データ 519 世代を観察してフィールドを特定した:

```
idx=  0  ctx   2,522/256,000  prompt 22,812  out 178  cached       0  thoughts  80
idx=240  ctx 234,987/256,000  prompt  4,901  out 180  cached 227,183  thoughts  94
idx=300  ctx 146,536/256,000  prompt  3,660  out  84  cached 137,957  thoughts  68  <- compact
```

`1.9.10.1` が `1.9.10.4`（256,000）に対して増加し、compaction で落ちる。`1.4.*` の世代ごとの数値の合計は数%以内で一致する。

**スキーマが無いので、全レイヤを「不確かなら何も出さない」で作った**（バッジは compact を判断するために読まれるものなので）:

- `antigravity-proto.ts`: 要求されたパスだけを歩き、他フィールドは長さでスキップ（740KB の行でも数十バイトの読み取り）。理解できないバイトに当たったら**再同期せずに停止**。例外は投げない
- `antigravity-usage.ts`: 窓が 1KB〜100M の外、`used` が窓超過、カウントが 10 億超、リーフ欠落 — いずれも**答え全体を捨てる**（部分合計は「小さい数」ではなく「間違った数」）
- 2 つのバッジは独立。会計が読めなくてもモデル名は出る

将来 agy がフィールドを振り直したら、agy セルはモデル名だけの表示に戻る（#1465 以前の挙動）。**間違った % は出ない。**

### 実データでしか出なかった 2 点（テストで固定済み）

- `node:sqlite` は `limit ?` で `column index out of range` を投げる。名前付き `$limit` なら通る
- **大きすぎる varint は「読めない」で走査を止めてはいけない**。agy は ctx と同じメッセージに `18446744073709551615` を置いており、初版は「表現できない = 継続できない」として停止し、ctx を全く読めなかった — **合成フィクスチャは全部 green のまま**。スキップに値は要らない

### 鮮度

agy にはターン終了が無いため、ctx% は最初に読んだ値で凍結してしまう。セルは 1 分ごとにバッジを読み直す（indexed な sqlite 1 行 + 64KB の head 読み）。agy に activity tracker が入った日に消すべきもの、とコメントに書いてある。

## 確認

- `yarn format` / `yarn lint`（error 0）/ `yarn typecheck` / `yarn test`（8636 passed）
- フィクスチャだけでなく**実ログに対して**（上記 2 バグはここでしか出なかった）:

```
a4dbbf1e | Gemini 3.6 Flash (High) | ctx 199141/256000 (78%) | in 4258938 out 266486 cache 75671040
9ee2d1bb | Gemini 3.6 Flash (High) | ctx 209450/256000 (82%) | in 1789741 out  93143 cache 15236168
2658608b | Gemini 3.6 Flash (High) | ctx  82657/256000 (32%) | in  195827 out  12216 cache  1706889
unknown  | null                    | ctx 0/null              | in 0 out 0 cache 0
```

- テストは `~/.mulmoterminal/` に何も書かない（#1468 のテストは実 home に偽セッションを残していた）。フルスイート前後で行数不変を確認
- ブラウザでの目視確認は未実施（`yarn build` + サーバ再起動が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity session badges now display the detected model, context usage, and token usage when available.
  * Usage information refreshes automatically as activity arrives and periodically during active sessions.
  * Model labels are cleaner by removing unnecessary trailing qualifiers.
* **Documentation**
  * Updated Antigravity usage documentation to explain reported metrics and fallback behavior.
* **Bug Fixes**
  * Missing, malformed, or unavailable usage data now degrades gracefully without showing unreliable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->