### PR TITLE
refactor: code scanning の duplicate-code アラート 4 件を共有ヘルパ抽出で解消する

### DIFF
--- a/plans/refactor-jscpd-duplicates-1472.md
+++ b/plans/refactor-jscpd-duplicates-1472.md
@@ -1,0 +1,76 @@
+# refactor: code scanning の duplicate-code アラート 4 件を解消する (#1472)
+
+`duplication-scan` (jscpd 5.0.12, minTokens=50 / minLines=5) の open アラートは 4 件。
+SARIF は**片側の位置しか持たない**ので、対を知るには CI と同じ引数でローカル実行する
+（前回 `plans/refactor-jscpd-duplication.md` と同じ手順）:
+
+```
+npx jscpd@5.0.12 . --format "typescript,vue" \
+  --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" --reporters console
+```
+
+| alert | 片側 | 対 | tokens |
+| --- | --- | --- | --- |
+| 142 | `server/config/dir-config.ts` 165-174 | `server/config/dir-icon.ts` 26-35 | 69 |
+| 143 | `server/routes/ws-routes.ts` 635-643 | `server/routes/ws-routes.ts` 718-725 | 68 |
+| 144 | `server/routes/ws-routes.ts` 689-697 | `server/routes/ws-routes.ts` 766-774 | 56 |
+| 147 | `server/session/spawn-antigravity.ts` 37-69 | `server/session/spawn-grok.ts` 26-55 | 65 |
+
+4 件とも原因は同じ: **後から足したものが、隣にあった同型のコードを写して増えた**。
+icon は sound を、grok は antigravity を写している。写した側だけが直る drift が実バグなので、
+写しではなく共有ヘルパにする。挙動は変えない。
+
+## 1. cwd 配下へのファイル封じ込め (142)
+
+`resolveDirSound`（音）と `resolveIconFile`（アイコン）が同じ 4 段の規則を各自持つ:
+絶対パス拒否 → `path.resolve` → `isWithin` → 実在かつ通常ファイル → `realpathSync.native` で再チェック。
+dir-icon.ts のコメント自身が "the same rule, and the same order of checks, as resolveDirSound"
+と書いており、写しであることが明示されている。
+
+→ `server/config/dir-file.ts` に `resolveFileWithinDir(cwd, ref): string | null` を出し、両方から呼ぶ。
+mime 判定は icon 固有（拒否理由が違う）なので `resolveIconFile` 側に残す。
+
+## 2. live pty / tmux の事実収集 (143)
+
+`resolveCodexSession` / `resolveAntigravitySession` / `resolveGrokSession` / `resolveLaunchSession`
+が同じ 3 行で始まり、前 3 つは `resolveReattachableId` + 同じ形の return で終わる。
+
+→ ws-routes 内に `liveSessionFacts(requested)` と `resolveResumableSession(requested, resumeIdFor)`
+を置き、4 箇所から使う。codex の `resumeRolloutId` は codex の語彙なので、共通側は
+`resumeConversationId` で返し、codex の resolver だけが名前を付け替える。
+
+## 3. antigravity / grok の WS ハンドラ (144)
+
+この 2 つは「**MCP サーバをディレクトリの設定ファイルから読む**」同じ形のエージェント
+（agy = `.agents/mcp_config.json`、grok = `.grok/config.toml`）。claude / codex と違って per-session の
+`--mcp-config` が無く、`?gui=0` は dev terminal かどうかしか決めない。ハンドラ本体・`start*Entry`・
+`*Start` interface まで同型なので 1 つにまとめる。
+
+→ `handleDirectoryMcpAgentConnection(agent, deps, ws, req)` + `DirectoryMcpWsAgent` 記述子。
+差分は記述子が持つ:
+
+- `kind` / `label`（`TerminalWsKind` と失敗メッセージの表示名）
+- `hydrated` — antigravity だけが持つ「session→conversation マップの読み込み待ち」。grok は
+  on-disk マップを持たないので `null`。省略可にせず**必須**にして、理由をコメントで残す
+  （5 番目のエージェントが黙って待たずに済ませるのを防ぐ）
+- `resolveSession` / `spawn`
+
+## 4. spawner (147)
+
+`spawnAntigravityPty` と `spawnGrokPty` は、シグネチャ・`mcpGroups` の JSDoc・
+「reattach になる spawn では共有 MCP ファイルを書かない」ガード・`ptySpawn` 周りが同型。
+
+→ `server/session/spawn-directory-mcp.ts` に
+`DirectoryMcpSpawnOptions`（`mcpGroups` + `initialPrompt`）と
+`startDirectoryMcpPty(params)`（reattach ガード付き MCP 同期 → `ptySpawn` → 起動ログ → `ptys.set`）
+を出す。antigravity 固有の「spawn 前スナップショット → conversation 捕捉」と
+`wireAgentPtyRelay` は呼び出し側に残す。
+
+## 検証
+
+1. 上の jscpd コマンドで **clone 0 件**（抽出が中途半端だと 50 トークンを割らずに残るので、
+   目視ではなく実際に回して確認する）
+2. `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
+3. 既存 spec が挙動の担保: `spawn-antigravity.spec.ts`, `spawn-antigravity-mcp-sync.spec.ts`,
+   `spawn-grok-mcp-sync.spec.ts`, `ws-worktree-env.spec.ts`, `ws-unusable-cwd.spec.ts`。
+   加えて共有ヘルパ自身の spec（封じ込め規則、reattach ガード）を足す。

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -4,7 +4,7 @@
 // terminal falls back to the global theme/sound. Field validation lives in the zod
 // schemas of config-schema.ts; the path-confinement check for `sound` (the security
 // surface) stays here because it touches the filesystem.
-import { existsSync, statSync, realpathSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
 import { EMPTY_DIR_CHROME, type DirChrome } from "../../common/dirChrome.js";
@@ -16,7 +16,7 @@ import {
   type DirConfigSource,
   type DirConfigExtras,
 } from "../../common/dirConfigSource.js";
-import { isWithin } from "../infra/path-within.js";
+import { resolveFileWithinDir } from "./dir-file.js";
 import { resolveDirIcon, dirIconImage, dirIconNamed, dirIconRef, type DirIcon, type DirIconSetting } from "./dir-icon.js";
 import { detectDirIcon } from "./dir-icon-detect.js";
 import { getAutoDirIcon } from "./config-routes.js";
@@ -152,26 +152,13 @@ function resolveDirSounds(cwd: string, input: unknown): Partial<Record<NotifyKin
   return out;
 }
 
-// Confine the configured sound to a real file INSIDE cwd. Relative paths only;
-// anything absolute or escaping via "../" is rejected so an opened project can't
-// point the player at arbitrary files on disk. The lexical check only constrains the
-// path string, so we ALSO canonicalize with realpath and re-check — otherwise a file
-// inside cwd that is a symlink to a target outside it would slip through.
+// Confine the configured sound to a real file INSIDE cwd, so an opened project can't point the
+// player at arbitrary files on disk — the shared rule, see dir-file.ts for what it checks.
 export function resolveDirSound(cwd: string, input: unknown): string | null {
   if (typeof input !== "string") return null;
   const rel = input.trim();
-  if (!rel || path.isAbsolute(rel)) return null;
-  const base = path.resolve(cwd);
-  const resolved = path.resolve(base, rel);
-  if (!isWithin(base, resolved)) return null;
-  if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
-  try {
-    // .native for the 8.3 reason in files/pathContainment.ts — one spelling of a Windows path.
-    if (!isWithin(realpathSync.native(base), realpathSync.native(resolved))) return null;
-  } catch {
-    return null;
-  }
-  return resolved;
+  if (!rel) return null;
+  return resolveFileWithinDir(cwd, rel);
 }
 
 const EMPTY: DirConfig = {

--- a/server/config/dir-file.ts
+++ b/server/config/dir-file.ts
@@ -1,0 +1,33 @@
+// The one rule for "a file a DIRECTORY's own config named": relative to that directory, and
+// provably inside it.
+//
+// A `.mulmoterminal.json` is written by whoever owns the project, and this server reads it and
+// then reads the file it points at — so an opened project must not be able to aim that read at
+// anything outside its own tree. Two keys already need exactly this (`sound`, `icon`), and the
+// second was written by copying the first; the copy is what this file exists to stop, because a
+// containment rule that is fixed on one side and not the other is not a containment rule.
+import { existsSync, statSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { isWithin } from "../infra/path-within.js";
+
+/** The absolute path `ref` names under `cwd`, or null when it is not a real file inside it.
+ *
+ *  Four checks, in this order and all four required: relative only (an absolute path names
+ *  someone else's disk), lexically contained (no escaping via `..`), a file that exists (a
+ *  directory or a device is not a config value), and contained AGAIN after realpath — the
+ *  lexical check only constrains the path string, so a symlink sitting inside the directory
+ *  and pointing out of it would otherwise pass. */
+export function resolveFileWithinDir(cwd: string, ref: string): string | null {
+  if (path.isAbsolute(ref)) return null;
+  const base = path.resolve(cwd);
+  const resolved = path.resolve(base, ref);
+  if (!isWithin(base, resolved)) return null;
+  if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
+  try {
+    // .native for the 8.3 reason in files/pathContainment.ts — one spelling of a Windows path.
+    if (!isWithin(realpathSync.native(base), realpathSync.native(resolved))) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
+}

--- a/server/config/dir-icon.ts
+++ b/server/config/dir-icon.ts
@@ -5,34 +5,23 @@
 // project, which only this server can read — confined exactly like `sound` (dir-config.ts) and
 // streamed back through /api/dir-icon. An http(s) or data: URL is loaded by the browser itself,
 // so nothing here touches it beyond deciding that it is one.
-import { existsSync, statSync, realpathSync } from "node:fs";
-import path from "node:path";
-import { isWithin } from "../infra/path-within.js";
+import { resolveFileWithinDir } from "./dir-file.js";
 import { DIR_ICON_MAX_CHARS, dirIconMime, isRemoteDirIconUrl } from "../../common/dirIcon.js";
 
 // `ref` is the path AS WRITTEN, kept beside the resolved one because a worktree inherits this
 // key: a config derived from an absolute path would be rejected by the very rule that produced
 // it (relative only), while the relative path resolves again in the worktree's own tree.
-export type DirIcon = { source: "file"; path: string; ref: string; mime: string } | { source: "url"; url: string };
+export type DirIconFile = { source: "file"; path: string; ref: string; mime: string };
+export type DirIcon = DirIconFile | { source: "url"; url: string };
 
-// Confine a configured icon to a real image file INSIDE cwd — the same rule, and the same order
-// of checks, as resolveDirSound: relative only, no escaping via "../", and a realpath re-check so
-// a symlink inside the directory can't point out of it.
-export function resolveIconFile(cwd: string, ref: string): DirIcon | null {
-  if (path.isAbsolute(ref)) return null;
+// Confine a configured icon to a real image file INSIDE cwd — the shared rule (dir-file.ts), the
+// same one `sound` is held to. The extension check is this key's own: a path that IS inside the
+// directory but names something the browser cannot render is still not an icon.
+export function resolveIconFile(cwd: string, ref: string): DirIconFile | null {
   const mime = dirIconMime(ref);
   if (!mime) return null;
-  const base = path.resolve(cwd);
-  const resolved = path.resolve(base, ref);
-  if (!isWithin(base, resolved)) return null;
-  if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
-  try {
-    // .native for the 8.3 reason in files/pathContainment.ts — one spelling of a Windows path.
-    if (!isWithin(realpathSync.native(base), realpathSync.native(resolved))) return null;
-  } catch {
-    return null;
-  }
-  return { source: "file", path: resolved, ref, mime };
+  const resolved = resolveFileWithinDir(cwd, ref);
+  return resolved ? { source: "file", path: resolved, ref, mime } : null;
 }
 
 // What the FILE said, before anything is looked for on disk. Four answers, because three

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -52,6 +52,7 @@ import type {
   SpawnLauncherPty,
   ResolveLauncher,
 } from "../session/spawners.js";
+import type { SpawnDirectoryMcpPty } from "../session/spawn-directory-mcp.js";
 import { terminalWsKind, type TerminalWsKind } from "./terminal-ws-path.js";
 import { normalizeAgent, parseIndexParam } from "./routeParams.js";
 import { agentResumeId } from "../agents/agent-resume.js";
@@ -344,6 +345,47 @@ export function beginRunTerminal(deps: WsRouteDeps, ws: WebSocket, resolved: { c
   });
 }
 
+/** What is still RUNNING under a requested id — the two facts every reattachable endpoint starts
+ *  from, gathered in one place because they are asked in a fixed order and one of them costs a
+ *  subprocess: `tmuxHasSession` shells out, so a same-process pty must short-circuit it.
+ *
+ *  `hasLivePty` is `!!live` rather than a separate `ptys.has`, which is what it always meant —
+ *  the map holds no undefined entries — and saying it once removes the chance of the two answers
+ *  parting company. */
+function liveSessionFacts(requested: string | null): { hasLivePty: boolean; live: PtyEntry | undefined; tmuxAlive: boolean } {
+  const live = requested ? ptys.get(requested) : undefined;
+  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
+  return { hasLivePty: !!live, live, tmuxAlive };
+}
+
+/** The session a self-identifying agent connects as: the id it will run under, the same-process
+ *  pty to reattach if there is one, and the conversation to resume if there is one. */
+interface ResumableSession {
+  sessionId: string;
+  live: PtyEntry | undefined;
+  resumeConversationId: string | null;
+}
+
+/** The session a self-identifying agent (codex, antigravity, grok) connects as.
+ *
+ *  All three mint their OWN conversation id and tell nobody, so the id the browser holds is a key
+ *  this server minted and the conversation behind it has to be looked up. What differs between
+ *  them is only that lookup — a map on disk, a probe, or both — so it arrives as `resumeIdFor`
+ *  and everything around it is decided here.
+ *
+ *  claude is deliberately not one of these: it takes `--session-id`, so its id IS the
+ *  conversation's and resolveClaudeSession answers a different question (resume from disk).
+ */
+function resolveResumableSession(
+  requested: string | null,
+  resumeIdFor: (facts: { hasLivePty: boolean; tmuxAlive: boolean }) => string | null,
+): ResumableSession {
+  const { hasLivePty, live, tmuxAlive } = liveSessionFacts(requested);
+  const resumeConversationId = resumeIdFor({ hasLivePty, tmuxAlive });
+  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeConversationId }, randomUUID);
+  return { sessionId, live, resumeConversationId };
+}
+
 // Reattach a same-process live PTY, else spawn a launcher (which itself reattaches a
 // surviving tmux session or creates one). `command` is the resolved launcher command,
 // or the fallback for a tmux reattach with no launcher index.
@@ -362,9 +404,7 @@ function resolveLaunchSession(
   index: number,
   shell: boolean,
 ): { sessionId: string; live: PtyEntry | undefined; command: string } | null {
-  const hasLivePty = !!requested && ptys.has(requested);
-  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
-  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
+  const { hasLivePty, live, tmuxAlive } = liveSessionFacts(requested);
   // A live PTY / surviving tmux session reattaches regardless of the index; only a fresh
   // spawn needs the launcher resolved (the pty already IS the chosen program on reattach).
   const launcher = live || tmuxAlive ? null : deps.resolveLauncher(index);
@@ -379,17 +419,17 @@ function resolveLaunchSession(
 // pty / surviving tmux session (running codex picked up, no resume); else cold-resume a known
 // rollout id; else a fresh session (a new minted key).
 function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
-  const hasLivePty = !!requested && ptys.has(requested);
-  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
-  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
-  const resumeRolloutId = agentResumeId(requested, {
-    mappedId: requested ? codexRollouts.get(requested)?.conversationId : null,
-    conversationExists: () => !!requested && codexRolloutExists(codexSessionsRoot(), requested),
-    hasLivePty: !!live,
-    tmuxAlive,
-  });
-  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeRolloutId }, randomUUID);
-  return { sessionId, live, resumeRolloutId };
+  const { sessionId, live, resumeConversationId } = resolveResumableSession(requested, ({ hasLivePty, tmuxAlive }) =>
+    agentResumeId(requested, {
+      mappedId: requested ? codexRollouts.get(requested)?.conversationId : null,
+      conversationExists: () => !!requested && codexRolloutExists(codexSessionsRoot(), requested),
+      hasLivePty,
+      tmuxAlive,
+    }),
+  );
+  // "rollout" is codex's own word for the conversation file it resumes from — kept at this
+  // boundary, since everything downstream of here is codex-specific and reads better in it.
+  return { sessionId, live, resumeRolloutId: resumeConversationId };
 }
 
 // Grouped rather than eight positional arguments: what this needs is a session to (re)attach,
@@ -632,75 +672,18 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
   );
 }
 
-function resolveAntigravitySession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeConversationId: string | null } {
-  const hasLivePty = !!requested && ptys.has(requested);
-  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
-  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
-  // The same rule codex resumes by, including the part that is easy to drop: the key is only
-  // treated as a conversation id when a conversation by that name EXISTS. Without the check every
-  // key resumes, which means a stale one is handed to `agy --conversation` — agy answers a
-  // conversation it cannot find by starting a fresh one, silently, under the old session's id.
-  const resumeConversationId = agentResumeId(requested, {
-    mappedId: requested ? antigravityConversations.get(requested)?.conversationId : null,
-    conversationExists: () => !!requested && antigravityConversationExists(antigravityBrainRoot(), requested),
-    hasLivePty,
-    tmuxAlive,
-  });
-  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeConversationId }, randomUUID);
-  return { sessionId, live, resumeConversationId };
-}
-
-interface AntigravityStart {
-  sessionId: string;
-  live: PtyEntry | undefined;
-  resumeConversationId: string | null;
-  cwd: string;
-  attachGuiMcp: boolean;
-  mcpGroups: readonly ToolGroup[];
-}
-
-// Reattach or spawn, as ONE function handed to startAndWire — the reattach must not take a
-// shortcut around it. `reattachPty` only swaps the socket and replays the buffer; returning early
-// on it left a reloaded terminal printing output while ignoring every keystroke, and never
-// detaching or reaping when the socket closed.
-function startAntigravityEntry(deps: WsRouteDeps, ws: WebSocket, start: AntigravityStart): PtyEntry {
-  const { sessionId, live, resumeConversationId, cwd, attachGuiMcp, mcpGroups } = start;
-  const entry = live ? deps.reattachPty(live, ws, sessionId) : deps.spawnAntigravityPty(sessionId, ws, resumeConversationId, cwd, { mcpGroups });
-  // Single view (gui) = the attached session IS the actively-viewed pane. A grid dev-terminal
-  // cell (gui=0) is only "viewed" once focused, and says so with a `view` frame.
-  entry.active = attachGuiMcp;
-  return entry;
-}
-
-// antigravity terminal (?cwd=<dir>, ?session=<id> to reattach/resume). Unlike claude and codex
-// there is no per-session GUI MCP surface to attach or withhold: agy reads its servers from a file
-// in the DIRECTORY, so every session there reaches whatever that directory registered — `?gui=0`
-// only keeps a grid dev terminal out of the sidebar.
-async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
-  const { url, requested, cwd, unusable, size } = wsConnectionContext(req);
-  if (refuseUnusableWorkspace(ws, "antigravity", unusable, requested)) return;
-  const attachGuiMcp = url.searchParams.get("gui") !== "0";
-  // Before resolving, not after: the mapping this reads lives on disk, and a reconnect that
-  // arrives while the log is still being read would see an empty map and decline to resume a
-  // conversation that is right there — which is the restart case this exists for.
-  await antigravityConversationsHydrated;
-  const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
-  await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, "antigravity", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
-  if (!early) return;
-
-  // The directory's registered groups, read here because the lookup reads Claude Code's config
-  // files and the spawner is sync. Only for a SPAWN: a reattach keeps the tools its running
-  // process was started with, and rewriting the shared file on a reattach would speak for every
-  // other session in the directory.
-  const mcpGroups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
-  if (!clientStillConnected(ws, "antigravity", sessionId, early)) return;
-  // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps
-  // the socket and replays the buffer, so returning early here left a reloaded terminal printing
-  // output while ignoring every keystroke, and never detaching or reaping on close.
-  const startFailureMessage = startFailureMessageFor("Antigravity");
-  startAndWire(deps, ws, { id: sessionId, tag: "antigravity", early, startFailureMessage, size }, () =>
-    startAntigravityEntry(deps, ws, { sessionId, live, resumeConversationId, cwd, attachGuiMcp, mcpGroups }),
+function resolveAntigravitySession(requested: string | null): ResumableSession {
+  return resolveResumableSession(requested, ({ hasLivePty, tmuxAlive }) =>
+    // The same rule codex resumes by, including the part that is easy to drop: the key is only
+    // treated as a conversation id when a conversation by that name EXISTS. Without the check every
+    // key resumes, which means a stale one is handed to `agy --conversation` — agy answers a
+    // conversation it cannot find by starting a fresh one, silently, under the old session's id.
+    agentResumeId(requested, {
+      mappedId: requested ? antigravityConversations.get(requested)?.conversationId : null,
+      conversationExists: () => !!requested && antigravityConversationExists(antigravityBrainRoot(), requested),
+      hasLivePty,
+      tmuxAlive,
+    }),
   );
 }
 
@@ -715,55 +698,68 @@ async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req
 // and the spawn, `tmux new-session -A` re-runs the command — and there `--resume <id>` reattaches
 // the conversation where `--session-id <id>` ABORTS ("Session ID … is already in use", measured).
 // Withholding the resume in that window makes the window fatal.
-function resolveGrokSession(requested: string | null, cwd: string): { sessionId: string; live: PtyEntry | undefined; resumeConversationId: string | null } {
-  const hasLivePty = !!requested && ptys.has(requested);
-  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
-  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
-  // Only when a conversation by that name EXISTS in this directory. Without the check every key
-  // resumes, which means a stale one is handed to `grok --resume` — and an agent asked for a
-  // conversation it cannot find starts a fresh one, silently, under the old session's id.
-  const resumeConversationId = !hasLivePty && requested && grokConversationExists(grokSessionsRoot(), cwd, requested) ? requested : null;
-  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeConversationId }, randomUUID);
-  return { sessionId, live, resumeConversationId };
+function resolveGrokSession(requested: string | null, cwd: string): ResumableSession {
+  return resolveResumableSession(requested, ({ hasLivePty }) =>
+    // Only when a conversation by that name EXISTS in this directory. Without the check every key
+    // resumes, which means a stale one is handed to `grok --resume` — and an agent asked for a
+    // conversation it cannot find starts a fresh one, silently, under the old session's id.
+    !hasLivePty && requested && grokConversationExists(grokSessionsRoot(), cwd, requested) ? requested : null,
+  );
 }
 
-interface GrokStart {
-  sessionId: string;
-  live: PtyEntry | undefined;
-  resumeConversationId: string | null;
-  cwd: string;
-  attachGuiMcp: boolean;
-  mcpGroups: readonly ToolGroup[];
+// The two agents that read their MCP servers from a file in the DIRECTORY rather than from a
+// per-session flag: agy from `.agents/mcp_config.json`, grok from `.grok/config.toml`. That one
+// fact decides their whole connection shape and is what claude and codex do NOT share — for them
+// `?gui=0` picks which tools the session gets, while here every session in a directory reaches
+// whatever that directory registered and the flag only keeps a grid cell out of the sidebar.
+//
+// So this describes what differs between the two, and handleDirectoryMcpAgentConnection below
+// owns everything that does not. grok arrived as a copy of antigravity's handler (#1441) and the
+// two had already drifted in wording by the time jscpd named them.
+export interface DirectoryMcpWsAgent {
+  kind: TerminalWsKind;
+  /** How a failed start names this agent to the user. */
+  label: string;
+  /** Awaited BEFORE the session is resolved, for an agent that keeps a session -> conversation map
+   *  on disk: a reconnect arriving mid-read would see an empty map and decline to resume a
+   *  conversation that is right there, which is the server-restart case the map exists for.
+   *
+   *  Required rather than optional, and `null` where there is nothing to wait for (grok mints no
+   *  id of its own, so it keeps no map) — an agent added later has to answer this question rather
+   *  than inherit "no" by leaving a key out. */
+  hydrated: Promise<unknown> | null;
+  resolveSession: (requested: string | null, cwd: string) => ResumableSession;
+  spawn: (deps: WsRouteDeps) => SpawnDirectoryMcpPty;
 }
 
-// Reattach or spawn, as ONE function handed to startAndWire — the reattach must not take a shortcut
-// around it. `reattachPty` only swaps the socket and replays the buffer; returning early on it left
-// a reloaded terminal printing output while ignoring every keystroke, and never detaching or
-// reaping when the socket closed.
-function startGrokEntry(deps: WsRouteDeps, ws: WebSocket, start: GrokStart): PtyEntry {
-  const { sessionId, live, resumeConversationId, cwd, attachGuiMcp, mcpGroups } = start;
-  const entry = live ? deps.reattachPty(live, ws, sessionId) : deps.spawnGrokPty(sessionId, ws, resumeConversationId, cwd, { mcpGroups });
-  // Single view (gui) = the attached session IS the actively-viewed pane. A grid dev-terminal cell
-  // (gui=0) is only "viewed" once focused, and says so with a `view` frame.
-  entry.active = attachGuiMcp;
-  return entry;
-}
+export const ANTIGRAVITY_WS_AGENT: DirectoryMcpWsAgent = {
+  kind: "antigravity",
+  label: "Antigravity",
+  hydrated: antigravityConversationsHydrated,
+  resolveSession: (requested) => resolveAntigravitySession(requested),
+  spawn: (deps) => deps.spawnAntigravityPty,
+};
 
-// grok terminal (?cwd=<dir>, ?session=<id> to reattach/resume). Like antigravity and unlike claude
-// and codex there is no per-session GUI MCP surface to attach or withhold: grok reads its servers
-// from `.grok/config.toml` in the DIRECTORY, so every session there reaches whatever that directory
-// registered — `?gui=0` only keeps a grid dev terminal out of the sidebar.
-async function handleGrokConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
+export const GROK_WS_AGENT: DirectoryMcpWsAgent = {
+  kind: "grok",
+  label: "Grok",
+  hydrated: null,
+  resolveSession: resolveGrokSession,
+  spawn: (deps) => deps.spawnGrokPty,
+};
+
+// antigravity (?cwd=<dir>, ?session=<id> to reattach/resume) and grok, which connect identically —
+// see DirectoryMcpWsAgent for why those two and not claude or codex.
+export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAgent, deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   const { url, requested, cwd, unusable, size } = wsConnectionContext(req);
-  if (refuseUnusableWorkspace(ws, "grok", unusable, requested)) return;
+  if (refuseUnusableWorkspace(ws, agent.kind, unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
-  // No `await …Hydrated` here, and that is not an oversight: the two agents that need one keep a
-  // session -> conversation map on disk, and grok has no such map to wait for.
-  const { sessionId, live, resumeConversationId } = resolveGrokSession(requested, cwd);
-  // The directory's per-tree PORT / DB_NAME (#1367), like every other spawn path — a grok cell in a
+  if (agent.hydrated) await agent.hydrated;
+  const { sessionId, live, resumeConversationId } = agent.resolveSession(requested, cwd);
+  // The directory's per-tree PORT / DB_NAME (#1367), like every other spawn path — a cell in a
   // worktree gets that tree's own values, not the ones another tree is already serving on.
   await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, "grok", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+  const early = await admitAgentSession(ws, agent.kind, { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
   if (!early) return;
 
   // The directory's registered groups, read here because the lookup reads Claude Code's config
@@ -771,11 +767,18 @@ async function handleGrokConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpg
   // was started with, and rewriting the shared file on a reattach would speak for every other
   // session in the directory.
   const mcpGroups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
-  if (!clientStillConnected(ws, "grok", sessionId, early)) return;
-  const startFailureMessage = startFailureMessageFor("Grok");
-  startAndWire(deps, ws, { id: sessionId, tag: "grok", early, startFailureMessage, size }, () =>
-    startGrokEntry(deps, ws, { sessionId, live, resumeConversationId, cwd, attachGuiMcp, mcpGroups }),
-  );
+  if (!clientStillConnected(ws, agent.kind, sessionId, early)) return;
+  const startFailureMessage = startFailureMessageFor(agent.label);
+  // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps
+  // the socket and replays the buffer, so returning early here left a reloaded terminal printing
+  // output while ignoring every keystroke, and never detaching or reaping on close.
+  startAndWire(deps, ws, { id: sessionId, tag: agent.kind, early, startFailureMessage, size }, () => {
+    const entry = live ? deps.reattachPty(live, ws, sessionId) : agent.spawn(deps)(sessionId, ws, resumeConversationId, cwd, { mcpGroups });
+    // Single view (gui) = the attached session IS the actively-viewed pane. A grid dev-terminal
+    // cell (gui=0) is only "viewed" once focused, and says so with a `view` frame.
+    entry.active = attachGuiMcp;
+    return entry;
+  });
 }
 
 export function mountTerminalWebSockets(deps: WsRouteDeps) {
@@ -828,6 +831,6 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
   runWss.on("connection", (ws, req) => handleRunConnection(deps, ws, req));
   runLaunchWss.on("connection", (ws, req) => void handleLaunchConnection(deps, ws, req));
   runCodexWss.on("connection", (ws, req) => void handleCodexConnection(deps, ws, req));
-  runAntigravityWss.on("connection", (ws, req) => void handleAntigravityConnection(deps, ws, req));
-  runGrokWss.on("connection", (ws, req) => void handleGrokConnection(deps, ws, req));
+  runAntigravityWss.on("connection", (ws, req) => void handleDirectoryMcpAgentConnection(ANTIGRAVITY_WS_AGENT, deps, ws, req));
+  runGrokWss.on("connection", (ws, req) => void handleDirectoryMcpAgentConnection(GROK_WS_AGENT, deps, ws, req));
 }

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -5,7 +5,7 @@ import { antigravityAdapter } from "../agents/antigravity.js";
 import { buildAntigravityArgs } from "../agents/antigravity-args.js";
 import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
-import { startDirectoryMcpPty, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
+import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
@@ -30,16 +30,17 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
 
   const spawnAntigravityPty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
-    // Snapshotted BEFORE the spawn: the capture below tells agy's new conversation from the ones
-    // that were already on disk by the difference.
-    const root = antigravityBrainRoot();
-    const before = snapshotAntigravitySessions(root);
-
-    const args = buildAntigravityArgs({ resume: resumeConversationId, model: deps.antigravityModel, skipPermissions: true, initialPrompt });
     // agy reads its MCP servers from `.agents/mcp_config.json` in the directory rather than from a
     // flag, so that file is brought in line with the groups on the way past: a directory whose
     // switches were flipped before this shipped — or with the `claude mcp` CLI directly — needs no
     // second action to work (#1443).
+    syncDirectoryMcpForSpawn(sessionId, cwd, mcpGroups, syncAntigravityMcpConfig);
+    // Snapshotted between the sync and the spawn: the capture below tells agy's new conversation
+    // from the ones already on disk by the difference, so it must be the world agy is about to find.
+    const root = antigravityBrainRoot();
+    const before = snapshotAntigravitySessions(root);
+
+    const args = buildAntigravityArgs({ resume: resumeConversationId, model: deps.antigravityModel, skipPermissions: true, initialPrompt });
     const { entry, spawnedAtMs } = startDirectoryMcpPty({
       sessionId,
       ws,
@@ -49,8 +50,6 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
       binEnvVar: antigravityAdapter.binEnvVar,
       args,
       resumeConversationId,
-      mcpGroups,
-      syncMcpConfig: syncAntigravityMcpConfig,
     });
 
     if (resumeConversationId) {

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -1,19 +1,13 @@
 // Starting an Antigravity (`agy`) session in a PTY. Like codex, agy mints its conversation id
 // itself, so a fresh session is watched until that id appears — that is what lets a later cold
 // reconnect resume it.
-import type { WebSocket } from "ws";
-import { PORT } from "../config/env.js";
-import type { ToolGroup } from "../../common/toolGroups.js";
-import { guiMcpEnv } from "./mcp-config.js";
 import { antigravityAdapter } from "../agents/antigravity.js";
 import { buildAntigravityArgs } from "../agents/antigravity-args.js";
 import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
-import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
+import { startDirectoryMcpPty, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
-import { ptyStartLine } from "./pty-exit-log.js";
 import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
-import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createAntigravitySpawner(deps: SpawnDeps) {
@@ -34,55 +28,30 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
       .catch(() => {});
   }
 
-  function spawnAntigravityPty(
-    sessionId: string,
-    ws: WebSocket | null,
-    resumeConversationId: string | null,
-    cwd: string,
-    options: {
-      /** The tool groups this cell's DIRECTORY has registered, read by the caller (the lookup
-       *  reads Claude Code's config files, and this is sync). agy reads its MCP servers from a
-       *  file in the directory rather than from a flag, so that file is brought in line with them
-       *  here, on the way past: a directory whose switches were flipped before this shipped — or
-       *  with the `claude mcp` CLI directly — needs no second action to work.
-       *
-       *  REQUIRED, and deliberately not defaulted: the file is shared by every session in the
-       *  directory, so a caller that had not looked the groups up would not merely spawn without
-       *  GUI tools — it would CLEAR the entries every other session there is using. */
-      mcpGroups: readonly ToolGroup[];
-      /** Run this as the session's first turn (a collection action, a background chat). */
-      initialPrompt?: string | null;
-    },
-  ): PtyEntry {
+  const spawnAntigravityPty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
-    // Only for a spawn that will really START agy. After a server restart `ptys` is empty but the
-    // tmux session can still be there, so this function is reached for what turns out to be a
-    // REATTACH — and the agy already running in that pane read `.agents/mcp_config.json` once, at
-    // its own start. Rewriting it now cannot affect that process; it can only speak for the OTHER
-    // sessions in the directory, which is the one thing this file must never do.
-    //
-    // The damaging case is not hypothetical: the caller resolves the groups with
-    // `.catch(() => [])`, so a transient failure reading Claude Code's config would arrive here as
-    // "no groups" and CLEAR the entries every live agy in that directory is using. Skipping the
-    // reattach leaves the file exactly as the running sessions expect it (#1443; grok, which has
-    // the same per-directory shape, was fixed in #1441).
-    if (!ptyWouldReattach(sessionId, true)) syncAntigravityMcpConfig(cwd, mcpGroups);
+    // Snapshotted BEFORE the spawn: the capture below tells agy's new conversation from the ones
+    // that were already on disk by the difference.
     const root = antigravityBrainRoot();
     const before = snapshotAntigravitySessions(root);
 
     const args = buildAntigravityArgs({ resume: resumeConversationId, model: deps.antigravityModel, skipPermissions: true, initialPrompt });
-    // The session id reaches the GUI MCP bridge through this environment and nowhere else — the
-    // config file agy reads is shared by every session in the directory (see antigravity-mcp.ts).
-    const { term, tmux, reattached } = ptySpawn(sessionId, deps.antigravityBin, args, cwd, true, {
-      env: guiMcpEnv(sessionId, PORT),
+    // agy reads its MCP servers from `.agents/mcp_config.json` in the directory rather than from a
+    // flag, so that file is brought in line with the groups on the way past: a directory whose
+    // switches were flipped before this shipped — or with the `claude mcp` CLI directly — needs no
+    // second action to work (#1443).
+    const { entry, spawnedAtMs } = startDirectoryMcpPty({
+      sessionId,
+      ws,
+      cwd,
+      agent: "antigravity",
+      bin: deps.antigravityBin,
       binEnvVar: antigravityAdapter.binEnvVar,
+      args,
+      resumeConversationId,
+      mcpGroups,
+      syncMcpConfig: syncAntigravityMcpConfig,
     });
-    const spawnedAtMs = Date.now();
-    const note = resumeConversationId ? `resume ${resumeConversationId}` : null;
-    console.log(ptyStartLine({ agent: "antigravity", pid: term.pid, cwd, tmux, reattached, sessionId, note }));
-
-    const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "antigravity" };
-    ptys.set(sessionId, entry);
 
     if (resumeConversationId) {
       // Recorded on resume too, not just on the spawn that discovered it: a session resumed by the
@@ -96,7 +65,7 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
 
     wireAgentPtyRelay(entry, sessionId, spawnedAtMs, deps);
     return entry;
-  }
+  };
 
   return { spawnAntigravityPty };
 }

--- a/server/session/spawn-directory-mcp.ts
+++ b/server/session/spawn-directory-mcp.ts
@@ -37,6 +37,31 @@ export type SpawnDirectoryMcpPty = (
   options: DirectoryMcpSpawnOptions,
 ) => PtyEntry;
 
+/** Point the directory's shared config at `groups` — but only for a spawn that will really START
+ *  the agent.
+ *
+ *  After a server restart `ptys` is empty while the tmux session can still be there, so a spawner
+ *  is reached for what turns out to be a REATTACH — and the agent already running in that pane
+ *  read the config file once, at its own start. Rewriting it now cannot affect that process; it
+ *  can only speak for the OTHER sessions in the directory, which is the one thing this must never
+ *  do.
+ *
+ *  The damaging case is not hypothetical: the route resolves the groups with `.catch(() => [])`,
+ *  so a transient failure reading Claude Code's config arrives as "no groups" and would clear the
+ *  entries every live session in that directory is using (#1441, #1443).
+ *
+ *  Its own function rather than a step inside the spawn, so a caller that must observe the world
+ *  as the agent will find it can do so BETWEEN the two — which is what antigravity's conversation
+ *  snapshot is. */
+export function syncDirectoryMcpForSpawn(
+  sessionId: string,
+  cwd: string,
+  groups: readonly ToolGroup[],
+  sync: (cwd: string, groups: readonly ToolGroup[]) => void,
+): void {
+  if (!ptyWouldReattach(sessionId, true)) sync(cwd, groups);
+}
+
 interface DirectoryMcpStart {
   sessionId: string;
   ws: WebSocket | null;
@@ -47,26 +72,12 @@ interface DirectoryMcpStart {
   args: string[];
   /** Named in the start line, so the log says which conversation a session picked up. */
   resumeConversationId: string | null;
-  mcpGroups: readonly ToolGroup[];
-  /** Bring the directory's shared config file in line with `mcpGroups`. */
-  syncMcpConfig: (cwd: string, groups: readonly ToolGroup[]) => void;
 }
 
-/** Sync the directory's config, start the pty, register it. `spawnedAtMs` comes back because the
- *  caller wires the relay (and may have its own work to do first). */
+/** Start the pty and register it. `spawnedAtMs` comes back because the caller wires the relay
+ *  (and may have its own work to do first). */
 export function startDirectoryMcpPty(start: DirectoryMcpStart): { entry: PtyEntry; spawnedAtMs: number } {
-  const { sessionId, ws, cwd, agent, bin, binEnvVar, args, resumeConversationId, mcpGroups, syncMcpConfig } = start;
-  // Only for a spawn that will really START the agent. After a server restart `ptys` is empty but
-  // the tmux session can still be there, so this is reached for what turns out to be a REATTACH —
-  // and the agent already running in that pane read the config file once, at its own start.
-  // Rewriting it now cannot affect that process; it can only speak for the OTHER sessions in the
-  // directory, which is the one thing this must never do.
-  //
-  // The damaging case is not hypothetical: the caller resolves the groups with `.catch(() => [])`,
-  // so a transient failure reading Claude Code's config would arrive here as "no groups" and clear
-  // the entries every live session in that directory is using.
-  if (!ptyWouldReattach(sessionId, true)) syncMcpConfig(cwd, mcpGroups);
-
+  const { sessionId, ws, cwd, agent, bin, binEnvVar, args, resumeConversationId } = start;
   // The session id reaches the GUI MCP bridge through this environment and nowhere else — the
   // config file the agent reads is shared by every session in the directory.
   const { term, tmux, reattached } = ptySpawn(sessionId, bin, args, cwd, true, { env: guiMcpEnv(sessionId, PORT), binEnvVar });

--- a/server/session/spawn-directory-mcp.ts
+++ b/server/session/spawn-directory-mcp.ts
@@ -1,0 +1,80 @@
+// Starting an agent whose MCP servers come from a file in the DIRECTORY rather than from a
+// per-session flag: agy (`.agents/mcp_config.json`) and grok (`.grok/config.toml`).
+//
+// That one fact is what makes these two the same shape and claude/codex a different one. Because
+// the file is SHARED by every session in the directory, writing it is not a private act — it
+// speaks for terminals this spawn knows nothing about — which is where both of the bugs below
+// came from, and why the rule lives here once instead of in each spawner (#1441, #1443).
+import type { WebSocket } from "ws";
+import { PORT } from "../config/env.js";
+import type { SessionAgent } from "../../common/sessionAgent.js";
+import type { ToolGroup } from "../../common/toolGroups.js";
+import { guiMcpEnv } from "./mcp-config.js";
+import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
+import { ptyStartLine } from "./pty-exit-log.js";
+import { ptys } from "./registry.js";
+import type { PtyEntry } from "./types.js";
+
+/** What such a spawn takes beyond the session itself. */
+export interface DirectoryMcpSpawnOptions {
+  /** The tool groups this cell's DIRECTORY has registered, read by the caller (the lookup reads
+   *  Claude Code's config files, and this is sync).
+   *
+   *  REQUIRED, and deliberately not defaulted: the file is shared by every session in the
+   *  directory, so a caller that had not looked the groups up would not merely spawn without GUI
+   *  tools — it would clear the entries every other session there is using. */
+  mcpGroups: readonly ToolGroup[];
+  /** Run this as the session's first turn (a collection action, a background chat). */
+  initialPrompt?: string | null;
+}
+
+/** The signature both directory-MCP spawners have, for a caller that holds either one. */
+export type SpawnDirectoryMcpPty = (
+  sessionId: string,
+  ws: WebSocket | null,
+  resumeConversationId: string | null,
+  cwd: string,
+  options: DirectoryMcpSpawnOptions,
+) => PtyEntry;
+
+interface DirectoryMcpStart {
+  sessionId: string;
+  ws: WebSocket | null;
+  cwd: string;
+  agent: SessionAgent;
+  bin: string;
+  binEnvVar: string;
+  args: string[];
+  /** Named in the start line, so the log says which conversation a session picked up. */
+  resumeConversationId: string | null;
+  mcpGroups: readonly ToolGroup[];
+  /** Bring the directory's shared config file in line with `mcpGroups`. */
+  syncMcpConfig: (cwd: string, groups: readonly ToolGroup[]) => void;
+}
+
+/** Sync the directory's config, start the pty, register it. `spawnedAtMs` comes back because the
+ *  caller wires the relay (and may have its own work to do first). */
+export function startDirectoryMcpPty(start: DirectoryMcpStart): { entry: PtyEntry; spawnedAtMs: number } {
+  const { sessionId, ws, cwd, agent, bin, binEnvVar, args, resumeConversationId, mcpGroups, syncMcpConfig } = start;
+  // Only for a spawn that will really START the agent. After a server restart `ptys` is empty but
+  // the tmux session can still be there, so this is reached for what turns out to be a REATTACH —
+  // and the agent already running in that pane read the config file once, at its own start.
+  // Rewriting it now cannot affect that process; it can only speak for the OTHER sessions in the
+  // directory, which is the one thing this must never do.
+  //
+  // The damaging case is not hypothetical: the caller resolves the groups with `.catch(() => [])`,
+  // so a transient failure reading Claude Code's config would arrive here as "no groups" and clear
+  // the entries every live session in that directory is using.
+  if (!ptyWouldReattach(sessionId, true)) syncMcpConfig(cwd, mcpGroups);
+
+  // The session id reaches the GUI MCP bridge through this environment and nowhere else — the
+  // config file the agent reads is shared by every session in the directory.
+  const { term, tmux, reattached } = ptySpawn(sessionId, bin, args, cwd, true, { env: guiMcpEnv(sessionId, PORT), binEnvVar });
+  const spawnedAtMs = Date.now();
+  const note = resumeConversationId ? `resume ${resumeConversationId}` : null;
+  console.log(ptyStartLine({ agent, pid: term.pid, cwd, tmux, reattached, sessionId, note }));
+
+  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent };
+  ptys.set(sessionId, entry);
+  return { entry, spawnedAtMs };
+}

--- a/server/session/spawn-grok.ts
+++ b/server/session/spawn-grok.ts
@@ -8,69 +8,33 @@
 //
 // It is antigravity-shaped on the OTHER axis: grok reads its MCP servers from a file in the
 // directory rather than from a flag, so that file is brought in line on the way past.
-import type { WebSocket } from "ws";
-import { PORT } from "../config/env.js";
-import type { ToolGroup } from "../../common/toolGroups.js";
-import { guiMcpEnv } from "./mcp-config.js";
 import { grokAdapter } from "../agents/grok.js";
 import { buildGrokArgs } from "../agents/grok-args.js";
 import { syncGrokMcpConfig } from "../agents/grok-mcp.js";
-import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
+import { startDirectoryMcpPty, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
-import { ptyStartLine } from "./pty-exit-log.js";
-import { ptys } from "./registry.js";
-import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createGrokSpawner(deps: SpawnDeps) {
-  function spawnGrokPty(
-    sessionId: string,
-    ws: WebSocket | null,
-    resumeConversationId: string | null,
-    cwd: string,
-    options: {
-      /** The tool groups this cell's DIRECTORY has registered, read by the caller (the lookup reads
-       *  Claude Code's config files, and this is sync).
-       *
-       *  REQUIRED, and deliberately not defaulted, for the reason antigravity's is: the file is
-       *  shared by every session in the directory, so a caller that had not looked the groups up
-       *  would not merely spawn without GUI tools — it would DEREGISTER the ones every other
-       *  session there is using. */
-      mcpGroups: readonly ToolGroup[];
-      /** Run this as the session's first turn (a collection action, a background chat). */
-      initialPrompt?: string | null;
-    },
-  ): PtyEntry {
+  const spawnGrokPty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
-    // Only for a spawn that will really START grok. After a server restart `ptys` is empty but the
-    // tmux session can still be there, so this function is reached for what turns out to be a
-    // REATTACH — and the grok already running in that pane read `.grok/config.toml` once, at its
-    // own start. Rewriting it now cannot affect that process; it can only speak for the OTHER
-    // sessions in the directory, which is the one thing this file must never do.
-    //
-    // The damaging case is not hypothetical: the caller resolves the groups with
-    // `.catch(() => [])`, so a transient failure reading Claude Code's config would arrive here as
-    // "no groups" and DEREGISTER the servers every live grok in that directory is using. Skipping
-    // the reattach leaves the file exactly as the running sessions expect it (Codex review, #1441).
-    if (!ptyWouldReattach(sessionId, true)) syncGrokMcpConfig(cwd, mcpGroups);
-
     const args = buildGrokArgs({ sessionId, resume: resumeConversationId, model: deps.grokModel, skipPermissions: true, initialPrompt });
-    // The session id reaches the GUI MCP bridge through this environment and nowhere else — the
-    // config file grok reads is shared by every session in the directory (see grok-mcp.ts).
-    const { term, tmux, reattached } = ptySpawn(sessionId, deps.grokBin, args, cwd, true, {
-      env: guiMcpEnv(sessionId, PORT),
+    const { entry, spawnedAtMs } = startDirectoryMcpPty({
+      sessionId,
+      ws,
+      cwd,
+      agent: "grok",
+      bin: deps.grokBin,
       binEnvVar: grokAdapter.binEnvVar,
+      args,
+      resumeConversationId,
+      mcpGroups,
+      syncMcpConfig: syncGrokMcpConfig,
     });
-    const spawnedAtMs = Date.now();
-    const note = resumeConversationId ? `resume ${resumeConversationId}` : null;
-    console.log(ptyStartLine({ agent: "grok", pid: term.pid, cwd, tmux, reattached, sessionId, note }));
-
-    const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "grok" };
-    ptys.set(sessionId, entry);
 
     wireAgentPtyRelay(entry, sessionId, spawnedAtMs, deps);
     return entry;
-  }
+  };
 
   return { spawnGrokPty };
 }

--- a/server/session/spawn-grok.ts
+++ b/server/session/spawn-grok.ts
@@ -11,13 +11,15 @@
 import { grokAdapter } from "../agents/grok.js";
 import { buildGrokArgs } from "../agents/grok-args.js";
 import { syncGrokMcpConfig } from "../agents/grok-mcp.js";
-import { startDirectoryMcpPty, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
+import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createGrokSpawner(deps: SpawnDeps) {
   const spawnGrokPty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
+    syncDirectoryMcpForSpawn(sessionId, cwd, mcpGroups, syncGrokMcpConfig);
+
     const args = buildGrokArgs({ sessionId, resume: resumeConversationId, model: deps.grokModel, skipPermissions: true, initialPrompt });
     const { entry, spawnedAtMs } = startDirectoryMcpPty({
       sessionId,
@@ -28,8 +30,6 @@ export function createGrokSpawner(deps: SpawnDeps) {
       binEnvVar: grokAdapter.binEnvVar,
       args,
       resumeConversationId,
-      mcpGroups,
-      syncMcpConfig: syncGrokMcpConfig,
     });
 
     wireAgentPtyRelay(entry, sessionId, spawnedAtMs, deps);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -61,7 +61,7 @@ import {
 import { CELL_STATUS, DOT_STATUS, HEADER_STATUS } from "./cellStatusClasses";
 import { handoffTargets, pullLastTurn, slotLabel, type HandoffTarget } from "../composables/useHandoff";
 import { runOneExchange, liveCrossTalkDeps } from "../composables/useCrossTalk";
-import { runRoundTable, liveRoundTableDeps, memberFromTarget, type TableMember } from "../composables/useRoundTable";
+import { runRoundTable, memberFromTarget, type TableMember } from "../composables/useRoundTable";
 import { roundTableMessage } from "../composables/roundTableRules";
 import RoundTableMenu from "./RoundTableMenu.vue";
 import { outcomeMessage } from "../composables/exchangeRules";
@@ -716,7 +716,7 @@ async function startTable(targets: HandoffTarget[], budget: number) {
   const { outcome, turnsTaken } = await runRoundTable(
     [self, ...targets.map(memberFromTarget)],
     budget,
-    liveRoundTableDeps(() => tableStop),
+    liveCrossTalkDeps(() => tableStop),
   );
   tableRunning.value = false;
   showAskMsg(`${roundTableMessage(outcome)} · ${turnsTaken} turn${turnsTaken === 1 ? "" : "s"}`);

--- a/src/composables/useRoundTable.ts
+++ b/src/composables/useRoundTable.ts
@@ -13,9 +13,8 @@
 // It runs in the browser, like the exchange it generalises: close the tab and the table stops. A
 // conversation that continues where nobody is watching is a different feature with a different
 // safety argument.
-import { pasteAndSubmit, listSlots } from "./useTerminalConnections";
 import { waitVerdict } from "./exchangeRules";
-import { fetchLastTurn, type HandoffSource, type HandoffTarget } from "./useHandoff";
+import type { HandoffSource, HandoffTarget } from "./useHandoff";
 import { endsTheTable, nextSpeaker, roundTablePrompt, type RoundTableOutcome } from "./roundTableRules";
 import type { TurnFetch, CrossTalkDeps } from "./useCrossTalk";
 import { ANSWER_TIMEOUT_MS, POLL_MS } from "./useCrossTalk";
@@ -33,7 +32,11 @@ export interface RoundTableRun {
   turnsTaken: number;
 }
 
-/** The same dependency surface the exchange uses — one runner shape, one set of fakes. */
+/** The same dependency surface the exchange uses — one runner shape, one set of fakes.
+ *
+ *  Which is why the table has no `liveRoundTableDeps` of its own: it was byte-identical to
+ *  `liveCrossTalkDeps` (jscpd caught it), and a second factory for one type is a second place to
+ *  change when the sockets move. Callers use `liveCrossTalkDeps`. */
 export type RoundTableDeps = CrossTalkDeps;
 
 /** Poll a member's log until the turn OUR message produced appears. Same rule as the exchange:
@@ -109,19 +112,6 @@ export async function runRoundTable(members: readonly TableMember[], budget: num
   } catch {
     return { outcome: "failed", turnsTaken };
   }
-}
-
-/** The real wiring. Identical to the exchange's — the table is the same machine with a longer
- *  loop, so it borrows the same sockets rather than growing a second set. */
-export function liveRoundTableDeps(isAborted: () => boolean): RoundTableDeps {
-  return {
-    fetchTurn: (source, shape) => fetchLastTurn(source, shape),
-    submit: pasteAndSubmit,
-    runsSession: (key, sessionId) => listSlots().some((slot) => slot.key === key && slot.sessionId === sessionId),
-    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
-    now: () => performance.now(),
-    isAborted,
-  };
 }
 
 /** A handoff target as a seat at the table — the picker lists the same cells the exchange menu

--- a/test/server/config/dir-file.spec.ts
+++ b/test/server/config/dir-file.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+//
+// The containment rule a directory's own config is held to, and — the point of this file — the
+// fact that BOTH keys that name a file are held to the same one.
+//
+// `icon` was written by copying `sound`'s four checks, which is how a rule ends up fixed on one
+// side and not the other: each caller's own spec would still be green while the two disagreed
+// about what escapes. So the pairs below assert the two answers TOGETHER.
+import { describe, it, expect } from "vitest";
+import { makeTempDir } from "../../support/tempDir.js";
+import { writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import path from "node:path";
+import { resolveFileWithinDir } from "../../../server/config/dir-file";
+import { resolveDirSound } from "../../../server/config/dir-config";
+import { resolveIconFile } from "../../../server/config/dir-icon";
+
+const tmp = () => makeTempDir("mt-dirfile-");
+
+// A .png so the icon side gets past its own extension check and both callers are really being
+// asked the same question — containment, not "is this an image".
+const IMAGE = "logo.png";
+
+/** What each caller answers for `ref`, as one value: null / null when the rule refuses. */
+const bothAnswers = (dir: string, ref: string): { sound: string | null; icon: string | null } => ({
+  sound: resolveDirSound(dir, ref),
+  icon: resolveIconFile(dir, ref)?.path ?? null,
+});
+
+describe("resolveFileWithinDir", () => {
+  it("resolves a relative path, including into a subdirectory", () => {
+    const dir = tmp();
+    mkdirSync(path.join(dir, "assets"));
+    writeFileSync(path.join(dir, "assets", IMAGE), "x");
+    expect(resolveFileWithinDir(dir, `assets/${IMAGE}`)).toBe(path.join(dir, "assets", IMAGE));
+    expect(resolveFileWithinDir(dir, `./assets/${IMAGE}`)).toBe(path.join(dir, "assets", IMAGE));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("refuses an absolute path and an escape via ..", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "proj");
+    mkdirSync(dir);
+    writeFileSync(path.join(parent, IMAGE), "x");
+    expect(resolveFileWithinDir(dir, path.join(parent, IMAGE))).toBeNull();
+    expect(resolveFileWithinDir(dir, `../${IMAGE}`)).toBeNull();
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  // The lexical check alone passes here — the string never leaves the directory. Only the realpath
+  // re-check catches it, which is why the rule is four checks and not three.
+  it("refuses a symlink inside the directory that points out of it", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "proj");
+    mkdirSync(dir);
+    writeFileSync(path.join(parent, IMAGE), "x");
+    symlinkSync(path.join(parent, IMAGE), path.join(dir, IMAGE));
+    expect(resolveFileWithinDir(dir, IMAGE)).toBeNull();
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  it("refuses what is not a file: a missing path, and a directory", () => {
+    const dir = tmp();
+    mkdirSync(path.join(dir, "assets"));
+    expect(resolveFileWithinDir(dir, IMAGE)).toBeNull();
+    expect(resolveFileWithinDir(dir, "assets")).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("`sound` and `icon` are confined by the same rule", () => {
+  it("both resolve a file that really is inside the directory", () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, IMAGE), "x");
+    expect(bothAnswers(dir, `./${IMAGE}`)).toEqual({ sound: path.join(dir, IMAGE), icon: path.join(dir, IMAGE) });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("both refuse an absolute path, a .. escape, and an outward symlink", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "proj");
+    mkdirSync(dir);
+    writeFileSync(path.join(parent, IMAGE), "x");
+    symlinkSync(path.join(parent, IMAGE), path.join(dir, "link.png"));
+    const refused = { sound: null, icon: null };
+    expect(bothAnswers(dir, path.join(parent, IMAGE))).toEqual(refused);
+    expect(bothAnswers(dir, `../${IMAGE}`)).toEqual(refused);
+    expect(bothAnswers(dir, "./link.png")).toEqual(refused);
+    rmSync(parent, { recursive: true, force: true });
+  });
+});

--- a/test/server/routes/directory-mcp-ws-agent.spec.ts
+++ b/test/server/routes/directory-mcp-ws-agent.spec.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+//
+// agy and grok connect through ONE handler, because they are the same kind of agent: their MCP
+// servers come from a file in the DIRECTORY, shared by every session running there, rather than
+// from a per-session flag. grok's endpoint arrived as a copy of antigravity's, and the copy is how
+// #1441 happened — the reattach rule was fixed on one side while the other went on rewriting a
+// file its running sessions were using.
+//
+// So these assert the two agents TOGETHER on everything they must agree about, and separately on
+// the one thing they must not: only antigravity keeps a session -> conversation map on disk, so
+// only antigravity waits for it to be read.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { WebSocket } from "ws";
+
+// Resolved by hand, so "did this connection wait?" is a question the test can ask rather than a
+// race it has to hope for.
+let releaseAntigravityMap: () => void = () => {};
+const antigravityMapRead = new Promise<void>((resolve) => {
+  releaseAntigravityMap = resolve;
+});
+
+const ptys = new Map<string, unknown>();
+vi.mock("../../../server/session/registry.js", () => ({
+  ptys,
+  antigravityConversations: new Map(),
+  antigravityConversationsHydrated: antigravityMapRead,
+  codexRollouts: new Map(),
+  codexRolloutsHydrated: Promise.resolve(),
+  customAgentSessionsHydrated: Promise.resolve(),
+  markDevTerminalSession: vi.fn(),
+  markAttachedSessionPlaced: vi.fn(),
+}));
+
+vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/infra/tmux.js")>()),
+  tmuxAvailable: () => false,
+  tmuxHasSession: () => false,
+}));
+
+// The directory's registered tool groups, read off Claude Code's config files on the real path.
+const registeredGuiMcpGroups = vi.fn(() => Promise.resolve(["render"]));
+vi.mock("../../../server/infra/gui-mcp-registration.js", () => ({ registeredGuiMcpGroups }));
+
+vi.mock("../../../server/config/worktree-env.js", () => ({
+  ensureWorktreeEnv: vi.fn(() => Promise.resolve({})),
+  reservedWorktreeEnv: () => ({}),
+}));
+
+// A real occupancy read runs git against the cwd; this spec is about the handler's shape.
+vi.mock("../../../server/session/worktree-session-limit.js", () => ({
+  claimLaunch: () => ({ release: vi.fn(), contended: false }),
+  worktreeOccupancy: () => Promise.resolve({ isWorktree: false, session: null }),
+}));
+
+const { handleDirectoryMcpAgentConnection, ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT } = await import("../../../server/routes/ws-routes.js");
+
+const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
+
+function fakeWs() {
+  const sent: string[] = [];
+  return {
+    sent,
+    readyState: 1,
+    OPEN: 1,
+    send: (raw: string) => sent.push(raw),
+    close: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+  };
+}
+
+// The five arguments a directory-MCP spawner is called with, recorded per agent.
+const spawnAntigravityPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+const spawnGrokPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+const reattachPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+
+const makeDeps = () =>
+  ({
+    spawnAntigravityPty,
+    spawnGrokPty,
+    reattachPty,
+    handleClientFrame: vi.fn(),
+    handleClientClose: vi.fn(),
+  }) as never;
+
+const spawnerFor = (kind: string) => (kind === "antigravity" ? spawnAntigravityPty : spawnGrokPty);
+
+let dir = "";
+const request = (query = "") => ({ url: `/ws?cwd=${encodeURIComponent(dir)}${query}` });
+
+// Both agents, so a rule asserted once is asserted for the pair. Named so a failure says which.
+const AGENTS = [ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT];
+
+beforeEach(() => {
+  ptys.clear();
+  vi.clearAllMocks();
+  registeredGuiMcpGroups.mockResolvedValue(["render"]);
+  releaseAntigravityMap();
+  dir = mkdtempSync(path.join(tmpdir(), "mt-dirmcp-"));
+});
+afterEach(() => {
+  ptys.clear();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe.each(AGENTS.map((agent) => [agent.kind, agent] as const))("/ws/%s", (kind, agent) => {
+  const spawn = () => spawnerFor(kind);
+
+  it("announces the session id before spawning", async () => {
+    const ws = fakeWs();
+    await handleDirectoryMcpAgentConnection(agent, makeDeps(), ws as unknown as WebSocket, request());
+    expect(JSON.parse(ws.sent[0] ?? "{}")).toMatchObject({ type: "session", cwd: dir });
+    expect(spawn()).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole reason the groups are read in the route rather than in the spawner: the lookup is
+  // async and the spawner is not, so a spawn that did not receive them would clear the entries
+  // every other session in the directory is using.
+  it("hands the spawner the directory's registered tool groups", async () => {
+    await handleDirectoryMcpAgentConnection(agent, makeDeps(), fakeWs() as unknown as WebSocket, request());
+    expect(spawn()).toHaveBeenCalledWith(expect.any(String), expect.anything(), null, dir, { mcpGroups: ["render"] });
+  });
+
+  // A reattach keeps the tools its running process was started with — nothing re-reads the file,
+  // so rewriting it could only speak for the other sessions there.
+  it("reattaches a live pty instead of spawning, and looks up no groups", async () => {
+    const live = { term: fakeTerm(), cwd: dir };
+    const session = "11111111-2222-4333-8444-555555555555";
+    ptys.set(session, live);
+    await handleDirectoryMcpAgentConnection(agent, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
+    expect(reattachPty).toHaveBeenCalledTimes(1);
+    expect(spawn()).not.toHaveBeenCalled();
+    expect(registeredGuiMcpGroups).not.toHaveBeenCalled();
+  });
+
+  // `?gui=0` is a grid cell rather than the single view. For these two agents it decides only that
+  // — never which tools the session reaches, which is what claude and codex use it for.
+  it("marks the session active for the single view and inactive for a grid cell", async () => {
+    await handleDirectoryMcpAgentConnection(agent, makeDeps(), fakeWs() as unknown as WebSocket, request());
+    expect(spawn().mock.results[0]?.value).toMatchObject({ active: true });
+    await handleDirectoryMcpAgentConnection(agent, makeDeps(), fakeWs() as unknown as WebSocket, request("&gui=0"));
+    expect(spawn().mock.results[1]?.value).toMatchObject({ active: false });
+  });
+});
+
+// The one asymmetry, and it is structural: agy mints its own conversation id and this server keeps
+// the mapping on disk, so a reconnect arriving mid-read would see an empty map and start a fresh
+// conversation under the old session's id. grok takes `--session-id`, keeps no such map, and has
+// nothing to wait for.
+describe("waiting for the on-disk conversation map", () => {
+  it("antigravity resolves nothing until its map has been read", async () => {
+    let readable = () => {};
+    const pending = new Promise<void>((resolve) => {
+      readable = resolve;
+    });
+    const connection = handleDirectoryMcpAgentConnection(
+      { ...ANTIGRAVITY_WS_AGENT, hydrated: pending },
+      makeDeps(),
+      fakeWs() as unknown as WebSocket,
+      request(),
+    );
+    // A macrotask turn, not one microtask: every OTHER await on this path is an already-resolved
+    // promise, so a handler that skipped the wait would be all the way through and spawned by now.
+    // With a single `await Promise.resolve()` this test passes either way (measured).
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(spawnAntigravityPty).not.toHaveBeenCalled();
+    readable();
+    await connection;
+    expect(spawnAntigravityPty).toHaveBeenCalledTimes(1);
+  });
+
+  it("grok declares it has nothing to wait for, rather than leaving the question out", () => {
+    expect(GROK_WS_AGENT.hydrated).toBeNull();
+    expect(ANTIGRAVITY_WS_AGENT.hydrated).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Code scanning の `jscpd/duplicate-code` open アラート **4 件（142 / 143 / 144 / 147）をすべて解消**した。
挙動は変えていない（純粋なリファクタ）。

4 件とも原因は同じ: **後から足したものが、隣にあった同型のコードを写して増えた**。
`icon` は `sound` を、grok は antigravity を写している。写した側だけが直る drift が実バグで、
実際 #1441（grok の reattach で共有 MCP ファイルを書き潰す）はその形で起きている。
なので写しを消すのではなく、**共有ヘルパにして片側だけ直せないようにした**。

| alert | 重複していたもの | 対応 |
| --- | --- | --- |
| 142 | `resolveDirSound` ↔ `resolveIconFile` の封じ込め 4 段 | `server/config/dir-file.ts` の `resolveFileWithinDir` に集約 |
| 143 | `resolveCodexSession` / `resolveAntigravitySession` / `resolveGrokSession` / `resolveLaunchSession` の頭と尾 | `liveSessionFacts` / `resolveResumableSession` |
| 144 | antigravity と grok の WS ハンドラ | `handleDirectoryMcpAgentConnection` + `DirectoryMcpWsAgent` 記述子 |
| 147 | `spawnAntigravityPty` ↔ `spawnGrokPty` | `server/session/spawn-directory-mcp.ts` の `startDirectoryMcpPty` |

CI と同じ引数で jscpd を回して **clone 0 件**（before: 4 clone / 57 lines / 258 tokens）。

**追記（main マージ後）**: main を取り込んだところ #1458（Round table）が新しい clone を 1 件持ち込んでいた
（`liveRoundTableDeps` が `liveCrossTalkDeps` と byte-identical。型も既に `RoundTableDeps = CrossTalkDeps`）。
**アラートを 1 件残さず 0 にするため、これも本 PR で潰した**（ユーザー確認済み）。

## Items to Confirm / Review

人間に見てほしいのはこの 6 点。**1 と 2 は後から足したもので、ここが一番見てほしい**:

1. **#1458（Round table）のコードに触れている** — `src/composables/useRoundTable.ts` /
   `src/components/TerminalCell.vue`。重複していた `liveRoundTableDeps` を削除し、呼び出しを
   `liveCrossTalkDeps` に寄せた。型は元から同一（`export type RoundTableDeps = CrossTalkDeps`）なので
   値の意味は変わらないが、**直前にマージされた他の機能への変更**なので意図に反していないか確認してほしい。
2. **spawner の順序を一度壊しかけた** — 共有ヘルパに MCP 同期を畳み込んだ結果、antigravity の
   conversation スナップショットが「同期の前」に動いていた。実害はない（同期はプロジェクト cwd、
   スナップショットは agy の brain root を見るので内容は変わらず、広がる窓は agy 起動の数秒に対して
   マイクロ秒）が、このリファクタが動かす理由のない順序変更だった。
   `syncDirectoryMcpForSpawn` として分離し、**元の順序（同期 → スナップショット → spawn）に戻した**。
   **Codex は LGTM（inline 指摘 0）で見逃しており、自分のレビューで見つけた**。
3. **`DirectoryMcpWsAgent.hydrated` を optional ではなく必須 + `null` 許容にした**。
   agy だけが session→conversation マップをディスクに持つので、agy は読み込み待ちが要る / grok は要らない。
   optional にすると「5 番目のエージェントがキーを書き忘れて黙って待たない」が起きるので、
   **明示的に `null` と書かせる**設計にした。この判断でよいか。
4. **codex の `resumeRolloutId` という呼び名を境界で付け替えている**。共有側は `resumeConversationId` で返し、
   `resolveCodexSession` だけが `resumeRolloutId` にリネームして返す（rollout は codex 固有の語彙のため）。
5. **`liveSessionFacts` で `hasLivePty` を `ptys.has()` から `!!ptys.get()` に変えた**。
   `ptys: Map<string, PtyEntry>` に undefined は入らないので等価だが、意図的な変更。
6. **`resolveIconFile` の戻り値を `DirIcon` → `DirIconFile`（file 側だけ）に狭めた**。
   この関数は url 側を返しえないので型を実態に合わせた。`DirIcon` 自体は従来どおり union。

## User Prompt

> fix duplicate
> https://github.com/receptron/mulmoterminal/security/code-scanning

## 実装方針

### アラートの対を特定する

SARIF / API のアラートは**片側の位置しか持たない**ので、相手を知るには CI と同じ引数でローカル実行するしかない
（前回 `plans/refactor-jscpd-duplication.md` と同じ手順）:

```
npx jscpd@5.0.12 . --format "typescript,vue" \
  --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" --reporters console
```

### 1. cwd 配下へのファイル封じ込め (142)

`dir-icon.ts` のコメント自身が "the same rule, and the same order of checks, as resolveDirSound" と
書いていた通りの写し。4 段（絶対パス拒否 → `path.resolve` → `isWithin` → 実在かつ通常ファイル →
`realpathSync.native` で再チェック）を `resolveFileWithinDir` に出した。
拡張子判定は icon 固有（拒否理由が違う）なので `resolveIconFile` に残した。

### 2. live pty / tmux の事実収集 (143)

4 つの resolver が同じ 3 行で始まり、うち 3 つが `resolveReattachableId` + 同じ return で終わっていた。
違うのは **resume id の探し方だけ**（ディスク上のマップ / 実在プローブ / 両方）なので、それをコールバックで受け、
残りは共通側が決める形にした。claude は `--session-id` を取るので別問題（`resolveClaudeSession` はそのまま）。

### 3. antigravity / grok の WS ハンドラ (144)

この 2 つは「**MCP サーバをディレクトリの設定ファイルから読む**」同じ形のエージェント
（agy = `.agents/mcp_config.json`、grok = `.grok/config.toml`）。claude / codex と違って per-session の
`--mcp-config` が無く、`?gui=0` は dev terminal かどうかしか決めない。
ハンドラ本体・`start*Entry`・`*Start` interface まで同型だったので 1 つにまとめ、差分は記述子に持たせた。

### 4. spawner (147)

シグネチャ・`mcpGroups` の JSDoc・「reattach になる spawn では共有 MCP ファイルを書かない」ガード・
`ptySpawn` 周りが同型。2 つに分けた:

- `syncDirectoryMcpForSpawn` — reattach ガード付きの MCP 同期（長い WHY コメントもここに 1 つだけ）
- `startDirectoryMcpPty` — `ptySpawn` → 起動ログ → `ptys.set`

**分けたのは順序のため**。1 つに畳むと antigravity の conversation スナップショットが同期の前に動いてしまい、
「agy がこれから見る世界を撮る」というスナップショットの役目とずれる。分けたことで各 spawner が
自分の順序を保てる（antigravity: 同期 → スナップショット → spawn）。
conversation 捕捉と `wireAgentPtyRelay` は従来どおり呼び出し側。

## 検証

- **jscpd（CI と同じ引数）: `Found 0 clones.`**（main マージで増えた #1458 由来の 1 件も含めて 0）
- `yarn format` / `yarn lint`（error 0、warning 12 は既存の max-lines）/ `yarn typecheck` / `yarn build` すべて緑
- `yarn test`: **605 files / 8709 passed**（新規 16 件を含む）
- **新しいテストが「落ちること」も確認した**（壊れないテストを足しても意味がないので）:
  - `realpathSync` 再チェックを外す → symlink のテストが 3 件落ちる（`dir-icon.spec.ts` の既存分も含む）
  - `mcpGroups` の lookup を `[]` に潰す → 両エージェントのテストが落ちる
  - hydration の `await` を外す → antigravity の順序テストが落ちる。
    なおこのテストは最初 `await Promise.resolve()` を使っていて**壊しても通ってしまった**ので、
    macrotask 1 ターン待つ形に直した（この経緯はテスト内にコメントとして残してある）
  - reattach ガードを `syncDirectoryMcpForSpawn` に移したあと、ガードを潰して
    既存の mcp-sync spec 4 件が落ちることを確認（移動でカバレッジが抜けていないことの担保）
- **実機確認**（build 成功 ≠ 動作する、なので）: サーバを実際に起動し、`/ws/antigravity` を本物の
  WebSocket で叩いた。`{"type":"session",...}` の通知 → agy が tmux 経由で起動
  （`[pty] started antigravity (pid=… via tmux)`）→ 実端末出力 37 フレームを確認。
  同じ session id で再接続すると **id が保たれ、新しい pty は起動しない**（reattach）ことも確認。
  grok は手元に CLI が無いため実機未確認 — 共通ハンドラを通るので spec でカバーしている。

refs #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2
