### PR TITLE
docs: RoundTableDeps = CrossTalkDeps が暫定であることをコードに書く

### DIFF
--- a/src/composables/useRoundTable.ts
+++ b/src/composables/useRoundTable.ts
@@ -35,8 +35,14 @@ export interface RoundTableRun {
 /** The same dependency surface the exchange uses — one runner shape, one set of fakes.
  *
  *  Which is why the table has no `liveRoundTableDeps` of its own: it was byte-identical to
- *  `liveCrossTalkDeps` (jscpd caught it), and a second factory for one type is a second place to
- *  change when the sockets move. Callers use `liveCrossTalkDeps`. */
+ *  `liveCrossTalkDeps`, and a second factory building one type is a second place to change when
+ *  the sockets move. Callers use `liveCrossTalkDeps`.
+ *
+ *  Whether the two STAY one is open, so here is the rule for splitting them again: a separate
+ *  type and a separate factory are earned when the table needs something the exchange genuinely
+ *  does not — its own socket, its own clock, a fact only a ring of N cells has. Until then it is
+ *  a copy whose only job is to be a copy, and a copy is the thing that gets fixed on one side.
+ *  So: if the table is never going to become a different feature, do not bring the copy back. */
 export type RoundTableDeps = CrossTalkDeps;
 
 /** Poll a member's log until the turn OUR message produced appears. Same rule as the exchange:


### PR DESCRIPTION
## Summary

`export type RoundTableDeps = CrossTalkDeps`（#1473 で `liveRoundTableDeps` を削除して 1 本化したもの）
の **暫定性をコードのコメントに明記**する。コメントのみの変更で、実行されるコードは 1 行も変わらない。

#1473 の時点でコメントが語っていたのは「なぜ 1 つにしたか」だけだった。そのため次の読み手には
**「意図的に共有している」のか「まだ分けていないだけ」なのか区別がつかず**、2 つのファイルが
それぞれ自前の factory を欲しがった瞬間にコピーが復活する。

そこで**分岐を認める条件**を書いた:

> a separate type and a separate factory are earned when the table needs something the exchange
> genuinely does not — its own socket, its own clock, a fact only a ring of N cells has.
> Until then it is a copy whose only job is to be a copy, and a copy is the thing that gets fixed
> on one side. So: if the table is never going to become a different feature, do not bring the
> copy back.

## Items to Confirm / Review

1. **「別機能になるなら分ける / ならないならコピーを戻さない」という条件の書き方**でよいか。
   これはユーザーの指示（「コピーだけで将来的に別機能にしないなら、コピーはやめる」）を
   コード側のルールとして表現したもの。
2. **issue / plan ファイルは作っていない**。コメント 6 行のみで、#1472 の直接の後追いのため。
   必要なら追加する。

## User Prompt

> RoundTableDeps = CrossTalkDeps はpending 。あとで変更あるかも知れないしないかも。メモっておいて後で確認

> コードにもコメントを書いておこう。コピーだけで将来的に別機能にしないなら、コピーはやめる、と。

## 検証

- `yarn format` / `yarn lint`（error 0、warning 12 は既存の max-lines）/ `yarn typecheck` /
  `yarn build` / `yarn test`（605 files / 8709 passed）すべて緑
- コメントのみの変更なので挙動の差分なし

refs #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2
