### PR TITLE
fix(test): Windows CI で worktree-pr.spec が本物の gh を起動してタイムアウトする問題を直す

### DIFF
--- a/plans/fix-1481-windows-gh-spawn-timeout.md
+++ b/plans/fix-1481-windows-gh-spawn-timeout.md
@@ -1,0 +1,71 @@
+# fix #1481 — Windows CI: worktree-pr.spec.ts times out on the real `gh`
+
+## The failure
+
+`Windows (daily)` on main, [run 31055365939](https://github.com/receptron/mulmoterminal/actions/runs/31055365939)
+(node 24.x), and before it [run 31041081619](https://github.com/receptron/mulmoterminal/actions/runs/31041081619):
+
+```
+FAIL test/server/git/worktree-pr.spec.ts > push / PR actions >
+  createOrOpenPR pushes, then reports no-forge for a remote on no forge it knows
+Error: Test timed out in 30000ms.
+Error: EPERM, Permission denied: ...\Temp\mt-pr-home-AgjGhf   ← rmDirRetrying, afterEach
+```
+
+## Where the time goes
+
+Measured, not guessed — from the **passing 22.x job of the same commit**, which prints per-test
+durations:
+
+| test | duration |
+| --- | --- |
+| pushes the worktree branch to origin | 2150 ms |
+| refuses to push when there is no origin remote | 1384 ms |
+| refuses a path that isn't a managed worktree | 887 ms |
+| **createOrOpenPR … reports no-forge** | **20858 ms** |
+
+Every test in the file runs the same `beforeEach` (three temp dirs, `git init --bare`, `git init`,
+config, commit) and the first one additionally creates a worktree, commits and pushes — the whole
+of the failing test except its last line. So ~19 s belongs to `createOrOpenPR`'s tail:
+
+- ~5 more `git` calls (`repoRoot`, `defaultBaseBranch`, `git remote get-url` twice)
+- **two real `gh` spawns** — `gh pr create`, then `gh pr list` when that fails
+
+A `git` spawn on that runner is ~100 ms (28 tests of `worktrees.spec.ts`, 10+ spawns each, in
+32 s), so the extra git accounts for ~0.5 s of the 19 s. The rest is the two `gh` starts. `git.exe`
+is warm — the suite spawns it hundreds of times; `gh.exe` is started exactly twice in the whole
+suite and is read cold off a slow NTFS volume. On macOS the same two calls cost 154 ms measured
+directly, which is why nothing but Windows ever saw this.
+
+`worktree-pr.spec.ts` is the only spec in the suite that spawns a real `gh` — and it is the only
+one that timed out.
+
+The `EPERM` is downstream of the timeout, not a second defect: vitest abandons the test at 30 s
+while its children are still alive with a cwd inside the temp dir, and Windows will not remove a
+directory that is a live process's cwd. `rmDirRetrying`'s 10 retries span 5.5 s and lose to a
+process that is still running. It cannot happen once the test does not time out, so nothing in
+teardown is changed here — swallowing it would mask the next real hang.
+
+## The fix
+
+Stub `gh` in that spec; keep `git` real.
+
+The test's own comment already says what it assumes: *"No CLI can make a request here"*. That was
+an assumption about the machine, not an assertion — so state it, instead of relying on an ambient
+`gh` erroring its way to the same answer at whatever cost the platform charges. `spawn-collect` is
+mocked with a passthrough for `git` and a fixed failure for anything else, which is exactly the
+`no-forge` precondition.
+
+What the test still exercises for real: a real repo, a real managed worktree, a real
+`git push -u origin`, the branch actually landing on the bare remote, and `repoForDir` reading a
+real remote URL and finding no forge.
+
+What already covers the `gh` argv and the create→list→fallback wiring: `worktree-pr-timeout.spec.ts`
+(mocked `spawnCollect`) and `pr-finalize-body.spec.ts` (injected `Runner`).
+
+## Verification
+
+- locally: the file is green and the test drops to roughly its siblings' cost
+- ground truth: `workflow_dispatch` the Windows workflow on this branch and read the test's
+  duration out of the log — the claim is falsifiable there. If it stays ~20 s, the attribution
+  above is wrong and the run says so.

--- a/plans/fix-1481-windows-gh-spawn-timeout.md
+++ b/plans/fix-1481-windows-gh-spawn-timeout.md
@@ -5,7 +5,7 @@
 `Windows (daily)` on main, [run 31055365939](https://github.com/receptron/mulmoterminal/actions/runs/31055365939)
 (node 24.x), and before it [run 31041081619](https://github.com/receptron/mulmoterminal/actions/runs/31041081619):
 
-```
+```text
 FAIL test/server/git/worktree-pr.spec.ts > push / PR actions >
   createOrOpenPR pushes, then reports no-forge for a remote on no forge it knows
 Error: Test timed out in 30000ms.

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { makeTempDir } from "../../support/tempDir.js";
 import { writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -7,6 +7,18 @@ import path from "node:path";
 import { createWorktree, gitTopLevel } from "../../../server/git/worktrees.js";
 import { compareUrl, pushWorktree, createOrOpenPR } from "../../../server/git/worktree-pr.js";
 import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "./wtTestUtil.js";
+
+// git runs for real here — the point of these tests is a real repo, a real worktree and a real
+// push. `gh` does not: it is the one external binary the suite would otherwise start, and two
+// cold `gh.exe` starts cost ~19s of this file's 30s budget on the Windows runner while the same
+// tests' git work costs ~2s (#1481). "No CLI can answer here" is the CONDITION being tested, so
+// say it, rather than leaving it to whatever `gh` the machine happens to have.
+vi.mock("../../../server/git/spawn-collect.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../server/git/spawn-collect.js")>();
+  const spawnCollect: typeof actual.spawnCollect = (bin, args, opts) =>
+    bin === "git" ? actual.spawnCollect(bin, args, opts) : Promise.resolve({ ok: false, stdout: "", stderr: `${bin}: no such CLI here` });
+  return { ...actual, spawnCollect };
+});
 
 describe("compareUrl", () => {
   it("builds the GitHub compare/open-PR url, keeping the branch slash raw", () => {
@@ -106,7 +118,8 @@ describe("push / PR actions", () => {
       g(wt.path, "commit", "-m", "work");
 
       const res = await createOrOpenPR(wt.path);
-      // No CLI can make a request here and the remote is on no forge we know → no page to fall back to
+      // No CLI can make or find the request (stubbed above) and the remote is on no forge we
+      // know → no page to fall back to
       expect(res.ok).toBe(false);
       expect(res.reason).toBe("no-forge");
       // but the push half still landed the branch on the remote


### PR DESCRIPTION
## Summary

`Windows (daily)` が main で落ちていた（[run 31055365939](https://github.com/receptron/mulmoterminal/actions/runs/31055365939)、その前に [run 31041081619](https://github.com/receptron/mulmoterminal/actions/runs/31041081619)）。原因は `test/server/git/worktree-pr.spec.ts` の 1 テストが**本物の `gh` バイナリを 2 回起動している**こと。Windows ランナーではその 2 回で 30 秒の予算のうち ~19 秒を使い切る。

同じスペックの他のテスト（git の作業は同一で PR 部分だけが無い）は ~2 秒。そこで `gh` だけをスタブし、`git` は本物のまま残した。

refs #1481

## Items to Confirm / Review

- **時間の帰属は測定によるもので、推測ではない。** 同一コミットで**成功した 22.x ジョブ**のテスト別時間から:

  | test | duration |
  | --- | --- |
  | pushes the worktree branch to origin | 2150 ms |
  | refuses to push when there is no origin remote | 1384 ms |
  | refuses a path that isn't a managed worktree | 887 ms |
  | **createOrOpenPR … reports no-forge** | **20858 ms** |

  差分は `createOrOpenPR` の末尾（git 5 回程度 + `gh pr create` / `gh pr list`）だけ。Windows での git spawn は ~100ms（`worktrees.spec.ts` の 28 テスト・10+ spawn/テストで 32 秒）なので git 分は ~0.5 秒、残り ~18 秒が 2 回の `gh` 起動。`git.exe` はスイート全体で何百回も起動されて温まっている一方、`gh.exe` はスイート中ちょうど 2 回しか起動されずコールドで読み込まれる。macOS では同じ 2 コールを直接計測して 154 ms なので、Windows でしか出ない。
- **スタブが本当に効いているか（テストが別の理由で通っていないか）を反証で確認した**: スタブを「gh 成功」に書き換えるとこのテストは落ちる。つまり `no-forge` の判定は確かにこの経路を通っている。
- **`EPERM` は原因ではなく結果**。30 秒でテストが打ち切られた時点で子プロセスが temp ディレクトリを cwd にしたまま生きており、Windows は生きたプロセスの cwd を削除できない。タイムアウトが消えれば起きないので、teardown（`rmDirRetrying`）には手を入れていない — ここで握りつぶすと次の本物のハングが見えなくなる。
- **カバレッジは落ちていない**: 実リポジトリ・実 worktree・実 `git push`・ブランチが bare remote に本当に載ること・`repoForDir` が実 remote URL を読んで forge なしと判定すること、はすべて本物のまま。`gh` の argv と create→list→fallback の配線は既に `worktree-pr-timeout.spec.ts`（`spawnCollect` を mock）と `pr-finalize-body.spec.ts`（`Runner` を注入）が見ている。
- スイート中で本物の `gh` を起動していたスペックはこの 1 つだけ。

## User Prompt

> fix https://github.com/receptron/mulmoterminal/actions/runs/31055365939

## 実装

`test/server/git/worktree-pr.spec.ts` で `server/git/spawn-collect.js` を mock し、`git` は本物へパススルー、それ以外（`gh` / `glab`）は固定の失敗を返す。テスト自身のコメントが既に *"No CLI can make a request here"* と書いていたとおり、これは**テスト対象の前提条件**であって、たまたまその場にある `gh` がエラーで同じ結論に辿り着くのに任せる必要はない。

設計メモは `plans/fix-1481-windows-gh-spawn-timeout.md`。

## 検証

- ローカル (macOS): 該当テストは 582ms → 411ms（兄弟テスト 384ms とほぼ同じ）。`yarn format` / `lint` / `typecheck` / `build` / `test`（614 files, 8816 tests）すべて green。
- ground truth: このブランチに対して Windows ワークフローを `workflow_dispatch` で実行し、ログ上のテスト実行時間で確認する（下にコメントする）。~20 秒のままなら上の帰属が誤りだったことがその run で分かる。

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows test reliability by preventing external CLI processes from causing timeouts.
  * Preserved coverage for real Git operations, repository and worktree handling, push behavior, remote URLs, and pull request fallback scenarios.

* **Documentation**
  * Added a plan outlining the Windows CI timeout fix and recommended verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->