### PR TITLE
fix(test): Windows で rooms の 'cannot be read' テスト 2 件が落ちるのを直す

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -89,6 +89,19 @@ machine that runs the suite. Not `endsWith` either: `unplaced-sessions.json` end
 `yarn test` on macOS/Linux cannot see any of this — the whole class only appears where the
 separator and the drive letter differ.
 
+## File permissions
+
+**`chmod` moves the read-only attribute and nothing else.** There are no POSIX permission bits
+on NTFS, so `chmodSync(file, 0o000)` leaves the file perfectly **readable** — only writing is
+refused. A test that makes a file unreadable to prove a read failure is reported (rather than
+answered as "empty") therefore proves nothing there: the read succeeds and the assertion fails
+(`rooms.spec.ts` and `room-routes.spec.ts`, #1484).
+
+A `process.getuid?.() !== 0` guard does not cover this. It is there because root defeats the
+bit too — but on Windows `process.getuid` is **undefined**, so `undefined !== 0` is true and the
+assertion runs anyway. Skip the whole test with `it.skipIf(process.platform === "win32")`, the
+way `test/server/session/session-settings.spec.ts` does for the owner-only-mode check.
+
 ## Filesystem watching
 
 **`fs.watch` on an 8.3 short path is unreliable, and can abort the process.** `os.tmpdir()`

--- a/test/server/rooms/rooms.spec.ts
+++ b/test/server/rooms/rooms.spec.ts
@@ -60,7 +60,10 @@ describe("postToRoom / readRoom", () => {
   // "Nothing has been said" and "I could not find out" are different answers, and they were both
   // being given as an empty conversation — so a caller carried on without history it needed
   // (CodeRabbit review on #1456).
-  it("throws rather than answering empty when the room cannot be read", () => {
+  //
+  // Not on Windows: chmod there moves the read-only attribute and nothing else, so `0o000` leaves
+  // the file perfectly readable and the read this test needs to fail simply succeeds (#1484).
+  it.skipIf(process.platform === "win32")("throws rather than answering empty when the room cannot be read", () => {
     postToRoom("locked", "#1", "secret");
     const file = roomFile("locked");
     if (!file) throw new Error("expected a file");

--- a/test/server/routes/room-routes.spec.ts
+++ b/test/server/routes/room-routes.spec.ts
@@ -65,7 +65,10 @@ describe("GET /api/rooms/:room", () => {
 
   // A read failure must NOT look like an empty conversation, or the caller carries on without
   // history it needed (CodeRabbit review on #1456).
-  it("answers 500 rather than 200-with-nothing when the room cannot be read", async () => {
+  //
+  // Not on Windows: chmod there moves the read-only attribute and nothing else, so `0o000` leaves
+  // the file perfectly readable and the read this test needs to fail simply succeeds (#1484).
+  it.skipIf(process.platform === "win32")("answers 500 rather than 200-with-nothing when the room cannot be read", async () => {
     postToRoom("locked", "#1", "secret");
     const file = roomFile("locked");
     if (!file) throw new Error("expected a file");


### PR DESCRIPTION
## Summary

`Windows (daily)` が main で落ちている残り 2 件を直す（[run 31056446517](https://github.com/receptron/mulmoterminal/actions/runs/31056446517)）。#1482 で `worktree-pr` のタイムアウトを直した後、Windows CI に残っていたのはこの 2 件だけ。

- `test/server/rooms/rooms.spec.ts > throws rather than answering empty when the room cannot be read`
- `test/server/routes/room-routes.spec.ts > answers 500 rather than 200-with-nothing when the room cannot be read`

どちらも「読めないファイル」を `chmodSync(file, 0o000)` で作っているが、**Windows の chmod は read-only 属性しか動かさない**（NTFS に POSIX のパーミッションビットは無い）。ファイルは普通に読めるままなので `readRoom` は成功し、throw も 500 も起きない。

既存の `process.getuid?.() !== 0` ガードは root 用で、Windows では `process.getuid` が undefined のため `undefined !== 0` が true になり、アサーションが走ってしまう。

refs #1484

## Items to Confirm / Review

- **スキップという選択について。** Windows には「読めないファイル」を chmod で作る手段が無いので、テストの前提条件自体が作れない。同じ理由・同じ書き方で既にスキップしている前例が `test/server/session/session-settings.spec.ts` の "keeps the file readable only by its owner"（`it.skipIf(process.platform === "win32")`）。
- **代わりにポータブルな「読めない」条件（ファイルの代わりにディレクトリを置く等）にしなかった理由**: それは permission denied ではなく別種の失敗で、テストのコメントが言っている条件と変わる。Windows で本当にありがちな読み取り失敗（他プロセスによるロック）のカバレッジが欲しいなら、それは別のテストとして足すべきで、この修正の範囲外。
- `docs/windows-gotchas.md` に 1 項目追加（「実際に踏んだ罠」を集めるファイルなので）。`getuid` ガードが Windows をカバーしない点も明記した。

## User Prompt

> fix https://github.com/receptron/mulmoterminal/actions/runs/31055365939

（元の run の失敗は #1482 で修正済み。その検証のために Windows ワークフローを回したところ、この 2 件が main でも落ちていることが分かったため、続けて直すよう指示を受けた。）

## 検証

- ローカル (macOS): `yarn format` / `lint` / `typecheck` / `build` / `test`（614 files, 8816 tests）green。macOS では従来どおり実行される（スキップされるのは Windows だけ）。
- ground truth: このブランチで Windows ワークフローを `workflow_dispatch` 実行して確認する（結果は下にコメントする）。

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)