### PR TITLE
fix: claude のターン境界を推測せず stop_reason から読む (#1487)

### DIFF
--- a/plans/fix-1487-turn-boundary.md
+++ b/plans/fix-1487-turn-boundary.md
@@ -4,7 +4,7 @@
 
 3席のラウンドテーブルを実機で回したら、3人目の発言が
 
-```
+```text
 I'll read the actual files before weighing in.
 ```
 

--- a/plans/fix-1487-turn-boundary.md
+++ b/plans/fix-1487-turn-boundary.md
@@ -1,0 +1,48 @@
+# claude のターン境界を推測せずに読む — #1487
+
+## 何が起きたか
+
+3席のラウンドテーブルを実機で回したら、3人目の発言が
+
+```
+I'll read the actual files before weighing in.
+```
+
+だけで確定され、40秒後に書かれた本題が部屋に入らなかった。後続の席はこの前置きしか読めず、
+「全員合意」で終了した。失われた本文には**両者への反論**が入っていた。
+
+## 原因
+
+`lastTurnFromClaudeParsed` は、アシスタントの散文レコードが1つ来た時点で
+`lastComplete` を更新する。Claude Code はツールを呼ぶ前に前置きを1レコード出すので、
+そこがターンの終わりとして扱われる。
+
+境界自体は記録されている（`stop_reason`）。このファイル自身の方針
+「a turn boundary that is recorded rather than guessed」に反していたのは実装のほうだった。
+codex 側は `task_complete` を読んでいるので無傷。
+
+実 transcript 12本・散文レコード 1957件のうち **1524件 (78%) が `tool_use`** =
+ターン継続中。ツールを使ってから答えるターンはすべて対象。
+
+## 直し方
+
+- `ConversationTurn` に `endsTurn` を足し、アシスタントレコードの `stop_reason` から立てる。
+  `tool_use` **だけ**が「まだ続く」。`end_turn` / `stop_sequence` / `max_tokens` は終わり。
+- `stop_reason` が無いレコードは**終わり扱い**。逆に倒すとターンが永久に完了せず、
+  exchange が必ずタイムアウトする — 現状維持側に倒すほうが安全。
+- `lastTurnFromClaudeParsed` は `endsTurn` のターンだけを完了として記録する。
+- `conversationTurnsFromParsed` の他の利用者（ロスターの「いま何を言っているか」、
+  タイトル要約）は**途中発言が欲しい**ので、`endsTurn` を無視する＝挙動は変わらない。
+
+## テスト
+
+- 前置き（`tool_use`）→ ツール →結論（`end_turn`）の並びで、**結論**が返ること
+- 前置きだけ書いてまだ動いている最中は、**ひとつ前の完了ターン**が返ること
+- `stop_reason` が無いレコードは完了として扱われること（現状維持）
+- ロスターの `latestAssistantTextFromParsed` は途中発言を返し続けること（回帰防止）
+- 実機の3席テーブルで、3人目の本題が部屋に入ること（これが本題）
+
+## やらないこと
+
+`appendSystemPrompt`（クロージングサマリ）が部屋の投稿の半分以上を占める件は別。
+#1456 側に書く。

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -14,10 +14,17 @@ export interface LastTurn {
 
 export const EMPTY_TURN: LastTurn = { prompt: null, reply: null };
 
-// Claude's transcript interleaves narration and tool calls as separate assistant
-// records; the LAST prose record of a turn is its conclusion, which is what a reader
-// in another session wants. A turn only counts once it has that reply, so a prompt
-// still being worked on falls back to the previous exchange.
+// Claude's transcript interleaves narration and tool calls as separate assistant records; the
+// prose record that ENDS the turn is its conclusion, which is what a reader in another session
+// wants. A turn only counts once it has that reply, so a prompt still being worked on falls back
+// to the previous exchange.
+//
+// "Ends the turn" is read from the record's own stop reason, not inferred from there being prose.
+// Claude writes a preamble before it runs any tool, so the two are different facts, and taking the
+// first for the second handed another cell "I'll read the actual files before weighing in." as a
+// seat's whole contribution to a round table — the real answer, which disagreed with the others,
+// arrived 40 seconds later and was never passed on (#1487). 78% of the assistant prose records in a
+// sample of real transcripts were mid-turn, so this is the ordinary case, not an edge one.
 export function lastTurnFromClaudeParsed(records: Record<string, unknown>[]): LastTurn {
   let open: LastTurn | null = null;
   let lastComplete: LastTurn | null = null;
@@ -26,6 +33,7 @@ export function lastTurnFromClaudeParsed(records: Record<string, unknown>[]): La
       open = { prompt: turn.text, reply: null };
       continue;
     }
+    if (!turn.endsTurn) continue; // still working — this is narration, not the answer
     open = { prompt: open?.prompt ?? null, reply: turn.text };
     lastComplete = open;
   }

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -109,7 +109,23 @@ export const aiTitleFromJsonl = (raw: string): string | null => aiTitleFromParse
 export interface ConversationTurn {
   role: "user" | "assistant";
   text: string;
+  /** Assistant only: does this record END the turn, or is the agent still working?
+   *
+   *  Claude writes a preamble ("I'll read the files first") as a complete assistant record BEFORE
+   *  it runs any tool, so "there is prose" and "the turn is over" are different facts — and reading
+   *  the first as the second relayed a preamble to another cell as its answer (#1487). Most callers
+   *  here WANT the in-flight prose (the roster shows what an agent is saying right now); only
+   *  `lastTurnFromClaudeParsed` needs the boundary, so it is carried rather than filtered. */
+  endsTurn?: boolean;
 }
+
+/** `tool_use` is the only stop reason that means "I am not finished" — everything else
+ *  (`end_turn`, `stop_sequence`, `max_tokens`, a refusal) ends the turn one way or another.
+ *
+ *  A record with NO stop reason counts as ending it. That is the pre-#1487 behaviour, and it is the
+ *  safe direction to be wrong in: treating an unrecognised record as still-running would leave a
+ *  turn that never completes, and every exchange waiting on it would time out. */
+const endsTurn = (message: Record<string, unknown>): boolean => message.stop_reason !== "tool_use";
 
 // The joined text of an assistant turn's content: only "text" blocks (tool_use blocks
 // carry no prose a title would use). A plain-string content is returned as-is.
@@ -124,22 +140,23 @@ function assistantText(content: unknown): string | null {
   return joined || null;
 }
 
+// One record as a turn, or null when it carries no prose (a tool-only assistant record, a
+// slash-command wrapper).
+function turnFromRecord(o: Record<string, unknown>): ConversationTurn | null {
+  const message = isRecord(o.message) ? o.message : null;
+  const content = message?.content;
+  if (o.type === "user") {
+    const text = userPromptText(content);
+    return text ? { role: "user", text } : null;
+  }
+  if (o.type !== "assistant") return null;
+  const text = assistantText(content);
+  return text ? { role: "assistant", text, endsTurn: message ? endsTurn(message) : true } : null;
+}
+
 // Ordered user/assistant turns as plain text, skipping slash/local-command wrappers and
 // tool-only assistant turns. Feeds the header-title summarizer.
-export function conversationTurnsFromParsed(records: Record<string, unknown>[]): ConversationTurn[] {
-  const turns: ConversationTurn[] = [];
-  for (const o of records) {
-    const content = isRecord(o.message) ? o.message.content : undefined;
-    if (o.type === "user") {
-      const text = userPromptText(content);
-      if (text) turns.push({ role: "user", text });
-    } else if (o.type === "assistant") {
-      const text = assistantText(content);
-      if (text) turns.push({ role: "assistant", text });
-    }
-  }
-  return turns;
-}
+export const conversationTurnsFromParsed = (records: Record<string, unknown>[]): ConversationTurn[] => records.flatMap((o) => turnFromRecord(o) ?? []);
 export const conversationTurnsFromJsonl = (raw: string): ConversationTurn[] => conversationTurnsFromParsed(parseJsonl(raw));
 
 // How many user turns the transcript holds, so the roster can tell whether a session has

--- a/test/server/session/last-turn.spec.ts
+++ b/test/server/session/last-turn.spec.ts
@@ -6,7 +6,13 @@ import { parseJsonl } from "../../../server/session/transcript.js";
 const line = (o: unknown) => JSON.stringify(o);
 const user = (text: string) => line({ type: "user", message: { content: text } });
 const assistant = (text: string) => line({ type: "assistant", message: { content: [{ type: "text", text }] } });
-const toolUse = (name: string) => line({ type: "assistant", message: { content: [{ type: "tool_use", name, input: {} }] } });
+// The real file carries a stop reason on every assistant record, and `tool_use` is the one that
+// means "still working". The helper above omits it on purpose — a record without one has to keep
+// counting as the end of a turn (#1487) — so these two model what Claude actually writes.
+const narrating = (text: string) => line({ type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "text", text }] } });
+const concluding = (text: string, stopReason = "end_turn") =>
+  line({ type: "assistant", message: { stop_reason: stopReason, content: [{ type: "text", text }] } });
+const toolUse = (name: string) => line({ type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "tool_use", name, input: {} }] } });
 
 // codex rollout rows, in the shape the real ~/.codex/sessions/**/rollout-*.jsonl uses:
 // only the turn boundaries carry turn_id, and task_complete carries the whole reply.
@@ -26,6 +32,31 @@ describe("lastTurnFromClaudeParsed", () => {
   it("takes the LAST prose record of a turn, not the narration before the tools", () => {
     const raw = [user("do X"), assistant("let me look"), toolUse("Read"), assistant("done — here is why")].join("\n");
     expect(lastTurnFromClaudeJsonl(raw)).toEqual({ prompt: "do X", reply: "done — here is why" });
+  });
+
+  // The case above with the stop reasons the real file carries. Without them the fixture passed
+  // while the shipped code relayed the preamble: a round table seat contributed "I'll read the
+  // actual files before weighing in." and its real answer — which disagreed with the others —
+  // arrived 40 seconds later and was never passed on (#1487).
+  it("does not mistake the preamble before a tool call for the answer", () => {
+    const raw = [user("do X"), narrating("I'll read the actual files before weighing in."), toolUse("Read"), concluding("LRU, and here is why")].join("\n");
+    expect(lastTurnFromClaudeJsonl(raw)).toEqual({ prompt: "do X", reply: "LRU, and here is why" });
+  });
+
+  // The same records, caught mid-flight: the preamble is on disk and the answer is not yet. The
+  // previous exchange is the honest answer — handing on the preamble is what the bug did.
+  it("falls back to the previous exchange while the agent is still narrating", () => {
+    const raw = [user("first"), concluding("first answer"), user("do X"), narrating("let me look"), toolUse("Read")].join("\n");
+    expect(lastTurnFromClaudeJsonl(raw)).toEqual({ prompt: "first", reply: "first answer" });
+  });
+
+  // Every stop reason other than tool_use ends the turn one way or another, and a record with no
+  // stop reason at all counts as ending it — being wrong the other way would leave a turn that
+  // never completes, so every exchange waiting on it would time out.
+  it("treats any non-tool_use stop reason, and a missing one, as the end of the turn", () => {
+    expect(lastTurnFromClaudeJsonl([user("q"), concluding("a", "stop_sequence")].join("\n"))).toEqual({ prompt: "q", reply: "a" });
+    expect(lastTurnFromClaudeJsonl([user("q"), concluding("a", "max_tokens")].join("\n"))).toEqual({ prompt: "q", reply: "a" });
+    expect(lastTurnFromClaudeJsonl([user("q"), assistant("a")].join("\n"))).toEqual({ prompt: "q", reply: "a" });
   });
 
   it("falls back to the previous exchange while a turn is still in flight", () => {

--- a/test/server/session/session-title.spec.ts
+++ b/test/server/session/session-title.spec.ts
@@ -251,7 +251,9 @@ describe("maybeGenerateTitle", () => {
     await vi.waitFor(() => expect(summarized).toHaveLength(1));
     expect(summarized[0]).toEqual([
       { role: "user", text: "add a retry to the uploader" },
-      { role: "assistant", text: "Added it." },
+      // The summarizer reads whatever the agent has said, finished or not — `endsTurn` rides along
+      // for the one reader that needs the boundary (#1487) and is ignored here.
+      { role: "assistant", text: "Added it.", endsTurn: true },
     ]);
   });
 

--- a/test/server/session/transcript.spec.ts
+++ b/test/server/session/transcript.spec.ts
@@ -61,6 +61,17 @@ describe("userPromptText", () => {
 });
 
 describe("latestAssistantTextFromJsonl", () => {
+  // The roster line wants what the agent is saying RIGHT NOW, which is the opposite of what
+  // `lastTurnFromClaudeParsed` wants — so #1487's turn-boundary fix must not reach this reader.
+  it("keeps showing narration written before the tools, while the turn is still running", () => {
+    const raw = [
+      line({ type: "user", message: { content: "do X" } }),
+      line({ type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "text", text: "let me look" }] } }),
+      line({ type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "tool_use", name: "Read", input: {} }] } }),
+    ].join("\n");
+    expect(latestAssistantTextFromJsonl(raw)).toBe("let me look");
+  });
+
   it("returns the most recent assistant prose turn", () => {
     const raw = [
       line({ type: "user", message: { content: "do X" } }),
@@ -381,7 +392,8 @@ describe("conversationTurnsFromJsonl", () => {
     ].join("\n");
     expect(conversationTurnsFromJsonl(raw)).toEqual([
       { role: "user", text: "fix the parser" },
-      { role: "assistant", text: "Looking at it" },
+      // An assistant record with no stop reason ends its turn — see #1487 for why that direction.
+      { role: "assistant", text: "Looking at it", endsTurn: true },
       { role: "user", text: "2番目にして" },
     ]);
   });
@@ -406,7 +418,7 @@ describe("conversationTurnsFromJsonl", () => {
         ],
       },
     });
-    expect(conversationTurnsFromJsonl(raw)).toEqual([{ role: "assistant", text: "part one part two" }]);
+    expect(conversationTurnsFromJsonl(raw)).toEqual([{ role: "assistant", text: "part one part two", endsTurn: true }]);
   });
 });
 


### PR DESCRIPTION
## Summary

**A claude turn was being declared finished as soon as it said anything** — so another cell was
handed the agent's opening line instead of its answer.

Found by running a real 3-seat round table. The third seat's whole contribution to the room was:

```
I'll read the actual files before weighing in.
```

Its real answer arrived 40 seconds later and **disagreed with the other two** — the only point of
difference at the table. It was never passed on. The later turns read only the preamble and closed
as "everyone agrees".

`lastTurnFromClaudeParsed` treated "there is an assistant prose record" as "the turn is over".
Claude Code writes a preamble as a complete assistant record **before** it runs any tool, so those
are different facts. The boundary is recorded — `stop_reason` — which is what
`server/session/last-turn.ts` said it was doing all along ("a turn boundary that is recorded rather
than guessed"). The implementation was the part that guessed.

**This is not a round-table bug.** Everything reading `/api/transcript/last-turn` had it, including
the one-turn exchange **shipped in 4.6.0**.

### How common

12 real transcripts on this machine, 1957 assistant prose records:

| `stop_reason` | count |
| --- | --- |
| `tool_use` (still working) | **1524 (78%)** |
| `end_turn` | 422 |
| `stop_sequence` | 9 |
| absent | 2 |

Any turn that uses a tool before answering is exposed, and that is most turns.

## Items to Confirm / Review

1. **A record with no `stop_reason` counts as ENDING the turn.** Deliberate, and the direction
   matters: being wrong the other way leaves a turn that never completes, so every exchange
   waiting on it times out. Two records in the sample above had none.
2. **Only `tool_use` means "still going".** `end_turn`, `stop_sequence`, `max_tokens` and a refusal
   all end the turn one way or another, so the test is `!== "tool_use"` rather than a whitelist —
   a stop reason nobody has seen yet should end a turn, not hang one.
3. **`endsTurn` rides on `ConversationTurn` rather than being filtered inside it.** The other
   readers want the OPPOSITE thing: the roster line shows what an agent is saying *right now*, and
   the title summarizer wants whatever is there. `transcript.spec.ts` now pins that, so a later
   "simplification" that filters in the shared walker fails a test instead of silently blanking the
   roster.
4. **A turn whose concluding record carries no prose now falls back to the previous exchange.**
   Correct — there is no conclusion to relay — but it is a behaviour change: that case used to
   return the mid-turn narration.

## The test that existed and passed anyway

`last-turn.spec.ts` already had this exact scenario:

```ts
it("takes the LAST prose record of a turn, not the narration before the tools", ...)
```

It passed because the `assistant()` helper writes **no `stop_reason`** — so both records counted as
ending the turn and "last one wins" gave the right answer. **The fixture was simplified in exactly
the dimension that carried the bug.** Added `narrating()` / `concluding()` helpers in the real
file's shape; reverting only the source (keeping the new tests) fails on the mid-flight case with
`reply: "let me look"`.

## Verified against a running app

Same script, same three cells (claude / codex / claude), same question, before and after:

| | before | after |
| --- | --- | --- |
| turn 3 (`#2 claude`) | **46 chars** — `I'll read the actual files before weighing in.` | **1149 chars** — the real answer, with an argument the other two had not made |
| turn 4 (`#0 claude`) | could only reference `#1` | `#2 の2点に、node で実測した2点を足します` — builds on the third seat |

Turn 4 is also the first live proof that #1476's whole-conversation read-back does what it is for:
a seat two places back is visible. A 2-seat table cannot show that, which is why the earlier 2-seat
live run passed while this bug was present.

`yarn format` / `lint` / `typecheck` / `build` / `test` (8906 passing) all green.

## User Prompt

> 実機できちんと対話テストできるまで作ってテストしてほしい！！

(Asked after establishing that the round-table conversation had never been exercised end to end with
real agents since #1476 changed what each speaker reads.)

Closes #1487

work in mulmoterminal5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude response handling to correctly identify when a turn is complete.
  - Prevented in-progress narration and tool interactions from being mistaken for the final response.
  - Ensured the latest completed assistant message is selected after tool use.
  - Preserved intermediate assistant text while a turn remains active.

- **Tests**
  - Added coverage for tool use, narration, missing completion details, and multi-part responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->