### PR TITLE
fix: read remote-host collection/feed records through the store seam

### DIFF
--- a/server/backends/remoteHost/getCollection.spec.ts
+++ b/server/backends/remoteHost/getCollection.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+//
+// Unit tests for the remote-host getCollection handler, engine stubbed via
+// GetCollectionDeps so these assert wiring, derivation and pagination rather than
+// the real collection engine. The end-to-end read against a real on-disk dataDir
+// lives in getFeed.spec.ts (same page path).
+//
+// The store-seam test is the one this file exists for (#1488): records must come
+// from `listRecords` (storeFor(...).list() in production), never from a dataDir
+// read, or a CSV/SQLite-backed collection pages as empty on the phone.
+import { describe, it, expect } from "vitest";
+
+import { createGetCollection, type GetCollectionDeps } from "./handlers/getCollection.js";
+
+const records = (count: number) => Array.from({ length: count }, (_unused, index) => ({ id: `r${index}` }));
+
+/** A collection whose dataDir holds nothing — as a `dataSource` CSV or SQLite
+ *  collection's does. Everything the handler returns therefore had to come
+ *  through `listRecords`. */
+const collectionDeps = (all: Record<string, unknown>[]): GetCollectionDeps => ({
+  loadCollection: (async (slug: string) =>
+    slug === "missing"
+      ? null
+      : {
+          slug,
+          dataDir: `/nonexistent/${slug}`,
+          schema: { primaryKey: "id", fields: { id: { type: "string" }, won: { type: "number" }, points: { type: "derived", formula: "won * 3" } } },
+        }) as unknown as GetCollectionDeps["loadCollection"],
+  listRecords: (async () => all) as unknown as GetCollectionDeps["listRecords"],
+  toDetail: ((collection: { slug: string; schema: unknown }) => ({
+    slug: collection.slug,
+    title: collection.slug,
+    icon: "x",
+    source: "preset",
+    schema: collection.schema,
+  })) as unknown as GetCollectionDeps["toDetail"],
+});
+
+describe("createGetCollection", () => {
+  it("reads records through the store seam, handing it the loaded collection", async () => {
+    const seen: unknown[] = [];
+    const deps = collectionDeps(records(2));
+    const handler = createGetCollection({
+      ...deps,
+      listRecords: (async (collection: { slug: string }) => {
+        seen.push(collection);
+        return records(2);
+      }) as unknown as GetCollectionDeps["listRecords"],
+    });
+    const result = (await handler({ slug: "csv-backed" })) as unknown as { items: unknown[]; total: number };
+    // The dataDir is empty, so a dataDir-backed read would have returned nothing.
+    expect(result.total).toBe(2);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ slug: "csv-backed" });
+  });
+
+  it("returns a page of records + detail + total", async () => {
+    const handler = createGetCollection(collectionDeps(records(5)));
+    const result = (await handler({ slug: "clients", offset: 1, limit: 2 })) as unknown as {
+      collection: { slug: string };
+      items: { id: string }[];
+      total: number;
+      offset: number;
+      limit: number;
+    };
+    expect(result.total).toBe(5);
+    expect(result.items.map((item) => item.id)).toEqual(["r1", "r2"]);
+    expect(result.offset).toBe(1);
+    expect(result.limit).toBe(2);
+    expect(result.collection.slug).toBe("clients");
+  });
+
+  it("resolves record-local derived formulas before paging", async () => {
+    const handler = createGetCollection(collectionDeps([{ id: "r0", won: 2 }]));
+    const result = (await handler({ slug: "clients" })) as unknown as { items: { points?: number }[] };
+    expect(result.items[0]?.points).toBe(6);
+  });
+
+  it("throws when the collection is not found", async () => {
+    const handler = createGetCollection(collectionDeps(records(3)));
+    await expect(handler({ slug: "missing" })).rejects.toThrow(/collection 'missing' not found/);
+  });
+
+  it("clamps a runaway limit and a negative offset, defaults a bad limit", async () => {
+    const handler = createGetCollection(collectionDeps(records(500)));
+    const huge = (await handler({ slug: "x", limit: 100000 })) as unknown as { limit: number };
+    expect(huge.limit).toBe(200); // MAX_LIMIT
+    const neg = (await handler({ slug: "x", offset: -5, limit: 0 })) as unknown as { offset: number; limit: number };
+    expect(neg.offset).toBe(0);
+    expect(neg.limit).toBe(50); // DEFAULT_LIMIT
+  });
+});

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
 //
-// getFeed reuses the collection page path (listItems + toDetail + pageResult)
+// getFeed reuses the collection page path (storeFor + toDetail + pageResult)
 // over a feed located in the feed registry. This exercises it end-to-end with a
 // real on-disk dataDir, mocking only listFeeds so the test needn't stand up the
 // full feed-discovery/host stack. Kept in its own file so the module-level
 // listFeeds mock can't reach handlers.spec's real-collection-host listSkills test.
+//
+// The last block stubs the store seam instead, covering the non-file case the
+// on-disk fixture cannot reach (#1488).
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -12,13 +15,14 @@ import path from "node:path";
 
 import { listFeeds } from "@mulmoclaude/core/feeds/server";
 import { createRemoteHostHandlers } from "./handlers/index.js";
+import { createGetFeed, type GetFeedDeps } from "./handlers/getFeed.js";
 import { initCollectionsBackend } from "../collections.js";
 
-// Only listFeeds is stubbed; listItems/toDetail/deriveItems/pageResult stay real.
+// Only listFeeds is stubbed; storeFor/toDetail/deriveItems/pageResult stay real.
 vi.mock("@mulmoclaude/core/feeds/server", () => ({ listFeeds: vi.fn(), readFeedState: vi.fn() }));
 
 // A feed is a LoadedCollection with an `ingest` block. dataDir points at a real
-// temp dir so the real listItems reads the records off disk.
+// temp dir so the real file store reads the records off disk.
 const feedFixture = (dataDir: string) => ({
   slug: "news",
   source: "feed" as const,
@@ -46,7 +50,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
   // different workspace, so configure it once for the whole block.
   beforeAll(() => {
     ws = mkdtempSync(path.join(tmpdir(), "mt-rh-feed-"));
-    // listItems resolves against the configured collection host's workspace root.
+    // The file store resolves against the configured collection host's workspace root.
     initCollectionsBackend({ workspace: ws });
     // Records live at the real feed layout, <ws>/data/feeds/<slug>.
     dataDir = path.join(ws, "data", "feeds", "news");
@@ -102,5 +106,52 @@ describe("createRemoteHostHandlers · getFeed", () => {
   it("throws when the feed slug is not registered", async () => {
     vi.mocked(listFeeds).mockResolvedValue([feedFixture(dataDir)] as never);
     await expect(handlers.getFeed({ slug: "missing" })).rejects.toThrow(/feed 'missing' not found/);
+  });
+});
+
+// A feed whose records live somewhere other than `<dataDir>/*.json` — a dataSource
+// CSV, a SQLite file. The on-disk fixture above cannot express one (the CSV store
+// needs DuckDB), so the seam is stubbed instead: what matters is that the handler
+// asks `listRecords` for the records and never reads the dataDir itself.
+describe("createGetFeed · store seam", () => {
+  const feedDeps = (all: Record<string, unknown>[]): GetFeedDeps => ({
+    listFeeds: (async () => [
+      { slug: "news", dataDir: "/nonexistent/news", schema: { primaryKey: "id", fields: { id: { type: "string" } } } },
+    ]) as unknown as GetFeedDeps["listFeeds"],
+    listRecords: (async () => all) as unknown as GetFeedDeps["listRecords"],
+    toDetail: ((feed: { slug: string }) => ({
+      slug: feed.slug,
+      title: feed.slug,
+      icon: "rss",
+      source: "feed",
+      schema: {},
+    })) as unknown as GetFeedDeps["toDetail"],
+    workspaceRoot: "/ws",
+  });
+
+  it("pages records the dataDir does not hold", async () => {
+    const handler = createGetFeed(feedDeps([{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }]));
+    const result = (await handler({ slug: "news", offset: 0, limit: 3 })) as unknown as { items: unknown[]; total: number; collection: { slug: string } };
+    expect(result.total).toBe(4);
+    expect(result.items).toHaveLength(3);
+    expect(result.collection.slug).toBe("news");
+  });
+
+  it("throws when the feed slug is not in the registry", async () => {
+    const handler = createGetFeed(feedDeps([{ id: "a" }]));
+    await expect(handler({ slug: "ghost" })).rejects.toThrow(/feed 'ghost' not found/);
+  });
+
+  it("passes the workspace root it was built with to the registry", async () => {
+    const seen: unknown[] = [];
+    const handler = createGetFeed({
+      ...feedDeps([{ id: "a" }]),
+      listFeeds: (async (root: string) => {
+        seen.push(root);
+        return [{ slug: "news", dataDir: "/nonexistent/news", schema: { primaryKey: "id", fields: {} } }];
+      }) as unknown as GetFeedDeps["listFeeds"],
+    });
+    await handler({ slug: "news" });
+    expect(seen).toEqual(["/ws"]);
   });
 });

--- a/server/backends/remoteHost/handlers/getCollection.ts
+++ b/server/backends/remoteHost/handlers/getCollection.ts
@@ -2,17 +2,38 @@
 //
 // One collection's detail + a PAGE of its records (pagination mandatory — the result
 // rides inside a 1 MiB Firestore command doc).
-import { listItems, loadCollection, toDetail } from "@mulmoclaude/core/collection/server";
+//
+// Records come from the STORE seam, never a raw `listItems(dataDir)`: a collection
+// backed by a `dataSource` CSV or SQLite keeps no `.json` records on disk, so the
+// dataDir read returned an empty page to the phone while the desktop UI (which has
+// always gone through `storeFor`) showed the rows (#1488).
+//
+// Factory (createGetCollection) keeps the mapping unit-testable with the engine
+// stubbed; the default export wires the real engine functions. Mirrors
+// MulmoClaude's server/remoteHost/handlers/getCollection.ts.
+import { loadCollection, storeFor, toDetail, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import type { CollectionItem } from "@mulmoclaude/core/collection";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
 import { readString } from "../../../../common/readString.js";
 
-export const getCollection: CommandHandlers["getCollection"] = async (params: JsonObject) => {
-  const slug = readString(params.slug);
-  const offset = clampOffset(params.offset);
-  const limit = clampLimit(params.limit);
-  const collection = await loadCollection(slug);
-  if (!collection) throw new Error(`collection '${slug}' not found`);
-  const all = deriveItems(collection.schema, await listItems(collection.dataDir));
-  return pageResult(toDetail(collection), all, offset, limit);
-};
+export interface GetCollectionDeps {
+  loadCollection: typeof loadCollection;
+  /** Store-aware records loader (file records or a dataSource CSV's rows). */
+  listRecords: (collection: LoadedCollection) => Promise<CollectionItem[]>;
+  toDetail: typeof toDetail;
+}
+
+export const createGetCollection =
+  (deps: GetCollectionDeps): CommandHandlers["getCollection"] =>
+  async (params: JsonObject) => {
+    const slug = readString(params.slug);
+    const offset = clampOffset(params.offset);
+    const limit = clampLimit(params.limit);
+    const collection = await deps.loadCollection(slug);
+    if (!collection) throw new Error(`collection '${slug}' not found`);
+    const all = deriveItems(collection.schema, await deps.listRecords(collection));
+    return pageResult(deps.toDetail(collection), all, offset, limit);
+  };
+
+export const getCollection = createGetCollection({ loadCollection, listRecords: (collection) => storeFor(collection).list(), toDetail });

--- a/server/backends/remoteHost/handlers/getFeed.ts
+++ b/server/backends/remoteHost/handlers/getFeed.ts
@@ -2,22 +2,40 @@
 //
 // One feed's detail + a PAGE of its records. A feed IS a LoadedCollection with an `ingest` block,
 // located via the feed registry (feeds live under their own registry, not the collections dir), so
-// this reuses the exact collection page path and returns the SAME shape as getCollection — the
-// phone renders feed records with the same card view.
-import { listItems, toDetail } from "@mulmoclaude/core/collection/server";
+// this reuses the exact collection page path (storeFor + toDetail + collectionPage) and returns the
+// SAME shape as getCollection — the phone renders feed records with the same card view. That
+// includes reading through the STORE seam rather than a raw dataDir `listItems`; see
+// getCollection.ts for why (#1488).
+//
+// Two factories, unlike MulmoClaude's single one: this host's workspace root is wired at runtime
+// from server/index.ts rather than being a module constant, so `getFeedFor` is the real wiring and
+// `createGetFeed` the fully-stubbable seam.
+import { storeFor, toDetail, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import type { CollectionItem } from "@mulmoclaude/core/collection";
 import { listFeeds } from "@mulmoclaude/core/feeds/server";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
 import { readString } from "../../../../common/readString.js";
 
+export interface GetFeedDeps {
+  listFeeds: typeof listFeeds;
+  /** Store-aware records loader (file records or a dataSource CSV's rows). */
+  listRecords: (collection: LoadedCollection) => Promise<CollectionItem[]>;
+  toDetail: typeof toDetail;
+  workspaceRoot: string;
+}
+
 export const createGetFeed =
-  (workspace: string): CommandHandlers["getFeed"] =>
+  (deps: GetFeedDeps): CommandHandlers["getFeed"] =>
   async (params: JsonObject) => {
     const slug = readString(params.slug);
     const offset = clampOffset(params.offset);
     const limit = clampLimit(params.limit);
-    const feed = (await listFeeds(workspace)).find((entry) => entry.slug === slug);
+    const feed = (await deps.listFeeds(deps.workspaceRoot)).find((entry) => entry.slug === slug);
     if (!feed) throw new Error(`feed '${slug}' not found`);
-    const all = deriveItems(feed.schema, await listItems(feed.dataDir));
-    return pageResult(toDetail(feed), all, offset, limit);
+    const all = deriveItems(feed.schema, await deps.listRecords(feed));
+    return pageResult(deps.toDetail(feed), all, offset, limit);
   };
+
+export const getFeedFor = (workspaceRoot: string): CommandHandlers["getFeed"] =>
+  createGetFeed({ listFeeds, listRecords: (collection) => storeFor(collection).list(), toDetail, workspaceRoot });

--- a/server/backends/remoteHost/handlers/index.ts
+++ b/server/backends/remoteHost/handlers/index.ts
@@ -14,7 +14,7 @@
 import type { CommandHandlers } from "@mulmoclaude/core/remote-host";
 import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCalendars, googleCalendarListEvents } from "../googleCalendar.js";
 import { getCollection } from "./getCollection.js";
-import { createGetFeed } from "./getFeed.js";
+import { getFeedFor } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
 import { createIssueWorkHandlers } from "./issueWork.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
@@ -52,7 +52,7 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     "google.calendar.colors": googleCalendarColors,
 
     listFeeds: createListFeeds(workspace),
-    getFeed: createGetFeed(workspace),
+    getFeed: getFeedFor(workspace),
     listShortcuts: createListShortcuts(workspace),
     listSkills: createListSkills(workspace),
     listAccountingBooks: createListAccountingBooks(workspace),


### PR DESCRIPTION
Fixes #1488.

## The bug

`server/backends/remoteHost/handlers/getCollection.ts` loaded records with `listItems(collection.dataDir)` — the file-backed path only. A collection backed by a `dataSource` CSV or SQLite keeps no `.json` records on disk, so the phone got an **empty page** while the desktop UI, which has always gone through `storeFor`, showed the rows.

`getFeed.ts` had the identical bypass. The issue names only `getCollection`; MulmoClaude converted **both**, so both are fixed here.

## The fix

Both handlers take a deps object with a store-aware `listRecords`, mirroring MulmoClaude's `server/remoteHost/handlers/{getCollection,getFeed}.ts`. The wired exports pass `listRecords: (collection) => storeFor(collection).list()` — the same seam `server/backends/remoteView.ts:302` already uses here.

**File-backed collections are unaffected by construction**, not merely by test: in `@mulmoclaude/core`, `fileStoreFor(...).list` is literally `listItems(collection.dataDir, opts)` — same function, same arguments. `offset` / `limit` / `total` are untouched.

## One deliberate divergence from MulmoClaude

`getFeed` exports two functions where MulmoClaude exports one. MulmoClaude can export a wired `getFeed` const because its `workspacePath` is a module constant; this host's workspace root is wired at runtime from `server/index.ts`. So `createGetFeed(deps)` is the fully-stubbable seam and `getFeedFor(workspaceRoot)` is the real wiring that `handlers/index.ts` calls. The reason is stated in the file.

## Tests

- New `server/backends/remoteHost/getCollection.spec.ts` — the handler previously had **no** behavioural coverage (`handlers.spec.ts` only asserted it is a function). Covers the MulmoClaude cases (paging, derived formulas, not-found, limit/offset clamping) plus a store-seam test whose fixture `dataDir` is `/nonexistent/...`, so every record returned had to arrive via `listRecords`.
- `getFeed.spec.ts` gains a `createGetFeed · store seam` block for the non-file case; its stale `listItems` comments are corrected. The existing end-to-end block against a real on-disk dataDir is unchanged and still passes — that is the file-backed regression evidence.
- A real CSV fixture is not feasible in this suite: `csvStoreFor.list` goes through DuckDB. The issue offered the stubbed seam as the fallback.

## Verification

`yarn format`, `yarn lint` (0 errors; 13 pre-existing warnings, none in touched files), `yarn typecheck`, `yarn test` — 8738 passed / 45 skipped.

Not live-verified against a paired remote-host client; the changed path is phone-only and the desktop tools (`presentCollection` / `manageCollection`) do not exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote-host collection and feed loading through the configured data store.
  * Preserved pagination, validation, detail conversion, and missing-resource error handling.
  * Ensured feed data is loaded from the correct workspace location, including records outside the default data directory.

* **Tests**
  * Expanded coverage for collection and feed retrieval, pagination, derived fields, configuration, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->