### PR TITLE
fix: gate REST item create/update on the schema before writing

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -194,6 +194,26 @@ function resolveWriteTarget(res: Response, collection: ResolvedCollection, body:
   return { write, record };
 }
 
+/** Gate a record on its schema before it reaches the store, answering 400 with the
+ *  problem when it fails. True means the request is already answered — stop.
+ *
+ *  The same `validateRecordObject` call the other two write paths make: view-data
+ *  PUT (writeViewItem, below) and the agent's manageCollection putItems (core's
+ *  putOneItem). REST create/update wrote straight through, so a client — a UI bug,
+ *  a curl, a future remote writer — could persist a missing required field or an
+ *  off-enum value that the detail route then reports back as `issues` with a Repair
+ *  button, rather than the write being refused at the door (#1489).
+ *
+ *  The tier is core's default `"enforced"`: primaryKey↔id identity, required fields
+ *  non-empty, enum membership. Deliberately NOT the `"strict"` tier, which exists to
+ *  REPORT (a legacy record whose `number` field holds a string stays editable). */
+function rejectedInvalidRecord(res: Response, collection: ResolvedCollection, record: CollectionItem, itemId: string): boolean {
+  const problem = validateRecordObject(record, itemId, collection.schema);
+  if (!problem) return false;
+  res.status(400).json({ error: problem });
+  return true;
+}
+
 /** The action's skill template, or null after sending a 500. Shared by the per-record
  *  and collection-level action routes. */
 async function readActionTemplateOr500(res: Response, collection: ResolvedCollection, action: { id: string; template: string }): Promise<string | null> {
@@ -384,6 +404,7 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   const { collection, target } = resolved;
   const itemId = resolveCreateItemId(collection.schema, target.record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...target.record, [collection.schema.primaryKey]: itemId };
+  if (rejectedInvalidRecord(res, collection, recordWithId, itemId)) return;
   const result = await target.write(itemId, recordWithId, { refuseOverwrite: true });
   if (isCommonStoreFailure(result)) {
     respondForStoreFailure(res, collection.slug, result);
@@ -408,6 +429,7 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
     return;
   }
   const recordWithId: CollectionItem = { ...target.record, [primaryKey]: req.params.itemId };
+  if (rejectedInvalidRecord(res, collection, recordWithId, req.params.itemId)) return;
   const result = await target.write(req.params.itemId, recordWithId);
   if (isCommonStoreFailure(result)) {
     respondForStoreFailure(res, collection.slug, result);

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -24,6 +24,7 @@ import {
   enrichItems,
   readCustomViewHtml,
   validateRecordObject,
+  recordFieldProblem,
   generateItemId,
   resolveCreateItemId,
   readSkillTemplate,
@@ -46,7 +47,7 @@ import {
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
 // CollectionItem + actionVisible live in the isomorphic core entry.
-import { actionVisible, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+import { actionVisible, fieldVisible, COMPUTED_TYPES, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
@@ -194,21 +195,54 @@ function resolveWriteTarget(res: Response, collection: ResolvedCollection, body:
   return { write, record };
 }
 
+/** First enforced-tier schema problem on a record about to be written by REST, or
+ *  null. Runs core's own `recordFieldProblem` — the exact per-field check
+ *  `validateRecordObject` runs, so the messages a REST client sees are identical
+ *  to the ones view-data PUT and manageCollection putItems report — over the
+ *  fields a WRITER can actually be held to:
+ *
+ *  - COMPUTED_TYPES are skipped, as core's own compiled validator skips them
+ *    (they are never stored; the host derives them).
+ *  - A `when`-HIDDEN field is skipped, which `validateRecordObject` does not do.
+ *    That difference is deliberate and is why this loop exists rather than a
+ *    plain `validateRecordObject` call: the collection editor treats a hidden
+ *    field as never-missing (core's `validateOneField`: "a `when`-hidden field
+ *    has no input the user can fill"), and its draft cannot populate one. A
+ *    required-behind-`when` field would therefore make the editor's own valid
+ *    save come back 400 (caught in review on #1497).
+ *
+ *  The primaryKey↔id identity check `validateRecordObject` opens with is not
+ *  repeated: both callers build the record with `[primaryKey]: itemId` from a
+ *  string id, so it holds by construction.
+ *
+ *  Core's `validateOneField` is the visibility-aware check, but it reads an
+ *  editor DRAFT rather than a record, so it cannot be reused here. If core grows
+ *  a visibility-aware record validator, this should become a call to it. */
+function firstEnforcedProblem(record: CollectionItem, schema: ResolvedCollection["schema"]): string | null {
+  for (const [key, spec] of Object.entries(schema.fields)) {
+    if (COMPUTED_TYPES.has(spec.type)) continue;
+    if (!fieldVisible(spec, record)) continue;
+    const problem = recordFieldProblem(key, spec, record[key], "enforced");
+    if (problem) return problem;
+  }
+  return null;
+}
+
 /** Gate a record on its schema before it reaches the store, answering 400 with the
  *  problem when it fails. True means the request is already answered — stop.
  *
- *  The same `validateRecordObject` call the other two write paths make: view-data
- *  PUT (writeViewItem, below) and the agent's manageCollection putItems (core's
- *  putOneItem). REST create/update wrote straight through, so a client — a UI bug,
- *  a curl, a future remote writer — could persist a missing required field or an
+ *  The gate the other two write paths already have: view-data PUT (writeViewItem,
+ *  below) and the agent's manageCollection putItems (core's putOneItem) both
+ *  validate. REST create/update wrote straight through, so a client — a UI bug, a
+ *  curl, a future remote writer — could persist a missing required field or an
  *  off-enum value that the detail route then reports back as `issues` with a Repair
  *  button, rather than the write being refused at the door (#1489).
  *
- *  The tier is core's default `"enforced"`: primaryKey↔id identity, required fields
- *  non-empty, enum membership. Deliberately NOT the `"strict"` tier, which exists to
- *  REPORT (a legacy record whose `number` field holds a string stays editable). */
-function rejectedInvalidRecord(res: Response, collection: ResolvedCollection, record: CollectionItem, itemId: string): boolean {
-  const problem = validateRecordObject(record, itemId, collection.schema);
+ *  The tier is core's `"enforced"`: required fields non-empty, enum membership.
+ *  Deliberately NOT the `"strict"` tier, which exists to REPORT (a legacy record
+ *  whose `number` field holds a string stays editable). */
+function rejectedInvalidRecord(res: Response, collection: ResolvedCollection, record: CollectionItem): boolean {
+  const problem = firstEnforcedProblem(record, collection.schema);
   if (!problem) return false;
   res.status(400).json({ error: problem });
   return true;
@@ -404,7 +438,7 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   const { collection, target } = resolved;
   const itemId = resolveCreateItemId(collection.schema, target.record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...target.record, [collection.schema.primaryKey]: itemId };
-  if (rejectedInvalidRecord(res, collection, recordWithId, itemId)) return;
+  if (rejectedInvalidRecord(res, collection, recordWithId)) return;
   const result = await target.write(itemId, recordWithId, { refuseOverwrite: true });
   if (isCommonStoreFailure(result)) {
     respondForStoreFailure(res, collection.slug, result);
@@ -429,7 +463,7 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
     return;
   }
   const recordWithId: CollectionItem = { ...target.record, [primaryKey]: req.params.itemId };
-  if (rejectedInvalidRecord(res, collection, recordWithId, req.params.itemId)) return;
+  if (rejectedInvalidRecord(res, collection, recordWithId)) return;
   const result = await target.write(req.params.itemId, recordWithId);
   if (isCommonStoreFailure(result)) {
     respondForStoreFailure(res, collection.slug, result);

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -99,6 +99,24 @@ beforeAll(async () => {
   mkdirSync(path.join(ws, "data", "skills", "singletoncol", "views"), { recursive: true });
   writeFileSync(path.join(ws, "data", "skills", "singletoncol", "views", "sv.html"), "<head></head><body>editable</body>");
 
+  // A collection with a REQUIRED non-primary field, so the REST write gate's
+  // required-field case can be covered. Isolated from testcol because that
+  // collection's view-data tests write partial records on purpose.
+  const REQUIRED_SCHEMA = {
+    title: "Required",
+    icon: "checklist",
+    dataPath: "data/reqcol/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      title: { type: "string", label: "Title", required: true },
+    },
+  };
+  mkdirSync(path.join(ws, ".claude", "skills", "reqcol"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "reqcol", "schema.json"), JSON.stringify(REQUIRED_SCHEMA));
+  mkdirSync(path.join(ws, "data", "reqcol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "reqcol", "items", "r1.json"), JSON.stringify({ id: "r1", title: "Kept" }));
+
   // A collection with a mobile view that declares an image field, so the
   // remote-view items route can inline a real thumbnail (isolated from testcol so
   // its record counts don't perturb the detail/view-data tests above).
@@ -473,6 +491,61 @@ describe("record CRUD", () => {
   it("400s on a non-object create body", async () => {
     const res = await request(ITEMS, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify([1, 2, 3]) });
     expect(res.status).toBe(400);
+  });
+
+  // The write gate REST shares with view-data PUT and manageCollection putItems
+  // (#1489): before this, any client could persist an off-enum value or drop a
+  // required field, and the bad record came back later as a detail `issue` with a
+  // Repair button instead of being refused at the door.
+  it("400s a create with an off-enum value, writing nothing", async () => {
+    const res = await request(ITEMS, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "badenum", name: "Nope", status: "bogus" }),
+    });
+    expect(res.status).toBe(400);
+    // The same problem string view-data's `rejected[].problem` carries.
+    expect(((await res.json()) as { error: string }).error).toContain("not one of");
+    expect((await detailItems()).find((i) => i.id === "badenum")).toBeUndefined();
+  });
+
+  it("400s an update with an off-enum value, leaving the stored record untouched", async () => {
+    const res = await request(itemUrl("item1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "item1", name: "Clobbered", status: "bogus" }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("not one of");
+    expect((await detailItems()).find((i) => i.id === "item1")).toMatchObject({ name: "Foo" });
+  });
+
+  it("400s a create missing a required field, and one that supplies it succeeds", async () => {
+    const bad = await request("/api/collections/reqcol/items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "r2" }),
+    });
+    expect(bad.status).toBe(400);
+    expect(((await bad.json()) as { error: string }).error).toContain("missing required field 'title'");
+
+    const good = await request("/api/collections/reqcol/items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "r2", title: "Fine" }),
+    });
+    expect(good.status).toBe(200);
+  });
+
+  it("400s an update that empties a required field", async () => {
+    const res = await request("/api/collections/reqcol/items/r1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "r1", title: "" }),
+    });
+    expect(res.status).toBe(400);
+    const items = ((await (await request("/api/collections/reqcol/detail")).json()) as { items: Array<{ id: string; title?: string }> }).items;
+    expect(items.find((i) => i.id === "r1")).toMatchObject({ title: "Kept" });
   });
 
   it("404s update/delete on a missing collection", async () => {

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -110,6 +110,10 @@ beforeAll(async () => {
     fields: {
       id: { type: "string", label: "ID", primary: true, required: true },
       title: { type: "string", label: "Title", required: true },
+      // Required, but only once `visited` is true — the editor hides it and
+      // treats it as never-missing until then, so the write gate must too.
+      visited: { type: "boolean", label: "Visited" },
+      rating: { type: "string", label: "Rating", required: true, when: { field: "visited", in: ["true"] } },
     },
   };
   mkdirSync(path.join(ws, ".claude", "skills", "reqcol"), { recursive: true });
@@ -546,6 +550,27 @@ describe("record CRUD", () => {
     expect(res.status).toBe(400);
     const items = ((await (await request("/api/collections/reqcol/detail")).json()) as { items: Array<{ id: string; title?: string }> }).items;
     expect(items.find((i) => i.id === "r1")).toMatchObject({ title: "Kept" });
+  });
+
+  // A field that is `required` only behind a `when` predicate: the editor hides
+  // it and treats it as never-missing (core's validateOneField), so a gate built
+  // on the visibility-blind validateRecordObject would 400 the editor's own valid
+  // save. Caught in review on #1497.
+  it("does not require a when-hidden field, but does once the predicate holds", async () => {
+    const hidden = await request("/api/collections/reqcol/items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "r3", title: "Not visited", visited: false }),
+    });
+    expect(hidden.status).toBe(200);
+
+    const shown = await request("/api/collections/reqcol/items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "r4", title: "Visited", visited: true }),
+    });
+    expect(shown.status).toBe(400);
+    expect(((await shown.json()) as { error: string }).error).toContain("missing required field 'rating'");
   });
 
   it("404s update/delete on a missing collection", async () => {


### PR DESCRIPTION
Fixes #1489.

## The bug

`POST /api/collections/:slug/items` and `PUT /api/collections/:slug/items/:itemId` handed the request body to `store.write` with no schema gate. The other two write paths over the same records already validate — view-data PUT (`writeViewItem`) and the agent's `manageCollection` putItems (core's `putOneItem`).

So any client (a UI bug, a curl, a future remote writer) could persist a missing required field or an off-enum value. The record then came back through the detail route as an `issue` with a Repair affordance — bad data as a first-class citizen rather than a rejected write.

## The fix

One shared helper, `rejectedInvalidRecord`, called by both handlers: `validateRecordObject(record, itemId, schema)` → 400 with the problem, nothing written. It sits next to `writeViewItem`, which makes the identical call, so the three write paths now agree.

**Tier is core's default `"enforced"`** — primaryKey↔id identity, required fields non-empty, enum membership. Deliberately *not* the `"strict"` tier: core documents that one as report-only, so a legacy record whose `number` field holds a string stays editable rather than becoming unsaveable. That is also why this cannot lock users out of existing data in general — the enforced tier is exactly the historical three checks that `validateCollectionRecords` has always reported.

## What I did NOT do, and why

The issue says "also consider the computed-key checks putItems runs (`computedKeyProblem`) so host-computed fields cannot be forged via REST". I left that out on purpose:

1. **`computedKeyProblem` is not exported from core.** It is a private function in `manageTool.ts`. Adding it here means a MulmoTerminal-local reimplementation of shared semantics — the kind of divergence CLAUDE.md warns about, and MulmoClaude's REST has no such check either.
2. **It can reject writes the UI legitimately makes.** Inline table editing goes through core's `buildUpdatedRecord`, which spreads the row object as-is. A record that already carries a stale computed key on disk (written by an agent before any gate existed, or a persisted `toggle` projection) would start 400-ing on every inline edit, telling the user to remove a field the form does not show. `draftToRecord` skips computed types, so the edit panel is safe, but the inline path is not.

If we want it, the right shape is exporting `computedKeyProblem` from `@mulmoclaude/core` and adopting it in **both** hosts at once, after checking real workspaces for records that already carry computed keys. Happy to file that as a follow-up.

## Tests

Four cases added to `record CRUD` in `test/server/backends/collections.spec.ts`, each **verified to fail without the gate** (reverted the handler change, watched all four go red, restored it):

- create with an off-enum value → 400, and the item never appears in detail
- update with an off-enum value → 400, and the stored record still reads `name: "Foo"`
- create missing a required field → 400 naming the field, and the same create with the field succeeds
- update that empties a required field → 400, stored value untouched

The off-enum assertions check for the same `"not one of"` problem string the existing view-data test asserts on `rejected[].problem`, which is the parity acceptance item.

A new `reqcol` fixture provides a required non-primary field; `testcol` could not, since its view-data tests write partial records on purpose.

## Verification

`yarn format`, `yarn lint` (0 errors; 13 pre-existing warnings, none in touched files), `yarn typecheck`, `yarn test` — 8914 passed / 45 skipped. Existing CRUD cases pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal