### PR TITLE
feat: catch the custom-view host surface up to MulmoClaude (#1490)

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,22 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+- **Custom views catch up to MulmoClaude's host surface** (#1490): a collection's custom view can
+  now read its translations, resolve a stored image, and press a declared mutate action — the three
+  things core's own authoring docs (which MulmoTerminal serves to the agent through
+  `manageCollection`'s `schemaDocs`) already told view authors it could.
+  `GET …/view-i18n` returns the active locale's dict, and the iframe bootstrap gained the
+  `__MC_VIEW.dict` / `__MC_VIEW.t(key, named)` half of the bridge it had been missing entirely — an
+  i18n-declaring view used to render raw keys, with nothing reporting a problem. `GET
+  …/view-data/image` turns an image field's stored path into a downscaled `data:` thumbnail, which
+  is how a desktop view shows a picture at all (the sandboxed iframe cannot put its token on an
+  `<img>`); the authorization rule is the record scan itself, so only a **current** value of an
+  image field resolves and never an arbitrary workspace file. `POST
+  …/view-data/actions/:actionId` lets a write-capable view press a declared **mutate** action
+  instead of hand-rolling the same transition as a raw write — mutate only, so a view token still
+  cannot start LLM work. All three run the shared `@mulmoclaude/core` engines, and the two scoped
+  ones sit behind per-minute budgets with images in a roomier bucket than actions.
+
 ## mulmoterminal@4.6.0 — 2026-08-06
 
 > **Setup guide:** [Cells that talk to each other, and a history that knows whose it is](https://receptron.github.io/mulmoterminal/guide/en/v4.6.0.html) — written at release time. ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.6.0.html))

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -6,7 +6,7 @@ the two hosts can't drift. This doc records where that effort stands: which
 subsystems are shared today, which are deliberately **not**, and what picking
 up each remaining item would involve.
 
-Status date: **2026-07-18** (core `0.23.0`, collection-plugin `0.11.1`).
+Status date: **2026-08-05** (core `2.1.0`, collection-plugin `2.0.0`).
 
 ---
 
@@ -100,7 +100,37 @@ remaining item with correctness stakes.
 `server/index.ts`) that applies the shared mirror rule, plus committing to the
 `data/skills/` authoring convention in this app.
 
-### 4. `kind: "agent"` collection actions run visible, not hidden
+### 4. Custom-view host surface — shipped, with two known edges
+
+The token-scoped surface a sandboxed custom view talks to is now the same on
+both hosts (#1490). This is deliberately parity-tracked rather than "MT's own
+API", because core's bundled authoring docs — which MulmoTerminal itself serves
+through `manageCollection`'s `schemaDocs` — tell collection authors these exist:
+
+| Endpoint | Where |
+| --- | --- |
+| `GET …/view-i18n` (parent-side; feeds `__MC_VIEW.dict` / `t()`) | `server/backends/customViewRoutes.ts` |
+| `GET …/view-data/image` | same file (+ `isAuthorizedImagePath`) |
+| `POST …/view-data/actions/:actionId` | same file — mutate kind only |
+| `POST …/view-data/query`, `GET`/`PUT …/view-data` | `server/backends/collections.ts` (#167) |
+
+Rules worth keeping when touching these: the image route's authorization *is*
+the record scan (only a **current** value of an `image` field resolves, never an
+arbitrary workspace path), and the action route is **mutate-only** — a view
+token must never be able to start LLM work, so `chat` / `agent` actions stay on
+the parent-side route. Both sit behind per-minute budgets
+(`server/backends/viewRateLimit.ts`), images in a roomier bucket than actions
+because a gallery's first paint is legitimately dozens of fetches.
+
+Two differences remain, both benign but real:
+
+- **`GET …/view-data` ignores `ids` / `fields`.** MulmoClaude routes that read
+  through `manageCollection`'s `getItems`; MulmoTerminal returns every enriched
+  record. A view that passes `?fields=…` (as the core doc's examples do) gets a
+  superset, so it renders correctly — it just transfers more than it asked for.
+- **The registry is list + import only** — no preview or export route.
+
+### 5. `kind: "agent"` collection actions run visible, not hidden
 
 Not part of the PR4/PR5 series, but a real behavioral difference documented
 during the collection-plugin `0.11` upgrade (#383).

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -102,9 +102,11 @@ remaining item with correctness stakes.
 
 ### 4. Custom-view host surface — shipped, with two known edges
 
-The token-scoped surface a sandboxed custom view talks to is now the same on
-both hosts (#1490). This is deliberately parity-tracked rather than "MT's own
-API", because core's bundled authoring docs — which MulmoTerminal itself serves
+The endpoints a sandboxed custom view talks to, and the authorization rules
+guarding them, are now the same on both hosts (#1490) — the response *bodies*
+still differ in the one place noted at the end of this section. This is
+deliberately parity-tracked rather than "MT's own API", because core's bundled
+authoring docs — which MulmoTerminal itself serves
 through `manageCollection`'s `schemaDocs` — tell collection authors these exist:
 
 | Endpoint | Where |

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -880,6 +880,9 @@ export function mountCollectionRoutes(app: Express): void {
   app.options("/api/collections/:slug/view-data/query", viewDataCors, (_req: Request, res: Response) => {
     res.status(204).end();
   });
+  // Not `guarded` like its neighbours, on purpose: the handler catches its own
+  // throw so it can answer a FIXED message. A raw engine error can carry host
+  // paths, and `guarded` would put exactly that in the body for a scoped view.
   app.post("/api/collections/:slug/view-data/query", viewDataCors, viewActionRateLimit, viewQueryConcurrency, requireViewToken("read"), viewDataQueryHandler);
 
   // The rest of the custom-view surface (customViewRoutes.ts: the i18n dict, the

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -51,6 +51,10 @@ import { actionVisible, fieldVisible, COMPUTED_TYPES, type ActionWithWhen, type 
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
+// The rest of the custom-view surface (view-i18n, scoped image resolve, scoped
+// mutate action), mounted at the bottom of mountCollectionRoutes with the
+// helpers those routes share with the ones here.
+import { mountCustomViewRoutes, viewActionRateLimit } from "./customViewRoutes.js";
 // Mobile custom-view builder — shared with the remote-host channel handlers so
 // the desktop phone-frame preview renders the EXACT artifact the phone receives.
 import {
@@ -876,5 +880,18 @@ export function mountCollectionRoutes(app: Express): void {
   app.options("/api/collections/:slug/view-data/query", viewDataCors, (_req: Request, res: Response) => {
     res.status(204).end();
   });
-  app.post("/api/collections/:slug/view-data/query", viewDataCors, viewQueryConcurrency, requireViewToken("read"), viewDataQueryHandler);
+  app.post("/api/collections/:slug/view-data/query", viewDataCors, viewActionRateLimit, viewQueryConcurrency, requireViewToken("read"), viewDataQueryHandler);
+
+  // The rest of the custom-view surface (customViewRoutes.ts: the i18n dict, the
+  // scoped image resolve, the scoped mutate action), handed the loader / view
+  // lookup / mutate executor / gate it shares with the routes above.
+  mountCustomViewRoutes(app, {
+    resolveCollection,
+    resolveView,
+    respondForMutateAction,
+    visibilityGate,
+    guarded,
+    cors: viewDataCors,
+    queryConcurrency: viewQueryConcurrency,
+  });
 }

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -1,0 +1,213 @@
+// The custom-view routes a view needs beyond reading its records (#1490): its
+// translations (parent-side), and — under its scoped token — resolving one image
+// and pressing one DECLARED mutate action. All three are ports of MulmoClaude's
+// host routes at the same paths, because core's bundled custom-view doc (served
+// here through manageCollection's schemaDocs) tells collection authors they
+// exist: a view written on one host has to work on the other.
+//
+// They live outside collections.ts only because that file is at its line budget;
+// the helpers they need are handed in at mount time rather than imported back,
+// so there is no cycle between the two modules.
+import type { Express, Request, RequestHandler, Response } from "express";
+import { clampImageMaxEdge } from "@mulmoclaude/core/remote-view";
+import { collectionWritable, readCustomViewI18n, readOnlyRefusal, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
+import { actionVisible, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+// The same thumbnail resolver the mobile view's image inlining uses, so a desktop
+// view's <img> and the phone's inlined one are the same bytes.
+import { resolveThumbnail } from "./thumbnailStore.js";
+import { makeViewActionRateLimiter, ONE_MINUTE_MS, VIEW_ACTION_RATE_LIMIT_PER_MINUTE, VIEW_IMAGE_RATE_LIMIT_PER_MINUTE } from "./viewRateLimit.js";
+import { requireViewToken } from "./viewToken.js";
+import { hostLogger } from "./hostLogger.js";
+import { isRecord } from "../../common/isRecord.js";
+
+const log = hostLogger;
+
+/** What these routes need from the collections backend: its 404-answering loader,
+ *  its mutate executor, the action gate both spellings of `when` fold into, and
+ *  the two middlewares the whole view-data family shares. */
+export interface CustomViewRouteDeps {
+  /** Load a collection, answering 404 itself; null means the response was sent. */
+  resolveCollection: (res: Response, slug: string) => Promise<LoadedCollection | null>;
+  /** Locate a declared custom view, answering 404 itself; null means sent. */
+  resolveView: (res: Response, collection: LoadedCollection, viewId: string) => { i18n?: string | undefined } | null;
+  /** Apply a mutate action and answer with the written record (or its refusal). */
+  respondForMutateAction: (
+    res: Response,
+    collection: LoadedCollection,
+    action: CollectionMutateAction,
+    itemId: string,
+    body: { params?: unknown } | undefined,
+  ) => Promise<void>;
+  /** An action's state gate, in the shape `actionVisible` reads. */
+  visibilityGate: (action: CollectionAction) => ActionWithWhen;
+  /** Wrap a handler so a throw becomes a logged 500. */
+  guarded: <P extends Record<string, string>>(op: string, handler: RequestHandler<P>) => RequestHandler<P>;
+  /** `Access-Control-*` for the opaque-origin iframe's preflighted fetch. */
+  cors: RequestHandler;
+  /** Per-slug in-flight cap shared with /query — both are full record scans. */
+  queryConcurrency: RequestHandler;
+}
+
+/** True when `relPath` is a CURRENT value of one of the schema's `image`-type
+ *  fields (top-level only, matching the mobile view's `inlineFields` rule) across
+ *  `items`. This is the authorization rule for the image route: a scoped view
+ *  token may resolve exactly these paths and nothing else, never an arbitrary
+ *  workspace file. Early-exit scan; exported for the spec. */
+export function isAuthorizedImagePath(schema: LoadedCollection["schema"], items: CollectionItem[], relPath: string): boolean {
+  const imageFields = Object.entries(schema.fields)
+    .filter(([, spec]) => spec.type === "image")
+    .map(([name]) => name);
+  if (imageFields.length === 0 || relPath.length === 0) return false;
+  return items.some((item) => imageFields.some((field) => item[field] === relPath));
+}
+
+// Translation dict for ONE custom view, locale-filtered server-side. The client
+// passes its active app locale; the host returns only that locale's strings
+// (fallback "en", then {}). The view never sees other locales' strings — the
+// host is the picker, the iframe is the consumer. Behind the same guard as the
+// rest of the parent-side routes (not the view token): the parent fetches it
+// and passes the dict into the srcdoc bootstrap, so the iframe never calls here.
+//
+// `{ locale: "", dict: {} }` when the view declares no `i18n` or the file is
+// absent / malformed — the iframe's `__MC_VIEW.t(key)` then echoes the key, so
+// an i18n-less view keeps working unchanged. Same contract as MulmoClaude's
+// `viewI18n` route, which is what core's bundled custom-view docs (served here
+// through schemaDocs) tell collection authors to expect.
+const makeI18nHandler =
+  (deps: CustomViewRouteDeps): RequestHandler<{ slug: string }> =>
+  async (req, res) => {
+    const viewId = typeof req.query.id === "string" ? req.query.id : "";
+    const locale = typeof req.query.locale === "string" ? req.query.locale : "";
+    const collection = await deps.resolveCollection(res, req.params.slug);
+    if (!collection) return;
+    const view = deps.resolveView(res, collection, viewId);
+    if (!view) return;
+    if (!view.i18n) {
+      // The documented "no i18n" shape, so the client needs no special case.
+      res.json({ locale: "", dict: {} });
+      return;
+    }
+    res.json(await readCustomViewI18n(collection, view.i18n, locale));
+  };
+
+// Scoped image read: resolve one record-referenced image path into a downscaled
+// `data:` thumbnail (same resolver + clamps as the mobile view's imageFields
+// inlining). The record scan doubles as the authorization check. A sandboxed view
+// cannot attach its token to an `<img>`, so the JSON `{ dataUrl }` shape
+// (fetch → img.src) is the contract the custom-view doc documents.
+const makeImageHandler =
+  (deps: CustomViewRouteDeps): RequestHandler<{ slug: string }> =>
+  async (req, res) => {
+    const collection = await deps.resolveCollection(res, req.params.slug);
+    if (!collection) return;
+    const relPath = typeof req.query.path === "string" ? req.query.path : "";
+    if (relPath.length === 0) {
+      res.status(400).json({ error: "pass `path` — an image field's workspace-relative value" });
+      return;
+    }
+    try {
+      const items = await storeFor(collection).list();
+      if (!isAuthorizedImagePath(collection.schema, items, relPath)) {
+        res.status(404).json({ error: "path is not a current value of this collection's image fields" });
+        return;
+      }
+      const dataUrl = await resolveThumbnail(relPath, clampImageMaxEdge(req.query.maxEdge));
+      if (dataUrl === null) {
+        res.status(404).json({ error: "image could not be resolved" });
+        return;
+      }
+      res.json({ path: relPath, dataUrl });
+    } catch (err) {
+      // The token holder gets a FIXED message — a raw resolver error can carry
+      // host paths, and a scoped view is not a trusted audience for those.
+      log.warn("collections", "view-data image failed", { slug: collection.slug, error: err instanceof Error ? err.message : String(err) });
+      res.status(500).json({ error: "image resolve failed" });
+    }
+  };
+
+// Token-scoped mutate-action invocation: lets a `write`-capable custom view press
+// a DECLARED mutate button instead of re-encoding the transition as a hand-rolled
+// PUT /view-data (which would skip `require` and duplicate the `set` logic into
+// the view's HTML). Mutate kind ONLY — a view token must never be able to start
+// LLM work, so chat/agent actions stay on the parent-side action route.
+const makeActionHandler =
+  (deps: CustomViewRouteDeps): RequestHandler<{ slug: string; actionId: string }> =>
+  async (req, res) => {
+    const collection = await deps.resolveCollection(res, req.params.slug);
+    if (!collection) return;
+    const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
+    if (!action) {
+      res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+      return;
+    }
+    if (action.kind !== "mutate") {
+      res.status(403).json({ error: `action '${action.id}' has kind "${action.kind}" — view tokens can only invoke "mutate" actions` });
+      return;
+    }
+    // Schema validation already rejects mutate actions on a dataSource collection;
+    // this is the defensive twin the parent-side action route also carries.
+    if (!collectionWritable(collection)) {
+      res.status(405).json({ error: readOnlyRefusal(collection.slug) });
+      return;
+    }
+    const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
+    const itemId = typeof body.itemId === "string" ? body.itemId.trim() : "";
+    if (!itemId) {
+      res.status(400).json({ error: "`itemId` is required (the record's primary-key value)" });
+      return;
+    }
+    const record = await storeFor(collection).read(itemId);
+    if (!record) {
+      res.status(404).json({ error: `item '${itemId}' not found` });
+      return;
+    }
+    // The same visibility-is-authorization re-check the parent-side route runs.
+    if (!actionVisible(deps.visibilityGate(action), record)) {
+      res.status(409).json({ error: `action '${action.id}' is not available for item '${itemId}' in its current state` });
+      return;
+    }
+    await deps.respondForMutateAction(res, collection, action, itemId, body);
+  };
+
+// Per-minute budgets, keyed by IP + slug. Two buckets on purpose: a gallery's
+// first paint is legitimately dozens of image fetches, which would exhaust the
+// action budget on its own.
+const imageRateLimit = makeViewActionRateLimiter(VIEW_IMAGE_RATE_LIMIT_PER_MINUTE, ONE_MINUTE_MS);
+const actionRateLimit = makeViewActionRateLimiter(VIEW_ACTION_RATE_LIMIT_PER_MINUTE, ONE_MINUTE_MS);
+
+/** Mount `GET …/view-i18n`, `GET …/view-data/image` and
+ *  `POST …/view-data/actions/:actionId` — the last two with the preflight the
+ *  sandboxed iframe's cross-origin fetch needs. */
+export function mountCustomViewRoutes(app: Express, deps: CustomViewRouteDeps): void {
+  const preflight = (_req: Request, res: Response): void => {
+    res.status(204).end();
+  };
+
+  // Parent-side (no view token): the app fetches the dict and passes it into the
+  // srcdoc bootstrap, so the iframe never calls this itself.
+  app.get("/api/collections/:slug/view-i18n", deps.guarded("view-i18n read", makeI18nHandler(deps)));
+
+  app.options("/api/collections/:slug/view-data/image", deps.cors, preflight);
+  app.get(
+    "/api/collections/:slug/view-data/image",
+    deps.cors,
+    imageRateLimit,
+    deps.queryConcurrency,
+    requireViewToken("read"),
+    deps.guarded("view-data image", makeImageHandler(deps)),
+  );
+
+  app.options("/api/collections/:slug/view-data/actions/:actionId", deps.cors, preflight);
+  app.post(
+    "/api/collections/:slug/view-data/actions/:actionId",
+    deps.cors,
+    actionRateLimit,
+    requireViewToken("write"),
+    deps.guarded("view-data action", makeActionHandler(deps)),
+  );
+}
+
+/** The action/query budget, exported so collections.ts can put `/query` on the
+ *  same bucket its MulmoClaude counterpart uses. */
+export const viewActionRateLimit = actionRateLimit;

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -189,6 +189,14 @@ export function mountCustomViewRoutes(app: Express, deps: CustomViewRouteDeps): 
   app.get("/api/collections/:slug/view-i18n", deps.guarded("view-i18n read", makeI18nHandler(deps)));
 
   app.options("/api/collections/:slug/view-data/image", deps.cors, preflight);
+  // `queryConcurrency` (4 in flight per slug, shared with /query) is deliberate,
+  // and matching MulmoClaude here is not incidental: core's custom-view doc — the
+  // one this app serves to the agent — states the cap, tells authors never to
+  // `Promise.all` over every record, and ships a worker-pool + 429-retry snippet
+  // to obey it. A view that fires N parallel fetches gets 429s on BOTH hosts, by
+  // design; raising the cap here would make a view that only works on
+  // MulmoTerminal look correct. The high per-minute image budget is the other
+  // axis — it exists so a throttled pool of 3 isn't starved over a full gallery.
   app.get(
     "/api/collections/:slug/view-data/image",
     deps.cors,

--- a/server/backends/viewRateLimit.ts
+++ b/server/backends/viewRateLimit.ts
@@ -19,9 +19,17 @@ export const ONE_MINUTE_MS = 60_000;
  *  spec can drive the window without waiting on a real clock. */
 export function makeViewActionRateLimiter(max: number, windowMs: number, now: () => number = Date.now) {
   const hits = new Map<string, { count: number; resetAt: number }>();
+  let nextSweepAt = 0;
   return (req: Request<{ slug?: string }>, res: Response, next: NextFunction): void => {
     const nowMs = now();
-    if (hits.size > SWEEP_THRESHOLD) {
+    // Deliberate divergence from MulmoClaude, which gates this on map size alone:
+    // the limiter runs BEFORE `requireViewToken`, so unauthenticated requests
+    // create entries too. Past the threshold with every entry still inside its
+    // window, a size-only gate sweeps on every request and deletes nothing —
+    // O(n) per request while the map keeps growing. Sweeping at most once per
+    // window bounds that; the rate decisions below are unchanged either way.
+    if (hits.size > SWEEP_THRESHOLD && nowMs >= nextSweepAt) {
+      nextSweepAt = nowMs + windowMs;
       for (const [key, entry] of hits) if (entry.resetAt <= nowMs) hits.delete(key);
     }
     const key = `${req.ip ?? ""}\n${req.params.slug ?? ""}`;

--- a/server/backends/viewRateLimit.ts
+++ b/server/backends/viewRateLimit.ts
@@ -1,0 +1,49 @@
+// Per-minute request budget for the token-scoped custom-view endpoints —
+// MulmoTerminal's port of MulmoClaude's `makeViewActionRateLimiter`
+// (server/api/routes/collections.ts).
+//
+// The view token already bounds WHAT a sandboxed iframe may touch (one slug,
+// read/write); this bounds HOW OFTEN. Each of the endpoints behind it costs a
+// full record scan plus real work (a mutate write, a thumbnail decode), so a
+// runaway `onChange` loop in LLM-authored HTML must not be able to spin the
+// host. Keyed by IP + slug, fixed window, in memory: the same shape as
+// MulmoClaude's, so a view that behaves on one host behaves on the other.
+import type { Request, Response, NextFunction } from "express";
+
+/** Entries are swept lazily, when the map grows past this. */
+const SWEEP_THRESHOLD = 1000;
+
+export const ONE_MINUTE_MS = 60_000;
+
+/** `max` requests per `windowMs` per (IP, slug). `now` is injectable so the
+ *  spec can drive the window without waiting on a real clock. */
+export function makeViewActionRateLimiter(max: number, windowMs: number, now: () => number = Date.now) {
+  const hits = new Map<string, { count: number; resetAt: number }>();
+  return (req: Request<{ slug?: string }>, res: Response, next: NextFunction): void => {
+    const nowMs = now();
+    if (hits.size > SWEEP_THRESHOLD) {
+      for (const [key, entry] of hits) if (entry.resetAt <= nowMs) hits.delete(key);
+    }
+    const key = `${req.ip ?? ""}\n${req.params.slug ?? ""}`;
+    const entry = hits.get(key);
+    if (!entry || entry.resetAt <= nowMs) {
+      hits.set(key, { count: 1, resetAt: nowMs + windowMs });
+      next();
+      return;
+    }
+    entry.count += 1;
+    if (entry.count > max) {
+      res.status(429).json({ error: "rate limit exceeded — retry shortly" });
+      return;
+    }
+    next();
+  };
+}
+
+/** Mutate actions and aggregation queries share one budget. */
+export const VIEW_ACTION_RATE_LIMIT_PER_MINUTE = 60;
+
+/** Image thumbnails get their own, roomier bucket: a gallery legitimately fetches
+ *  dozens of images on first paint, so the action budget would starve it — while
+ *  the endpoint still needs a ceiling (record scan + thumbnail decode each). */
+export const VIEW_IMAGE_RATE_LIMIT_PER_MINUTE = 300;

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -21,6 +21,7 @@ import type {
   CollectionRemoteViewResult,
   CollectionRemoteViewMutateResult,
   CollectionRemoteViewItemsResult,
+  CollectionViewI18nResult,
 } from "@mulmoclaude/collection-plugin/vue";
 import type {
   CollectionDetailResponse,
@@ -200,10 +201,14 @@ configureCollectionUi({
       `/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/items${remoteViewItemsQuery(request)}`,
     ),
 
-  // MulmoTerminal serves no per-view translations — return the documented
-  // "no i18n" shape ({ locale: "", dict: {} }) so the iframe's __MC_VIEW.t(key)
-  // echoes keys instead of failing.
-  fetchViewI18n: () => Promise.resolve({ ok: true as const, data: { locale: "", dict: {} } }),
+  // The view's translations, already locale-picked server-side (the host is the
+  // picker, the iframe only ever sees the active locale's strings). The route
+  // answers the documented "no i18n" shape ({ locale: "", dict: {} }) when the
+  // view declares none, and the iframe's __MC_VIEW.t(key) then echoes keys.
+  fetchViewI18n: (slug, viewId, locale) =>
+    apiGet<CollectionViewI18nResult>(
+      `/api/collections/${encodeURIComponent(slug)}/view-i18n?id=${encodeURIComponent(viewId)}&locale=${encodeURIComponent(locale)}`,
+    ),
 
   // ── record CRUD: create / update (e.g. checking a to-do item) / delete. ──
   createItem: (slug, record) => apiPost<ItemMutationResponse>(`/api/collections/${encodeURIComponent(slug)}/items`, record),

--- a/src/utils/customViewSrcdoc.ts
+++ b/src/utils/customViewSrcdoc.ts
@@ -4,7 +4,7 @@
 // Injected at the START of <head> so the bootstrap runs before the view's own
 // scripts: (1) a CSP <meta> locking connect-src to the server origin (the view may
 // fetch its data endpoint but no third party), and (2)
-// `window.__MC_VIEW = { slug, token, dataUrl, origin, onChange, openItem, startChat }`
+// `window.__MC_VIEW = { slug, token, dataUrl, origin, locale, dict, onChange, openItem, startChat, t }`
 // — the scoped token + absolute data URL the view reads, PLUS the view↔host bridge
 // (onChange live-refresh + openItem + startChat helpers that postMessage the parent,
 // which @mulmoclaude/collection-plugin's CollectionCustomView consumes). Without the
@@ -43,6 +43,14 @@ export interface CustomViewBootstrap {
   slug: string;
   /** Scoped capability token (Authorization: Bearer <token>). */
   token: string;
+  /** The locale the dict was picked for (e.g. `"en"`, `"ja"`); empty when the view
+   *  declares no `i18n` or no locale block matched. Always exposed as
+   *  `__MC_VIEW.locale` — an empty string means "no translations". */
+  locale?: string;
+  /** Flat key→string map the HOST already locale-filtered (GET /view-i18n). The
+   *  iframe sees ONLY this locale's strings, via `__MC_VIEW.dict` and the
+   *  `__MC_VIEW.t(key, named?)` helper. */
+  dict?: Record<string, string>;
   /** Data endpoint URL; absolutised against `origin` when root-relative (the iframe
    *  is `about:srcdoc`, so a relative `/api/...` would not resolve). */
   dataUrl: string;
@@ -59,14 +67,21 @@ function absoluteDataUrl(dataUrl: string, origin: string): string {
 const ONCHANGE_DEBOUNCE_MS = 150;
 
 /** The in-iframe view↔host bridge appended after `window.__MC_VIEW = {…}`. Ported
- *  verbatim from MulmoClaude (src/utils/html/customViewSrcdoc.ts). Defines the three
- *  functions the custom view calls — they postMessage the parent, which
+ *  verbatim from MulmoClaude (src/utils/html/customViewSrcdoc.ts). Defines the four
+ *  functions the custom view calls — three postMessage the parent, which
  *  @mulmoclaude/collection-plugin's CollectionCustomView already handles (mc-open-item /
  *  mc-start-chat) and pings (mc-collection-changed) for live refresh. No secret crosses
- *  the boundary; openItem/startChat go to the known parent `v.origin`. Self-contained
- *  string (no `</script>`, no `<`, no `${`) so it survives inlining into the <script>. */
+ *  the boundary; openItem/startChat go to the known parent `v.origin`.
+ *
+ *  The fourth is `t(key, named)`: a tiny vue-i18n-COMPATIBLE lookup (`dict[key]`, then
+ *  `{name}` interpolation from `named`, else the key itself) over the dict the host
+ *  already locale-filtered. Compatible so an author can copy their app's locale JSON
+ *  verbatim — without the ~50KB vue-i18n runtime being shipped into every iframe.
+ *
+ *  Self-contained string (no `</script>`, no `<`, no `${`) so it survives inlining
+ *  into the <script>. */
 function viewBridgeBootstrap(): string {
-  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};v.startChat=function(prompt,role){window.parent.postMessage({type:'mc-start-chat',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},v.origin);};})();`;
+  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};v.startChat=function(prompt,role){window.parent.postMessage({type:'mc-start-chat',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},v.origin);};v.dict=v.dict||{};v.t=function(key,named){var s=v.dict[key];if(typeof s!=='string')return typeof key==='string'?key:String(key);if(!named||typeof named!=='object')return s;return s.replace(/\\{(\\w+)\\}/g,function(m,n){var x=named[n];return x==null?m:String(x);});};})();`;
 }
 
 export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): string {
@@ -77,6 +92,11 @@ export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): 
     token: boot.token,
     dataUrl: absoluteDataUrl(boot.dataUrl, boot.origin),
     origin: boot.origin, // target origin for openItem/startChat postMessage to the parent
+    // Host-picked translations. The same `<`-escape covers them: `dict` is
+    // author-written JSON, so a `</script>` literal in a string must not close
+    // the tag it is being inlined into.
+    locale: boot.locale ?? "",
+    dict: boot.dict ?? {},
   }).replace(/</g, "\\u003c");
   const injection = `${cspMeta}<script>window.__MC_VIEW=${json};${viewBridgeBootstrap()}</script>`;
   if (/<head\b[^>]*>/i.test(html)) {

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -6,6 +6,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { appRequest } from "../../helpers/appRequest.js";
 import { initCollectionsBackend, mountCollectionRoutes, visibilityGate } from "../../../server/backends/collections.js";
+import { isAuthorizedImagePath } from "../../../server/backends/customViewRoutes.js";
 import { actionVisible } from "@mulmoclaude/core/collection";
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 
@@ -57,7 +58,7 @@ const SCHEMA = {
   },
   views: [
     { id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] },
-    { id: "v2", file: "views/v2.html", label: "Editable", capabilities: ["read", "write"] },
+    { id: "v2", file: "views/v2.html", label: "Editable", capabilities: ["read", "write"], i18n: "views/v2.i18n.json" },
     { id: "phone", file: "views/phone.html", label: "Phone", target: "mobile", editableFields: ["name"] },
   ],
   actions: [{ id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" }],
@@ -80,6 +81,39 @@ beforeAll(async () => {
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v2.html"), "<head></head><body>editable</body>");
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "phone.html"), "<head></head><body>phone-view</body>");
+  // v2's translations, in the on-disk `{ <locale>: { <key>: <string> } }` shape.
+  // The host picks ONE locale block per request — the view never sees the rest.
+  writeFileSync(
+    path.join(ws, "data", "skills", "testcol", "views", "v2.i18n.json"),
+    JSON.stringify({ en: { greet: "Hello {name}" }, ja: { greet: "こんにちは {name}" } }),
+  );
+
+  // A collection whose custom view may press a DECLARED mutate action under its
+  // view token: one mutate action gated by `require`, one chat action (which a
+  // view token must never be able to invoke), and a write-capable view.
+  const VIEW_ACTION_SCHEMA = {
+    title: "View Actions",
+    icon: "bolt",
+    dataPath: "data/viewactcol/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      status: { type: "enum", label: "Status", values: ["open", "closed"] },
+    },
+    actions: [
+      { id: "close", label: "Close", kind: "mutate", set: { status: "closed" }, require: { field: "status", in: ["open"] } },
+      { id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" },
+    ],
+    views: [{ id: "board", file: "views/board.html", label: "Board", capabilities: ["read", "write"] }],
+  };
+  mkdirSync(path.join(ws, ".claude", "skills", "viewactcol", "templates"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "viewactcol", "schema.json"), JSON.stringify(VIEW_ACTION_SCHEMA));
+  writeFileSync(path.join(ws, ".claude", "skills", "viewactcol", "templates", "enrich.md"), "ENRICH");
+  mkdirSync(path.join(ws, "data", "viewactcol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "viewactcol", "items", "a1.json"), JSON.stringify({ id: "a1", status: "open" }));
+  writeFileSync(path.join(ws, "data", "viewactcol", "items", "a2.json"), JSON.stringify({ id: "a2", status: "closed" }));
+  mkdirSync(path.join(ws, "data", "skills", "viewactcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "viewactcol", "views", "board.html"), "<head></head><body>board</body>");
 
   // A singleton collection with a write-capable view, to prove PUT /view-data
   // enforces the singleton invariant (only the fixed id is writable).
@@ -134,12 +168,18 @@ beforeAll(async () => {
       name: { type: "string", label: "Name" },
       photo: { type: "image", label: "Photo" },
     },
-    views: [{ id: "gallery", file: "views/gallery.html", label: "Gallery", target: "mobile", imageFields: ["photo"] }],
+    views: [
+      { id: "gallery", file: "views/gallery.html", label: "Gallery", target: "mobile", imageFields: ["photo"] },
+      // A desktop view: it can't inline images the way the phone page does, so
+      // it resolves each one through GET /view-data/image under its token.
+      { id: "wall", file: "views/wall.html", label: "Wall", capabilities: ["read"] },
+    ],
   };
   mkdirSync(path.join(ws, ".claude", "skills", "photoscol"), { recursive: true });
   writeFileSync(path.join(ws, ".claude", "skills", "photoscol", "schema.json"), JSON.stringify(PHOTOS_SCHEMA));
   mkdirSync(path.join(ws, "data", "skills", "photoscol", "views"), { recursive: true });
   writeFileSync(path.join(ws, "data", "skills", "photoscol", "views", "gallery.html"), "<head></head><body>gallery</body>");
+  writeFileSync(path.join(ws, "data", "skills", "photoscol", "views", "wall.html"), "<head></head><body>wall</body>");
   mkdirSync(path.join(ws, "data", "photoscol", "images"), { recursive: true });
   const pic = await sharp({ create: { width: 40, height: 24, channels: 3, background: { r: 200, g: 30, b: 90 } } })
     .png()
@@ -871,5 +911,162 @@ describe("visibilityGate", () => {
     const gate = visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" }, require: WHEN });
     expect(actionVisible(gate, { status: "draft" })).toBe(false);
     expect(actionVisible(gate, { status: "ready" })).toBe(true);
+  });
+});
+
+// The three token-scoped / view-facing endpoints MulmoTerminal used to be missing
+// (issue #1490): the i18n dict a view's `t()` reads, the image resolve a desktop
+// view needs (it cannot inline thumbnails the way the phone page does), and the
+// mutate-action invocation that keeps a view from hand-rolling the transition.
+describe("custom-view i18n (GET /:slug/view-i18n)", () => {
+  it("returns the requested locale's block, flattened", async () => {
+    const res = await request("/api/collections/testcol/view-i18n?id=v2&locale=ja");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ locale: "ja", dict: { greet: "こんにちは {name}" } });
+  });
+
+  it("falls back to en for a locale the file has no block for", async () => {
+    const res = await request("/api/collections/testcol/view-i18n?id=v2&locale=fr");
+    expect(await res.json()).toEqual({ locale: "en", dict: { greet: "Hello {name}" } });
+  });
+
+  it("returns the documented empty shape for a view that declares no i18n", async () => {
+    const res = await request("/api/collections/testcol/view-i18n?id=v1&locale=ja");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ locale: "", dict: {} });
+  });
+
+  it("404s an unknown view id", async () => {
+    expect((await request("/api/collections/testcol/view-i18n?id=nope")).status).toBe(404);
+  });
+});
+
+describe("custom-view image resolve (GET /:slug/view-data/image)", () => {
+  const mintWall = async (): Promise<string> => {
+    const mint = await request("/api/collections/photoscol/view-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "wall" }),
+    });
+    return ((await mint.json()) as { token: string }).token;
+  };
+
+  it("401s without a token", async () => {
+    const res = await request("/api/collections/photoscol/view-data/image?path=data/photoscol/images/pic.png");
+    expect(res.status).toBe(401);
+  });
+
+  it("resolves a current image-field value into a data: thumbnail", async () => {
+    const token = await mintWall();
+    const res = await request("/api/collections/photoscol/view-data/image?path=data%2Fphotoscol%2Fimages%2Fpic.png&maxEdge=32", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string; dataUrl: string };
+    expect(body.path).toBe("data/photoscol/images/pic.png");
+    expect(body.dataUrl.startsWith("data:image/")).toBe(true);
+  });
+
+  it("400s when `path` is missing", async () => {
+    const token = await mintWall();
+    const res = await request("/api/collections/photoscol/view-data/image", { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(400);
+  });
+
+  // The authorization rule: only a CURRENT value of an image field resolves, so
+  // the token can never be used to read an arbitrary workspace file.
+  it("404s a path no record holds in an image field", async () => {
+    const token = await mintWall();
+    const res = await request("/api/collections/photoscol/view-data/image?path=data%2Fphotoscol%2Fitems%2Fp1.json", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toContain("image fields");
+  });
+
+  it("preflights", async () => {
+    const res = await request("/api/collections/photoscol/view-data/image", { method: "OPTIONS" });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});
+
+describe("isAuthorizedImagePath", () => {
+  const schema = {
+    fields: { id: { type: "string" }, photo: { type: "image" }, note: { type: "string" } },
+  } as unknown as Parameters<typeof isAuthorizedImagePath>[0];
+
+  it("accepts a current image-field value", () => {
+    expect(isAuthorizedImagePath(schema, [{ id: "a", photo: "img/a.png" }], "img/a.png")).toBe(true);
+  });
+
+  it("rejects a value held by a non-image field", () => {
+    expect(isAuthorizedImagePath(schema, [{ id: "a", note: "img/a.png" }], "img/a.png")).toBe(false);
+  });
+
+  it("rejects an empty path and a schema with no image fields", () => {
+    expect(isAuthorizedImagePath(schema, [{ id: "a", photo: "img/a.png" }], "")).toBe(false);
+    const noImages = { fields: { id: { type: "string" } } } as unknown as Parameters<typeof isAuthorizedImagePath>[0];
+    expect(isAuthorizedImagePath(noImages, [{ id: "a", photo: "img/a.png" }], "img/a.png")).toBe(false);
+  });
+});
+
+describe("custom-view mutate actions (POST /:slug/view-data/actions/:actionId)", () => {
+  const mintBoard = async (): Promise<string> => {
+    const mint = await request("/api/collections/viewactcol/view-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "board" }),
+    });
+    return ((await mint.json()) as { token: string }).token;
+  };
+  const run = async (actionId: string, body: unknown, token: string) =>
+    request(`/api/collections/viewactcol/view-data/actions/${actionId}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  it("401s without a token", async () => {
+    const res = await request("/api/collections/viewactcol/view-data/actions/close", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ itemId: "a1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("applies a declared mutate action and returns the written record", async () => {
+    const res = await run("close", { itemId: "a1" }, await mintBoard());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { written: boolean; item: { id: string; status: string } };
+    expect(body.written).toBe(true);
+    expect(body.item.status).toBe("closed");
+  });
+
+  // A view token must never be able to start LLM work — that is the whole reason
+  // this endpoint is mutate-only rather than a second door onto the action route.
+  it("403s a chat action", async () => {
+    const res = await run("enrich", { itemId: "a2" }, await mintBoard());
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toContain("mutate");
+  });
+
+  it("409s an action whose `require` the record does not satisfy", async () => {
+    const res = await run("close", { itemId: "a2" }, await mintBoard());
+    expect(res.status).toBe(409);
+  });
+
+  it("400s a missing itemId and 404s an unknown item / action", async () => {
+    const token = await mintBoard();
+    expect((await run("close", {}, token)).status).toBe(400);
+    expect((await run("close", { itemId: "ghost" }, token)).status).toBe(404);
+    expect((await run("nope", { itemId: "a1" }, token)).status).toBe(404);
+  });
+
+  it("preflights", async () => {
+    const res = await request("/api/collections/viewactcol/view-data/actions/close", { method: "OPTIONS" });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
   });
 });

--- a/test/server/backends/viewRateLimit.spec.ts
+++ b/test/server/backends/viewRateLimit.spec.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response } from "express";
+import { makeViewActionRateLimiter, ONE_MINUTE_MS } from "../../../server/backends/viewRateLimit.js";
+
+// Minimal express stand-ins: the limiter only reads req.ip / req.params.slug and
+// only ever calls res.status().json() on refusal, so driving it directly is both
+// exact and free of an HTTP round trip.
+const reqFor = (ip: string, slug: string) => ({ ip, params: { slug } }) as unknown as Request<{ slug?: string }>;
+
+function resSpy() {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { res: { status } as unknown as Response, status, json };
+}
+
+describe("makeViewActionRateLimiter", () => {
+  it("passes requests up to the budget, then 429s", () => {
+    const limit = makeViewActionRateLimiter(3, ONE_MINUTE_MS, () => 1000);
+    const next = vi.fn();
+    const { res, status } = resSpy();
+    for (let i = 0; i < 3; i += 1) limit(reqFor("client-a", "col"), res, next);
+    expect(next).toHaveBeenCalledTimes(3);
+    limit(reqFor("client-a", "col"), res, next);
+    expect(next).toHaveBeenCalledTimes(3);
+    expect(status).toHaveBeenCalledWith(429);
+  });
+
+  it("keys by IP AND slug, so one view's burst can't starve another", () => {
+    const limit = makeViewActionRateLimiter(1, ONE_MINUTE_MS, () => 1000);
+    const next = vi.fn();
+    const { res, status } = resSpy();
+    limit(reqFor("client-a", "colA"), res, next);
+    limit(reqFor("client-a", "colB"), res, next); // different slug — own bucket
+    limit(reqFor("client-b", "colA"), res, next); // different IP — own bucket
+    expect(next).toHaveBeenCalledTimes(3);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh window once the old one has elapsed", () => {
+    let now = 1000;
+    const limit = makeViewActionRateLimiter(1, ONE_MINUTE_MS, () => now);
+    const next = vi.fn();
+    const { res, status } = resSpy();
+    limit(reqFor("client-a", "col"), res, next);
+    limit(reqFor("client-a", "col"), res, next);
+    expect(status).toHaveBeenCalledWith(429);
+    now += ONE_MINUTE_MS + 1;
+    limit(reqFor("client-a", "col"), res, next);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/src/utils/customViewSrcdoc.spec.ts
+++ b/test/src/utils/customViewSrcdoc.spec.ts
@@ -54,6 +54,43 @@ describe("buildCustomViewSrcdoc", () => {
     expect(out).toContain("v.startChat=function");
   });
 
+  // The i18n half of the bridge (#1490). Run the injected bootstrap against a
+  // stand-in `window` rather than string-matching it: what has to hold is what
+  // `t()` RETURNS for an author who copied their app's vue-i18n locale JSON.
+  const runBootstrap = (out: string): { locale: string; dict: Record<string, string>; t: (key: string, named?: Record<string, unknown>) => string } => {
+    const script = /<script>([\s\S]*?)<\/script>/.exec(out)?.[1] ?? "";
+    const win: Record<string, unknown> = { addEventListener: () => {} };
+    // The bootstrap only EXISTS as a string (it is inlined into the iframe's <script>), so running it
+    // is the only way to assert what a view actually gets. The input is this repo's own literal, not
+    // anything a user or collection author can influence.
+    // eslint-disable-next-line sonarjs/code-eval, no-new-func
+    new Function("window", script)(win);
+    return win.__MC_VIEW as ReturnType<typeof runBootstrap>;
+  };
+
+  it("carries the host-picked locale + dict into __MC_VIEW", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", { ...boot, locale: "ja", dict: { greet: "こんにちは {name}" } });
+    const view = runBootstrap(out);
+    expect(view.locale).toBe("ja");
+    expect(view.dict).toEqual({ greet: "こんにちは {name}" });
+  });
+
+  it("t() substitutes named placeholders and falls back to the key", () => {
+    const view = runBootstrap(buildCustomViewSrcdoc("<head></head>", { ...boot, locale: "en", dict: { greet: "Hello {name}" } }));
+    expect(view.t("greet", { name: "Ada" })).toBe("Hello Ada");
+    expect(view.t("greet")).toBe("Hello {name}");
+    expect(view.t("missing")).toBe("missing");
+  });
+
+  // A view whose collection declares no i18n still gets a working t() — that is
+  // what lets an i18n-less view use t() unconditionally.
+  it("defaults to an empty dict when the host passes none", () => {
+    const view = runBootstrap(buildCustomViewSrcdoc("<head></head>", boot));
+    expect(view.locale).toBe("");
+    expect(view.dict).toEqual({});
+    expect(view.t("anything")).toBe("anything");
+  });
+
   it("includes origin so openItem/startChat can postMessage the known parent", () => {
     const out = buildCustomViewSrcdoc("<head></head>", boot);
     expect(out).toContain('"origin":"http://localhost:5173"');


### PR DESCRIPTION
Closes #1490 — option **A** (implement), not B (document the gap).

## Why A

The gap was not a scope choice we had made; it was drift nobody could see from inside this repo. Core's bundled custom-view docs — which MulmoTerminal itself serves to the agent through `manageCollection`'s `schemaDocs` — document `<dataUrl>/image`, `<dataUrl>/actions/<id>` and `"i18n": "views/<name>.i18n.json"` as things a view author can use. On this host, a view following those instructions rendered raw keys, showed broken images, or 404'd, with nothing reporting a problem anywhere.

## What ships

New `server/backends/customViewRoutes.ts`, all three running the shared `@mulmoclaude/core` engines:

| Route | Notes |
| --- | --- |
| `GET …/view-i18n` | Parent-side (not the view token) — core's `readCustomViewI18n`, one locale picked host-side. `{ locale: "", dict: {} }` when a view declares no `i18n`. |
| `GET …/view-data/image` | Scoped token. Resolves an image field's stored path to a downscaled `data:` thumbnail via the same `resolveThumbnail` the phone path uses. |
| `POST …/view-data/actions/:actionId` | Scoped **write** token. **Mutate kind only** — 403 otherwise. |

Two rules worth keeping when this code is touched again:

- The image route's **authorization is the record scan**. `isAuthorizedImagePath` accepts only a **current** value of an `image` field, so a scoped token can never be turned into an arbitrary workspace file read.
- The action route is **mutate-only** on purpose. A view token must never be able to start LLM work, so `chat` / `agent` actions stay on the parent-side route. It otherwise runs the identical pipeline the UI button does: `require` re-checked against the record, params validated, write gate, atomic write.

`server/backends/viewRateLimit.ts` ports MulmoClaude's per-(IP, slug) budget. Images get their own roomier bucket (300/min) because a gallery's first paint is legitimately dozens of fetches; actions share 60/min with `/query`, which had no limiter here before.

**UI side.** `fetchViewI18n` was a stub returning the empty dict; it is now a real fetch. More importantly, `customViewSrcdoc.ts` was missing the i18n half of the bridge *entirely* — no `dict`, no `locale`, and `__MC_VIEW.t` simply `undefined`, so the issue's "falls back to raw keys" was optimistic. Both boot fields and the vue-i18n-compatible `t(key, named)` helper are now there, matching MulmoClaude's string verbatim. `@mulmoclaude/collection-plugin` already called `fetchViewI18n` and forwarded both fields into `buildViewSrcdoc`, so nothing in the plugin needed changing.

## Structure

The handlers sit in their own module behind a deps seam (`resolveCollection`, `resolveView`, `respondForMutateAction`, `visibilityGate`, `guarded`, the CORS and concurrency middlewares handed in at mount time) rather than in `collections.ts`, which is at its 600-line lint budget. Passing the helpers in also keeps the two modules free of an import cycle.

## Parity notes

`docs/mulmoclaude-parity.md` gains a section recording this surface as shared, and states the two differences left open deliberately so the next host binding does not re-open them as accidental drift:

- `GET …/view-data` ignores `ids` / `fields`. MulmoClaude routes that through `manageCollection`'s `getItems`; MT returns every enriched record, so a view passing `?fields=…` (as the core doc's examples do) gets a working superset — it just transfers more than it asked for.
- The registry is list + import only — no preview or export route.

Route paths, status codes and refusal wording were checked against `../mulmoclaude/server/api/routes/collections.ts` and `src/config/apiRoutes.ts` rather than guessed.

## Tests

`yarn typecheck`, `yarn lint` (0 errors), `yarn test` — 8939 passed, 45 skipped.

- 12 route tests over real fixtures: a real PNG through `sharp` for the image route (plus the negative case — a path held by a non-image field 404s), a `require`-gated mutate action for the 200 / 403 / 409 / 400 / 404 mapping, a two-locale i18n file for locale pick, `en` fallback and the no-`i18n` shape.
- 3 unit tests for `isAuthorizedImagePath`, 3 for the rate limiter (budget, per-key isolation, window reset).
- 3 srcdoc tests that **execute** the bootstrap against a stand-in `window` and assert what `t()` returns, rather than string-matching the bundle.

Not verified in a live browser yet — that needs a `yarn build` and a restart against a collection with an image field and a custom view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom-view support for locale-specific translations with fallback text and named placeholders.
  * Added secure image resolution for current view data, including downscaled previews.
  * Added declared custom-view actions for updating eligible records.
  * Added authorization, validation, CORS handling, and separate rate limits for image and action operations.
* **Documentation**
  * Documented the custom-view host surface, endpoint behavior, access rules, and known parity gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->