### PR TITLE
feat: accent collection records that have a pending completion bell (#1491)

### DIFF
--- a/common/collectionNotifyTarget.ts
+++ b/common/collectionNotifyTarget.ts
@@ -1,0 +1,37 @@
+// The navigate target a collection-completion bell carries, and the one narrowing
+// that reads it back. Shared because BOTH sides decide from it: the server writes
+// the target when it publishes a bell (server/backends/collectionNotifierAdapter.ts)
+// and the UI reads it to accent the record's card (src/utils/collectionNotified.ts).
+// A second copy of the literal in the reader is exactly how a writer/reader pair
+// drifts silently — the bell keeps arriving, only the accent stops appearing.
+//
+// CROSS-APP: the shape is MulmoClaude's, which spells the view constant
+// `NOTIFICATION_VIEWS.collections` in its own app source. The VALUE is what
+// crosses the workspace, so keeping it in one place here (rather than importing a
+// constant that isn't published) changes nothing on the wire — entries from either
+// app narrow identically.
+import { isRecord } from "./isRecord.js";
+
+/** `pluginData.action.target.view` for a bell pointing at a collection record. */
+export const COLLECTION_NOTIFY_VIEW = "collections";
+
+export interface CollectionNotifyTarget {
+  slug: string;
+  /** Absent on a collection-level bell — those can't accent a specific record. */
+  itemId?: string | undefined;
+}
+
+/** Narrow a notification's opaque `pluginData` to its collection navigate target,
+ *  or null when it isn't one. `pluginData` reaches the browser as `unknown` (it is
+ *  whatever the publishing app put there, and the other app's version of this
+ *  repo may be older), so every level is checked rather than trusted. */
+export function collectionNotifyTargetOf(pluginData: unknown): CollectionNotifyTarget | null {
+  if (!isRecord(pluginData)) return null;
+  const { action } = pluginData;
+  if (!isRecord(action)) return null;
+  const { target } = action;
+  if (!isRecord(target)) return null;
+  const { view, slug, itemId } = target;
+  if (view !== COLLECTION_NOTIFY_VIEW || typeof slug !== "string" || slug.length === 0) return null;
+  return { slug, itemId: typeof itemId === "string" && itemId.length > 0 ? itemId : undefined };
+}

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,15 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+- **A record with a pending completion bell is now visible in the board** (#1491): the collection
+  view's Kanban cards accent (red for urgent, amber for a nudge) when a completion watcher has an
+  open bell for that record. The publishing half already ran — `collectionWatchers` writes into the
+  shared notifier file, and MulmoTerminal's bell has shown those entries for some time — but the
+  binding the plugin asks for the per-record severities returned an empty map, so nothing in the
+  board reflected it. It now reads the live bell, which means a bell **MulmoClaude** published
+  accents the same card here. Read-only: the one-bell-per-record rule stays where it was enforced,
+  on the shared `legacyId` server-side.
+
 - **Custom views catch up to MulmoClaude's host surface** (#1490): a collection's custom view can
   now read its translations, resolve a stored image, and press a declared mutate action — the three
   things core's own authoring docs (which MulmoTerminal serves to the agent through

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -132,6 +132,12 @@ read-only card over the shared workspace:
   `buildViewSrcdoc`/`listFeeds` → typed failure; `reconcileShortcuts`/`unpin` → no-op;
   `notifiedSeverities` → empty map; `startChat` → no-op (the card uses the `sendTextMessage` prop, not
   this binding hook).
+
+  > **This bullet is the Tier-1 plan, not the current state.** Every binding listed here has since
+  > been wired for real; `notifiedSeverities` was the last of them, in #1491 — it now maps the live
+  > bell's entries (`useNotifications().active` → `src/utils/collectionNotified.ts`) to
+  > `itemId → severity`, which is what accents a Kanban card that has a pending completion bell.
+  > Left as written because the rest of this section records how the increment was scoped.
 - **Asset URLs:** `imageSrc`/`fileAssetUrl` resolve to `GET /api/files/raw?path=<workspace-relative>`
   (server/backends/files.ts), mirroring MulmoClaude's `resolveImageSrc`, so `image`/`file` fields and
   custom-view `<img>` thumbnails render. `fileRoutePath` stays null (no in-app File Explorer).

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -244,6 +244,10 @@ via `useCollectionBrowse`). Verified: MulmoClaude's pinned collections appear in
 toolbar from the shared file; the overlay opens and the index renders. Still open: `startChat` is a
 no-op (collection "create"/action buttons that seed a chat are inert), and Tier 1 write routes.
 
+Both of those have since shipped — `startChat` seeds a visible chat (`startCollectionChat`) and the
+Tier 1 write routes are mounted in `server/backends/collections.ts` — which is what the note under the
+stub list above refers to. The sentence before this one is left as the record of where Tier 2 stopped.
+
 Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
 in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,
 then the toolbar/favorites/browse panel for the actual ask.

--- a/server/backends/collectionNotifierAdapter.ts
+++ b/server/backends/collectionNotifierAdapter.ts
@@ -8,6 +8,9 @@
 import type { CompletionPriority } from "@mulmoclaude/core/collection-watchers";
 import type { NotifierSeverity } from "@mulmoclaude/core/notifier";
 import { isRecord } from "../../common/isRecord.js";
+// The view marker the UI narrows on when it accents a notified record — shared so
+// the writer here and the reader there cannot drift apart.
+import { COLLECTION_NOTIFY_VIEW } from "../../common/collectionNotifyTarget.js";
 
 // `legacy: true` + a string `legacyId` + a string `kind` is the marker both apps'
 // readEntry recognise; the navigate `action` preserves the bell's icon/routing.
@@ -47,7 +50,7 @@ export function buildPluginData(input: { legacyId: string; slug: string; itemId:
     legacyId,
     kind: "todo",
     priority: priority === "high" ? "high" : "normal",
-    action: { type: "navigate", target: { view: "collections", slug, itemId } },
+    action: { type: "navigate", target: { view: COLLECTION_NOTIFY_VIEW, slug, itemId } },
   };
 }
 

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -11,8 +11,8 @@
 // Google-calendar push (via @mulmoclaude/core/google — see server/backends/calendarPush.ts),
 // collection/feed/view deletion and the Discover registry tab (listRegistry/importRegistry
 // via @mulmoclaude/core/collection — see server/backends/collections.ts), and state-based
-// navigation (useCollectionBrowse — the toolbar + browse overlay).
-// Still stubbed: the notifier.
+// navigation (useCollectionBrowse — the toolbar + browse overlay), and the live bell's
+// per-record severities (useNotifications → the Kanban accent).
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type {
   CollectionApiResult,
@@ -27,7 +27,6 @@ import type {
   CollectionDetailResponse,
   CollectionsListResponse,
   CollectionOntologyResponse,
-  CollectionNotifySeverity,
   ItemMutationResponse,
   FeedsListResponse,
 } from "@mulmoclaude/core/collection";
@@ -38,6 +37,8 @@ import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { fetchJson, errorMessage, readErrorBody } from "../utils/fetchJson";
 import { htmlPreviewUrl, remoteViewItemsQuery } from "./collectionUiRules";
 import { useShortcuts } from "./useShortcuts";
+import { useNotifications } from "./useNotifications";
+import { collectionNotifiedSeverities } from "../utils/collectionNotified";
 import {
   browseGotoIndex,
   browseGotoDetail,
@@ -254,8 +255,14 @@ configureCollectionUi({
   // input box without an Enter (server: spawnBackgroundChat draft:true), so the user
   // reviews / edits / sends. `role` is ignored (MulmoTerminal has no roles).
   startNewChatDraft: (prompt) => void startCollectionChat(prompt, { hidden: false, draft: true }),
-  // No notifier in MulmoTerminal.
-  notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
+  // Which of this collection's records currently have a completion bell, and how
+  // urgent — the Kanban view accents those cards. Read live: `active` is a ref, so
+  // reading it inside the call registers the plugin's `computed` as a dependency and
+  // the accents follow a watcher publishing or clearing without any extra plumbing.
+  // `useNotifications()` is a module singleton and its init is idempotent, so calling
+  // it per invocation costs nothing after the first (and keeps the pubsub subscription
+  // out of this module's import).
+  notifiedSeverities: (slug: string) => collectionNotifiedSeverities(useNotifications().active.value, slug),
 
   // ── runtime translation: POST /api/translation (hidden-chat LLM). Enables the
   //    new-collection starter modal's localized cards; omitted ⇒ English fallback. ──

--- a/src/utils/collectionNotified.ts
+++ b/src/utils/collectionNotified.ts
@@ -1,0 +1,45 @@
+// Map active bell notifications back to the collection records they point at, so
+// the plugin's Kanban view can accent a card that has a pending completion bell.
+// MulmoTerminal's port of MulmoClaude's src/utils/collections/notifiedItems.ts —
+// it lives in that app's source rather than in @mulmoclaude/core, so the logic is
+// mirrored here and pinned by a spec against what our own publisher writes.
+//
+// The entries come from the live bell (`useNotifications().active`), which is fed
+// by both apps' publishers over the shared notifier file — so a bell MulmoClaude
+// published accents the same card here. Reading is all this does: the one-bell-per
+// -record invariant is enforced server-side on `legacyId`, and nothing on this path
+// can publish, clear, or duplicate an entry.
+import { collectionNotifyTargetOf } from "../../common/collectionNotifyTarget";
+
+/** Bell severities, worst last — mirrors the notifier's own `severity`. The Kanban
+ *  accent colours by this so a card matches the bell badge (urgent red, nudge amber). */
+export type NotifiedSeverity = "info" | "nudge" | "urgent";
+
+const SEVERITY_RANK: Record<NotifiedSeverity, number> = { info: 0, nudge: 1, urgent: 2 };
+
+function asSeverity(value: unknown): NotifiedSeverity {
+  return value === "urgent" || value === "nudge" ? value : "info";
+}
+
+/** The minimum entry shape this module reads — a structural subset of the bell's
+ *  `NotifierEntry`, so callers pass `useNotifications().active` straight in. */
+export interface NotifiedEntryLike {
+  pluginData?: unknown | undefined;
+  severity?: string | undefined;
+}
+
+/** itemId → worst active severity, for records of `slug`. Entries without a concrete
+ *  `itemId` are skipped (a collection-level bell can't point at one card), and when a
+ *  record has several bells the highest severity wins so the accent matches the most
+ *  urgent one. */
+export function collectionNotifiedSeverities(entries: readonly NotifiedEntryLike[], slug: string): Map<string, NotifiedSeverity> {
+  const out = new Map<string, NotifiedSeverity>();
+  for (const entry of entries) {
+    const target = collectionNotifyTargetOf(entry.pluginData);
+    if (!target || target.slug !== slug || !target.itemId) continue;
+    const severity = asSeverity(entry.severity);
+    const existing = out.get(target.itemId);
+    if (!existing || SEVERITY_RANK[severity] > SEVERITY_RANK[existing]) out.set(target.itemId, severity);
+  }
+  return out;
+}

--- a/test/src/utils/collectionNotified.spec.ts
+++ b/test/src/utils/collectionNotified.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { collectionNotifiedSeverities, type NotifiedEntryLike } from "../../../src/utils/collectionNotified";
+import { buildPluginData } from "../../../server/backends/collectionNotifierAdapter.js";
+
+// A bell as the UI sees it: `pluginData` is whatever the publishing app wrote (it
+// reaches the browser as `unknown`), `severity` is the notifier's own.
+const entry = (slug: string, itemId: string | undefined, severity: string): NotifiedEntryLike => ({
+  severity,
+  pluginData: { action: { type: "navigate", target: { view: "collections", slug, ...(itemId ? { itemId } : {}) } } },
+});
+
+describe("collectionNotifiedSeverities", () => {
+  it("keys by itemId, for the requested slug only", () => {
+    const map = collectionNotifiedSeverities([entry("tasks", "t1", "nudge"), entry("other", "o1", "urgent")], "tasks");
+    expect([...map]).toEqual([["t1", "nudge"]]);
+  });
+
+  // A collection-level bell has no record to accent — including it would key the
+  // map on `undefined` and light up nothing (or the wrong card).
+  it("skips an entry with no itemId", () => {
+    expect(collectionNotifiedSeverities([entry("tasks", undefined, "urgent")], "tasks").size).toBe(0);
+  });
+
+  it("keeps the worst severity when a record has several bells", () => {
+    const map = collectionNotifiedSeverities([entry("tasks", "t1", "nudge"), entry("tasks", "t1", "urgent"), entry("tasks", "t1", "info")], "tasks");
+    expect(map.get("t1")).toBe("urgent");
+  });
+
+  it("does not let a later, milder bell downgrade the accent", () => {
+    const map = collectionNotifiedSeverities([entry("tasks", "t1", "urgent"), entry("tasks", "t1", "info")], "tasks");
+    expect(map.get("t1")).toBe("urgent");
+  });
+
+  it("treats an unknown severity as info rather than dropping the record", () => {
+    expect(collectionNotifiedSeverities([entry("tasks", "t1", "catastrophic")], "tasks").get("t1")).toBe("info");
+  });
+
+  it("ignores entries whose pluginData is missing, malformed, or targets another view", () => {
+    const junk: NotifiedEntryLike[] = [
+      { severity: "urgent" },
+      { severity: "urgent", pluginData: null },
+      { severity: "urgent", pluginData: "nope" },
+      { severity: "urgent", pluginData: { action: "navigate" } },
+      { severity: "urgent", pluginData: { action: { target: { view: "files", slug: "tasks", itemId: "t1" } } } },
+      { severity: "urgent", pluginData: { action: { target: { view: "collections", slug: 7, itemId: "t1" } } } },
+    ];
+    expect(collectionNotifiedSeverities(junk, "tasks").size).toBe(0);
+  });
+
+  // The point of the whole path: what OUR publisher writes must be what this reads.
+  // Both sides go through common/collectionNotifyTarget, and this is the test that
+  // fails if either end stops using it.
+  it("reads back a bell built by this app's own publisher", () => {
+    const published: NotifiedEntryLike = {
+      severity: "urgent",
+      pluginData: buildPluginData({ legacyId: "todo:tasks/t1", slug: "tasks", itemId: "t1", priority: "high" }),
+    };
+    expect(collectionNotifiedSeverities([published], "tasks").get("t1")).toBe("urgent");
+  });
+});


### PR DESCRIPTION
Closes #1491 — the "wire it" branch, not the "drop the affordance" one.

## The premise had gone stale, which makes this small

The stub carried the comment `// No notifier in MulmoTerminal.` That stopped being true a while ago. `src/composables/useNotifications.ts` keeps a live `active` list fed by `/api/notifications` plus the `notifications` pubsub channel, and `NotificationBell.vue` renders it — so step 1 of the issue's proposed fix ("expose a read of active notifications to the browser, or a thin `/api/…` over `active.json`") needed nothing at all.

Both hard halves were already done, in fact:

- `server/backends/collectionWatchers.ts` publishes completion bells into the shared notifier file, and `collectionNotifierAdapter.ts` writes MulmoClaude's exact `pluginData.action.target = { view: "collections", slug, itemId }`.
- The browser already holds those entries live.

What was missing was the mapper between them. So the Kanban view — which colours a card's left border from `notifiedSeverities` — never accented anything, on either app's bells.

## What ships

- **`common/collectionNotifyTarget.ts`** — the `view: "collections"` marker plus the defensive narrowing of `pluginData.action.target`. In `common/` deliberately: the server writes this target and the UI reads it, so per CLAUDE.md it is a value both sides decide from. A second copy of the literal in the reader is precisely how that pair drifts without a symptom — the bell keeps arriving, only the accent quietly stops. The adapter now builds from the same constant.
- **`src/utils/collectionNotified.ts`** — a port of MulmoClaude's `collectionNotifiedSeverities` (`src/utils/collections/notifiedItems.ts`). That file is MulmoClaude **app source**, not `@mulmoclaude/core`, so it cannot be imported — same situation as `isAuthorizedImagePath` in #1490. `itemId → worst severity`; entries carrying a slug but no concrete `itemId` are skipped, since a collection-level bell has no single card to accent.
- **The binding** reads `useNotifications().active` *inside* the call. That is what makes it live: the plugin wraps the binding in a `computed`, so reading the ref during evaluation registers the dependency and the accents follow a watcher publishing or clearing. `useNotifications()` is a module singleton with an idempotent init, and `usePubSub` has no lifecycle hooks, so calling it per invocation is safe outside `setup`.

## Against the issue's acceptance criteria

- **Live severities update when watchers publish/clear** — yes, via the reactive read above.
- **No double bells across apps** — unaffected, and it could not be otherwise: this path only reads. Dedupe stays where it already was, on the shared `legacyId` server-side. The upside of sharing the wire shape is the inverse — a bell **MulmoClaude** published accents the same card here.
- **Spec for the map keying** — 7 tests, including the one that matters: a `pluginData` built by this app's own publisher (`buildPluginData`) is read back by the mapper. That fails if either end stops going through the shared module.

## Docs

`docs/collection-plugin-integration.md` listed `notifiedSeverities → empty map` in its Tier-1 stub table, which the issue flagged. I annotated the bullet rather than rewriting it — every binding in that list is real now, and the section is a record of how the increment was scoped, so editing it in place would rewrite history rather than update it.

## Tests

`yarn typecheck`, `yarn lint` (0 errors), `yarn test` — 8946 passed, 45 skipped.

Not verified in a live browser yet: that needs `yarn build` + a restart, a collection with a `kanban` group field, and a watcher-published bell against one of its records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection boards now display active notification accents for records with pending completion reminders.
  * Notifications support informational, nudge, and urgent severity levels.
  * Multiple notifications for the same record are represented using the highest active severity.

* **Documentation**
  * Updated release and integration documentation to describe live notification severity mapping and board behavior.

* **Tests**
  * Added coverage for filtering, severity precedence, malformed data, and unknown severity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->