### PR TITLE
fix: 殺されたのが tmux クライアントなら、セッションを道連れにしない (#1496)

### DIFF
--- a/plans/fix-1496-keep-session-when-client-dies.md
+++ b/plans/fix-1496-keep-session-when-client-dies.md
@@ -1,0 +1,106 @@
+# fix #1496 — a killed tmux CLIENT is not a finished session
+
+## What was reported
+
+The phone's list lost its Claude Code terminals; reloading a desktop tab brought them back. The
+server had not restarted, and tmux still held sessions. The log, at the moment of the reload:
+
+```text
+[pty] claude exited code=0 signal=9 … session A
+[pty] claude exited code=0 signal=9 … session B
+[ws] disconnected A / B
+[ws] reattach <three others>
+[ws] client connected (resume A) → [pty] started claude … resume A
+```
+
+## Why it happens
+
+**With tmux, our pty is the tmux CLIENT, not the agent.** `[pty] claude exited … signal=9` therefore
+says *something killed our client*, not *claude finished*. Two things establish that it came from
+outside this app:
+
+- `node-pty`'s `kill()` sends **SIGHUP** (`process.kill(pid, signal || 'SIGHUP')`), and `reap()`
+  calls it with no argument — our own teardown can only ever log `signal=1`.
+- The exit handler is what closes the socket (`sendExitAndClose`), so `[ws] disconnected` *after*
+  `[pty] exited` means the socket was still attached when the pty died. An idle reap needs a
+  DETACHED socket, so it cannot have been one.
+
+And the exit handler reaps unconditionally:
+
+```ts
+entry.term.onExit(…) => { …; deps.reap(sessionId); }     // spawn-claude.ts, pty-relay.ts
+```
+
+while `reap()` does:
+
+```ts
+if (entry.tmux) tmuxKillSession(id);        // ends the tmux session that still has the agent in it
+knownSessions.delete(id); deps.forgetTitle(id); lastPrompts.delete(id);
+```
+
+So when something outside kills our client, **we destroy the live session it was a client to** —
+and forget its title, which is what drops it from the phone's list (a nameless, non-live row is
+filtered out by design). A desktop reload then brings it back as a **new process** resumed from the
+transcript, which is exactly what the reporter saw.
+
+Nothing in any exit path asks tmux whether the session survived; `tmuxHasSession` is called only on
+the three CONNECT paths.
+
+## The fix
+
+Ask tmux before tearing anything down. One rule, one place:
+
+- **the tmux session is gone** → the agent really exited → reap, exactly as today.
+- **the tmux session is alive** → only our client died → drop the dead pty entry and keep everything
+  else. The next connection reattaches through the path that already exists (`tmuxAlive` in
+  ws-routes), and the title is never forgotten, so the phone keeps listing it.
+- **no live entry at all** → an explicit close already reaped it; do nothing.
+
+Deliberately NOT in this change: respawning a client automatically. A client that keeps dying would
+respawn in a loop, and the cell can already recover by reconnecting. The cell whose socket was open
+still sees the session exit and shows it as ended until it reconnects — the same recovery the
+reporter is already doing, minus the destruction.
+
+## Why this cannot leak sessions
+
+The objection to keeping a session alive is that nothing would ever clean it up. That is no longer
+true as of #1467: the boot sweep ends anything unattached and idle past `sessionIdleReapDays`
+(default 7). A client killed today either gets reattached, or is swept a week later.
+
+## Files
+
+| file | |
+|---|---|
+| `server/session/pty-exit.ts` (new) | the pure rule, and the wire-up both handlers call |
+| `server/session/spawn-claude.ts`, `server/session/pty-relay.ts`, `server/session/spawn-shell.ts` | call it instead of `deps.reap` |
+
+**All THREE**, which the first attempt got wrong: the fix was written for claude and the shared relay
+(codex / agy / grok), and the staged repro then destroyed a session anyway — because a **launcher**
+cell is spawned by `spawn-shell.ts`, which has its own exit handler. Its fourth sibling there
+(`spawnCommandPty`, the Run menu) needs nothing: it is ephemeral, not tmux-backed, and never reaps.
+
+## Tests
+
+- the rule: tmux alive → keep; tmux gone → reap; no live entry → neither; a non-tmux pty → reap
+  (nothing else could be holding it).
+- the wiring: the kept path deletes the pty entry (a reconnect must reattach, not reuse a dead pty)
+  and does not reap.
+
+## Verification
+
+Staged against a real server and real tmux, on both versions of the code — a launcher cell started
+from a real browser, then its tmux CLIENT process `kill -9`ed the way the report describes:
+
+```text
+# before (main)
+[pty] launcher exited code=0 signal=9 … session f0e10fe5-…
+tmux session mt-f0e10fe5-… → DESTROYED
+
+# after
+[pty] launcher exited code=0 signal=9 … session eded52c9-…
+[pty] eded52c9-… lost its client, but its tmux session is still running — keeping it
+tmux session mt-eded52c9-… → STILL ALIVE
+```
+
+And the case that must NOT change — the program itself ending (staged by ending the tmux session,
+which is what happens when the agent exits): `signal=0`, no "keeping it" line, reaped as before.

--- a/server/session/pty-exit.ts
+++ b/server/session/pty-exit.ts
@@ -1,0 +1,55 @@
+// What a dead pty means (#1496).
+//
+// Under tmux our pty is the tmux CLIENT, not the agent — so a pty that exits says one of two very
+// different things, and the exit handlers used to read both as the same one:
+//
+//   - the program inside ended, and tmux closed the session with it   → tear the session down
+//   - something killed our client while the session kept running      → keep it, drop the client
+//
+// The second is not hypothetical: `[pty] claude exited code=0 signal=9` is a SIGKILL, and nothing
+// here sends one (node-pty's `kill()` sends SIGHUP), so it came from outside — macOS ending a
+// process under memory pressure, in the reported case. Reaping there kills a tmux session with a
+// live agent in it, and forgets the title, which is what drops the row from the phone's list.
+import { ptys } from "./registry.js";
+import { tmuxHasSession } from "../infra/tmux.js";
+
+/** What the pty's death is evidence of. */
+export type PtyExitDisposition = "reap" | "keep" | "gone";
+
+/**
+ * Pure, because it is the whole decision: which of the two events just happened.
+ *
+ * `gone` is the third case and not an edge one — an explicit close reaps the session and only then
+ * does the pty die, so the exit arrives with nothing left to act on.
+ */
+export function ptyExitDisposition(facts: { stillRegistered: boolean; tmuxBacked: boolean; tmuxAlive: boolean }): PtyExitDisposition {
+  if (!facts.stillRegistered) return "gone";
+  return facts.tmuxBacked && facts.tmuxAlive ? "keep" : "reap";
+}
+
+/**
+ * Apply that decision. `reap` is passed in rather than imported because it belongs to the lifecycle
+ * the spawners already receive it from — and because it is the half that must NOT run for a session
+ * that is still alive.
+ */
+export function handlePtyExit(sessionId: string, reap: (id: string) => void): PtyExitDisposition {
+  const entry = ptys.get(sessionId);
+  const tmuxBacked = !!entry?.tmux;
+  const disposition = ptyExitDisposition({
+    stillRegistered: !!entry,
+    tmuxBacked,
+    // Asked only when it can matter: a non-tmux pty has nothing that could outlive it, and this
+    // shells out.
+    tmuxAlive: tmuxBacked && tmuxHasSession(sessionId),
+  });
+  if (disposition === "keep") {
+    // The entry has to go even though the session stays: `ptys.has()` is what every reconnect path
+    // reads as "there is a live pty here", and a dead one left in the table would be reused instead
+    // of reattached.
+    ptys.delete(sessionId);
+    console.log(`[pty] ${sessionId} lost its client, but its tmux session is still running — keeping it (reattaches on the next connect)`);
+  } else if (disposition === "reap") {
+    reap(sessionId);
+  }
+  return disposition;
+}

--- a/server/session/pty-relay.ts
+++ b/server/session/pty-relay.ts
@@ -6,6 +6,7 @@
 // NOT shared with claude's spawner: that one drives hooks, transcripts and the draft injector off
 // the same stream, and folding those in would make this the thing it exists to avoid. If a second
 // agent ever needs one of them, move it here then.
+import { handlePtyExit } from "./pty-exit.js";
 import { appendBoundedOutput } from "./terminal-replay.js";
 import { ptyExitLine } from "./pty-exit-log.js";
 import { sendExitAndClose, sendFrame } from "./ws-frames.js";
@@ -30,6 +31,7 @@ export function wireAgentPtyRelay(entry: PtyEntry, sessionId: string, spawnedAtM
   entry.term.onExit(({ exitCode, signal }) => {
     console.log(ptyExitLine({ agent: entry.agent ?? "agent", exitCode, signal, lifetimeMs: Date.now() - spawnedAtMs, cwd: entry.cwd, sessionId }));
     sendExitAndClose(entry.ws, exitCode, signal);
-    deps.reap(sessionId);
+    // See spawn-claude's copy: a tmux client killed from outside is not a finished session (#1496).
+    handlePtyExit(sessionId, deps.reap);
   });
 }

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -27,6 +27,7 @@ import { appendBoundedOutput } from "./terminal-replay.js";
 import { sessionExistsOnDisk } from "./session-reads.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
+import { handlePtyExit } from "./pty-exit.js";
 import { loadDirConfig } from "../config/dir-config.js";
 import { repoRootSync } from "../git/repo-root-sync.js";
 import { workdirFooter } from "../git/pr-footer.js";
@@ -316,7 +317,9 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       // exits on its own — e.g. a brand-new session that never persisted —
       // doesn't linger in the sidebar.
       deps.setWorking(sessionId, false);
-      deps.reap(sessionId);
+      // Not always a reap: under tmux this pty is the CLIENT, and one killed from outside leaves
+      // the session running (#1496). handlePtyExit asks tmux which of the two just happened.
+      handlePtyExit(sessionId, deps.reap);
     });
 
     return entry;

--- a/server/session/spawn-shell.ts
+++ b/server/session/spawn-shell.ts
@@ -4,6 +4,7 @@
 // Split from index.ts (#548 step 3c).
 import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
+import { handlePtyExit } from "./pty-exit.js";
 import { getLaunchers } from "../config/config-routes.js";
 import { launcherAt, shellInvocation } from "./shell-command.js";
 import { ptys } from "./registry.js";
@@ -69,7 +70,9 @@ export function createShellSpawners(deps: SpawnDeps) {
     term.onExit(({ exitCode, signal }) => {
       console.log(ptyExitLine({ agent: "launcher", exitCode, signal, lifetimeMs: Date.now() - spawnedAtMs, cwd, sessionId }));
       sendExitAndClose(entry.ws, exitCode, signal);
-      deps.reap(sessionId);
+      // A launcher is persistent and tmux-backed like an agent cell, so it has the same two ways to
+      // lose its pty — and only one of them means the program is over (#1496).
+      handlePtyExit(sessionId, deps.reap);
     });
     return entry;
   }

--- a/test/server/session/pty-exit.spec.ts
+++ b/test/server/session/pty-exit.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+// What a dead pty is evidence of (#1496).
+//
+// Under tmux the pty is the CLIENT, so its death says either "the agent finished" or "something
+// killed our client while the agent kept running" — and the exit handlers used to read both as the
+// first. The second is what a `signal=9` in the report was: nothing here sends SIGKILL (node-pty's
+// `kill()` sends SIGHUP), so it came from outside, and reaping there ends a tmux session with a
+// live agent in it.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hasSession = vi.fn<(id: string) => boolean>(() => false);
+vi.mock("../../../server/infra/tmux.js", () => ({ tmuxHasSession: (id: string) => hasSession(id) }));
+
+const { ptyExitDisposition, handlePtyExit } = await import("../../../server/session/pty-exit.js");
+const { ptys } = await import("../../../server/session/registry.js");
+
+const register = (id: string, tmux: boolean) => {
+  // Only `tmux` is read here; the rest of the entry stands in for a live pty.
+  ptys.set(id, { tmux, cwd: "/repo", agent: "claude" } as unknown as NonNullable<ReturnType<typeof ptys.get>>);
+};
+
+beforeEach(() => {
+  ptys.clear();
+  // Cleared, not just re-stubbed: the "never asks tmux" assertion below reads the CALL COUNT, and
+  // a shared mock carries the previous test's calls into it.
+  hasSession.mockClear();
+  hasSession.mockReturnValue(false);
+});
+
+describe("ptyExitDisposition", () => {
+  it("keeps a session whose tmux is still running — only the client died", () => {
+    expect(ptyExitDisposition({ stillRegistered: true, tmuxBacked: true, tmuxAlive: true })).toBe("keep");
+  });
+
+  it("reaps when tmux no longer has the session — the agent really exited", () => {
+    expect(ptyExitDisposition({ stillRegistered: true, tmuxBacked: true, tmuxAlive: false })).toBe("reap");
+  });
+
+  // Without tmux nothing can outlive the pty, so its death is the session's death.
+  it("reaps a pty that was never tmux-backed", () => {
+    expect(ptyExitDisposition({ stillRegistered: true, tmuxBacked: false, tmuxAlive: false })).toBe("reap");
+  });
+
+  // The close button reaps first and the pty dies afterwards, so the exit arrives with nothing to
+  // act on. Reaping again is harmless, but "gone" is the honest answer and keeps the log quiet.
+  it("does nothing for a session that was already torn down", () => {
+    expect(ptyExitDisposition({ stillRegistered: false, tmuxBacked: true, tmuxAlive: true })).toBe("gone");
+  });
+});
+
+describe("handlePtyExit", () => {
+  it("does not reap a session tmux still has, and drops the dead pty entry", () => {
+    const reap = vi.fn();
+    register("s-1", true);
+    hasSession.mockReturnValue(true);
+
+    expect(handlePtyExit("s-1", reap)).toBe("keep");
+    expect(reap).not.toHaveBeenCalled();
+    // The entry MUST go: `ptys.has()` is what every reconnect path reads as "there is a live pty
+    // here", so a dead one left behind would be reused instead of reattached.
+    expect(ptys.has("s-1")).toBe(false);
+  });
+
+  it("reaps when the tmux session went with the program", () => {
+    const reap = vi.fn();
+    register("s-1", true);
+    hasSession.mockReturnValue(false);
+
+    expect(handlePtyExit("s-1", reap)).toBe("reap");
+    expect(reap).toHaveBeenCalledWith("s-1");
+  });
+
+  // Asked only when it could matter: a non-tmux pty has nothing that could outlive it, and the
+  // question shells out to tmux.
+  it("does not ask tmux about a pty that was never tmux-backed", () => {
+    const reap = vi.fn();
+    register("s-1", false);
+
+    expect(handlePtyExit("s-1", reap)).toBe("reap");
+    expect(hasSession).not.toHaveBeenCalled();
+    expect(reap).toHaveBeenCalledWith("s-1");
+  });
+
+  it("neither reaps nor logs for a session that is already gone", () => {
+    const reap = vi.fn();
+    hasSession.mockReturnValue(true);
+
+    expect(handlePtyExit("never-registered", reap)).toBe("gone");
+    expect(reap).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Under tmux, the pty this app holds is the **tmux client**, not the agent. So a pty that exits means
one of two very different things — and every exit handler read both as the first:

| what happened | what we did | what we should do |
|---|---|---|
| the program ended, tmux closed the session with it | reap | reap ✅ |
| **something killed our client** while the session kept running | **reap — killing a live agent** | keep it |

`reap()` ends the tmux session (`if (entry.tmux) tmuxKillSession(id)`) and forgets the title, so the
second case destroyed a running agent **and** dropped its row from the phone's list (a nameless,
non-live row is filtered out by design). Reloading a desktop tab then brought it back as a *new*
process resumed from the transcript — exactly what #1496 reports.

Closes #1496.

## How we know the kill came from outside

Two things in the reporter's log, neither of which needed guessing:

- `signal=9`. `node-pty`'s `kill()` sends **SIGHUP** (`process.kill(pid, signal || 'SIGHUP')`) and
  `reap()` calls it with no argument — our own teardown can only produce `signal=1`.
- `[ws] disconnected` appears **after** `[pty] exited`, and the exit handler is what closes the
  socket (`sendExitAndClose`). So the socket was still attached when the pty died, which rules out
  the idle reap (it requires a detached socket).

The trigger itself — macOS ending a process under memory pressure, on a per-user LaunchAgent with
several agents running — is the reporter's environment and not something this PR can fix. What it
fixes is our reaction to it.

## Items to Confirm / Review

1. **The kept session's cell still shows "exited" until it reconnects.** The exit frame is sent
   before this decision, and the cell recovers by reconnecting — the same reload the reporter is
   already doing, minus the destruction. Auto-respawning a client instead was deliberately left out:
   a client that keeps dying would respawn in a loop.
2. **The pty entry is deleted even when we keep the session.** `ptys.has()` is what every reconnect
   path reads as "there is a live pty here", so a dead entry left behind would be reused instead of
   reattached. Pinned by a test.
3. **This cannot leak sessions**, which is the obvious objection. As of #1467 the boot sweep ends
   anything unattached and idle past `sessionIdleReapDays` (default 7 days). A client killed today
   is either reattached, or swept a week later.
4. **Three handlers, not two.** `spawn-claude.ts`, the shared `pty-relay.ts` (codex / agy / grok)
   and `spawn-shell.ts`'s launcher. The fourth (`spawnCommandPty`, the Run menu) needs nothing: it
   is ephemeral, not tmux-backed, and never reaps.

## The miss worth reporting

The first implementation covered claude and the shared relay — **and the staged repro destroyed the
session anyway**, because a launcher cell is spawned by `spawn-shell.ts`, which has its own exit
handler. Every unit test passed at that point. It was the real-server run that found it, which is
why the verification below is the shape it is.

## Verification

Staged against a real server, a real browser and real tmux, on **both** versions of the code: launch
a cell, then `kill -9` its tmux CLIENT process the way the report describes.

```text
# before (main)
[pty] launcher exited code=0 signal=9 … session f0e10fe5-…
tmux session mt-f0e10fe5-…  →  DESTROYED

# after
[pty] launcher exited code=0 signal=9 … session eded52c9-…
[pty] eded52c9-… lost its client, but its tmux session is still running — keeping it
tmux session mt-eded52c9-…  →  STILL ALIVE
```

And the case that must **not** change — the program itself ending, staged by ending the tmux session:
`signal=0`, no "keeping it" line, reaped exactly as before.

Local: `yarn format` / `lint` (0 errors) / `typecheck` / `test` (**8951 passed**) / `build`.

## Tests

`ptyExitDisposition` is the whole decision, so it is pure and pinned directly: tmux alive → keep,
tmux gone → reap, never tmux-backed → reap, already torn down → do nothing. Plus the wiring: the
kept path drops the pty entry and does not reap, and a non-tmux pty never even asks tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tmux-backed sessions when a client or PTY exits unexpectedly, allowing reconnection.
  * Reaped sessions only when the underlying tmux session has ended.
  * Improved handling of already-removed or unknown sessions without unnecessary cleanup.

* **Tests**
  * Added coverage for session preservation, cleanup, reaping, and unknown-session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->