### PR TITLE
docs: collection ドキュメントの現況反映と API パス差異の明文化 (#1492)

### DIFF
--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -1,6 +1,28 @@
 # Integrating `@mulmoclaude/collection-plugin` into MulmoTerminal
 
-Status: **the cross-repo blocker is gone.** The package shipped `0.5.0`/`0.5.1` with exactly the
+> **HISTORICAL — do not read this as the current state (marked 2026-08-06, #1492).**
+>
+> This is the *plan* that brought collections into MulmoTerminal, kept for the reasoning:
+> why the read path needs a server at all, why favorites are a shared on-disk file, how the
+> Shadow-DOM teleport works, and which decisions were taken and rejected along the way.
+>
+> **All three tiers below have shipped.** Everything the tier list, the gap table's `[term]`
+> markers and the stub list describe as future work is now real — the write routes
+> (`items` / `item` / actions / refresh / calendar-push), the registry import, remote views,
+> `manageCollection`, and a `startChat` that seeds a visible chat. If a passage here says
+> something is a stub or a no-op, it is telling you what was true when the increment was scoped.
+>
+> **For the current state, read instead:**
+> - [`mulmoclaude-parity.md`](mulmoclaude-parity.md) — what is shared with MulmoClaude today,
+>   the three deliberate API-path divergences, and the differences that remain (custom-view
+>   response bodies, `kind: "agent"` dispatch).
+> - `server/backends/collections.ts` — the mounted routes, one line each.
+> - `src/composables/collectionUi.ts` — every host-capability binding, real ones and the
+>   handful still deliberately inert.
+>
+> Nothing below is edited to match new behaviour; that is what keeps it readable as a record.
+
+Status at the time of writing: **the cross-repo blocker is gone.** The package shipped `0.5.0`/`0.5.1` with exactly the
 host-contract changes this doc originally said were still needed (ToolPlugin entry, router-optional
 nav, configurable teleport target, server engine). What remains is **MulmoTerminal-side wiring only** —
 **no MulmoClaude changes are required.**

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -44,8 +44,10 @@ Everything else matches character-for-character: `items`, `item`,
 `remote-view` (+ `/mutate`, `/items`), `view-token`, `view-data` (+ `/query`,
 `/actions/:actionId`, `/image`), `view-i18n`, `views/:viewId`. So this is three
 named exceptions, not a drifting surface — and they are listed here so the next
-host binding or external script copies one of these two spellings instead of
-inventing a third (CLAUDE.md's parity rule; #907 is the cautionary tale).
+host binding or external script uses **the spelling of the host it talks to**
+(MulmoTerminal's column against this server, MulmoClaude's against that one)
+instead of inventing a third (CLAUDE.md's parity rule; #907 is the cautionary
+tale).
 
 | Concern | MulmoClaude | MulmoTerminal |
 | --- | --- | --- |
@@ -54,19 +56,23 @@ inventing a third (CLAUDE.md's parity rule; #907 is the cautionary tale).
 | Registry | `/api/collections-registry/*` | `/api/collections/registry/*` |
 
 **Why.** All three come from one instinct: keep a literal segment from ever
-being read as a `:slug`. MulmoClaude distinguishes them by HTTP method and by a
-separate top-level `collections-registry` prefix; MulmoTerminal instead put the
-literal *inside* the `/api/collections` namespace, which forces the suffixes —
-`/api/collections/registry/list` only stays unambiguous because it is mounted
-**before** the `:slug` routes (`server/backends/collections.ts`, which says so
-at the mount site), and `list` / `detail` sidestep the question entirely. The
-response *shapes* are MulmoClaude's; only the URLs differ.
+being read as a `:slug`. MulmoClaude leans on path *shape* — list and detail are
+both `GET`, told apart only by whether a segment follows `/api/collections`, and
+the registry sits outside the namespace entirely under its own top-level
+`collections-registry` prefix. MulmoTerminal instead put every literal *inside*
+`/api/collections`, which forces the suffixes: `/api/collections/registry/list`
+only stays unambiguous because it is mounted **before** the `:slug` routes
+(`server/backends/collections.ts` says so at the mount site), and `list` /
+`detail` sidestep the shape question rather than relying on it. The response
+*shapes* are MulmoClaude's; only the URLs differ.
 
 **Consumer of record: `src/composables/collectionUi.ts`.** The plugin's UI
-binding is what actually calls these, and it is self-consistent with the server,
-which is exactly why nothing here ever fails a test. Treat that file plus the
-mount block in `server/backends/collections.ts` as the pair that has to agree —
-and this table as the record of why they don't agree with MulmoClaude.
+binding is what actually calls these, and it is self-consistent with the server —
+`test/server/backends/collections.spec.ts` pins MulmoTerminal's own spelling
+(`GET /api/collections/list`, `/:slug/detail`), as it should. So no test here can
+catch the divergence; only a comparison against MulmoClaude shows it, which is
+what this table is for. Treat that binding plus the mount block in
+`server/backends/collections.ts` as the pair that has to agree.
 
 **Not fixed here, on purpose.** Renaming the runtime paths, or adding aliases at
 MulmoClaude's spellings, are both live options and both out of scope for the

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -36,6 +36,46 @@ linking once on a machine serves both apps.
 
 ---
 
+## Collection API paths — three deliberate divergences
+
+The collection REST surface is the same on both hosts **except for three paths**.
+Everything else matches character-for-character: `items`, `item`,
+`itemAction`, `collectionAction`, `refresh`, `calendar-push`, `view-file`,
+`remote-view` (+ `/mutate`, `/items`), `view-token`, `view-data` (+ `/query`,
+`/actions/:actionId`, `/image`), `view-i18n`, `views/:viewId`. So this is three
+named exceptions, not a drifting surface — and they are listed here so the next
+host binding or external script copies one of these two spellings instead of
+inventing a third (CLAUDE.md's parity rule; #907 is the cautionary tale).
+
+| Concern | MulmoClaude | MulmoTerminal |
+| --- | --- | --- |
+| List | `GET /api/collections` | `GET /api/collections/list` |
+| Detail | `GET /api/collections/:slug` | `GET /api/collections/:slug/detail` |
+| Registry | `/api/collections-registry/*` | `/api/collections/registry/*` |
+
+**Why.** All three come from one instinct: keep a literal segment from ever
+being read as a `:slug`. MulmoClaude distinguishes them by HTTP method and by a
+separate top-level `collections-registry` prefix; MulmoTerminal instead put the
+literal *inside* the `/api/collections` namespace, which forces the suffixes —
+`/api/collections/registry/list` only stays unambiguous because it is mounted
+**before** the `:slug` routes (`server/backends/collections.ts`, which says so
+at the mount site), and `list` / `detail` sidestep the question entirely. The
+response *shapes* are MulmoClaude's; only the URLs differ.
+
+**Consumer of record: `src/composables/collectionUi.ts`.** The plugin's UI
+binding is what actually calls these, and it is self-consistent with the server,
+which is exactly why nothing here ever fails a test. Treat that file plus the
+mount block in `server/backends/collections.ts` as the pair that has to agree —
+and this table as the record of why they don't agree with MulmoClaude.
+
+**Not fixed here, on purpose.** Renaming the runtime paths, or adding aliases at
+MulmoClaude's spellings, are both live options and both out of scope for the
+documentation (#1492). Nothing outside this app depends on the MulmoTerminal
+spellings today — remote-host commands do not go through these URLs — so the
+cost of aliasing later is low; the cost of a *third* spelling is not.
+
+---
+
 ## Remaining differences
 
 These were the tail of the shared-services plan (originally labeled PR4c, PR4d,

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -848,8 +848,10 @@ const viewDataQueryHandler: RequestHandler<{ slug: string }> = async (req, res) 
  *  three PATHS deliberately differ from it: list is `/list` (MulmoClaude: `GET
  *  /api/collections`), detail is `/:slug/detail` (`GET /api/collections/:slug`), and the
  *  registry lives under `/api/collections/registry/*` (`/api/collections-registry/*`).
- *  Reason and the standing decision: docs/mulmoclaude-parity.md. Copy one of those two
- *  spellings in a new caller; do not invent a third.
+ *  Reason and the standing decision: docs/mulmoclaude-parity.md. A new caller against THIS
+ *  server uses the paths mounted below — `/api/collections/list`,
+ *  `/api/collections/:slug/detail`, `/api/collections/registry/*` — never MulmoClaude's
+ *  spelling and never a third one.
  *  One app.METHOD(path, handler) per endpoint — the handlers live above. */
 export function mountCollectionRoutes(app: Express): void {
   // Registered before the ":slug" routes so "registry" is never captured as a slug.

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -843,9 +843,13 @@ const viewDataQueryHandler: RequestHandler<{ slug: string }> = async (req, res) 
   }
 };
 
-/** Mount the read-side REST surface. Mirrors MulmoClaude's
- *  GET /api/collections + GET /api/collections/:slug response shapes, which is what
- *  the package's UI binding (fetchCollectionDetail / listCollections) expects.
+/** Mount the collection REST surface. The response SHAPES are MulmoClaude's, which is
+ *  what the package's UI binding (fetchCollectionDetail / listCollections) expects — but
+ *  three PATHS deliberately differ from it: list is `/list` (MulmoClaude: `GET
+ *  /api/collections`), detail is `/:slug/detail` (`GET /api/collections/:slug`), and the
+ *  registry lives under `/api/collections/registry/*` (`/api/collections-registry/*`).
+ *  Reason and the standing decision: docs/mulmoclaude-parity.md. Copy one of those two
+ *  spellings in a new caller; do not invent a third.
  *  One app.METHOD(path, handler) per endpoint — the handlers live above. */
 export function mountCollectionRoutes(app: Express): void {
   // Registered before the ":slug" routes so "registry" is never captured as a slug.

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -134,7 +134,11 @@ function rawFileUrl(value: unknown): string {
 // artifacts/html/*.html with the sandboxed preview CSP so it renders in a new tab;
 // everything else falls back to the raw-file route. See htmlPreviewUrl.
 configureCollectionUi({
-  // ── real (read side) ──
+  // ── real (read side). The two paths below are MulmoClaude's response shapes on
+  //    MulmoTerminal's own URLs — `/list` and `/:slug/detail`, where MulmoClaude has
+  //    `GET /api/collections` and `GET /api/collections/:slug` (registry diverges too,
+  //    see below). This file is the consumer of record for that; the divergence table
+  //    and the reason are in docs/mulmoclaude-parity.md. ──
   fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
   listCollections: () => apiGet<CollectionsListResponse>("/api/collections/list"),
   // Map tab: raw workspace-ontology entries; the plugin builds the graph
@@ -238,7 +242,9 @@ configureCollectionUi({
   deleteView: (slug, viewId) => apiDelete(`/api/collections/${encodeURIComponent(slug)}/views/${encodeURIComponent(viewId)}`),
   listFeeds: () => apiGet<FeedsListResponse>("/api/feeds"),
   // ── Discover/registry tab: the shared @mulmoclaude/core registry engine, wired
-  //    over /api/collections/registry/* (server/backends/collections.ts). ──
+  //    over /api/collections/registry/* (server/backends/collections.ts) — MulmoClaude
+  //    serves the same engine at /api/collections-registry/*, one of the three known
+  //    path divergences (docs/mulmoclaude-parity.md). ──
   listRegistry: () => apiGet<RegistryListResponse>("/api/collections/registry/list"),
   importRegistry: (author, slug, registry) => apiPost<RegistryImportResponse>("/api/collections/registry/import", { author, slug, registry }),
 


### PR DESCRIPTION
Closes #1492.

collection まわりのドキュメントの二つの問題を直す。ドキュメントとコメントのみで、ランタイムの挙動は変えていない。

## 1. `docs/collection-plugin-integration.md` が計画書のまま

Tier 一覧・gap 表の `[term]` マーカー・stub 一覧が「write routes と `startChat` はまだ」と読めるが、三つの Tier はすべて出荷済み。あとから貼られた「これは既に shipped」という注記が二箇所あるだけで、飛ばし読みすると誤読する。

日付入りの HISTORICAL バナーを冒頭に付けた。本文は書き換えていない — なぜ read path にサーバが要るのか、favorites がなぜ共有ファイルなのか、Shadow DOM の teleport の仕組み、といった設計判断の記録として読めることが、historical 化する理由そのものなので。現況の参照先 (parity doc / ルート定義 / binding) をバナーから示している。

## 2. 三つの API パス差異が未記録

| Concern | MulmoClaude | MulmoTerminal |
|---|---|---|
| List | `GET /api/collections` | `GET /api/collections/list` |
| Detail | `GET /api/collections/:slug` | `GET /api/collections/:slug/detail` |
| Registry | `/api/collections-registry/*` | `/api/collections/registry/*` |

これ以外の collection ルートは `items` / `item` / actions / `refresh` / `calendar-push` / `view-file` / `remote-view*` / `view-token` / `view-data*` / `view-i18n` / `views/:viewId` まで完全に一致している。つまり「三つの例外」であって、崩れつつある面ではない — parity doc にはそのことも書いた。

理由も三つとも同じで、literal な segment が `:slug` として捕まらないようにする措置。MulmoClaude は HTTP method と別プレフィックスで分けたが、MulmoTerminal は literal を `/api/collections` の内側に置いたので suffix が要る。レスポンスの shape は MulmoClaude のもの。

`docs/mulmoclaude-parity.md` に表・理由・consumer of record (`src/composables/collectionUi.ts`) を追加。ランタイムのパス変更と alias 追加はどちらも生きた選択肢だが issue の範囲外である旨も残した。

## 3. ついでに見つかったもの

`mountCollectionRoutes` の JSDoc が「MulmoClaude の `GET /api/collections` と `GET /api/collections/:slug` を mirror している」と書いていた — 実際には使っていない方のパスを名指ししており、差異を調べに来た人が最初に見る場所で誤った説明をしていた。修正した。binding 側にも該当箇所にコメントを足している。

## 確認

- `yarn format` / `yarn lint` (0 errors, warning 14 件はすべて既存で本 PR の対象ファイル外) / `yarn typecheck` / `yarn test` (9018 passed, 45 skipped) すべて通過
- parity doc への内部リンクが解決することを確認

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a historical-status notice clarifying that the collection integration plan is outdated and shipped tiers are documented elsewhere.
  * Documented collection REST endpoints, registry and custom-view routes, and intentional path differences between MulmoTerminal and MulmoClaude.
  * Clarified current integration status, including remaining terminal wiring and published package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->