### PR TITLE
Codexの作業worktree表示とペイン使用量表示を改善

### DIFF
--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -65,13 +65,23 @@ export function turnBoundaries(lines: string[]): CodexTurnBoundary[] {
   });
 }
 
-/** A Codex turn_context row may announce the agent's current working directory. */
-export function turnContextCwds(lines: string[]): string[] {
+/** Extract explicit workdirs from exec custom tool calls in rollout response items. */
+export function explicitWorkdirs(lines: string[]): string[] {
   return lines.flatMap((line) => {
     try {
       const doc: unknown = JSON.parse(line);
-      if (!isRecord(doc) || doc.type !== "turn_context" || !isRecord(doc.payload)) return [];
-      return typeof doc.payload.cwd === "string" && doc.payload.cwd ? [doc.payload.cwd] : [];
+      if (!isRecord(doc) || doc.type !== "response_item" || !isRecord(doc.payload)) return [];
+      if (doc.payload.type !== "custom_tool_call" || doc.payload.name !== "exec") return [];
+      if (isRecord(doc.payload.input) && typeof doc.payload.input.workdir === "string") return doc.payload.input.workdir ? [doc.payload.input.workdir] : [];
+      if (typeof doc.payload.input !== "string") return [];
+      const result: string[] = [];
+      for (const call of doc.payload.input.matchAll(/tools\.exec_command\s*\(\s*\{([\s\S]*?)\}\s*\)/g)) {
+        const body = call[1];
+        if (body === undefined) continue;
+        const value = /(?:"workdir"|workdir)\s*:\s*"([^"]*)"/.exec(body)?.[1];
+        if (value) result.push(value);
+      }
+      return result;
     } catch {
       return [];
     }

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -65,6 +65,19 @@ export function turnBoundaries(lines: string[]): CodexTurnBoundary[] {
   });
 }
 
+/** A Codex turn_context row may announce the agent's current working directory. */
+export function turnContextCwds(lines: string[]): string[] {
+  return lines.flatMap((line) => {
+    try {
+      const doc: unknown = JSON.parse(line);
+      if (!isRecord(doc) || doc.type !== "turn_context" || !isRecord(doc.payload)) return [];
+      return typeof doc.payload.cwd === "string" && doc.payload.cwd ? [doc.payload.cwd] : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
 // What a boundary does: the flag changes, and whether the phone should hear about it.
 // Both come from claude's tables so the two agents cannot drift apart — a codex turn that
 // finishes has to notify exactly as a claude Stop does, or half the grid stays silent.

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -11,6 +11,7 @@ import { activityHookEffects, pushKindFor, resolveHookCwd, resolveHookSessionId 
 import { runCompletionHook } from "../session/completion-hooks.js";
 import { messageOf } from "../errors.js";
 import { headerHookEffect } from "../session/header-hook.js";
+import { noteLiveCwd } from "../session/live-cwd.js";
 import { lastPrompts, lastResponses, ptys } from "../session/registry.js";
 import { clearedTranscripts, markTranscriptCleared } from "../session/cleared-transcripts.js";
 import { latestUserPrompt } from "../session/session-reads.js";
@@ -175,6 +176,7 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     const entry = ptys.get(sessionId);
     const active = !!(entry && entry.active);
     const cwd = resolveHookCwd(body.cwd, entry?.cwd);
+    void noteLiveCwd(sessionId, body.cwd).catch(() => undefined);
     await applyHeaderHooks(deps, sessionId, event, body, cwd);
     // Before the activity publish below, so the row it mirrors to the phone already carries this
     // hook's phase (a turn's first Edit must read as "editing" in the same push, not the next one).

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -39,6 +39,7 @@ import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { parseTerminalSize, type TerminalSize } from "../../common/terminalSize.js";
 import { handleCommandFrame } from "../session/pty-connection.js";
 import { closeWithError } from "../session/ws-frames.js";
+import { replayLiveCwd } from "../session/live-cwd.js";
 import { ProviderRefusedError } from "../session/provider-env.js";
 import { sessionExistsOnDisk } from "../session/session-reads.js";
 import { canStartLauncher, isContinuingSession, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
@@ -253,7 +254,7 @@ async function admitAgentSession(
   markAttachedSessionPlaced(sessionId, requested);
   // The EFFECTIVE cwd, not this request's: on a reattach the live PTY's own directory is where the
   // agent really runs, and the request's `?cwd=` is ignored by everything downstream.
-  return announceSession(ws, sessionId, live?.cwd ?? cwd);
+  return announceSession(ws, sessionId, live?.cwd ?? cwd, !!live);
 }
 
 async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
@@ -580,8 +581,9 @@ export function startAndWire(
 // Tell the browser which session this is, and from that moment collect what it sends: its first
 // frame is the terminal's real geometry, and it arrives while the caller is still reading config
 // files, so without this it lands on the floor (see early-frames.ts).
-function announceSession(ws: WebSocket, sessionId: string, cwd: string): EarlyFrames {
+function announceSession(ws: WebSocket, sessionId: string, cwd: string, _reattached = false): EarlyFrames {
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd }));
+  replayLiveCwd(ws, sessionId, cwd);
   return bufferEarlyFrames(ws);
 }
 

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -254,7 +254,7 @@ async function admitAgentSession(
   markAttachedSessionPlaced(sessionId, requested);
   // The EFFECTIVE cwd, not this request's: on a reattach the live PTY's own directory is where the
   // agent really runs, and the request's `?cwd=` is ignored by everything downstream.
-  return announceSession(ws, sessionId, live?.cwd ?? cwd, !!live);
+  return announceSession(ws, sessionId, live?.cwd ?? cwd);
 }
 
 async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
@@ -581,7 +581,7 @@ export function startAndWire(
 // Tell the browser which session this is, and from that moment collect what it sends: its first
 // frame is the terminal's real geometry, and it arrives while the caller is still reading config
 // files, so without this it lands on the floor (see early-frames.ts).
-function announceSession(ws: WebSocket, sessionId: string, cwd: string, _reattached = false): EarlyFrames {
+function announceSession(ws: WebSocket, sessionId: string, cwd: string): EarlyFrames {
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd }));
   replayLiveCwd(ws, sessionId, cwd);
   return bufferEarlyFrames(ws);

--- a/server/session/cleared-transcripts.ts
+++ b/server/session/cleared-transcripts.ts
@@ -23,7 +23,7 @@ import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import { isRecord } from "../../common/isRecord.js";
 import { messageOf } from "../errors.js";
-import { projectSessionsDir } from "./project-dir.js";
+import { transcriptFile } from "./transcript-locate.js";
 
 const CLEARED_DIR = path.join(MULMOTERMINAL_HOME, "cleared-transcripts");
 
@@ -55,7 +55,7 @@ const markerFile = (dir: string, id: string) => path.join(dir, `${id}.json`);
 
 async function transcriptSize(cwd: string, id: string): Promise<number> {
   try {
-    return (await fs.stat(path.join(projectSessionsDir(cwd), `${id}.jsonl`))).size;
+    return (await fs.stat(transcriptFile(id, cwd))).size;
   } catch {
     return 0; // no transcript on disk (a session cleared before its first turn was written)
   }

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -43,7 +43,7 @@ const sizeOf = (file: string) => async (): Promise<number | null> => {
   }
 };
 
-function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: CodexActivityTrackDeps): void {
+function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: CodexActivityTrackDeps, notify = true): void {
   const event = HOOK_EVENT_FOR[boundary];
   const { effects, push } = boundaryOutcome(boundary, deps.isActive());
   for (const eff of effects) {
@@ -52,7 +52,7 @@ function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: Cod
   }
   // `message` is empty: codex has no Notification equivalent, and a finished turn's body
   // comes from its reply, not from a hook payload.
-  if (push) void notifyTaskFinished(sessionId, push, "", deps.uiPort);
+  if (notify && push) void notifyTaskFinished(sessionId, push, "", deps.uiPort);
 }
 
 // Start tailing; it stops on its own once the session is gone. `startAtEnd` skips a
@@ -63,6 +63,7 @@ export function trackCodexActivity(sessionId: string, file: string, startAtEnd: 
     fileSize: sizeOf(file),
     readSlice: readSliceOf(file),
     onBoundary: (boundary) => applyBoundary(sessionId, boundary, deps),
+    onInitialBoundary: (boundary) => applyBoundary(sessionId, boundary, deps, false),
     onCwd: (cwd) => {
       void noteLiveCwd(sessionId, cwd).catch(() => undefined);
     },

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -7,6 +7,7 @@ import { promises as fs } from "node:fs";
 import { HOOK_EVENT_FOR, boundaryOutcome, type CodexTurnBoundary } from "../agents/codex-activity.js";
 import { notifyTaskFinished } from "./task-push.js";
 import { watchCodexActivity } from "./codex-activity-watch.js";
+import { noteLiveCwd } from "./live-cwd.js";
 
 export interface CodexActivityTrackDeps {
   setWorking: (id: string, working: boolean, event?: string) => void;
@@ -62,6 +63,9 @@ export function trackCodexActivity(sessionId: string, file: string, startAtEnd: 
     fileSize: sizeOf(file),
     readSlice: readSliceOf(file),
     onBoundary: (boundary) => applyBoundary(sessionId, boundary, deps),
+    onCwd: (cwd) => {
+      void noteLiveCwd(sessionId, cwd).catch(() => undefined);
+    },
     isAlive: deps.isAlive,
     startAtEnd,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -20,6 +20,7 @@ export interface CodexActivityDeps {
   /** The rollout's bytes in [from, to). */
   readSlice: (from: number, to: number) => Promise<string>;
   onBoundary: (boundary: CodexTurnBoundary) => void;
+  onInitialBoundary?: (boundary: CodexTurnBoundary) => void;
   onCwd?: (cwd: string) => void;
   /** False once the session's pty is gone — the loop stops on the next tick. */
   isAlive: () => boolean;
@@ -59,7 +60,10 @@ const startingOffset = async (deps: CodexActivityDeps): Promise<number> => {
   const taken = takeCompleteLines("", tail);
   const lines = (from > 0 ? taken.lines.slice(1) : taken.lines).concat(taken.pending ? [taken.pending] : []);
   const cwds = explicitWorkdirs(lines);
-  const latest = cwds.at(-1);
-  if (latest) deps.onCwd?.(latest);
+  const latestCwd = cwds.at(-1);
+  if (latestCwd) deps.onCwd?.(latestCwd);
+  const boundaries = turnBoundaries(lines);
+  const latestBoundary = boundaries.at(-1);
+  if (latestBoundary) deps.onInitialBoundary?.(latestBoundary);
   return size;
 };

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -9,7 +9,7 @@
 // Every dependency is injected so the loop can be driven with fakes: the real one reads
 // the filesystem and mutates session flags, neither of which a test should need.
 
-import { nextReadRange, takeCompleteLines, turnBoundaries, type CodexTurnBoundary } from "../agents/codex-activity.js";
+import { nextReadRange, takeCompleteLines, turnBoundaries, turnContextCwds, type CodexTurnBoundary } from "../agents/codex-activity.js";
 
 export const CODEX_ACTIVITY_POLL_MS = 1000;
 
@@ -19,6 +19,7 @@ export interface CodexActivityDeps {
   /** The rollout's bytes in [from, to). */
   readSlice: (from: number, to: number) => Promise<string>;
   onBoundary: (boundary: CodexTurnBoundary) => void;
+  onCwd?: (cwd: string) => void;
   /** False once the session's pty is gone — the loop stops on the next tick. */
   isAlive: () => boolean;
   /** Resume only: skip what the rollout already holds. A fresh session starts at 0 so its
@@ -42,6 +43,7 @@ export async function watchCodexActivity(deps: CodexActivityDeps): Promise<void>
     const taken = takeCompleteLines(pending, await deps.readSlice(range.from, range.to));
     pending = taken.pending;
     offset = range.to;
+    turnContextCwds(taken.lines).forEach((cwd) => deps.onCwd?.(cwd));
     turnBoundaries(taken.lines).forEach(deps.onBoundary);
   }
 }

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -9,9 +9,10 @@
 // Every dependency is injected so the loop can be driven with fakes: the real one reads
 // the filesystem and mutates session flags, neither of which a test should need.
 
-import { nextReadRange, takeCompleteLines, turnBoundaries, turnContextCwds, type CodexTurnBoundary } from "../agents/codex-activity.js";
+import { nextReadRange, takeCompleteLines, turnBoundaries, explicitWorkdirs, type CodexTurnBoundary } from "../agents/codex-activity.js";
 
 export const CODEX_ACTIVITY_POLL_MS = 1000;
+const RESUME_TAIL_BYTES = 4 * 1024 * 1024;
 
 export interface CodexActivityDeps {
   /** Byte length of the rollout, or null while it doesn't exist yet. */
@@ -43,11 +44,22 @@ export async function watchCodexActivity(deps: CodexActivityDeps): Promise<void>
     const taken = takeCompleteLines(pending, await deps.readSlice(range.from, range.to));
     pending = taken.pending;
     offset = range.to;
-    turnContextCwds(taken.lines).forEach((cwd) => deps.onCwd?.(cwd));
+    explicitWorkdirs(taken.lines).forEach((cwd) => deps.onCwd?.(cwd));
     turnBoundaries(taken.lines).forEach(deps.onBoundary);
   }
 }
 
 // A rollout that doesn't exist yet has no history to skip, so a resume that beat codex to
 // the file still starts from 0 and sees its first turn.
-const startingOffset = async (deps: CodexActivityDeps): Promise<number> => (await deps.fileSize()) ?? 0;
+const startingOffset = async (deps: CodexActivityDeps): Promise<number> => {
+  const size = await deps.fileSize();
+  if (size === null) return 0;
+  const from = Math.max(0, size - RESUME_TAIL_BYTES);
+  const tail = await deps.readSlice(from, size);
+  const taken = takeCompleteLines("", tail);
+  const lines = (from > 0 ? taken.lines.slice(1) : taken.lines).concat(taken.pending ? [taken.pending] : []);
+  const cwds = explicitWorkdirs(lines);
+  const latest = cwds.at(-1);
+  if (latest) deps.onCwd?.(latest);
+  return size;
+};

--- a/server/session/codex-legacy-rollout.ts
+++ b/server/session/codex-legacy-rollout.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import { SESSION_ID_RE } from "../config/env.js";
+
+const ROLLOUT_ID_RE = SESSION_ID_RE;
+
+export function parseLegacyCodexRolloutId(contents: string, sessionId: string): string | null {
+  if (!SESSION_ID_RE.test(sessionId)) return null;
+  let found: string | null = null;
+  for (const line of contents.split(/\r?\n/u)) {
+    const [sid, rollout] = line.split("\t");
+    if (sid === sessionId && rollout && ROLLOUT_ID_RE.test(rollout)) found = rollout;
+  }
+  return found;
+}
+
+export function readLegacyCodexRolloutId(home: string, sessionId: string): string | null {
+  try {
+    return parseLegacyCodexRolloutId(fs.readFileSync(path.join(home, "codex-rollout-ids.tsv"), "utf8"), sessionId);
+  } catch {
+    return null;
+  }
+}

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import type { Express, Response } from "express";
 import { parseJsonl } from "./transcript.js";
 import { createTranscriptFold } from "./transcript-fold.js";
+import { transcriptFile } from "./transcript-locate.js";
 import type { FileStamp } from "./file-cache.js";
 import { isRecord } from "../../common/isRecord.js";
 import { projectSessionsDir } from "./project-dir.js";
@@ -193,7 +194,8 @@ async function readFileCost(dir: string, file: string, stamp?: FileStamp): Promi
 /** One session's cost. Exported so the route does not build the transcript path itself — and so the
  *  fold underneath it can be tested without an HTTP request. */
 export async function sessionCost(cwd: string, id: string): Promise<JsonlCost> {
-  return readFileCost(projectSessionsDir(cwd), `${id}.jsonl`);
+  const full = transcriptFile(id, cwd);
+  return readFileCost(path.dirname(full), path.basename(full));
 }
 
 async function fileStamp(full: string): Promise<FileStamp> {

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -32,6 +32,8 @@ import {
   isFailedWorker,
 } from "./registry.js";
 import { clearedTranscripts, forgetClearedTranscript } from "./cleared-transcripts.js";
+import { forgetLiveCwd } from "./live-cwd.js";
+import { forgetTranscriptLocation } from "./transcript-locate.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
 import { sessionRow, shouldRefreshReply } from "./activity-transition.js";
 import { flagEffect, type ActivityFlag } from "./activity-flag.js";
@@ -151,6 +153,8 @@ function reap(deps: SessionLifecycleDeps, id: string) {
   // The transcript stops being frozen here: the next claude on this id (`--resume`, or a restart
   // after `/exit` — which reaches reap through term.onExit) appends to that file again.
   forgetClearedTranscript(id);
+  forgetLiveCwd(id);
+  forgetTranscriptLocation(id);
   deps.forgetTitle(id);
   deps.sessionActivityPublisher.forget(id); // drop the phone's copy so its picker has no ghosts
   deps.forgetWorkPhase(id); // the live turn dies with the session

--- a/server/session/live-cwd.ts
+++ b/server/session/live-cwd.ts
@@ -1,0 +1,102 @@
+// Where a session's agent is working RIGHT NOW, as opposed to the directory its PTY was
+// spawned in. Claude reports its live cwd in every hook payload, so a session that moves
+// into another git work tree mid-run (a worktree the agent created, or one it was sent to)
+// can say so — but this value is for DISPLAY ONLY.
+//
+// `PtyEntry.cwd` deliberately stays the spawn dir: it is where the process actually runs, and
+// every reattach, tmux lookup and file-serving check is written against it.
+//
+// It is NOT, despite what this comment first claimed, where the session's transcript lives. The
+// CLI MOVES that file to the new directory's project dir when the session changes cwd, which is
+// why a moved session stops resolving as reattachable and its cockpit reads zero — see
+// plans/live-cwd-header.md. Making the transcript reads follow is a separate change; what
+// matters here is that "where the process was started" and "which directory the session is
+// about" are two questions, and they stopped having one answer.
+import { gitTopLevel } from "../git/worktrees.js";
+import { ptys } from "./registry.js";
+import { sendFrame, type FrameSocket } from "./ws-frames.js";
+
+// id -> the directory to display, already rounded to its work-tree root.
+const liveCwds = new Map<string, string>();
+
+// dir -> its work-tree root (null: not a git work tree). A hook fires on EVERY tool call,
+// and a directory's work-tree root only changes when git's layout does, so re-running
+// `rev-parse` per hook would spawn a process per tool use to re-learn a constant.
+const workTreeRoots = new Map<string, string | null>();
+
+/**
+ * The work-tree root `dir` belongs to, or `dir` itself when it is not in a git work tree.
+ *
+ * Rounding is what keeps the header still. A tool that runs in `<repo>/app` is the same
+ * work tree as one that runs in `<repo>`, and a header that redrew per `cd` would be noise
+ * rather than information — the question it answers is "which checkout", not "which folder".
+ */
+export async function workTreeRootOf(dir: string): Promise<string> {
+  if (!workTreeRoots.has(dir)) workTreeRoots.set(dir, await gitTopLevel(dir));
+  return workTreeRoots.get(dir) ?? dir;
+}
+
+/** The live directory a session last reported, or null when it has never reported one. */
+export function liveCwd(id: string): string | null {
+  return liveCwds.get(id) ?? null;
+}
+
+/** Drop a torn-down session's directory (called from reap, alongside the other per-id tables). */
+export function forgetLiveCwd(id: string): void {
+  liveCwds.delete(id);
+}
+
+/** Tell a browser which directory to show for a session. */
+export function sendLiveCwd(socket: FrameSocket | null | undefined, id: string, cwd: string): boolean {
+  return sendFrame(socket, { type: "cwd", id, cwd });
+}
+
+/**
+ * Tell a freshly-attached browser about a move that happened before it connected.
+ *
+ * The `session` frame reports the session's IDENTITY, which does not move. Without this a
+ * reload would put the header back on the directory the agent left — and it would STAY there,
+ * because `noteLiveCwd` only speaks on a CHANGE and the server already believes it has said
+ * this. One missed frame is otherwise permanent; this is what makes it recoverable.
+ *
+ * Deliberately NOT gated on the connection being a recognised reattach. That gate looked like
+ * caution and was the whole bug: a session whose agent has moved no longer resolves as
+ * reattachable — its transcript moved to the new directory's project dir, so the
+ * exists-on-disk check fails and the socket is logged as "new" — which is exactly the session
+ * that needs replaying. What keeps this safe is not the connection kind but the map: an id
+ * only has an entry while its session is alive, because reap forgets it.
+ */
+export function replayLiveCwd(socket: FrameSocket | null | undefined, id: string, reportedCwd: string): boolean {
+  const moved = liveCwd(id);
+  return !!moved && moved !== reportedCwd && sendLiveCwd(socket, id, moved);
+}
+
+/**
+ * Which directory to display, given where a hook says the agent is and where its PTY was
+ * spawned. Inside the SPAWN work tree the answer is the spawn dir unchanged — a session
+ * that never left keeps the exact header it has today, including one started in a
+ * subdirectory, so rounding cannot quietly rewrite a display nobody asked to change. Once
+ * the agent is in a different work tree, that tree's root is the answer.
+ */
+export async function displayCwdFor(hookCwd: string, spawnCwd: string): Promise<string> {
+  const root = await workTreeRootOf(hookCwd);
+  return root === (await workTreeRootOf(spawnCwd)) ? spawnCwd : root;
+}
+
+/**
+ * Record where a hook says a session is, and push it to that session's browser when it
+ * changed. Live sessions only: an id with no PTY has no socket to tell and no reap to
+ * forget it, so remembering one would only grow the map.
+ */
+export async function noteLiveCwd(id: string, hookCwd: unknown): Promise<void> {
+  if (typeof hookCwd !== "string" || !hookCwd) return;
+  const entry = ptys.get(id);
+  if (!entry) return;
+  const next = await displayCwdFor(hookCwd, entry.cwd);
+  // Absent means "has not moved", i.e. the spawn dir — so the first hook of a session that
+  // stayed put sends nothing, rather than a frame restating what the browser already shows.
+  const previous = liveCwds.get(id) ?? entry.cwd;
+  liveCwds.set(id, next);
+  if (next === previous) return;
+  sendLiveCwd(entry.ws, id, next);
+}

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -27,7 +27,7 @@ import { createTranscriptFold, type FoldedAt } from "./transcript-fold.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRollouts, codexRolloutsHydrated, isBackgroundSession, isFailedWorker, knownSessions, sessionMemos } from "./registry.js";
-import { projectSessionsDir } from "./project-dir.js";
+import { transcriptFile } from "./transcript-locate.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
 import { forEachJsonlRecordIn, readTailRecords } from "../infra/jsonl-file.js";
 import { copySummaryState, emptySummaryState, foldSummary, summaryPartsOf, type SummaryState } from "./summary-scan.js";
@@ -49,7 +49,7 @@ export function readLatestResponse(id: string, cwd: string): string | null {
   try {
     // The tail, not the file: a transcript reaches 585 MB, which readFile cannot hold at all —
     // and the newest reply is in the last few lines either way (#998).
-    const text = latestAssistantTextFromParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
+    const text = latestAssistantTextFromParsed(readTailRecords(transcriptFile(id, cwd)));
     return text ? text.slice(0, LAST_RESPONSE_MAX) : null;
   } catch {
     return null; // no transcript yet / unreadable
@@ -59,7 +59,7 @@ export function readLatestResponse(id: string, cwd: string): string | null {
 // Whether a session has an on-disk transcript (claude only writes it after the
 // first prompt) in the given workspace. Determines whether `--resume` will work.
 export function sessionExistsOnDisk(id: string, cwd: string): boolean {
-  return existsSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`));
+  return existsSync(transcriptFile(id, cwd));
 }
 
 // readdirSync that yields [] instead of throwing on a missing / unreadable dir.
@@ -91,7 +91,7 @@ export function claudeOnDiskSessionIds(): Set<string> {
 // there's no transcript yet (a never-prompted session) or it can't be read.
 export async function latestUserPrompt(cwd: string, id: string): Promise<string | null> {
   try {
-    return latestMeaningfulUserPromptFromParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
+    return latestMeaningfulUserPromptFromParsed(readTailRecords(transcriptFile(id, cwd)));
   } catch {
     return null;
   }
@@ -157,7 +157,7 @@ const summaryFold = createTranscriptFold<SummaryState>({
 });
 
 export async function readSessionSummary(cwd: string, id: string): Promise<SessionSummary> {
-  const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
+  const file = transcriptFile(id, cwd);
   try {
     const st = await fs.stat(file);
     const parts = summaryPartsOf(await summaryFold.read(file, { mtimeMs: st.mtimeMs, size: st.size }), LAST_RESPONSE_MAX);
@@ -216,7 +216,7 @@ const timelineFold = createTranscriptFold<TimelineScan>({
 });
 
 export async function sessionTimeline(cwd: string, id: string): Promise<{ events: TimelineEvent[]; truncated: boolean }> {
-  const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
+  const file = transcriptFile(id, cwd);
   try {
     const st = await fs.stat(file);
     const scan = await timelineFold.read(file, { mtimeMs: st.mtimeMs, size: st.size });
@@ -266,7 +266,7 @@ export async function sessionLastTurn(cwd: string, id: string, agent: TerminalAg
   // the format would be worse than silence.
   if (agent === "antigravity" || agent === "grok") return EMPTY_TURN;
   try {
-    return lastTurnFromClaudeParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
+    return lastTurnFromClaudeParsed(readTailRecords(transcriptFile(id, cwd)));
   } catch {
     return EMPTY_TURN; // no transcript on disk yet
   }

--- a/server/session/session-title.ts
+++ b/server/session/session-title.ts
@@ -8,13 +8,12 @@
 // generating one from that same pre-clear file, an in-flight set so a Stop hook and a roster
 // view do not both summarize, and a retry floor so a viewed-but-failing session is not
 // re-summarized on every poll.
-import path from "node:path";
 import { conversationTurnsFromParsed, isTrivialPrompt, type ConversationTurn } from "./transcript.js";
 import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { shouldFreshenViewedTitle, shouldRegenerateTitle, TITLE_REGEN_EVERY_TURNS, VIEW_TITLE_REGEN_TURNS } from "../config/header-title.js";
 import { aiTitles, lastTitleAttemptMs, lastTitledUserTurns, titleEpoch, titleInFlight, titlePending, titleTurnCounts } from "./registry.js";
 import { clearedTranscripts } from "./cleared-transcripts.js";
-import { projectSessionsDir } from "./project-dir.js";
+import { transcriptFile } from "./transcript-locate.js";
 
 // How long a viewed session that failed to summarize waits before being tried again, so a
 // roster poll cannot spawn a summarizer per request.
@@ -76,7 +75,7 @@ export function createTitleManager(deps: TitleDeps) {
       // needs (how many user turns there were), so the transcript is never held as a string.
       const turns: ConversationTurn[] = [];
       let read = true;
-      await forEachJsonlRecord(path.join(projectSessionsDir(cwd), `${sessionId}.jsonl`), (record) => {
+      await forEachJsonlRecord(transcriptFile(sessionId, cwd), (record) => {
         turns.push(...conversationTurnsFromParsed([record]));
       }).catch(() => (read = false));
       const title = read && turns.length ? await deps.generateTitle(turns) : null;

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -15,6 +15,8 @@ import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { attachCodexAutoRun } from "./draft-injection.js";
+import { mulmoterminalHome } from "../infra/mulmoterminal-home.js";
+import { readLegacyCodexRolloutId } from "./codex-legacy-rollout.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
@@ -103,7 +105,10 @@ export function createCodexSpawner(deps: SpawnDeps) {
     console.log(ptyStartLine({ agent: "codex", pid: term.pid, cwd, tmux, reattached, sessionId, note }));
     const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "codex" };
     ptys.set(sessionId, entry);
-    const activityRolloutId = codexActivityRolloutId(resumeRolloutId, reattached, codexRollouts.get(sessionId)?.conversationId ?? null);
+    const mapped = codexRollouts.get(sessionId)?.conversationId ?? null;
+    const legacy = reattached ? readLegacyCodexRolloutId(mulmoterminalHome(), sessionId) : null;
+    const legacyExisting = legacy && codexRolloutPath(root, legacy) ? legacy : null;
+    const activityRolloutId = codexActivityRolloutId(resumeRolloutId, reattached, legacyExisting ?? mapped);
     if (activityRolloutId) {
       // Recorded on resume too, not just on the spawn that discovered it: a session resumed by the
       // rollout id itself carries no mapping yet, and one whose cell moved needs the new cwd.

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -10,7 +10,7 @@ import { codexGuiMcpServers } from "./mcp-config.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
-import { claimedCodexRollouts, claimFullGuiMcp, ptys, rememberCodexRollout } from "./registry.js";
+import { claimedCodexRollouts, claimFullGuiMcp, codexRollouts, ptys, rememberCodexRollout } from "./registry.js";
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
@@ -27,6 +27,13 @@ const activityDepsFor = (sessionId: string, entry: PtyEntry, deps: SpawnDeps) =>
   uiPort: deps.uiPort,
   isAlive: () => ptys.get(sessionId) === entry,
 });
+
+/** Resolve the rollout to watch when tmux survives but the browser request carries no resume id. */
+export function codexActivityRolloutId(resumeRolloutId: string | null, reattached: boolean, mappedConversationId: string | null): string | null {
+  if (resumeRolloutId) return resumeRolloutId;
+  if (reattached) return mappedConversationId;
+  return null;
+}
 
 export function createCodexSpawner(deps: SpawnDeps) {
   // codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
@@ -96,13 +103,14 @@ export function createCodexSpawner(deps: SpawnDeps) {
     console.log(ptyStartLine({ agent: "codex", pid: term.pid, cwd, tmux, reattached, sessionId, note }));
     const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "codex" };
     ptys.set(sessionId, entry);
-    if (resumeRolloutId) {
+    const activityRolloutId = codexActivityRolloutId(resumeRolloutId, reattached, codexRollouts.get(sessionId)?.conversationId ?? null);
+    if (activityRolloutId) {
       // Recorded on resume too, not just on the spawn that discovered it: a session resumed by the
       // rollout id itself carries no mapping yet, and one whose cell moved needs the new cwd.
-      rememberCodexRollout(sessionId, resumeRolloutId, cwd);
-      const file = codexRolloutPath(root, resumeRolloutId);
+      rememberCodexRollout(sessionId, activityRolloutId, cwd);
+      const file = codexRolloutPath(root, activityRolloutId);
       if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
-    } else {
+    } else if (!reattached) {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher
       // could overwrite the known id with a mis-attributed concurrent rollout.
       captureCodexRollout(sessionId, entry, root, before, cwd);

--- a/server/session/transcript-locate.ts
+++ b/server/session/transcript-locate.ts
@@ -1,0 +1,26 @@
+import { existsSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { projectSessionsDir } from "./project-dir.js";
+
+const located = new Map<string, string>();
+const root = () => path.join(os.homedir(), ".claude", "projects");
+const file = (dir: string, id: string) => path.join(dir, `${id}.jsonl`);
+
+export function transcriptDir(id: string, cwd: string): string {
+  const hinted = projectSessionsDir(cwd);
+  if (existsSync(file(hinted, id))) { located.set(id, hinted); return hinted; }
+  const remembered = located.get(id);
+  if (remembered && existsSync(file(remembered, id))) return remembered;
+  try {
+    for (const entry of readdirSync(root())) {
+      const dir = path.join(root(), entry);
+      if (existsSync(file(dir, id))) { located.set(id, dir); return dir; }
+    }
+  } catch { /* missing projects root */ }
+  located.delete(id);
+  return hinted;
+}
+
+export const transcriptFile = (id: string, cwd: string): string => file(transcriptDir(id, cwd), id);
+export const forgetTranscriptLocation = (id: string): void => { located.delete(id); };

--- a/server/session/transcript-locate.ts
+++ b/server/session/transcript-locate.ts
@@ -9,18 +9,28 @@ const file = (dir: string, id: string) => path.join(dir, `${id}.jsonl`);
 
 export function transcriptDir(id: string, cwd: string): string {
   const hinted = projectSessionsDir(cwd);
-  if (existsSync(file(hinted, id))) { located.set(id, hinted); return hinted; }
+  if (existsSync(file(hinted, id))) {
+    located.set(id, hinted);
+    return hinted;
+  }
   const remembered = located.get(id);
   if (remembered && existsSync(file(remembered, id))) return remembered;
   try {
     for (const entry of readdirSync(root())) {
       const dir = path.join(root(), entry);
-      if (existsSync(file(dir, id))) { located.set(id, dir); return dir; }
+      if (existsSync(file(dir, id))) {
+        located.set(id, dir);
+        return dir;
+      }
     }
-  } catch { /* missing projects root */ }
+  } catch {
+    /* missing projects root */
+  }
   located.delete(id);
   return hinted;
 }
 
 export const transcriptFile = (id: string, cwd: string): string => file(transcriptDir(id, cwd), id);
-export const forgetTranscriptLocation = (id: string): void => { located.delete(id); };
+export const forgetTranscriptLocation = (id: string): void => {
+  located.delete(id);
+};

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -364,6 +364,7 @@ function onAddTerminal() {
 }
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
 const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
+const onLiveCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
 const onAgent = (uid: number, agent: TerminalAgent) => (state.value = setCellAgent(state.value, uid, agent));
 const onPark = (uid: number, parked: boolean) => (state.value = setCellParked(state.value, uid, parked));
 // Pass the on-screen order so closing the zoomed cell stays zoomed on its filmstrip
@@ -790,6 +791,7 @@ onBeforeUnmount(detachSpawnedChat);
       @agent="onAgent"
       @park="onPark"
       @cwd="onCwd"
+      @live-cwd="onLiveCwd"
       @record-cwd="recordPreset"
       @remove-preset="removePreset"
       @close="onClose"

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
-import { modelBadge, type BadgeAgent } from "./modelBadge";
+import { modelBadge, shortModelLabel, type BadgeAgent, type ModelBadge } from "./modelBadge";
 import { badgeTip } from "./tipContent";
 
 // Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Nothing renders until
@@ -16,9 +16,18 @@ const props = defineProps<{
   contextWindow: number | null | undefined;
 }>();
 
-const badge = computed(() => (props.model ? modelBadge(props.agent, props.model, props.contextTokens, props.contextWindow) : null));
+const MODEL_ONLY_AGENT_NAME: Partial<Record<BadgeAgent, string>> = { claude: "Claude", codex: "Codex" };
 
-// The badge shortens the model to `Opus`; the tip is where the full name and the token counts live.
+function paneBadge(agent: BadgeAgent, model: string, contextTokens: number, contextWindow: number | null | undefined): ModelBadge {
+  const agentName = MODEL_ONLY_AGENT_NAME[agent];
+  if (agentName) return { text: shortModelLabel(model), title: `${agentName} · ${model}` };
+  return modelBadge(agent, model, contextTokens, contextWindow);
+}
+
+const badge = computed(() => (props.model ? paneBadge(props.agent, props.model, props.contextTokens, props.contextWindow) : null));
+
+// The badge shortens the model to `Opus`; the tip keeps the full name. Token counts stay out of
+// Claude/Codex pane chrome, while the other agents retain their existing context reading.
 const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => badgeTip(badge.value?.title ?? ""));
 </script>
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -88,7 +88,7 @@ const props = defineProps<{
   // text, and the icon buttons. Hex #rrggbb or null for the theme default.
 }>();
 const emit = defineEmits<{
-  (e: "session" | "cwd", value: string): void;
+  (e: "session" | "cwd" | "live-cwd", value: string): void;
   (e: "exit", exitCode: number | null): void;
   (e: "run", command: RunCommand): void;
   // The user typed (or pasted) into this terminal. Output the server writes back never fires it.
@@ -265,6 +265,7 @@ onMounted(() => {
     {
       onSession: (id) => emit("session", id),
       onCwd: (c) => emit("cwd", c),
+      onLiveCwd: (c) => emit("live-cwd", c),
       onExit: (exitCode) => emit("exit", exitCode),
       onInput: () => emit("input"),
       onInputDropped: (willReconnect) => void showHint(willReconnect ? INPUT_DROPPED_EN : INPUT_DROPPED_ENDED_EN, "cloud_off"),

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -992,7 +992,7 @@ async function saveMemo() {
 
 // Per-cell token usage badge: ⇡ total input (fresh + cache) · ⇣ output generated.
 const usageView = computed(() => usageBadge(usage.value));
-const showUsage = computed(() => usageView.value.show);
+const showUsage = computed(() => agent.value !== "claude" && agent.value !== "codex" && usageView.value.show);
 const usageLabel = computed(() => usageView.value.label);
 const usageTitle = computed(() =>
   usage.value

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -121,7 +121,7 @@ const emit = defineEmits<
   GridCellEmits & {
     // `record-cwd`: auto-record a fresh launch's server-confirmed cwd as a preset.
     // `remove-preset`: drop a preset (its close button) from the shared list — value is the path.
-    (e: "session" | "cwd" | "record-cwd" | "remove-preset", value: string): void;
+    (e: "session" | "cwd" | "live-cwd" | "record-cwd" | "remove-preset", value: string): void;
     // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
     // terminal's header menu, which must NOT replace the session — it runs in a new cell.
     (e: "run" | "runSpare", value: RunCommand): void;
@@ -547,6 +547,7 @@ function onServerCwd(c: string) {
   }
   emit("cwd", c);
 }
+function onLiveCwd(c: string) { cwd.value = c; emit("live-cwd", c); }
 
 // "Open on GitHub": when this cell's dir is a GitHub repo, the server returns its
 // repository URL (null otherwise) and the header shows a popover linking to the
@@ -1354,6 +1355,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           @session="onSession"
           @input="onTerminalInput"
           @cwd="onServerCwd"
+          @live-cwd="onLiveCwd"
           @run="(cmd) => emit('runSpare', cmd)"
         >
           <!-- Row 2 — actions on the SESSION, gathered onto the terminal's header row beside the

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -547,7 +547,10 @@ function onServerCwd(c: string) {
   }
   emit("cwd", c);
 }
-function onLiveCwd(c: string) { cwd.value = c; emit("live-cwd", c); }
+function onLiveCwd(c: string) {
+  cwd.value = c;
+  emit("live-cwd", c);
+}
 
 // "Open on GitHub": when this cell's dir is a GitHub repo, the server returns its
 // repository URL (null otherwise) and the header shows a popover linking to the

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -98,7 +98,7 @@ const props = defineProps<{
   listMode: boolean;
 }>();
 const emit = defineEmits<{
-  (e: "session" | "cwd", uid: number, value: string): void;
+  (e: "session" | "cwd" | "live-cwd", uid: number, value: string): void;
   (e: "close" | "toggle-expand" | "focus-cell", uid: number): void;
   (e: "run" | "runSpare", uid: number, command: RunCommand): void;
   (e: "launch", uid: number, pick: LaunchPick): void;
@@ -1207,6 +1207,7 @@ watch(
           @session="(id) => emit('session', cell.uid, id)"
           @agent="(a) => emit('agent', cell.uid, a)"
           @cwd="(c) => emit('cwd', cell.uid, c)"
+          @live-cwd="(c) => emit('live-cwd', cell.uid, c)"
           @record-cwd="(c) => emit('record-cwd', c)"
           @remove-preset="(path) => emit('remove-preset', path)"
           @run="(cmd) => emit('run', cell.uid, cmd)"

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -257,7 +257,7 @@ function fitAndSyncSize(c: Conn): void {
 
 // The reactive projection the view binds to (status pill, RunMenu cwd). Keyed by
 // the same slot key; a slot that hasn't connected yet (or was released) is absent.
-export const connView = reactive(new Map<string, { status: ConnStatus; serverCwd: string | null; liveCwd: string | null }>());
+export const connView = reactive(new Map<string, { status: ConnStatus; serverCwd: string | null }>());
 
 function setStatus(c: Conn, s: ConnStatus) {
   const v = connView.get(c.key);
@@ -576,7 +576,7 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     lastDroppedInputNoticeMs: Number.NEGATIVE_INFINITY,
   };
   conns.set(key, c);
-  connView.set(key, { status: "connecting", serverCwd: target.cwd, liveCwd: null });
+  connView.set(key, { status: "connecting", serverCwd: target.cwd });
   wireTerminalToConn(term, c);
   return c;
 }
@@ -647,7 +647,7 @@ function connect(c: Conn) {
   // Drop the previous session's resolved cwd so the Run menu can't list/launch the
   // prior project's scripts before the new `session` message arrives.
   const v = connView.get(c.key);
-  if (v) { v.serverCwd = c.target.cwd; v.liveCwd = null; }
+  if (v) v.serverCwd = c.target.cwd;
   c.liveCwd = null;
 
   // Resume the known id (server-learned, or the prop) so a reconnect re-attaches the
@@ -724,7 +724,10 @@ function handleMessage(c: Conn, event: MessageEvent) {
   } else if (msg.type === "session") {
     applySessionFrame(c, msg);
   } else if (msg.type === "cwd") {
-    if (typeof msg.cwd === "string") { c.liveCwd = msg.cwd; const v = connView.get(c.key); if (v) v.liveCwd = msg.cwd; c.handlers.onLiveCwd?.(msg.cwd); }
+    if (typeof msg.cwd === "string") {
+      c.liveCwd = msg.cwd;
+      c.handlers.onLiveCwd?.(msg.cwd);
+    }
   } else {
     applyTerminalFrame(c, msg);
   }

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -151,6 +151,7 @@ const submittableFor = (c: Conn, text: string): string => (isClaudeTarget(c.targ
 export interface ConnHandlers {
   onSession?: (id: string) => void;
   onCwd?: (cwd: string) => void;
+  onLiveCwd?: (cwd: string) => void;
   // `exitCode` is the command's status when the server reported one, else null (a start
   // failure, or an agent session that ended without one). A Run cell reads it to tell a
   // clean finish from a broken build.
@@ -190,6 +191,7 @@ interface Conn {
   ws: WebSocket | null;
   knownSessionId: string | null;
   knownCwd: string | null; // server-resolved cwd, replayed on (re)attach
+  liveCwd: string | null;
   target: ConnTarget;
   handlers: ConnHandlers;
   sawExit: boolean; // an intentional end (exit/superseded/error) — suppress reconnect
@@ -255,7 +257,7 @@ function fitAndSyncSize(c: Conn): void {
 
 // The reactive projection the view binds to (status pill, RunMenu cwd). Keyed by
 // the same slot key; a slot that hasn't connected yet (or was released) is absent.
-export const connView = reactive(new Map<string, { status: ConnStatus; serverCwd: string | null }>());
+export const connView = reactive(new Map<string, { status: ConnStatus; serverCwd: string | null; liveCwd: string | null }>());
 
 function setStatus(c: Conn, s: ConnStatus) {
   const v = connView.get(c.key);
@@ -558,6 +560,7 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     ws: null,
     knownSessionId: target.sessionId,
     knownCwd: null,
+    liveCwd: null,
     target,
     handlers: {},
     sawExit: false,
@@ -573,7 +576,7 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     lastDroppedInputNoticeMs: Number.NEGATIVE_INFINITY,
   };
   conns.set(key, c);
-  connView.set(key, { status: "connecting", serverCwd: target.cwd });
+  connView.set(key, { status: "connecting", serverCwd: target.cwd, liveCwd: null });
   wireTerminalToConn(term, c);
   return c;
 }
@@ -644,7 +647,8 @@ function connect(c: Conn) {
   // Drop the previous session's resolved cwd so the Run menu can't list/launch the
   // prior project's scripts before the new `session` message arrives.
   const v = connView.get(c.key);
-  if (v) v.serverCwd = c.target.cwd;
+  if (v) { v.serverCwd = c.target.cwd; v.liveCwd = null; }
+  c.liveCwd = null;
 
   // Resume the known id (server-learned, or the prop) so a reconnect re-attaches the
   // same session instead of spawning a fresh one each retry.
@@ -719,6 +723,8 @@ function handleMessage(c: Conn, event: MessageEvent) {
     if (typeof msg.data === "string") c.term.write(msg.data);
   } else if (msg.type === "session") {
     applySessionFrame(c, msg);
+  } else if (msg.type === "cwd") {
+    if (typeof msg.cwd === "string") { c.liveCwd = msg.cwd; const v = connView.get(c.key); if (v) v.liveCwd = msg.cwd; c.handlers.onLiveCwd?.(msg.cwd); }
   } else {
     applyTerminalFrame(c, msg);
   }
@@ -740,6 +746,7 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   // useful update; the parent's setters are idempotent for already-known values.
   if (c.knownSessionId) handlers.onSession?.(c.knownSessionId);
   if (c.knownCwd) handlers.onCwd?.(c.knownCwd);
+  if (c.liveCwd) handlers.onLiveCwd?.(c.liveCwd);
   el.appendChild(c.host);
   if (theme) {
     c.theme = theme;

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { nextReadRange, takeCompleteLines, turnBoundaries, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
+import { nextReadRange, takeCompleteLines, turnBoundaries, turnContextCwds, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
@@ -99,6 +99,20 @@ describe("turnBoundaries", () => {
 
   it("is empty for no lines", () => {
     expect(turnBoundaries([])).toEqual([]);
+  });
+});
+
+describe("turnContextCwds", () => {
+  it("extracts only non-empty cwd strings from turn_context rows", () => {
+    expect(
+      turnContextCwds([
+        turnContext("a"),
+        line({ type: "turn_context", payload: { cwd: "" } }),
+        line({ type: "turn_context", payload: { cwd: 42 } }),
+        line({ type: "event_msg", payload: { type: "turn_context", cwd: "/no" } }),
+        "{malformed",
+      ]),
+    ).toEqual(["/w"]);
   });
 });
 

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { nextReadRange, takeCompleteLines, turnBoundaries, turnContextCwds, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
+import { nextReadRange, takeCompleteLines, turnBoundaries, explicitWorkdirs, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
@@ -9,7 +9,9 @@ const aborted = (turnId = "t1") => line({ type: "event_msg", payload: { type: "t
 const agentMessage = () => line({ type: "event_msg", payload: { type: "agent_message", message: "thinking" } });
 // A turn_context row carries a turn_id but no payload.type — the shape most likely to be
 // misread as a boundary.
-const turnContext = (turnId = "t1") => line({ type: "turn_context", payload: { turn_id: turnId, cwd: "/w" } });
+const execCwd = (cwd: string) =>
+  line({ type: "response_item", payload: { type: "custom_tool_call", name: "exec", input: `tools.exec_command({cmd:"pwd",workdir:"${cwd}"})` } });
+const turnContext = () => line({ type: "turn_context", payload: { cwd: "/w" } });
 
 describe("nextReadRange", () => {
   it("reads the appended bytes when the file grew", () => {
@@ -102,17 +104,23 @@ describe("turnBoundaries", () => {
   });
 });
 
-describe("turnContextCwds", () => {
-  it("extracts only non-empty cwd strings from turn_context rows", () => {
+describe("explicitWorkdirs", () => {
+  it("extracts explicit workdirs from real exec records", () => {
     expect(
-      turnContextCwds([
-        turnContext("a"),
-        line({ type: "turn_context", payload: { cwd: "" } }),
-        line({ type: "turn_context", payload: { cwd: 42 } }),
-        line({ type: "event_msg", payload: { type: "turn_context", cwd: "/no" } }),
+      explicitWorkdirs([
+        execCwd("/w"),
+        line({ type: "response_item", payload: { type: "custom_tool_call", name: "exec", input: 'tools.exec_command({"cmd":"apply_patch workdir /bad"})' } }),
+        line({ type: "turn_context", payload: { cwd: "/no" } }),
         "{malformed",
       ]),
     ).toEqual(["/w"]);
+  });
+  it("accepts quoted workdir keys too", () => {
+    expect(
+      explicitWorkdirs([
+        line({ type: "response_item", payload: { type: "custom_tool_call", name: "exec", input: 'tools.exec_command({"workdir":"/quoted"})' } }),
+      ]),
+    ).toEqual(["/quoted"]);
   });
 });
 

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -5,6 +5,8 @@ import type { CodexTurnBoundary } from "../../../server/agents/codex-activity.js
 
 const line = (o: unknown) => JSON.stringify(o);
 const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } }) + "\n";
+const execCwd = (cwd: string) =>
+  line({ type: "response_item", payload: { type: "custom_tool_call", name: "exec", input: `tools.exec_command({cmd:"pwd",workdir:"${cwd}"})` } }) + "\n";
 const complete = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_complete", turn_id: turnId, last_agent_message: "done" } }) + "\n";
 
 // A fake rollout the test appends to, driving the loop one tick at a time. `sleep`
@@ -51,7 +53,7 @@ describe("watchCodexActivity", () => {
     const h = harness("", false);
     const cwds: string[] = [];
     h.deps.onCwd = (cwd) => cwds.push(cwd);
-    h.appendAt(1, line({ type: "turn_context", payload: { cwd: "/work" } }) + "\n");
+    h.appendAt(1, execCwd("/work"));
     await h.run();
     expect(cwds).toEqual(["/work"]);
   });
@@ -60,7 +62,7 @@ describe("watchCodexActivity", () => {
     const h = harness("", false);
     const cwds: string[] = [];
     h.deps.onCwd = (cwd) => cwds.push(cwd);
-    const whole = line({ type: "turn_context", payload: { cwd: "/split" } }) + "\n";
+    const whole = execCwd("/split");
     h.appendAt(1, whole.slice(0, 18));
     h.appendAt(2, whole.slice(18));
     await h.run();
@@ -68,13 +70,13 @@ describe("watchCodexActivity", () => {
   });
 
   it("does not replay resumed cwd history, but reports new cwd rows", async () => {
-    const old = line({ type: "turn_context", payload: { cwd: "/old" } }) + "\n";
+    const old = execCwd("/old");
     const h = harness(old, true);
     const cwds: string[] = [];
     h.deps.onCwd = (cwd) => cwds.push(cwd);
-    h.appendAt(2, line({ type: "turn_context", payload: { cwd: "/new" } }) + "\n");
+    h.appendAt(2, execCwd("/new"));
     await h.run();
-    expect(cwds).toEqual(["/new"]);
+    expect(cwds).toEqual(["/old", "/new"]);
   });
 
   it("reads a fresh session's existing content, so its first turn isn't missed", async () => {

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -16,6 +16,7 @@ function harness(initial: string, startAtEnd: boolean) {
   let ticks = 0;
   const maxTicks = 12;
   const boundaries: CodexTurnBoundary[] = [];
+  const initialBoundaries: CodexTurnBoundary[] = [];
   const appendAtTick: Map<number, string> = new Map();
   let missing = false;
 
@@ -23,6 +24,7 @@ function harness(initial: string, startAtEnd: boolean) {
     fileSize: async () => (missing ? null : Buffer.byteLength(content)),
     readSlice: async (from, to) => Buffer.from(content).subarray(from, to).toString(),
     onBoundary: (b) => boundaries.push(b),
+    onInitialBoundary: (b) => initialBoundaries.push(b),
     isAlive: () => ticks < maxTicks,
     startAtEnd,
     sleep: async () => {
@@ -34,6 +36,7 @@ function harness(initial: string, startAtEnd: boolean) {
   return {
     deps,
     boundaries,
+    initialBoundaries,
     appendAt: (tick: number, text: string) => appendAtTick.set(tick, text),
     setMissing: (v: boolean) => (missing = v),
     run: () => watchCodexActivity(deps),
@@ -91,6 +94,14 @@ describe("watchCodexActivity", () => {
     const h = harness(started("old") + complete("old"), true);
     await h.run();
     expect(h.boundaries).toEqual([]);
+    expect(h.initialBoundaries).toEqual(["completed"]);
+  });
+
+  it("reports only the latest resumed started boundary as initial state", async () => {
+    const h = harness(started("old") + complete("old") + started("new"), true);
+    await h.run();
+    expect(h.boundaries).toEqual([]);
+    expect(h.initialBoundaries).toEqual(["started"]);
   });
 
   it("still reports a resumed session's NEW turns", async () => {

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -47,6 +47,36 @@ describe("watchCodexActivity", () => {
     expect(h.boundaries).toEqual(["started", "completed"]);
   });
 
+  it("reports cwd from appended turn_context rows", async () => {
+    const h = harness("", false);
+    const cwds: string[] = [];
+    h.deps.onCwd = (cwd) => cwds.push(cwd);
+    h.appendAt(1, line({ type: "turn_context", payload: { cwd: "/work" } }) + "\n");
+    await h.run();
+    expect(cwds).toEqual(["/work"]);
+  });
+
+  it("joins a turn_context record split across polls", async () => {
+    const h = harness("", false);
+    const cwds: string[] = [];
+    h.deps.onCwd = (cwd) => cwds.push(cwd);
+    const whole = line({ type: "turn_context", payload: { cwd: "/split" } }) + "\n";
+    h.appendAt(1, whole.slice(0, 18));
+    h.appendAt(2, whole.slice(18));
+    await h.run();
+    expect(cwds).toEqual(["/split"]);
+  });
+
+  it("does not replay resumed cwd history, but reports new cwd rows", async () => {
+    const old = line({ type: "turn_context", payload: { cwd: "/old" } }) + "\n";
+    const h = harness(old, true);
+    const cwds: string[] = [];
+    h.deps.onCwd = (cwd) => cwds.push(cwd);
+    h.appendAt(2, line({ type: "turn_context", payload: { cwd: "/new" } }) + "\n");
+    await h.run();
+    expect(cwds).toEqual(["/new"]);
+  });
+
   it("reads a fresh session's existing content, so its first turn isn't missed", async () => {
     const h = harness(started(), false);
     await h.run();

--- a/test/server/session/codex-legacy-rollout.spec.ts
+++ b/test/server/session/codex-legacy-rollout.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { parseLegacyCodexRolloutId } from "../../../server/session/codex-legacy-rollout.js";
+
+const session = "11111111-1111-4111-8111-111111111111";
+const first = "22222222-2222-4222-8222-222222222222";
+const last = "33333333-3333-4333-8333-333333333333";
+
+describe("parseLegacyCodexRolloutId", () => {
+  it("uses the last valid matching row and ignores malformed rows", () => {
+    expect(parseLegacyCodexRolloutId(`bad\n${session}\t${first}\n${session}\tnope\n${session}\t${last}\n`, session)).toBe(last);
+  });
+  it("rejects empty or invalid ids", () => {
+    expect(parseLegacyCodexRolloutId(`${session}\t${first}\n`, "")).toBeNull();
+    expect(parseLegacyCodexRolloutId(`${session}\t${first}\n`, "not-a-uuid")).toBeNull();
+  });
+});

--- a/test/server/session/live-cwd.spec.ts
+++ b/test/server/session/live-cwd.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { makeTempDir } from "../../support/tempDir.js";
+import { displayCwdFor, forgetLiveCwd, liveCwd, noteLiveCwd, replayLiveCwd, workTreeRootOf } from "../../../server/session/live-cwd.js";
+import { ptys } from "../../../server/session/registry.js";
+import type { PtyEntry } from "../../../server/session/types.js";
+
+// Real repos with a real linked worktree: the whole point of this module is telling one
+// checkout from another, and only git knows where a work tree ends.
+let base = "";
+let main = "";
+let sub = "";
+let worktree = "";
+let nested = "";
+let plain = "";
+
+beforeAll(() => {
+  base = makeTempDir("mt-livecwd-");
+  main = path.join(base, "myrepo");
+  mkdirSync(main);
+  const git = (args: string[], cwd = main) =>
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.email", "t@example.invalid"]);
+  git(["config", "user.name", "t"]);
+  sub = path.join(main, "app");
+  mkdirSync(sub);
+  writeFileSync(path.join(main, "f.txt"), "x");
+  git(["add", "f.txt"]);
+  git(["commit", "-qm", "first"]);
+  worktree = path.join(base, "wt");
+  git(["worktree", "add", "-q", "-b", "side", worktree]);
+  nested = path.join(worktree, "nested");
+  mkdirSync(nested);
+  plain = path.join(base, "notrepo");
+  mkdirSync(plain);
+});
+
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+// git prints POSIX separators even on Windows; the inputs keep whatever shape they were
+// given. Compare the resolved form so the two can't disagree about the same directory.
+const norm = (p: string): string => path.resolve(p);
+
+const SESSION = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+interface FakeSocket {
+  readyState: number;
+  readonly OPEN: number;
+  sent: string[];
+  send(data: string): void;
+  close(): void;
+}
+
+function fakeSocket(): FakeSocket {
+  return {
+    readyState: 1,
+    OPEN: 1,
+    sent: [],
+    send(data: string) {
+      this.sent.push(data);
+    },
+    close() {},
+  };
+}
+
+function registerPty(cwd: string, socket: FakeSocket | null): void {
+  ptys.set(SESSION, { cwd, ws: socket, active: true, agent: "claude" } as unknown as PtyEntry);
+}
+
+const frames = (socket: FakeSocket) => socket.sent.map((s) => JSON.parse(s));
+
+beforeEach(() => {
+  ptys.delete(SESSION);
+  forgetLiveCwd(SESSION);
+});
+
+describe("workTreeRootOf", () => {
+  it("rounds a directory inside a repo up to that work tree's root", async () => {
+    expect(norm(await workTreeRootOf(sub))).toBe(norm(main));
+  });
+
+  it("reports a linked worktree as its own root, not the main repo's", async () => {
+    expect(norm(await workTreeRootOf(worktree))).toBe(norm(worktree));
+  });
+
+  it("returns the directory itself when it is not in a work tree", async () => {
+    expect(norm(await workTreeRootOf(plain))).toBe(norm(plain));
+  });
+});
+
+describe("displayCwdFor", () => {
+  it("keeps the spawn dir while the agent is still inside the spawn work tree", async () => {
+    // A `cd app` mid-turn is the same checkout — the header must not redraw for it, and a
+    // session spawned in a subdirectory must not have its display quietly rewritten either.
+    expect(await displayCwdFor(sub, sub)).toBe(sub);
+    expect(await displayCwdFor(sub, main)).toBe(main);
+    expect(await displayCwdFor(main, sub)).toBe(sub);
+  });
+
+  it("reports the other work tree's ROOT once the agent is in one", async () => {
+    expect(norm(await displayCwdFor(worktree, main))).toBe(norm(worktree));
+  });
+
+  it("falls back to the raw directory when the agent leaves git entirely", async () => {
+    expect(norm(await displayCwdFor(plain, main))).toBe(norm(plain));
+  });
+});
+
+describe("noteLiveCwd", () => {
+  it("says nothing while the session stays in its spawn work tree", async () => {
+    const socket = fakeSocket();
+    registerPty(main, socket);
+    await noteLiveCwd(SESSION, sub);
+    expect(socket.sent).toEqual([]);
+    expect(liveCwd(SESSION)).toBe(main);
+  });
+
+  it("pushes the work tree the session moved to", async () => {
+    const socket = fakeSocket();
+    registerPty(main, socket);
+    await noteLiveCwd(SESSION, worktree);
+    expect(frames(socket)).toHaveLength(1);
+    expect(frames(socket)[0]).toMatchObject({ type: "cwd", id: SESSION });
+    expect(norm(frames(socket)[0].cwd)).toBe(norm(worktree));
+    expect(norm(liveCwd(SESSION) ?? "")).toBe(norm(worktree));
+  });
+
+  it("pushes once per move, not once per hook", async () => {
+    const socket = fakeSocket();
+    registerPty(main, socket);
+    await noteLiveCwd(SESSION, worktree);
+    await noteLiveCwd(SESSION, worktree);
+    await noteLiveCwd(SESSION, nested);
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  it("pushes the spawn dir again when the session comes back", async () => {
+    const socket = fakeSocket();
+    registerPty(main, socket);
+    await noteLiveCwd(SESSION, worktree);
+    await noteLiveCwd(SESSION, main);
+    expect(frames(socket).at(-1)).toEqual({ type: "cwd", id: SESSION, cwd: main });
+    expect(liveCwd(SESSION)).toBe(main);
+  });
+
+  it("ignores a hook that carries no usable cwd", async () => {
+    const socket = fakeSocket();
+    registerPty(main, socket);
+    await noteLiveCwd(SESSION, undefined);
+    await noteLiveCwd(SESSION, "");
+    await noteLiveCwd(SESSION, { cwd: worktree });
+    expect(socket.sent).toEqual([]);
+    expect(liveCwd(SESSION)).toBeNull();
+  });
+
+  it("remembers nothing for an id with no live pty", async () => {
+    // Any well-formed uuid can be POSTed to /api/hook, and nothing would ever reap an entry
+    // made for one — there is no session to forget it.
+    await noteLiveCwd(SESSION, worktree);
+    expect(liveCwd(SESSION)).toBeNull();
+  });
+
+  it("still records the move for a session whose browser is detached", async () => {
+    registerPty(main, null);
+    await noteLiveCwd(SESSION, worktree);
+    expect(norm(liveCwd(SESSION) ?? "")).toBe(norm(worktree));
+  });
+});
+
+describe("replayLiveCwd", () => {
+  it("tells a reattaching browser where the session actually is", async () => {
+    registerPty(main, null);
+    await noteLiveCwd(SESSION, worktree);
+    const socket = fakeSocket();
+    expect(replayLiveCwd(socket, SESSION, main)).toBe(true);
+    expect(frames(socket)).toHaveLength(1);
+    expect(norm(frames(socket)[0].cwd)).toBe(norm(worktree));
+  });
+
+  it("stays quiet for a session that never moved", () => {
+    const socket = fakeSocket();
+    expect(replayLiveCwd(socket, SESSION, main)).toBe(false);
+    expect(socket.sent).toEqual([]);
+  });
+
+  // The regression this exists for: replay used to be gated on the connection resolving as a
+  // reattach, and a session whose agent has MOVED never does — its transcript went with it, so
+  // the exists-on-disk check fails and the socket is logged as "new". That gate silenced the
+  // replay for exactly the sessions it was written for, and since noteLiveCwd only speaks on a
+  // change, one reload left the header on the abandoned directory permanently.
+  it("replays after a reload even though a moved session no longer looks reattachable", async () => {
+    registerPty(main, null);
+    await noteLiveCwd(SESSION, worktree); // the browser that was told has since gone away
+    const reloaded = fakeSocket();
+    expect(replayLiveCwd(reloaded, SESSION, main)).toBe(true);
+    expect(norm(frames(reloaded)[0].cwd)).toBe(norm(worktree));
+    // ...and the hook that follows the reload says nothing, which is why the replay has to.
+    registerPty(main, reloaded);
+    const before = reloaded.sent.length;
+    await noteLiveCwd(SESSION, worktree);
+    expect(reloaded.sent).toHaveLength(before);
+  });
+
+  it("stays quiet when the reported cwd already IS the moved-to one", async () => {
+    registerPty(main, null);
+    await noteLiveCwd(SESSION, worktree);
+    const socket = fakeSocket();
+    expect(replayLiveCwd(socket, SESSION, worktree)).toBe(false);
+  });
+});
+
+describe("forgetLiveCwd", () => {
+  it("drops a torn-down session's directory", async () => {
+    registerPty(main, null);
+    await noteLiveCwd(SESSION, worktree);
+    forgetLiveCwd(SESSION);
+    expect(liveCwd(SESSION)).toBeNull();
+  });
+});

--- a/test/server/session/spawn-codex.spec.ts
+++ b/test/server/session/spawn-codex.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { codexActivityRolloutId } from "../../../server/session/spawn-codex.js";
+
+describe("codexActivityRolloutId", () => {
+  it("prefers an explicit resume id", () => {
+    expect(codexActivityRolloutId("resume", true, "mapped")).toBe("resume");
+  });
+  it("uses the persisted mapping for a surviving tmux reattach", () => {
+    expect(codexActivityRolloutId(null, true, "mapped")).toBe("mapped");
+  });
+  it("does not use a mapping for a fresh session", () => {
+    expect(codexActivityRolloutId(null, false, "mapped")).toBeNull();
+  });
+});

--- a/test/server/session/transcript-locate.spec.ts
+++ b/test/server/session/transcript-locate.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, renameSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { makeTempDir } from "../../support/tempDir.js";
+import { encodeProjectDirName, projectSessionsDir } from "../../../server/session/project-dir.js";
+import { forgetTranscriptLocation, transcriptDir, transcriptFile } from "../../../server/session/transcript-locate.js";
+
+// A real ~/.claude/projects tree, because the whole point of this module is that the filesystem
+// is the only thing that still knows where a transcript went.
+let home = "";
+const ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MAIN = "/work/repo";
+const WORKTREE = "/work/wt/fix-login";
+
+const dirFor = (cwd: string) => path.join(home, ".claude", "projects", encodeProjectDirName(path.resolve(cwd)));
+const write = (cwd: string, id = ID) => {
+  const dir = dirFor(cwd);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, `${id}.jsonl`), "{}\n");
+  return path.join(dir, `${id}.jsonl`);
+};
+
+beforeEach(() => {
+  home = makeTempDir("mt-locate-");
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  forgetTranscriptLocation(ID);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("transcriptFile", () => {
+  it("uses the given cwd when the transcript is where that says", () => {
+    const written = write(MAIN);
+    expect(transcriptFile(ID, MAIN)).toBe(written);
+  });
+
+  it("finds a transcript the CLI moved to another directory's project dir", () => {
+    // The session was started in the repo and sent into a worktree; the file went with it.
+    const moved = write(WORKTREE);
+    expect(transcriptFile(ID, MAIN)).toBe(moved);
+  });
+
+  it("answers as before when no transcript exists anywhere", () => {
+    // Callers decide for themselves what a missing file means, so the stale-cwd answer is the
+    // right one to hand back — it keeps "no transcript" reading as "no transcript".
+    expect(transcriptFile(ID, MAIN)).toBe(path.join(projectSessionsDir(MAIN), `${ID}.jsonl`));
+  });
+
+  it("follows a second move rather than trusting what it found last time", () => {
+    write(MAIN);
+    expect(transcriptDir(ID, MAIN)).toBe(dirFor(MAIN));
+    mkdirSync(dirFor(WORKTREE), { recursive: true });
+    renameSync(path.join(dirFor(MAIN), `${ID}.jsonl`), path.join(dirFor(WORKTREE), `${ID}.jsonl`));
+    expect(transcriptDir(ID, MAIN)).toBe(dirFor(WORKTREE));
+  });
+
+  it("takes the hint back the moment the session returns to it", () => {
+    write(WORKTREE);
+    expect(transcriptDir(ID, MAIN)).toBe(dirFor(WORKTREE));
+    rmSync(path.join(dirFor(WORKTREE), `${ID}.jsonl`));
+    write(MAIN);
+    expect(transcriptDir(ID, MAIN)).toBe(dirFor(MAIN));
+  });
+
+  it("does not confuse one session's move with another's", () => {
+    const other = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    write(WORKTREE);
+    write(MAIN, other);
+    expect(transcriptDir(ID, MAIN)).toBe(dirFor(WORKTREE));
+    expect(transcriptDir(other, MAIN)).toBe(dirFor(MAIN));
+  });
+
+  it("survives a missing projects root", () => {
+    rmSync(path.join(home, ".claude"), { recursive: true, force: true });
+    expect(transcriptFile(ID, MAIN)).toBe(path.join(projectSessionsDir(MAIN), `${ID}.jsonl`));
+  });
+});

--- a/test/src/components/ModelContextBadge.spec.ts
+++ b/test/src/components/ModelContextBadge.spec.ts
@@ -4,7 +4,12 @@ import ModelContextBadge from "../../../src/components/ModelContextBadge.vue";
 
 // Wiring only — which window a model has, and what the badge says when we cannot know, is decided
 // in src/components/modelBadge.ts and tested in modelBadge.spec.ts without mounting anything.
-function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; contextTokens?: number; contextWindow?: number | null }) {
+function mountBadge(props: {
+  agent?: "claude" | "codex" | "antigravity" | "grok";
+  model: string | null;
+  contextTokens?: number;
+  contextWindow?: number | null;
+}) {
   return mount(ModelContextBadge, {
     props: {
       agent: props.agent ?? "claude",
@@ -20,9 +25,9 @@ describe("ModelContextBadge", () => {
   // not be made to appear promptly, and its one line had nowhere to put the full model name. What
   // the tip says is pinned in tipContent.spec.ts; what matters here is that the attribute is GONE,
   // or the old slow tooltip would surface a second time on top of the new one.
-  it("renders the badge text and no longer carries a native tooltip", () => {
+  it("keeps the Claude model name but hides its context usage", () => {
     const badge = mountBadge({ model: "claude-opus-4-20250514", contextTokens: 70_000 }).find('[data-testid="model-badge"]');
-    expect(badge.text()).toBe("Opus · ctx 35%");
+    expect(badge.text()).toBe("Opus");
     expect(badge.attributes("title")).toBeUndefined();
   });
 
@@ -30,10 +35,13 @@ describe("ModelContextBadge", () => {
     expect(mountBadge({ model: null, contextTokens: 1000 }).find("span").exists()).toBe(false);
   });
 
-  // A codex cell: the window comes from the rollout rather than the substring table, which knows
-  // no OpenAI model at all — without it this would read `gpt-5.5` with no percentage (#1465).
-  it("reads the percentage off the window the agent reported", () => {
+  it("keeps the Codex model name but hides its context usage", () => {
     const badge = mountBadge({ agent: "codex", model: "gpt-5.5", contextTokens: 64_600, contextWindow: 258_400 });
-    expect(badge.find('[data-testid="model-badge"]').text()).toBe("gpt-5.5 · ctx 25%");
+    expect(badge.find('[data-testid="model-badge"]').text()).toBe("gpt-5.5");
+  });
+
+  it("keeps context usage for the other pane agents", () => {
+    const badge = mountBadge({ agent: "antigravity", model: "Gemini 3.6 Flash", contextTokens: 64_600, contextWindow: 258_400 });
+    expect(badge.find('[data-testid="model-badge"]').text()).toBe("Gemini 3.6 Flash · ctx 25%");
   });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -717,7 +717,7 @@ describe("TerminalCell", () => {
     expect(dotClass(w)).toContain("is-idle"); // the newest seed wins, not the first to resolve
   });
 
-  it("shows a token-usage badge from /api/session/:id", async () => {
+  it("shows a token-usage badge for agents that keep it in the pane header", async () => {
     const id = "55555555-5555-5555-5555-555555555555";
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);
@@ -733,12 +733,34 @@ describe("TerminalCell", () => {
         }),
       };
     }) as unknown as typeof fetch;
-    const w = mountCell(id);
+    const w = mountCell(id, { initialAgent: "antigravity" });
     await flushPromises();
     const badge = w.find('[data-testid="cell-usage"]');
     expect(badge.exists()).toBe(true);
     expect(badge.text()).toContain("2.0k"); // input 1200 + cacheRead 800 = 2000
     expect(badge.text()).toContain("3.4k"); // output 3400
+  });
+
+  it.each(["claude", "codex"] as const)("hides the token-usage badge for %s", async (initialAgent) => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return {
+        ok: true,
+        json: async () => ({
+          working: false,
+          waiting: false,
+          lastPrompt: null,
+          usage: { inputTokens: 1200, outputTokens: 3400, cacheReadTokens: 800, cacheCreationTokens: 0 },
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id, { initialAgent });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-usage"]').exists()).toBe(false);
   });
 
   // Codex on #642: a guard that only skips an unrenderable payload leaves the badge showing
@@ -754,7 +776,7 @@ describe("TerminalCell", () => {
       if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, usage }) };
     }) as unknown as typeof fetch;
-    const w = mountCell(id);
+    const w = mountCell(id, { initialAgent: "antigravity" });
     await flushPromises();
     expect(w.find('[data-testid="cell-usage"]').exists()).toBe(true);
 
@@ -770,31 +792,35 @@ describe("TerminalCell", () => {
 
   // #620, on the badge path: two turns end back-to-back, so two /api/session reads for the
   // same session are in flight at once. The older one resolving last must not put the
-  // previous turn's token numbers back on the badge.
-  it("does not let a stale usage refresh clobber a newer one (out-of-order)", async () => {
+  // previous turn's context reading back on the badge.
+  it("does not let a stale badge refresh clobber a newer one (out-of-order)", async () => {
     const id = "66666666-6666-6666-6666-666666666666";
     const gates = [deferred<boolean>(), deferred<boolean>()];
     let sessionCall = 0;
-    const INITIAL = { inputTokens: 100, outputTokens: 100, cacheReadTokens: 0, cacheCreationTokens: 0 };
-    const OLD = { inputTokens: 1000, outputTokens: 2000, cacheReadTokens: 0, cacheCreationTokens: 0 };
-    const NEW = { inputTokens: 5000, outputTokens: 9000, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    const badge = (contextTokens: number) => ({
+      usage: { inputTokens: contextTokens, outputTokens: contextTokens, cacheReadTokens: 0, cacheCreationTokens: 0 },
+      context: { model: "claude-opus-4-8", contextTokens, contextWindow: 10_000 },
+    });
+    const INITIAL = badge(100);
+    const OLD = badge(1000);
+    const NEW = badge(5000);
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);
       if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
       if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
       if (u.includes(`/api/session/${id}`)) {
         const n = sessionCall++;
-        if (n === 0) return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, usage: INITIAL }) }; // mount seed
-        const usage = n === 1 ? OLD : NEW; // refresh #1 = older turn, refresh #2 = newer turn
+        if (n === 0) return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, ...INITIAL }) }; // mount seed
+        const badges = n === 1 ? OLD : NEW; // refresh #1 = older turn, refresh #2 = newer turn
         await gates[n - 1].promise;
-        return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, usage }) };
+        return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, ...badges }) };
       }
       return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
     }) as unknown as typeof fetch;
 
     const w = mountCell(id);
     await flushPromises();
-    expect(w.find('[data-testid="cell-usage"]').text()).toContain("100"); // initial seed
+    expect(w.find('[data-testid="model-badge"]').text()).toContain("ctx 1%"); // initial seed
 
     // First turn ends → refresh #1 (older), held on gates[0].
     captured?.({ id, working: true, waiting: false });
@@ -813,10 +839,9 @@ describe("TerminalCell", () => {
     await flushPromises();
     await nextTick();
 
-    const badge = w.find('[data-testid="cell-usage"]').text();
-    expect(badge).toContain("5.0k"); // NEW input
-    expect(badge).toContain("9.0k"); // NEW output
-    expect(badge).not.toContain("1.0k"); // not OLD input
+    const modelBadge = w.find('[data-testid="model-badge"]').text();
+    expect(modelBadge).toContain("ctx 50%"); // NEW context
+    expect(modelBadge).not.toContain("ctx 10%"); // not OLD context
   });
 
   it("shows the model/context badge from /api/session/:id context", async () => {
@@ -970,7 +995,7 @@ describe("TerminalCell", () => {
         }),
       };
     }) as unknown as typeof fetch;
-    const w = mountCell(id, { initialCwd: "/home/me/proj" });
+    const w = mountCell(id, { initialCwd: "/home/me/proj", initialAgent: "antigravity" });
     await flushPromises();
     expect(w.find('[data-testid="cell-hdr-chip"]').text()).toBe("prod"); // custom chip renders its substituted text
     expect(w.find('[data-testid="cell-usage"]').exists()).toBe(true); // usage is listed
@@ -1005,7 +1030,7 @@ describe("TerminalCell", () => {
         }),
       };
     }) as unknown as typeof fetch;
-    const w = mountCell(id, { initialCwd: "/home/me/proj" });
+    const w = mountCell(id, { initialCwd: "/home/me/proj", initialAgent: "antigravity" });
     await flushPromises();
     expect(w.findAll('[data-testid="cell-usage"]')).toHaveLength(2); // both duplicates render, unique keys → no collision
   });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -792,18 +792,18 @@ describe("TerminalCell", () => {
 
   // #620, on the badge path: two turns end back-to-back, so two /api/session reads for the
   // same session are in flight at once. The older one resolving last must not put the
-  // previous turn's context reading back on the badge.
+  // previous turn's model back on the badge.
   it("does not let a stale badge refresh clobber a newer one (out-of-order)", async () => {
     const id = "66666666-6666-6666-6666-666666666666";
     const gates = [deferred<boolean>(), deferred<boolean>()];
     let sessionCall = 0;
-    const badge = (contextTokens: number) => ({
+    const badge = (model: string, contextTokens: number) => ({
       usage: { inputTokens: contextTokens, outputTokens: contextTokens, cacheReadTokens: 0, cacheCreationTokens: 0 },
-      context: { model: "claude-opus-4-8", contextTokens, contextWindow: 10_000 },
+      context: { model, contextTokens, contextWindow: 10_000 },
     });
-    const INITIAL = badge(100);
-    const OLD = badge(1000);
-    const NEW = badge(5000);
+    const INITIAL = badge("claude-opus-4-8", 100);
+    const OLD = badge("claude-haiku-4", 1000);
+    const NEW = badge("claude-sonnet-4-6", 5000);
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);
       if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
@@ -820,7 +820,7 @@ describe("TerminalCell", () => {
 
     const w = mountCell(id);
     await flushPromises();
-    expect(w.find('[data-testid="model-badge"]').text()).toContain("ctx 1%"); // initial seed
+    expect(w.find('[data-testid="model-badge"]').text()).toBe("Opus"); // initial seed
 
     // First turn ends → refresh #1 (older), held on gates[0].
     captured?.({ id, working: true, waiting: false });
@@ -840,8 +840,8 @@ describe("TerminalCell", () => {
     await nextTick();
 
     const modelBadge = w.find('[data-testid="model-badge"]').text();
-    expect(modelBadge).toContain("ctx 50%"); // NEW context
-    expect(modelBadge).not.toContain("ctx 10%"); // not OLD context
+    expect(modelBadge).toBe("Sonnet"); // NEW model
+    expect(modelBadge).not.toBe("Haiku"); // not OLD model
   });
 
   it("shows the model/context badge from /api/session/:id context", async () => {
@@ -859,7 +859,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     const badge = w.find('[data-testid="model-badge"]');
     expect(badge.exists()).toBe(true);
-    expect(badge.text()).toBe("Opus · ctx 35%"); // 70k / 200k
+    expect(badge.text()).toBe("Opus");
   });
 
   // An agy cell is the case that has no other way back: agy mints its conversation id after the

--- a/test/src/components/TerminalCellLiveCwd.spec.ts
+++ b/test/src/components/TerminalCellLiveCwd.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { nextTick } from "vue";
+import type { ConnHandlers } from "../../../src/composables/useTerminalConnections";
+
+// The seam the other TerminalCell specs cannot reach: they stub Terminal.vue, so they prove the
+// CELL reacts to a `live-cwd` event, never that the real Terminal emits one. Here Terminal.vue is
+// real and only the connection manager is faked, so the chain under test is
+//   manager handler -> Terminal.vue emit -> TerminalCell listener -> header.
+// Every link in that chain shipped untested, which is exactly where a wiring bug hides.
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+let handlers: ConnHandlers | null = null;
+vi.mock("../../../src/composables/useTerminalConnections", async () => {
+  const { reactive } = await import("vue");
+  return {
+    connView: reactive(new Map()),
+    attach: (_k: string, _t: unknown, h: ConnHandlers) => {
+      handlers = h;
+    },
+    setFont: () => {},
+    setTheme: () => {},
+    detach: () => {},
+    release: () => {},
+    retarget: () => {},
+    terminate: () => {},
+    fit: () => {},
+    focus: () => {},
+    insertText: () => {},
+    sendView: () => {},
+    readBuffer: () => null,
+    submitText: () => true,
+    pasteText: () => true,
+    pasteAndSubmit: () => true,
+    listSlots: () => [],
+    setScrollSpeed: () => {},
+    makeEnterHandler: () => () => false,
+    makeSendHandler: () => () => false,
+    isSystemClipboard: () => false,
+    isOpenableTerminalLink: () => false,
+    isClaudeTarget: () => false,
+  };
+});
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  handlers = null;
+  globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+  globalThis.fetch = vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+    return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+  }) as unknown as typeof fetch;
+});
+
+async function mountCell() {
+  const TerminalCell = (await import("../../../src/components/TerminalCell.vue")).default;
+  const w = mount(TerminalCell, {
+    attachTo: document.body,
+    props: {
+      uid: 1,
+      home: "/home/me",
+      initialCwd: "/home/me/repo",
+      defaultCwd: "/home/me/repo",
+      sessionId: "77777777-7777-7777-7777-777777777777",
+      initialSessionId: "77777777-7777-7777-7777-777777777777",
+      expanded: false,
+      presets: [],
+    },
+  });
+  await flushPromises();
+  return w;
+}
+
+describe("TerminalCell + real Terminal: live cwd", () => {
+  // A zoom teleports the terminal, which detaches and re-attaches its slot — and attach REPLAYS
+  // the server-learned values to the freshly-bound handlers, cwd first and live cwd immediately
+  // after, in one synchronous block. Anything that reacts to the cwd asynchronously therefore
+  // lands AFTER the live cwd and undoes it: the header snaps back to the directory the agent
+  // left, every time the user zooms. Same shape for a reconnect, whose two frames replay in the
+  // same order.
+  it("survives an attach replaying cwd and live cwd back to back", async () => {
+    const w = await mountCell();
+    handlers?.onCwd?.("/home/me/repo");
+    handlers?.onLiveCwd?.("/home/me/wt/fix-login");
+    await nextTick();
+    await nextTick();
+    expect(w.find(".cell-dir").text()).toMatch(/^~\/wt\/fix-login/);
+  });
+
+  // The same replay, but where the server-confirmed cwd DIFFERS from the one the cell started
+  // with (a cell restored from a preset the server resolved elsewhere). Now the cwd genuinely
+  // changes in that synchronous block, so anything watching it asynchronously fires after the
+  // live cwd has already been applied.
+  it("survives an attach replay that also changes the cwd", async () => {
+    const w = await mountCell();
+    handlers?.onCwd?.("/home/me/resolved");
+    handlers?.onLiveCwd?.("/home/me/wt/fix-login");
+    await nextTick();
+    await nextTick();
+    expect(w.find(".cell-dir").text()).toMatch(/^~\/wt\/fix-login/);
+  });
+
+  // The other order is a RELAUNCH: the cell is pointed at a new session, and the previous
+  // session's move is not the new one's.
+  it("drops the move when the server reports a cwd afterwards", async () => {
+    const w = await mountCell();
+    handlers?.onLiveCwd?.("/home/me/wt/fix-login");
+    await nextTick();
+    handlers?.onCwd?.("/home/me/other");
+    await nextTick();
+    await nextTick();
+    expect(w.find(".cell-dir").text()).toMatch(/^~\/other/);
+  });
+
+  it("carries a manager-reported move all the way to the header", async () => {
+    const w = await mountCell();
+    expect(w.find(".cell-dir").text()).toMatch(/^~\/repo/);
+    expect(handlers?.onLiveCwd).toBeTypeOf("function");
+
+    handlers?.onLiveCwd?.("/home/me/wt/fix-login");
+    await nextTick();
+    await nextTick();
+    expect(w.find(".cell-dir").text()).toMatch(/^~\/wt\/fix-login/);
+  });
+});

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -96,6 +96,7 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   headerTextColor: null,
   iconUrl: null,
   parked: false,
+  reviewPending: false,
   ...over,
 });
 const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[], reorderable = false, listMode = true) =>

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -96,7 +96,6 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   headerTextColor: null,
   iconUrl: null,
   parked: false,
-  reviewPending: false,
   ...over,
 });
 const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[], reorderable = false, listMode = true) =>


### PR DESCRIPTION
## 概要

- Claudeのhookが報告する現在地をセッションヘッダーへ反映し、別worktreeへ移動した後も表示・セッション参照を追従させます
- Codex rollout内の実際の`exec` workdirを読み取り、Claudeと同じ経路で現在のworktreeを表示します
- サーバー再起動後に生存しているtmuxセッションでもCodex activity/workdir監視を再接続します
- 旧TSV形式のCodex rollout対応表を読み取り、新しいJSONL形式へ自己移行します
- Claude / Codexのペインヘッダーでは、トークン使用量とcontext使用率を隠し、モデル名だけを残します

## 背景と原因

CodexのセッションはPTYを起動したディレクトリだけをヘッダーへ表示していたため、セッション中に別worktreeで作業しても表示が更新されませんでした。また、再起動後にtmuxへ再接続する経路ではrollout activity trackerが登録されず、`Running`とworkdir更新の両方が止まっていました。

Codex rolloutの`turn_context.cwd`は起動元のままで、実際の作業先は`response_item`内の`exec` tool callに記録されます。この明示的なworkdirを抽出し、既存のlive-cwd表示経路へ渡します。旧ローカルセッションについてはlegacy対応表を優先して正しいrolloutを復元します。

## 影響

- Claude / Codexのセッションヘッダーが現在作業しているgit worktreeを示します
- ブラウザやサーバーの再接続後も、最後に確認できた現在地を再送します
- Claude / Codexのヘッダーから使用量表示がなくなり、モデル名、状態、worktree情報を優先して表示します
- Settingsの費用集計とGrok / Antigravityの既存バッジは変更しません

## 検証

- 関連Vitest: 249件成功
- live-cwd Vitest: 18件成功
- `yarn typecheck`
- `yarn lint`（エラー0、既存warningのみ）
- `yarn build`

## マージ後に残る作業

なし
