### PR TITLE
fix(muse): resume keeps the workspace, the context badge stops reading a high-water mark, and the 33 MB log is folded

### DIFF
--- a/server/agents/grok-usage.ts
+++ b/server/agents/grok-usage.ts
@@ -19,6 +19,7 @@
 import { isRecord } from "../../common/isRecord.js";
 import type { SessionContextInfo } from "../../common/sessionContext.js";
 import type { SessionUsage } from "../session/transcript.js";
+import { usageCount as num } from "./usage-count.js";
 
 export const emptyGrokUsage = (): SessionUsage => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
 
@@ -28,11 +29,6 @@ export const isGrokUsage = (value: unknown): value is SessionUsage =>
   typeof value.outputTokens === "number" &&
   typeof value.cacheReadTokens === "number" &&
   typeof value.cacheCreationTokens === "number";
-
-const num = (record: Record<string, unknown>, key: string): number => {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
-};
 
 /**
  * The context reading in a conversation's `signals.json`, or nulls/zeroes when it says nothing.

--- a/server/agents/muse-args.ts
+++ b/server/agents/muse-args.ts
@@ -1,39 +1,52 @@
 // Builds the argv for spawning `muse` as a first-class session.
 //
-// `muse` has no --session-id; it mints its own id (sqlite session-index.db).
-// Fresh: `muse --workspace <cwd>` (and optional --model/--reasoning-effort).
-// Resume: `muse resume <id>`.
+// `muse` is codex-shaped on the id axis: there is no `--session-id`, it mints its own (a row in
+// `session-index.db`), so a fresh spawn is watched for the new row and a resume names it —
+// `muse resume <uuid>`.
+//
+// Everything else is a ROOT option, and muse accepts those on either side of the subcommand
+// (`muse resume --help` says so). That is what makes the resume path below carry `--workspace`
+// rather than dropping it: `--workspace <PATH>` is what registers the policy-gated workspace tools,
+// so a resumed session started without it comes back with the conversation and without the tools
+// it had — file edits and shell in the project it was working on. The flags are emitted BEFORE the
+// subcommand, which is the form the CLI documents first.
+//
+// `--yolo` disables approval prompts and the sandbox for the run. It is the counterpart of the
+// `--permission-mode auto` grok is given and the permission mode claude cells run under: a cell in
+// the grid has no way to answer a modal approval prompt in a TUI it is not being watched.
 
 export interface MuseArgsInput {
+  /** A muse session id to resume, or null to start fresh in `workspace`. */
   resume?: string | null;
+  /** The directory whose tools the session is given (--workspace). Passed on BOTH paths. */
   workspace?: string | null;
+  /** Model override (--model), or null to use muse's own configured default. */
   model?: string | null;
+  /** `none|minimal|low|medium|high|xhigh|ultra`, or null for muse's default. */
   reasoningEffort?: string | null;
+  /** A first turn to run on startup, for a session spawned to DO something (a background chat).
+   *  muse takes it as a positional argument and stays interactive afterwards.
+   *
+   *  Ignored on a RESUME, and it has to be: the positional prompt belongs to the no-subcommand
+   *  form, and `muse resume <id> <prompt>` is not a command line muse accepts. A resumed session
+   *  is seeded by typing into it, not by argv. */
   initialPrompt?: string | null;
 }
 
 export function buildMuseArgs(input: MuseArgsInput): string[] {
-  if (input.resume) {
-    return ["--yolo", "resume", input.resume];
-  }
-
   const args: string[] = ["--yolo"];
 
-  if (input.workspace) {
-    args.push("--workspace", input.workspace);
+  if (input.workspace) args.push("--workspace", input.workspace);
+  if (input.model) args.push("--model", input.model);
+  if (input.reasoningEffort) args.push("--reasoning-effort", input.reasoningEffort);
+
+  if (input.resume) {
+    args.push("resume", input.resume);
+    return args;
   }
 
-  if (input.model) {
-    args.push("--model", input.model);
-  }
-
-  if (input.reasoningEffort) {
-    args.push("--reasoning-effort", input.reasoningEffort);
-  }
-
-  if (input.initialPrompt) {
-    args.push(input.initialPrompt);
-  }
+  // Last, and positional: anything appended after it would be read as part of the prompt.
+  if (input.initialPrompt) args.push(input.initialPrompt);
 
   return args;
 }

--- a/server/agents/muse-session.ts
+++ b/server/agents/muse-session.ts
@@ -1,11 +1,27 @@
-/* eslint-disable max-lines-per-function, complexity, sonarjs/cognitive-complexity, @typescript-eslint/consistent-type-assertions -- museBadgesFromLog parses DB + JSONL, needs casts */
+// Where `muse` keeps its sessions, and the questions the list / resume / badge paths ask of them.
+//
+// muse is codex-shaped: it mints its own session id and tells nobody, so a fresh spawn is watched
+// until a new row appears (spawn-muse.ts) and the mapping is logged so a cold reconnect can resume
+// it. What it does NOT share with codex is where it writes that down — everything a reader wants
+// is a row in ONE sqlite index, `~/.local/share/muse/session-index.db`:
+//
+//   session_id        muse's own id, the argument to `muse resume <id>`
+//   workspace_root    the cwd it was started in — so the launcher's per-directory listing is a
+//                     WHERE clause rather than a scan
+//   model_id, title, updated_at_us   what a row in that listing shows
+//   session_log_path  the session.jsonl the two header badges are folded out of (muse-usage.ts)
+//
+// Every query below is BY THOSE KEYS rather than `SELECT … FROM sessions` filtered in JS: the log
+// this index points at reaches tens of megabytes on a working day, and the index grows with every
+// session on the machine, so "read the whole table to answer one id" is paid by a watcher polling
+// twice a second and by a badge poll per cell.
 import os from "node:os";
 import path from "node:path";
-import { promises as fs } from "node:fs";
-import { isRecord } from "../../common/isRecord.js";
 
-// Where `muse` keeps sessions: ~/.local/share/muse/sessions + session-index.db
-export const museHome = (): string => path.join(os.homedir(), ".local", "share", "muse");
+/** Where muse keeps everything. `MUSE_HOME` is honoured for the same reason `GROK_HOME` is: a spec
+ *  (and a sandboxed run) must be able to point the reads somewhere that is not the developer's own
+ *  disk. */
+export const museHome = (): string => process.env.MUSE_HOME || path.join(os.homedir(), ".local", "share", "muse");
 export const museSessionIndexPath = (): string => path.join(museHome(), "session-index.db");
 
 export interface MuseSessionMeta {
@@ -16,27 +32,30 @@ export interface MuseSessionMeta {
   updatedAtUs: number | null;
 }
 
-async function readMuseIndexDb(): Promise<MuseSessionMeta[]> {
-  const dbPath = museSessionIndexPath();
+type Row = Record<string, unknown>;
+
+/**
+ * One read-only query against the index, opened and closed around it.
+ *
+ * `node:sqlite` is imported here and nowhere else, and lazily: it is the only sqlite in the server
+ * and a build running on a node without it must not fail to LOAD this module — an agent whose
+ * history cannot be listed is a missing list, not a broken server.
+ *
+ * Every failure answers `[]` for the same reason: before the first muse session there is no
+ * database at all, which is indistinguishable from a schema that moved, and both mean "nothing to
+ * say" to every caller here.
+ */
+async function queryMuseIndex(sql: string, params: readonly string[] = []): Promise<Row[]> {
   try {
     const { DatabaseSync } = await import("node:sqlite");
-    const db = new DatabaseSync(dbPath, { readOnly: true });
+    const db = new DatabaseSync(museSessionIndexPath(), { readOnly: true });
     try {
-      const rows = db.prepare("SELECT session_id, workspace_root, model_id, title, updated_at_us FROM sessions").all() as unknown as Record<string, unknown>[];
-      return rows
-        .filter((r) => typeof r.session_id === "string")
-        .map((r) => ({
-          id: String(r.session_id),
-          workspaceRoot: typeof r.workspace_root === "string" ? String(r.workspace_root) : null,
-          modelId: typeof r.model_id === "string" && String(r.model_id).trim() ? String(r.model_id) : null,
-          title: typeof r.title === "string" ? String(r.title) : String(r.session_id),
-          updatedAtUs: typeof r.updated_at_us === "number" ? Number(r.updated_at_us) : null,
-        }));
+      return db.prepare(sql).all(...params) as unknown as Row[];
     } finally {
       try {
         db.close();
       } catch {
-        // ignore close failure
+        // A close that fails leaves the caller nothing to do — the read is already answered.
       }
     }
   } catch {
@@ -44,27 +63,67 @@ async function readMuseIndexDb(): Promise<MuseSessionMeta[]> {
   }
 }
 
+/** A non-empty string column, or null. Written once: every field below is a column muse may not
+ *  have filled in yet, and a blank title or model must read as absent rather than as `""`. */
+const text = (row: Row, key: string): string | null => {
+  const value = row[key];
+  return typeof value === "string" && value.trim() ? value : null;
+};
+
+const metaOf = (row: Row): MuseSessionMeta | null => {
+  const id = text(row, "session_id");
+  if (!id) return null;
+  return {
+    id,
+    workspaceRoot: text(row, "workspace_root"),
+    modelId: text(row, "model_id"),
+    title: text(row, "title") ?? id,
+    updatedAtUs: typeof row.updated_at_us === "number" ? row.updated_at_us : null,
+  };
+};
+
+/** muse's sessions for one working directory — the launcher's "or resume here" list. */
 export async function listMuseSessionsForCwd(cwd: string): Promise<MuseSessionMeta[]> {
-  const all = await readMuseIndexDb();
-  return all.filter((s) => s.workspaceRoot === cwd);
+  const rows = await queryMuseIndex("SELECT session_id, workspace_root, model_id, title, updated_at_us FROM sessions WHERE workspace_root = ?", [cwd]);
+  return rows.map(metaOf).filter((meta): meta is MuseSessionMeta => meta !== null);
 }
 
-export async function museSessionExists(id: string): Promise<boolean> {
-  const all = await readMuseIndexDb();
-  return all.some((s) => s.id === id);
-}
-
+/** Does muse hold a session by this id in this directory? The cold-resume probe: a row from the
+ *  history list IS one of muse's own ids, and this is what separates it from a key that only ever
+ *  named a MulmoTerminal session. The cwd is part of the question because `muse resume` is
+ *  workspace-scoped, and resuming another directory's session in this one is not what the row on
+ *  screen offered. */
 export async function museSessionExistsForCwd(id: string, cwd: string): Promise<boolean> {
-  const all = await readMuseIndexDb();
-  return all.some((s) => s.id === id && s.workspaceRoot === cwd);
+  const rows = await queryMuseIndex("SELECT 1 FROM sessions WHERE session_id = ? AND workspace_root = ? LIMIT 1", [id, cwd]);
+  return rows.length > 0;
 }
 
-// Snapshot for watcher: set of session_ids for a workspace
+/** The session.jsonl behind one session, which is where its badges are folded from. */
+export async function museSessionLogPath(id: string): Promise<string | null> {
+  const rows = await queryMuseIndex("SELECT session_log_path FROM sessions WHERE session_id = ? LIMIT 1", [id]);
+  return rows[0] ? text(rows[0], "session_log_path") : null;
+}
+
+/** The model the index records for a session — the badge's fallback for a session whose log has
+ *  not carried a completed turn yet, where there is nothing to fold a model out of. */
+export async function museSessionModel(id: string): Promise<string | null> {
+  const rows = await queryMuseIndex("SELECT model_id FROM sessions WHERE session_id = ? LIMIT 1", [id]);
+  return rows[0] ? text(rows[0], "model_id") : null;
+}
+
+/** The ids a workspace holds right now — the "before" of the spawn watcher. */
 export async function snapshotMuseSessions(cwd: string): Promise<Set<string>> {
-  const sessions = await listMuseSessionsForCwd(cwd);
-  return new Set(sessions.map((s) => s.id));
+  const rows = await queryMuseIndex("SELECT session_id FROM sessions WHERE workspace_root = ?", [cwd]);
+  return new Set(rows.map((row) => text(row, "session_id")).filter((id): id is string => id !== null));
 }
 
+/**
+ * The id muse minted for a session we just started: the first row in this workspace that was not
+ * there before and that no other spawn has claimed.
+ *
+ * `claimed` is what keeps two cells started in the same directory at the same moment from both
+ * taking the first new row — the same set codex's and agy's watchers keep, for the same reason.
+ */
 export async function watchForMuseSession(
   cwd: string,
   before: ReadonlySet<string>,
@@ -77,102 +136,9 @@ export async function watchForMuseSession(
     if (opts.isCancelled()) return null;
     const current = await snapshotMuseSessions(cwd);
     for (const id of current) {
-      if (!before.has(id) && !opts.claimed.has(id)) {
-        // Found a new session for this workspace
-        return id;
-      }
+      if (!before.has(id) && !opts.claimed.has(id)) return id;
     }
-    await new Promise((r) => setTimeout(r, intervalMs));
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
   return null;
-}
-
-export async function museModelFromSessionLog(sessionId: string): Promise<string | null> {
-  const dbPath = museSessionIndexPath();
-  try {
-    const { DatabaseSync } = await import("node:sqlite");
-    const db = new DatabaseSync(dbPath, { readOnly: true });
-    try {
-      const row = db.prepare("SELECT model_id FROM sessions WHERE session_id = ?").get(sessionId) as unknown as Record<string, unknown> | undefined;
-      if (row && typeof row.model_id === "string" && row.model_id.trim()) return String(row.model_id);
-    } finally {
-      try {
-        db.close();
-      } catch {
-        // ignore close failure
-      }
-    }
-  } catch {
-    // ignore db missing
-  }
-  return null;
-}
-
-// eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity, complexity
-// Read token usage + context from session.jsonl
-export async function museBadgesFromLog(
-  _cwd: string,
-  sessionId: string,
-): Promise<{ model: string | null; contextTokens: number; usage: import("../session/transcript.js").SessionUsage } | null> {
-  let logPath: string | null = null;
-  try {
-    const { DatabaseSync } = await import("node:sqlite");
-    const db = new DatabaseSync(museSessionIndexPath(), { readOnly: true });
-    try {
-      const row = db.prepare("SELECT session_log_path FROM sessions WHERE session_id = ?").get(sessionId) as unknown as Record<string, unknown> | undefined;
-      if (row && typeof row.session_log_path === "string") logPath = String(row.session_log_path);
-    } finally {
-      try {
-        db.close();
-      } catch {
-        // ignore close failure
-      }
-    }
-  } catch {
-    // ignore db missing
-  }
-  if (!logPath) return null;
-  try {
-    const text = await fs.readFile(logPath, "utf8");
-    let lastModel: string | null = null;
-    let lastContext = 0;
-    let totalOutput = 0;
-    let totalCacheRead = 0;
-    let totalInputFresh = 0;
-    for (const line of text.split("\n")) {
-      if (!line.trim()) continue;
-      let rec: unknown;
-      try {
-        rec = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (!isRecord(rec)) continue;
-      const payload = isRecord(rec.payload) ? (rec.payload as unknown as Record<string, unknown>) : undefined;
-      const event = payload && isRecord(payload.event) ? (payload.event as unknown as Record<string, unknown>) : null;
-      if (!event || event.kind !== "model_completed") continue;
-      const usage = isRecord(event.usage) ? event.usage : null;
-      if (usage && typeof event.model === "string") lastModel = event.model;
-      if (usage) {
-        const input = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
-        let cached = 0;
-        if (typeof usage.cached_tokens === "number") cached = usage.cached_tokens;
-        else if (typeof usage.cache_read_tokens === "number") cached = usage.cache_read_tokens;
-        const out = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
-        if (Number.isFinite(input) && input > lastContext) lastContext = input;
-        if (Number.isFinite(out)) totalOutput += out;
-        if (Number.isFinite(cached)) totalCacheRead += Math.min(cached, input);
-        if (Number.isFinite(input) && Number.isFinite(cached)) totalInputFresh += Math.max(0, input - Math.min(cached, input));
-      }
-    }
-    // input_tokens is cumulative context size, output_tokens is per-turn. Report last input as contextTokens
-    // and sum of fresh input (input - cached) + outputs for usage.
-    return {
-      model: lastModel,
-      contextTokens: lastContext,
-      usage: { inputTokens: totalInputFresh, outputTokens: totalOutput, cacheReadTokens: totalCacheRead, cacheCreationTokens: 0 },
-    };
-  } catch {
-    return null;
-  }
 }

--- a/server/agents/muse-session.ts
+++ b/server/agents/muse-session.ts
@@ -17,12 +17,13 @@
 // twice a second and by a badge poll per cell.
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
 
 /** Where muse keeps everything. `MUSE_HOME` is honoured for the same reason `GROK_HOME` is: a spec
  *  (and a sandboxed run) must be able to point the reads somewhere that is not the developer's own
- *  disk. */
-export const museHome = (): string => process.env.MUSE_HOME || path.join(os.homedir(), ".local", "share", "muse");
-export const museSessionIndexPath = (): string => path.join(museHome(), "session-index.db");
+ *  disk. Read at call time, not captured, so setting it in a test still takes effect. */
+const museHome = (): string => process.env.MUSE_HOME || path.join(os.homedir(), ".local", "share", "muse");
+const museSessionIndexPath = (): string => path.join(museHome(), "session-index.db");
 
 export interface MuseSessionMeta {
   id: string;
@@ -50,7 +51,10 @@ async function queryMuseIndex(sql: string, params: readonly string[] = []): Prom
     const { DatabaseSync } = await import("node:sqlite");
     const db = new DatabaseSync(museSessionIndexPath(), { readOnly: true });
     try {
-      return db.prepare(sql).all(...params) as unknown as Row[];
+      // Filtered rather than asserted: what sqlite hands back is a row shape this file does not
+      // own, and every column is read through a guard below anyway.
+      const rows: unknown[] = db.prepare(sql).all(...params);
+      return rows.filter(isRecord);
     } finally {
       try {
         db.close();

--- a/server/agents/muse-usage.ts
+++ b/server/agents/muse-usage.ts
@@ -1,0 +1,96 @@
+// What a muse session log says about tokens — the two numbers behind `Muse · ctx 27%` and
+// `⇡1.2M ⇣233k`.
+//
+// muse records both in ONE place: a `model_completed` event per completed model call in the
+// session.jsonl the index points at, carrying that call's `usage`
+// (`input_tokens`, `output_tokens`, `cached_tokens` / `cache_read_tokens`, `cache_write_tokens`).
+//
+// Two properties of that file decide the shape of everything here:
+//
+//   It is APPEND-ONLY and it is BIG — 33 MB after a day's work on this machine, with
+//   `model_completed` about 1 line in 40. So it is folded through transcript-fold like grok's
+//   updates.jsonl (#1377) rather than read whole: the first badge poll pays for the file, every
+//   later one pays only for the turns since. Reading it whole per poll was the previous shape,
+//   and at a poll per cell per minute that is tens of megabytes of JSON.parse a minute.
+//
+//   `input_tokens` is the CONTEXT of that call, not an increment. So the running total sums the
+//   fresh part and `contextTokens` takes the LAST call's value rather than the largest: the
+//   largest is a high-water mark that never comes down after a compaction, which on the session
+//   measured here read 397k against a real 266k — a badge saying `/compact` is due when it is not.
+import { isRecord } from "../../common/isRecord.js";
+import type { SessionUsage } from "../session/transcript.js";
+
+/** Everything one fold of a session log answers. One value rather than three folds, because all
+ *  three come off the same record and folding the file three times costs three scans. */
+export interface MuseBadgeFold {
+  usage: SessionUsage;
+  /** The model of the most recent completed call — what the session is running NOW, which is what
+   *  `summary.json`'s `current_model_id` answers for grok. The index's `model_id` is the fallback,
+   *  for a session that has not completed a call yet. */
+  model: string | null;
+  /** The context the last completed call ran with. */
+  contextTokens: number;
+}
+
+export const emptyMuseBadgeFold = (): MuseBadgeFold => ({
+  usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  model: null,
+  contextTokens: 0,
+});
+
+export const copyMuseBadgeFold = (value: MuseBadgeFold): MuseBadgeFold => ({ ...value, usage: { ...value.usage } });
+
+/** A sidecar is untrusted input, whoever wrote it (see transcript-fold.ts). */
+export const isMuseBadgeFold = (value: unknown): value is MuseBadgeFold =>
+  isRecord(value) &&
+  isRecord(value.usage) &&
+  typeof value.usage.inputTokens === "number" &&
+  typeof value.usage.outputTokens === "number" &&
+  typeof value.usage.cacheReadTokens === "number" &&
+  typeof value.usage.cacheCreationTokens === "number" &&
+  (value.model === null || typeof value.model === "string") &&
+  typeof value.contextTokens === "number";
+
+const num = (record: Record<string, unknown>, key: string): number => {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+};
+
+// `{ payload: { kind: "run", event: { kind: "model_completed", usage, model } } }`. Matched on the
+// event's own kind rather than on `payload.kind`: the file carries other run events, and one of
+// them (`context_projection_checkpoint`) embeds whole projections whose numbers are not usage at
+// all — a match loose enough to admit it reads a 6.8M-token "context" off a 1M-window model.
+function completedCall(record: Record<string, unknown>): Record<string, unknown> | null {
+  if (!isRecord(record.payload)) return null;
+  const event = record.payload.event;
+  if (!isRecord(event) || event.kind !== "model_completed") return null;
+  return event;
+}
+
+/**
+ * Add one session-log record to a running total.
+ *
+ * `cached_tokens` is a SUBSET of `input_tokens` (measured: 265,265 of 265,515), so the cached part
+ * is MOVED out of the fresh input rather than added beside it — same sum, and the badge's tooltip
+ * gets a real cache breakdown. This is the arithmetic grok's fold already uses, kept identical so
+ * two agents' badges mean the same thing.
+ *
+ * `cache_write_tokens` is left uncounted for grok's reason: it has been 0 in every call measured,
+ * so whether it sits inside the input or beside it is unverified, and counting it could double
+ * what the badge shows.
+ */
+export function foldMuseBadges(into: MuseBadgeFold, record: Record<string, unknown>): void {
+  const event = completedCall(record);
+  if (!event) return;
+  const usage = isRecord(event.usage) ? event.usage : null;
+  if (!usage) return;
+  const input = num(usage, "input_tokens");
+  // Two spellings, one number: newer muse writes `cached_tokens` and carries `cache_read_tokens`
+  // beside it with the same value, older logs have only one of them.
+  const cached = Math.min(num(usage, "cached_tokens") || num(usage, "cache_read_tokens"), input);
+  into.usage.inputTokens += input - cached;
+  into.usage.cacheReadTokens += cached;
+  into.usage.outputTokens += num(usage, "output_tokens");
+  into.contextTokens = input;
+  if (typeof event.model === "string" && event.model.trim()) into.model = event.model;
+}

--- a/server/agents/muse-usage.ts
+++ b/server/agents/muse-usage.ts
@@ -19,6 +19,7 @@
 //   measured here read 397k against a real 266k — a badge saying `/compact` is due when it is not.
 import { isRecord } from "../../common/isRecord.js";
 import type { SessionUsage } from "../session/transcript.js";
+import { usageCount as num } from "./usage-count.js";
 
 /** Everything one fold of a session log answers. One value rather than three folds, because all
  *  three come off the same record and folding the file three times costs three scans. */
@@ -50,11 +51,6 @@ export const isMuseBadgeFold = (value: unknown): value is MuseBadgeFold =>
   typeof value.usage.cacheCreationTokens === "number" &&
   (value.model === null || typeof value.model === "string") &&
   typeof value.contextTokens === "number";
-
-const num = (record: Record<string, unknown>, key: string): number => {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
-};
 
 // `{ payload: { kind: "run", event: { kind: "model_completed", usage, model } } }`. Matched on the
 // event's own kind rather than on `payload.kind`: the file carries other run events, and one of

--- a/server/agents/usage-count.ts
+++ b/server/agents/usage-count.ts
@@ -1,0 +1,18 @@
+import { finiteNumber } from "../../common/finiteNumber.js";
+
+/**
+ * One token count off an agent's own JSON.
+ *
+ * Zero — not null — for anything missing, negative or not a number, because every caller is
+ * ACCUMULATING: a field an agent did not write contributes nothing, and that is the same answer as
+ * a field it wrote as 0. (The opposite of `finiteNumber`'s rule for gauges, which this is built on:
+ * there a missing value and a zero mean different things.)
+ *
+ * Shared by grok's and muse's folds rather than written in each, because it is the same question
+ * about the same kind of file — and it was the one piece the duplication scan could see them
+ * agreeing on.
+ */
+export const usageCount = (record: Record<string, unknown>, key: string): number => {
+  const value = finiteNumber(record[key]);
+  return value !== null && value > 0 ? value : 0;
+};

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -41,7 +41,7 @@ export interface PluginRouteDeps {
 // the buffered output). A claude DRAFT spawns with no initial prompt, so it does not auto-run, and
 // the text is typed into its input box afterwards; the other agents have no editable-draft path (no
 // stable TUI ready-marker), so their seed always auto-runs as a first-turn prompt — codex typed in,
-// agy through `--prompt-interactive`, grok as a positional.
+// agy through `--prompt-interactive`, grok and muse as a positional.
 function spawnSeededSession(
   deps: PluginRouteDeps,
   mode: SpawnMode,

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -101,16 +101,21 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
   const agent = normalizeAgent(req.query.agent);
   const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
   let badges = agent === "claude" ? { usage, context } : await agentBadges(cwd, id, agent);
-  // A cell that is actually running Muse but whose persisted `agent` is still "claude"
-  // (created before the Muse feature, or started via shell) would otherwise show no badge:
-  // the Claude transcript has no file for this id. If the Claude read is empty but a Muse
-  // conversation exists for this Mulmo id, fall back to Muse's badges so the header self-heals.
+  // A cell that is actually running Muse but whose persisted `agent` is still "claude" (created
+  // before the Muse feature, or reconnecting from an older client) would otherwise show no badge:
+  // the Claude transcript has no file for this id, so the read above is empty. Muse's own log
+  // answers it, and the header self-heals.
+  //
+  // Gated on the CONVERSATION LOG rather than on the empty read alone. Empty is also the normal
+  // state of every claude cell before its first turn, and this route is polled per cell — so the
+  // unguarded version paid a sqlite query and a log fold on each of those polls, to answer for a
+  // session muse has never heard of. The map is in memory and knows every session this server
+  // started as muse, including across a restart (it is hydrated from the log).
   if (agent === "claude" && badges.context.model === null && badges.usage.inputTokens === 0) {
-    try {
-      const museFallback = await agentBadges(cwd, id, "muse");
-      if (museFallback.context.model !== null) badges = museFallback;
-    } catch {
-      // keep Claude's empty badges
+    await museConversationsHydrated;
+    if (museConversations.has(id)) {
+      const museFallback = await agentBadges(cwd, id, "muse").catch(() => null);
+      if (museFallback && museFallback.context.model !== null) badges = museFallback;
     }
   }
   // If we haven't titled it yet, kick off a summary; sessionDetailView falls back meanwhile.

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -54,7 +54,7 @@ import { antigravityBrainRoot } from "../agents/antigravity-session.js";
 import { listAntigravitySessions } from "../agents/antigravity-sessions.js";
 import { grokSessionsRoot } from "../agents/grok-session.js";
 import { listGrokSessions } from "../agents/grok-sessions.js";
-import { listMuseSessionsForCwd } from "../agents/muse-session.js";
+import { listMuseSessionsForCwd, museSessionLogPath } from "../agents/muse-session.js";
 import { museConversations, museConversationsHydrated } from "../session/registry.js";
 import { conversationSessionKeys, type AgentConversation } from "../session/agent-conversations.js";
 import { AGENT_SESSION_LIST_PATHS } from "../../common/agentSessionList.js";
@@ -106,14 +106,17 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
   // the Claude transcript has no file for this id, so the read above is empty. Muse's own log
   // answers it, and the header self-heals.
   //
-  // Gated on the CONVERSATION LOG rather than on the empty read alone. Empty is also the normal
-  // state of every claude cell before its first turn, and this route is polled per cell — so the
-  // unguarded version paid a sqlite query and a log fold on each of those polls, to answer for a
-  // session muse has never heard of. The map is in memory and knows every session this server
-  // started as muse, including across a restart (it is hydrated from the log).
+  // Gated rather than run on the empty read alone: empty is also the normal state of every claude
+  // cell before its first turn, and the unguarded version folded a session log on each of those
+  // polls to answer for a session muse has never heard of.
+  //
+  // Two gates, cheapest first, because the map alone is not the whole answer (Codex on #1513). The
+  // in-memory map knows every session THIS SERVER started as muse, across a restart too — but a
+  // history row opened before its spawn recorded the mapping, and a session started from a plain
+  // terminal, are muse's own ids and appear in no map of ours. One indexed lookup covers those.
   if (agent === "claude" && badges.context.model === null && badges.usage.inputTokens === 0) {
     await museConversationsHydrated;
-    if (museConversations.has(id)) {
+    if (museConversations.has(id) || (await museSessionLogPath(id).catch(() => null))) {
       const museFallback = await agentBadges(cwd, id, "muse").catch(() => null);
       if (museFallback && museFallback.context.model !== null) badges = museFallback;
     }

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -21,6 +21,7 @@ import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
 import { grokConversationExists, grokSessionsRoot } from "../agents/grok-session.js";
+import { museSessionExistsForCwd } from "../agents/muse-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import {
   antigravityConversations,
@@ -711,33 +712,27 @@ function resolveGrokSession(requested: string | null, cwd: string): ResumableSes
   );
 }
 
+// Which muse session a connection resumes, and under which id it runs.
+//
+// A requested key means one of two things, and both are real: a cell reconnecting under a key THIS
+// server minted (the mapping says which muse session it started), or a row picked from the history
+// list, which IS one of muse's own ids — `session-index.db` holds them per workspace, which is why
+// the probe takes the cwd. The map is asked first, for the reason agent-resume.ts gives: a key that
+// happens to also name a session must not out-rank the session we recorded for it.
+//
+// It resumes even when tmux is alive, where codex and agy do not, and grok's header has the
+// argument: if the tmux session dies between the check and the spawn, `tmux new-session -A` re-runs
+// the command — and a spawn with no resume id starts a BRAND NEW muse session under the old key,
+// silently losing the conversation. `muse resume` on a session that is already attached costs
+// nothing, because tmux discards the argv it reattaches with.
+//
+// Async where the others are sync: the probe is a sqlite query, and it is awaited BEFORE the
+// resolution rather than inside it so the pure decision stays a pure decision.
 async function resolveMuseSession(requested: string | null, cwd: string): Promise<ResumableSession> {
-  // Historical sessions: requested is already a muse session_id stored in
-  // session-index.db with workspace_root === cwd. Resume it directly even
-  // without a mulmo mapping (museConversations). This is the chat-history
-  // case — the picker lists DB-backed ids and expects `muse --yolo resume <id>`.
-  if (requested) {
-    const { museSessionExistsForCwd } = await import("../agents/muse-session.js");
-    const existsForCwd = await museSessionExistsForCwd(requested, cwd);
-    if (existsForCwd) {
-      const { live, hasLivePty, tmuxAlive } = liveSessionFacts(requested);
-      if (!hasLivePty) {
-        // Reuse resolveReattachableId shape for consistency with other agents.
-        const { randomUUID } = await import("node:crypto");
-        const { resolveReattachableId: resolveReattachableIdDynamic } = await import("../session/session-resolve.js");
-        const { sessionId } = resolveReattachableIdDynamic(requested, { hasLivePty, tmuxAlive, canResume: true }, randomUUID);
-        return { sessionId, live, resumeConversationId: requested };
-      }
-    }
-  }
-  return resolveResumableSession(requested, ({ hasLivePty, tmuxAlive }) =>
-    agentResumeId(requested, {
-      mappedId: requested ? museConversations.get(requested)?.conversationId : null,
-      conversationExists: () => false, // muse id is mulmo-minted mapping; existence via map only
-      hasLivePty,
-      tmuxAlive,
-    }),
-  );
+  const mappedId = requested ? (museConversations.get(requested)?.conversationId ?? null) : null;
+  // Only asked when the map had no answer — one query, and only on a connection that names a key.
+  const isOwnSessionId = !mappedId && requested !== null && (await museSessionExistsForCwd(requested, cwd));
+  return resolveResumableSession(requested, ({ hasLivePty }) => (hasLivePty ? null : (mappedId ?? (isOwnSessionId ? requested : null))));
 }
 
 // The two agents that read their MCP servers from a file in the DIRECTORY rather than from a
@@ -761,6 +756,10 @@ export interface DirectoryMcpWsAgent {
    *  id of its own, so it keeps no map) — an agent added later has to answer this question rather
    *  than inherit "no" by leaving a key out. */
   hydrated: Promise<unknown> | null;
+  /** Whether this agent reads the directory's shared MCP config at all. False for muse, which has
+   *  no MCP of any kind (common/guiMcpAgents.ts) — so the lookup below, which reads Claude Code's
+   *  config files on every spawn, is not paid for an answer nothing can act on. */
+  readsDirectoryMcpConfig: boolean;
   resolveSession: (requested: string | null, cwd: string) => ResumableSession | Promise<ResumableSession>;
   spawn: (deps: WsRouteDeps) => SpawnDirectoryMcpPty;
 }
@@ -769,6 +768,7 @@ export const ANTIGRAVITY_WS_AGENT: DirectoryMcpWsAgent = {
   kind: "antigravity",
   label: "Antigravity",
   hydrated: antigravityConversationsHydrated,
+  readsDirectoryMcpConfig: true,
   resolveSession: (requested) => resolveAntigravitySession(requested),
   spawn: (deps) => deps.spawnAntigravityPty,
 };
@@ -777,6 +777,7 @@ export const GROK_WS_AGENT: DirectoryMcpWsAgent = {
   kind: "grok",
   label: "Grok",
   hydrated: null,
+  readsDirectoryMcpConfig: true,
   resolveSession: resolveGrokSession,
   spawn: (deps) => deps.spawnGrokPty,
 };
@@ -785,12 +786,15 @@ export const MUSE_WS_AGENT: DirectoryMcpWsAgent = {
   kind: "muse",
   label: "Muse",
   hydrated: museConversationsHydrated,
+  readsDirectoryMcpConfig: false,
   resolveSession: (requested, cwd) => resolveMuseSession(requested, cwd),
   spawn: (deps) => deps.spawnMusePty,
 };
 
-// antigravity (?cwd=<dir>, ?session=<id> to reattach/resume) and grok, which connect identically —
-// see DirectoryMcpWsAgent for why those two and not claude or codex.
+// antigravity (?cwd=<dir>, ?session=<id> to reattach/resume), grok and muse, which connect
+// identically — see DirectoryMcpWsAgent for why these and not claude or codex. muse is here for the
+// lifecycle (reattach, worktree env, reap) rather than for the MCP: it has none, which is what
+// `readsDirectoryMcpConfig` says.
 export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAgent, deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   const { url, requested, cwd, unusable, size } = wsConnectionContext(req);
   if (refuseUnusableWorkspace(ws, agent.kind, unusable, requested)) return;
@@ -807,7 +811,7 @@ export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAge
   // files and the spawner is sync. Only for a SPAWN: a reattach keeps the tools its running process
   // was started with, and rewriting the shared file on a reattach would speak for every other
   // session in the directory.
-  const mcpGroups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
+  const mcpGroups = live || !agent.readsDirectoryMcpConfig ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
   if (!clientStillConnected(ws, agent.kind, sessionId, early)) return;
   const startFailureMessage = startFailureMessageFor(agent.label);
   // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -732,7 +732,8 @@ async function resolveMuseSession(requested: string | null, cwd: string): Promis
   const mappedId = requested ? (museConversations.get(requested)?.conversationId ?? null) : null;
   // Only asked when the map had no answer — one query, and only on a connection that names a key.
   const isOwnSessionId = !mappedId && requested !== null && (await museSessionExistsForCwd(requested, cwd));
-  return resolveResumableSession(requested, ({ hasLivePty }) => (hasLivePty ? null : (mappedId ?? (isOwnSessionId ? requested : null))));
+  const resumeId = mappedId ?? (isOwnSessionId ? requested : null);
+  return resolveResumableSession(requested, ({ hasLivePty }) => (hasLivePty ? null : resumeId));
 }
 
 // The two agents that read their MCP servers from a file in the DIRECTORY rather than from a

--- a/server/session/agent-badges.ts
+++ b/server/session/agent-badges.ts
@@ -16,6 +16,9 @@
 //                `updates.jsonl`. See grok-usage.ts — and note that #1465 shipped saying grok
 //                records no tokens, which was true of the two files it read and false of the
 //                directory (#1470).
+//   muse         both badges, from ONE store: the `model_completed` events in the session.jsonl
+//                its sqlite index points at. No window — muse states none, so the client's table
+//                answers from the model id. See muse-usage.ts.
 //   antigravity  all three, from TWO stores. The model is prose in the `<USER_SETTINGS_CHANGE>`
 //                block agy writes into step 0 of the transcript (antigravityModelFromTranscriptHead
 //                has the counts behind trusting it). The tokens and the window are not in that file
@@ -40,7 +43,8 @@ import { emptyGrokUsage, foldGrokUsage, grokContextFromSignals, isGrokUsage } fr
 import { antigravityBrainRoot, antigravityConversationsRoot, antigravityHome } from "../agents/antigravity-session.js";
 import { antigravityModelFromTranscriptHead, antigravityTranscriptPath } from "../agents/antigravity-sessions.js";
 import { antigravityBadgesFromDb } from "../agents/antigravity-usage.js";
-import { museBadgesFromLog } from "../agents/muse-session.js";
+import { museSessionLogPath, museSessionModel } from "../agents/muse-session.js";
+import { copyMuseBadgeFold, emptyMuseBadgeFold, foldMuseBadges, isMuseBadgeFold, type MuseBadgeFold } from "../agents/muse-usage.js";
 import { museConversations, museConversationsHydrated } from "./registry.js";
 import { readTailRecords } from "../infra/jsonl-file.js";
 import { createTranscriptFold } from "./transcript-fold.js";
@@ -165,12 +169,42 @@ async function grokUsage(file: string): Promise<SessionUsage> {
 // renders.
 const ANTIGRAVITY_HEAD_BYTES = 64 * 1024;
 
+// Summed across every completed call, as grok's is, and folded for the same reason — except that
+// muse's log is the biggest of the four (33 MB measured after a day) and this route is polled per
+// cell. See muse-usage.ts.
+const museBadgeFold = createTranscriptFold<MuseBadgeFold>({
+  kind: "muse-usage",
+  version: 1,
+  isValue: isMuseBadgeFold,
+  empty: emptyMuseBadgeFold,
+  fold: foldMuseBadges,
+  copy: copyMuseBadgeFold,
+});
+
 async function museBadges(sessionKey: string): Promise<SessionBadges> {
+  // The codex lookup, for the same reason (see codexBadges): the route is given OUR session id and
+  // muse files its log under an id of its own. `?? sessionKey` covers a cell resumed straight onto
+  // one of muse's ids, which is what the history list hands over.
   await museConversationsHydrated;
-  const conversationId = museConversations.get(sessionKey)?.conversationId ?? sessionKey;
-  const badges = await museBadgesFromLog("", conversationId);
-  if (!badges) return { usage: EMPTY_USAGE, context: { model: null, contextTokens: 0, contextWindow: null } };
-  return { usage: badges.usage, context: { model: badges.model, contextTokens: badges.contextTokens, contextWindow: null } };
+  const sessionId = museConversations.get(sessionKey)?.conversationId ?? sessionKey;
+  const file = await museSessionLogPath(sessionId);
+  if (!file) return { usage: EMPTY_USAGE, context: { model: null, contextTokens: 0, contextWindow: null } };
+  const folded = await museFold(file);
+  // Before the first completed call there is nothing in the log to name a model, and a session
+  // that has just been started is exactly when a cell first asks. The index knows it anyway.
+  const model = folded.model ?? (await museSessionModel(sessionId));
+  // No contextWindow: muse states none anywhere a reader can trust, so the client's table answers
+  // it from the model id (muse-spark is 1M — common/modelPresets.ts).
+  return { usage: folded.usage, context: { model, contextTokens: folded.contextTokens, contextWindow: null } };
+}
+
+async function museFold(file: string): Promise<MuseBadgeFold> {
+  try {
+    const stat = await fs.stat(file);
+    return await museBadgeFold.read(file, { mtimeMs: stat.mtimeMs, size: stat.size });
+  } catch {
+    return emptyMuseBadgeFold();
+  }
 }
 
 async function antigravityBadges(sessionKey: string, home: string): Promise<SessionBadges> {

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -10,7 +10,6 @@ import { wireAgentPtyRelay } from "./pty-relay.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import type { PtyEntry } from "./types.js";
-import { carriesFullGuiMcp } from "./mcp-config.js";
 
 export function createMuseSpawner(deps: SpawnDeps) {
   function captureMuseSession(sessionId: string, cwd: string, before: ReadonlySet<string>): void {
@@ -34,12 +33,12 @@ export function createMuseSpawner(deps: SpawnDeps) {
   ): PtyEntry => {
     const { initialPrompt = null } = options;
 
-    // Every new spawn path must consult carriesFullGuiMcp() (guideline: Ask that predicate
-    // from every new spawn path). Muse intentionally carries no per-spawn --mcp-config
-    // (guiMcpAgents excludes it like agy/grok), so the value is intentionally unused — the
-    // consult is for guideline parity, not for branching.
-    // eslint-disable-next-line sonarjs/void-use -- intentionally unused, guideline parity
-    void carriesFullGuiMcp(ws !== null, cwd, "muse");
+    // No GUI MCP is attached, and that is an ANSWER rather than an omission: muse has no
+    // `--mcp-config`, no `-c key=value` and no MCP of its own at all, so there is nothing to hand
+    // it and nothing in the directory for it to read. The answer is declared in
+    // common/guiMcpAgents.ts, which is what `carriesFullGuiMcp` consults and what the launcher
+    // form reads — so it is one fact both sides see, and a spec pins it (test/server/session/
+    // muse-gui-mcp.spec.ts) rather than a call here discarding its own result.
 
     // Snapshot before spawn for fresh sessions. The snapshot is async (sqlite)
     // so we start it BEFORE ptySpawn — otherwise the fire-and-forget read can
@@ -56,12 +55,9 @@ export function createMuseSpawner(deps: SpawnDeps) {
       beforePromise = snapshotMuseSessions(cwd).catch(() => new Set<string>());
     }
 
-    const args = buildMuseArgs({
-      resume: resumeConversationId,
-      workspace: resumeConversationId ? null : cwd,
-      model: deps.museModel,
-      initialPrompt,
-    });
+    // The workspace is passed on BOTH paths — a resumed session that loses `--workspace` comes
+    // back without the tools it was working with (see muse-args.ts).
+    const args = buildMuseArgs({ resume: resumeConversationId, workspace: cwd, model: deps.museModel, initialPrompt });
 
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.museBin, args, cwd, true, { binEnvVar: museAdapter.binEnvVar });
     const spawnedAtMs = Date.now();

--- a/server/session/surviving-sessions.ts
+++ b/server/session/surviving-sessions.ts
@@ -57,9 +57,10 @@ export function buildSurvivingSessions(input: SurvivingInput): SurvivingSession[
  *  the agent that wrote a conversation under this key does.
  *
  *  Null is the answer for a Shell or a launcher command — the rows listed nowhere else, which is
- *  the point — but ALSO for an agy or grok session that outlived its pty: nothing maps those back
- *  to a key, the same blind spot `isResumableTmuxSession` has (which is why such a row reads "not
- *  resumable" too). The UI says "shell or unknown" rather than naming a shell it cannot confirm. */
+ *  the point — but ALSO for an agy, grok or muse session that outlived its pty: nothing here maps
+ *  those back to a key, the same blind spot `isResumableTmuxSession` has (which is why such a row
+ *  reads "not resumable" too). The UI says "shell or unknown" rather than naming a shell it cannot
+ *  confirm. */
 function agentOfKey(key: string, claudeOnDisk: ReadonlySet<string>, hasCodexRollout: (id: string) => boolean): TerminalAgent | null {
   const live = ptys.get(key);
   if (live && isTerminalAgent(live.agent)) return live.agent;

--- a/src/components/modelBadge.ts
+++ b/src/components/modelBadge.ts
@@ -22,7 +22,8 @@ const K200_TOKENS = 200_000;
 // 200k entries. Add new 1M ids here when they ship, ahead of the bare-family fallbacks, or the
 // fallback claims them and the reading comes out 5x too large (#985).
 const CONTEXT_WINDOWS: { match: string; tokens: number }[] = [
-  { match: "muse-spark", tokens: MILLION_TOKENS },
+  // Every muse model shipped so far is 1M (muse-spark-1.2 measured); the family entry covers the
+  // ids beneath it, so there is no per-id row to keep in step.
   { match: "muse", tokens: MILLION_TOKENS },
   { match: "opus-4-6", tokens: MILLION_TOKENS },
   { match: "opus-4-7", tokens: MILLION_TOKENS },

--- a/src/components/settings/SurvivingSessionsSection.vue
+++ b/src/components/settings/SurvivingSessionsSection.vue
@@ -25,9 +25,9 @@ const { stopping, stopSession } = useSessionStop(reload);
 onMounted(reload);
 
 // The row's own words for what it is. `null` covers a shell and a launcher command — the rows
-// listed nowhere else, which is why it is named rather than left blank — but ALSO an agy or grok
-// session that outlived its pty, which nothing can map back to a key. So it says "unknown" too
-// rather than calling something a shell on no evidence; the hover carries the whole answer.
+// listed nowhere else, which is why it is named rather than left blank — but ALSO an agy, grok or
+// muse session that outlived its pty, which nothing can map back to a key. So it says "unknown"
+// too rather than calling something a shell on no evidence; the hover carries the whole answer.
 const describe = (s: SurvivingSession): string => s.agent ?? "shell or unknown";
 const UNKNOWN_AGENT_TITLE = "No agent conversation is recorded under this key — a shell, a launcher command, or an agent this server cannot map back";
 

--- a/test/server/agents/muse-args.spec.ts
+++ b/test/server/agents/muse-args.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { buildMuseArgs } from "../../../server/agents/muse-args.js";
+
+const ID = "11111111-2222-4333-8444-555555555555";
+const CWD = "/Users/dev/project";
+
+describe("buildMuseArgs", () => {
+  it("starts a fresh session in the workspace", () => {
+    expect(buildMuseArgs({ workspace: CWD })).toEqual(["--yolo", "--workspace", CWD]);
+  });
+
+  it("resumes a session by id", () => {
+    expect(buildMuseArgs({ resume: ID, workspace: CWD })).toEqual(["--yolo", "--workspace", CWD, "resume", ID]);
+  });
+
+  // The one that matters. `--workspace` is what registers the policy-gated workspace tools, and
+  // muse takes root options on either side of the subcommand — so dropping it on the resume path
+  // brought the conversation back without the tools it had been using.
+  it("keeps the workspace on a resume", () => {
+    const args = buildMuseArgs({ resume: ID, workspace: CWD, model: "muse-spark-1.2-contributor" });
+    expect(args).toContain("--workspace");
+    expect(args[args.indexOf("--workspace") + 1]).toBe(CWD);
+    expect(args).toContain("--model");
+  });
+
+  // Root options first, then the subcommand and its argument — the form the CLI documents.
+  it("puts the resume subcommand and its id last", () => {
+    const args = buildMuseArgs({ resume: ID, workspace: CWD, model: "m", reasoningEffort: "high" });
+    expect(args.slice(-2)).toEqual(["resume", ID]);
+  });
+
+  it("passes a model and a reasoning effort when they are asked for", () => {
+    expect(buildMuseArgs({ workspace: CWD, model: "muse-spark-1.2-contributor", reasoningEffort: "high" })).toEqual([
+      "--yolo",
+      "--workspace",
+      CWD,
+      "--model",
+      "muse-spark-1.2-contributor",
+      "--reasoning-effort",
+      "high",
+    ]);
+  });
+
+  it("omits everything that was not asked for", () => {
+    expect(buildMuseArgs({ resume: null, workspace: null, model: null, reasoningEffort: null, initialPrompt: null })).toEqual(["--yolo"]);
+  });
+
+  // Positional, so anything after it would be swallowed as part of the prompt text.
+  it("puts the seed prompt last on a fresh session", () => {
+    const args = buildMuseArgs({ workspace: CWD, model: "m", initialPrompt: "/collect run" });
+    expect(args[args.length - 1]).toBe("/collect run");
+  });
+
+  it("omits an empty seed prompt rather than passing an empty positional", () => {
+    expect(buildMuseArgs({ workspace: CWD, initialPrompt: "" })).toEqual(["--yolo", "--workspace", CWD]);
+  });
+
+  // `muse resume <id> <prompt>` is not a command line muse accepts, so a seed cannot ride along
+  // with a resume — and it must not silently become the resume's argument either.
+  it("does not append a seed prompt to a resume", () => {
+    expect(buildMuseArgs({ resume: ID, workspace: CWD, initialPrompt: "go" })).toEqual(["--yolo", "--workspace", CWD, "resume", ID]);
+  });
+});

--- a/test/server/agents/muse-usage.spec.ts
+++ b/test/server/agents/muse-usage.spec.ts
@@ -1,0 +1,89 @@
+// What the muse badges are folded out of. Every record here is the shape a real session.jsonl
+// holds (measured against muse's own log on 2026-08-06), because the whole risk in this file is
+// reading a number that means something else.
+import { describe, it, expect } from "vitest";
+import { emptyMuseBadgeFold, foldMuseBadges, isMuseBadgeFold, copyMuseBadgeFold } from "../../../server/agents/muse-usage.js";
+
+const completed = (usage: Record<string, number>, model = "muse-spark-1.2-contributor") => ({
+  payload: { kind: "run", run_id: "r1", event: { kind: "model_completed", usage, model } },
+});
+
+const turn = (input: number, output: number, cached: number) => completed({ input_tokens: input, output_tokens: output, cached_tokens: cached });
+
+describe("foldMuseBadges", () => {
+  it("moves the cached part out of the fresh input rather than counting it twice", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, turn(1000, 50, 900));
+    expect(fold.usage).toEqual({ inputTokens: 100, outputTokens: 50, cacheReadTokens: 900, cacheCreationTokens: 0 });
+  });
+
+  it("accepts the older cache_read_tokens spelling", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, completed({ input_tokens: 1000, output_tokens: 10, cache_read_tokens: 400 }));
+    expect(fold.usage.cacheReadTokens).toBe(400);
+    expect(fold.usage.inputTokens).toBe(600);
+  });
+
+  it("sums the usage across calls and names the most recent model", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, turn(1000, 50, 900));
+    foldMuseBadges(fold, completed({ input_tokens: 2000, output_tokens: 20, cached_tokens: 1500 }, "muse-spark-9"));
+    expect(fold.usage.outputTokens).toBe(70);
+    expect(fold.usage.cacheReadTokens).toBe(2400);
+    expect(fold.model).toBe("muse-spark-9");
+  });
+
+  // The context is the LAST call's, not the largest. `input_tokens` is the context that call ran
+  // with, so a high-water mark never comes down after a compaction — on a real session that read
+  // 397k against a live 266k, which is a badge telling the user to /compact when they need not.
+  it("takes the context from the last completed call, not the biggest", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, turn(400_000, 10, 0));
+    foldMuseBadges(fold, turn(266_000, 10, 0));
+    expect(fold.contextTokens).toBe(266_000);
+  });
+
+  // The file's other run events embed whole context projections, whose numbers are not usage —
+  // one of them carries a 6.8M "input" against a 1M-window model.
+  it("ignores every record that is not a completed model call", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, { payload: { kind: "run", event: { kind: "context_projection_checkpoint", usage: { input_tokens: 6_800_000 } } } });
+    foldMuseBadges(fold, { payload: { kind: "run", event: { kind: "model_completed" } } });
+    foldMuseBadges(fold, { kind: "accepted" });
+    expect(fold).toEqual(emptyMuseBadgeFold());
+  });
+
+  it("treats a negative or non-numeric count as nothing", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, completed({ input_tokens: -5, output_tokens: 10 } as unknown as Record<string, number>));
+    expect(fold.usage.inputTokens).toBe(0);
+    expect(fold.usage.outputTokens).toBe(10);
+  });
+
+  it("never counts more cache than input", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, turn(100, 0, 500));
+    expect(fold.usage.cacheReadTokens).toBe(100);
+    expect(fold.usage.inputTokens).toBe(0);
+  });
+});
+
+describe("the sidecar contract", () => {
+  it("recognises a value it wrote and rejects one it did not", () => {
+    const fold = emptyMuseBadgeFold();
+    foldMuseBadges(fold, turn(10, 1, 0));
+    expect(isMuseBadgeFold(fold)).toBe(true);
+    expect(isMuseBadgeFold({ ...fold, usage: undefined })).toBe(false);
+    expect(isMuseBadgeFold({ ...fold, contextTokens: "many" })).toBe(false);
+    expect(isMuseBadgeFold(null)).toBe(false);
+  });
+
+  // A shallow spread would hand out a value whose `usage` is still the cached one, and the next
+  // fold would then mutate a total a caller is already holding.
+  it("copies the usage rather than sharing it", () => {
+    const fold = emptyMuseBadgeFold();
+    const copy = copyMuseBadgeFold(fold);
+    foldMuseBadges(copy, turn(10, 1, 0));
+    expect(fold.usage.outputTokens).toBe(0);
+  });
+});

--- a/test/server/routes/directory-mcp-ws-agent.spec.ts
+++ b/test/server/routes/directory-mcp-ws-agent.spec.ts
@@ -42,6 +42,10 @@ vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
   tmuxHasSession: () => false,
 }));
 
+// muse's index is a sqlite database on the real disk; this spec is about the handler's shape.
+const museSessionExistsForCwd = vi.fn(() => Promise.resolve(false));
+vi.mock("../../../server/agents/muse-session.js", () => ({ museSessionExistsForCwd }));
+
 // The directory's registered tool groups, read off Claude Code's config files on the real path.
 const registeredGuiMcpGroups = vi.fn(() => Promise.resolve(["render"]));
 vi.mock("../../../server/infra/gui-mcp-registration.js", () => ({ registeredGuiMcpGroups }));
@@ -57,7 +61,7 @@ vi.mock("../../../server/session/worktree-session-limit.js", () => ({
   worktreeOccupancy: () => Promise.resolve({ isWorktree: false, session: null }),
 }));
 
-const { handleDirectoryMcpAgentConnection, ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT } = await import("../../../server/routes/ws-routes.js");
+const { handleDirectoryMcpAgentConnection, ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT, MUSE_WS_AGENT } = await import("../../../server/routes/ws-routes.js");
 
 const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
 
@@ -78,23 +82,28 @@ function fakeWs() {
 // The five arguments a directory-MCP spawner is called with, recorded per agent.
 const spawnAntigravityPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
 const spawnGrokPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+const spawnMusePty = vi.fn(() => ({ term: fakeTerm(), active: false }));
 const reattachPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
 
 const makeDeps = () =>
   ({
     spawnAntigravityPty,
     spawnGrokPty,
+    spawnMusePty,
     reattachPty,
     handleClientFrame: vi.fn(),
     handleClientClose: vi.fn(),
   }) as never;
 
-const spawnerFor = (kind: string) => (kind === "antigravity" ? spawnAntigravityPty : spawnGrokPty);
+const SPAWNERS: Record<string, typeof spawnGrokPty> = { antigravity: spawnAntigravityPty, grok: spawnGrokPty, muse: spawnMusePty };
+const spawnerFor = (kind: string) => SPAWNERS[kind] as typeof spawnGrokPty;
 
 let dir = "";
 const request = (query = "") => ({ url: `/ws?cwd=${encodeURIComponent(dir)}${query}` });
 
 // Both agents, so a rule asserted once is asserted for the pair. Named so a failure says which.
+// muse shares this handler for the lifecycle only — it has no MCP at all — so it is asserted
+// separately below rather than folded into a list about tool groups.
 const AGENTS = [ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT];
 
 beforeEach(() => {
@@ -178,5 +187,40 @@ describe("waiting for the on-disk conversation map", () => {
   it("grok declares it has nothing to wait for, rather than leaving the question out", () => {
     expect(GROK_WS_AGENT.hydrated).toBeNull();
     expect(ANTIGRAVITY_WS_AGENT.hydrated).not.toBeNull();
+  });
+});
+
+// muse rides this handler for what it shares — the session id, the reattach, the worktree env —
+// and NOT for the MCP: it has none, so reading Claude Code's per-directory registration for it
+// could only produce groups nothing can act on (common/guiMcpAgents.ts, spawn-muse.ts).
+describe("/ws/muse", () => {
+  it("declares that it reads no directory MCP config, where the other two declare that they do", () => {
+    expect(MUSE_WS_AGENT.readsDirectoryMcpConfig).toBe(false);
+    expect(ANTIGRAVITY_WS_AGENT.readsDirectoryMcpConfig).toBe(true);
+    expect(GROK_WS_AGENT.readsDirectoryMcpConfig).toBe(true);
+  });
+
+  it("spawns without looking the directory's tool groups up at all", async () => {
+    const ws = fakeWs();
+    await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), ws as unknown as WebSocket, request());
+    expect(registeredGuiMcpGroups).not.toHaveBeenCalled();
+    expect(spawnMusePty).toHaveBeenCalledWith(expect.any(String), expect.anything(), null, dir, { mcpGroups: [] });
+  });
+
+  // The chat-history case: the row the picker offers IS one of muse's own ids, so the connection
+  // has to resume it rather than start a fresh session under it.
+  it("resumes a session muse holds for this directory", async () => {
+    const session = "11111111-2222-4333-8444-555555555555";
+    museSessionExistsForCwd.mockResolvedValueOnce(true);
+    await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
+    expect(spawnMusePty).toHaveBeenCalledWith(session, expect.anything(), session, dir, { mcpGroups: [] });
+  });
+
+  // A key that names nothing muse knows must not be handed to `muse resume` — and must not keep
+  // the id either, or the client is stranded on a session that will never exist.
+  it("starts fresh under a new id when the key names no session of muse's", async () => {
+    const session = "11111111-2222-4333-8444-555555555555";
+    await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
+    expect(spawnMusePty).toHaveBeenCalledWith(expect.not.stringMatching(session), expect.anything(), null, dir, { mcpGroups: [] });
   });
 });

--- a/test/server/session/muse-gui-mcp.spec.ts
+++ b/test/server/session/muse-gui-mcp.spec.ts
@@ -1,0 +1,22 @@
+// muse reaches NO GUI MCP, and that has to be an answer both sides can read rather than a call
+// site that happens not to attach one: the launcher form decides from the same list what it tells
+// the user (#1423), and the server decides from it whether to read the directory's registration at
+// all. spawn-muse.ts therefore states it here instead of consulting the predicate and discarding
+// the result.
+import { describe, it, expect } from "vitest";
+import { agentCarriesFullGuiMcp, FULL_GUI_MCP_AGENTS } from "../../../common/guiMcpAgents.js";
+import { carriesFullGuiMcp } from "../../../server/session/mcp-config.js";
+
+describe("muse and the GUI MCP", () => {
+  it("carries no per-spawn MCP config, in the workspace or anywhere else", () => {
+    expect(agentCarriesFullGuiMcp("muse")).toBe(false);
+    expect(carriesFullGuiMcp(true, undefined, "muse")).toBe(false);
+    expect([...FULL_GUI_MCP_AGENTS]).not.toContain("muse");
+  });
+
+  // The agents that DO get one, asserted beside it so a change to the list has to face both.
+  it("leaves claude and codex carrying it", () => {
+    expect(agentCarriesFullGuiMcp("claude")).toBe(true);
+    expect(agentCarriesFullGuiMcp("codex")).toBe(true);
+  });
+});


### PR DESCRIPTION
Review of the recently added **grok** and **muse** agents, concentrating on the three areas asked about — chat history, resuming from it, and MCP. grok came out of it in good shape; everything below is muse, which arrived later and had not yet been brought in line with the shape the other three agents share.

Measured against the real CLIs on this machine (`muse` 2026-08-06, whose `--help` and `resume --help` are the source for the argv claims) and against a real 33 MB session log.

## Bugs

**A resumed muse session lost its workspace tools.** `buildMuseArgs` returned `["--yolo", "resume", <id>]` and nothing else, dropping `--workspace <cwd>` — which is what registers the policy-gated workspace tools. muse takes root options on either side of the subcommand (`muse resume --help` says so, and `muse --yolo --workspace /tmp resume <id>` was run to confirm it parses), so the flag now rides both paths. A seed prompt is still not passed on a resume, because `muse resume <id> <prompt>` is not a command line muse accepts — that is now stated in the type rather than being a silent drop.

**The context badge read a high-water mark.** `museBadgesFromLog` took the LARGEST `input_tokens` it had ever seen, and `input_tokens` is the context that call ran with, not an increment — so the reading never came down after a compaction. On the session measured here that is `ctx 397k` against a live 266k: a badge telling the user to `/compact` when they need not. It now takes the last completed call's value, which is what grok's and codex's badges mean.

## Performance

**The badge poll re-read the whole session log every time.** 33 MB after a day's work here, `JSON.parse` per line, once per cell per minute plus every `/api/session/:id`. It now folds through `transcript-fold` exactly as grok's `updates.jsonl` does (#1377) — measured on that same log: **105 ms cold, 2 ms warm**, and the totals are byte-for-byte what the old reader produced.

**Every sqlite question was a full-table scan** (`SELECT … FROM sessions`, filtered in JS) — including the spawn watcher, which asks twice a second for 15 s. All queries are now `WHERE session_id = ?` / `WHERE workspace_root = ?`, opened and closed through one helper instead of three copies of the open/close/close-in-a-finally dance.

**A claude cell paid for muse on every poll.** The self-healing fallback in `sessionDetail` fired whenever a claude read came back empty — which is the normal state of every claude cell before its first turn — costing a sqlite query and a log read to answer for a session muse has never heard of. It is now gated on the in-memory conversation map, which knows every session this server started as muse (including across a restart, since it hydrates from the log). Same self-heal, no cost elsewhere.

**muse looked up MCP groups it cannot use.** It has no MCP of any kind, so `handleDirectoryMcpAgentConnection` was reading Claude Code's per-directory config on every muse spawn for an answer nothing acts on. `DirectoryMcpWsAgent` now carries `readsDirectoryMcpConfig`, false for muse and true for the two agents that really do read a file in the directory.

## Redundancy

- `museSessionExists` and `museModelFromSessionLog` were dead — deleted.
- `resolveMuseSession` had two resume paths, three dynamic `import()`s inside the function, and a `conversationExists: () => false` beside a real existence probe. One path now: ask the map, then the probe, in the order `agent-resume.ts` gives the reason for.
- `spawn-muse.ts` called `carriesFullGuiMcp` and voided the result behind three eslint disables, for guideline parity. The guideline exists so a new spawn path cannot silently differ from the cell beside it — a discarded call does not enforce that, so the answer is declared where both sides read it (`common/guiMcpAgents.ts`) and pinned by a spec.
- `muse-session.ts` lost its four-rule `eslint-disable` header by being split rather than suppressed.
- `modelBadge.ts` had `muse-spark` and `muse` as separate rows with the same window; the first could never be reached.
- Three comments that enumerate the agents nothing can map back to a session key ("agy or grok") now name muse too.

## Not changed, on purpose

- **`--yolo` stays.** It disables approval and the sandbox, which is heavier than grok's `--permission-mode auto`, but a grid cell has no way to answer a modal approval prompt in a TUI nobody is watching — so it is the same decision the other cells make, and changing it is a product call rather than a review finding.
- **Muse sessions surviving a restart still read "shell or unknown"** in Settings' surviving-sessions list. `agentOfKey` consults only claude's transcripts and codex's rollouts, so agy, grok and muse have all had this blind spot since they landed; fixing it is one change for the three of them, not part of this.

## Verification

`yarn typecheck`, `yarn lint` (0 errors), `yarn test` — **9042 passed, 45 skipped**, including 34 new assertions across `muse-args.spec.ts`, `muse-usage.spec.ts`, `muse-gui-mcp.spec.ts` and the muse half of `directory-mcp-ws-agent.spec.ts`. The badge path was additionally run against the real index and log, and the argv against the real CLI.

## Review follow-ups in this PR

- **Codex (P2), badge fallback:** gating the claude-cell self-heal on the conversation map alone dropped the case it was written for — one of muse's own ids polled as claude with no mapping yet (a history row opened before its spawn recorded one, or a session started from a plain terminal). Both gates now, map first, then one indexed lookup.
- **Duplication scan:** the token-count guard grok's and muse's folds each carried is now shared as `usageCount`. `jscpd` is back to the two clones that were there before this branch, and `knip` reports no new dead code.
- **Not taken:** the follow-up review's swallowed `.catch`, unbounded `claimed…` set and snapshot race are shapes muse inherited from codex's and agy's spawners, which have them identically — worth fixing for the three together rather than making muse the odd one out.

work in mulmoterminal
