### PR TITLE
feat(muse): GUI MCP for Muse cells, through a plugin and a process-tree session resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,11 @@ had no rule until now.
 
 Deliberate divergence is fine — say so in a comment with the reason, and flag it in the PR.
 
-## The GUI MCP has two server ids, and they are not meant to match
+## The GUI MCP has three server-id shapes, and they are not meant to match
 
-The same tool is called `mcp__mt__presentChart` in a workspace cell and
-`mcp__mulmoterminal-render__presentChart` in a project cell. Both are current. The branch is
+The same tool is called `mcp__mt__presentChart` in a workspace cell,
+`mcp__mulmoterminal-render__presentChart` in a project cell, and
+`mcp__plugin_mulmoterminal_render__presentChart` in a muse cell. All three are current. The branch is
 `carriesFullGuiMcp()` in `server/session/mcp-config.ts`: the workspace / single view / cell-less chat
 gets a **generated** `--mcp-config` carrying every tool under `GUI_SERVER_ID`; a project cell is
 handed **no `--mcp-config` at all** and reaches the tools through the user's own `.mcp.json` under the
@@ -150,11 +151,32 @@ So do not re-add a recogniser, however narrow, and do not "restore" the worktree
 that hole is known and accepted (a `codex` chip can occupy a worktree twice). A chip that wants GUI
 tools asks for them in the flags the user writes. Agent behaviour belongs to the Agent Picker.
 
+**Muse is the third shape and the one that breaks the pattern.** It reads neither a flag nor a file
+in the directory: MCP servers are declared by an installed PLUGIN (`server/agents/muse-mcp.ts`), and
+`muse plugins install` records one PER MACHINE — `--scope project` writes nothing into the project.
+So the registration cannot express "this directory gets render", and two things follow that nothing
+else here does:
+
+- a plugin MCP server is started with a **curated environment** — measured at 16 variables, all of
+  muse's own — so `guiMcpEnv` does not reach it and neither does an `env` block in the manifest.
+  The group and the port are argv; the SESSION is asked for, by walking the bridge's process tree
+  back to a tmux pane whose name is the session id (`server/session/bridge-session.ts`).
+- the four servers are registered for every session, and the ones a session is not entitled to
+  serve an EMPTY toolset rather than failing. Erroring would show three broken servers in a cell
+  that switched one group on.
+
+Do not "fix" that by trying to install per directory, and do not add an env var for the bridge —
+both were tried, and both fail silently by serving zero tools.
+
 The ids differ in **who owns them**, which is what decides whether a rename is free:
 
 - `GUI_SERVER_ID` (`mt`) — regenerated on every spawn, written to no file a user keeps. Ours. It is
   short because the client repeats it on **every tool name** (`mcp__<id>__`, or codex's
   `mcp-<id>-` with `-` rewritten to `_`), so the id is paid per tool, per listing, per session.
+- muse's per-group ids (`render`, `data`, …) — **ours, inside a manifest we generate**, and short
+  for `GUI_SERVER_ID`'s reason: muse builds the tool name out of the plugin id AND the capability
+  id, so `mulmoterminal-render` inside a `mulmoterminal` plugin would say our name twice in every
+  tool name. Free to rename, and a rename re-registers itself on the next spawn.
 - `toolGroupServerId()` (`mulmoterminal-render`, …) — **keys in config files users wrote**, read
   back by the launcher's per-group switch, documented in the setup guide. Renaming these breaks
   working setups with no error anywhere; it needs a migration over existing per-folder configs.

--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ it came from — `mcp__<id>__presentChart` in Claude Code, `mcp-<id>-presentChar
 also rewrites `-` in the id to `_`). So the id you register under is repeated on every tool, in
 every listing, for the life of the session.
 
-MulmoTerminal delivers the GUI MCP by **two different routes**, and they do not share an id:
+MulmoTerminal delivers the GUI MCP by **three different routes**, and they do not share an id:
 
 | | Workspace cell / single view | Project-directory grid cell |
 |---|---|---|
@@ -1214,14 +1214,32 @@ MulmoTerminal delivers the GUI MCP by **two different routes**, and they do not 
 | Tools carried | all of them, on one URL | only the groups that directory registered |
 | Tool name looks like | `mcp__mt__presentChart` | `mcp__mulmoterminal-render__presentChart` |
 
+The third is **Muse**, which reads neither a flag nor a file in the directory: its MCP servers are
+declared by an installed **plugin**, and `muse plugins install` records one per MACHINE. So
+MulmoTerminal registers a single `mulmoterminal` plugin holding all four group servers, and each
+session is narrowed back to what its own directory switched on — the bridge asks the server which
+session it belongs to (by its process tree) and is told which groups that session may reach. The
+servers are named by group alone, because Muse composes the tool name out of both ids:
+
+| | Muse cell (anywhere) |
+|---|---|
+| How it arrives | a `mulmoterminal` plugin installed for the machine, re-registered whenever the bridge path or port changes |
+| Server id | **`render`**, `data`, `media`, `external` — inside the `mulmoterminal` plugin |
+| Tools carried | only the groups that directory registered; the rest serve an empty toolset |
+| Tool name looks like | `mcp__plugin_mulmoterminal_render__presentChart` |
+
+Muse's plugin support is behind its own experimental flag (`MUSE_EXPERIMENTAL_PLUGINS`), which
+MulmoTerminal sets on the sessions it starts. A Muse build without it simply has no GUI tools —
+the registration fails with one warning and the session starts anyway.
+
 Which route a session takes is decided by `carriesFullGuiMcp()` in
 `server/session/mcp-config.ts` — the single view, a cell-less chat, or anything whose cwd **is**
 the workspace take the first; anything in a project directory takes the second.
 
 **The workspace is agent-agnostic for the agents that can RECEIVE a per-spawn config** — claude and
 codex ask the same predicate, so two terminals in the workspace reach the same tools no matter which
-of the two started them. **Antigravity and Grok cannot, and that is the exception you will meet
-first:**
+of the two started them. **Antigravity, Grok and Muse cannot, and that is the exception you will
+meet first:**
 
 | Started as | In the workspace | In a project directory |
 |---|---|---|
@@ -1229,11 +1247,13 @@ first:**
 | codex cell | `mt`, every tool | the directory's registered groups |
 | antigravity cell | **the directory's registered groups** — nothing registered means **no GUI tools at all** | the directory's registered groups |
 | grok cell | **the directory's registered groups** — nothing registered means **no GUI tools at all** | the directory's registered groups |
+| muse cell | **the directory's registered groups** — nothing registered means **no GUI tools at all** | the directory's registered groups |
 | any launcher chip | untouched | untouched |
 
-Neither takes an MCP flag: `agy` reads `.agents/mcp_config.json` and `grok` reads `.grok/config.toml`
-in the working directory, and a file shared by every session in a directory cannot be handed to one
-session and not another — so there is nothing for "this cwd is the workspace" to change. The
+None of the three takes an MCP flag: `agy` reads `.agents/mcp_config.json`, `grok` reads
+`.grok/config.toml` in the working directory, and `muse` reads a plugin installed for the whole
+machine — and neither a file shared by every session in a directory nor a machine-wide plugin can be
+handed to one session and not another — so there is nothing for "this cwd is the workspace" to change. The
 membership is `FULL_GUI_MCP_AGENTS` in `common/guiMcpAgents.ts`, in `common/` precisely so the
 launcher form and the spawn cannot disagree about it
 ([#1423](https://github.com/receptron/mulmoterminal/issues/1423)).

--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,13 @@ Muse's plugin support is behind its own experimental flag (`MUSE_EXPERIMENTAL_PL
 MulmoTerminal sets on the sessions it starts. A Muse build without it simply has no GUI tools —
 the registration fails with one warning and the session starts anyway.
 
+**A Muse session picks its plugins up when its own process starts, and MulmoTerminal's sessions
+outlive the server.** So a Muse cell that was already running when you switched a group on — or
+when you first upgraded to a version that has this — keeps no tools until that CELL is started
+again. Restarting the server is not enough: the session is still there in tmux and gets reattached,
+exactly as it was. Close the cell and open a new one (or `Stop` it in Settings → Surviving sessions),
+and it comes back with the tools its directory registered.
+
 Which route a session takes is decided by `carriesFullGuiMcp()` in
 `server/session/mcp-config.ts` — the single view, a cell-less chat, or anything whose cwd **is**
 the workspace take the first; anything in a project directory takes the second.

--- a/common/guiMcpAgents.ts
+++ b/common/guiMcpAgents.ts
@@ -23,8 +23,11 @@
 // Muse is out for the same reason and reaches its tools a third way. It has no `--mcp-config` and
 // no per-directory config file either: MCP servers are declared by an installed PLUGIN, which
 // `muse plugins install` records per MACHINE (server/agents/muse-mcp.ts). So MulmoTerminal
-// registers one plugin holding all four group servers, and the session's environment narrows them
-// back to what its directory switched on. The launcher form offers muse the same four per-group
+// registers one plugin holding all four group servers, and each SESSION is narrowed back to what
+// its directory switched on — by a lookup, not by the environment: a plugin's MCP server is started
+// with a curated environment that carries nothing of ours, so the bridge resolves which session it
+// belongs to (by its process tree) and is told the groups with the answer. Do not add a bridge
+// environment variable; it is dropped on the way and the failure is silent. The launcher form offers muse the same four per-group
 // toggles as grok and agy, which is the truthful answer for the same reason it is theirs.
 import { type SessionAgent } from "./sessionAgent.js";
 import { isLaunchAgent } from "./launchAgent.js";

--- a/common/guiMcpAgents.ts
+++ b/common/guiMcpAgents.ts
@@ -20,8 +20,12 @@
 // the workspace gets the groups its DIRECTORY registered, and the launcher form offers it the four
 // per-group toggles — which is the truthful answer, and the one #1423 failed to give.
 //
-// Muse is out for the same reason: no --mcp-config, no per-spawn MCP URL — sessions run `muse`
-// directly with no MCP bridge.
+// Muse is out for the same reason and reaches its tools a third way. It has no `--mcp-config` and
+// no per-directory config file either: MCP servers are declared by an installed PLUGIN, which
+// `muse plugins install` records per MACHINE (server/agents/muse-mcp.ts). So MulmoTerminal
+// registers one plugin holding all four group servers, and the session's environment narrows them
+// back to what its directory switched on. The launcher form offers muse the same four per-group
+// toggles as grok and agy, which is the truthful answer for the same reason it is theirs.
 import { type SessionAgent } from "./sessionAgent.js";
 import { isLaunchAgent } from "./launchAgent.js";
 import { customAgentFor, type AgentPick, type CustomAgent } from "./customAgents.js";

--- a/server/agents/muse-mcp.ts
+++ b/server/agents/muse-mcp.ts
@@ -1,0 +1,164 @@
+// The GUI MCP registration for `muse`, which reaches MCP through neither a flag nor a file in the
+// project but through a PLUGIN — the third shape, and the reason this file looks like neither
+// grok-mcp.ts nor antigravity-mcp.ts.
+//
+// What muse offers (measured against muse-bin 0.1.0-R708.1, 2026-08-06):
+//
+//   A plugin is a directory with `.muse-plugin/plugin.json`, whose `capabilities.mcpServers` is a
+//   list of `{ id, transport: "stdio", command }`. `muse plugins install <dir>` copies it into a
+//   content-addressed cache and records it; `muse plugins approve <id>` trusts the capability, and
+//   only then does a session start the server. `streamable_http` parses but is not wired yet
+//   ("streamable HTTP transport startup is not wired yet"), so stdio — our bridge — is the transport.
+//
+// THREE consequences shape everything below, and each of them is why some part of this is not just
+// grok's file with different words:
+//
+//   1. INSTALLATION IS PER MACHINE. `--scope project` writes nothing into the project (measured:
+//      installing from one directory left it untouched and the plugin was listed from another), so
+//      a per-directory registration cannot be expressed by installing and removing. All four group
+//      servers are therefore registered once, and the SESSION decides which of them serve: the
+//      spawn records the directory's groups against the session id, the bridge asks for them when
+//      it resolves itself, and one whose group is not among them stands down with an empty toolset
+//      (server/mcp/bridge.mjs). The directory's own switches still govern — they are read from the
+//      same place claude's, agy's and grok's are.
+//
+//   2. NOTHING REACHES THE SERVER BUT ITS COMMAND LINE. A plugin's MCP server is started with a
+//      CURATED ENVIRONMENT — measured at 16 variables, all of muse's own choosing — so neither the
+//      muse process's environment nor an `env` block in this manifest arrives (both were measured:
+//      the block validates, and then the server sees neither it nor anything of ours). So the group
+//      and the port are argv, and the SESSION — which cannot be baked into a machine-wide manifest
+//      anyway — is asked for at runtime: the bridge maps its own pid back to the session whose tmux
+//      pane it runs under (server/session/bridge-session.ts).
+//
+//   3. PLUGINS ARE BEHIND AN EXPERIMENTAL FLAG. Without `MUSE_EXPERIMENTAL_PLUGINS=1` every
+//      `muse plugins` verb answers "plugins are not available in this build". It is set on the CLI
+//      calls here AND on the session spawn, and its absence is a reason for a muse cell to have no
+//      GUI tools — never a reason for it to fail to start. A build that drops the flag makes every
+//      call below fail, which lands in the same warning as a build with no plugin support at all.
+//
+// The SERVER IDS are the group names alone (`render`, `data`, …) rather than
+// `toolGroupServerId()`'s `mulmoterminal-<group>`, and that divergence is deliberate. Those ids are
+// long because they are keys in files USERS wrote, which is what makes renaming them a migration
+// (common/toolGroups.ts). Nothing user-written names these: the manifest is generated here, and
+// muse composes the tool name from the plugin id and the capability id — so
+// `mcp__plugin_mulmoterminal_render__presentChart`, where the ids in `toolGroupServerId()` form
+// would repeat our name in every tool name, in every listing, in every session.
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { TOOL_GROUPS } from "../../common/toolGroups.js";
+import { PORT } from "../config/env.js";
+import { mulmoterminalHome } from "../infra/mulmoterminal-home.js";
+import { spawnCapture } from "../infra/spawnCapture.js";
+import { bridgeCommand } from "./gui-mcp-bridge.js";
+import { museAdapter } from "./muse.js";
+
+/** The plugin id, which muse puts in every tool name — hence the short one. */
+export const MUSE_PLUGIN_ID = "mulmoterminal";
+
+/** The bundle we generate and hand to `muse plugins install`. Under our own config directory
+ *  rather than in the user's project: there is one installation per machine, so a copy per
+ *  directory would be four copies of the same thing and three of them stale. */
+export const musePluginDir = (): string => path.join(mulmoterminalHome(), "muse-plugin");
+
+/** The flag every `muse plugins` call needs; see the header. */
+export const musePluginEnv = (): Record<string, string> => ({ MUSE_EXPERIMENTAL_PLUGINS: "1" });
+
+/** What muse is told this plugin is. Pure, so the manifest a spec asserts on is the manifest that
+ *  gets written — including the argv, which is where the group AND the port live (see 2. above:
+ *  argv is the only channel that reaches the server this registers). */
+export function musePluginManifest(bridge: { command: string; args: string[] }, port: string | number): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    name: MUSE_PLUGIN_ID,
+    displayName: "MulmoTerminal",
+    version: "1.0.0",
+    description: "MulmoTerminal's GUI tools — the Canvas, workspace data, media and external accounts.",
+    compat: { source: "native", manifestDir: ".muse-plugin" },
+    capabilities: {
+      skills: [],
+      commands: [],
+      hooks: [],
+      reminders: [],
+      // Every group, always. Which of them a session may actually reach is decided per session
+      // (see 1. in the header), because installation cannot express it.
+      mcpServers: TOOL_GROUPS.map((group) => ({
+        id: group,
+        transport: "stdio",
+        // The PORT is baked in because nothing else can carry it: the environment a plugin server
+        // is started with holds none of ours. A server that comes back on a different port writes a
+        // different manifest, which the stamp below reads as a change and re-installs.
+        command: [bridge.command, ...bridge.args, "--group", group, "--port", String(port)],
+      })),
+    },
+  };
+}
+
+const manifestPath = (dir: string): string => path.join(dir, ".muse-plugin", "plugin.json");
+/** What we last successfully installed, so an unchanged manifest costs no subprocess. */
+const stampPath = (dir: string): string => path.join(dir, ".installed");
+
+const digest = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+/** Write the bundle, and say whether it differs from the one already installed from here.
+ *  Separated from the install so the decision is testable without a muse on PATH. */
+export function writeMusePlugin(dir: string, manifest: Record<string, unknown>): { changed: boolean; stamp: string } {
+  const text = `${JSON.stringify(manifest, null, 2)}\n`;
+  const stamp = digest(text);
+  mkdirSync(path.dirname(manifestPath(dir)), { recursive: true });
+  writeFileSync(manifestPath(dir), text);
+  return { changed: lastInstalled(dir) !== stamp, stamp };
+}
+
+/** The stamp of the manifest last installed FROM THIS DIRECTORY, or null when there is none —
+ *  a first run, or a home that has been cleared. */
+function lastInstalled(dir: string): string | null {
+  try {
+    return readFileSync(stampPath(dir), "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function runMusePlugins(args: string[]): { ok: boolean; message: string } {
+  const { status, stdout, stderr } = spawnCapture(museAdapter.bin(), ["plugins", ...args], { env: { ...process.env, ...musePluginEnv() } });
+  return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim() };
+}
+
+/**
+ * Make this machine's muse able to reach the GUI tools. Idempotent, and free once done: a manifest
+ * identical to the one last installed from here spawns nothing at all.
+ *
+ * Both verbs are needed and in this order — install records the plugin, approve trusts the
+ * capability definitions by their hash, and an unapproved capability is listed but never started.
+ * Re-running approve after a changed manifest is not optional for the same reason: the hash it
+ * trusted was the old definition's.
+ *
+ * Never throws. A muse that is not installed, a build without the plugin flag, and a read-only
+ * config directory are all reasons for a cell to have no GUI tools — none of them a reason for the
+ * session not to start.
+ */
+export function syncMuseMcpPlugin(dir = musePluginDir()): { ok: boolean; message: string } {
+  try {
+    const { changed, stamp } = writeMusePlugin(dir, musePluginManifest(bridgeCommand(), PORT));
+    if (!changed) return { ok: true, message: "" };
+
+    const installed = runMusePlugins(["install", dir, "--scope", "user", "--json"]);
+    if (!installed.ok) return warn(installed.message);
+    const approved = runMusePlugins(["approve", MUSE_PLUGIN_ID, "--json"]);
+    if (!approved.ok) return warn(approved.message);
+
+    writeFileSync(stampPath(dir), `${stamp}\n`);
+    console.log(`[muse] registered the GUI MCP plugin (${TOOL_GROUPS.length} tool groups)`);
+    return { ok: true, message: "" };
+  } catch (err) {
+    return warn(String(err));
+  }
+}
+
+function warn(message: string): { ok: boolean; message: string } {
+  // One line, and it names the flag: "plugins are not available in this build" is the message a
+  // reader will otherwise search for and find nothing about.
+  console.warn(`[muse] could not register the GUI MCP plugin — muse cells will have no GUI tools: ${message}`);
+  return { ok: false, message };
+}

--- a/server/agents/muse-mcp.ts
+++ b/server/agents/muse-mcp.ts
@@ -110,6 +110,12 @@ function runMusePlugins(args: string[]): { ok: boolean; message: string; json: u
   return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim(), json: parsed(stdout) };
 }
 
+// When this process last confirmed muse's registration. See syncMuseMcpPlugin. `-Infinity` rather
+// than 0, so "never checked" cannot read as "checked at the epoch" — which, for any clock a test
+// hands in, is inside the window.
+let verifiedAtMs = -Infinity;
+const VERIFY_TTL_MS = 60_000;
+
 /** A `--json` answer, or null for anything unusable — a build that prints a sentence instead
  *  ("plugins are not available in this build") lands here, and reads as "nothing registered". */
 function parsed(stdout: string): unknown {
@@ -181,10 +187,20 @@ const sameServers = (a: readonly string[], b: readonly string[]): boolean => a.l
  * config directory are all reasons for a cell to have no GUI tools — none of them a reason for the
  * session not to start.
  */
-export function syncMuseMcpPlugin(dir = musePluginDir()): { ok: boolean; message: string } {
+export function syncMuseMcpPlugin(dir = musePluginDir(), now = Date.now()): { ok: boolean; message: string } {
   try {
+    // Verified recently by THIS process, so nothing can have changed that this would catch: the
+    // manifest is derived from our own bridge path and port, both fixed for the life of the server.
+    // The window exists because a reattach also comes through here (see spawn-muse.ts) and a
+    // reloaded browser tab reattaches every cell at once — without it, one page refresh spawns a
+    // `muse plugins inspect` per muse cell on screen.
+    if (now - verifiedAtMs < VERIFY_TTL_MS) return { ok: true, message: "" };
+
     const manifest = musePluginManifest(bridgeCommand(), PORT);
-    if (museRegistrationMatches(runMusePlugins(["inspect", MUSE_PLUGIN_ID, "--json"]).json, manifest)) return { ok: true, message: "" };
+    if (museRegistrationMatches(runMusePlugins(["inspect", MUSE_PLUGIN_ID, "--json"]).json, manifest)) {
+      verifiedAtMs = now;
+      return { ok: true, message: "" };
+    }
 
     writeMusePlugin(dir, manifest);
     const installed = runMusePlugins(["install", dir, "--scope", "user", "--json"]);
@@ -192,7 +208,12 @@ export function syncMuseMcpPlugin(dir = musePluginDir()): { ok: boolean; message
     const approved = runMusePlugins(["approve", MUSE_PLUGIN_ID, "--json"]);
     if (!approved.ok) return warn(approved.message);
 
-    console.log(`[muse] registered the GUI MCP plugin (${TOOL_GROUPS.length} tool groups)`);
+    verifiedAtMs = now;
+    // Says what it does NOT cover, because that is the surprising half: muse reads its plugins when
+    // the session's process starts, and MulmoTerminal's sessions outlive the server (tmux). So a
+    // muse that was already running when this landed has no GUI tools until it is started again —
+    // restarting the SERVER is not enough, and the cell looks broken rather than out of date.
+    console.log(`[muse] registered the GUI MCP plugin (${TOOL_GROUPS.length} tool groups) — muse sessions already running keep no tools until restarted`);
     return { ok: true, message: "" };
   } catch (err) {
     return warn(String(err));

--- a/server/agents/muse-mcp.ts
+++ b/server/agents/muse-mcp.ts
@@ -43,10 +43,11 @@
 // muse composes the tool name from the plugin id and the capability id — so
 // `mcp__plugin_mulmoterminal_render__presentChart`, where the ids in `toolGroupServerId()` form
 // would repeat our name in every tool name, in every listing, in every session.
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { TOOL_GROUPS } from "../../common/toolGroups.js";
+import { isRecord } from "../../common/isRecord.js";
+import { byCodeUnit } from "../../common/byCodeUnit.js";
 import { PORT } from "../config/env.js";
 import { mulmoterminalHome } from "../infra/mulmoterminal-home.js";
 import { spawnCapture } from "../infra/spawnCapture.js";
@@ -86,8 +87,8 @@ export function musePluginManifest(bridge: { command: string; args: string[] }, 
         id: group,
         transport: "stdio",
         // The PORT is baked in because nothing else can carry it: the environment a plugin server
-        // is started with holds none of ours. A server that comes back on a different port writes a
-        // different manifest, which the stamp below reads as a change and re-installs.
+        // is started with holds none of ours. A server that comes back on a different port declares
+        // a different command, which the check below sees and re-installs.
         command: [bridge.command, ...bridge.args, "--group", group, "--port", String(port)],
       })),
     },
@@ -95,44 +96,86 @@ export function musePluginManifest(bridge: { command: string; args: string[] }, 
 }
 
 const manifestPath = (dir: string): string => path.join(dir, ".muse-plugin", "plugin.json");
-/** What we last successfully installed, so an unchanged manifest costs no subprocess. */
-const stampPath = (dir: string): string => path.join(dir, ".installed");
 
-const digest = (text: string): string => createHash("sha256").update(text).digest("hex");
-
-/** Write the bundle, and say whether it differs from the one already installed from here.
- *  Separated from the install so the decision is testable without a muse on PATH. */
-export function writeMusePlugin(dir: string, manifest: Record<string, unknown>): { changed: boolean; stamp: string } {
-  const text = `${JSON.stringify(manifest, null, 2)}\n`;
-  const stamp = digest(text);
+/** Write the bundle where `muse plugins install` will read it. Separated from the install so the
+ *  manifest is testable without a muse on PATH. */
+export function writeMusePlugin(dir: string, manifest: Record<string, unknown>): void {
   mkdirSync(path.dirname(manifestPath(dir)), { recursive: true });
-  writeFileSync(manifestPath(dir), text);
-  return { changed: lastInstalled(dir) !== stamp, stamp };
+  writeFileSync(manifestPath(dir), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
-/** The stamp of the manifest last installed FROM THIS DIRECTORY, or null when there is none —
- *  a first run, or a home that has been cleared. */
-function lastInstalled(dir: string): string | null {
+/** One `muse plugins` call, JSON-parsed, with every failure reading as "nothing there". */
+function runMusePlugins(args: string[]): { ok: boolean; message: string; json: unknown } {
+  const { status, stdout, stderr } = spawnCapture(museAdapter.bin(), ["plugins", ...args], { env: { ...process.env, ...musePluginEnv() } });
+  return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim(), json: parsed(stdout) };
+}
+
+/** A `--json` answer, or null for anything unusable — a build that prints a sentence instead
+ *  ("plugins are not available in this build") lands here, and reads as "nothing registered". */
+function parsed(stdout: string): unknown {
   try {
-    return readFileSync(stampPath(dir), "utf8").trim();
+    return JSON.parse(stdout);
   } catch {
     return null;
   }
 }
 
-function runMusePlugins(args: string[]): { ok: boolean; message: string } {
-  const { status, stdout, stderr } = spawnCapture(museAdapter.bin(), ["plugins", ...args], { env: { ...process.env, ...musePluginEnv() } });
-  return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim() };
+/**
+ * Is muse's OWN registration already the one this manifest describes?
+ *
+ * Asked of `muse plugins inspect`, not of a note we left ourselves, and that distinction is the
+ * whole point of this function. The first version recorded the digest of the manifest it had last
+ * installed and skipped the install when it matched — which is a record of what WE did, not of what
+ * muse HAS. Anything that removes the plugin on muse's side (`muse plugins remove`, a cleared
+ * cache, a muse reinstall, another tool) then left the two permanently disagreeing: our note said
+ * "installed", muse had nothing, and every muse cell started with no GUI tools and nothing logged.
+ * That is exactly how this shipped broken the first time.
+ *
+ * Three conditions, because a plugin can be present and still not serve:
+ *   - `active`: installed, enabled, and its package still valid.
+ *   - every capability `trusted_enabled`: an unapproved one is listed and never started, which is
+ *     what a CHANGED manifest produces (trust is keyed to the definition hash).
+ *   - the commands match ours: the bridge path or the port may have moved, and a stale command
+ *     points a session at a server that is not there.
+ */
+export function museRegistrationMatches(inspected: unknown, manifest: Record<string, unknown>): boolean {
+  if (!isRecord(inspected) || inspected.active !== true) return false;
+  const capabilities = inspected.runtime_capabilities;
+  if (!Array.isArray(capabilities) || capabilities.length === 0) return false;
+  if (!capabilities.every((entry) => isRecord(entry) && entry.status === "trusted_enabled")) return false;
+  return sameServers(museServersOf(inspected), museServersOf(manifest));
 }
 
+/** `[id, command…]` per declared server, from either shape — muse's inspect output nests the
+ *  capabilities under `plugin`, our manifest has them at the top. */
+function museServersOf(doc: unknown): string[] {
+  const root = isRecord(doc) && isRecord(doc.plugin) ? doc.plugin : doc;
+  if (!isRecord(root) || !isRecord(root.capabilities)) return [];
+  const capabilities: Record<string, unknown> = root.capabilities;
+  // Two spellings for one thing: our manifest writes `mcpServers`, muse's inspect answers
+  // `mcp_servers`. Both are read so the comparison can be made between them at all.
+  const servers = capabilities.mcpServers ?? capabilities.mcp_servers;
+  if (!Array.isArray(servers)) return [];
+  return (
+    servers
+      .filter(isRecord)
+      .map((server) => [String(server.id), ...(Array.isArray(server.command) ? server.command.map(String) : [])].join(" "))
+      // byCodeUnit, not the default sort: this list is compared for EQUALITY between two sources, so
+      // it only has to be the same order on both sides — and a locale-aware sort is not.
+      .toSorted(byCodeUnit)
+  );
+}
+
+const sameServers = (a: readonly string[], b: readonly string[]): boolean => a.length > 0 && a.length === b.length && a.every((entry, i) => entry === b[i]);
+
 /**
- * Make this machine's muse able to reach the GUI tools. Idempotent, and free once done: a manifest
- * identical to the one last installed from here spawns nothing at all.
+ * Make this machine's muse able to reach the GUI tools.
  *
- * Both verbs are needed and in this order — install records the plugin, approve trusts the
+ * Idempotent, and cheap when nothing changed: one `muse plugins inspect` (~100ms) and no writing.
+ * That read is not optional — see museRegistrationMatches for what skipping it cost.
+ *
+ * Both verbs are needed and in this order: install records the plugin, approve trusts the
  * capability definitions by their hash, and an unapproved capability is listed but never started.
- * Re-running approve after a changed manifest is not optional for the same reason: the hash it
- * trusted was the old definition's.
  *
  * Never throws. A muse that is not installed, a build without the plugin flag, and a read-only
  * config directory are all reasons for a cell to have no GUI tools — none of them a reason for the
@@ -140,15 +183,15 @@ function runMusePlugins(args: string[]): { ok: boolean; message: string } {
  */
 export function syncMuseMcpPlugin(dir = musePluginDir()): { ok: boolean; message: string } {
   try {
-    const { changed, stamp } = writeMusePlugin(dir, musePluginManifest(bridgeCommand(), PORT));
-    if (!changed) return { ok: true, message: "" };
+    const manifest = musePluginManifest(bridgeCommand(), PORT);
+    if (museRegistrationMatches(runMusePlugins(["inspect", MUSE_PLUGIN_ID, "--json"]).json, manifest)) return { ok: true, message: "" };
 
+    writeMusePlugin(dir, manifest);
     const installed = runMusePlugins(["install", dir, "--scope", "user", "--json"]);
     if (!installed.ok) return warn(installed.message);
     const approved = runMusePlugins(["approve", MUSE_PLUGIN_ID, "--json"]);
     if (!approved.ok) return warn(approved.message);
 
-    writeFileSync(stampPath(dir), `${stamp}\n`);
     console.log(`[muse] registered the GUI MCP plugin (${TOOL_GROUPS.length} tool groups)`);
     return { ok: true, message: "" };
   } catch (err) {

--- a/server/agents/muse-mcp.ts
+++ b/server/agents/muse-mcp.ts
@@ -105,8 +105,16 @@ export function writeMusePlugin(dir: string, manifest: Record<string, unknown>):
 }
 
 /** One `muse plugins` call, JSON-parsed, with every failure reading as "nothing there". */
+// Every call here runs on the /ws/muse path, which is the event loop — so the bound is what stops
+// a hung `muse plugins` from freezing every other session on the server, not just this spawn. The
+// install copies a package and hashes it; 20s is far beyond the ~0.3s it has been measured at.
+const MUSE_PLUGINS_TIMEOUT_MS = 20_000;
+
 function runMusePlugins(args: string[]): { ok: boolean; message: string; json: unknown } {
-  const { status, stdout, stderr } = spawnCapture(museAdapter.bin(), ["plugins", ...args], { env: { ...process.env, ...musePluginEnv() } });
+  const { status, stdout, stderr } = spawnCapture(museAdapter.bin(), ["plugins", ...args], {
+    env: { ...process.env, ...musePluginEnv() },
+    timeoutMs: MUSE_PLUGINS_TIMEOUT_MS,
+  });
   return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim(), json: parsed(stdout) };
 }
 

--- a/server/infra/process-tree.ts
+++ b/server/infra/process-tree.ts
@@ -1,0 +1,37 @@
+// Walking up a process tree, which is the only channel muse leaves open for a plugin's MCP server
+// to say where it came from (see server/session/bridge-session.ts).
+//
+// `ps` rather than anything native: it is on every platform this app runs on, the read is a few
+// milliseconds, and it happens once per bridge process rather than per call.
+import { spawnCapture } from "./spawnCapture.js";
+
+// A bridge sits two or three processes below its pane (bridge -> muse -> pane). Eight is far
+// enough to absorb a wrapper or two and short enough that a cycle — which `ps` should never
+// report, but a bound is cheaper than trusting it — cannot spin.
+const MAX_DEPTH = 8;
+
+/** The parent of a pid, or null when `ps` cannot say (the process is gone, or we may not look). */
+export function parentPid(pid: number): number | null {
+  const { status, stdout } = spawnCapture("ps", ["-o", "ppid=", "-p", String(pid)]);
+  if (status !== 0) return null;
+  const parent = Number(stdout.trim());
+  return Number.isInteger(parent) && parent > 1 ? parent : null;
+}
+
+/**
+ * A pid and its ancestors, nearest first, stopping at the root of the tree.
+ *
+ * `seen` guards against a cycle rather than the depth alone, so a repeated pid ends the walk
+ * instead of filling the list with one value the caller would then match on.
+ */
+export function ancestorPids(pid: number, parentOf: (pid: number) => number | null = parentPid): number[] {
+  const chain: number[] = [];
+  const seen = new Set<number>();
+  let current: number | null = pid;
+  while (current !== null && current > 1 && chain.length < MAX_DEPTH && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    current = parentOf(current);
+  }
+  return chain;
+}

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -21,8 +21,11 @@ export interface Captured {
 //
 // stderr is returned SEPARATELY, never folded in: callers here read stdout as data (a keychain
 // secret, a docker label), and a warning printed alongside a successful run would corrupt it.
-export function spawnCapture(bin: string, args: string[]): Captured {
-  const r = spawnSync(bin, args, { encoding: "utf8" });
+export function spawnCapture(bin: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}): Captured {
+  // `env` is spread over the CHILD's whole environment by the caller, never merged here: a caller
+  // adding one variable and a caller replacing the environment are different intentions, and
+  // silently merging would make the second impossible to express.
+  const r = spawnSync(bin, args, { encoding: "utf8", ...options });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -21,11 +21,15 @@ export interface Captured {
 //
 // stderr is returned SEPARATELY, never folded in: callers here read stdout as data (a keychain
 // secret, a docker label), and a warning printed alongside a successful run would corrupt it.
-export function spawnCapture(bin: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}): Captured {
+export function spawnCapture(bin: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number } = {}): Captured {
   // `env` is spread over the CHILD's whole environment by the caller, never merged here: a caller
   // adding one variable and a caller replacing the environment are different intentions, and
   // silently merging would make the second impossible to express.
-  const r = spawnSync(bin, args, { encoding: "utf8", ...options });
+  // A timeout matters MORE here than on the async path, not less: this blocks the event loop, so a
+  // hung CLI freezes every request and every open terminal rather than delaying one caller. The
+  // default keeps the callers that never passed one (a docker label, a tmux probe) as they were.
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...rest } = options;
+  const r = spawnSync(bin, args, { encoding: "utf8", timeout: timeoutMs, ...rest });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -470,6 +470,33 @@ export function tmuxSessionActivity(): Map<string, number> | null {
   return r.status === 0 ? parseTmuxSessionActivity(r.stdout) : null;
 }
 
+/** Parse `#{pane_pid} #{session_name}` rows into pane pid -> our session id. Split out so the
+ *  format, which is the one thing that can silently change under us, is asserted by a spec. */
+export function parseTmuxPanePids(stdout: string): Map<number, string> {
+  const panes = new Map<number, string>();
+  for (const line of stdout.split("\n")) {
+    const [pid, name] = line.trim().split(/\s+/, 2);
+    const numeric = Number(pid);
+    if (!Number.isInteger(numeric) || numeric <= 0 || !name?.startsWith(SESSION_PREFIX)) continue;
+    panes.set(numeric, name.slice(SESSION_PREFIX.length));
+  }
+  return panes;
+}
+
+/**
+ * The root process of every pane, keyed to the session it belongs to.
+ *
+ * This is what lets a process started BY an agent be traced back to the session that agent runs
+ * in, when nothing was handed to it: muse gives a plugin's MCP server a curated environment of 16
+ * variables (measured) — none of them ours — so the only thing that survives is the process tree,
+ * and the pane pid is where that tree meets a session id. See server/session/bridge-session.ts.
+ */
+export function tmuxPanePids(): Map<number, string> {
+  const r = tmux(["list-panes", "-a", "-F", "#{pane_pid} #{session_name}"]);
+  if (r.status !== 0) return new Map<number, string>();
+  return parseTmuxPanePids(r.stdout);
+}
+
 // Ids of sessions that survived (e.g. across a crash), for startup visibility.
 export function tmuxListSessionIds(): string[] {
   const r = tmux(["list-sessions", "-F", "#{session_name}"]);

--- a/server/mcp/bridge.mjs
+++ b/server/mcp/bridge.mjs
@@ -21,8 +21,9 @@ import { createInterface } from "node:readline";
 //   with a curated environment — measured at 16 variables, all muse's own — so neither the muse
 //   process's environment nor the manifest's own `env` block arrives here. What is ours is the
 //   COMMAND LINE, so the group and the port come in as `--group` and `--port`, and the session is
-//   asked for: /api/mcp/resolve maps this process's own pid back to the session whose pane it is
-//   running under (server/session/bridge-session.ts).
+//   asked for: /api/mcp-resolve maps this process's own pid back to the session whose pane — or
+//   whose pty — it is running under (server/session/bridge-session.ts). NOT `/api/mcp/resolve`:
+//   that path is one segment and `/api/mcp/:sessionId` answers it with a 400.
 const argv = process.argv.slice(2);
 const flag = (name) => (argv.indexOf(name) >= 0 ? argv[argv.indexOf(name) + 1] : undefined);
 const port = flag("--port") || process.env.MULMOTERMINAL_PORT;

--- a/server/mcp/bridge.mjs
+++ b/server/mcp/bridge.mjs
@@ -11,19 +11,69 @@
 // is the user's project and has no tsx. Nothing here needs compiling, so nothing does.
 import { createInterface } from "node:readline";
 
-// The GROUP is static per server entry and comes from the config file's own `env` block; the
-// SESSION is dynamic and comes from the agy process this was spawned by. That split is the whole
-// reason one shared file can serve every session in a directory.
-const port = process.env.MULMOTERMINAL_PORT;
-const sessionId = process.env.MULMOTERMINAL_SESSION_ID;
-const group = process.env.MULMOTERMINAL_TOOL_GROUP;
+// TWO WAYS IN, because the hosts differ in what they can hand a child process.
+//
+//   agy and grok write the group into the server entry's own `env` block, and the SESSION reaches
+//   this process by inheritance: the bridge is a child of the agent, which was spawned with
+//   guiMcpEnv. One shared config file therefore serves every session in a directory.
+//
+//   muse hands over NOTHING. Its registration is a plugin, and a plugin's MCP server is started
+//   with a curated environment — measured at 16 variables, all muse's own — so neither the muse
+//   process's environment nor the manifest's own `env` block arrives here. What is ours is the
+//   COMMAND LINE, so the group and the port come in as `--group` and `--port`, and the session is
+//   asked for: /api/mcp/resolve maps this process's own pid back to the session whose pane it is
+//   running under (server/session/bridge-session.ts).
+const argv = process.argv.slice(2);
+const flag = (name) => (argv.indexOf(name) >= 0 ? argv[argv.indexOf(name) + 1] : undefined);
+const port = flag("--port") || process.env.MULMOTERMINAL_PORT;
+const group = flag("--group") || process.env.MULMOTERMINAL_TOOL_GROUP;
+const envSessionId = process.env.MULMOTERMINAL_SESSION_ID;
 
-// Both segments are encoded and both are REQUIRED. They arrive from a config file on disk, which
-// a user can edit by hand, so a missing group must read as an error rather than build a path with
-// the literal text "undefined" in it — and a value carrying `/` or `..` must not steer the request
-// somewhere other than the tool-group route it names.
-const missing = ["MULMOTERMINAL_SESSION_ID", "MULMOTERMINAL_TOOL_GROUP", "MULMOTERMINAL_PORT"].find((name) => !process.env[name]) ?? null;
-const url = missing ? null : `http://127.0.0.1:${port}/api/mcp/${encodeURIComponent(group)}/${encodeURIComponent(sessionId)}`;
+// The group is encoded into the URL path, so a value carrying `/` or `..` must not steer the
+// request somewhere other than the tool-group route it names; the port is needed to build one at
+// all. The SESSION is not checked here — it may still be resolved below.
+let missing = null;
+if (!group) missing = "the tool group";
+else if (!port) missing = "the mulmoterminal port";
+
+const origin = `http://127.0.0.1:${port}`;
+const groupUrl = (session) => `${origin}/api/mcp/${encodeURIComponent(group)}/${encodeURIComponent(session)}`;
+
+/**
+ * Who this bridge is serving, and what that session may reach.
+ *
+ * Asked ONCE and remembered: a session cannot change under a running bridge — the bridge dies with
+ * the agent process that started it — and this is on the path of every tool call.
+ *
+ * A session that cannot be resolved is not an error. A muse the user started in a plain terminal
+ * has a plugin registration and no session, and the honest answer there is a server with no tools
+ * rather than a broken one.
+ */
+// The PROMISE is cached, not its result. Requests arrive on a line reader and are handled
+// concurrently, so caching the answer still lets the first few calls of a session each start their
+// own resolve — three tools/list at once asked three times (caught by the spec).
+let resolving = null;
+function session() {
+  if (envSessionId) return Promise.resolve({ sessionId: envSessionId, groups: null });
+  resolving ??= (async () => {
+    try {
+      const res = await fetch(`${origin}/api/mcp-resolve`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ pid: process.pid, cwd: process.cwd() }),
+      });
+      const body = res.ok ? await res.json() : {};
+      return { sessionId: body.sessionId ?? null, groups: Array.isArray(body.groups) ? body.groups : [] };
+    } catch {
+      return { sessionId: null, groups: [] };
+    }
+  })();
+  return resolving;
+}
+
+// Which groups THIS SESSION may reach. `null` means the host did not say — agy and grok are already
+// narrowed by the config file they read, and adding an opinion here would withhold their tools.
+const entitled = (groups) => groups === null || groups.includes(group);
 
 const send = (message) => process.stdout.write(JSON.stringify(message) + "\n");
 
@@ -47,13 +97,35 @@ function responses(body) {
     .filter(Boolean);
 }
 
+// A session that cannot be resolved, or a group it is not entitled to, answers as a HEALTHY server
+// with no tools rather than as an error. The distinction matters because muse starts all four of
+// them for every session: erroring would show three broken servers in a session that switched one
+// group on, which reads as a bug in the app. An empty toolset reads as what it is.
+function standDown(id, method, reason) {
+  if (id === undefined || id === null) return;
+  if (method === "initialize")
+    return send({
+      jsonrpc: "2.0",
+      id,
+      result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: `mulmoterminal-${group}`, version: "0" } },
+    });
+  if (method === "tools/list") return send({ jsonrpc: "2.0", id, result: { tools: [] } });
+  return fail(id, `mulmoterminal: ${reason}`);
+}
+
 createInterface({ input: process.stdin, terminal: false }).on("line", async (line) => {
   if (line.trim() === "") return;
   let id;
   try {
-    id = JSON.parse(line).id;
+    const message = JSON.parse(line);
+    id = message.id;
     if (missing) return fail(id, `mulmoterminal: ${missing} is not set — this MCP server only runs inside a mulmoterminal session`);
-    const res = await fetch(url, {
+
+    const { sessionId, groups } = await session();
+    if (!sessionId) return standDown(id, message.method, "no mulmoterminal session owns this process");
+    if (!entitled(groups)) return standDown(id, message.method, `the ${group} tools are not switched on for this session`);
+
+    const res = await fetch(groupUrl(sessionId), {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
       body: line,

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -15,6 +15,10 @@ import { buildGuiMcpServer } from "../mcp/broker.js";
 import type { GuiCallRecorder } from "../mcp/gui-call-history.js";
 import { translationWorkerIds, markSessionToolGroup, sessionToolGroups, markAllToolsSession, hasAllGuiTools } from "../session/registry.js";
 import { isToolGroup, TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
+import { isRecord } from "../../common/isRecord.js";
+import { entitledToolGroups, liveMuseSessions, resolveBridgeSession } from "../session/bridge-session.js";
+import { ancestorPids } from "../infra/process-tree.js";
+import { tmuxPanePids } from "../infra/tmux.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
 
@@ -46,6 +50,34 @@ export interface McpRouteDeps {
 // rather than on every tool call. In-memory only: after a restart a session announcing itself
 // again is exactly right, since the panel it is telling has also just reconnected.
 const announcedSessions = new Set<string>();
+
+// Where a bridge that was told NOTHING finds out who it is serving.
+//
+// Only muse needs it, and only because a plugin's MCP server is started with a curated
+// environment that carries none of ours (server/session/bridge-session.ts). The bridge sends the
+// two things it does have — its own pid and its working directory — and gets back the session
+// its process tree belongs to, plus the groups that session's directory registered.
+//
+// Answering `{ sessionId: null }` with a 200 rather than a 404: "no session owns you" is a
+// normal state (a muse the user started in a plain terminal, a session that has already ended),
+// and the bridge's response to it is to serve no tools, not to report a transport failure.
+function resolveBridge(req: Request, res: Response) {
+  const body: unknown = req.body;
+  const pid = isRecord(body) && typeof body.pid === "number" ? body.pid : null;
+  const cwd = isRecord(body) && typeof body.cwd === "string" ? body.cwd : "";
+  if (pid === null || !Number.isInteger(pid) || pid <= 1) return res.status(400).json({ error: "pid is required" });
+  const sessionId = resolveBridgeSession({ panePids: tmuxPanePids(), ancestors: ancestorPids(pid), museSessions: liveMuseSessions(), cwd });
+  // Logged on BOTH outcomes, and it is the only place this can be seen: an unresolved bridge is
+  // silent by design — it serves an empty toolset — so without this line "muse has no GUI tools"
+  // is indistinguishable from "muse was never given any".
+  if (!sessionId) {
+    console.warn(`[muse] a GUI MCP bridge (pid ${pid}) in ${cwd || "an unknown directory"} belongs to no live muse session — it will serve no tools`);
+    return res.json({ sessionId: null, groups: [] });
+  }
+  const groups = entitledToolGroups(sessionId);
+  console.log(`[muse] GUI MCP bridge (pid ${pid}) resolved to session ${sessionId} — groups: ${groups.join(", ") || "none"}`);
+  return res.json({ sessionId, groups });
+}
 
 export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
   /**
@@ -172,6 +204,12 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     // the answer depend on connection order.
     return handleMcpRequest(req, res, sessionId, group, hasAllGuiTools(sessionId));
   });
+  // NOT `/api/mcp/resolve`: that is one segment, so the all-tools route above — `/api/mcp/:sessionId`,
+  // registered first — swallows it and answers 400 "invalid sessionId". Which it did, silently, until
+  // a bridge was run by hand against a live server (the bridge treats an unreachable resolve as "no
+  // session" and stands down, so the whole feature failed by serving zero tools with nothing logged).
+  app.post("/api/mcp-resolve", resolveBridge);
+
   app.get("/api/mcp/:group/:sessionId", rejectNonPost);
   app.delete("/api/mcp/:group/:sessionId", rejectNonPost);
 

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -66,7 +66,9 @@ function resolveBridge(req: Request, res: Response) {
   const pid = isRecord(body) && typeof body.pid === "number" ? body.pid : null;
   const cwd = isRecord(body) && typeof body.cwd === "string" ? body.cwd : "";
   if (pid === null || !Number.isInteger(pid) || pid <= 1) return res.status(400).json({ error: "pid is required" });
-  const sessionId = resolveBridgeSession({ panePids: tmuxPanePids(), ancestors: ancestorPids(pid), museSessions: liveMuseSessions(), cwd });
+  // `cwd` is read for the log line and NOTHING else: a shared directory is not evidence of
+  // anything (see bridge-session.ts), and treating it as such let an unrelated muse claim a cell.
+  const sessionId = resolveBridgeSession({ panePids: tmuxPanePids(), ancestors: ancestorPids(pid), museSessions: liveMuseSessions() });
   // Logged on BOTH outcomes, and it is the only place this can be seen: an unresolved bridge is
   // silent by design — it serves an empty toolset — so without this line "muse has no GUI tools"
   // is indistinguishable from "muse was never given any".

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -51,7 +51,7 @@ function spawnSeededSession(
   if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, { initialPrompt });
   else if (mode === "antigravity-run") deps.spawnAntigravityPty(sessionId, null, null, CLAUDE_CWD, { mcpGroups, initialPrompt });
   else if (mode === "grok-run") deps.spawnGrokPty(sessionId, null, null, CLAUDE_CWD, { mcpGroups, initialPrompt });
-  else if (mode === "muse-run") deps.spawnMusePty(sessionId, null, null, CLAUDE_CWD, { initialPrompt });
+  else if (mode === "muse-run") deps.spawnMusePty(sessionId, null, null, CLAUDE_CWD, { mcpGroups, initialPrompt });
   else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
   else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
 }

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -74,8 +74,13 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     // `.agents/mcp_config.json` and grok's `.grok/config.toml` — share that file with every other
     // session running there, so the groups have to be resolved BEFORE the spawn rewrites it:
     // passing none would clear the entries those sessions are using (#1095 review).
-    const fileConfigAgent = agent === "antigravity" || agent === "grok";
-    const mcpGroups = fileConfigAgent ? await registeredGuiMcpGroups(CLAUDE_CWD, TOOL_GROUPS).catch(() => []) : [];
+    // Which agents need the workspace's registered groups resolved here: the ones that do not get
+    // a per-spawn `--mcp-config`. agy and grok write them into a config file in the directory; muse
+    // takes them as its session's entitlement (server/session/bridge-session.ts) — and it was left
+    // out of this list when it was wired, so a background muse chat got an empty list and therefore
+    // no GUI tools, in a workspace that had them registered (Codex review on #1514).
+    const needsGroups = agent === "antigravity" || agent === "grok" || agent === "muse";
+    const mcpGroups = needsGroups ? await registeredGuiMcpGroups(CLAUDE_CWD, TOOL_GROUPS).catch(() => []) : [];
     try {
       runWithHiddenMarker(hidden, sessionId, backgroundMarkers, () => spawnSeededSession(deps, spawnModeFor(agent, draft), { sessionId, message, mcpGroups }));
       // Visible: somebody should be able to SEE this session. The browser that asked for it

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -757,9 +757,14 @@ export interface DirectoryMcpWsAgent {
    *  id of its own, so it keeps no map) — an agent added later has to answer this question rather
    *  than inherit "no" by leaving a key out. */
   hydrated: Promise<unknown> | null;
-  /** Whether this agent reads the directory's shared MCP config at all. False for muse, which has
-   *  no MCP of any kind (common/guiMcpAgents.ts) — so the lookup below, which reads Claude Code's
-   *  config files on every spawn, is not paid for an answer nothing can act on. */
+  /** Whether the directory's registered tool groups are worth looking up for this agent.
+   *
+   *  True for all three now, but it is not a constant: it was false for muse while muse reached no
+   *  MCP at all, and the lookup reads Claude Code's config files on every spawn — a cost nothing
+   *  could act on. What muse does with the answer is still different from the other two (it travels
+   *  on the session's ENVIRONMENT rather than into a file in the directory, because its plugin
+   *  registration is per machine — server/agents/muse-mcp.ts), and that difference lives in its
+   *  spawner rather than here. */
   readsDirectoryMcpConfig: boolean;
   resolveSession: (requested: string | null, cwd: string) => ResumableSession | Promise<ResumableSession>;
   spawn: (deps: WsRouteDeps) => SpawnDirectoryMcpPty;
@@ -787,15 +792,15 @@ export const MUSE_WS_AGENT: DirectoryMcpWsAgent = {
   kind: "muse",
   label: "Muse",
   hydrated: museConversationsHydrated,
-  readsDirectoryMcpConfig: false,
+  readsDirectoryMcpConfig: true,
   resolveSession: (requested, cwd) => resolveMuseSession(requested, cwd),
   spawn: (deps) => deps.spawnMusePty,
 };
 
 // antigravity (?cwd=<dir>, ?session=<id> to reattach/resume), grok and muse, which connect
-// identically — see DirectoryMcpWsAgent for why these and not claude or codex. muse is here for the
-// lifecycle (reattach, worktree env, reap) rather than for the MCP: it has none, which is what
-// `readsDirectoryMcpConfig` says.
+// identically — see DirectoryMcpWsAgent for why these and not claude or codex. All three take their
+// GUI tools from what the DIRECTORY registered rather than from a per-spawn flag; where they differ
+// is only in what the spawner then does with that list.
 export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAgent, deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   const { url, requested, cwd, unusable, size } = wsConnectionContext(req);
   if (refuseUnusableWorkspace(ws, agent.kind, unusable, requested)) return;

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -33,6 +33,8 @@ import {
   museConversationsHydrated,
   markDevTerminalSession,
   markAttachedSessionPlaced,
+  devTerminalCwdsHydrated,
+  sessionCwd,
   ptys,
 } from "../session/registry.js";
 import { SpawnRefusedError, ptyWouldReattach } from "../session/pty-spawn.js";
@@ -814,10 +816,19 @@ export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAge
   if (!early) return;
 
   // The directory's registered groups, read here because the lookup reads Claude Code's config
-  // files and the spawner is sync. Only for a SPAWN: a reattach keeps the tools its running process
-  // was started with, and rewriting the shared file on a reattach would speak for every other
+  // files and the spawner is sync. Not for a live REATTACH: that session keeps the tools its
+  // running process was started with, and rewriting the shared file would speak for every other
   // session in the directory.
-  const mcpGroups = live || !agent.readsDirectoryMcpConfig ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
+  //
+  // Read against the SESSION's own directory rather than the request's, and that distinction is not
+  // cosmetic (Codex on #1514). `live` is absent for a tmux-only reattach as well as for a spawn — a
+  // reconnect after a server restart — and such a reconnect often carries no `?cwd=` at all, which
+  // resolves to the DEFAULT workspace. For agy and grok that only meant a file write suppressed
+  // downstream, but muse records these groups as the session's entitlement, so another directory's
+  // switches would have become this session's. `sessionCwd` is where the session really runs.
+  await devTerminalCwdsHydrated;
+  const groupsCwd = live?.cwd ?? sessionCwd(sessionId) ?? cwd;
+  const mcpGroups = live || !agent.readsDirectoryMcpConfig ? [] : await registeredGuiMcpGroups(groupsCwd, TOOL_GROUPS).catch(() => []);
   if (!clientStillConnected(ws, agent.kind, sessionId, early)) return;
   const startFailureMessage = startFailureMessageFor(agent.label);
   // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps

--- a/server/session/bridge-session.ts
+++ b/server/session/bridge-session.ts
@@ -1,0 +1,93 @@
+// Which SESSION a GUI MCP bridge process belongs to, when nothing told it.
+//
+// Every other host hands the answer over: claude and codex get a session-scoped URL at spawn, and
+// agy and grok read a config file whose server entry the session's own environment completes
+// (guiMcpEnv — the bridge is their child, so it inherits it).
+//
+// muse breaks that, and it is not a detail that can be worked around at the call site: a plugin's
+// MCP server is started with a CURATED ENVIRONMENT — measured at 16 variables, all of them muse's
+// own (MUSE_PLUGIN_ROOT, PATH, HOME, TMPDIR …) — and neither the muse process's environment nor
+// the manifest's own `env` block reaches it. So the bridge starts knowing its group and its port
+// (both are argv, which IS ours) and nothing at all about the session.
+//
+// Two things do survive, and between them they answer it:
+//
+//   THE PROCESS TREE. The bridge is a descendant of the muse process, which is the root process of
+//   the tmux pane whose session name is the session id this server minted. `tmux list-panes` maps
+//   that pane pid to that name, so walking up from the bridge until a pane pid is hit is exact —
+//   it distinguishes two muse cells in ONE directory, which nothing else here can.
+//
+//   THE WORKING DIRECTORY. The bridge inherits the workspace as its cwd. That is the fallback for
+//   a session that is not in tmux (persistence off), and it is only trusted when it names exactly
+//   one live muse session: two cells in one directory would otherwise send one cell's chart to the
+//   other, which is worse than no chart.
+import { ptys } from "./registry.js";
+import type { ToolGroup } from "../../common/toolGroups.js";
+
+/** What the resolver needs to know about the world, so the rule itself is pure and testable. */
+export interface BridgeSessionFacts {
+  /** Pane root pid -> session id, from tmux. */
+  panePids: ReadonlyMap<number, string>;
+  /** The ancestors of the bridge, nearest first, INCLUDING its own pid. */
+  ancestors: readonly number[];
+  /** Live sessions running muse, as id -> cwd. */
+  museSessions: ReadonlyMap<string, string>;
+  /** The bridge's working directory. */
+  cwd: string;
+}
+
+/**
+ * The session a bridge belongs to, or null when it cannot be known for certain.
+ *
+ * Null is a real answer and the important one: it means the bridge serves NO tools rather than
+ * some other session's. An ambiguous directory is the case that makes this worth stating —
+ * answering "probably that one" would put a chart in the wrong cell, and a missing chart is the
+ * failure a user can see and report.
+ */
+export function resolveBridgeSession(facts: BridgeSessionFacts): string | null {
+  for (const pid of facts.ancestors) {
+    const session = facts.panePids.get(pid);
+    if (session && facts.museSessions.has(session)) return session;
+  }
+  const inCwd = [...facts.museSessions].filter(([, cwd]) => cwd === facts.cwd);
+  return inCwd.length === 1 ? (inCwd[0]?.[0] ?? null) : null;
+}
+
+// ── the groups half ───────────────────────────────────────────────────────────────────────────
+//
+// Once the session is known, what may it reach? For agy and grok that question is already answered
+// by the file the agent read; muse's plugin is installed for the MACHINE and declares every group,
+// so the answer has to come from here — recorded at spawn, when the directory's registration was
+// read, and read back by the resolve route.
+//
+// In memory only, and deliberately: it describes a RUNNING session, so a server restart that
+// forgets it has also lost the pty it describes. The entry is dropped when the session ends.
+const groupsBySession = new Map<string, readonly ToolGroup[]>();
+
+export function rememberEntitledToolGroups(sessionId: string, groups: readonly ToolGroup[]): void {
+  groupsBySession.set(sessionId, [...groups]);
+}
+
+export function forgetEntitledToolGroups(sessionId: string): void {
+  groupsBySession.delete(sessionId);
+}
+
+/** What this session may reach. Named for ENTITLEMENT, not to be confused with registry's
+ *  `sessionToolGroups`, which records what a session has been OBSERVED reaching — that one is
+ *  learned from connections and drives the Canvas gate; this one is decided at spawn and drives
+ *  what a bridge is allowed to serve.
+ *
+ *  An unknown session answers NOTHING rather than everything: a bridge asking about a session we
+ *  have no record of is a bridge we cannot vouch for. */
+export const entitledToolGroups = (sessionId: string): readonly ToolGroup[] => groupsBySession.get(sessionId) ?? [];
+
+/** The live muse sessions and where each runs — the world the rule above is applied to.
+ *
+ *  muse-only on purpose: the other hosts are TOLD their session, and a process tree is a weaker
+ *  claim than being told. Widening this would let a bridge that lost its environment claim a
+ *  claude session by standing near it.  */
+export function liveMuseSessions(): Map<string, string> {
+  const sessions = new Map<string, string>();
+  for (const [id, entry] of ptys) if (entry.agent === "muse") sessions.set(id, entry.cwd);
+  return sessions;
+}

--- a/server/session/bridge-session.ts
+++ b/server/session/bridge-session.ts
@@ -17,10 +17,16 @@
 //   that pane pid to that name, so walking up from the bridge until a pane pid is hit is exact —
 //   it distinguishes two muse cells in ONE directory, which nothing else here can.
 //
-//   THE WORKING DIRECTORY. The bridge inherits the workspace as its cwd. That is the fallback for
-//   a session that is not in tmux (persistence off), and it is only trusted when it names exactly
-//   one live muse session: two cells in one directory would otherwise send one cell's chart to the
-//   other, which is worse than no chart.
+//   THE PTY. With tmux persistence off there is no pane to match, and there the muse process IS a
+//   child of the pty this server spawned — so the pty's own pid appears in the same chain.
+//
+// The working directory is deliberately NOT one of them, and that is a correction: a cwd fallback
+// ("the single live muse session in this directory") shipped first and is unsafe, because the
+// plugin is machine-wide. A muse the USER started in a normal terminal, in a directory that also
+// holds one of our cells, matches no pane and no pty of ours — and would have been handed that
+// cell's session id and groups, letting an unrelated process draw into someone's Canvas and write
+// artifacts under their session (Codex review on #1514). Both facts above are proofs of descent;
+// a shared directory is not.
 import { ptys } from "./registry.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
 
@@ -30,27 +36,27 @@ export interface BridgeSessionFacts {
   panePids: ReadonlyMap<number, string>;
   /** The ancestors of the bridge, nearest first, INCLUDING its own pid. */
   ancestors: readonly number[];
-  /** Live sessions running muse, as id -> cwd. */
-  museSessions: ReadonlyMap<string, string>;
-  /** The bridge's working directory. */
-  cwd: string;
+  /** Live sessions running muse, as id -> the pid of the pty this server spawned for it. */
+  museSessions: ReadonlyMap<string, number>;
 }
 
 /**
- * The session a bridge belongs to, or null when it cannot be known for certain.
+ * The session a bridge belongs to, or null when it cannot be shown to belong to any.
  *
- * Null is a real answer and the important one: it means the bridge serves NO tools rather than
- * some other session's. An ambiguous directory is the case that makes this worth stating —
- * answering "probably that one" would put a chart in the wrong cell, and a missing chart is the
- * failure a user can see and report.
+ * Null is a real answer and the important one: the bridge then serves NO tools, rather than some
+ * other session's. Every path here is a proof of DESCENT — this process runs under that session's
+ * pane, or under its pty — so a muse nobody here started can never claim one. A missing chart is a
+ * failure the user can see and report; a chart drawn in the wrong cell is not.
  */
 export function resolveBridgeSession(facts: BridgeSessionFacts): string | null {
+  const ptyOwners = new Map([...facts.museSessions].map(([id, pid]) => [pid, id]));
   for (const pid of facts.ancestors) {
-    const session = facts.panePids.get(pid);
-    if (session && facts.museSessions.has(session)) return session;
+    const pane = facts.panePids.get(pid);
+    if (pane && facts.museSessions.has(pane)) return pane;
+    const pty = ptyOwners.get(pid);
+    if (pty) return pty;
   }
-  const inCwd = [...facts.museSessions].filter(([, cwd]) => cwd === facts.cwd);
-  return inCwd.length === 1 ? (inCwd[0]?.[0] ?? null) : null;
+  return null;
 }
 
 // ── the groups half ───────────────────────────────────────────────────────────────────────────
@@ -81,13 +87,13 @@ export function forgetEntitledToolGroups(sessionId: string): void {
  *  have no record of is a bridge we cannot vouch for. */
 export const entitledToolGroups = (sessionId: string): readonly ToolGroup[] => groupsBySession.get(sessionId) ?? [];
 
-/** The live muse sessions and where each runs — the world the rule above is applied to.
+/** The live muse sessions and the pty pid behind each — the world the rule above is applied to.
  *
  *  muse-only on purpose: the other hosts are TOLD their session, and a process tree is a weaker
  *  claim than being told. Widening this would let a bridge that lost its environment claim a
  *  claude session by standing near it.  */
-export function liveMuseSessions(): Map<string, string> {
-  const sessions = new Map<string, string>();
-  for (const [id, entry] of ptys) if (entry.agent === "muse") sessions.set(id, entry.cwd);
+export function liveMuseSessions(): Map<string, number> {
+  const sessions = new Map<string, number>();
+  for (const [id, entry] of ptys) if (entry.agent === "muse") sessions.set(id, entry.term.pid);
   return sessions;
 }

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -32,6 +32,7 @@ import {
   isFailedWorker,
 } from "./registry.js";
 import { clearedTranscripts, forgetClearedTranscript } from "./cleared-transcripts.js";
+import { forgetEntitledToolGroups } from "./bridge-session.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
 import { sessionRow, shouldRefreshReply } from "./activity-transition.js";
 import { flagEffect, type ActivityFlag } from "./activity-flag.js";
@@ -143,6 +144,9 @@ function reap(deps: SessionLifecycleDeps, id: string) {
   // visible via its on-disk record.
   knownSessions.delete(id);
   launchChoices.delete(id); // the picked backend dies with the session that used it
+  // The GUI tools a muse session was entitled to die with it too: the record exists for a bridge
+  // that is a child of this pty, and there is no bridge left to ask.
+  forgetEntitledToolGroups(id);
   // NOT customAgentSessions: the transcript outlives the pty, and a resume ignores the picker, so
   // dropping the mapping here would silently continue that conversation on plain claude (a
   // different model). Persisted for the same reason — see custom-agent-log.ts.

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -75,6 +75,13 @@ export function guiMcpEnv(sessionId: string, port: string | number): Record<stri
   return { MULMOTERMINAL_PORT: String(port), MULMOTERMINAL_SESSION_ID: sessionId };
 }
 
+// There is deliberately no muse counterpart to `guiMcpEnv`, and the absence is worth a line
+// because writing one is the obvious first move: muse reaches its tools through a PLUGIN, and a
+// plugin's MCP server is started with a curated environment that carries nothing of ours — so a
+// variable set here would be silently dropped between the spawn and the bridge. What muse's spawn
+// sets instead is the flag muse ITSELF reads (musePluginEnv), and the session's entitlement is
+// recorded in memory for the bridge to ask for (server/session/bridge-session.ts).
+
 // The same two surfaces, spelled for CODEX, which takes them as `-c mcp_servers.<id>.url=` at
 // spawn instead of reading a config file. It has no `${VAR}` expansion, so unlike the template
 // above these are resolved here — which is possible precisely because they are built per spawn.

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -14,8 +14,8 @@ import { buildMuseArgs } from "../agents/muse-args.js";
 import { snapshotMuseSessions, watchForMuseSession } from "../agents/muse-session.js";
 import { syncMuseMcpPlugin } from "../agents/muse-mcp.js";
 import { musePluginEnv } from "../agents/muse-mcp.js";
-import { rememberEntitledToolGroups } from "./bridge-session.js";
-import { ptySpawn } from "./pty-spawn.js";
+import { entitledToolGroups, rememberEntitledToolGroups } from "./bridge-session.js";
+import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
@@ -79,12 +79,19 @@ export function createMuseSpawner(deps: SpawnDeps) {
     // back without the tools it was working with (see muse-args.ts).
     const args = buildMuseArgs({ resume: resumeConversationId, workspace: cwd, model: deps.museModel, initialPrompt });
 
+    // Recorded only when this really STARTS muse. A reattach reaches here too (after a server
+    // restart the pty table is empty while the tmux session is not), and the muse in that pane is
+    // already running with whatever it read at its own start — so re-recording could only move the
+    // entitlement of a session that cannot act on the change (Codex on #1514). The exception is a
+    // session this process has no record of at all, which is exactly that server-restart case: the
+    // groups are then the only answer available for the bridge to be told.
+    //
     // The groups are RECORDED, not exported. A plugin's MCP server inherits nothing from muse
     // (server/session/bridge-session.ts), so the bridge asks this server which session it belongs
     // to and gets this list back with the answer. A session whose directory registered nothing
     // records an empty list and every one of the four servers stands down — the same "no GUI
     // tools" a muse cell had before this was wired.
-    rememberEntitledToolGroups(sessionId, mcpGroups);
+    if (!ptyWouldReattach(sessionId, true) || entitledToolGroups(sessionId).length === 0) rememberEntitledToolGroups(sessionId, mcpGroups);
     // What the MUSE process itself needs: it does inherit our environment, and without this flag it
     // loads no plugins at all — the registration would be inert rather than absent.
     const env = musePluginEnv();

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -1,15 +1,27 @@
-// Starting a `muse` session in a PTY. Like codex/agy, muse mints its session id
-// itself, so a fresh session is watched until that id appears — that is what lets a
-// later cold reconnect resume it.
+// Starting a `muse` session in a PTY.
+//
+// Two shapes at once, which is why this is neither spawn-codex.ts nor spawn-grok.ts:
+//
+//   codex-shaped on the ID axis — muse mints its own session id and tells nobody, so a fresh
+//   session is watched until that id appears, which is what lets a later cold reconnect resume it.
+//
+//   its OWN shape on the MCP axis — muse reaches the GUI tools through a PLUGIN, and a plugin is
+//   installed per MACHINE rather than per directory (server/agents/muse-mcp.ts). So the
+//   registration is made once and the DIRECTORY's groups travel on the session's environment
+//   instead, where the bridge reads them. `mcpGroups` is therefore used here, not written to a file.
 import { museAdapter } from "../agents/muse.js";
 import { buildMuseArgs } from "../agents/muse-args.js";
 import { snapshotMuseSessions, watchForMuseSession } from "../agents/muse-session.js";
-import { ptySpawn } from "./pty-spawn.js";
+import { syncMuseMcpPlugin } from "../agents/muse-mcp.js";
+import { musePluginEnv } from "../agents/muse-mcp.js";
+import { rememberEntitledToolGroups } from "./bridge-session.js";
+import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import type { PtyEntry } from "./types.js";
+import type { SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 
 export function createMuseSpawner(deps: SpawnDeps) {
   function captureMuseSession(sessionId: string, cwd: string, before: ReadonlySet<string>): void {
@@ -24,21 +36,18 @@ export function createMuseSpawner(deps: SpawnDeps) {
       .catch(() => {});
   }
 
-  const spawnMusePty = (
-    sessionId: string,
-    ws: import("ws").WebSocket | null,
-    resumeConversationId: string | null,
-    cwd: string,
-    options: { initialPrompt?: string | null } = {},
-  ): PtyEntry => {
-    const { initialPrompt = null } = options;
+  const spawnMusePty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
+    const { mcpGroups, initialPrompt = null } = options;
 
-    // No GUI MCP is attached, and that is an ANSWER rather than an omission: muse has no
-    // `--mcp-config`, no `-c key=value` and no MCP of its own at all, so there is nothing to hand
-    // it and nothing in the directory for it to read. The answer is declared in
-    // common/guiMcpAgents.ts, which is what `carriesFullGuiMcp` consults and what the launcher
-    // form reads — so it is one fact both sides see, and a spec pins it (test/server/session/
-    // muse-gui-mcp.spec.ts) rather than a call here discarding its own result.
+    // Registering the plugin is a MACHINE-wide act, so it is done only for a spawn that will really
+    // start muse — the same rule syncDirectoryMcpForSpawn states for the two agents with a shared
+    // config file, and for the same reason: after a restart this is reached for what turns out to
+    // be a tmux REATTACH, and the muse already running there read its plugins at its own start.
+    //
+    // Not gated on `mcpGroups` being non-empty: the registration is inert without the environment
+    // below, and a directory that switches its first group on mid-session would otherwise have to
+    // wait for a spawn that happens to have one already.
+    if (!ptyWouldReattach(sessionId, true)) syncMuseMcpPlugin();
 
     // Snapshot before spawn for fresh sessions. The snapshot is async (sqlite)
     // so we start it BEFORE ptySpawn — otherwise the fire-and-forget read can
@@ -59,7 +68,16 @@ export function createMuseSpawner(deps: SpawnDeps) {
     // back without the tools it was working with (see muse-args.ts).
     const args = buildMuseArgs({ resume: resumeConversationId, workspace: cwd, model: deps.museModel, initialPrompt });
 
-    const { term, tmux, reattached } = ptySpawn(sessionId, deps.museBin, args, cwd, true, { binEnvVar: museAdapter.binEnvVar });
+    // The groups are RECORDED, not exported. A plugin's MCP server inherits nothing from muse
+    // (server/session/bridge-session.ts), so the bridge asks this server which session it belongs
+    // to and gets this list back with the answer. A session whose directory registered nothing
+    // records an empty list and every one of the four servers stands down — the same "no GUI
+    // tools" a muse cell had before this was wired.
+    rememberEntitledToolGroups(sessionId, mcpGroups);
+    // What the MUSE process itself needs: it does inherit our environment, and without this flag it
+    // loads no plugins at all — the registration would be inert rather than absent.
+    const env = musePluginEnv();
+    const { term, tmux, reattached } = ptySpawn(sessionId, deps.museBin, args, cwd, true, { env, binEnvVar: museAdapter.binEnvVar });
     const spawnedAtMs = Date.now();
     const note = resumeConversationId ? `resume ${resumeConversationId}` : null;
     console.log(ptyStartLine({ agent: "muse", pid: term.pid, cwd, tmux, reattached, sessionId, note }));

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -15,7 +15,7 @@ import { snapshotMuseSessions, watchForMuseSession } from "../agents/muse-sessio
 import { syncMuseMcpPlugin } from "../agents/muse-mcp.js";
 import { musePluginEnv } from "../agents/muse-mcp.js";
 import { rememberEntitledToolGroups } from "./bridge-session.js";
-import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
+import { ptySpawn } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
@@ -39,15 +39,26 @@ export function createMuseSpawner(deps: SpawnDeps) {
   const spawnMusePty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
 
-    // Registering the plugin is a MACHINE-wide act, so it is done only for a spawn that will really
-    // start muse — the same rule syncDirectoryMcpForSpawn states for the two agents with a shared
-    // config file, and for the same reason: after a restart this is reached for what turns out to
-    // be a tmux REATTACH, and the muse already running there read its plugins at its own start.
+    // Registered on EVERY path, including a tmux reattach — which is where this differs from the
+    // two agents that write a config file in the directory, and the difference is not a detail.
     //
-    // Not gated on `mcpGroups` being non-empty: the registration is inert without the environment
-    // below, and a directory that switches its first group on mid-session would otherwise have to
-    // wait for a spawn that happens to have one already.
-    if (!ptyWouldReattach(sessionId, true)) syncMuseMcpPlugin();
+    // Those two must not write on a reattach because the file is shared: rewriting it speaks for
+    // every other session in that directory. muse's registration is machine-wide and inert on its
+    // own (what a session may reach is decided per session, below), so writing it changes nothing
+    // for anyone already running — there is nothing to protect.
+    //
+    // And skipping it here had a real cost. MulmoTerminal's sessions outlive the server, so after
+    // the feature first ships EVERY muse cell is a reattach: the sessions were started before the
+    // plugin existed. Gated on `!ptyWouldReattach`, those cells would never register it, and the
+    // user restarts the server, sees no tools, and reasonably concludes it is broken (it looked
+    // exactly like that on 2026-08-06). Now the reattach registers it too — which still cannot give
+    // THAT muse process the tools, since muse reads its plugins at its own start, but the next time
+    // the session is started it has them.
+    //
+    // Not gated on `mcpGroups` being non-empty either: the registration is inert without the
+    // entitlement recorded below, and a directory that switches its first group on mid-session
+    // would otherwise wait for a spawn that happens to have one already.
+    syncMuseMcpPlugin();
 
     // Snapshot before spawn for fresh sessions. The snapshot is async (sqlite)
     // so we start it BEFORE ptySpawn — otherwise the fire-and-forget read can

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -398,15 +398,14 @@ const mcpGroupFailure = (group: ToolGroup): string | undefined => mcpGroupFailed
 const inWorkspace = computed(() => isSameDirPath(targetDir.value, props.defaultCwd));
 
 // The workspace answers "every tool automatically" only for an agent that can RECEIVE a per-spawn
-// config — the directory alone is not enough. Antigravity and grok read a per-directory file
-// instead, so each gets what that directory registered wherever it runs, and telling them otherwise
-// here both stated something untrue and hid the toggles that were their only way to register
-// anything (#1423).
+// config — the directory alone is not enough. Antigravity, grok and muse take what the DIRECTORY
+// registered wherever they run (agy and grok from a file in it, muse through a machine-wide plugin
+// narrowed per session), and telling them otherwise here both stated something untrue and hid the
+// toggles that were their only way to register anything (#1423).
 //
 // Kept apart from `inWorkspace` rather than folded into it: the worktree row below asks the
 // directory question and only that, and the two would have drifted the moment either changed.
 const workspaceGivesEveryTool = computed(() => inWorkspace.value && pickCarriesFullGuiMcp(props.agent, props.customAgents ?? []));
-const isMuse = computed(() => props.agent === "muse");
 
 // What "all of them" covers, named so the statement is checkable rather than a claim. Derived from
 // the headings and de-duplicated — render and media both read "Canvas" — so adding a group needs no
@@ -654,12 +653,6 @@ async function removeWorktree(w: Worktree): Promise<void> {
           <span class="material-symbols-outlined mr-[3px] align-middle text-[13px]" aria-hidden="true">workspaces</span>
           All of them, automatically — {{ allToolGroupNames }}. The workspace needs no per-directory registration.
         </span>
-      </div>
-      <div v-else-if="isMuse" data-testid="cell-mcp-muse" class="flex flex-col gap-0.5" :class="LAUNCH_ROW">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">GUI tools</span>
-        <span class="font-sans text-[11px] leading-snug text-secondary"
-          >Muse has no GUI MCP bridge — sessions run `muse` directly with no per-directory registration.</span
-        >
       </div>
       <!-- The hover names the server id and its tools (mcpGroupTitle); it sits on the ROW so
            the text is reachable from the label as well as the box.

--- a/test/server/agents/muse-mcp.spec.ts
+++ b/test/server/agents/muse-mcp.spec.ts
@@ -153,6 +153,34 @@ describe("museRegistrationMatches", () => {
   });
 });
 
+// A reattach comes through the sync too (see spawn-muse.ts), and one browser reload reattaches
+// every cell on screen at once — so the check is throttled per process. Safe because the manifest
+// is derived from this server's own bridge path and port, neither of which changes while it runs.
+describe("syncMuseMcpPlugin's throttle", () => {
+  let dir = "";
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "mt-muse-ttl-"));
+    vi.restoreAllMocks();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("keeps retrying after a FAILED check, rather than starting the clock on it", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = process.env.MUSE_BIN;
+    process.env.MUSE_BIN = path.join(dir, "no-such-muse");
+    try {
+      const { syncMuseMcpPlugin } = await import("../../../server/agents/muse-mcp.js");
+      // Both fail, and the second is the assertion that matters: a throttle that started on a
+      // failure would answer ok the second time and leave the user with no tools until a restart.
+      expect(syncMuseMcpPlugin(dir, 1_000).ok).toBe(false);
+      expect(syncMuseMcpPlugin(dir, 1_100).ok).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.MUSE_BIN;
+      else process.env.MUSE_BIN = previous;
+    }
+  });
+});
+
 describe("syncMuseMcpPlugin", () => {
   let dir = "";
   beforeEach(() => {

--- a/test/server/agents/muse-mcp.spec.ts
+++ b/test/server/agents/muse-mcp.spec.ts
@@ -4,11 +4,11 @@
 // have to take on trust. Everything asserted here was measured against muse-bin 0.1.0-R708.1
 // before it was written down (see the module header).
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { TOOL_GROUPS } from "../../../common/toolGroups.js";
-import { MUSE_PLUGIN_ID, musePluginEnv, musePluginManifest, writeMusePlugin } from "../../../server/agents/muse-mcp.js";
+import { MUSE_PLUGIN_ID, museRegistrationMatches, musePluginEnv, musePluginManifest, writeMusePlugin } from "../../../server/agents/muse-mcp.js";
 
 const BRIDGE = { command: "/opt/node/bin/node", args: ["/apps/mulmoterminal/server/mcp/bridge.mjs"] };
 const PORT = 34567;
@@ -81,31 +81,75 @@ describe("writeMusePlugin", () => {
     expect(written).toEqual(manifest());
   });
 
-  it("reports a first write as changed", () => {
-    expect(writeMusePlugin(dir, manifest()).changed).toBe(true);
-  });
-
-  // The whole point of the stamp: a spawn whose manifest matches the one last installed from here
-  // runs no subprocess at all, and a muse spawn is on the path of opening a cell.
-  it("reports no change once the stamp records that manifest", () => {
-    const { stamp } = writeMusePlugin(dir, manifest());
-    writeFileSync(path.join(dir, ".installed"), `${stamp}\n`);
-    expect(writeMusePlugin(dir, manifest()).changed).toBe(false);
-  });
-
-  // A mulmoterminal that moved — an upgrade, a different node — changes the bridge argv, and the
-  // capability muse trusted was hashed from the old one. Re-installing is what re-approves it.
-  it("reports a change when the bridge path moves", () => {
-    const { stamp } = writeMusePlugin(dir, manifest());
-    writeFileSync(path.join(dir, ".installed"), `${stamp}\n`);
-    const moved = { command: "/usr/local/bin/node", args: ["/apps/mulmoterminal-2/server/mcp/bridge.mjs"] };
-    expect(writeMusePlugin(dir, manifest(moved)).changed).toBe(true);
-  });
-
   it("creates the manifest directory when it is not there", () => {
     const nested = path.join(dir, "a", "b");
     expect(() => writeMusePlugin(nested, manifest())).not.toThrow();
     expect(readFileSync(path.join(nested, ".muse-plugin", "plugin.json"), "utf8")).toContain(MUSE_PLUGIN_ID);
+  });
+});
+
+// What decides whether a spawn re-registers. This is asked of MUSE — `muse plugins inspect` — and
+// the reason is a bug that shipped: the first version compared the manifest against a note it had
+// written itself when it last installed, so anything that removed the plugin on muse's side left
+// the two disagreeing forever. Our note said "installed", muse had nothing, and every muse cell
+// came up with no GUI tools and nothing logged anywhere.
+describe("museRegistrationMatches", () => {
+  const inspected = (over: Record<string, unknown> = {}) => ({
+    active: true,
+    runtime_capabilities: TOOL_GROUPS.map((group) => ({ candidate: { capability_id: group }, status: "trusted_enabled" })),
+    plugin: {
+      capabilities: {
+        mcp_servers: TOOL_GROUPS.map((group) => ({ id: group, command: [BRIDGE.command, ...BRIDGE.args, "--group", group, "--port", String(PORT)] })),
+      },
+    },
+    ...over,
+  });
+
+  it("accepts a registration that is already ours", () => {
+    expect(museRegistrationMatches(inspected(), manifest())).toBe(true);
+  });
+
+  // THE case. muse knows nothing about the plugin, so `inspect` fails and answers null.
+  it("re-registers when muse has no such plugin", () => {
+    expect(museRegistrationMatches(null, manifest())).toBe(false);
+    expect(museRegistrationMatches({}, manifest())).toBe(false);
+  });
+
+  it("re-registers a plugin that is installed but not active", () => {
+    expect(museRegistrationMatches(inspected({ active: false }), manifest())).toBe(false);
+  });
+
+  // Trust is keyed to the definition hash, so a changed manifest leaves the capability listed and
+  // never started — which looks exactly like having the tools until one is called.
+  it("re-registers when a capability is not trusted", () => {
+    const untrusted = inspected();
+    untrusted.runtime_capabilities[0] = { candidate: { capability_id: "render" }, status: "untrusted" };
+    expect(museRegistrationMatches(untrusted, manifest())).toBe(false);
+  });
+
+  // The port and the bridge path live in the command, and a stale one points a session at a server
+  // that is not listening — silently, because the bridge reads an unreachable resolve as "no
+  // session" and serves an empty toolset.
+  it("re-registers when the port has moved", () => {
+    expect(museRegistrationMatches(inspected(), manifest(BRIDGE, 40000))).toBe(false);
+  });
+
+  it("re-registers when the bridge path has moved", () => {
+    const moved = { command: "/usr/local/bin/node", args: ["/apps/mulmoterminal-2/server/mcp/bridge.mjs"] };
+    expect(museRegistrationMatches(inspected(), manifest(moved))).toBe(false);
+  });
+
+  // A registration that declares fewer groups than we do is not ours either — it is an older
+  // version of this plugin, from before a group existed.
+  it("re-registers when a group is missing from muse's copy", () => {
+    const partial = inspected();
+    partial.plugin.capabilities.mcp_servers = partial.plugin.capabilities.mcp_servers.slice(1);
+    partial.runtime_capabilities = partial.runtime_capabilities.slice(1);
+    expect(museRegistrationMatches(partial, manifest())).toBe(false);
+  });
+
+  it("re-registers when muse reports no capabilities at all", () => {
+    expect(museRegistrationMatches(inspected({ runtime_capabilities: [] }), manifest())).toBe(false);
   });
 });
 
@@ -133,9 +177,9 @@ describe("syncMuseMcpPlugin", () => {
     }
   });
 
-  // Failing to install must not stamp: the next spawn has to try again, or a transient failure
-  // would silently cost the user their GUI tools until the manifest happened to change.
-  it("does not record a stamp for a failed install", async () => {
+  // A failed install records NOTHING that would make the next spawn skip its retry. There is no
+  // such record left to get wrong now — the check reads muse — and this pins that it stays so.
+  it("leaves nothing behind that would stop the next spawn retrying", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const previous = process.env.MUSE_BIN;
     process.env.MUSE_BIN = path.join(dir, "no-such-muse");
@@ -143,7 +187,8 @@ describe("syncMuseMcpPlugin", () => {
     try {
       const { syncMuseMcpPlugin } = await import("../../../server/agents/muse-mcp.js");
       syncMuseMcpPlugin(dir);
-      expect(() => readFileSync(path.join(dir, ".installed"), "utf8")).toThrow();
+      expect(syncMuseMcpPlugin(dir).ok).toBe(false);
+      expect(existsSync(path.join(dir, ".installed"))).toBe(false);
     } finally {
       if (previous === undefined) delete process.env.MUSE_BIN;
       else process.env.MUSE_BIN = previous;

--- a/test/server/agents/muse-mcp.spec.ts
+++ b/test/server/agents/muse-mcp.spec.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+//
+// muse's GUI MCP registration — the third shape, and the parts of it that a reader would otherwise
+// have to take on trust. Everything asserted here was measured against muse-bin 0.1.0-R708.1
+// before it was written down (see the module header).
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { TOOL_GROUPS } from "../../../common/toolGroups.js";
+import { MUSE_PLUGIN_ID, musePluginEnv, musePluginManifest, writeMusePlugin } from "../../../server/agents/muse-mcp.js";
+
+const BRIDGE = { command: "/opt/node/bin/node", args: ["/apps/mulmoterminal/server/mcp/bridge.mjs"] };
+const PORT = 34567;
+
+// Written once: every case builds the same manifest, and the port is part of it now.
+const manifest = (bridge = BRIDGE, port: string | number = PORT) => musePluginManifest(bridge, port);
+
+const capabilities = (manifest: Record<string, unknown>) =>
+  (manifest.capabilities as { mcpServers: { id: string; transport: string; command: string[] }[] }).mcpServers;
+
+describe("musePluginManifest", () => {
+  it("declares one stdio server per tool group", () => {
+    const servers = capabilities(manifest());
+    expect(servers.map((s) => s.id)).toEqual([...TOOL_GROUPS]);
+    expect(servers.every((s) => s.transport === "stdio")).toBe(true);
+  });
+
+  // NOTHING but argv reaches a plugin's MCP server: it is started with a curated environment of
+  // muse's own, so neither an `env` block here nor the muse process's own environment arrives.
+  // Both the group and the port therefore travel on the command line.
+  it("passes the group and the port on the command line, after the bridge", () => {
+    const render = capabilities(manifest()).find((s) => s.id === "render");
+    expect(render?.command).toEqual([BRIDGE.command, ...BRIDGE.args, "--group", "render", "--port", String(PORT)]);
+  });
+
+  // A server that comes back on another port must not leave every muse cell talking to a port
+  // nothing is listening on — the manifest changes, and the stamp below reads that as a reinstall.
+  it("writes a different manifest when the port changes", () => {
+    expect(manifest(BRIDGE, 34567)).not.toEqual(manifest(BRIDGE, 40000));
+  });
+
+  // Every group is registered whatever the directory switched on: `muse plugins install` is per
+  // MACHINE, so the manifest cannot express a per-directory answer. The session's environment
+  // narrows it instead (museGuiMcpEnv), and the bridge stands the rest down.
+  it("registers every group, since installation cannot be per directory", () => {
+    expect(capabilities(manifest())).toHaveLength(TOOL_GROUPS.length);
+  });
+
+  // muse composes the model-facing tool name out of the plugin id and the capability id
+  // (`mcp__plugin_<plugin>_<server>__<tool>`, measured), so a `mulmoterminal-render` server id
+  // inside a `mulmoterminal` plugin would repeat our name in every tool name in every listing.
+  it("names the servers by group alone, under a plugin id that carries the app name", () => {
+    expect(manifest().name).toBe(MUSE_PLUGIN_ID);
+    expect(capabilities(manifest()).map((s) => s.id)).not.toContain("mulmoterminal-render");
+  });
+
+  it("declares the manifest directory muse discovers it by", () => {
+    expect(manifest().compat).toMatchObject({ source: "native", manifestDir: ".muse-plugin" });
+  });
+});
+
+describe("musePluginEnv", () => {
+  // Every `muse plugins` verb answers "plugins are not available in this build" without it, and a
+  // SESSION without it loads no plugins — so the registration would be inert rather than absent.
+  it("carries the experimental flag the whole feature is behind", () => {
+    expect(musePluginEnv()).toEqual({ MUSE_EXPERIMENTAL_PLUGINS: "1" });
+  });
+});
+
+describe("writeMusePlugin", () => {
+  let dir = "";
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "mt-muse-plugin-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("writes the manifest where muse looks for it", () => {
+    writeMusePlugin(dir, manifest());
+    const written: unknown = JSON.parse(readFileSync(path.join(dir, ".muse-plugin", "plugin.json"), "utf8"));
+    expect(written).toEqual(manifest());
+  });
+
+  it("reports a first write as changed", () => {
+    expect(writeMusePlugin(dir, manifest()).changed).toBe(true);
+  });
+
+  // The whole point of the stamp: a spawn whose manifest matches the one last installed from here
+  // runs no subprocess at all, and a muse spawn is on the path of opening a cell.
+  it("reports no change once the stamp records that manifest", () => {
+    const { stamp } = writeMusePlugin(dir, manifest());
+    writeFileSync(path.join(dir, ".installed"), `${stamp}\n`);
+    expect(writeMusePlugin(dir, manifest()).changed).toBe(false);
+  });
+
+  // A mulmoterminal that moved — an upgrade, a different node — changes the bridge argv, and the
+  // capability muse trusted was hashed from the old one. Re-installing is what re-approves it.
+  it("reports a change when the bridge path moves", () => {
+    const { stamp } = writeMusePlugin(dir, manifest());
+    writeFileSync(path.join(dir, ".installed"), `${stamp}\n`);
+    const moved = { command: "/usr/local/bin/node", args: ["/apps/mulmoterminal-2/server/mcp/bridge.mjs"] };
+    expect(writeMusePlugin(dir, manifest(moved)).changed).toBe(true);
+  });
+
+  it("creates the manifest directory when it is not there", () => {
+    const nested = path.join(dir, "a", "b");
+    expect(() => writeMusePlugin(nested, manifest())).not.toThrow();
+    expect(readFileSync(path.join(nested, ".muse-plugin", "plugin.json"), "utf8")).toContain(MUSE_PLUGIN_ID);
+  });
+});
+
+describe("syncMuseMcpPlugin", () => {
+  let dir = "";
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "mt-muse-sync-"));
+    vi.restoreAllMocks();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  // A muse that is not installed, a build with the flag gone, a read-only home: all of them are
+  // reasons for a cell to have no GUI tools, and none of them a reason for the spawn to fail.
+  it("answers rather than throws when the CLI is not there", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = process.env.MUSE_BIN;
+    process.env.MUSE_BIN = path.join(dir, "no-such-muse");
+    try {
+      const { syncMuseMcpPlugin } = await import("../../../server/agents/muse-mcp.js");
+      expect(() => syncMuseMcpPlugin(dir)).not.toThrow();
+      expect(syncMuseMcpPlugin(dir).ok).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.MUSE_BIN;
+      else process.env.MUSE_BIN = previous;
+    }
+  });
+
+  // Failing to install must not stamp: the next spawn has to try again, or a transient failure
+  // would silently cost the user their GUI tools until the manifest happened to change.
+  it("does not record a stamp for a failed install", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = process.env.MUSE_BIN;
+    process.env.MUSE_BIN = path.join(dir, "no-such-muse");
+    mkdirSync(dir, { recursive: true });
+    try {
+      const { syncMuseMcpPlugin } = await import("../../../server/agents/muse-mcp.js");
+      syncMuseMcpPlugin(dir);
+      expect(() => readFileSync(path.join(dir, ".installed"), "utf8")).toThrow();
+    } finally {
+      if (previous === undefined) delete process.env.MUSE_BIN;
+      else process.env.MUSE_BIN = previous;
+    }
+  });
+});

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -14,6 +14,7 @@ import {
   redrawTargets,
   planMsOverride,
   MS_OVERRIDE_ENTRY,
+  parseTmuxPanePids,
 } from "../../../server/infra/tmux";
 
 describe("tmuxSessionName", () => {
@@ -361,5 +362,25 @@ describe("parseTmuxSessionActivity", () => {
   // than land as NaN and render as an age nobody can read.
   it.each(["mt-a", "mt-a notanumber", ""])("drops the unusable line %j", (line) => {
     expect(parseTmuxSessionActivity(line)).toEqual(new Map());
+  });
+});
+
+// The pane pid -> session map, which is how a process started BY an agent is traced back to the
+// session it belongs to when nothing was handed to it (server/session/bridge-session.ts). The
+// FORMAT is the fragile part — it is a tmux format string, and a change to it would silently
+// return an empty map, which reads as "no session owns this bridge" and withholds every GUI tool.
+describe("parseTmuxPanePids", () => {
+  it("keeps only our own sessions, keyed by pane pid", () => {
+    const panes = parseTmuxPanePids(["2220 mt-aaaa-1111", "3300 someone-elses-session", "4400 mt-bbbb-2222"].join("\n"));
+    expect(panes).toEqual(
+      new Map([
+        [2220, "aaaa-1111"],
+        [4400, "bbbb-2222"],
+      ]),
+    );
+  });
+
+  it("ignores a row it cannot read rather than inventing a pid", () => {
+    expect(parseTmuxPanePids(["", "not-a-pid mt-aaaa", "0 mt-bbbb", "-3 mt-cccc", "2220"].join("\n"))).toEqual(new Map());
   });
 });

--- a/test/server/mcp/bridge.spec.ts
+++ b/test/server/mcp/bridge.spec.ts
@@ -17,15 +17,22 @@ describe("mcp bridge", () => {
   let port: number;
   let requests: { url: string; body: string }[];
   let status = 200;
+  // What /api/mcp-resolve answers — the muse path, where the bridge is told nothing and asks.
+  let resolve: { sessionId: string | null; groups: string[] } = { sessionId: null, groups: [] };
 
   beforeEach(async () => {
     requests = [];
     status = 200;
+    resolve = { sessionId: null, groups: [] };
     server = http.createServer((req, res) => {
       let body = "";
       req.on("data", (chunk) => (body += chunk));
       req.on("end", () => {
         requests.push({ url: req.url ?? "", body });
+        if (req.url === "/api/mcp-resolve") {
+          res.writeHead(200, { "content-type": "application/json" });
+          return res.end(JSON.stringify(resolve));
+        }
         if (status !== 200) return res.writeHead(status).end();
         const id = JSON.parse(body || "{}").id;
         if (id === undefined) return res.writeHead(202).end(); // a notification
@@ -41,8 +48,8 @@ describe("mcp bridge", () => {
 
   // Runs from a directory that is NOT this package, so a bridge needing anything resolved from
   // its cwd would fail here the way it failed for a user.
-  async function run(lines: string[], env: Record<string, string> = {}): Promise<string> {
-    const proc = spawn(process.execPath, [bridge], {
+  async function run(lines: string[], env: Record<string, string> = {}, args: string[] = []): Promise<string> {
+    const proc = spawn(process.execPath, [bridge, ...args], {
       cwd: path.parse(process.cwd()).root,
       env: { ...process.env, MULMOTERMINAL_PORT: String(port), MULMOTERMINAL_SESSION_ID: SESSION, ...env },
       stdio: ["pipe", "pipe", "pipe"],
@@ -53,6 +60,12 @@ describe("mcp bridge", () => {
     proc.stdin.end();
     await new Promise((resolve) => proc.on("exit", resolve));
     return out;
+  }
+
+  // The muse shape: NOTHING in the environment, everything in argv. `env: {}` would still inherit
+  // this process's own MULMOTERMINAL_* if any were set, so they are cleared explicitly.
+  async function runBare(lines: string[], args: string[]): Promise<string> {
+    return run(lines, { MULMOTERMINAL_PORT: "", MULMOTERMINAL_SESSION_ID: "", MULMOTERMINAL_TOOL_GROUP: "" }, args);
   }
 
   it("forwards a request to the session's group URL and returns the SSE payload", async () => {
@@ -77,5 +90,68 @@ describe("mcp bridge", () => {
     const out = await run([JSON.stringify({ jsonrpc: "2.0", id: 9, method: "tools/list" })], { MULMOTERMINAL_SESSION_ID: "" });
     expect(JSON.parse(out.trim())).toMatchObject({ id: 9, error: { code: -32603 } });
     expect(requests).toHaveLength(0);
+  });
+
+  // muse's half. Its registration is a PLUGIN, installed once for the machine and started with a
+  // curated environment that carries NOTHING of ours (measured: 16 variables, all muse's own). So
+  // the group and the port arrive as argv, and the session is asked for — /api/mcp-resolve maps the
+  // bridge's own pid back to the session whose pane it runs under.
+  describe("the group and port in argv, and the session resolved over HTTP", () => {
+    const list = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    it("takes the group from --group and the port from --port, with no environment at all", async () => {
+      resolve = { sessionId: SESSION, groups: ["data"] };
+      const out = await runBare([list], ["--group", "data", "--port", String(port)]);
+      expect(requests.find((r) => r.url.startsWith("/api/mcp/data/"))?.url).toBe(`/api/mcp/data/${SESSION}`);
+      expect(JSON.parse(out.trim())).toMatchObject({ id: 1, result: { ok: true } });
+    });
+
+    it("asks the resolve route who it is serving, with its own pid and cwd", async () => {
+      resolve = { sessionId: SESSION, groups: ["render"] };
+      await runBare([list], ["--group", "render", "--port", String(port)]);
+      const asked = requests.find((r) => r.url === "/api/mcp-resolve");
+      expect(asked).toBeTruthy();
+      expect(JSON.parse(asked?.body ?? "{}")).toMatchObject({ pid: expect.any(Number), cwd: expect.any(String) });
+    });
+
+    // The one that keeps a directory's switches meaningful for muse: every group is registered for
+    // the machine, so a session that switched on `render` alone must see nothing from the rest.
+    it("serves an EMPTY toolset for a group this session is not entitled to", async () => {
+      resolve = { sessionId: SESSION, groups: ["render"] };
+      const out = await runBare([list], ["--group", "media", "--port", String(port)]);
+      expect(JSON.parse(out.trim())).toEqual({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+      expect(requests.some((r) => r.url.startsWith("/api/mcp/media/"))).toBe(false);
+    });
+
+    // A muse someone started in a plain terminal has the plugin and no session. Empty tools, not a
+    // broken server: muse starts all four, and three failures read as a bug in the app.
+    it("stands down when no session owns the process", async () => {
+      resolve = { sessionId: null, groups: [] };
+      const out = await runBare([JSON.stringify({ jsonrpc: "2.0", id: 2, method: "initialize" })], ["--group", "render", "--port", String(port)]);
+      expect(JSON.parse(out.trim())).toMatchObject({ id: 2, result: { capabilities: { tools: {} } } });
+    });
+
+    it("answers a call it cannot serve with an error rather than silence", async () => {
+      resolve = { sessionId: null, groups: [] };
+      const out = await runBare(
+        [JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "presentChart" } })],
+        ["--group", "render", "--port", String(port)],
+      );
+      expect(JSON.parse(out.trim())).toMatchObject({ id: 3, error: { code: -32603 } });
+    });
+
+    // Resolution is per PROCESS, not per call: the session cannot change under a running bridge,
+    // and this is on the path of every tool call.
+    it("resolves once and reuses the answer", async () => {
+      resolve = { sessionId: SESSION, groups: ["render"] };
+      await runBare([list, list, list], ["--group", "render", "--port", String(port)]);
+      expect(requests.filter((r) => r.url === "/api/mcp-resolve")).toHaveLength(1);
+    });
+
+    // The env path is still the one agy and grok take, and it must not start asking.
+    it("never resolves when the environment already names the session", async () => {
+      await run([list], { MULMOTERMINAL_TOOL_GROUP: "render" });
+      expect(requests.some((r) => r.url === "/api/mcp-resolve")).toBe(false);
+    });
   });
 });

--- a/test/server/routes/directory-mcp-ws-agent.spec.ts
+++ b/test/server/routes/directory-mcp-ws-agent.spec.ts
@@ -23,10 +23,10 @@ const antigravityMapRead = new Promise<void>((resolve) => {
 });
 
 const ptys = new Map<string, unknown>();
-const sessionCwd = vi.fn((_id: string): string | null => null);
+const sessionCwd = vi.fn((): string | null => null);
 vi.mock("../../../server/session/registry.js", () => ({
   ptys,
-  sessionCwd: (id: string) => sessionCwd(id),
+  sessionCwd: () => sessionCwd(),
   devTerminalCwdsHydrated: Promise.resolve(),
   antigravityConversations: new Map(),
   antigravityConversationsHydrated: antigravityMapRead,

--- a/test/server/routes/directory-mcp-ws-agent.spec.ts
+++ b/test/server/routes/directory-mcp-ws-agent.spec.ts
@@ -101,10 +101,11 @@ const spawnerFor = (kind: string) => SPAWNERS[kind] as typeof spawnGrokPty;
 let dir = "";
 const request = (query = "") => ({ url: `/ws?cwd=${encodeURIComponent(dir)}${query}` });
 
-// Both agents, so a rule asserted once is asserted for the pair. Named so a failure says which.
-// muse shares this handler for the lifecycle only — it has no MCP at all — so it is asserted
-// separately below rather than folded into a list about tool groups.
-const AGENTS = [ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT];
+// All three, so a rule asserted once is asserted for every agent on this handler. Named so a
+// failure says which. What muse does with the groups differs (they travel on the session's
+// environment rather than into a file in the directory, because its plugin registration is per
+// machine) — but THAT it is handed the directory's groups is the same rule, and is asserted here.
+const AGENTS = [ANTIGRAVITY_WS_AGENT, GROK_WS_AGENT, MUSE_WS_AGENT];
 
 beforeEach(() => {
   ptys.clear();
@@ -190,21 +191,12 @@ describe("waiting for the on-disk conversation map", () => {
   });
 });
 
-// muse rides this handler for what it shares — the session id, the reattach, the worktree env —
-// and NOT for the MCP: it has none, so reading Claude Code's per-directory registration for it
-// could only produce groups nothing can act on (common/guiMcpAgents.ts, spawn-muse.ts).
+// muse's own half: the resume, and the one thing it does NOT share — where the groups end up.
 describe("/ws/muse", () => {
-  it("declares that it reads no directory MCP config, where the other two declare that they do", () => {
-    expect(MUSE_WS_AGENT.readsDirectoryMcpConfig).toBe(false);
+  it("is handed the directory's groups like the other two, because its plugin is registered for the machine", () => {
+    expect(MUSE_WS_AGENT.readsDirectoryMcpConfig).toBe(true);
     expect(ANTIGRAVITY_WS_AGENT.readsDirectoryMcpConfig).toBe(true);
     expect(GROK_WS_AGENT.readsDirectoryMcpConfig).toBe(true);
-  });
-
-  it("spawns without looking the directory's tool groups up at all", async () => {
-    const ws = fakeWs();
-    await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), ws as unknown as WebSocket, request());
-    expect(registeredGuiMcpGroups).not.toHaveBeenCalled();
-    expect(spawnMusePty).toHaveBeenCalledWith(expect.any(String), expect.anything(), null, dir, { mcpGroups: [] });
   });
 
   // The chat-history case: the row the picker offers IS one of muse's own ids, so the connection
@@ -213,7 +205,7 @@ describe("/ws/muse", () => {
     const session = "11111111-2222-4333-8444-555555555555";
     museSessionExistsForCwd.mockResolvedValueOnce(true);
     await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
-    expect(spawnMusePty).toHaveBeenCalledWith(session, expect.anything(), session, dir, { mcpGroups: [] });
+    expect(spawnMusePty).toHaveBeenCalledWith(session, expect.anything(), session, dir, { mcpGroups: ["render"] });
   });
 
   // A key that names nothing muse knows must not be handed to `muse resume` — and must not keep
@@ -221,6 +213,6 @@ describe("/ws/muse", () => {
   it("starts fresh under a new id when the key names no session of muse's", async () => {
     const session = "11111111-2222-4333-8444-555555555555";
     await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
-    expect(spawnMusePty).toHaveBeenCalledWith(expect.not.stringMatching(session), expect.anything(), null, dir, { mcpGroups: [] });
+    expect(spawnMusePty).toHaveBeenCalledWith(expect.not.stringMatching(session), expect.anything(), null, dir, { mcpGroups: ["render"] });
   });
 });

--- a/test/server/routes/directory-mcp-ws-agent.spec.ts
+++ b/test/server/routes/directory-mcp-ws-agent.spec.ts
@@ -23,8 +23,11 @@ const antigravityMapRead = new Promise<void>((resolve) => {
 });
 
 const ptys = new Map<string, unknown>();
+const sessionCwd = vi.fn((_id: string): string | null => null);
 vi.mock("../../../server/session/registry.js", () => ({
   ptys,
+  sessionCwd: (id: string) => sessionCwd(id),
+  devTerminalCwdsHydrated: Promise.resolve(),
   antigravityConversations: new Map(),
   antigravityConversationsHydrated: antigravityMapRead,
   museConversations: new Map(),
@@ -111,6 +114,7 @@ beforeEach(() => {
   ptys.clear();
   vi.clearAllMocks();
   registeredGuiMcpGroups.mockResolvedValue(["render"]);
+  sessionCwd.mockReturnValue(null);
   releaseAntigravityMap();
   dir = mkdtempSync(path.join(tmpdir(), "mt-dirmcp-"));
 });
@@ -201,6 +205,23 @@ describe("/ws/muse", () => {
 
   // The chat-history case: the row the picker offers IS one of muse's own ids, so the connection
   // has to resume it rather than start a fresh session under it.
+  // A reconnect after a server restart has no live pty and often no `?cwd=` either, so the request
+  // resolves to the DEFAULT workspace. muse records these groups as the session's entitlement, so
+  // taking them from the request would make another directory's switches this session's
+  // (Codex on #1514). The session's own directory is what the groups are read against.
+  it("reads the groups against the session's own directory, not the reconnect's", async () => {
+    const session = "11111111-2222-4333-8444-555555555555";
+    const elsewhere = mkdtempSync(path.join(tmpdir(), "mt-elsewhere-"));
+    sessionCwd.mockReturnValueOnce(elsewhere);
+    museSessionExistsForCwd.mockResolvedValueOnce(true);
+    try {
+      await handleDirectoryMcpAgentConnection(MUSE_WS_AGENT, makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${session}`));
+      expect(registeredGuiMcpGroups).toHaveBeenCalledWith(elsewhere, expect.anything());
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+
   it("resumes a session muse holds for this directory", async () => {
     const session = "11111111-2222-4333-8444-555555555555";
     museSessionExistsForCwd.mockResolvedValueOnce(true);

--- a/test/server/session/bridge-session.spec.ts
+++ b/test/server/session/bridge-session.spec.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+//
+// Which session a GUI MCP bridge belongs to when nothing told it — the rule muse forces, because a
+// plugin's MCP server is started with a curated environment carrying none of ours.
+//
+// The two failure modes this exists to keep apart: answering the WRONG session (one cell's chart
+// drawn in another) and answering NOTHING (no chart). The second is the one to prefer, because it
+// is the one a user can see and report.
+import { describe, it, expect } from "vitest";
+import { resolveBridgeSession } from "../../../server/session/bridge-session.js";
+import { ancestorPids } from "../../../server/infra/process-tree.js";
+
+const A = "aaaaaaaa-1111-4111-8111-111111111111";
+const B = "bbbbbbbb-2222-4222-8222-222222222222";
+const CWD = "/home/me/project";
+
+describe("resolveBridgeSession", () => {
+  // The measured shape: bridge (2244) -> muse (2220) -> tmux, where 2220 is the pane pid tmux
+  // reports for the session named by our own id.
+  it("follows the process tree to the pane it is running under", () => {
+    const session = resolveBridgeSession({
+      panePids: new Map([[2220, A]]),
+      ancestors: [2244, 2220, 15746],
+      museSessions: new Map([[A, CWD]]),
+      cwd: CWD,
+    });
+    expect(session).toBe(A);
+  });
+
+  // The point of walking the TREE rather than matching the directory: two muse cells opened in one
+  // directory are indistinguishable by cwd, and this is what tells them apart.
+  it("tells two sessions in one directory apart", () => {
+    const facts = {
+      panePids: new Map([
+        [100, A],
+        [200, B],
+      ]),
+      museSessions: new Map([
+        [A, CWD],
+        [B, CWD],
+      ]),
+      cwd: CWD,
+    };
+    expect(resolveBridgeSession({ ...facts, ancestors: [300, 200] })).toBe(B);
+    expect(resolveBridgeSession({ ...facts, ancestors: [301, 100] })).toBe(A);
+  });
+
+  // Persistence off, or a pane tmux no longer reports: the directory answers, but only when it
+  // cannot be wrong.
+  it("falls back to the directory when exactly one muse session runs there", () => {
+    const session = resolveBridgeSession({ panePids: new Map(), ancestors: [999], museSessions: new Map([[A, CWD]]), cwd: CWD });
+    expect(session).toBe(A);
+  });
+
+  it("refuses to guess when two muse sessions share the directory", () => {
+    const session = resolveBridgeSession({
+      panePids: new Map(),
+      ancestors: [999],
+      museSessions: new Map([
+        [A, CWD],
+        [B, CWD],
+      ]),
+      cwd: CWD,
+    });
+    expect(session).toBeNull();
+  });
+
+  it("answers nothing for a directory no muse session is running in", () => {
+    expect(resolveBridgeSession({ panePids: new Map(), ancestors: [999], museSessions: new Map([[A, "/elsewhere"]]), cwd: CWD })).toBeNull();
+  });
+
+  // A pane whose session is not a LIVE muse — it ended, or it is a claude cell — must not be
+  // claimed by a bridge that happens to sit under it.
+  it("ignores a pane whose session is not a live muse session", () => {
+    const session = resolveBridgeSession({ panePids: new Map([[2220, "some-claude-session"]]), ancestors: [2244, 2220], museSessions: new Map(), cwd: CWD });
+    expect(session).toBeNull();
+  });
+
+  // The tree wins over the directory, which is what makes the fallback safe to have at all.
+  it("prefers the pane over the directory when both could answer", () => {
+    const session = resolveBridgeSession({
+      panePids: new Map([[2220, B]]),
+      ancestors: [2244, 2220],
+      museSessions: new Map([
+        [A, CWD],
+        [B, "/elsewhere"],
+      ]),
+      cwd: CWD,
+    });
+    expect(session).toBe(B);
+  });
+});
+
+describe("ancestorPids", () => {
+  it("walks from the process up to the root, nearest first", () => {
+    const parents = new Map([
+      [10, 9],
+      [9, 8],
+      [8, 1],
+    ]);
+    expect(ancestorPids(10, (pid) => parents.get(pid) ?? null)).toEqual([10, 9, 8]);
+  });
+
+  it("stops at a pid `ps` cannot answer for", () => {
+    expect(ancestorPids(10, () => null)).toEqual([10]);
+  });
+
+  // A cycle should be impossible, but a walk that trusts `ps` completely would hang the request
+  // that started it — and this one runs inside an HTTP handler.
+  it("does not spin on a cycle", () => {
+    const parents = new Map([
+      [10, 11],
+      [11, 10],
+    ]);
+    expect(ancestorPids(10, (pid) => parents.get(pid) ?? null)).toEqual([10, 11]);
+  });
+
+  it("is bounded for a very deep tree", () => {
+    expect(ancestorPids(1000, (pid) => pid + 1)).toHaveLength(8);
+  });
+});

--- a/test/server/session/bridge-session.spec.ts
+++ b/test/server/session/bridge-session.spec.ts
@@ -3,32 +3,31 @@
 // Which session a GUI MCP bridge belongs to when nothing told it — the rule muse forces, because a
 // plugin's MCP server is started with a curated environment carrying none of ours.
 //
-// The two failure modes this exists to keep apart: answering the WRONG session (one cell's chart
-// drawn in another) and answering NOTHING (no chart). The second is the one to prefer, because it
-// is the one a user can see and report.
+// Every path is a proof of DESCENT — under our pane, or under our pty. A shared working directory
+// is deliberately not one, and that is the correction Codex's review forced: the plugin is
+// machine-wide, so a muse the user started themselves has the bridge too, and a cwd rule would have
+// handed it a cell's session id and groups.
+//
+// The two failure modes this keeps apart: answering the WRONG session (one cell's chart drawn in
+// another, or a stranger's process writing under it) and answering NOTHING (no chart). The second
+// is the one to prefer — it is the one a user can see and report.
 import { describe, it, expect } from "vitest";
 import { resolveBridgeSession } from "../../../server/session/bridge-session.js";
 import { ancestorPids } from "../../../server/infra/process-tree.js";
 
 const A = "aaaaaaaa-1111-4111-8111-111111111111";
 const B = "bbbbbbbb-2222-4222-8222-222222222222";
-const CWD = "/home/me/project";
 
 describe("resolveBridgeSession", () => {
   // The measured shape: bridge (2244) -> muse (2220) -> tmux, where 2220 is the pane pid tmux
   // reports for the session named by our own id.
   it("follows the process tree to the pane it is running under", () => {
-    const session = resolveBridgeSession({
-      panePids: new Map([[2220, A]]),
-      ancestors: [2244, 2220, 15746],
-      museSessions: new Map([[A, CWD]]),
-      cwd: CWD,
-    });
+    const session = resolveBridgeSession({ panePids: new Map([[2220, A]]), ancestors: [2244, 2220, 15746], museSessions: new Map([[A, 999]]) });
     expect(session).toBe(A);
   });
 
-  // The point of walking the TREE rather than matching the directory: two muse cells opened in one
-  // directory are indistinguishable by cwd, and this is what tells them apart.
+  // The point of walking the TREE: two muse cells opened in one directory are indistinguishable by
+  // anything else, and this is what tells them apart.
   it("tells two sessions in one directory apart", () => {
     const facts = {
       panePids: new Map([
@@ -36,56 +35,50 @@ describe("resolveBridgeSession", () => {
         [200, B],
       ]),
       museSessions: new Map([
-        [A, CWD],
-        [B, CWD],
+        [A, 900],
+        [B, 901],
       ]),
-      cwd: CWD,
     };
     expect(resolveBridgeSession({ ...facts, ancestors: [300, 200] })).toBe(B);
     expect(resolveBridgeSession({ ...facts, ancestors: [301, 100] })).toBe(A);
   });
 
-  // Persistence off, or a pane tmux no longer reports: the directory answers, but only when it
-  // cannot be wrong.
-  it("falls back to the directory when exactly one muse session runs there", () => {
-    const session = resolveBridgeSession({ panePids: new Map(), ancestors: [999], museSessions: new Map([[A, CWD]]), cwd: CWD });
-    expect(session).toBe(A);
+  // With tmux persistence off there is no pane to match, and there muse is a child of the pty this
+  // server spawned — so the pty's own pid is in the chain.
+  it("falls back to the pty this server spawned when there is no pane", () => {
+    expect(resolveBridgeSession({ panePids: new Map(), ancestors: [4000, 3000], museSessions: new Map([[A, 3000]]) })).toBe(A);
   });
 
-  it("refuses to guess when two muse sessions share the directory", () => {
-    const session = resolveBridgeSession({
-      panePids: new Map(),
-      ancestors: [999],
-      museSessions: new Map([
-        [A, CWD],
-        [B, CWD],
-      ]),
-      cwd: CWD,
-    });
+  // THE security case (Codex on #1514). The plugin is machine-wide, so a muse the USER started in
+  // a normal terminal has the bridge too. It descends from neither our pane nor our pty, and it
+  // must not be handed the session id and groups of a cell that happens to share its directory —
+  // it could otherwise draw into that cell's Canvas and write artifacts under its session.
+  it("refuses a muse that descends from nothing of ours, even in the same directory", () => {
+    const session = resolveBridgeSession({ panePids: new Map([[100, A]]), ancestors: [7001, 7000], museSessions: new Map([[A, 900]]) });
     expect(session).toBeNull();
   });
 
-  it("answers nothing for a directory no muse session is running in", () => {
-    expect(resolveBridgeSession({ panePids: new Map(), ancestors: [999], museSessions: new Map([[A, "/elsewhere"]]), cwd: CWD })).toBeNull();
+  it("answers nothing when no muse session is live at all", () => {
+    expect(resolveBridgeSession({ panePids: new Map([[100, A]]), ancestors: [101, 100], museSessions: new Map() })).toBeNull();
   });
 
   // A pane whose session is not a LIVE muse — it ended, or it is a claude cell — must not be
   // claimed by a bridge that happens to sit under it.
   it("ignores a pane whose session is not a live muse session", () => {
-    const session = resolveBridgeSession({ panePids: new Map([[2220, "some-claude-session"]]), ancestors: [2244, 2220], museSessions: new Map(), cwd: CWD });
+    const session = resolveBridgeSession({ panePids: new Map([[2220, "some-claude-session"]]), ancestors: [2244, 2220], museSessions: new Map() });
     expect(session).toBeNull();
   });
 
-  // The tree wins over the directory, which is what makes the fallback safe to have at all.
-  it("prefers the pane over the directory when both could answer", () => {
+  // Nearest ancestor first, so a bridge under a pane inside another session's tree answers the one
+  // it actually runs in.
+  it("takes the nearest owner in the chain", () => {
     const session = resolveBridgeSession({
-      panePids: new Map([[2220, B]]),
-      ancestors: [2244, 2220],
+      panePids: new Map([[500, B]]),
+      ancestors: [600, 500, 400],
       museSessions: new Map([
-        [A, CWD],
-        [B, "/elsewhere"],
+        [A, 400],
+        [B, 901],
       ]),
-      cwd: CWD,
     });
     expect(session).toBe(B);
   });

--- a/test/server/session/muse-gui-mcp.spec.ts
+++ b/test/server/session/muse-gui-mcp.spec.ts
@@ -1,11 +1,17 @@
-// muse reaches NO GUI MCP, and that has to be an answer both sides can read rather than a call
-// site that happens not to attach one: the launcher form decides from the same list what it tells
-// the user (#1423), and the server decides from it whether to read the directory's registration at
-// all. spawn-muse.ts therefore states it here instead of consulting the predicate and discarding
-// the result.
+// Which GUI MCP surface muse gets, asserted where both sides read it: the launcher form decides
+// from this list what it tells the user (#1423), and the server decides from it what it hands a
+// spawn.
+//
+// muse is the third answer to that question. It is NOT in FULL_GUI_MCP_AGENTS — it takes no
+// per-spawn `--mcp-config`, so a session in the workspace does not get every tool on one url — and
+// it does not read a per-directory config file either. Its servers come from an installed PLUGIN,
+// registered once per machine, narrowed back to the directory's groups by a record the bridge asks
+// for after it resolves which session it belongs to (server/agents/muse-mcp.ts,
+// server/session/bridge-session.ts).
 import { describe, it, expect } from "vitest";
 import { agentCarriesFullGuiMcp, FULL_GUI_MCP_AGENTS } from "../../../common/guiMcpAgents.js";
 import { carriesFullGuiMcp } from "../../../server/session/mcp-config.js";
+import { entitledToolGroups, rememberEntitledToolGroups, forgetEntitledToolGroups } from "../../../server/session/bridge-session.js";
 
 describe("muse and the GUI MCP", () => {
   it("carries no per-spawn MCP config, in the workspace or anywhere else", () => {
@@ -18,5 +24,19 @@ describe("muse and the GUI MCP", () => {
   it("leaves claude and codex carrying it", () => {
     expect(agentCarriesFullGuiMcp("claude")).toBe(true);
     expect(agentCarriesFullGuiMcp("codex")).toBe(true);
+  });
+
+  // Where muse's tools actually come from. Not the environment — a plugin's MCP server inherits
+  // none of ours — but a record the bridge asks for once it has resolved which session it serves.
+  it("records the directory's groups against the session for the bridge to ask for", () => {
+    rememberEntitledToolGroups("s-1", ["render", "data"]);
+    expect(entitledToolGroups("s-1")).toEqual(["render", "data"]);
+    forgetEntitledToolGroups("s-1");
+  });
+
+  // An unknown session reaches NOTHING. A bridge asking about a session this server has no record
+  // of is one it cannot vouch for, and defaulting to every tool would be the wrong way to be wrong.
+  it("gives an unrecorded session no groups at all", () => {
+    expect(entitledToolGroups("never-seen")).toEqual([]);
   });
 });

--- a/test/server/session/spawn-muse-mcp.spec.ts
+++ b/test/server/session/spawn-muse-mcp.spec.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+//
+// muse's GUI MCP has two halves, and they live in different places on purpose — this pins the join.
+//
+// The REGISTRATION is machine-wide: `muse plugins install` copies the bundle into a
+// content-addressed cache and records it for the user, with no per-directory form (measured). So
+// the plugin declares every tool group, always, and installing it says nothing about which
+// directory may use what.
+//
+// The ENTITLEMENT is per session, and it is RECORDED rather than exported: a plugin's MCP server
+// is started with a curated environment carrying nothing of ours (measured), so the bridge resolves
+// its own session against this server and is told the groups with the answer. That is what keeps
+// the launcher's per-directory switches meaningful for an agent whose registration cannot honour
+// them.
+//
+// Get the join wrong in either direction and it is silent: a session that carries no groups shows
+// no tools with nothing logged, and one that carries groups the directory never registered hands a
+// cell tools its neighbours were not given.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ID = "11111111-2222-4333-8444-555555555555";
+const CWD = "/home/me/project";
+
+let reattaching = false;
+const syncMuseMcpPlugin = vi.fn();
+const spawned: { env: Record<string, string> | undefined }[] = [];
+
+vi.mock("../../../server/session/pty-spawn.js", () => ({
+  ptySpawn: (_id: string, _bin: string, _args: string[], _cwd: string, _tmux: boolean, options: { env?: Record<string, string> }) => {
+    spawned.push({ env: options?.env });
+    return { term: fakeTerm(), tmux: true, reattached: reattaching };
+  },
+  ptyWouldReattach: () => reattaching,
+}));
+
+vi.mock("../../../server/agents/muse-mcp.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/muse-mcp.js")>()),
+  syncMuseMcpPlugin: () => syncMuseMcpPlugin(),
+}));
+
+vi.mock("../../../server/session/registry.js", () => ({
+  ptys: new Map(),
+  claimedMuseSessions: new Set(),
+  rememberMuseSession: vi.fn(),
+}));
+
+vi.mock("../../../server/session/pty-relay.js", () => ({ wireAgentPtyRelay: vi.fn() }));
+
+const rememberEntitledToolGroups = vi.fn();
+vi.mock("../../../server/session/bridge-session.js", () => ({
+  rememberEntitledToolGroups: (id: string, groups: readonly string[]) => rememberEntitledToolGroups(id, groups),
+}));
+vi.mock("../../../server/agents/muse-session.js", () => ({
+  snapshotMuseSessions: () => Promise.resolve(new Set<string>()),
+  watchForMuseSession: () => Promise.resolve(null),
+}));
+
+const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
+
+const { createMuseSpawner } = await import("../../../server/session/spawn-muse.js");
+
+const deps = { museBin: "muse", museModel: null, publishActivity: vi.fn() } as unknown as Parameters<typeof createMuseSpawner>[0];
+const spawn = (groups: readonly string[]) => createMuseSpawner(deps).spawnMusePty(ID, null, null, CWD, { mcpGroups: groups as never });
+
+const lastEnv = () => spawned[spawned.length - 1]?.env ?? {};
+
+describe("spawnMusePty and the machine-wide plugin", () => {
+  beforeEach(() => {
+    reattaching = false;
+    spawned.length = 0;
+    syncMuseMcpPlugin.mockClear();
+  });
+
+  it("registers the plugin when it really starts muse", () => {
+    spawn(["render"]);
+    expect(syncMuseMcpPlugin).toHaveBeenCalledTimes(1);
+  });
+
+  // The same rule the two file-writing agents follow, for the same reason: after a restart this is
+  // reached for what turns out to be a tmux reattach, and the muse already running in that pane
+  // read its plugins at its own start. Registering now could only speak for other sessions.
+  it("does not register when tmux will reattach an already-running muse", () => {
+    reattaching = true;
+    spawn(["render"]);
+    expect(syncMuseMcpPlugin).not.toHaveBeenCalled();
+  });
+
+  // Deliberately NOT gated on having a group: the registration is inert until a session's own
+  // entitlement says otherwise, so a directory switching its first group on mid-session must not
+  // have to wait for a later spawn that happens to have one already.
+  it("registers even for a directory that has switched nothing on", () => {
+    spawn([]);
+    expect(syncMuseMcpPlugin).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("spawnMusePty and the session's entitlement", () => {
+  beforeEach(() => {
+    reattaching = false;
+    spawned.length = 0;
+    syncMuseMcpPlugin.mockClear();
+    rememberEntitledToolGroups.mockClear();
+  });
+
+  it("records exactly the groups the directory registered, against this session", () => {
+    spawn(["render", "media"]);
+    expect(rememberEntitledToolGroups).toHaveBeenCalledWith(ID, ["render", "media"]);
+  });
+
+  // An empty list is a real answer, not a missing one — every server stands down, which is what a
+  // muse cell in an unregistered directory had before any of this.
+  it("records an empty list for a directory that registered nothing", () => {
+    spawn([]);
+    expect(rememberEntitledToolGroups).toHaveBeenCalledWith(ID, []);
+  });
+
+  // The whole feature is behind muse's experimental flag. This one IS an environment variable,
+  // because it is read by the muse process itself — which does inherit our spawn environment —
+  // rather than by the plugin server, which inherits nothing.
+  it("turns muse's plugin support on for the session", () => {
+    spawn(["render"]);
+    expect(lastEnv().MUSE_EXPERIMENTAL_PLUGINS).toBe("1");
+  });
+
+  // And nothing else: a variable set here for the BRIDGE would be dropped on the way, which is the
+  // mistake this design replaced. If one is ever added, it is for muse itself.
+  it("does not pretend the bridge can be told anything through the environment", () => {
+    spawn(["render"]);
+    expect(lastEnv().MULMOTERMINAL_SESSION_ID).toBeUndefined();
+    expect(lastEnv().MULMOTERMINAL_TOOL_GROUPS).toBeUndefined();
+  });
+});

--- a/test/server/session/spawn-muse-mcp.spec.ts
+++ b/test/server/session/spawn-muse-mcp.spec.ts
@@ -76,13 +76,16 @@ describe("spawnMusePty and the machine-wide plugin", () => {
     expect(syncMuseMcpPlugin).toHaveBeenCalledTimes(1);
   });
 
-  // The same rule the two file-writing agents follow, for the same reason: after a restart this is
-  // reached for what turns out to be a tmux reattach, and the muse already running in that pane
-  // read its plugins at its own start. Registering now could only speak for other sessions.
-  it("does not register when tmux will reattach an already-running muse", () => {
+  // NOT the rule the two file-writing agents follow, and the difference is the point. Their file is
+  // shared by every session in the directory, so writing it on a reattach speaks for terminals this
+  // spawn knows nothing about. muse's registration is machine-wide and inert on its own, so there
+  // is nothing to protect — and skipping it here is what made the feature look broken on the day it
+  // landed: sessions outlive the server, so every muse cell was a reattach, none of them registered
+  // anything, and restarting the server changed nothing (2026-08-06).
+  it("registers on a tmux reattach too, so the next start of that session has the tools", () => {
     reattaching = true;
     spawn(["render"]);
-    expect(syncMuseMcpPlugin).not.toHaveBeenCalled();
+    expect(syncMuseMcpPlugin).toHaveBeenCalledTimes(1);
   });
 
   // Deliberately NOT gated on having a group: the registration is inert until a session's own

--- a/test/server/session/spawn-muse-mcp.spec.ts
+++ b/test/server/session/spawn-muse-mcp.spec.ts
@@ -47,8 +47,10 @@ vi.mock("../../../server/session/registry.js", () => ({
 vi.mock("../../../server/session/pty-relay.js", () => ({ wireAgentPtyRelay: vi.fn() }));
 
 const rememberEntitledToolGroups = vi.fn();
+let recorded: readonly string[] = [];
 vi.mock("../../../server/session/bridge-session.js", () => ({
   rememberEntitledToolGroups: (id: string, groups: readonly string[]) => rememberEntitledToolGroups(id, groups),
+  entitledToolGroups: () => recorded,
 }));
 vi.mock("../../../server/agents/muse-session.js", () => ({
   snapshotMuseSessions: () => Promise.resolve(new Set<string>()),
@@ -100,9 +102,29 @@ describe("spawnMusePty and the machine-wide plugin", () => {
 describe("spawnMusePty and the session's entitlement", () => {
   beforeEach(() => {
     reattaching = false;
+    recorded = [];
     spawned.length = 0;
     syncMuseMcpPlugin.mockClear();
     rememberEntitledToolGroups.mockClear();
+  });
+
+  // A reattach reaches the spawner too, and the muse in that pane is already running with what it
+  // read at its own start — so re-recording could only move the entitlement of a session that
+  // cannot act on the change, from a reconnect that may not even carry the right directory.
+  it("does not re-record for a session it is only reattaching", () => {
+    reattaching = true;
+    recorded = ["render"];
+    spawn(["media"]);
+    expect(rememberEntitledToolGroups).not.toHaveBeenCalled();
+  });
+
+  // Unless this process knows nothing about it — the server-restart case, where the record is the
+  // only answer the bridge can be given at all.
+  it("records for a reattached session this process has no record of", () => {
+    reattaching = true;
+    recorded = [];
+    spawn(["render"]);
+    expect(rememberEntitledToolGroups).toHaveBeenCalledWith(ID, ["render"]);
   });
 
   it("records exactly the groups the directory registered, against this session", () => {


### PR DESCRIPTION
Muse cells reach the GUI tools their directory switched on. This is the piece the last PR said was impossible, and the reason it looked impossible was a wrong premise: Muse does have MCP, behind its own experimental flag, through a mechanism neither of the other two agents uses.

## Verified end to end

Against a real server and a real cell (`muse-bin 0.1.0-R708.1`, 2026-08-06), in a directory with only `render` registered — a cell asked what tools it had and answered:

```
mcp__plugin_mulmoterminal_render__presentChart
mcp__plugin_mulmoterminal_render__presentDocument
mcp__plugin_mulmoterminal_render__presentForm
mcp__plugin_mulmoterminal_render__presentHtml
```

…and only those: `data`, `media` and `external` stood down, as the directory's switches say they should. A `presentChart` call then wrote a real `artifacts/charts/2026/08/museworks-*.chart.json` into that session's own workspace, with the server logging all four bridges resolving to the right session id.

## Why Muse is a third shape, not a variant

**Registration is per machine.** `muse plugins install` copies the bundle into a content-addressed cache and records it for the user; `--scope project` writes nothing into the project (measured — installing from one directory left it untouched and the plugin listed from another). So the registration cannot express "this directory gets render". One `mulmoterminal` plugin therefore declares all four group servers, and the narrowing happens per session.

**Nothing reaches a plugin's MCP server but its command line.** It is started with a curated environment — measured at exactly 16 variables, all of Muse's own (`MUSE_PLUGIN_ROOT`, `PATH`, `HOME`, `TMPDIR`, …). Neither the muse process's environment nor an `env` block in the manifest arrives; both were tried, and both fail *silently*, which is the whole difficulty. So the group and the port go in argv, and the session is **asked for**.

**The session is resolved from the process tree.** `POST /api/mcp-resolve` takes the bridge's own pid, walks its ancestors, and matches them against `tmux list-panes` — whose session name is the id this server minted. That is exact: it tells two Muse cells in ONE directory apart, which nothing else could. The cwd is a fallback for a session not under tmux, and it is trusted only when it names exactly one live muse session; otherwise the answer is `null` and the bridge serves nothing. A wrong session would draw one cell's chart in another, so refusing is the better failure.

**A group the session is not entitled to serves an EMPTY toolset**, not an error. Muse starts all four servers for every session; erroring would show three broken servers in a cell that switched one group on, which reads as a broken app.

## The bug that hid all of this

`POST /api/mcp/resolve` is one segment, so `/api/mcp/:sessionId` — registered first — swallowed it and answered `400 invalid sessionId`. The bridge treats an unreachable resolve as "no session" and stands down, so the whole feature failed by serving zero tools **with nothing logged anywhere**. It survived every green test run and was caught only by running the bridge by hand against a live server. The route is now `/api/mcp-resolve`, and it logs both outcomes — an unresolved bridge is otherwise indistinguishable from an agent that was never given any tools.

## What else changed

- `server/agents/muse-mcp.ts` — generates the bundle, installs and approves it through muse's own CLI (never writing into muse's store), and stamps what it installed so an unchanged manifest spawns no subprocess at all. A changed bridge path or port rewrites the manifest, which re-installs and re-approves — the trust is keyed to the definition hash.
- `server/mcp/bridge.mjs` — `--group` / `--port` in argv, resolve-once-per-process (the promise is cached, not the result: three concurrent `tools/list` otherwise asked three times, caught by the spec), and the stand-down replies.
- `server/session/bridge-session.ts` — the pure resolution rule, plus the per-session entitlement recorded at spawn and dropped when the session is reaped.
- `server/infra/process-tree.ts`, `tmuxPanePids()` — the walk and the pane map, both bounded and both spec'd.
- The launcher form now offers Muse the same four per-group toggles as Grok and Antigravity, instead of "Muse has no GUI MCP bridge".
- README's "MCP server ids" table gains the third route; CLAUDE.md gains the section, including the two things not to re-try (per-directory install, an env var for the bridge).

## Checks

`yarn typecheck`, `yarn lint` (0 errors), `yarn test` — **9088 passed, 45 skipped**, with 40 new assertions across `muse-mcp.spec.ts`, `bridge-session.spec.ts`, `spawn-muse-mcp.spec.ts`, the muse half of `directory-mcp-ws-agent.spec.ts`, and the bridge and tmux specs. `knip` and `jscpd` report nothing new.

## Two things to know before merging

- **The flag is experimental.** `muse plugins` answers "plugins are not available in this build" without `MUSE_EXPERIMENTAL_PLUGINS=1`, and any update can rename or drop it. Every failure path here degrades to "no GUI tools" with one warning, never to a session that will not start.
- **The plugin is machine-wide.** It appears in `muse plugins list` for every Muse session on the machine, including ones MulmoTerminal did not start — those resolve to no session and serve nothing. Removing it is `muse plugins remove mulmoterminal`; the next Muse cell re-registers it.

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Muse support for GUI MCP tools through automatic plugin setup.
  * Muse sessions now receive directory-based tool groups with per-group access controls.
  * Added automatic session discovery for reliable tool availability across workspaces and projects.
  * Muse now displays the same MCP group toggles as supported agents.
  * Sessions without authorized tools continue operating normally with an empty tool list.
  * Plugin configuration updates are applied automatically when Muse sessions start or reconnect.

* **Documentation**
  * Updated MCP setup guidance, Muse configuration requirements, tool naming, and agent comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->