### PR TITLE
fix: Windows で appendSystemPrompt が Claude を起動不能にするのを直す (#1516)

### DIFF
--- a/plans/fix-1516-append-system-prompt-windows.md
+++ b/plans/fix-1516-append-system-prompt-windows.md
@@ -79,16 +79,21 @@ PR の matrix は ubuntu/macOS のみだが、**今回の見逃しはそこで�
 フラグ名は `claude-args.ts` に残す（`--append-system-prompt` と `--append-system-prompt-file` は
 別フラグなので、値だけでなく「どちらか」が伝わる必要がある）。判別可能な値を返す。
 
-### 2. `sessionIdFromFileName` を一般化する
+### 2. `sessionIdFromFileName` に新しい名前を教える
 
 今は `.json` 固定で `-mcp` だけを剥がす。プロンプトファイル（`.txt`）を足すと**孤児掃除の対象から
-漏れる**。拡張子と接尾辞を集合にして、新しい種類を足したら自動的に掃除対象になる形にする。
-`cleanupSessionSettings` にも追加する。
+漏れる**。`cleanupSessionSettings` にも追加する。
+
+一度「拡張子の集合 × 接尾辞の集合」という直積で書いたが、これは Codex レビューの指摘どおり**広すぎた**:
+こちらが一度も書かない `<id>.txt` まで一致してしまい、「自分が書いたものだけ消す」という既存の不変
+条件を弱める。**書く名前そのもの**（`<id>.json` / `<id>-mcp.json` / `<id>-prompt.txt`）を列挙する形に
+直した。
 
 ### 3. `claude-args.ts` — 受け取った形に応じてフラグを置く
 
-pure builder のまま。ファイル書き込みは呼び出し側（`spawn-claude.ts`）が既に
-`settingsArgument` / `mcpConfigArgument` でやっているのと同じ位置で行う。
+pure builder のまま。ファイルを書くのは `session-settings.ts` の `appendedPromptArgument` 自身で、
+`settingsArgument` / `mcpConfigArgument` と同じ。`spawn-claude.ts` はそれを**呼ぶ**だけで、書き込みは
+しない — 既に他の2つを呼んでいるのと同じ位置に並べる、という意味。
 
 ## テスト
 
@@ -97,4 +102,7 @@ pure builder のまま。ファイル書き込みは呼び出し側（`spawn-cla
 - **横断テスト**: Windows の spawn が作る引数の**すべて**がコマンドラインに載せられること。将来
   複数行を運ぶフラグが増えたら、ユーザーではなくテストが落ちる
 - `appendedPromptArgument` の単体テスト（win32 はファイル・パスを返す / それ以外は inline）
-- 孤児掃除がプロンプトファイルも拾うこと
+- プロンプトを改行込みで verbatim に書くこと
+- **消える経路すべて**: reap（`cleanupSessionSettings`）、spawn 失敗（`withSettingsCleanup`）、
+  起動時の孤児掃除（`pruneOrphanSettings`）
+- 書かない名前（`<id>.txt` / `<id>-prompt.json` / `<id>-other.txt`）を掃除しないこと

--- a/plans/fix-1516-append-system-prompt-windows.md
+++ b/plans/fix-1516-append-system-prompt-windows.md
@@ -1,0 +1,100 @@
+# fix: Windows で appendSystemPrompt が Claude セッションを起動不能にする（#1516）
+
+## User Prompt
+
+> https://github.com/receptron/mulmoterminal/issues/1516
+> 現象を ci 上で調査して、対策できるなら対策をしてほしい。windows の特定の条件のときに、、。
+> CR・LF・NUL を append-system-prompt で escape すればよい？ escape の副作用ってないかな？
+> きちんと調べて adhoc じゃなくて根本を直してね
+
+## 質問への回答: escape はできない。そして「代用」には副作用がある
+
+**Windows のコマンドラインには CR・LF・NUL を表す方法が存在しない。** CR/LF は行を終わらせ、NUL は
+文字列を終わらせる。cmd.exe の `^` は行継続であって、改行を引数の中に入れる手段ではない。つまり
+`escapeBatchArgument` に「エスケープ規則を足す」という直し方は取れない。あの throw は正しい。
+
+やれるのは escape ではなく **置換**（改行を `\n` というリテラルや空白に変える）で、これには副作用が
+ある:
+
+- 渡している本文は markdown（見出し・箇条書き・段落）で、改行を潰すと**別の文章**になる。箇条書きが
+  1行に連結され、見出しが本文に混ざる
+- system prompt は「エージェントへの指示」なので、内容が変わるとは**指示が変わる**ということ。これは
+  `cmd-escape.ts` が明示的に避けている失敗そのもの:
+  「Thrown rather than silently mangled: a truncated argument reaches the agent as a DIFFERENT
+  instruction.」
+- しかも壊れ方が静か。起動は成功するので、誰も気づかないまま全 Windows セッションが変質した指示で
+  走る。今の「起動に失敗する」より悪い
+
+なので根本の直し方は「引数に載せるのをやめる」。
+
+## 根本原因: このリポジトリには既に規則があり、この1箇所だけ従っていない
+
+`server/session/session-settings.ts` に同じ問題の答えが既にある:
+
+> Windows has a second, unrelated reason to use a file: there, a `.cmd`-installed Claude is
+> launched through cmd.exe (#798), so a JSON argument is parsed by cmd and then by the child's
+> CRT, and the two disagree about quoting. **A path has no quotes and no metacharacters, which
+> removes that layer rather than escaping through it** (#813).
+
+`--settings`（#579, #813）と `--mcp-config` は Windows でファイル渡しになっている
+（`mustUseFile = secret || platform === "win32"`）。
+
+`--append-system-prompt` は #942 で後から追加され（mulmoterminal v2.3.0）、**この規則に従わなかった
+唯一の引数**。しかも中身は既定で 44 行・2562 文字の複数行プリセットなので、Windows の `.cmd`
+インストールでは必ず落ちる。報告どおり v2.3.0 以降ずっと再現する。
+
+`claude-args.ts` には inline を選んだ理由が書かれている:
+
+> Inline, not --append-system-prompt-file: the sandbox spawn runs in a container that cannot
+> read a host path
+
+**この前提は既に消えている。** Docker sandbox は #1195（`6752e1a8 feat: remove the Docker sandbox`）で
+削除済み。理由が無くなったまま選択だけが残っていた。
+
+## 事実確認したこと
+
+- `--append-system-prompt-file` は実在し、**複数行ファイルを読む**（claude 2.1.223 で実測。印を仕込んだ
+  ファイルを渡して応答が変わることと、フラグ無しでは変わらないことの両方を確認）
+- 追加時期は claude **2.0.0 → 2.1.0 の間**（npm の各版の `cli.js` を grep して確認）。それより古い
+  claude では未知のフラグになるが、**そのユーザーは今すでに起動できない**ので後退にはならない
+- 再現はプラットフォーム非依存に書ける。`resolvePtyLaunch` は platform と `fileExists` を注入できるので、
+  macOS 上で `UnsafeArgumentError` を再現できた
+
+## CI 側の穴
+
+Windows CI は**存在し、`yarn test` まで回って green**（`.github/workflows/windows-daily.yaml`）。
+PR の matrix は ubuntu/macOS のみだが、**今回の見逃しはそこではない** — この不変条件を検査する
+テストが1つも無かった。
+
+だから追加するテストは Windows ランナーを必要としない形にする。platform を注入すれば
+**PR ごとの ubuntu/macOS の CI で落ちる**。日次 Windows ジョブを待つ必要はない。
+
+## 修正
+
+### 1. `session-settings.ts` — 規則を持っているモジュールに追加する
+
+`appendedPromptArgument(sessionId, prompt, platform)` を `settingsArgument` / `mcpConfigArgument` の
+隣に置く。inline か file かを決めるのはこのモジュールの役目で、`mustUseFile` をそのまま使う。
+
+フラグ名は `claude-args.ts` に残す（`--append-system-prompt` と `--append-system-prompt-file` は
+別フラグなので、値だけでなく「どちらか」が伝わる必要がある）。判別可能な値を返す。
+
+### 2. `sessionIdFromFileName` を一般化する
+
+今は `.json` 固定で `-mcp` だけを剥がす。プロンプトファイル（`.txt`）を足すと**孤児掃除の対象から
+漏れる**。拡張子と接尾辞を集合にして、新しい種類を足したら自動的に掃除対象になる形にする。
+`cleanupSessionSettings` にも追加する。
+
+### 3. `claude-args.ts` — 受け取った形に応じてフラグを置く
+
+pure builder のまま。ファイル書き込みは呼び出し側（`spawn-claude.ts`）が既に
+`settingsArgument` / `mcpConfigArgument` でやっているのと同じ位置で行う。
+
+## テスト
+
+- **回帰テスト（落ちることを確認してから直す）**: 既定の appendedSystemPrompt → `buildClaudeArgs` →
+  `resolvePtyLaunch(platform: "win32", .cmd shim)` が throw しないこと
+- **横断テスト**: Windows の spawn が作る引数の**すべて**がコマンドラインに載せられること。将来
+  複数行を運ぶフラグが増えたら、ユーザーではなくテストが落ちる
+- `appendedPromptArgument` の単体テスト（win32 はファイル・パスを返す / それ以外は inline）
+- 孤児掃除がプロンプトファイルも拾うこと

--- a/server/agents/claude-args.ts
+++ b/server/agents/claude-args.ts
@@ -7,6 +7,8 @@
 // made a parameter: no caller would set it, and a one-valued flag is the weld waiting to be
 // re-made. `rate-limit-probe.ts` still passes it, for a different and measured reason.
 
+import type { AppendedPromptArgument } from "../session/session-settings.js";
+
 export interface ClaudeArgsInput {
   sessionId: string;
   resume: string | null;
@@ -36,23 +38,34 @@ export interface ClaudeArgsInput {
   // Extra directories the session may read/edit (#908). Absolute, existing, deduped by the
   // config layer — this builder only places them.
   addDirs?: string[] | null | undefined;
-  // What `--append-system-prompt` carries, already assembled (see appended-prompt.ts), or null
-  // when every section of it is switched off — the flag is then left out entirely. Resolved by
-  // the caller: which sections apply is a config decision, and this builder only places argv.
+  // What `--append-system-prompt` carries, already assembled (see appended-prompt.ts) AND already
+  // placed — inline, or in a file whose path this passes instead (see appendedPromptArgument).
+  // Null when every section of it is switched off, and the flag is then left out entirely.
+  // Resolved by the caller: which sections apply is a config decision, where the text may travel
+  // is a platform one, and this builder only places argv.
   //
   // Required, unlike the other optional fields: they default to adding nothing, while forgetting
   // this one would silently drop an instruction every session used to carry. A new spawn path has
   // to answer for it, and `null` is how it says no. `undefined` is in the type but the KEY is
   // still mandatory — a value that was never resolved can arrive, but a caller cannot omit it.
-  appendedPrompt: string | null | undefined;
+  appendedPrompt: AppendedPromptArgument | null | undefined;
 }
 
 export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
   const guiArgs = ["--permission-mode", input.permissionMode];
-  // Inline, not --append-system-prompt-file: the sandbox spawn runs in a container that cannot
-  // read a host path, which is why --settings is already passed inline too. A prompt this size
-  // is nowhere near the tmux arg limit that forced the seed prompt out of the argv (#942).
-  if (input.appendedPrompt) guiArgs.push("--append-system-prompt", input.appendedPrompt);
+  // Two flags for one setting, because Claude Code names the file form separately. Which one is
+  // not this builder's call — a Windows command line cannot carry the newlines this text has, so
+  // there the caller writes a file and sends its path (#1516, session-settings.ts).
+  //
+  // The inline form was once the only one, on the grounds that the Docker sandbox could not read
+  // a host path. That sandbox is gone (#1195), so the file form costs nothing anywhere.
+  if (input.appendedPrompt) {
+    const { kind } = input.appendedPrompt;
+    guiArgs.push(
+      kind === "file" ? "--append-system-prompt-file" : "--append-system-prompt",
+      kind === "file" ? input.appendedPrompt.path : input.appendedPrompt.text,
+    );
+  }
   if (input.model) guiArgs.push("--model", input.model);
   // --mcp-config ADDS our broker; it does not replace anything. `--strict-mcp-config` used to
   // ride along on this same line, and that is what made "give this session the GUI panel" also

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -130,21 +130,24 @@ function isOlderThan(file: string, cutoff: number): boolean {
   }
 }
 
-// `<id>.json` and `<id>-mcp.json` are the two we write, and `<id>` is always a session id —
-// every caller takes one from randomUUID() or a SESSION_ID_RE match. Requiring that shape is
-// what keeps this from deleting a file that merely happens to end in `.json`: the directory
-// is ours, but "ours" is not a good enough reason to remove something we did not write.
-// Every file kind a session can leave in this directory, as the pieces its name is built from.
-// The sweep reads the id back out through these, so a kind missing from the lists is a file
-// nothing ever collects — which is what a plain `.json`-only rule did to the prompt file (#1516).
-const FILE_EXTENSIONS = [".json", ".txt"] as const;
-const FILE_SUFFIXES = ["-mcp", "-prompt"] as const;
+// Every name a session writes here, WHOLE — not a set of extensions crossed with a set of
+// suffixes. `<id>` is always a session id (every caller takes one from randomUUID() or a
+// SESSION_ID_RE match), and requiring the exact shape is what keeps this from deleting a file that
+// merely happens to end in `.json` or `.txt`: the directory is ours, but "ours" is not a good
+// enough reason to remove something we did not write. A cross-product would have swept `<id>.txt`,
+// which nothing here produces.
+//
+// A file kind missing from this list is one nothing ever collects — which is what a `.json`-only
+// rule did to the prompt file (#1516). Add the kind here when you add the writer.
+const FILE_ENDINGS = [".json", "-mcp.json", "-prompt.txt"] as const;
 
 function sessionIdFromFileName(name: string): string | null {
-  const extension = FILE_EXTENSIONS.find((candidate) => name.endsWith(candidate));
-  if (!extension) return null;
-  const stem = name.slice(0, -extension.length);
-  const suffix = FILE_SUFFIXES.find((candidate) => stem.endsWith(candidate));
-  const id = suffix ? stem.slice(0, -suffix.length) : stem;
-  return SESSION_ID_RE.test(id) ? id : null;
+  // First ending whose remainder is a session id wins: `<id>-mcp.json` also ends in `.json`, and
+  // the id check is what rejects that reading before `-mcp.json` gets its turn.
+  for (const ending of FILE_ENDINGS) {
+    if (!name.endsWith(ending)) continue;
+    const id = name.slice(0, -ending.length);
+    if (SESSION_ID_RE.test(id)) return id;
+  }
+  return null;
 }

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -19,6 +19,7 @@ const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
 
 const settingsFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}.json`);
 const mcpConfigFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-mcp.json`);
+const appendedPromptFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-prompt.txt`);
 
 // Windows has a second, unrelated reason to use a file: there, a `.cmd`-installed Claude is
 // launched through cmd.exe (#798), so a JSON argument is parsed by cmd and then by the
@@ -44,6 +45,23 @@ export function mcpConfigArgument(sessionId: string, json: string, platform: Nod
   return mustUseFile(false, platform) ? writePrivate(mcpConfigFile(sessionId), json) : json;
 }
 
+/** Where `--append-system-prompt`'s text travels. Its own type because Claude Code names the two
+ *  forms with DIFFERENT flags, unlike `--settings`, which takes either. */
+export type AppendedPromptArgument = { kind: "inline"; text: string } | { kind: "file"; path: string };
+
+// And the same again for the appended system prompt — with a harder version of the Windows
+// reason. The other two are merely awkward to quote through cmd.exe; this one is impossible: a
+// Windows command line has no encoding for a newline at all (CR/LF end the line), and the text is
+// a MULTI-LINE preset by default, so escapeBatchArgument refused it and every Claude session on a
+// `.cmd` install failed to start (#1516).
+//
+// There is nothing to escape it INTO. Substituting the newlines away would hand the agent a
+// different instruction, which is the exact failure cmd-escape.ts throws to prevent — so the
+// answer is the one already used above: give Claude Code the path and let it read the file.
+export function appendedPromptArgument(sessionId: string, prompt: string, platform: NodeJS.Platform = process.platform): AppendedPromptArgument {
+  return mustUseFile(false, platform) ? { kind: "file", path: writePrivate(appendedPromptFile(sessionId), prompt) } : { kind: "inline", text: prompt };
+}
+
 // Run a spawn, taking the session's settings file with it if the spawn throws. A session
 // that never starts never reaches reap(), where the cleanup normally happens — so without
 // this a failed spawn leaves a token-bearing file behind (#579).
@@ -60,6 +78,7 @@ export function withSettingsCleanup<T>(sessionId: string, spawn: () => T): T {
 export function cleanupSessionSettings(sessionId: string): void {
   removeQuietly(settingsFile(sessionId));
   removeQuietly(mcpConfigFile(sessionId));
+  removeQuietly(appendedPromptFile(sessionId));
 }
 
 /** Drop settings files left behind by a server that never got to reap.
@@ -115,9 +134,17 @@ function isOlderThan(file: string, cutoff: number): boolean {
 // every caller takes one from randomUUID() or a SESSION_ID_RE match. Requiring that shape is
 // what keeps this from deleting a file that merely happens to end in `.json`: the directory
 // is ours, but "ours" is not a good enough reason to remove something we did not write.
+// Every file kind a session can leave in this directory, as the pieces its name is built from.
+// The sweep reads the id back out through these, so a kind missing from the lists is a file
+// nothing ever collects — which is what a plain `.json`-only rule did to the prompt file (#1516).
+const FILE_EXTENSIONS = [".json", ".txt"] as const;
+const FILE_SUFFIXES = ["-mcp", "-prompt"] as const;
+
 function sessionIdFromFileName(name: string): string | null {
-  if (!name.endsWith(".json")) return null;
-  const stem = name.slice(0, -".json".length);
-  const id = stem.endsWith("-mcp") ? stem.slice(0, -"-mcp".length) : stem;
+  const extension = FILE_EXTENSIONS.find((candidate) => name.endsWith(candidate));
+  if (!extension) return null;
+  const stem = name.slice(0, -extension.length);
+  const suffix = FILE_SUFFIXES.find((candidate) => stem.endsWith(candidate));
+  const id = suffix ? stem.slice(0, -suffix.length) : stem;
   return SESSION_ID_RE.test(id) ? id : null;
 }

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -33,7 +33,7 @@ import { repoRootSync } from "../git/repo-root-sync.js";
 import { workdirFooter } from "../git/pr-footer.js";
 import { getProviders } from "../config/config-routes.js";
 import { requireResolution, resolveProvider, type DirModelChoice } from "./provider-env.js";
-import { settingsArgument, mcpConfigArgument, withSettingsCleanup } from "./session-settings.js";
+import { settingsArgument, mcpConfigArgument, appendedPromptArgument, withSettingsCleanup, type AppendedPromptArgument } from "./session-settings.js";
 import { ensureDropsDir } from "./session-drops.js";
 import { effectiveChoice } from "./launch-choice.js";
 import { customAgentLaunch } from "./custom-agent-command.js";
@@ -77,10 +77,15 @@ function sessionWorkdirFooter(cwd: string): string | null {
   return root ? workdirFooter(root) : null;
 }
 
-// What `--append-system-prompt` carries for this session (#1062). Every source is read per spawn,
-// so switching any section off needs no restart.
-function sessionAppendedPrompt(cwd: string, dirSetting: boolean | null): string | null {
-  return appendedSystemPrompt({ dirSetting, globalSetting: getAppendSystemPrompt(), workdirFooter: sessionWorkdirFooter(cwd) });
+// What `--append-system-prompt` carries for this session (#1062), and where it travels. Every
+// source is read per spawn, so switching any section off needs no restart.
+//
+// The placement happens here, beside the other two arguments a Windows spawn has to send as a
+// path (settingsArgument / mcpConfigArgument): the text is multi-line, and a Windows command line
+// cannot carry a newline at all (#1516).
+function sessionAppendedPrompt(sessionId: string, cwd: string, dirSetting: boolean | null): AppendedPromptArgument | null {
+  const prompt = appendedSystemPrompt({ dirSetting, globalSetting: getAppendSystemPrompt(), workdirFooter: sessionWorkdirFooter(cwd) });
+  return prompt === null ? null : appendedPromptArgument(sessionId, prompt);
 }
 
 // The sidebar row a session gets before it has a transcript. A session spawned to run something
@@ -236,7 +241,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       // that path never went through our allowlist before.
       allowedTools: fullGuiMcp ? fullGuiAllowedTools(deps.guiMcpTools, getUserMcpServers()) : deps.gridMcpTools,
       addDirs,
-      appendedPrompt: sessionAppendedPrompt(cwd, dir.appendSystemPrompt),
+      appendedPrompt: sessionAppendedPrompt(sessionId, cwd, dir.appendSystemPrompt),
     });
 
     console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -14,7 +14,7 @@ const base: ClaudeArgsInput = {
   allowedTools: "mcp__gui__a,mcp__gui__b",
   // What a default spawn resolves to (appended-prompt.ts). The builder treats it as opaque
   // text; the real constant is used here so the asserted argv is the one that ships.
-  appendedPrompt: SESSION_SUMMARY_PROMPT,
+  appendedPrompt: { kind: "inline", text: SESSION_SUMMARY_PROMPT },
 };
 
 const cfg = (over: Partial<ClaudeArgsInput> = {}): ClaudeArgsInput => ({ ...base, ...over });
@@ -160,6 +160,19 @@ describe("appended system prompt", () => {
     ["every section is switched off", null],
     ["nothing was resolved at all", undefined],
   ])("omits the flag entirely when %s", (_case, appendedPrompt) => {
-    expect(buildClaudeArgs(cfg({ appendedPrompt }))).not.toContain("--append-system-prompt");
+    const args = buildClaudeArgs(cfg({ appendedPrompt }));
+    // Both spellings: the file form is a separate flag, so checking only the inline one would
+    // pass on an argv that still carried the prompt (#1516).
+    expect(args).not.toContain("--append-system-prompt");
+    expect(args).not.toContain("--append-system-prompt-file");
+  });
+
+  // The file form names a path, so it needs the OTHER flag — passing a path under
+  // `--append-system-prompt` would append the literal string "C:\\…\\x-prompt.txt".
+  it("names the file flag when the prompt travels as a path", () => {
+    const args = buildClaudeArgs(cfg({ appendedPrompt: { kind: "file", path: "C:\\s\\x-prompt.txt" } }));
+    expect(args).toContain("--append-system-prompt-file");
+    expect(args[args.indexOf("--append-system-prompt-file") + 1]).toBe("C:\\s\\x-prompt.txt");
+    expect(args).not.toContain("--append-system-prompt");
   });
 });

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -249,14 +249,18 @@ describe("pruneOrphanSettings", () => {
     expect(existsSync(path.join(dir, `${ALIVE}-prompt.txt`))).toBe(true);
   });
 
-  // The guard that keeps this from clearing out a directory that is ours but not only ours.
-  it("still ignores a name that is not a session file", () => {
-    const dir = tmpDir();
-    write(dir, "notes.txt");
-    write(dir, "README.json");
-    expect(pruneOrphanSettings(new Set(), dir)).toEqual([]);
-    expect(existsSync(path.join(dir, "notes.txt"))).toBe(true);
-  });
+  // The guard that keeps this from clearing out a directory that is ours but not only ours —
+  // including a name that is a session id in a shape we never write. Widening the parser by
+  // crossing extensions with suffixes would have swept `<id>.txt`, which nothing here produces.
+  it.each([["notes.txt"], ["README.json"], [`${DEAD}.txt`], [`${DEAD}-prompt.json`], [`${DEAD}-other.txt`]])(
+    "leaves %s alone — not a name a session writes",
+    (name) => {
+      const dir = tmpDir();
+      write(dir, name);
+      expect(pruneOrphanSettings(new Set(), dir)).toEqual([]);
+      expect(existsSync(path.join(dir, name))).toBe(true);
+    },
+  );
 
   // The field incident (#1061): on Windows there is no tmux, so `liveIds` is empty and every
   // settings file read as a leftover — including the eight belonging to a peer's LIVE sessions.

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -80,6 +80,22 @@ describe("withSettingsCleanup", () => {
     expect(withSettingsCleanup(SESSION, () => "entry")).toBe("entry");
     expect(existsSync(fileFor(SESSION))).toBe(true);
   });
+
+  // The prompt file is written while argv is being built, so a spawn that throws afterwards
+  // leaves it behind exactly as the settings file used to (#1516). Every file kind a Windows
+  // spawn writes has to come back out on this path, not just the one it was written for.
+  it("removes every file a Windows spawn wrote when it throws", () => {
+    settingsArgument(SESSION, "{}", false, "win32");
+    mcpConfigArgument(SESSION, "{}", "win32");
+    appendedPromptArgument(SESSION, "first line\nsecond line", "win32");
+    expect([fileFor(SESSION), mcpFileFor(SESSION), promptFileFor(SESSION)].every(existsSync)).toBe(true);
+    expect(() =>
+      withSettingsCleanup(SESSION, () => {
+        throw new Error("spawn failed");
+      }),
+    ).toThrow(/spawn failed/);
+    expect([fileFor(SESSION), mcpFileFor(SESSION), promptFileFor(SESSION)].filter(existsSync)).toEqual([]);
+  });
 });
 
 describe("cleanupSessionSettings", () => {

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -11,7 +11,9 @@ import {
   mcpConfigArgument,
   withSettingsCleanup,
   pruneOrphanSettings,
+  appendedPromptArgument,
 } from "../../../server/session/session-settings.js";
+import { resolvePtyLaunch } from "../../../server/infra/resolve-bin.js";
 import { hookSettingsJson } from "../../../server/session/hook-settings.js";
 import { buildClaudeArgs } from "../../../server/agents/claude-args.js";
 import { appendedSystemPrompt } from "../../../server/agents/appended-prompt.js";
@@ -19,6 +21,7 @@ import { appendedSystemPrompt } from "../../../server/agents/appended-prompt.js"
 const SESSION = "settings-spec-session";
 const fileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}.json`);
 const mcpFileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}-mcp.json`);
+const promptFileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}-prompt.txt`);
 
 afterEach(() => cleanupSessionSettings(SESSION));
 
@@ -121,27 +124,47 @@ describe("the Windows reason for a file", () => {
 
   // reap() calls this once per session; it has to take BOTH files or the mcp one outlives
   // every Windows session.
-  it("cleans up both files", () => {
+  it("cleans up every file a session wrote", () => {
     settingsArgument(SESSION, json, false, "win32");
     mcpConfigArgument(SESSION, "{}", "win32");
+    appendedPromptArgument(SESSION, "line one\nline two", "win32");
     cleanupSessionSettings(SESSION);
     expect(existsSync(fileFor(SESSION))).toBe(false);
     expect(existsSync(mcpFileFor(SESSION))).toBe(false);
+    expect(existsSync(promptFileFor(SESSION))).toBe(false);
+  });
+
+  // The whole point of the file: the newlines survive it, which is what the command line
+  // could not do.
+  it("writes the prompt verbatim, newlines and all", () => {
+    const written = appendedPromptArgument(SESSION, "line one\nline two\n", "win32");
+    expect(written).toEqual({ kind: "file", path: promptFileFor(SESSION) });
+    if (written.kind !== "file") throw new Error("expected a file");
+    expect(readFileSync(written.path, "utf8")).toBe("line one\nline two\n");
   });
 });
 
-// The property that makes #813 impossible, stated once over the arguments a real spawn
-// builds: with the two JSON payloads travelling as files, NOTHING claude is launched with
-// contains a quote — so no parser downstream, however unforgiving, has anything to lose.
+// What a real Windows spawn produces, asserted against the thing that actually decides —
+// cmd-escape, through the resolver that calls it. Stating it here rather than per flag is the
+// point: #813 was a quote, #1516 was a newline in a flag added two years later, and a test that
+// checks the characters it happens to know about only ever catches the bug it was written for.
 describe("the argv a Windows spawn ends up with", () => {
-  it("contains no quote at all once the JSON payloads are files", () => {
+  // An npm-global install: `claude` on PATH is a .cmd shim, so the launch goes through cmd.exe.
+  const asWindowsLaunch = (args: string[]) =>
+    resolvePtyLaunch("claude", args, "win32", "C:\\npm;C:\\Windows\\System32", "C:\\Windows\\System32\\cmd.exe", (candidate) =>
+      /claude\.cmd$|cmd\.exe$/i.test(candidate),
+    );
+
+  const windowsSpawnArgs = () => {
     const settings = settingsArgument(SESSION, hookSettingsJson({ host: "127.0.0.1", port: 34567, sessionId: SESSION }), false, "win32");
     const mcpConfig = mcpConfigArgument(
       SESSION,
       JSON.stringify({ mcpServers: { "mulmoterminal-gui": { type: "http", url: "http://127.0.0.1:34567/api/mcp/x" } } }),
       "win32",
     );
-    const args = buildClaudeArgs({
+    // Both sections on, exactly as a default spawn resolves them: 40-odd lines of markdown.
+    const prompt = appendedSystemPrompt({ dirSetting: null, globalSetting: true, workdirFooter: "work in mulmoterminal2" });
+    return buildClaudeArgs({
       model: null,
       sessionId: SESSION,
       resume: null,
@@ -151,11 +174,34 @@ describe("the argv a Windows spawn ends up with", () => {
       attachGuiMcp: true,
       mcpConfig,
       allowedTools: "mulmoterminal_readXPost,mulmoterminal_searchX",
-      // Resolved as a real spawn resolves it, both sections on — this argument is prose written
-      // by hand, so it is the one most likely to grow a quote (#942, #973).
-      appendedPrompt: appendedSystemPrompt({ dirSetting: null, globalSetting: true, workdirFooter: "work in mulmoterminal2" }),
+      appendedPrompt: prompt === null ? null : appendedPromptArgument(SESSION, prompt, "win32"),
     });
-    expect(args.filter((a) => a.includes('"'))).toEqual([]);
+  };
+
+  // The regression itself (#1516): every Claude session on a .cmd install failed to start,
+  // because the appended prompt is multi-line and a command line cannot encode a newline.
+  it("can actually be put on a command line", () => {
+    expect(() => asWindowsLaunch(windowsSpawnArgs())).not.toThrow();
+  });
+
+  // Named individually so a failure says WHICH argument, not just that the line was refused.
+  it("carries no argument a command line cannot represent", () => {
+    const unrepresentable = windowsSpawnArgs().filter((arg) => /[\0\r\n]/.test(arg));
+    expect(unrepresentable).toEqual([]);
+  });
+
+  // #813: with every large payload travelling as a path, nothing claude is launched with holds a
+  // quote — so no parser downstream, however unforgiving, has anything to lose.
+  it("contains no quote at all once the payloads are files", () => {
+    expect(windowsSpawnArgs().filter((a) => a.includes('"'))).toEqual([]);
+  });
+
+  // The prompt reaches the session either way; only the flag differs. Off Windows it stays inline,
+  // so nothing about the common path changed.
+  it("sends the prompt by path on Windows and inline everywhere else", () => {
+    expect(windowsSpawnArgs()).toContain("--append-system-prompt-file");
+    const prompt = appendedSystemPrompt({ dirSetting: null, globalSetting: true, workdirFooter: null });
+    expect(appendedPromptArgument(SESSION, prompt ?? "", "darwin")).toEqual({ kind: "inline", text: prompt });
   });
 });
 
@@ -176,13 +222,18 @@ describe("pruneOrphanSettings", () => {
   const DEAD = "11111111-2222-3333-4444-555555555555";
   const ALIVE = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
-  it("drops both files of a session that did not survive", () => {
+  // EVERY file kind, not just the two that existed when this was written: the sweep reads the
+  // session id back out of the name, so a kind the parser does not know is one nothing ever
+  // collects. The prompt file is `.txt`, which a `.json`-only rule silently skipped (#1516).
+  it("drops every file of a session that did not survive", () => {
     const dir = tmpDir();
     write(dir, `${DEAD}.json`);
     write(dir, `${DEAD}-mcp.json`);
-    expect(pruneOrphanSettings(new Set(), dir).sort()).toEqual([`${DEAD}-mcp.json`, `${DEAD}.json`]);
+    write(dir, `${DEAD}-prompt.txt`);
+    expect(pruneOrphanSettings(new Set(), dir).sort()).toEqual([`${DEAD}-mcp.json`, `${DEAD}-prompt.txt`, `${DEAD}.json`]);
     expect(existsSync(path.join(dir, `${DEAD}.json`))).toBe(false);
     expect(existsSync(path.join(dir, `${DEAD}-mcp.json`))).toBe(false);
+    expect(existsSync(path.join(dir, `${DEAD}-prompt.txt`))).toBe(false);
   });
 
   // The whole point of the liveIds argument: a tmux-backed session is still running with the
@@ -191,9 +242,20 @@ describe("pruneOrphanSettings", () => {
     const dir = tmpDir();
     write(dir, `${ALIVE}.json`);
     write(dir, `${ALIVE}-mcp.json`);
+    write(dir, `${ALIVE}-prompt.txt`);
     expect(pruneOrphanSettings(new Set([ALIVE]), dir)).toEqual([]);
     expect(existsSync(path.join(dir, `${ALIVE}.json`))).toBe(true);
     expect(existsSync(path.join(dir, `${ALIVE}-mcp.json`))).toBe(true);
+    expect(existsSync(path.join(dir, `${ALIVE}-prompt.txt`))).toBe(true);
+  });
+
+  // The guard that keeps this from clearing out a directory that is ours but not only ours.
+  it("still ignores a name that is not a session file", () => {
+    const dir = tmpDir();
+    write(dir, "notes.txt");
+    write(dir, "README.json");
+    expect(pruneOrphanSettings(new Set(), dir)).toEqual([]);
+    expect(existsSync(path.join(dir, "notes.txt"))).toBe(true);
   });
 
   // The field incident (#1061): on Windows there is no tmux, so `liveIds` is empty and every


### PR DESCRIPTION
## Summary

Windows の `.cmd` インストールで、**全 Claude セッションが必ず起動に失敗**していました（v2.3.0 以降）。`--append-system-prompt` が運ぶのは既定で 44 行・2562 文字の複数行プリセットで、Windows のコマンドラインには改行を載せる方法が無いためです。

**このリポジトリには既に同じ問題の答えがあり、この1箇所だけが従っていませんでした。** `session-settings.ts` の `--settings` / `--mcp-config` は Windows でファイル渡しになっていて、理由も書かれています:

> **A path has no quotes and no metacharacters, which removes that layer rather than escaping through it** (#813)

`--append-system-prompt` は #942 で後から追加され、この規則の外に置かれたままでした。規則を持っているモジュールに `appendedPromptArgument` を足し、Windows では `--append-system-prompt-file` にパスを渡します。**Windows 以外は inline のままで挙動は変わりません。**

## Items to Confirm / Review

1. **「CR/LF/NUL をエスケープすればよいか」への回答は「できない」です。** Windows のコマンドラインには CR・LF・NUL を表す**符号化が存在しません**（CR/LF は行を終わらせ、NUL は文字列を終わらせる。cmd.exe の `^` は行継続であって、引数の中に改行を入れる手段ではない）。やれるのは escape ではなく**置換**で、それには副作用があります:
   - 本文は markdown（見出し・箇条書き・段落）なので、改行を潰すと**別の文章**になる
   - system prompt は指示なので、内容が変わる＝**指示が変わる**。これは `cmd-escape.ts` が明示的に避けている失敗そのもの（"a truncated argument reaches the agent as a DIFFERENT instruction"）
   - しかも**静かに壊れる**。起動は成功するので誰も気づかず、全 Windows セッションが変質した指示で走る。今の「起動に失敗する」より悪い
   
   なので `escapeBatchArgument` の throw は残し、引数に載せるのをやめました。**ここが一番レビューしてほしい判断です。**

2. **`--append-system-prompt-file` は claude 2.0.0 → 2.1.0 の間で追加されたフラグです。** それより古い claude を使う Windows ユーザーは未知のフラグでエラーになりますが、**そのユーザーは今すでに起動できない**ので後退ではありません（`appendSystemPrompt` を切っている人は今も修正後も影響なし）。バージョン検出は入れていません — 入れるべきかは判断をお願いします。
   - 実在と動作は実測で確認: 印を仕込んだ複数行ファイルを渡すと応答が変わり、フラグ無しでは変わらないこと（claude 2.1.223）。`--help` の一覧には出ませんが、バイナリにも存在します

3. **`claude-args.ts` の「inline にした理由」コメントの前提が消えていました。** 「sandbox spawn がホストのパスを読めないから」と書かれていましたが、その Docker sandbox は #1195（`6752e1a8`）で削除済みです。

4. **孤児掃除の穴も塞ぎました。** `sessionIdFromFileName` は `.json` 固定で `-mcp` だけを剥がしていたので、`.txt` のプロンプトファイルを**永久に拾えません**でした。拡張子と接尾辞を集合にして、種類を足せば掃除対象になる形にしています。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1516
> 現象を ci 上で調査して、対策できるなら対策をしてほしい。windows の特定の条件のときに、、。CR・LF・NUL を append-system-prompt で escape すればよい？ escape の副作用ってないかな？ きちんと調べて adhoc じゃなくて根本を直してね

## CI 側の調査結果

**Windows CI は存在し、`yarn test` まで回って green でした**（`.github/workflows/windows-daily.yaml`）。PR の matrix は ubuntu/macOS のみですが、**今回の見逃しの原因はそこではありません** — この不変条件を検査するテストが1つも無かったことです。

`resolvePtyLaunch` は platform と `fileExists` を注入できるので、**この不具合は Windows ランナー無しで再現できます**。実際 macOS 上で `UnsafeArgumentError` を再現しました。なので追加したテストは PR ごとの ubuntu/macOS の CI で落ちます。日次 Windows ジョブを待つ必要はありません。

（そのうえで、このブランチに対して `windows-daily` を `workflow_dispatch` で実走させ、実 Windows ランナーでも green を確認しています。）

## 実装

- `session-settings.ts` — `appendedPromptArgument(sessionId, prompt, platform)` を `settingsArgument` / `mcpConfigArgument` の隣に追加。`mustUseFile` をそのまま使う。フラグ名は `claude-args.ts` に残すため、判別可能な値（`{ kind: "inline" | "file" }`）を返す
- `claude-args.ts` — pure builder のまま、受け取った形に応じてフラグを置く
- `spawn-claude.ts` — 既に `settingsArgument` / `mcpConfigArgument` を呼んでいるのと同じ位置で配置を決める
- `cleanupSessionSettings` にプロンプトファイルを追加、`sessionIdFromFileName` を一般化

## テスト

**Windows spawn の argv を、代理指標ではなく本物の cmd-escape に通す形に変えました。** 既存テストは「引用符が無いこと」だけを見ており、#813（引用符）は捕まえられても #1516（2年後に足されたフラグの改行）は素通りでした。知っている文字だけ見るテストは、書かれたきっかけのバグしか捕まえません。

- `can actually be put on a command line` — `resolvePtyLaunch("claude", args, "win32", …)` が throw しないこと（回帰そのもの）
- `carries no argument a command line cannot represent` — どの引数が原因かが分かる形
- `contains no quote at all once the payloads are files` — #813 の維持
- `sends the prompt by path on Windows and inline everywhere else`
- プロンプトを改行込みで verbatim に書くこと / 掃除で消えること / 孤児掃除が拾うこと / セッションファイルでない名前は無視すること
- `claude-args`: ファイル形式では別フラグになること、prompt が無いときは**両方の綴り**が出ないこと

**テストに歯があることを確認済み**: 修正前の配線（Windows でも inline）に戻すと 3 件が落ち、issue と同じ `UnsafeArgumentError` が出ます。

ローカル: `yarn format` / `lint` / `typecheck` / `build` / `test`（9048 passed）。

Closes #1516

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows failures when prompts contain multiple lines or special characters.
  * Prompts now use a temporary file on Windows and continue using inline arguments on other platforms.
  * Improved cleanup of temporary prompt files, including orphaned files.

* **Tests**
  * Added coverage for Windows prompt handling, cleanup, argument validation, and cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->