### PR TITLE
fix(windows): 多行のシードプロンプトで grok / agy / muse が起動しないのを直す (#1518)

### DIFF
--- a/plans/fix-1518-seed-prompt-windows.md
+++ b/plans/fix-1518-seed-prompt-windows.md
@@ -1,0 +1,74 @@
+# fix: grok / antigravity / muse のシードプロンプトが Windows で起動を壊す（#1518）
+
+## User Prompt
+
+> （#1516 の調査中に発見。publish 後に）続きやって！！
+>
+> appendSystemPrompt が原因で起動しない、appendSystemPrompt をサポートしないなら問題ないなら、
+> 問題がある coding agent は appendSystemPrompt をサポートしない、というのもありだよ。
+> そのうえで A でよい
+
+## 診断
+
+`grok` / `antigravity` / `muse` は `initialPrompt` を **argv に直接載せる**（grok と muse は positional、
+antigravity は `--prompt-interactive` の値）。そしてシードを作る `codexifySkillSeed` 自身が改行を作る:
+
+```ts
+return rest ? `Use the "${slug}" skill.\n\n${rest}` : `Use the "${slug}" skill.`;
+```
+
+**引数付きスキルなら必ず多行**になるので、Windows の `.cmd` インストールでは毎回
+`UnsafeArgumentError` で起動に失敗する。#1516 と同じバグ族。
+
+## 検討して却下した案（B: TUI 打ち込み）
+
+claude と codex は既にシードを argv に載せず TUI に打ち込んでいる（`attachDraftInjection` /
+`attachCodexAutoRun`）。「同じ規則に3つも揃える」のが筋に見えたので**実際に実装して実機で試した**。
+
+**動かなかった。** 実機の `agy` に対して:
+
+| 計測 | 結果 |
+|---|---|
+| t=8s に固定で貼り付け | 成功（agy が Working... に入り、目印の文字列が届いた） |
+| agy 起動中の無出力ギャップ | t≈2.4s から **3.9 秒** |
+| codex 用の「1秒静穏」 | **t≈3.4s（起動途中）で打ってしまい、飲まれる** |
+| `?forshortcuts` マーカー | 別 run では 3201ms — **起動タイミングが run ごとに揺れる** |
+
+仕組みの形はエージェント非依存でも、**閾値は非依存ではない**。しかも `grok` と `muse` はこの環境に
+無いので閾値を検証できない。リポジトリの戒め（"a guessed one silently types into nothing"）どおり、
+失敗の仕方が静か（シードが実行されないだけ）で、今のクラッシュより気づきにくい。
+
+なので B は取らない。
+
+## 採る案（A: ファイル参照）
+
+シードをファイルに書き、コマンドラインには**それを読めという1行**を渡す。タイミングの当て推量が
+一切要らず、配送は CLI 自身が行う。#1516 で採った「引数に載せず、パスを渡す」と同じ形。
+
+置き場所は `session-settings.ts` — `settingsArgument` / `mcpConfigArgument` /
+`appendedPromptArgument` と同じモジュールで、掃除も孤児掃除も同じ経路に乗る。
+
+### 適用範囲を最小にする
+
+エージェントの最初の行動が「ファイルを読む」に変わるのは**実挙動の変化**なので、**直接渡しが
+不可能なときだけ**にする:
+
+```ts
+const seedNeedsFile = (prompt, platform) => platform === "win32" && /[\0\r\n]/.test(prompt);
+```
+
+- Windows 以外 → 常に従来どおり（多行でもそのまま）
+- Windows でも単行のシード → そのまま
+- Windows ＋ 多行 → ファイル＋参照1行（＝今クラッシュしている唯一のケース）
+
+「サポートしない」も選択肢として提示されたが、この3つでスキル起動が使えなくなるのは機能の欠落
+なので、届けられる A を採る。
+
+## 検証
+
+- 横断テスト（`seed-prompt-not-argv.spec.ts`）: Windows の argv がコマンドラインに載ること、
+  載せられない引数が1つも無いこと。**3エージェント分を1箇所で**述べる — 各エージェントの spec は
+  シードの argv 位置を主張していて、それは規則ではなくバグの形のテストだった
+- `seedPromptArgument` の単体テスト: Windows 以外は素通し / Windows でも単行は素通し /
+  多行は1行に置き換わりファイルに verbatim で入る / 掃除で消える
+- **旧配線に戻すと落ちる**ことを確認済み（issue と同じ `UnsafeArgumentError`）

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -20,6 +20,7 @@ const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
 const settingsFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}.json`);
 const mcpConfigFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-mcp.json`);
 const appendedPromptFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-prompt.txt`);
+const seedPromptFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-seed.txt`);
 
 // Windows has a second, unrelated reason to use a file: there, a `.cmd`-installed Claude is
 // launched through cmd.exe (#798), so a JSON argument is parsed by cmd and then by the
@@ -62,6 +63,30 @@ export function appendedPromptArgument(sessionId: string, prompt: string, platfo
   return mustUseFile(false, platform) ? { kind: "file", path: writePrivate(appendedPromptFile(sessionId), prompt) } : { kind: "inline", text: prompt };
 }
 
+// A seed prompt an agent takes as an ARGUMENT — grok and muse as a positional, antigravity as
+// `--prompt-interactive`'s value. None of the three can be handed a file, so the same answer as
+// above is not available: what goes on the command line has to be the prompt itself.
+//
+// And it cannot be, when it has a newline in it. A Windows command line has no encoding for one, so
+// escapeBatchArgument refuses the argument and the session never starts — and a skill seed with
+// arguments is ALWAYS multi-line, because codexifySkillSeed puts a blank line after the skill line
+// (#1518). Collapsing the newlines away is the substitution #1516 rejected: it hands the agent a
+// different instruction, silently.
+//
+// So the prompt travels in a file and the command line carries a single-line INSTRUCTION to read
+// it. The agent's first act becomes a file read, which is a real behaviour change — so it is made
+// only where the direct form is impossible: on Windows, and only for a prompt that actually
+// carries a newline. Everywhere else, and for a single-line seed anywhere, nothing changes.
+const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean => platform === "win32" && /[\0\r\n]/.test(prompt);
+
+export function seedPromptArgument(sessionId: string, prompt: string, platform: NodeJS.Platform = process.platform): string {
+  if (!seedNeedsFile(prompt, platform)) return prompt;
+  const file = writePrivate(seedPromptFile(sessionId), prompt);
+  // One line, and it names the file rather than describing it: an agent that reads nothing else
+  // still has the path. "first task" rather than "prompt" because the file IS the turn to run.
+  return `Your first task is written in this file — read it and carry it out: ${file}`;
+}
+
 // Run a spawn, taking the session's settings file with it if the spawn throws. A session
 // that never starts never reaches reap(), where the cleanup normally happens — so without
 // this a failed spawn leaves a token-bearing file behind (#579).
@@ -79,6 +104,7 @@ export function cleanupSessionSettings(sessionId: string): void {
   removeQuietly(settingsFile(sessionId));
   removeQuietly(mcpConfigFile(sessionId));
   removeQuietly(appendedPromptFile(sessionId));
+  removeQuietly(seedPromptFile(sessionId));
 }
 
 /** Drop settings files left behind by a server that never got to reap.
@@ -139,7 +165,7 @@ function isOlderThan(file: string, cutoff: number): boolean {
 //
 // A file kind missing from this list is one nothing ever collects — which is what a `.json`-only
 // rule did to the prompt file (#1516). Add the kind here when you add the writer.
-const FILE_ENDINGS = [".json", "-mcp.json", "-prompt.txt"] as const;
+const FILE_ENDINGS = [".json", "-mcp.json", "-prompt.txt", "-seed.txt"] as const;
 
 function sessionIdFromFileName(name: string): string | null {
   // First ending whose remainder is a session id wins: `<id>-mcp.json` also ends in `.json`, and

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -7,8 +7,14 @@ import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
 import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
+import { seedPromptArgument } from "./session-settings.js";
 import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
+
+// A seed this agent takes as an ARGUMENT cannot carry a newline on Windows, so it may travel in a
+// file with the command line naming it instead (#1518, session-settings.ts). Null stays null — the
+// builder then places no seed at all.
+const seedFor = (sessionId: string, prompt: string | null): string | null => (prompt === null ? null : seedPromptArgument(sessionId, prompt));
 
 export function createAntigravitySpawner(deps: SpawnDeps) {
   function captureAntigravityConversation(sessionId: string, root: string, before: ReadonlySet<string>, cwd: string): void {
@@ -40,7 +46,12 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
     const root = antigravityBrainRoot();
     const before = snapshotAntigravitySessions(root);
 
-    const args = buildAntigravityArgs({ resume: resumeConversationId, model: deps.antigravityModel, skipPermissions: true, initialPrompt });
+    const args = buildAntigravityArgs({
+      resume: resumeConversationId,
+      model: deps.antigravityModel,
+      skipPermissions: true,
+      initialPrompt: seedFor(sessionId, initialPrompt),
+    });
     const { entry, spawnedAtMs } = startDirectoryMcpPty({
       sessionId,
       ws,

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -7,7 +7,7 @@ import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
 import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
-import { seedPromptArgument } from "./session-settings.js";
+import { seedPromptArgument, withSettingsCleanup } from "./session-settings.js";
 import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
@@ -52,16 +52,21 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
       skipPermissions: true,
       initialPrompt: seedFor(sessionId, initialPrompt),
     });
-    const { entry, spawnedAtMs } = startDirectoryMcpPty({
-      sessionId,
-      ws,
-      cwd,
-      agent: "antigravity",
-      bin: deps.antigravityBin,
-      binEnvVar: antigravityAdapter.binEnvVar,
-      args,
-      resumeConversationId,
-    });
+    // The seed file may already be on disk (seedFor above), and a spawn that throws never reaches
+    // reap() — where the cleanup normally happens. Same guarantee spawn-claude takes for its
+    // settings file (#579, #1518).
+    const { entry, spawnedAtMs } = withSettingsCleanup(sessionId, () =>
+      startDirectoryMcpPty({
+        sessionId,
+        ws,
+        cwd,
+        agent: "antigravity",
+        bin: deps.antigravityBin,
+        binEnvVar: antigravityAdapter.binEnvVar,
+        args,
+        resumeConversationId,
+      }),
+    );
 
     if (resumeConversationId) {
       // Recorded on resume too, not just on the spawn that discovered it: a session resumed by the

--- a/server/session/spawn-grok.ts
+++ b/server/session/spawn-grok.ts
@@ -13,14 +13,26 @@ import { buildGrokArgs } from "../agents/grok-args.js";
 import { syncGrokMcpConfig } from "../agents/grok-mcp.js";
 import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
+import { seedPromptArgument } from "./session-settings.js";
 import type { SpawnDeps } from "./spawn-deps.js";
+
+// A seed this agent takes as an ARGUMENT cannot carry a newline on Windows, so it may travel in a
+// file with the command line naming it instead (#1518, session-settings.ts). Null stays null — the
+// builder then places no seed at all.
+const seedFor = (sessionId: string, prompt: string | null): string | null => (prompt === null ? null : seedPromptArgument(sessionId, prompt));
 
 export function createGrokSpawner(deps: SpawnDeps) {
   const spawnGrokPty: SpawnDirectoryMcpPty = (sessionId, ws, resumeConversationId, cwd, options) => {
     const { mcpGroups, initialPrompt = null } = options;
     syncDirectoryMcpForSpawn(sessionId, cwd, mcpGroups, syncGrokMcpConfig);
 
-    const args = buildGrokArgs({ sessionId, resume: resumeConversationId, model: deps.grokModel, skipPermissions: true, initialPrompt });
+    const args = buildGrokArgs({
+      sessionId,
+      resume: resumeConversationId,
+      model: deps.grokModel,
+      skipPermissions: true,
+      initialPrompt: seedFor(sessionId, initialPrompt),
+    });
     const { entry, spawnedAtMs } = startDirectoryMcpPty({
       sessionId,
       ws,

--- a/server/session/spawn-grok.ts
+++ b/server/session/spawn-grok.ts
@@ -13,7 +13,7 @@ import { buildGrokArgs } from "../agents/grok-args.js";
 import { syncGrokMcpConfig } from "../agents/grok-mcp.js";
 import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
-import { seedPromptArgument } from "./session-settings.js";
+import { seedPromptArgument, withSettingsCleanup } from "./session-settings.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 // A seed this agent takes as an ARGUMENT cannot carry a newline on Windows, so it may travel in a
@@ -33,16 +33,21 @@ export function createGrokSpawner(deps: SpawnDeps) {
       skipPermissions: true,
       initialPrompt: seedFor(sessionId, initialPrompt),
     });
-    const { entry, spawnedAtMs } = startDirectoryMcpPty({
-      sessionId,
-      ws,
-      cwd,
-      agent: "grok",
-      bin: deps.grokBin,
-      binEnvVar: grokAdapter.binEnvVar,
-      args,
-      resumeConversationId,
-    });
+    // The seed file may already be on disk (seedFor above), and a spawn that throws never reaches
+    // reap() — where the cleanup normally happens. Same guarantee spawn-claude takes for its
+    // settings file (#579, #1518).
+    const { entry, spawnedAtMs } = withSettingsCleanup(sessionId, () =>
+      startDirectoryMcpPty({
+        sessionId,
+        ws,
+        cwd,
+        agent: "grok",
+        bin: deps.grokBin,
+        binEnvVar: grokAdapter.binEnvVar,
+        args,
+        resumeConversationId,
+      }),
+    );
 
     wireAgentPtyRelay(entry, sessionId, spawnedAtMs, deps);
     return entry;

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -18,10 +18,16 @@ import { entitledToolGroups, rememberEntitledToolGroups } from "./bridge-session
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
+import { seedPromptArgument } from "./session-settings.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
+
+// A seed this agent takes as an ARGUMENT cannot carry a newline on Windows, so it may travel in a
+// file with the command line naming it instead (#1518, session-settings.ts). Null stays null — the
+// builder then places no seed at all.
+const seedFor = (sessionId: string, prompt: string | null): string | null => (prompt === null ? null : seedPromptArgument(sessionId, prompt));
 
 export function createMuseSpawner(deps: SpawnDeps) {
   function captureMuseSession(sessionId: string, cwd: string, before: ReadonlySet<string>): void {
@@ -77,7 +83,7 @@ export function createMuseSpawner(deps: SpawnDeps) {
 
     // The workspace is passed on BOTH paths — a resumed session that loses `--workspace` comes
     // back without the tools it was working with (see muse-args.ts).
-    const args = buildMuseArgs({ resume: resumeConversationId, workspace: cwd, model: deps.museModel, initialPrompt });
+    const args = buildMuseArgs({ resume: resumeConversationId, workspace: cwd, model: deps.museModel, initialPrompt: seedFor(sessionId, initialPrompt) });
 
     // Recorded only when this really STARTS muse. A reattach reaches here too (after a server
     // restart the pty table is empty while the tmux session is not), and the muse in that pane is

--- a/server/session/spawn-muse.ts
+++ b/server/session/spawn-muse.ts
@@ -18,7 +18,7 @@ import { entitledToolGroups, rememberEntitledToolGroups } from "./bridge-session
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
-import { seedPromptArgument } from "./session-settings.js";
+import { seedPromptArgument, withSettingsCleanup } from "./session-settings.js";
 import { claimedMuseSessions, ptys, rememberMuseSession } from "./registry.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import type { PtyEntry } from "./types.js";
@@ -101,7 +101,12 @@ export function createMuseSpawner(deps: SpawnDeps) {
     // What the MUSE process itself needs: it does inherit our environment, and without this flag it
     // loads no plugins at all — the registration would be inert rather than absent.
     const env = musePluginEnv();
-    const { term, tmux, reattached } = ptySpawn(sessionId, deps.museBin, args, cwd, true, { env, binEnvVar: museAdapter.binEnvVar });
+    // The seed file may already be on disk (seedFor above), and a spawn that throws never reaches
+    // reap() — where the cleanup normally happens. Same guarantee spawn-claude takes for its
+    // settings file (#579, #1518).
+    const { term, tmux, reattached } = withSettingsCleanup(sessionId, () =>
+      ptySpawn(sessionId, deps.museBin, args, cwd, true, { env, binEnvVar: museAdapter.binEnvVar }),
+    );
     const spawnedAtMs = Date.now();
     const note = resumeConversationId ? `resume ${resumeConversationId}` : null;
     console.log(ptyStartLine({ agent: "muse", pid: term.pid, cwd, tmux, reattached, sessionId, note }));

--- a/test/server/agents/seed-prompt-not-argv.spec.ts
+++ b/test/server/agents/seed-prompt-not-argv.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+//
+// One property over every agent that takes a seed prompt as an ARGUMENT: whatever ends up on the
+// command line can actually go on one.
+//
+// Stated once, here, rather than per agent — because that is how it went wrong. #1516 fixed the
+// same class for `--append-system-prompt`, and each of these agents' own specs went on asserting
+// the seed's argv POSITION, which tests the shape of the bug rather than the rule (#1518).
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { buildGrokArgs } from "../../../server/agents/grok-args.js";
+import { buildAntigravityArgs } from "../../../server/agents/antigravity-args.js";
+import { buildMuseArgs } from "../../../server/agents/muse-args.js";
+import { codexifySkillSeed } from "../../../server/agents/codex-skills.js";
+import { seedPromptArgument, cleanupSessionSettings } from "../../../server/session/session-settings.js";
+import { resolvePtyLaunch } from "../../../server/infra/resolve-bin.js";
+
+const SESSION = "seed-argv-spec-session";
+const CWD = "C:\\work\\project";
+const seedFileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}-seed.txt`);
+
+afterEach(() => cleanupSessionSettings(SESSION));
+
+// What the plugin routes actually hand a spawn. codexifySkillSeed puts a blank line between the
+// skill line and the rest, so ANY skill seed with arguments is multi-line — not a corner case.
+const SEED = codexifySkillSeed("/gh-review-loop 1517 をトリアージして");
+
+// An npm-global install: the agent on PATH is a .cmd shim, so the launch goes through cmd.exe,
+// whose command line has no encoding for a newline.
+const asWindowsLaunch = (bin: string, args: string[]) =>
+  resolvePtyLaunch(bin, args, "win32", "C:\\npm;C:\\Windows\\System32", "C:\\Windows\\System32\\cmd.exe", (candidate) =>
+    new RegExp(`${bin}\\.cmd$|cmd\\.exe$`, "i").test(candidate),
+  );
+
+// Each agent's argv as a WINDOWS spawn builds it — the seed resolved the way the spawner resolves
+// it, which is the step the bug was missing.
+const windowsArgv = (): Array<[string, string[]]> => {
+  const seed = seedPromptArgument(SESSION, SEED, "win32");
+  return [
+    ["grok", buildGrokArgs({ sessionId: "11111111-2222-4333-8444-555555555555", resume: null, model: "grok-4.5", skipPermissions: true, initialPrompt: seed })],
+    ["agy", buildAntigravityArgs({ resume: null, model: "agy-1", skipPermissions: true, initialPrompt: seed })],
+    ["muse", buildMuseArgs({ resume: null, workspace: CWD, model: "muse-spark-1.2", initialPrompt: seed })],
+  ];
+};
+
+describe("a seed prompt on a Windows command line", () => {
+  it("is multi-line for any skill seed with arguments — the reason this rule exists", () => {
+    expect(SEED).toContain("\n");
+  });
+
+  // The regression itself: with the raw seed on argv this threw UnsafeArgumentError and the
+  // session never started.
+  it("can actually be put on a command line, for every agent that takes one", () => {
+    for (const [agent, args] of windowsArgv()) {
+      expect(() => asWindowsLaunch(agent, args), agent).not.toThrow();
+    }
+  });
+
+  // Named per agent so a failure says WHICH argument, and so a future flag carrying free text
+  // fails here rather than at a user's machine.
+  it("carries no argument a command line cannot represent", () => {
+    for (const [agent, args] of windowsArgv()) {
+      expect(
+        args.filter((arg) => /[\0\r\n]/.test(arg)),
+        agent,
+      ).toEqual([]);
+    }
+  });
+});
+
+describe("seedPromptArgument", () => {
+  it("hands back a multi-line seed unchanged off Windows — nothing about that path moves", () => {
+    expect(seedPromptArgument(SESSION, SEED, "darwin")).toBe(SEED);
+    expect(existsSync(seedFileFor(SESSION))).toBe(false);
+  });
+
+  // The indirection is for the case that cannot work, not for Windows as such.
+  it("hands back a single-line seed unchanged even on Windows", () => {
+    expect(seedPromptArgument(SESSION, "/collect run", "win32")).toBe("/collect run");
+    expect(existsSync(seedFileFor(SESSION))).toBe(false);
+  });
+
+  it("puts a multi-line seed in a file and names it in one line", () => {
+    const argument = seedPromptArgument(SESSION, SEED, "win32");
+    expect(argument).not.toContain("\n");
+    expect(argument).toContain(seedFileFor(SESSION));
+    // Verbatim: the whole point is that the agent gets the instruction it was given, not a
+    // flattened paraphrase of it.
+    expect(readFileSync(seedFileFor(SESSION), "utf8")).toBe(SEED);
+  });
+
+  it("is cleaned up with the session's other files", () => {
+    seedPromptArgument(SESSION, SEED, "win32");
+    expect(existsSync(seedFileFor(SESSION))).toBe(true);
+    cleanupSessionSettings(SESSION);
+    expect(existsSync(seedFileFor(SESSION))).toBe(false);
+  });
+});

--- a/test/server/session/spawn-antigravity.spec.ts
+++ b/test/server/session/spawn-antigravity.spec.ts
@@ -3,16 +3,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createAntigravitySpawner } from "../../../server/session/spawn-antigravity.js";
 import { ptys } from "../../../server/session/registry.js";
 import type { SpawnDeps } from "../../../server/session/spawn-deps.js";
+import { cleanupSessionSettings } from "../../../server/session/session-settings.js";
 
 vi.mock("../../../server/session/pty-spawn.js", () => ({
-  ptySpawn: vi.fn(() => ({
-    term: {
-      pid: 1234,
-      onData: vi.fn(),
-      onExit: vi.fn(),
-    },
-    tmux: false,
-  })),
+  ptySpawn: vi.fn((_id: string, _bin: string, args: string[]) => {
+    spawnMocks.argv.push(args);
+    return {
+      term: {
+        pid: 1234,
+        onData: vi.fn(),
+        onExit: vi.fn(),
+      },
+      tmux: false,
+    };
+  }),
   // This spawn really starts agy, so it is the branch that syncs the directory's MCP config (#1443).
   ptyWouldReattach: vi.fn(() => false),
 }));
@@ -23,6 +27,8 @@ const CAPTURED_ID = "1c0f5b2e-9d84-4f21-a7c3-6b5e8d9a0f14";
 // ~/.mulmoterminal log. Both are stubbed: this file is about what the spawner does with a capture,
 // and a unit test must not write a session that never existed into the developer's own state.
 const mocks = vi.hoisted(() => ({ remembered: [] as { sessionId: string; conversationId: string; cwd: string }[] }));
+// The argv each spawn really handed the pty — the only place the seed wiring can be seen end to end.
+const spawnMocks = vi.hoisted(() => ({ argv: [] as string[][] }));
 
 vi.mock("../../../server/agents/antigravity-session.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../server/agents/antigravity-session.js")>()),
@@ -49,6 +55,7 @@ describe("createAntigravitySpawner", () => {
   beforeEach(() => {
     ptys.clear();
     mocks.remembered.length = 0;
+    spawnMocks.argv.length = 0;
     publishActivity.mockClear();
   });
 
@@ -59,6 +66,28 @@ describe("createAntigravitySpawner", () => {
     expect(entry.agent).toBe("antigravity");
     expect(entry.cwd).toBe("/test/dir");
     expect(ptys.get("session-1")).toBe(entry);
+  });
+
+  // The seed wiring, through the REAL spawner rather than through the argument builder: a test that
+  // calls seedPromptArgument itself would still pass if this spawner stopped calling it (#1518).
+  //
+  // Forced to win32 so the branch under test is the one that cannot work — on this machine's own
+  // platform a multi-line seed is passed straight through and there is nothing to see.
+  it("hands the pty a single-line seed reference on Windows, never the multi-line seed", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const { spawnAntigravityPty } = createAntigravitySpawner(dummyDeps);
+      spawnAntigravityPty("11111111-2222-4333-8444-555555555555", null, null, "/test/dir", {
+        mcpGroups: [],
+        initialPrompt: 'Use the "x" skill.\n\nand do the thing',
+      });
+      const args = spawnMocks.argv.at(-1) ?? [];
+      expect(args.filter((arg) => /[\0\r\n]/.test(arg))).toEqual([]);
+      expect(args.some((arg) => arg.includes("-seed.txt"))).toBe(true);
+    } finally {
+      platform.mockRestore();
+      cleanupSessionSettings("11111111-2222-4333-8444-555555555555");
+    }
   });
 
   // Without this the cell keeps the header badge it was given before agy had a conversation at all,

--- a/test/server/session/spawn-grok-mcp-sync.spec.ts
+++ b/test/server/session/spawn-grok-mcp-sync.spec.ts
@@ -14,15 +14,21 @@
 // sync would then DEREGISTER the servers every live grok in that directory is using — leaving them
 // with no GUI tools until something else re-registered them. (Codex review, #1441.)
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanupSessionSettings } from "../../../server/session/session-settings.js";
 
 const ID = "11111111-2222-4333-8444-555555555555";
 const CWD = "/home/me/project";
 
 let reattaching = false;
 const syncGrokMcpConfig = vi.fn();
+// The argv each spawn really handed the pty — where the seed wiring is visible end to end.
+const spawnedArgv: string[][] = [];
 
 vi.mock("../../../server/session/pty-spawn.js", () => ({
-  ptySpawn: () => ({ term: fakeTerm(), tmux: true, reattached: reattaching }),
+  ptySpawn: (_id: string, _bin: string, args: string[]) => {
+    spawnedArgv.push(args);
+    return { term: fakeTerm(), tmux: true, reattached: reattaching };
+  },
   ptyWouldReattach: () => reattaching,
 }));
 
@@ -65,5 +71,25 @@ describe("spawnGrokPty and the directory's shared .grok/config.toml", () => {
     reattaching = true;
     spawn([]);
     expect(syncGrokMcpConfig).not.toHaveBeenCalled();
+  });
+});
+
+// The seed wiring, through the REAL spawner rather than through the argument builder: a test that
+// calls seedPromptArgument itself would still pass if this spawner stopped calling it (#1518).
+//
+// Forced to win32 so the branch under test is the one that cannot work — on this machine's own
+// platform a multi-line seed is passed straight through and there is nothing to see.
+describe("the seed a Windows spawn hands the pty", () => {
+  it("is a single-line file reference, never the multi-line seed", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      createGrokSpawner(deps).spawnGrokPty(ID, null, null, CWD, { mcpGroups: [] as never, initialPrompt: 'Use the "x" skill.\n\nand do the thing' });
+      const args = spawnedArgv.at(-1) ?? [];
+      expect(args.filter((arg) => /[\0\r\n]/.test(arg))).toEqual([]);
+      expect(args.some((arg) => arg.includes("-seed.txt"))).toBe(true);
+    } finally {
+      platform.mockRestore();
+      cleanupSessionSettings(ID);
+    }
   });
 });

--- a/test/server/session/spawn-muse-mcp.spec.ts
+++ b/test/server/session/spawn-muse-mcp.spec.ts
@@ -17,6 +17,7 @@
 // no tools with nothing logged, and one that carries groups the directory never registered hands a
 // cell tools its neighbours were not given.
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanupSessionSettings } from "../../../server/session/session-settings.js";
 
 const ID = "11111111-2222-4333-8444-555555555555";
 const CWD = "/home/me/project";
@@ -24,10 +25,13 @@ const CWD = "/home/me/project";
 let reattaching = false;
 const syncMuseMcpPlugin = vi.fn();
 const spawned: { env: Record<string, string> | undefined }[] = [];
+// The argv each spawn really handed the pty — where the seed wiring is visible end to end.
+const spawnedArgv: string[][] = [];
 
 vi.mock("../../../server/session/pty-spawn.js", () => ({
-  ptySpawn: (_id: string, _bin: string, _args: string[], _cwd: string, _tmux: boolean, options: { env?: Record<string, string> }) => {
+  ptySpawn: (_id: string, _bin: string, args: string[], _cwd: string, _tmux: boolean, options: { env?: Record<string, string> }) => {
     spawned.push({ env: options?.env });
+    spawnedArgv.push(args);
     return { term: fakeTerm(), tmux: true, reattached: reattaching };
   },
   ptyWouldReattach: () => reattaching,
@@ -153,5 +157,25 @@ describe("spawnMusePty and the session's entitlement", () => {
     spawn(["render"]);
     expect(lastEnv().MULMOTERMINAL_SESSION_ID).toBeUndefined();
     expect(lastEnv().MULMOTERMINAL_TOOL_GROUPS).toBeUndefined();
+  });
+});
+
+// The seed wiring, through the REAL spawner rather than through the argument builder: a test that
+// calls seedPromptArgument itself would still pass if this spawner stopped calling it (#1518).
+//
+// Forced to win32 so the branch under test is the one that cannot work — on this machine's own
+// platform a multi-line seed is passed straight through and there is nothing to see.
+describe("the seed a Windows spawn hands the pty", () => {
+  it("is a single-line file reference, never the multi-line seed", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      createMuseSpawner(deps).spawnMusePty(ID, null, null, CWD, { mcpGroups: [] as never, initialPrompt: 'Use the "x" skill.\n\nand do the thing' });
+      const args = spawnedArgv.at(-1) ?? [];
+      expect(args.filter((arg) => /[\0\r\n]/.test(arg))).toEqual([]);
+      expect(args.some((arg) => arg.includes("-seed.txt"))).toBe(true);
+    } finally {
+      platform.mockRestore();
+      cleanupSessionSettings(ID);
+    }
   });
 });


### PR DESCRIPTION
## Summary

`grok` / `antigravity` / `muse` はシードプロンプトを **argv に直接載せて**います（grok と muse は positional、antigravity は `--prompt-interactive` の値）。そして `codexifySkillSeed` 自身が `Use the "x" skill.\n\n<rest>` を作るので、**引数付きスキルで起動すると必ず多行**になります。Windows のコマンドラインは改行を表現できないため、`.cmd` インストールでは毎回 `UnsafeArgumentError` で起動に失敗していました。#1516 と同じバグ族です。

シードを**ファイルに書き、コマンドラインには「それを読め」という1行**を渡します。置き場所は `session-settings.ts` — `settingsArgument` / `mcpConfigArgument` / `appendedPromptArgument` と同じモジュールで、掃除も孤児掃除も同じ経路に乗ります。

## Items to Confirm / Review

1. **エージェントの最初の行動が「ファイルを読む」に変わります。** これが実挙動の変化なので、**直接渡しが不可能なときだけ**に絞りました:

   | | 挙動 |
   |---|---|
   | Windows 以外 | 多行でも**そのまま**（変化なし） |
   | Windows ＋ 単行 | **そのまま**（変化なし） |
   | Windows ＋ 多行 | ファイル＋参照1行（＝**今クラッシュしている唯一のケース**） |

   **ここが一番レビューしてほしい判断です。** 「サポートしない」も選択肢として挙げていただきましたが、この3つでスキル起動が使えなくなるのは機能の欠落なので、届けられる形を採りました。

2. **参照文の文言** — `Your first task is written in this file — read it and carry it out: <path>`。1行であること、パスをそのまま含むこと（説明ではなく名指し）を意図しています。文言のご意見をください。

3. **TUI 打ち込み案（claude と codex がやっている形）は実装して実機で試したうえで却下しました。** 詳細は下記。

## User Prompt

> （#1516 の調査中に発見。publish 後に）続きやって！！
>
> appendSystemPrompt が原因で起動しない、appendSystemPrompt をサポートしないなら問題ないなら、問題がある coding agent は appendSystemPrompt をサポートしない、というのもありだよ。そのうえで A でよい

## 却下した案（B: TUI 打ち込み）と、その根拠

claude と codex は既にシードを argv に載せず TUI に打ち込んでいます（`attachDraftInjection` / `attachCodexAutoRun`）。「3つも同じ規則に揃える」のが筋に見えたので、**実装して実機の `agy` で試しました**。

**動きませんでした。** 計測:

| 計測 | 結果 |
|---|---|
| t=8s に固定で貼り付け | **成功**（agy が Working... に入り目印の文字列が届いた） |
| agy 起動中の無出力ギャップ | t≈2.4s から **3.9 秒** |
| codex 用の「1秒静穏」 | **t≈3.4s（起動途中）で打ってしまい飲まれる** |
| `?forshortcuts` マーカー | 別 run では 3201ms — **起動タイミングが run ごとに揺れる** |

仕組みの形はエージェント非依存でも、**閾値は非依存ではありません**。しかも `grok` と `muse` はこの環境に無いので閾値を検証できません。リポジトリ自身が

> the marker has to be read off a real grok TUI, and **a guessed one silently types into nothing**

と戒めているとおり、失敗の仕方が静か（シードが実行されないだけ）で、今のクラッシュより気づきにくくなります。A はタイミングの当て推量が一切要らず、配送は CLI 自身が行います。

## 実装

- `session-settings.ts` に `seedPromptArgument(sessionId, prompt, platform)`。`seedNeedsFile = win32 && /[\0\r\n]/` のときだけファイルに書いて参照1行を返し、それ以外は素通し
- `-seed.txt` を `cleanupSessionSettings` と `FILE_ENDINGS`（孤児掃除の名前照合）に追加
- 3つの spawner で argv に渡す直前に解決。**arg builder は無改造**

## テスト

**3エージェント分を1箇所で述べます。** 各エージェントの spec はシードの argv 位置を主張していましたが、それは規則ではなく**バグの形**のテストで、#1516 が同じ轍を踏んでいます。

- Windows の argv がコマンドラインに載ること / 載せられない引数が1つも無いこと
- `seedPromptArgument`: Windows 以外は素通し / Windows でも単行は素通し / 多行は1行に置き換わりファイルに **verbatim** で入る / 掃除で消える
- **旧配線に戻すと落ちることを確認済み**（issue と同じ `UnsafeArgumentError`）

ローカル: `yarn format` / `lint`（0 errors） / `typecheck` / `build` / `test`（9115 passed）。

Closes #1518

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows startup failures when launching Grok, Antigravity, or Muse with multiline seed prompts.
  * Preserved prompts exactly, including line breaks and special characters.
  * Added automatic cleanup of temporary prompt files when sessions end.
  * Maintained existing behavior for single-line prompts and non-Windows platforms.

* **Tests**
  * Added regression coverage for multiline prompt handling, cleanup, and compatibility across supported agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->