### PR TITLE
feat(picker): give each built-in agent its own mark in the Agent Picker

### DIFF
--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -20,6 +20,7 @@ import type { Launcher, LaunchPick } from "./launchers";
 import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import LaunchChipList from "./LaunchChipList.vue";
+import AgentMark from "./AgentMark.vue";
 import ModelPicker from "./ModelPicker.vue";
 import { LAUNCH_ROW } from "./launchFormClasses";
 import { jsonBody } from "../jsonBody";
@@ -96,6 +97,21 @@ const pickerOptions = computed(() => agentPickerOptions(props.customAgents ?? []
 // picker below, and nothing else — has to say yes for it too. Asked of the PICK rather than of a
 // resolved agent name, which is the same rule the model picker already followed for Shell.
 const launchesClaude = computed(() => props.agent === "claude" || customAgentIdOf(props.agent) !== null);
+
+// The mark each picker option wears. The five built-in agents have one drawn for them
+// (AgentMark.vue) — the same mark the rate-limit gauge uses, so an agent looks the same wherever
+// it is named. The other two options are not agents and get a Material Symbol instead: Shell is a
+// plain terminal, and a CUSTOM agent gets `tune` rather than Claude's burst, because it runs
+// Claude Code through a command of the user's own and must not be mistaken for the Claude row.
+// Narrowed here rather than in the template: the mark is a TerminalAgent and the picker's own type
+// is the wider AgentPick, so resolving it once per option keeps the template free of an assertion.
+const markedOptions = computed(() =>
+  pickerOptions.value.map((option) => ({
+    ...option,
+    mark: isTerminalAgent(option.agent) ? option.agent : null,
+    symbol: option.agent === "shell" ? "terminal" : "tune",
+  })),
+);
 
 // v-model over a prop the cell owns: typing reports the new path up, and the field shows what
 // comes back down.
@@ -572,18 +588,25 @@ async function removeWorktree(w: Worktree): Promise<void> {
       aria-label="Agent picker — what this terminal runs"
     >
       <button
-        v-for="option in pickerOptions"
+        v-for="option in markedOptions"
         :key="option.agent"
         type="button"
         :data-testid="`agent-picker-${option.agent}`"
-        class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
+        class="inline-flex cursor-pointer items-center gap-1.5 rounded-[5px] border-none px-3 py-1 font-sans text-[12px] font-medium"
         :class="agent === option.agent ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
         role="radio"
         :aria-checked="agent === option.agent"
         :title="option.title"
         @click="emit('update:agent', option.agent)"
       >
-        {{ option.label }}
+        <!-- The mark inherits `currentColor`, so the selected option's mark brightens with its
+             label rather than staying a fixed swatch beside dimmed text. -->
+        <AgentMark v-if="option.mark" :agent="option.mark" />
+        <span v-else class="material-symbols-outlined text-[13px]" aria-hidden="true">{{ option.symbol }}</span>
+        <!-- The label in its own element: a Material Symbol is a LIGATURE, so the icon's name is
+             real text inside the button and `.text()` reads "terminal Shell". Asking for the label
+             is what keeps a caller (and a test) able to say what the option is called. -->
+        <span data-testid="agent-picker-label">{{ option.label }}</span>
       </button>
     </div>
     <label class="flex flex-col items-center gap-1.5" :class="LAUNCH_ROW">

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -687,7 +687,7 @@ describe("the Agent Picker's custom agents (#1414)", () => {
     await flushPromises();
     const labels = w
       .find('[data-testid="agent-picker"]')
-      .findAll('[role="radio"]')
+      .findAll('[data-testid="agent-picker-label"]')
       .map((b) => b.text());
     expect(labels).toEqual(["Claude", "Codex", "Antigravity", "Grok", "Muse", "Nemotron", "Shell"]);
   });
@@ -718,6 +718,25 @@ describe("the Agent Picker's custom agents (#1414)", () => {
     // TERMINAL_AGENTS + Shell — asserted as a count derived from the list rather than a literal,
     // so adding a fifth agent does not read as this feature breaking.
     expect(w.find('[data-testid="agent-picker"]').findAll('[role="radio"]')).toHaveLength(TERMINAL_AGENTS.length + 1);
+  });
+
+  // Every option wears a mark, and the built-in agents wear their OWN one (AgentMark.vue's drawn
+  // shapes, the same the rate-limit gauge uses) rather than a Material Symbol — added because a row
+  // of six words in one weight said nothing about which tool each button starts. Derived from
+  // TERMINAL_AGENTS, so a new agent that reaches the picker without a mark fails here.
+  it("marks every built-in agent with its own drawn mark, and Shell with a symbol", async () => {
+    mockFetch();
+    const w = mountForm([], { customAgents: [nemotron] });
+    await flushPromises();
+    for (const agent of TERMINAL_AGENTS) {
+      const button = w.find(`[data-testid="agent-picker-${agent}"]`);
+      expect(button.find("svg").exists()).toBe(true);
+      expect(button.find(".material-symbols-outlined").exists()).toBe(false);
+    }
+    // The two that are not agents: a plain terminal, and `tune` for the user's own command — not
+    // Claude's burst, which would make a custom entry indistinguishable from the Claude row.
+    expect(w.find('[data-testid="agent-picker-shell"]').find(".material-symbols-outlined").text()).toBe("terminal");
+    expect(w.find('[data-testid="agent-picker-custom:nemotron"]').find(".material-symbols-outlined").text()).toBe("tune");
   });
 });
 

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import CellLaunchForm from "../../../src/components/CellLaunchForm.vue";
+import AgentMark from "../../../src/components/AgentMark.vue";
 import type { AgentPick, CustomAgent } from "../../../common/customAgents";
 import { TERMINAL_AGENTS } from "../../../common/sessionAgent";
 
@@ -730,6 +731,10 @@ describe("the Agent Picker's custom agents (#1414)", () => {
     await flushPromises();
     for (const agent of TERMINAL_AGENTS) {
       const button = w.find(`[data-testid="agent-picker-${agent}"]`);
+      // The mark is asked for its OWN agent, not merely for a mark: a row that rendered Claude's
+      // burst under every label would satisfy "an svg is present" while distinguishing nothing,
+      // which is the whole thing this feature exists to do (CodeRabbit on #1521).
+      expect(button.findComponent(AgentMark).props("agent")).toBe(agent);
       expect(button.find("svg").exists()).toBe(true);
       expect(button.find(".material-symbols-outlined").exists()).toBe(false);
     }

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -2471,7 +2471,7 @@ describe("TerminalCell launch target — the OS default shell (#1114)", () => {
     const w = mountCell(null);
     await flushPromises();
     const row = w.find('[role="radiogroup"]');
-    expect(row.findAll('[role="radio"]').map((b) => b.text())).toEqual(["Claude", "Codex", "Antigravity", "Grok", "Muse", "Shell"]);
+    expect(row.findAll('[data-testid="agent-picker-label"]').map((b) => b.text())).toEqual(["Claude", "Codex", "Antigravity", "Grok", "Muse", "Shell"]);
     expect(w.find('[data-testid="agent-picker-claude"]').attributes("aria-checked")).toBe("true");
     expect(w.find('[data-testid="agent-picker-shell"]').attributes("aria-checked")).toBe("false");
   });


### PR DESCRIPTION
## What

The Agent Picker was six words in one weight — nothing on it said which tool a button starts. Each of the five built-in agents now wears its own mark.

`src/components/AgentMark.vue` already draws all five (Anthropic's burst, Codex's crossed loops, Antigravity's four-point star, Grok's broken X, Muse's M) and was only ever used by the rate-limit gauge. The picker shows the same shapes, so an agent looks the same wherever it is named. They inherit `currentColor`, so the selected option's mark brightens with its label rather than sitting as a fixed swatch beside dimmed text.

The two options that are **not** agents get a Material Symbol instead:

- **Shell** — `terminal`
- **a custom agent** — `tune`, deliberately not Claude's burst. It runs Claude Code through a command the user wrote, and giving it Claude's mark would make it indistinguishable from the Claude row.

## The test change

A Material Symbol is a ligature, so the icon's name is real text inside the button and `.text()` reads `"terminal Shell"`. The label moved into its own `span[data-testid="agent-picker-label"]`, and the two specs that read the button's text now ask for that. No behaviour change.

## Testing

- New spec: every `TERMINAL_AGENTS` entry renders an `svg` and no Material Symbol; Shell renders `terminal` and a custom entry renders `tune`. Derived from `TERMINAL_AGENTS`, so a new agent that reaches the picker without a mark fails here.
- `yarn format` / `lint` (0 errors) / `typecheck` / `test` (9097 passed) / `build` all pass.
- Not yet eyeballed in a live browser — built only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual marks and icons to agent picker options.
  * Built-in agents now display their associated SVG marks, while Shell and custom agents use Material Symbols icons.
  * Improved label presentation for clearer and more accessible agent selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->