### PR TITLE
fix: 長すぎるシードプロンプトもファイルで渡す (#1518)

### DIFF
--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -75,9 +75,30 @@ export function appendedPromptArgument(sessionId: string, prompt: string, platfo
 //
 // So the prompt travels in a file and the command line carries a single-line INSTRUCTION to read
 // it. The agent's first act becomes a file read, which is a real behaviour change — so it is made
-// only where the direct form is impossible: on Windows, and only for a prompt that actually
-// carries a newline. Everywhere else, and for a single-line seed anywhere, nothing changes.
-const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean => platform === "win32" && /[\0\r\n]/.test(prompt);
+// only where the direct form is impossible.
+//
+// Impossible has TWO shapes, and they do not share a platform. The newline above is Windows-only.
+// LENGTH is not: a command line runs out of room everywhere, and on the platforms this server
+// actually runs tmux on it runs out FIRST. `ptySpawn` starts a persistent session through
+// `tmux new-session -A … -- <bin> <args>` (pty-spawn.ts, tmux.ts), and tmux answers a command line
+// past its own limit with "command too long" — which kills the session rather than the argument,
+// so it is a worse failure than the Windows one, not a milder one.
+//
+// The limit is on the WHOLE command line, not on any single argument: measured against tmux 3.7b,
+// 16,250 bytes in one argument was accepted and 16,375 refused, and two 10,000-byte arguments were
+// refused together. So the budget is shared with the socket path, the conf path, the session name,
+// `-c <cwd>`, every `-e KEY=VALUE` (muse's plugin env) and the bin's own flags. Windows brings its
+// own, smaller ceiling — cmd.exe stops at 8,191 characters.
+//
+// Gating on the SEED's size alone is still enough, because the seed is the only part of that line
+// with no bound: everything else is a path, a flag or a uuid, and together they run to hundreds of
+// bytes. A seed held to the budget below leaves the total far short of either ceiling.
+//
+// BYTES, not characters. tmux counts bytes and Japanese is three of them per character, so a
+// 3,000-character seed is 9,000 bytes — a character-count guard would wave it straight through.
+export const SEED_ARGV_MAX_BYTES = 4096;
+const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean =>
+  (platform === "win32" && /[\0\r\n]/.test(prompt)) || Buffer.byteLength(prompt, "utf8") > SEED_ARGV_MAX_BYTES;
 
 export function seedPromptArgument(sessionId: string, prompt: string, platform: NodeJS.Platform = process.platform): string {
   if (!seedNeedsFile(prompt, platform)) return prompt;

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -12,6 +12,7 @@
 import { writeFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { escapeBatchArgument } from "../infra/cmd-escape.js";
 import { removeQuietly } from "../infra/fs-cleanup.js";
 import { SESSION_ID_RE } from "../config/env.js";
 
@@ -96,9 +97,19 @@ export function appendedPromptArgument(sessionId: string, prompt: string, platfo
 //
 // BYTES, not characters. tmux counts bytes and Japanese is three of them per character, so a
 // 3,000-character seed is 9,000 bytes — a character-count guard would wave it straight through.
+//
+// Windows counts the other way round, and it counts what cmd.exe is HANDED, not what we hold: a
+// `.cmd` shim is run through `cmd /d /s /c "…"`, and escapeBatchArgument doubles every internal
+// quote on the way there. A seed of nothing but quotes therefore arrives at twice the size we
+// measured — 4,096 of them become 8,192 characters, past cmd's 8,191 ceiling, and the session does
+// not start. So the Windows arm measures the ESCAPED argument (codex review on #1522). Its unit is
+// characters because cmd's limit is; the newline test runs first, so nothing that would make
+// escapeBatchArgument throw ever reaches it.
 export const SEED_ARGV_MAX_BYTES = 4096;
-const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean =>
-  (platform === "win32" && /[\0\r\n]/.test(prompt)) || Buffer.byteLength(prompt, "utf8") > SEED_ARGV_MAX_BYTES;
+const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean => {
+  if (platform === "win32") return /[\0\r\n]/.test(prompt) || escapeBatchArgument(prompt).length > SEED_ARGV_MAX_BYTES;
+  return Buffer.byteLength(prompt, "utf8") > SEED_ARGV_MAX_BYTES;
+};
 
 export function seedPromptArgument(sessionId: string, prompt: string, platform: NodeJS.Platform = process.platform): string {
   if (!seedNeedsFile(prompt, platform)) return prompt;

--- a/test/server/agents/seed-prompt-not-argv.spec.ts
+++ b/test/server/agents/seed-prompt-not-argv.spec.ts
@@ -14,8 +14,9 @@ import { buildGrokArgs } from "../../../server/agents/grok-args.js";
 import { buildAntigravityArgs } from "../../../server/agents/antigravity-args.js";
 import { buildMuseArgs } from "../../../server/agents/muse-args.js";
 import { codexifySkillSeed } from "../../../server/agents/codex-skills.js";
-import { seedPromptArgument, cleanupSessionSettings } from "../../../server/session/session-settings.js";
+import { seedPromptArgument, cleanupSessionSettings, SEED_ARGV_MAX_BYTES } from "../../../server/session/session-settings.js";
 import { resolvePtyLaunch } from "../../../server/infra/resolve-bin.js";
+import { tmuxNewSessionArgs } from "../../../server/infra/tmux.js";
 
 const SESSION = "seed-argv-spec-session";
 const CWD = "C:\\work\\project";
@@ -34,16 +35,23 @@ const asWindowsLaunch = (bin: string, args: string[]) =>
     new RegExp(`${bin}\\.cmd$|cmd\\.exe$`, "i").test(candidate),
   );
 
-// Each agent's argv as a WINDOWS spawn builds it — the seed resolved the way the spawner resolves
-// it, which is the step the bug was missing.
-const windowsArgv = (): Array<[string, string[]]> => {
-  const seed = seedPromptArgument(SESSION, SEED, "win32");
+// A seed no command line has room for. Written in Japanese on purpose: 40,000 characters is 120,000
+// bytes, and bytes are what the limits are counted in.
+const LONG_SEED = "あ".repeat(40_000);
+
+// Each agent's argv, with the seed resolved the way the SPAWNER resolves it — the step the bug was
+// missing. Parameterised by platform because the two reasons a seed cannot ride argv do not share
+// one: a newline is refused only by Windows, while a command line runs out of room everywhere.
+const argvFor = (platform: NodeJS.Platform, seedText: string): Array<[string, string[]]> => {
+  const seed = seedPromptArgument(SESSION, seedText, platform);
   return [
     ["grok", buildGrokArgs({ sessionId: "11111111-2222-4333-8444-555555555555", resume: null, model: "grok-4.5", skipPermissions: true, initialPrompt: seed })],
     ["agy", buildAntigravityArgs({ resume: null, model: "agy-1", skipPermissions: true, initialPrompt: seed })],
     ["muse", buildMuseArgs({ resume: null, workspace: CWD, model: "muse-spark-1.2", initialPrompt: seed })],
   ];
 };
+
+const windowsArgv = (): Array<[string, string[]]> => argvFor("win32", SEED);
 
 describe("a seed prompt on a Windows command line", () => {
   it("is multi-line for any skill seed with arguments — the reason this rule exists", () => {
@@ -70,6 +78,48 @@ describe("a seed prompt on a Windows command line", () => {
   });
 });
 
+// The other half of "can go on a command line": there has to be ROOM for it. Asserted against the
+// line tmux is actually handed, not against the agent's argv alone — the limit is on the whole
+// command, and the agent's arguments are only part of what this server puts on it.
+describe("a seed prompt with no room on the command line", () => {
+  // Measured against tmux 3.7b on macOS: 16,250 bytes in a single argument was accepted, 16,375
+  // refused with "command too long", and two 10,000-byte arguments were refused together — so the
+  // ceiling is on the total, at about 16 KiB. The assertion below uses the largest size actually
+  // observed to work, so a tmux that raises its limit does not make this test pass for free.
+  const TMUX_OBSERVED_OK_BYTES = 16_250;
+
+  // What pty-spawn.ts really spawns for a persistent session. muse's env is the one that grows with
+  // the machine rather than the prompt, so it stands in for the rest of the shared budget.
+  const tmuxCommandLine = (bin: string, args: string[]): string =>
+    tmuxNewSessionArgs("11111111-2222-4333-8444-555555555555", `/usr/local/bin/${bin}`, args, "/Users/someone/git/some/deep/project", {
+      MUSE_PLUGIN_DIR: "/Users/someone/.mulmoterminal/muse-plugins",
+    }).join(" ");
+
+  it("still leaves the tmux command line well inside the size tmux accepts", () => {
+    for (const [agent, args] of argvFor("darwin", LONG_SEED)) {
+      expect(Buffer.byteLength(tmuxCommandLine(agent, args), "utf8"), agent).toBeLessThan(TMUX_OBSERVED_OK_BYTES);
+    }
+  });
+
+  // The same seed WITHOUT the rule, to show the assertion above is not passing on its own. This is
+  // the session-killing "command too long", which is why length is handled off Windows too.
+  it("would blow past that limit if the seed rode argv", () => {
+    const unguarded = buildMuseArgs({ resume: null, workspace: CWD, model: "muse-spark-1.2", initialPrompt: LONG_SEED });
+    expect(Buffer.byteLength(tmuxCommandLine("muse", unguarded), "utf8")).toBeGreaterThan(TMUX_OBSERVED_OK_BYTES);
+  });
+
+  it("carries no argument bigger than the budget, for every agent that takes one", () => {
+    for (const platform of ["darwin", "win32"] as const) {
+      for (const [agent, args] of argvFor(platform, LONG_SEED)) {
+        expect(
+          args.filter((arg) => Buffer.byteLength(arg, "utf8") > SEED_ARGV_MAX_BYTES),
+          `${agent} on ${platform}`,
+        ).toEqual([]);
+      }
+    }
+  });
+});
+
 describe("seedPromptArgument", () => {
   it("hands back a multi-line seed unchanged off Windows — nothing about that path moves", () => {
     expect(seedPromptArgument(SESSION, SEED, "darwin")).toBe(SEED);
@@ -89,6 +139,40 @@ describe("seedPromptArgument", () => {
     // Verbatim: the whole point is that the agent gets the instruction it was given, not a
     // flattened paraphrase of it.
     expect(readFileSync(seedFileFor(SESSION), "utf8")).toBe(SEED);
+  });
+
+  // Length is the reason that is NOT Windows-only: tmux is what runs out of room first, and tmux is
+  // what this server spawns through on macOS and Linux.
+  it("puts an oversized seed in a file on every platform, not just Windows", () => {
+    for (const platform of ["darwin", "linux", "win32"] as const) {
+      const argument = seedPromptArgument(SESSION, LONG_SEED, platform);
+      expect(argument, platform).toContain(seedFileFor(SESSION));
+      expect(readFileSync(seedFileFor(SESSION), "utf8"), platform).toBe(LONG_SEED);
+      cleanupSessionSettings(SESSION);
+    }
+  });
+
+  // A character-count guard would wave this straight through: 2,000 characters, 6,000 bytes. tmux
+  // counts the bytes.
+  it("measures bytes, not characters — a Japanese seed is three bytes a character", () => {
+    const japanese = "あ".repeat(2000);
+    expect(japanese.length).toBeLessThan(SEED_ARGV_MAX_BYTES);
+    expect(seedPromptArgument(SESSION, japanese, "darwin")).toContain(seedFileFor(SESSION));
+    cleanupSessionSettings(SESSION);
+
+    // Same character count in ASCII fits, and is left alone — the rule is about the size on the
+    // command line, not about how long the text looks.
+    const ascii = "a".repeat(2000);
+    expect(seedPromptArgument(SESSION, ascii, "darwin")).toBe(ascii);
+    expect(existsSync(seedFileFor(SESSION))).toBe(false);
+  });
+
+  it("takes a seed that exactly fills the budget, and files the next byte", () => {
+    const exact = "a".repeat(SEED_ARGV_MAX_BYTES);
+    expect(seedPromptArgument(SESSION, exact, "darwin")).toBe(exact);
+    expect(existsSync(seedFileFor(SESSION))).toBe(false);
+
+    expect(seedPromptArgument(SESSION, `${exact}a`, "darwin")).toContain(seedFileFor(SESSION));
   });
 
   it("is cleaned up with the session's other files", () => {

--- a/test/server/agents/seed-prompt-not-argv.spec.ts
+++ b/test/server/agents/seed-prompt-not-argv.spec.ts
@@ -16,6 +16,7 @@ import { buildMuseArgs } from "../../../server/agents/muse-args.js";
 import { codexifySkillSeed } from "../../../server/agents/codex-skills.js";
 import { seedPromptArgument, cleanupSessionSettings, SEED_ARGV_MAX_BYTES } from "../../../server/session/session-settings.js";
 import { resolvePtyLaunch } from "../../../server/infra/resolve-bin.js";
+import { escapeBatchArgument } from "../../../server/infra/cmd-escape.js";
 import { tmuxNewSessionArgs } from "../../../server/infra/tmux.js";
 
 const SESSION = "seed-argv-spec-session";
@@ -106,6 +107,29 @@ describe("a seed prompt with no room on the command line", () => {
   it("would blow past that limit if the seed rode argv", () => {
     const unguarded = buildMuseArgs({ resume: null, workspace: CWD, model: "muse-spark-1.2", initialPrompt: LONG_SEED });
     expect(Buffer.byteLength(tmuxCommandLine("muse", unguarded), "utf8")).toBeGreaterThan(TMUX_OBSERVED_OK_BYTES);
+  });
+
+  // cmd.exe stops at 8,191 characters, and what it is handed is the ESCAPED line — escapeBatchArgument
+  // doubles every internal quote, so a seed of nothing but quotes arrives at twice its measured size
+  // (codex review on #1522). Asserted on the line resolvePtyLaunch actually builds.
+  const CMD_MAX_CHARS = 8191;
+  const QUOTE_BOMB = '"'.repeat(SEED_ARGV_MAX_BYTES);
+
+  it("leaves the cmd.exe command line inside its limit even when every character doubles", () => {
+    for (const [agent, args] of argvFor("win32", QUOTE_BOMB)) {
+      const launch = asWindowsLaunch(agent, args);
+      // The batch path is the one that goes through cmd; a resolved .exe takes an argv array instead.
+      expect(typeof launch.args, agent).toBe("string");
+      expect((launch.args as unknown as string).length, agent).toBeLessThan(CMD_MAX_CHARS);
+    }
+  });
+
+  it("would blow past cmd's limit if the unescaped size were the measure", () => {
+    // Exactly what a byte-only guard would have let through: at the budget unescaped, over it escaped.
+    expect(Buffer.byteLength(QUOTE_BOMB, "utf8")).toBeLessThanOrEqual(SEED_ARGV_MAX_BYTES);
+    expect(escapeBatchArgument(QUOTE_BOMB).length).toBeGreaterThan(SEED_ARGV_MAX_BYTES);
+    const unguarded = buildMuseArgs({ resume: null, workspace: CWD, model: "muse-spark-1.2", initialPrompt: QUOTE_BOMB });
+    expect((asWindowsLaunch("muse", unguarded).args as unknown as string).length).toBeGreaterThan(CMD_MAX_CHARS);
   });
 
   it("carries no argument bigger than the budget, for every agent that takes one", () => {


### PR DESCRIPTION
## Summary

#1519 は、シードが argv に載らない理由のうち **改行だけ** を扱いました。同じ受け口が抱えるもう一つの理由は **長さ** で、そちらは Windows 限定ではありません。

`ptySpawn` は永続セッションを `tmux new-session -A … -- <bin> <args>` で起動します（`pty-spawn.ts`, `tmux.ts`）。コマンドラインが長すぎると tmux は `command too long` を返し、**引数ではなくセッションごと死にます** — Windows の失敗より軽いのではなく、重い失敗です。

`seedNeedsFile` に長さの条件を足しました。改行の条件は Windows 限定のまま、長さの条件は全プラットフォームです。

```ts
export const SEED_ARGV_MAX_BYTES = 4096;
const seedNeedsFile = (prompt: string, platform: NodeJS.Platform): boolean =>
  (platform === "win32" && /[\0\r\n]/.test(prompt)) || Buffer.byteLength(prompt, "utf8") > SEED_ARGV_MAX_BYTES;
```

## 実測した上限（tmux 3.7b / macOS、専用ソケットで二分探索）

| | 結果 |
|---|---|
| 16,250 バイトの引数1つ | 通る |
| 16,375 バイトの引数1つ | `command too long` |
| **10,000 バイトの引数2つ** | `command too long` |

3行目が設計上いちばん効きます。上限は**引数ごとではなくコマンドライン全体**にかかるので、予算はソケットパス、conf パス、セッション名、`-c <cwd>`、`-e KEY=VALUE`（muse のプラグイン env）、bin 自身のフラグと共有されます。Windows はさらに小さく、cmd.exe が 8,191 文字。

それでも **シードのバイト長だけを見れば足りる** のは、あの行で青天井なのがシードだけだからです。他はパスとフラグと uuid で、全部合わせても数百バイトにしかなりません。閾値 4,096 は cmd.exe の半分、tmux の 1/4 で、cwd や env が伸びても飲み込めます。

## 文字数ではなくバイト長で測っています

tmux が数えるのはバイトで、日本語は1文字3バイトです。`'あ' * 3000` は 3,000 文字 / 9,000 バイト。文字数の門番はこれを素通しします。テストで「2,000文字の日本語（6,000バイト）はファイル、同じ2,000文字の ASCII はそのまま」を切り分けて固定しました。

## Items to Confirm / Review

1. **閾値 4,096 バイト** — 上の見積もりが妥当かどうか。安全側に倒していますが、その分ファイル経由になるシードは #1519 の想定より増えます。
2. **長さの条件を Windows 限定にしなかったこと** — tmux の上限は macOS / Linux の問題なので、プラットフォームで分けていません。改行の条件とは効く範囲が違う、という形になっています。
3. **`initialPrompt` の受け口は残しています** — Issue #1518 の想定変更3（arg builder から外す）は採っていません。理由は下記。

## TUI 打ち込み案を採らなかった理由（今回あらためて実機で計測）

#1519 は「grok と muse が入っていないので閾値を検証できない」として TUI 打ち込みを却下しました。今回このマシンには両方入っていたので測り直しています。

| | grok | muse |
|---|---|---|
| 起動出力が止む時刻 | t≈956ms | **止まらない**（24秒間、起動後の最長ギャップ 56ms） |
| codex 式「1秒静穏」 | 使える | **発火しない**（15秒の上限で打つだけ） |
| readiness マーカー初出 | `ctrl+x:shortcuts` が 760 / 798 / 788ms（3回とも安定） | 全候補が ~220ms = 初回フレームと同時で、準備完了の証拠にならない |
| ペーストが入力箱に残る最早時刻 | 200ms は消える、500ms 以降は残る | 200ms から残る |

grok は claude と同じ「マーカー＋settle」で素直に載りますが、**muse は静穏にならないので codex 方式が構造的に使えず**、muse 専用の機構を新設することになります。それを「失敗が静か（シードが黙って実行されない）」という性質と引き換えに入れる価値は薄いと判断しました。この案はタイミングの当て推量が一切ありません。

なお計測中に、muse は端末への問い合わせ（DA / CPR / OSC 色クエリ）に応答が無いと 6.3 秒で自ら exit することが分かりました。素の pty で muse を測ろうとする人向けのメモです。

## テスト

`test/server/agents/seed-prompt-not-argv.spec.ts` に8件追加（このファイル13件、リポジトリ全体 9,125 件通過。lint / typecheck / prettier クリーン）。

長さの検証は agent の argv 単体ではなく、`tmuxNewSessionArgs` が実際に組み立てる**コマンドライン全体**に対して行っています。「ルール無しなら実測上限を超える」も併せて assert してあるので、アサーションが自力で通っているだけの状態にはなりません。境界（ちょうど 4,096 は素通し、+1 でファイル）も固定しています。

## 実機確認

ユニットテストでは答えられない「**エージェントが本当にファイルを読んで実行するか**」を、本番の `seedPromptArgument` / `buildGrokArgs` / `buildMuseArgs` をそのまま呼んで確認しました。

```
9,265 バイトのシード -> argv は 154 バイトの参照1行
grok   ファイルを読んで実行した
muse   ファイルを読んで実行した
```

#1519 はこの経路を Windows 限定で入れたため実機で走らせられていませんでしたが、今回 macOS でも発火するようになったので、ここは確認が必須でした。

## 残していること

`appendedPromptArgument`（`--append-system-prompt`）は手つかずです。同じ 16KB を共有する経路で、今は Windows 限定でしかファイル化されないので、長大なプリセットなら同じ `command too long` を踏み得ます。今回のスコープ外ですが、同じ形の穴です。

work in mag2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting sessions with seed prompts containing control characters or exceeding command-line size limits.
  * Large prompts, including those with multibyte characters, are now handled safely across platforms.
  * Added safeguards for exact command-line size boundaries and improved Windows and tmux compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->