### PR TITLE
refactor: code scanning の duplicate-code アラート 2 件を共有ガード抽出で解消する (#1523)

### DIFF
--- a/plans/refactor-jscpd-action-guards-1523.md
+++ b/plans/refactor-jscpd-action-guards-1523.md
@@ -1,0 +1,80 @@
+# refactor: code scanning の duplicate-code アラート 2 件を解消する (#1523)
+
+`duplication-scan` (jscpd 5.0.12, minTokens=50 / minLines=5) の open アラートは 2 件。
+SARIF は**片側の位置しか持たない**ので、対を知るには CI と同じ引数でローカル実行する
+（`plans/refactor-jscpd-duplicates-1472.md` と同じ手順）:
+
+```
+npx jscpd@5.0.12 . --format "typescript,vue" \
+  --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" --reporters console
+```
+
+| alert | 片側 | 対 | tokens |
+| --- | --- | --- | --- |
+| 150 | `server/backends/collections.ts` 556-562 | `server/backends/customViewRoutes.ts` 137-143 | 79 |
+| 151 | `server/backends/collections.ts` 773-778 | `server/backends/customViewRoutes.ts` 150-155 | 57 |
+
+## 何が重なっているか
+
+record-level action を押すルートは 2 本ある。宛先が同じで、通し方だけが違う:
+
+- 親側 `POST /:slug/items/:itemId/actions/:actionId` — `itemActionHandler`（collections.ts）。
+  seed 系（chat / agent）も mutate も通す。
+- view token 側 `POST /:slug/view-data/actions/:actionId` — `makeActionHandler`
+  （customViewRoutes.ts）。mutate だけを通す。
+
+同じ宛先なので前置きのガードが同型になり、それが写しのまま 2 本ある:
+
+1. **action の 404** — `schema.actions` から id で引き、無ければ同じ文言で 404（alert 150）
+2. **read-only collection の 405** — `collectionWritable` → `readOnlyRefusal`（alert 151。
+   collections.ts 側は `itemActionHandler` と `viewDataPutHandler` の 2 箇所にある）
+3. **record の 404 と `actionVisible` の 409** — jscpd は拾っていないが、
+   `itemId` の出どころ（route param か body か）が違うだけで文言・ステータスまで同一。
+   ここが「片方だけ直る」と、view から押した action だけ state gate が緩む/厳しくなる。
+
+参照ホストの MulmoClaude は 1 ファイルに全ルートがあるので jscpd には出ないが、
+同じ重複を `findActionOr404`（`server/api/routes/collections.ts`）で既に共有化しており、
+親側ルートと view token 側ルートの両方から呼んでいる。こちらも同じ形にする。
+
+## 置き場所 — 3 つ目のモジュールにする理由
+
+`customViewRoutes.ts` は `collections.ts` を import してはいけない。逆向き
+（collections.ts → customViewRoutes.ts）が既にあり、必要な helper は mount 時に
+`CustomViewRouteDeps` として渡している。ファイル先頭のコメントがその契約を明記している。
+
+よって共有ガードは**どちらにも属さない新規モジュール**
+`server/backends/collectionActionGuards.ts` に置き、両方から import する。
+このモジュールが import するのは `@mulmoclaude/core` と express の型だけなので循環しない。
+
+## 出すもの
+
+```ts
+// server/backends/collectionActionGuards.ts
+export const visibilityGate = (action: CollectionAction): ActionWithWhen => …
+export const resolveItemAction = (res, collection, actionId): CollectionAction | null => …
+export const refuseReadOnlyCollection = (res, collection): boolean => …
+export const resolveActionableRecord = (res, collection, action, itemId): Promise<CollectionItem | null> => …
+```
+
+- 応答を自分で返して `null` を返す作法は、collections.ts の既存 `resolveCollection` /
+  `resolveView` / `resolveWriteTarget` と同じ。`refuseReadOnlyCollection` だけは
+  「405 を返したか」を `boolean` で返す（返す値が無いガードなので）。
+- `visibilityGate` は collections.ts から**移す**。`resolveActionableRecord` が使うのと、
+  移せば `CustomViewRouteDeps.visibilityGate` の手渡しが 1 本消えるため。
+  spec の import 先も新モジュールに変える（再 export はしない）。
+- チェックの**順序は現状維持**。view token 側は `collectionWritable` を record 読みの前に、
+  親側は `actionVisible` の後に見ている。順序はルートごとの都合なので共有側に畳まない。
+
+## 検証
+
+1. 上の jscpd コマンドで **clone 0 件**（抽出が中途半端だと 50 トークンを割らずに残るので、
+   目視ではなく実際に回して確認する）
+2. `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
+3. 挙動の担保は既存 spec（`test/server/backends/collections.spec.ts`）:
+   `action routes (seed prompts)` の 404 2 種、`record-level mutate actions` の 404、
+   `custom-view mutate actions` の 403 / 409 / 400 / 404。**どちらのルートも 404 / 409 を
+   既に持っている**ので、共有側に畳んだあともルート越しに両方から確認できる。
+4. 共有ガード自身の spec を `test/server/backends/collectionActionGuards.spec.ts` に新設。
+   `visibilityGate` の既存 describe もそこへ移す（テスト対象と同居させる。collections.spec.ts は
+   既に max-lines 警告を出しているので、そこに足さない）。`resolveActionableRecord` は
+   `storeFor` 越しにディスクを読むため単体では持たず、上の 3 のルート spec で担保する。

--- a/server/backends/collectionActionGuards.ts
+++ b/server/backends/collectionActionGuards.ts
@@ -1,0 +1,67 @@
+// The guards both record-level action routes run before doing any work: the
+// parent-side POST /:slug/items/:itemId/actions/:actionId (collections.ts) and
+// the token-scoped POST /:slug/view-data/actions/:actionId (customViewRoutes.ts).
+// Same destination, so the same 404 / 405 / 409 — and each answer is part of the
+// API contract MulmoClaude's host shares, where the equivalent is `findActionOr404`.
+//
+// A third module rather than either file: customViewRoutes.ts must not import
+// collections.ts (the reverse edge exists, which is why its helpers are handed in
+// at mount time). This one imports only core, so neither direction cycles.
+import type { Response } from "express";
+import { collectionWritable, readOnlyRefusal, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import { actionVisible, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+
+// The action's state gate, rebuilt so core's exact-optional parameter accepts it: the schema
+// parse yields a `when: undefined` / `require: undefined` KEY, which that type rejects.
+//
+// BOTH names are forwarded. They are the same gate under two spellings — `when` on the seeded
+// kinds, `require` on mutate — and this call is the authorization check, so dropping either
+// would make that kind's actions unconditionally runnable by a crafted request.
+export const visibilityGate = (action: CollectionAction): ActionWithWhen => ({
+  ...("when" in action && action.when ? { when: action.when } : {}),
+  ...("require" in action && action.require ? { require: action.require } : {}),
+});
+
+/** Find a record-level action by id, answering 404 when the collection declares
+ *  no such action. A null return means the response is already sent. */
+export const resolveItemAction = (res: Response, collection: LoadedCollection, actionId: string): CollectionAction | null => {
+  const action = collection.schema.actions?.find((entry) => entry.id === actionId);
+  if (!action) {
+    res.status(404).json({ error: `action '${actionId}' not found on collection '${collection.slug}'` });
+    return null;
+  }
+  return action;
+};
+
+/** True once a 405 has been sent because the collection is read-only. Schema
+ *  validation already rejects mutate actions on a dataSource collection; this is
+ *  the defensive server-side twin both routes carry. */
+export const refuseReadOnlyCollection = (res: Response, collection: LoadedCollection): boolean => {
+  if (collectionWritable(collection)) return false;
+  res.status(405).json({ error: readOnlyRefusal(collection.slug) });
+  return true;
+};
+
+/** The record an action is about to run against, answering 404 when it is absent
+ *  and 409 when the action's state gate rejects it. A null return means the
+ *  response is already sent.
+ *
+ *  The gate is the authorization rule, not a display hint: the client hides
+ *  out-of-state buttons, but a stale or crafted request could still target one. */
+export const resolveActionableRecord = async (
+  res: Response,
+  collection: LoadedCollection,
+  action: CollectionAction,
+  itemId: string,
+): Promise<CollectionItem | null> => {
+  const record = await storeFor(collection).read(itemId);
+  if (!record) {
+    res.status(404).json({ error: `item '${itemId}' not found` });
+    return null;
+  }
+  if (!actionVisible(visibilityGate(action), record)) {
+    res.status(409).json({ error: `action '${action.id}' is not available for item '${itemId}' in its current state` });
+    return null;
+  }
+  return record;
+};

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -39,15 +39,14 @@ import {
   deleteCollectionRefusalMessage,
   deleteCustomView,
   applyMutateAction,
-  collectionWritable,
   readOnlyRefusal,
   storeFor,
   type LoadedCollection,
   type RecordIssue,
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
-// CollectionItem + actionVisible live in the isomorphic core entry.
-import { actionVisible, fieldVisible, COMPUTED_TYPES, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+// CollectionItem + fieldVisible live in the isomorphic core entry.
+import { fieldVisible, COMPUTED_TYPES, type CollectionItem } from "@mulmoclaude/core/collection";
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
@@ -55,6 +54,8 @@ import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalize
 // mutate action), mounted at the bottom of mountCollectionRoutes with the
 // helpers those routes share with the ones here.
 import { mountCustomViewRoutes, viewActionRateLimit } from "./customViewRoutes.js";
+// The 404 / 405 / 409 preamble those action routes share with the one here.
+import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
 // Mobile custom-view builder — shared with the remote-host channel handlers so
 // the desktop phone-frame preview renders the EXACT artifact the phone receives.
 import {
@@ -540,47 +541,19 @@ const respondForMutateAction = async (
   res.json({ written: true, itemId, item: outcome.item });
 };
 
-// The action's state gate, rebuilt so core's exact-optional parameter accepts it: the schema
-// parse yields a `when: undefined` / `require: undefined` KEY, which that type rejects.
-//
-// BOTH names are forwarded. They are the same gate under two spellings — `when` on the seeded
-// kinds, `require` on mutate — and this call is the authorization check, so dropping either
-// would make that kind's actions unconditionally runnable by a crafted request.
-export const visibilityGate = (action: CollectionAction): ActionWithWhen => ({
-  ...("when" in action && action.when ? { when: action.when } : {}),
-  ...("require" in action && action.require ? { require: action.require } : {}),
-});
-
 // Per-record action (e.g. Repair / enrich this record).
 const itemActionHandler: RequestHandler<{ slug: string; itemId: string; actionId: string }> = async (req, res) => {
   const collection = await resolveCollection(res, req.params.slug);
   if (!collection) return;
-  const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
-  if (!action) {
-    res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
-    return;
-  }
-  const record = await storeFor(collection).read(req.params.itemId);
-  if (!record) {
-    res.status(404).json({ error: `item '${req.params.itemId}' not found` });
-    return;
-  }
-  // The action's `when` predicate is the authorization rule: the client hides
-  // out-of-state buttons, but a stale/crafted request could still target one.
-  if (!actionVisible(visibilityGate(action), record)) {
-    res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
-    return;
-  }
+  const action = resolveItemAction(res, collection, req.params.actionId);
+  if (!action) return;
+  const record = await resolveActionableRecord(res, collection, action, req.params.itemId);
+  if (!record) return;
   // `kind: "mutate"` needs no template / seed / LLM — the host applies the
   // declarative write itself (`when` was just enforced above, same
   // visibility-is-authorization rule as the seeded kinds).
   if (action.kind === "mutate") {
-    // Schema validation already rejects mutate actions on a dataSource
-    // collection; this is the defensive server-side twin.
-    if (!collectionWritable(collection)) {
-      res.status(405).json({ error: readOnlyRefusal(collection.slug) });
-      return;
-    }
+    if (refuseReadOnlyCollection(res, collection)) return;
     await respondForMutateAction(res, collection, action, req.params.itemId, isRecord(req.body) ? req.body : undefined);
     return;
   }
@@ -770,10 +743,7 @@ const viewDataGetHandler: RequestHandler<{ slug: string }> = async (req, res) =>
 const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   const collection = await resolveCollection(res, req.params.slug);
   if (!collection) return;
-  if (!collectionWritable(collection)) {
-    res.status(405).json({ error: readOnlyRefusal(collection.slug) });
-    return;
-  }
+  if (refuseReadOnlyCollection(res, collection)) return;
   const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
   if (!Array.isArray(body.items)) {
     res.status(400).json({ error: "`items` must be an array" });
@@ -893,12 +863,11 @@ export function mountCollectionRoutes(app: Express): void {
 
   // The rest of the custom-view surface (customViewRoutes.ts: the i18n dict, the
   // scoped image resolve, the scoped mutate action), handed the loader / view
-  // lookup / mutate executor / gate it shares with the routes above.
+  // lookup / mutate executor it shares with the routes above.
   mountCustomViewRoutes(app, {
     resolveCollection,
     resolveView,
     respondForMutateAction,
-    visibilityGate,
     guarded,
     cors: viewDataCors,
     queryConcurrency: viewQueryConcurrency,

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -10,9 +10,11 @@
 // so there is no cycle between the two modules.
 import type { Express, Request, RequestHandler, Response } from "express";
 import { clampImageMaxEdge } from "@mulmoclaude/core/remote-view";
-import { collectionWritable, readCustomViewI18n, readOnlyRefusal, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import { readCustomViewI18n, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
 import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
-import { actionVisible, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+import type { CollectionItem } from "@mulmoclaude/core/collection";
+// The 404 / 405 / 409 preamble this action route shares with the parent-side one.
+import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
 // The same thumbnail resolver the mobile view's image inlining uses, so a desktop
 // view's <img> and the phone's inlined one are the same bytes.
 import { resolveThumbnail } from "./thumbnailStore.js";
@@ -24,8 +26,7 @@ import { isRecord } from "../../common/isRecord.js";
 const log = hostLogger;
 
 /** What these routes need from the collections backend: its 404-answering loader,
- *  its mutate executor, the action gate both spellings of `when` fold into, and
- *  the two middlewares the whole view-data family shares. */
+ *  its mutate executor, and the two middlewares the whole view-data family shares. */
 export interface CustomViewRouteDeps {
   /** Load a collection, answering 404 itself; null means the response was sent. */
   resolveCollection: (res: Response, slug: string) => Promise<LoadedCollection | null>;
@@ -39,8 +40,6 @@ export interface CustomViewRouteDeps {
     itemId: string,
     body: { params?: unknown } | undefined,
   ) => Promise<void>;
-  /** An action's state gate, in the shape `actionVisible` reads. */
-  visibilityGate: (action: CollectionAction) => ActionWithWhen;
   /** Wrap a handler so a throw becomes a logged 500. */
   guarded: <P extends Record<string, string>>(op: string, handler: RequestHandler<P>) => RequestHandler<P>;
   /** `Access-Control-*` for the opaque-origin iframe's preflighted fetch. */
@@ -136,37 +135,20 @@ const makeActionHandler =
   async (req, res) => {
     const collection = await deps.resolveCollection(res, req.params.slug);
     if (!collection) return;
-    const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
-    if (!action) {
-      res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
-      return;
-    }
+    const action = resolveItemAction(res, collection, req.params.actionId);
+    if (!action) return;
     if (action.kind !== "mutate") {
       res.status(403).json({ error: `action '${action.id}' has kind "${action.kind}" — view tokens can only invoke "mutate" actions` });
       return;
     }
-    // Schema validation already rejects mutate actions on a dataSource collection;
-    // this is the defensive twin the parent-side action route also carries.
-    if (!collectionWritable(collection)) {
-      res.status(405).json({ error: readOnlyRefusal(collection.slug) });
-      return;
-    }
+    if (refuseReadOnlyCollection(res, collection)) return;
     const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     const itemId = typeof body.itemId === "string" ? body.itemId.trim() : "";
     if (!itemId) {
       res.status(400).json({ error: "`itemId` is required (the record's primary-key value)" });
       return;
     }
-    const record = await storeFor(collection).read(itemId);
-    if (!record) {
-      res.status(404).json({ error: `item '${itemId}' not found` });
-      return;
-    }
-    // The same visibility-is-authorization re-check the parent-side route runs.
-    if (!actionVisible(deps.visibilityGate(action), record)) {
-      res.status(409).json({ error: `action '${action.id}' is not available for item '${itemId}' in its current state` });
-      return;
-    }
+    if (!(await resolveActionableRecord(res, collection, action, itemId))) return;
     await deps.respondForMutateAction(res, collection, action, itemId, body);
   };
 

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -11,8 +11,7 @@
 import type { Express, Request, RequestHandler, Response } from "express";
 import { clampImageMaxEdge } from "@mulmoclaude/core/remote-view";
 import { readCustomViewI18n, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
-import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
-import type { CollectionItem } from "@mulmoclaude/core/collection";
+import type { CollectionItem, CollectionMutateAction } from "@mulmoclaude/core/collection";
 // The 404 / 405 / 409 preamble this action route shares with the parent-side one.
 import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
 // The same thumbnail resolver the mobile view's image inlining uses, so a desktop

--- a/test/server/backends/collectionActionGuards.spec.ts
+++ b/test/server/backends/collectionActionGuards.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { actionVisible } from "@mulmoclaude/core/collection";
+import { refuseReadOnlyCollection, resolveItemAction, visibilityGate } from "../../../server/backends/collectionActionGuards.js";
+
+// `resolveActionableRecord` is not here: it reads through `storeFor`, so its 404 /
+// 409 are covered against real on-disk collections by both routes that call it, in
+// collections.spec.ts ("action routes (seed prompts)" and "custom-view mutate actions").
+
+// visibilityGate rebuilds an action's state gate so core's exact-optional parameter accepts it
+// (the schema parse leaves the key holding `undefined`). It is the AUTHORIZATION check — the
+// client hides out-of-state buttons, but a crafted request can still target one — so the two
+// spellings of the same gate must both survive the rebuild. `when` belongs to the seeded kinds,
+// `require` to mutate; forwarding only one silently makes that kind's actions always runnable.
+describe("visibilityGate", () => {
+  const WHEN = { field: "status", in: ["ready"] };
+
+  it("forwards a seeded action's `when`", () => {
+    expect(visibilityGate({ id: "a", label: "A", kind: "chat", role: "r", template: "t", when: WHEN })).toEqual({ when: WHEN });
+  });
+
+  it("forwards a mutate action's `require`", () => {
+    expect(visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" }, require: WHEN })).toEqual({ require: WHEN });
+  });
+
+  it("drops the key entirely for an ungated action, rather than leaving it undefined", () => {
+    const gate = visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" } });
+    expect(Object.hasOwn(gate, "when")).toBe(false);
+    expect(Object.hasOwn(gate, "require")).toBe(false);
+  });
+
+  // The gate is what actionVisible reads, so the round trip is what actually has to hold.
+  it("keeps a mutate action hidden on a record that fails its `require`", () => {
+    const gate = visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" }, require: WHEN });
+    expect(actionVisible(gate, { status: "draft" })).toBe(false);
+    expect(actionVisible(gate, { status: "ready" })).toBe(true);
+  });
+});
+
+// The two guards that answer the response themselves. What a CALLER sees is the
+// null / the boolean, and that is what decides whether it goes on — a route test
+// can only observe the status, so assert the return value here.
+describe("route-answering action guards", () => {
+  const fakeRes = () => {
+    const sent: { status: number; body: unknown } = { status: 0, body: null };
+    const res = {
+      status(code: number) {
+        sent.status = code;
+        return res;
+      },
+      json(body: unknown) {
+        sent.body = body;
+        return res;
+      },
+    };
+    return { res, sent };
+  };
+  const collectionWith = (extra: object) => ({ slug: "col", schema: {}, ...extra }) as unknown as Parameters<typeof resolveItemAction>[1];
+  const CLOSE = { id: "close", label: "Close", kind: "mutate", set: { status: "closed" } };
+
+  it("404s an action the collection does not declare, naming both ids", () => {
+    const { res, sent } = fakeRes();
+    expect(resolveItemAction(res as never, collectionWith({ schema: { actions: [CLOSE] } }), "nope")).toBeNull();
+    expect(sent.status).toBe(404);
+    expect((sent.body as { error: string }).error).toContain("'nope'");
+    expect((sent.body as { error: string }).error).toContain("'col'");
+  });
+
+  it("404s on a collection that declares no actions at all", () => {
+    const { res, sent } = fakeRes();
+    expect(resolveItemAction(res as never, collectionWith({}), "close")).toBeNull();
+    expect(sent.status).toBe(404);
+  });
+
+  it("returns the declared action without touching the response", () => {
+    const { res, sent } = fakeRes();
+    expect(resolveItemAction(res as never, collectionWith({ schema: { actions: [CLOSE] } }), "close")).toEqual(CLOSE);
+    expect(sent.status).toBe(0);
+  });
+
+  // The boolean IS the control flow — a guard that answered 405 but reported false
+  // would let its caller go on and write to a read-only collection.
+  it("reports whether it sent the read-only 405", () => {
+    const writable = fakeRes();
+    expect(refuseReadOnlyCollection(writable.res as never, collectionWith({ dataDir: "/data/col/items" }))).toBe(false);
+    expect(writable.sent.status).toBe(0);
+
+    const readOnly = fakeRes();
+    expect(refuseReadOnlyCollection(readOnly.res as never, collectionWith({ schema: { dataSource: { kind: "csv", path: "x.csv" } } }))).toBe(true);
+    expect(readOnly.sent.status).toBe(405);
+    expect((readOnly.sent.body as { error: string }).error).toContain("read-only");
+  });
+});

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -5,9 +5,8 @@ import sharp from "sharp";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { appRequest } from "../../helpers/appRequest.js";
-import { initCollectionsBackend, mountCollectionRoutes, visibilityGate } from "../../../server/backends/collections.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "../../../server/backends/collections.js";
 import { isAuthorizedImagePath } from "../../../server/backends/customViewRoutes.js";
-import { actionVisible } from "@mulmoclaude/core/collection";
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 
 // The registry engine fetches remote index.json / bundles — mock it so the route
@@ -881,36 +880,6 @@ describe("mobile custom views (phone-frame preview)", () => {
 
   it("GET /:slug/remote-view/:viewId/items 404s an unknown view", async () => {
     expect((await request("/api/collections/photoscol/remote-view/nope/items")).status).toBe(404);
-  });
-});
-
-// visibilityGate rebuilds an action's state gate so core's exact-optional parameter accepts it
-// (the schema parse leaves the key holding `undefined`). It is the AUTHORIZATION check — the
-// client hides out-of-state buttons, but a crafted request can still target one — so the two
-// spellings of the same gate must both survive the rebuild. `when` belongs to the seeded kinds,
-// `require` to mutate; forwarding only one silently makes that kind's actions always runnable.
-describe("visibilityGate", () => {
-  const WHEN = { field: "status", in: ["ready"] };
-
-  it("forwards a seeded action's `when`", () => {
-    expect(visibilityGate({ id: "a", label: "A", kind: "chat", role: "r", template: "t", when: WHEN })).toEqual({ when: WHEN });
-  });
-
-  it("forwards a mutate action's `require`", () => {
-    expect(visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" }, require: WHEN })).toEqual({ require: WHEN });
-  });
-
-  it("drops the key entirely for an ungated action, rather than leaving it undefined", () => {
-    const gate = visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" } });
-    expect(Object.hasOwn(gate, "when")).toBe(false);
-    expect(Object.hasOwn(gate, "require")).toBe(false);
-  });
-
-  // The gate is what actionVisible reads, so the round trip is what actually has to hold.
-  it("keeps a mutate action hidden on a record that fails its `require`", () => {
-    const gate = visibilityGate({ id: "a", label: "A", kind: "mutate", set: { status: "done" }, require: WHEN });
-    expect(actionVisible(gate, { status: "draft" })).toBe(false);
-    expect(actionVisible(gate, { status: "ready" })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Code scanning の `jscpd/duplicate-code` open アラート 2 件（150 / 151）を、共有ガードの抽出で解消する。
どちらも `server/backends/collections.ts` と `server/backends/customViewRoutes.ts` の間の重複で、
原因は同じ — **宣言済みの record-level action を押すルートが 2 本あり、同じ前置きガードを写しで持っている**こと。

- 親側 `POST /:slug/items/:itemId/actions/:actionId`（`itemActionHandler`）
- view token 側 `POST /:slug/view-data/actions/:actionId`（`makeActionHandler`）

共有した 4 つを新規モジュール `server/backends/collectionActionGuards.ts` に出した:

| 出したもの | 内容 | 呼ぶ側 |
| --- | --- | --- |
| `resolveItemAction` | action の 404（alert 150） | 上記 2 ルート |
| `refuseReadOnlyCollection` | read-only collection の 405（alert 151） | 上記 2 ルート + `viewDataPutHandler` |
| `resolveActionableRecord` | record の 404 と `actionVisible` の 409 | 上記 2 ルート |
| `visibilityGate` | action の state gate（collections.ts から移動） | 上記 |

`resolveActionableRecord` は jscpd が拾っていない同型ブロック。`itemId` の出どころ（route param か body か）が
違うだけで、ステータスも文言も両者同一だったので同時に畳んだ。ここが片方だけ直ると
「view から押した action だけ state gate がずれる」という認可の drift になる。

`visibilityGate` を移したことで `CustomViewRouteDeps` の手渡しが 1 本消えた。

**挙動は変えていない** — ステータス・文言・ルートごとのチェック順はそのまま
（view token 側は `collectionWritable` を record 読みの前に、親側は 409 の後に見る、という差も維持）。

### 検証

- CI と同じ引数の jscpd で **clone 0 件**（before: 2 件）
  ```
  npx jscpd@5.0.12 . --format "typescript,vue" \
    --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" --reporters console
  ```
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`（9131 passed / 45 skipped）
- lint の警告は main と同一（`collections.spec.ts` の max-lines が 888 → 868 に減っただけ）

## Items to Confirm / Review

1. **置き場所** — `customViewRoutes.ts` は `collections.ts` を import できない（逆向きが既にあり、
   helper は mount 時に渡す契約）ので、どちらにも属さない 3 つ目のモジュールにした。
   `collectionActionGuards.ts` という名前と粒度が妥当か。
2. **`visibilityGate` の移動** — 重複そのものではないが、`resolveActionableRecord` が使うので一緒に移した。
   spec の import 先も変わっている（再 export はしていない）。ここまでを 1 PR に含めてよいか。
3. **チェック順を共有側に畳まなかった判断** — 2 ルートで `collectionWritable` を見る位置が違う。
   順序はルートごとの都合なので各ルートに残したが、揃えるべきかどうか。
4. **`resolveActionableRecord` の戻り値を view 側で捨てている** — `respondForMutateAction` が
   record を読み直すため。`if (!(await resolveActionableRecord(...))) return;` の書き方の是非。
5. **参照ホストとの整合** — MulmoClaude は同じ重複を `findActionOr404` で共有化済み
   （`server/api/routes/collections.ts`、親側ルートと view token 側ルートの両方から呼んでいる）。
   引数順と命名だけこのリポの既存作法（`resolveCollection` / `resolveView` と同じ `res` 先頭）に合わせた。

## User Prompt

> 重複の退治
> https://github.com/receptron/mulmoterminal/security/code-scanning

## 実装メモ

設計判断の詳細は `plans/refactor-jscpd-action-guards-1523.md` を参照。

SARIF は片側の位置しか持たないので、対を知るには CI と同じ引数でローカル実行が要る:

| alert | 片側 | 対 | tokens |
| --- | --- | --- | --- |
| 150 | `collections.ts` 556-562 | `customViewRoutes.ts` 137-143 | 79 |
| 151 | `collections.ts` 773-778 | `customViewRoutes.ts` 150-155 | 57 |

テストは `test/server/backends/collectionActionGuards.spec.ts` を新設し、`visibilityGate` の既存 describe も
そこへ移した（`collections.spec.ts` は既に max-lines 警告が出ているので足さない）。
`resolveActionableRecord` は `storeFor` 越しにディスクを読むので単体 spec を持たず、
既存のルート spec（両ルートとも 404 / 409 を持っている）で担保している。

Closes #1523

work in mulmoterminal4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
