### PR TITLE
chore: move the codex review to the latest CLI (0.147.0) and model (gpt-5.6-terra)

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -10,18 +10,18 @@
 #     produces one review against the latest commit, not N reviews
 #   - `~/.npm` is cached, so `npm install -g @openai/codex` reuses
 #     the prior tarball + skips the network on warm runs
-#   - Azure deployment SKU caps TPM (5000 currently); throttling
+#   - Azure deployment SKU caps TPM (10000 currently); throttling
 #     happens at the model layer, not the workflow layer
 #
 # Auth: Azure OpenAI via the OpenAI-compatible `/openai/v1` endpoint.
-# Codex CLI 0.125.0 does NOT honour `OPENAI_BASE_URL` directly —
-# the iter-1 attempt 401'd against `api.openai.com` because the env
-# var was silently ignored. Workflow now writes an explicit
+# Codex CLI does NOT honour `OPENAI_BASE_URL` directly — the iter-1
+# attempt 401'd against `api.openai.com` because the env var was
+# silently ignored. Workflow now writes an explicit
 # `~/.codex/config.toml` with `[model_providers.azure]` before the
 # `codex exec` invocation. Required secrets:
 #   - AZURE_OPENAI_API_KEY        (the Azure key)
 #   - AZURE_OPENAI_BASE_URL       (e.g. https://<resource>.openai.azure.com — no path)
-#   - AZURE_OPENAI_DEPLOYMENT     (optional; defaults to gpt-5.4-mini)
+#   - AZURE_OPENAI_DEPLOYMENT     (optional; defaults to codex-review-terra)
 #   - AZURE_OPENAI_API_VERSION    (optional; defaults to `preview`)
 #
 # `workflow_dispatch` is also kept for manual re-runs (e.g.
@@ -62,7 +62,7 @@ permissions:
 # upgrades are explicit. Bump together with cache-version when
 # moving to a new Codex release.
 env:
-  CODEX_VERSION: "0.125.0"
+  CODEX_VERSION: "0.147.0"
 
 concurrency:
   group: codex-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
@@ -126,12 +126,17 @@ jobs:
           # Deployment name on the Azure resource (the LLM model
           # alias the workspace administrator created). Codex passes
           # this through as `model = ...` in the request body.
-          # Default `gpt-5.3-codex` is the codex-optimized GPT-5.3
-          # variant (deployed on `mulmo-sweden` 2026-04-30) — the
-          # MSFT-documented choice for Codex CLI agentic-coding
-          # workloads. Older `gpt-4o` still works as a fallback if
-          # the codex variant isn't deployed; override via secret.
-          AZURE_MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT || 'gpt-5.3-codex' }}
+          # `codex-review-terra` runs gpt-5.6-terra (deployed on
+          # `mulmo-sweden` 2026-08-07) under a name the CLI does NOT
+          # recognise, and that mismatch is deliberate: for a model it
+          # has metadata for, Codex nests the whole tool list under a
+          # `functions` namespace carrying an empty description, and
+          # Azure's Responses validator rejects that outright —
+          # `400 empty_string` on `input[0].tools[0].description`.
+          # An unknown name falls back to the flat tool list Azure
+          # accepts. Deploying gpt-5.6-terra under its own name breaks
+          # every review until upstream stops sending that payload.
+          AZURE_MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT || 'codex-review-terra' }}
         run: |
           mkdir -p "$HOME/.codex"
           # Strip trailing slash so concatenation never doubles up.
@@ -141,7 +146,7 @@ jobs:
           # so no accidental command substitution. envsubst then fills
           # ONLY the three whitelisted vars — anything else, including
           # a literal `$x` in TOML, is left untouched.
-          # Codex CLI 0.125.0 only supports the "responses" wire (Chat
+          # Codex CLI only supports the "responses" wire (Chat
           # Completions was removed); on Azure that needs
           # api-version >= 2025-03-01-preview on a deployment exposing
           # the Responses surface (recent gpt-4o / gpt-4.1 / gpt-5).


### PR DESCRIPTION
## Summary

CI の codex auto-review を **最新の CLI + 最新のモデル** に載せ替える。

| | before | after |
|---|---|---|
| Codex CLI | `0.125.0` | `0.147.0`（npm latest） |
| Azure deployment | `gpt-5.3-codex` | `codex-review-terra` = **gpt-5.6-terra**（2026-07-09 GA） |

`gpt-5.3-codex` は Codex 上ではすでに deprecated 扱い。gpt-5.6 系（sol / terra / luna）が現行ラインナップで、balanced の **terra** を選択。

Azure 側の作業は実施済み:
- `mulmo-sweden`（swedencentral）に `codex-review-terra` → `gpt-5.6-terra` (2026-07-09) を GlobalStandard / 10,000 TPM で deploy
- 旧 `gpt-5.3-codex` deployment はロールバック用にそのまま残置
- `AZURE_OPENAI_DEPLOYMENT` secret は 3 リポジトリとも未設定なので、workflow のデフォルト値変更だけで切り替わる

## Items to Confirm / Review

1. **deployment 名がモデル名を名乗っていないのは意図的** — ここがこの PR で一番説明が要る点。
   Codex CLI 0.147.0 は「自分がメタデータを持っているモデル名」のときだけ、tools を `input[0]` の
   `functions` namespace 形式で送る。その namespace の `description` が空文字で、Azure の Responses
   バリデータがこれを拒否する:
   ```
   400 Invalid 'input[0].tools[0].description': empty string.
       Expected a string with minimum length 1 (code: empty_string)
   ```
   つまり `gpt-5.6-terra` という名前で deploy すると **レビューが 100% 失敗する**。CLI が知らない名前
   （= `codex-review-terra`）にすると従来どおりフラットな tools 配列になり Azure が受理する。実行される
   モデルは Azure 側のマッピングどおり gpt-5.6-terra 本体。
   この構造は workflow のコメントにも残してある。upstream がこの payload を直したら素直な名前へ戻せる。

2. **メタデータ fallback の警告が出る** — `Model metadata for 'codex-review-terra' not found. Defaulting
   to fallback metadata` が毎回ログに出る。**これは現状の `gpt-5.3-codex` でも同じ**（CLI は 5.3-codex も
   知らない）ので新たな劣化ではないが、context window 等の仮定が既定値になる点は認識しておきたい。

3. **TPM を 5,000 → 10,000 に増やした**（terra の GlobalStandard quota 上限いっぱい）。従量課金なので
   待機コストは増えないが、スロットリングされにくくなった分レビューが詰まりにくいはず。

4. **この PR 自体が動作検証になる** — `pull_request` イベントは head ブランチの workflow 定義で走るので、
   この PR に付く codex レビューが新 CLI + 新モデルで実行される。緑なら CI 実機で確認できたことになる。

## 事前の動作確認（ローカル、Azure 実機）

`codex 0.147.0` + `codex-review-terra` を CI と同一の `~/.codex/config.toml`（`wire_api = "responses"`,
`api-version=preview`）で実行:

- 単純な応答: OK
- ツール実行込み（`git log` / `git diff --stat` を実行 → 差分を要約 → `CODEX VERDICT: LGTM` を出力）: OK

比較のため取得した実リクエストの tools 形状:

| model | tools の形 | Azure |
|---|---|---|
| `gpt-5.6-terra`（CLI が認識） | `input[0].tools[0]` = namespace `functions`, `description: ""` | **400** |
| `gpt-5.3-codex` / `codex-review-terra`（未認識） | top-level `tools[]` にフラットな function 10 個 | OK |

## User Prompt

> ci で使っている codex の review って model は最新？
>
> cli で azure 使えるからそれ含め動作させて確認して。で、変更できるんだったら変更、修正して。mulmoclaude と mulmoserver も同様に。
>
> codex は最新にしてよ。それが目的。それが出来ないなら変更不要。

mulmoclaude / mulmoserver にも同じ変更を用意済み。まずこの PR で CI の実動作を確認してから出す。

---

work in mulmoterminal6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Azure deployment guidance with clearer TPM requirements and compatibility notes.
  - Clarified Responses API compatibility information.
- **Chores**
  - Refreshed deployment defaults for improved Azure configuration.
  - Updated the integrated review tooling to a newer version for improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->