### PR TITLE
fix(roster): one border geometry for every cockpit row, and a louder cursor

### DIFF
--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -985,12 +985,22 @@ watch(
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUids.size > 0 }" :style="flipVars" @focusin="onFocusIn">
     <!-- Cockpit roster: a tall text row per cell (status / dir / memo / summary / prompt / latest
-         reply). Click a row to swap which terminal is enlarged. -->
+         reply). Click a row to swap which terminal is enlarged.
+         The 9px gap is 5px of visible channel plus the 2px ring every row paints on each side
+         (rosterAlertClasses). At the old 5px two neighbours' rings came within a pixel of each
+         other and the column read as one fused block.
+
+         `pr-0` is deliberate, and the right gutter is on the ROWS instead (`mr-1.5`, named by every
+         branch in rosterAlertClasses). The expanded row names none, so it ends flush with this
+         aside's edge and butts against the splitter — the shape that says it IS the terminal beside
+         it. Putting the gutter back here would reinstate the 6px of `bg-deep` that made the row
+         read as a card floating near the edge, and the negative margin that used to cancel it
+         silently mis-aligned the moment this padding changed. -->
     <aside
       v-if="zoomed && listMode"
       ref="roster"
       data-testid="cockpit"
-      class="flex min-w-0 shrink-0 grow-0 flex-col gap-[5px] overflow-y-auto bg-deep p-1.5"
+      class="flex min-w-0 shrink-0 grow-0 flex-col gap-[9px] overflow-y-auto bg-deep py-1.5 pr-0 pl-1.5"
       :style="{ flexBasis: `${rosterWidth}px` }"
     >
       <div
@@ -1000,7 +1010,7 @@ watch(
         role="button"
         :tabindex="0"
         data-testid="cockpit-row"
-        class="flex shrink-0 cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] px-2.5 py-2 text-left text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4a9eff]"
+        class="flex shrink-0 cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border px-2.5 py-2 text-left text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4a9eff]"
         :class="rosterAlertClass(row.status, { expanded: row.uid === expandedUid, blink: rosterBlink, parked: row.parked })"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
         @keydown.enter.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"

--- a/src/components/rosterAlertClasses.ts
+++ b/src/components/rosterAlertClasses.ts
@@ -4,8 +4,24 @@ import type { AttentionStatus } from "./attentionStatus";
 //
 // The row used to say its status in an 8px dot and a 10px badge, both sitting on a bar painted
 // with the DIRECTORY's configured colour — so an amber-ish directory swallowed the amber of
-// `waiting`, the same collision the launcher chips had in #1106. The row's own channels (left
-// edge, wash) were spent on something else entirely: which row is expanded.
+// `waiting`, the same collision the launcher chips had in #1106. The row's own channels (a 3px
+// left edge, the wash) were spent on something else entirely: which row is expanded.
+//
+// There are three channels now, and the words below name them exactly:
+//   RING   the 2px box-shadow OUTSIDE the row. Present on every branch, always 2px, and the only
+//          one carrying full-strength colour. This is the status.
+//   FRAME  the 1px `border`, uniform on all four sides. Neutral everywhere except the expanded
+//          row, where it goes blue and closes the ring into one solid 3px band.
+//   WASH   the row's background, the same hue again at 8-16%.
+//
+// There used to be a fourth — a 3px `border-l` STRIPE carrying the status colour at full strength,
+// inherited unexplained from the roster's first prototype (6f158893). It is gone. Two things were
+// wrong with it once the ring existed: the left side read 2px+3px of one hue against 3px on the
+// other three, so the frame looked mis-drawn (the ring/stripe pair fused into a single fat bar on
+// the expanded row, where both were solid blue); and where the two greens differed in strength the
+// stripe read as colour bleeding INSIDE the ring rather than as a channel of its own. The ring
+// says everything the stripe said, at the same strength, all the way round the row. Do not
+// re-add a `border-l-*` here — a status colour on one side only is what this replaced.
 //
 // So the status moves out to the row scale, in two strengths:
 //   blocked -> nothing proceeds until you answer  -> amber, and it MOVES
@@ -15,7 +31,7 @@ import type { AttentionStatus } from "./attentionStatus";
 // working row, so a second moving thing is a real cost — paid only for the state where the user
 // is what the work waits on, and switchable off (see useRosterAlert).
 //
-// Every branch names the frame colour, the left edge, the background AND the hover background. A
+// Every branch names the frame colour, the ring, the background AND the hover background. A
 // branch that set only what it changes would leave the other properties to the base class, and
 // which of two competing utilities wins is decided by Tailwind's output order rather than by the
 // order they are written (the same rule the cell dot and the launcher chip are built around).
@@ -38,28 +54,100 @@ const ROW_BLINK = "animate-roster-alert motion-reduce:animate-none";
 // pure white in Daylight, so an 8% wash sits within a few percent of white, every channel clips,
 // and the hovered row goes white — the state colour disappears exactly while you point at it.
 // A stronger mix of the SAME colour keeps the hue in all four themes.
+//
+// EVERY branch rings at the SAME 2px, including the ones with nothing to say, which ring in
+// `transparent`. The widths used to differ per state — 2px blocked, 1px done, none on the other
+// three — and stacked in a list that reads as one column of cards, three ring weights look like a
+// rendering bug rather than three meanings: the eye reads the WIDTH difference before it reads the
+// colour, so a green row beside a blue one looked mis-drawn rather than differently stated. The
+// ring is a box-shadow, so a transparent one costs no layout and keeps the geometry identical.
+// Colour is the only channel a status is allowed to move.
+//
+// And the ring's colour is now the FULL token — `var(--done)`, `#f59e0b` — not a mix of it with
+// transparent. It took the stripe's job when the stripe was removed, so it takes the stripe's
+// strength with it: the mixes (45% / 60%) existed to sit quieter than a solid line that was
+// already saying the same thing 2px further in, and with that line gone they only made the one
+// remaining mark of the status weaker than the mark it replaced.
+//
+// Each ring is spelled out in full rather than built from a shared `ring(color)` helper: Tailwind
+// finds classes by scanning this file's TEXT, so a class assembled at runtime is a class it never
+// generates — the row would simply have no ring, with nothing failing anywhere.
 const ROW_BLOCKED =
-  "border-border border-l-[#f59e0b] bg-[color-mix(in_srgb,#f59e0b_14%,var(--bg-panel))] hover:bg-[color-mix(in_srgb,#f59e0b_24%,var(--bg-panel))] shadow-[0_0_0_2px_color-mix(in_srgb,#f59e0b_60%,transparent)]";
+  "mr-1.5 border-border bg-[color-mix(in_srgb,#f59e0b_14%,var(--bg-panel))] hover:bg-[color-mix(in_srgb,#f59e0b_24%,var(--bg-panel))] shadow-[0_0_0_2px_#f59e0b]";
 // The green is --done, the token the grid cell's own `done` chrome names too (cellStatusClasses.ts).
 // It was this file's literal #22c55e while the cell ringed `done` in the theme accent, so the same
 // session changed colour when you enlarged it (#1307).
 const ROW_DONE =
-  "border-border border-l-done bg-[color-mix(in_srgb,var(--done)_8%,var(--bg-panel))] hover:bg-[color-mix(in_srgb,var(--done)_18%,var(--bg-panel))] shadow-[0_0_0_1px_color-mix(in_srgb,var(--done)_45%,transparent)]";
-// The row you are looking at, and a row with nothing to say — neither carries a status colour, so
-// their hover is the theme's own.
-const ROW_EXPANDED = "border-[#4a9eff] border-l-[#4a9eff] bg-panel hover:bg-hover";
-const ROW_PLAIN = "border-border border-l-transparent bg-panel hover:bg-hover";
-// A row the user has set aside (#992). It names the same frame, edge and background as a plain
+  "mr-1.5 border-border bg-[color-mix(in_srgb,var(--done)_8%,var(--bg-panel))] hover:bg-[color-mix(in_srgb,var(--done)_18%,var(--bg-panel))] shadow-[0_0_0_2px_var(--done)]";
+// The row you are looking at. It is the LOUDEST branch here, and that ordering is on purpose: it
+// used to be the quietest — a 1px blue frame and the theme's own background, no ring and no wash —
+// while `done` beside it carried a coloured ring AND a tinted body. So the list answered "which of
+// these finished?" more clearly than "which one am I in?", and finding your place meant reading the
+// terminal on the right and matching it back. Navigation outranks status in a list you navigate
+// with, so this row gets a channel none of the others use: its FRAME takes the same blue as its
+// ring, and the two read as one solid 3px band where a status row shows 2px of colour and then a
+// neutral hairline. Plus the strongest wash. Since the stripe went, that frame is the whole of
+// what separates the cursor from a status — do not neutralise it to "match the others".
+//
+// And its SHAPE, which is the part colour could not do. Widening this ring to 3px was tried first
+// and did not work: the list is already saturated — every row carries a directory-coloured header
+// bar and a full-strength status ring — so one more blue band among amber and green asks the eye
+// to answer "which blue?" before it can answer "where am I?". Colour was the wrong channel, not
+// the wrong amount of it. So the row opens on its RIGHT instead: square corners, and no right
+// gutter, which runs it flush to the roster's edge and hard against the splitter the enlarged
+// terminal begins after. It stops reading as "the selected item" and starts reading as "this row
+// IS the terminal beside it", which is the question actually being asked. The other three sides
+// keep the ring, so the status still gets said.
+//
+// This is why every OTHER branch names `mr-1.5` and the aside carries `pr-0` (TerminalGrid.vue).
+// The gutter is a property of the rows that have one, not of the container — the first version put
+// 6px of padding on the aside and cancelled it here with `-mr-1`, and a negative margin tuned to a
+// padding it cannot see mis-aligns silently the moment that padding changes. It also could not
+// reach the edge: 4px was the most that fit before `overflow-y-auto` (which resolves overflow-x to
+// `auto`) clipped the row and threatened a horizontal scrollbar, leaving 2px of `bg-deep` that kept
+// the row reading as a card near the edge rather than one joined to what is past it.
+//
+// The right 2px of this row's ring IS clipped by that same overflow, and that is the intent, not a
+// side effect: a box-shadow never counts toward scrollable overflow, so nothing scrolls, and what
+// gets cut is exactly the segment that would otherwise close the shape back up.
+//
+// `border-r-[3px]` pays for that clip. Everywhere else this row reads as a 3px band — 1px of frame
+// plus 2px of ring — and with the ring's right segment gone, the right edge was left showing the
+// frame's 1px alone, which looked like a mis-drawn border rather than an opening. The border takes
+// over the missing 2px so all four sides are 3px, and only the CORNERS say the row is open. It is
+// the one place a per-side border width is right here, and it is not the `border-l-*` stripe this
+// file forbids: that carried a status COLOUR on one side, where this only restores a thickness the
+// other three sides already have. Like `rounded-r-none`, it beats the base class's `border` on
+// Tailwind's output order (per-side longhands are emitted after the shorthand) — verified against
+// this repo's v4, same as the radius.
+//
+// `ml-1.5` is the 6px it gave up on the right, taken back on the left. So the row is the same WIDTH
+// as every other one and simply sits 6px further over — a shift, which the eye reads as one motion
+// toward the terminal, rather than a stretch, which reads as this row being bigger than its
+// neighbours. Size would compete with the status ring for "how much does this row matter";
+// position does not, because no status can move a row sideways.
+//
+// `rounded-r-none` overrides the `rounded-lg` on the row's base class in TerminalGrid.vue, and
+// that is order-dependent the way everything else in this file is — verified against this repo's
+// Tailwind (v4): the per-corner longhands are emitted after the shorthand, so this wins.
+const ROW_EXPANDED =
+  "ml-1.5 rounded-r-none border-r-[3px] border-[#4a9eff] bg-[color-mix(in_srgb,#4a9eff_16%,var(--bg-panel))] hover:bg-[color-mix(in_srgb,#4a9eff_16%,var(--bg-panel))] shadow-[0_0_0_2px_#4a9eff]";
+// The hover above is deliberately the SAME colour as the resting state, not a step up from it: the
+// click handler skips the expanded row (you are already there), so a row that lit under the pointer
+// would promise something pressing it does not do. It is still named, because a branch that names
+// no hover inherits nothing and Tailwind's order, not this file's, decides what wins.
+const ROW_PLAIN = "mr-1.5 border-border bg-panel hover:bg-hover shadow-[0_0_0_2px_transparent]";
+// A row the user has set aside (#992). It names the same frame, ring and background as a plain
 // row and sinks with `opacity` — the one property no branch above sets, so the two never race.
 const ROW_PARKED = `${ROW_PLAIN} opacity-45`;
-// Parked AND the row being looked at. The blue edge is NAVIGATION — "you are here" — so it stays;
+// Parked AND the row being looked at. The blue ring is NAVIGATION — "you are here" — so it stays;
 // the sink is the STATE, so it stays too. Dropping either would answer a different question than
 // the one that was asked: selecting a parked session must not make it read as awake.
 const ROW_PARKED_EXPANDED = `${ROW_EXPANDED} opacity-45`;
 
 interface RosterAlertContext {
   // The row whose terminal is enlarged beside the list. It never alerts: a session you are
-  // watching shows its own prompt, and its left edge already means "you are here" — one line
+  // watching shows its own prompt, and its ring already means "you are here" — one mark
   // carrying two meanings is what made the status hard to read in the first place.
   expanded: boolean;
   // The user's setting (default on). Off leaves both states their still colours, which is the

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -77,28 +77,38 @@
 }
 
 /* The cockpit roster's "this one is waiting on you" row (#1131).
-   Animates the RING around the row, its left edge and the depth of its wash — never opacity, which
-   would flicker the memo and the summary and make the row unreadable at the moment it is asking to
-   be read. The ring is what carries it: the row's own top bar is painted with the DIRECTORY's
-   colour and covers the upper half, so measured on screen a wash alone showed up only in the strip
-   below that bar — and on a directory tinted amber the bar read as the alert while the real status
-   sat in a 3px edge. A ring is outside the row's box, so nothing the directory owns can cover it.
-   Slower than the working dot on purpose: this one can sit on screen for minutes, where the dot
-   resolves in seconds. Amber is the roster's own hardcoded hue (CockpitHeader.vue), not a token. */
+   Animates the RING around the row and the depth of its wash — never opacity, which would flicker
+   the memo and the summary and make the row unreadable at the moment it is asking to be read. The
+   ring is what carries it: the row's own top bar is painted with the DIRECTORY's colour and covers
+   the upper half, so measured on screen a wash alone showed up only in the strip below that bar —
+   and on a directory tinted amber the bar read as the alert. A ring is outside the row's box, so
+   nothing the directory owns can cover it. Slower than the working dot on purpose: this one can sit
+   on screen for minutes, where the dot resolves in seconds. Amber is the roster's own hardcoded hue
+   (CockpitHeader.vue), not a token.
+
+   Two things it deliberately does NOT animate:
+
+   `border-left-color`, which it used to. The 3px left stripe it was pulsing is gone
+   (rosterAlertClasses) — the border is now a uniform 1px on all four sides, so animating the left
+   one alone would put an amber hairline down one side of an otherwise neutral frame and rebuild the
+   asymmetry that removal was for.
+
+   The ring's WIDTH, which it used to take from 1px to 3px. Every row now rings at exactly 2px and
+   only the colour says which state it is in, so a row that swells and shrinks is the one thing on
+   screen contradicting that rule — and it moves its neighbours' apparent spacing with it. The pulse
+   runs from a 45% mix to the solid amber the resting row already carries, at a fixed 2px. */
 @theme {
   --animate-roster-alert: roster-alert 1.6s ease-in-out infinite;
 
   @keyframes roster-alert {
     0%,
     100% {
-      border-left-color: color-mix(in srgb, #f59e0b 45%, transparent);
       background-color: color-mix(in srgb, #f59e0b 6%, var(--bg-panel));
-      box-shadow: 0 0 0 1px color-mix(in srgb, #f59e0b 30%, transparent);
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f59e0b 45%, transparent);
     }
     50% {
-      border-left-color: #f59e0b;
       background-color: color-mix(in srgb, #f59e0b 20%, var(--bg-panel));
-      box-shadow: 0 0 0 3px color-mix(in srgb, #f59e0b 75%, transparent);
+      box-shadow: 0 0 0 2px #f59e0b;
     }
   }
 }

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -295,7 +295,7 @@ describe("grid cockpit (list view)", () => {
 
   // #1131: the row's status used to live only in an 8px dot and a 10px badge, on a bar painted with
   // the DIRECTORY's colour — so it was invisible at the scale you scan the list at. Asserting on the
-  // row itself, and asserting that the row you are IN stays out of it: that edge already means
+  // row itself, and asserting that the row you are IN stays out of it: that blue ring already means
   // "you are here".
   it("marks a waiting row on the row itself, and leaves the expanded row alone", async () => {
     const w = mountCockpit([cell(0, "s0"), cell(1, "s1"), cell(2, "s2")], 0, [
@@ -305,12 +305,12 @@ describe("grid cockpit (list view)", () => {
     ]);
     await nextTick();
     const rows = w.findAll('[data-testid="cockpit-row"]');
-    expect(rows[0].classes()).toContain("border-l-[#4a9eff]");
+    expect(rows[0].classes()).toContain("shadow-[0_0_0_2px_#4a9eff]");
     expect(rows[0].classes()).not.toContain("animate-roster-alert");
     expect(rows[1].classes()).toContain("animate-roster-alert");
-    expect(rows[1].classes()).toContain("border-l-[#f59e0b]");
+    expect(rows[1].classes()).toContain("shadow-[0_0_0_2px_#f59e0b]");
     // The weak half of the split: finished is coloured, but it does not move.
-    expect(rows[2].classes()).toContain("border-l-done");
+    expect(rows[2].classes()).toContain("shadow-[0_0_0_2px_var(--done)]");
     expect(rows[2].classes()).not.toContain("animate-roster-alert");
   });
 

--- a/test/src/components/cellStatusClasses.spec.ts
+++ b/test/src/components/cellStatusClasses.spec.ts
@@ -9,7 +9,7 @@ import type { AttentionStatus } from "../../../src/components/attentionStatus";
 const STATUSES = ["blocked", "done", "working", "idle"] satisfies AttentionStatus[];
 
 // Whether a class string paints with the `--done` token, in either of the two forms a Tailwind
-// utility can name it: the mapped colour (`bg-done`, `border-l-done`) or the variable inside an
+// utility can name it: the mapped colour (`bg-done`, `border-done`) or the variable inside an
 // arbitrary value (`color-mix(…var(--done)…)`).
 //
 // Asserting on the TOKEN rather than on `#22c55e` is the point of these tests: what #1307 was
@@ -74,11 +74,13 @@ describe("done reads the same in every view", () => {
     expect(namesDone(SUNK_DOT_STATUS.done)).toBe(true);
   });
 
-  it("names the token in the roster row's edge, wash and ring", () => {
+  it("names the token in the roster row's ring and wash", () => {
     const row = rosterAlertClass("done", { expanded: false, blink: true, parked: false });
-    expect(row).toContain("border-l-done");
     expect(row).toContain("bg-[color-mix(in_srgb,var(--done)_8%,var(--bg-panel))]");
-    expect(row).toContain("shadow-[0_0_0_1px_color-mix(in_srgb,var(--done)_45%,transparent)]");
+    // The 2px width and the full (unmixed) strength are rosterAlertClasses' rules and its own
+    // spec's business. What this one is about is the COLOUR being the `--done` token rather than a
+    // literal green — and the ring is where the status lives now that the left stripe is gone.
+    expect(row).toContain("shadow-[0_0_0_2px_var(--done)]");
   });
 
   it("names the token in the roster and thumbnail header's dot and pill", () => {

--- a/test/src/components/rosterAlertClasses.spec.ts
+++ b/test/src/components/rosterAlertClasses.spec.ts
@@ -3,48 +3,154 @@ import { rosterAlertClass } from "../../../src/components/rosterAlertClasses";
 import type { AttentionStatus } from "../../../src/components/attentionStatus";
 
 const BLINK = "animate-roster-alert";
-const AMBER_EDGE = "border-l-[#f59e0b]";
-const GREEN_EDGE = "border-l-done";
+// The status lives in the RING now — the 3px `border-l` stripe these used to name was removed
+// once the ring carried the same colour at the same strength all the way round the row.
+const AMBER_RING = "shadow-[0_0_0_2px_#f59e0b]";
+const GREEN_RING = "shadow-[0_0_0_2px_var(--done)]";
+const BLUE_RING = "shadow-[0_0_0_2px_#4a9eff]";
 
 describe("rosterAlertClass", () => {
   it("blinks the row whose agent is waiting on the user", () => {
     const cls = rosterAlertClass("blocked", { expanded: false, blink: true, parked: false });
     expect(cls).toContain(BLINK);
-    expect(cls).toContain(AMBER_EDGE);
+    expect(cls).toContain(AMBER_RING);
   });
 
   // Off must not take the highlight away with the motion: the row still has to be findable, which
   // is why the setting is about blinking rather than about the alert.
-  it("keeps the amber edge and wash when blinking is off", () => {
+  it("keeps the amber ring and wash when blinking is off", () => {
     const cls = rosterAlertClass("blocked", { expanded: false, blink: false, parked: false });
     expect(cls).not.toContain(BLINK);
-    expect(cls).toContain(AMBER_EDGE);
+    expect(cls).toContain(AMBER_RING);
     expect(cls).toContain("#f59e0b_14%");
   });
 
   // The strong/weak split: a finished turn wants reading, not chasing, so it never moves — even
   // with blinking on.
-  it("never blinks a finished row, and gives it the green edge", () => {
+  it("never blinks a finished row, and gives it the green ring", () => {
     const cls = rosterAlertClass("done", { expanded: false, blink: true, parked: false });
     expect(cls).not.toContain(BLINK);
-    expect(cls).toContain(GREEN_EDGE);
+    expect(cls).toContain(GREEN_RING);
   });
 
-  // The left edge already means "you are here" on the expanded row, and a session you are watching
+  // The blue ring already means "you are here" on the expanded row, and a session you are watching
   // shows its own prompt — so the row you are in never alerts, whatever its status.
   it("leaves the expanded row alone, blocked or not", () => {
     for (const status of ["blocked", "done", "working", "idle"] satisfies AttentionStatus[]) {
       const cls = rosterAlertClass(status, { expanded: true, blink: true, parked: false });
-      expect(cls).toContain("border-l-[#4a9eff]");
+      expect(cls).toContain(BLUE_RING);
       expect(cls).not.toContain(BLINK);
-      expect(cls).not.toContain(AMBER_EDGE);
+      expect(cls).not.toContain(AMBER_RING);
     }
   });
 
   it("leaves working and idle rows plain", () => {
     for (const status of ["working", "idle"] satisfies AttentionStatus[]) {
-      expect(rosterAlertClass(status, { expanded: false, blink: true, parked: false })).toBe("border-border border-l-transparent bg-panel hover:bg-hover");
+      expect(rosterAlertClass(status, { expanded: false, blink: true, parked: false })).toBe(
+        "mr-1.5 border-border bg-panel hover:bg-hover shadow-[0_0_0_2px_transparent]",
+      );
     }
+  });
+
+  // One ring WIDTH for every state, colour the only channel that moves. The widths used to differ
+  // (2px blocked, 1px done, none on the rest) and in a column of stacked cards the eye reads the
+  // width difference before the colour, so the list looked mis-rendered rather than differently
+  // stated. A plain row rings in `transparent` rather than not at all, so the geometry is identical.
+  //
+  // The expanded row is NOT an exception here, and a 3px cursor ring was tried and reverted: in a
+  // list where every row already carries a status ring, a wider blue one reads as another status
+  // rather than as the cursor. It is separated by SHAPE instead — see the test below.
+  it("rings every branch at the same width", () => {
+    const statuses = ["blocked", "done", "working", "idle"] satisfies AttentionStatus[];
+    for (const status of statuses) {
+      for (const expanded of [true, false]) {
+        for (const blink of [true, false]) {
+          for (const parked of [true, false]) {
+            const cls = rosterAlertClass(status, { expanded, blink, parked });
+            const rings = cls.match(/shadow-\[0_0_0_(\d+)px_/g) ?? [];
+            expect(rings, cls).toHaveLength(1);
+            expect(rings[0]).toBe("shadow-[0_0_0_2px_");
+          }
+        }
+      }
+    }
+  });
+
+  // "Which one am I in?" has to be easier to answer than "which one finished?". The expanded row
+  // used to be the QUIETEST branch — a 1px frame, no ring, the theme's own background — beside a
+  // `done` row carrying both a coloured ring and a tinted body.
+  //
+  // Since every ring is now full strength, the FRAME is what separates the cursor from a status: on
+  // the expanded row it takes the ring's blue, so ring and frame read as one solid 3px band, where a
+  // status row shows 2px of colour and then the neutral hairline. It is the only branch that colours
+  // the frame, and this is the test that says so.
+  it("gives the expanded row the loudest chrome in the list", () => {
+    const cls = rosterAlertClass("idle", { expanded: true, blink: true, parked: false });
+    expect(cls).toContain(BLUE_RING);
+    expect(cls).toContain("border-[#4a9eff]");
+    expect(cls).toContain("bg-[color-mix(in_srgb,#4a9eff_16%,var(--bg-panel))]");
+    for (const status of ["done", "blocked"] satisfies AttentionStatus[]) {
+      expect(rosterAlertClass(status, { expanded: false, blink: false, parked: false })).toContain("border-border");
+    }
+  });
+
+  // The cursor is separated by SHAPE, not by more colour: square right corners and NO right gutter
+  // run it flush to the roster's edge, against the splitter the enlarged terminal begins after, so
+  // it reads as joined to that terminal rather than as one more coloured card in a list of coloured
+  // cards. Every other branch keeps `mr-1.5`, which is the gutter the aside gave up (`pr-0`) so the
+  // expanded row could reach the edge without a negative margin tuned to a padding it cannot see.
+  //
+  // Its right BORDER goes to 3px because the ring's right segment is clipped away by that flush
+  // edge: without it the row shows 3px of colour (1px frame + 2px ring) on three sides and 1px on
+  // the fourth, which reads as a mis-drawn border rather than as an opening. All four sides are
+  // 3px; only the corners say the row is open.
+  //
+  // It takes that same 6px back on the LEFT, so it is the same width as its neighbours and simply
+  // sits further over: a shift, not a stretch. A wider row would compete with the status ring for
+  // "how much does this row matter"; a moved one cannot, since no status shifts a row sideways.
+  //
+  // No status branch may take either class — a status that changed shape would be saying "you are
+  // here" in the cursor's own channel — and the expanded row must never take `mr-1.5` back, which
+  // is the whole of what puts it against the terminal.
+  it("opens the expanded row's right edge, and only the expanded row's", () => {
+    const statuses = ["blocked", "done", "working", "idle"] satisfies AttentionStatus[];
+    for (const status of statuses) {
+      for (const parked of [true, false]) {
+        const open = rosterAlertClass(status, { expanded: true, blink: true, parked });
+        expect(open).toContain("rounded-r-none");
+        expect(open).toContain("border-r-[3px]");
+        expect(open).toContain("ml-1.5");
+        expect(open).not.toMatch(/\bm[rx]-/);
+        const shut = rosterAlertClass(status, { expanded: false, blink: true, parked });
+        expect(shut).not.toContain("rounded-r-none");
+        expect(shut).not.toContain("border-r-");
+        expect(shut).not.toContain("ml-1.5");
+        expect(shut).toContain("mr-1.5");
+      }
+    }
+  });
+
+  // The stripe is gone and must not come back: a `border-l-*` would paint the status on one side
+  // only, at a width no other side has, which is the asymmetry the ring was widened to replace.
+  it("paints no left-only edge on any branch", () => {
+    const statuses = ["blocked", "done", "working", "idle"] satisfies AttentionStatus[];
+    for (const status of statuses) {
+      for (const expanded of [true, false]) {
+        for (const parked of [true, false]) {
+          expect(rosterAlertClass(status, { expanded, blink: true, parked })).not.toMatch(/\bborder-l-/);
+        }
+      }
+    }
+  });
+
+  // Clicking the expanded row does nothing — it is the one you are already on — so it must not
+  // light up under the pointer and promise otherwise. It still NAMES a hover, at the resting
+  // colour, because a branch that names none leaves the property to Tailwind's output order.
+  it("does not brighten the expanded row on hover", () => {
+    const cls = rosterAlertClass("idle", { expanded: true, blink: true, parked: false });
+    expect(cls).toContain("bg-[color-mix(in_srgb,#4a9eff_16%,var(--bg-panel))]");
+    expect(cls).toContain("hover:bg-[color-mix(in_srgb,#4a9eff_16%,var(--bg-panel))]");
+    expect(cls).not.toContain("hover:bg-hover");
   });
 
   // The state colour has to survive the pointer being on it (#1168): hovering used to brighten the
@@ -92,7 +198,7 @@ describe("rosterAlertClass", () => {
   // there until they act, so `blocked` outranks it. This is the accident the feature could cause.
   it("keeps the blocked alert on a parked row", () => {
     const cls = rosterAlertClass("blocked", { expanded: false, blink: true, parked: true });
-    expect(cls).toContain(AMBER_EDGE);
+    expect(cls).toContain(AMBER_RING);
     expect(cls).toContain(BLINK);
     expect(cls).not.toContain("opacity-45");
   });
@@ -102,25 +208,25 @@ describe("rosterAlertClass", () => {
   it("keeps a parked row sunk when its turn ends", () => {
     const cls = rosterAlertClass("done", { expanded: false, blink: true, parked: true });
     expect(cls).toContain("opacity-45");
-    expect(cls).not.toContain(GREEN_EDGE);
+    expect(cls).not.toContain(GREEN_RING);
   });
 
-  // Selecting a parked session must not make it read as awake — but the blue edge is navigation
+  // Selecting a parked session must not make it read as awake — but the blue ring is navigation
   // ("you are here"), not status, so it keeps that AND the sink. Losing either would answer a
   // different question than the one asked.
-  it("keeps the expanded row's edge and sinks it when parked", () => {
+  it("keeps the expanded row's ring and sinks it when parked", () => {
     const cls = rosterAlertClass("idle", { expanded: true, blink: true, parked: true });
-    expect(cls).toContain("border-l-[#4a9eff]");
+    expect(cls).toContain(BLUE_RING);
     expect(cls).toContain("opacity-45");
   });
 
   it("does not sink the expanded row when it is not parked", () => {
     const cls = rosterAlertClass("idle", { expanded: true, blink: true, parked: false });
-    expect(cls).toContain("border-l-[#4a9eff]");
+    expect(cls).toContain(BLUE_RING);
     expect(cls).not.toContain("opacity-45");
   });
 
-  // Every branch names the frame, the edge AND the background, because two competing utilities for
+  // Every branch names the frame, the ring AND the background, because two competing utilities for
   // one property are resolved by Tailwind's output order rather than by the order written here.
   it("names a background in every branch", () => {
     const statuses = ["blocked", "done", "working", "idle"] satisfies AttentionStatus[];


### PR DESCRIPTION
拡大モードの cockpit roster で、ボーダーの幅が状態ごとにバラバラで見苦しく、どの行にフォーカスがあるのか分かりにくい、という指摘から。どちらも色ではなく **ジオメトリ** の問題でした。

## 1. リング幅を全分岐で統一

外周のリングは `blocked` 2px / `done` 1px / 残り 3 状態はナシ、と幅が状態ごとに違っていました。カードが縦に積まれたリストでは、目は色より先に**幅の差**を読むので、3 種類の太さは「3 つの意味」ではなく「描画バグ」に見えます。

全分岐を **2px 固定**に統一し、言うことのない行は `transparent` で縁取ります。box-shadow なのでレイアウトコストはゼロで、ジオメトリは完全に同一になります。行間は 5px → 9px（隣り合う行のリングが 1px 差まで近づいて、列がひとかたまりに見えていたため）。

## 2. 3px の左ストライプを削除

`border-l-[3px]` はロスター最初のプロトタイプ (6f158893) から理由の記載なく引き継がれたものでした。リングが行を囲むようになった時点で、左辺だけが他の 3 辺と食い違う原因にしかなっていません — 片側だけ 2px+3px 対 3px。緑の濃さが違う `done` では「枠の内側に緑が滲んでいる」ように、青が両方ベタの選択行では「1 本の太い帯」に見えていました（実ピクセルを測って確認）。

リングがストライプの言っていたことを、同じ強さで、四辺すべてで言うので、リングの 45% / 60% ミックスも廃止してフル彩度に。あのミックスは「2px 内側に同じことを言うベタ線がある」前提で控えめにしていた値でした。

## 3. カーソルを最も目立つ分岐に

「今どの行にいるか」を答えるのが、リスト中でいちばん**弱い**表現になっていました（1px の青枠と素の背景のみ。隣の `done` は色付きリング＋着色ボディ）。ナビゲーションはステータスに優先するので、他のどの行も使わない 2 つのチャンネルを与えます。

- **frame** をリングと同じ青にして、リング＋枠を 1 本のベタ 3px の帯として読ませる
- **右辺を開く** — 角を落とし、右のガターを外して aside の端まで flush にし、splitter に突き当てる。「選択された項目」ではなく「この行＝隣のターミナル」と読ませるため

サイズは意図的に使っていません。どのステータスも行を横に動かさないので、位置はリングと「重要度」を奪い合いません（3px への増幅も試しましたが、ヘッダーバーと全彩度リングで既に飽和したリストでは「どの青？」を先に問わせてしまい機能しませんでした）。

## 4. blink キーフレームの追随

放置すると CSS でやめたことをアニメーションで再現してしまうため同時に修正:

- `border-left-color` のパルス → 均一になった枠の片側だけに琥珀色のヘアラインを描くので削除
- リング幅 1px → 3px のパルス → 幅一律の規則に唯一反し、行の見かけの間隔まで動かすので、**2px 固定で色のみ**のパルスに

## テスト

- リング幅がどの分岐でも 1 本・2px であること
- `border-l-*` がどの分岐にも出ないこと（ストライプの復活防止）
- 右辺を開くのは expanded 行だけで、他の行は `mr-1.5` を持つこと
- `--done` トークンがリングと wash に載っていること（cellStatusClasses 側の #1307 の取り決め）

`yarn format` / `lint` / `typecheck` / 全 9132 テスト green、`yarn build` 済み。生成 CSS に 4 種のリングが出ていることも確認しました。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved roster and cockpit row spacing for clearer visual separation.
  * Replaced left-edge status stripes with consistent 2px status rings and refined row positioning.
  * Enhanced blocked, completed, expanded, waiting, and parked row styling with clearer colors, spacing, hover states, and background treatments.
  * Updated alert animations to transition smoothly between subtle and prominent amber rings while preserving the existing background effect.

* **Tests**
  * Expanded coverage for status rings, row states, hover behavior, animations, and parked-row styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->