### PR TITLE
feat(roster): the picker's agent mark on every row, and none on a row that runs no agent

### DIFF
--- a/src/components/CockpitHeader.vue
+++ b/src/components/CockpitHeader.vue
@@ -13,12 +13,15 @@ import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
 import { textTip } from "./tipContent";
 import type { AttentionStatus } from "./attentionStatus";
-import { agentBadge } from "../../common/sessionAgent";
+import AgentMark from "./AgentMark.vue";
+import { isTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 
 const props = withDefaults(
   defineProps<{
     status: AttentionStatus;
-    agent: string;
+    // What the row is running, or null when nothing does yet (an empty cell) — see rosterAgent()
+    // in GridView.vue for how a cell answers this.
+    agent: string | null;
     cwd: string | null;
     home: string | null;
     headerColor: string | null;
@@ -61,8 +64,14 @@ const phaseInfo = computed(() => phaseDisplay(props.phase ?? "none"));
 // word, and a path truncated from the front.
 const { described: phaseDescribed, show: showPhaseTip, hide: hidePhaseTip } = useHoverTipAnchor(() => textTip(phaseInfo.value?.title));
 const { described: dirDescribed, show: showDirTip, hide: hideDirTip } = useHoverTipAnchor(() => textTip(props.cwd));
-// Null for claude (the default, so nearly every row) and for a shell, which is not an agent.
-const badge = computed(() => agentBadge(props.agent));
+const agentMark = computed<TerminalAgent | null>(() => (props.agent !== null && isTerminalAgent(props.agent) ? props.agent : null));
+// Same non-agent icon as the Agent Picker. Anything else — an empty cell, a session kind this
+// build does not know — gets no mark at all: the status dot and the directory still identify the
+// row, and defaulting to Claude's burst would tell the reader a launcher is an agent session.
+const agentSymbol = computed(() => (props.agent === "shell" ? "terminal" : null));
+// Names the mark for assistive tech, which cannot read a drawn glyph. The title says the same
+// thing on hover.
+const agentName = computed(() => agentMark.value ?? (agentSymbol.value ? "shell" : null));
 const phaseColor = computed(() => PHASE_CLASS[props.phase ?? "none"] ?? "text-[#9aa4b2]");
 const dirText = computed(() => formatCwd(props.cwd, props.home, props.dirLength ?? 44) || "—");
 const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTextColor));
@@ -90,7 +99,19 @@ const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTe
       @focusout="hidePhaseTip"
       >{{ phaseInfo.label }}</span
     >
-    <span v-if="badge" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">{{ badge.full }}</span>
+    <span
+      v-if="agentName"
+      data-testid="cockpit-agent-icon"
+      class="inline-flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[4px] border border-border text-[#9ab]"
+      role="img"
+      :title="agentName"
+      :aria-label="agentName"
+    >
+      <AgentMark v-if="agentMark" :agent="agentMark" />
+      <!-- A Material Symbol is a LIGATURE, so the icon's name is real text inside the row; hidden
+           here for the same reason the Agent Picker hides it, so only the aria-label is read. -->
+      <span v-else class="material-symbols-outlined text-[13px]" aria-hidden="true">{{ agentSymbol }}</span>
+    </span>
     <span
       data-testid="cockpit-dir"
       class="min-w-0 flex-auto text-[11px] text-[var(--cell-header-fg,var(--text-dim))]"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -6,6 +6,7 @@ import AppToolbar from "./AppToolbar.vue";
 import GuideLinks from "./GuideLinks.vue";
 import { startCollectionChat } from "../composables/useChatLauncher";
 import { skillSeed } from "./skillSeed";
+import { rosterAgent } from "./rosterAgent";
 import type { BundledSkillName } from "../../common/bundledSkills";
 import {
   initialState,
@@ -62,7 +63,7 @@ import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
 import { fetchDirConfig, invalidateDirConfig, useDirPriorities } from "../composables/useDirConfig";
 import { nextSortMode } from "./sortModeButton";
-import { asTerminalAgent, type SessionAgent, type TerminalAgent } from "../../common/sessionAgent";
+import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { router } from "../router";
 import { usePubSub } from "../composables/usePubSub";
 import type { LaunchAgent } from "../../common/launchAgent";
@@ -319,15 +320,6 @@ const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher
 // limit and made every field independently defaultable — which is how a field the roster never
 // wired up reads as a legitimate null rather than failing to typecheck.
 const chromeOf = (cwd: string | null): RowChrome => (cwd ? chromeByCwd.get(cwd) : undefined) ?? { headerColor: null, headerTextColor: null, iconUrl: null };
-// What a roster row says it is running. `Cell.agent` is absent for Claude AND for every cell that
-// is not an agent session at all (a launcher chip, a run-command cell, a cell nobody has launched
-// in yet), so reading it as "claude" put Anthropic's mark on all of them. Asked of the cell's kind
-// first: a launcher and a command cell both run the user's own command line, which the server
-// records as "shell" whatever it names (see CLAUDE.md — nothing here parses that command).
-const rosterAgent = (c: Cell): SessionAgent | null => {
-  if (c.command || c.launcher) return "shell";
-  return c.session ? (c.agent ?? "claude") : null;
-};
 const rosterRow = (c: Cell): CockpitRow => {
   const meta = (c.session ? sessionMeta.get(c.session) : undefined) ?? EMPTY_SESSION_META;
   const chrome = chromeOf(c.cwd);

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -62,7 +62,7 @@ import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
 import { fetchDirConfig, invalidateDirConfig, useDirPriorities } from "../composables/useDirConfig";
 import { nextSortMode } from "./sortModeButton";
-import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
+import { asTerminalAgent, type SessionAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { router } from "../router";
 import { usePubSub } from "../composables/usePubSub";
 import type { LaunchAgent } from "../../common/launchAgent";
@@ -319,13 +319,22 @@ const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher
 // limit and made every field independently defaultable — which is how a field the roster never
 // wired up reads as a legitimate null rather than failing to typecheck.
 const chromeOf = (cwd: string | null): RowChrome => (cwd ? chromeByCwd.get(cwd) : undefined) ?? { headerColor: null, headerTextColor: null, iconUrl: null };
+// What a roster row says it is running. `Cell.agent` is absent for Claude AND for every cell that
+// is not an agent session at all (a launcher chip, a run-command cell, a cell nobody has launched
+// in yet), so reading it as "claude" put Anthropic's mark on all of them. Asked of the cell's kind
+// first: a launcher and a command cell both run the user's own command line, which the server
+// records as "shell" whatever it names (see CLAUDE.md — nothing here parses that command).
+const rosterAgent = (c: Cell): SessionAgent | null => {
+  if (c.command || c.launcher) return "shell";
+  return c.session ? (c.agent ?? "claude") : null;
+};
 const rosterRow = (c: Cell): CockpitRow => {
   const meta = (c.session ? sessionMeta.get(c.session) : undefined) ?? EMPTY_SESSION_META;
   const chrome = chromeOf(c.cwd);
   return {
     uid: c.uid,
     cwd: c.cwd,
-    agent: c.agent ?? "claude",
+    agent: rosterAgent(c),
     status: statusForSort.value[c.uid] ?? "idle",
     memo: meta.memo,
     summary: meta.aiTitle,

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -44,7 +44,7 @@ import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 import { isRecord } from "../../common/isRecord";
-import type { TerminalAgent } from "../../common/sessionAgent";
+import type { SessionAgent, TerminalAgent } from "../../common/sessionAgent";
 import { buildCanvasCard, seedCanvasCard, hasStoredCard, absoluteUnder } from "../composables/canvasOpenFile";
 import { jsonBody } from "../jsonBody";
 import { isUnknownArray } from "../../common/isUnknownArray";
@@ -61,7 +61,10 @@ import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 export interface CockpitRow {
   uid: number;
   cwd: string | null;
-  agent: string;
+  // What the row runs: an agent, "shell" for a launcher or a run-command cell, or null for a cell
+  // that has launched nothing yet. Null rather than a default, so the header can decline to mark
+  // a row it cannot name — see rosterAgent() in GridView.vue.
+  agent: SessionAgent | null;
   status: AttentionStatus;
   memo: string | null; // the user's own one-line note (#1084)
   summary: string | null; // AI title

--- a/src/components/rosterAgent.ts
+++ b/src/components/rosterAgent.ts
@@ -1,0 +1,25 @@
+// What a cockpit roster row says it is RUNNING, which is not the same question as `Cell.agent`.
+//
+// That field is absent for Claude — the default, stored as the absence of the key — and equally
+// absent for every cell that is no agent session at all: a launcher chip, an ephemeral run-command
+// cell, a cell nobody has launched in yet. Reading it as "claude" therefore put Anthropic's mark on
+// all of them, so the roster claimed a `yarn dev` chip was a Claude session (the row wore the
+// agent's NAME before, and only for non-Claude agents, so the collision had nothing to show).
+//
+// Asked of the cell's KIND first, then of its agent:
+//
+//   - a launcher and a command cell both run the user's own command line, and this answers "shell"
+//     whatever that line names. It is the same answer the server records (spawnLauncherPty writes
+//     `agent: "shell"` however the command is spelled) and the same rule as CLAUDE.md's: nothing
+//     here parses a launcher command. A `button` RunCommand does carry an `agent`, but that is the
+//     session context the button was resolved against — not what the command cell itself runs.
+//   - a session cell keeps its agent, defaulting to Claude for the absent case that really is one.
+//   - a cell running nothing answers null, and the header marks it with nothing at all: the status
+//     dot and the directory already identify the row, and any mark would be a guess.
+import type { Cell } from "./gridTabs";
+import type { SessionAgent } from "../../common/sessionAgent";
+
+export const rosterAgent = (c: Cell): SessionAgent | null => {
+  if (c.command || c.launcher) return "shell";
+  return c.session ? (c.agent ?? "claude") : null;
+};

--- a/test/src/components/CockpitHeader.spec.ts
+++ b/test/src/components/CockpitHeader.spec.ts
@@ -6,7 +6,7 @@ import type { PrPhase, WorkPhase } from "../../../src/components/rosterPhase";
 
 type Props = {
   status: AttentionStatus;
-  agent: string;
+  agent: string | null;
   cwd: string | null;
   home: string | null;
   headerColor: string | null;
@@ -43,9 +43,26 @@ describe("CockpitHeader", () => {
     expect(mountH({ phase: "ready" }).find('[data-testid="cockpit-phase"]').exists()).toBe(true);
   });
 
-  it("tags codex cells and not claude ones", () => {
-    expect(mountH({ agent: "codex" }).text()).toContain("codex");
-    expect(mountH({ agent: "claude" }).text()).not.toContain("codex");
+  it("shows the picker-style agent icon for every built-in agent and shell", () => {
+    for (const agent of ["claude", "codex", "antigravity", "grok", "muse", "shell"]) {
+      expect(mountH({ agent }).find('[data-testid="cockpit-agent-icon"]').exists()).toBe(true);
+    }
+  });
+
+  // A cell that has launched nothing has no kind to show, and Claude's burst is the wrong guess:
+  // the status dot and the directory already identify the row.
+  it("marks nothing when the row runs nothing", () => {
+    expect(mountH({ agent: null }).find('[data-testid="cockpit-agent-icon"]').exists()).toBe(false);
+  });
+
+  it("names the mark for assistive tech, which cannot read a drawn glyph", () => {
+    expect(mountH({ agent: "codex" }).find('[data-testid="cockpit-agent-icon"]').attributes("aria-label")).toBe("codex");
+    expect(mountH({ agent: "shell" }).find('[data-testid="cockpit-agent-icon"]').attributes("aria-label")).toBe("shell");
+  });
+
+  it("does not print the agent name beside the icon", () => {
+    expect(mountH({ agent: "codex" }).text()).not.toContain("codex");
+    expect(mountH({ agent: "shell" }).text()).not.toContain("Shell");
   });
 
   it("renders the directory and the trailing slot", () => {

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -180,6 +180,32 @@ describe("GridView roster ordering (#720)", () => {
     expect(rows.map((r: { parked: boolean }) => r.parked)).toEqual([false, true]);
     w.unmount();
   });
+
+  // `Cell.agent` is absent for Claude AND for a cell that is no agent session at all, so reading
+  // it as "claude" (which the row did) put Anthropic's mark on every launcher chip and shell
+  // terminal in the roster. The row has to answer "shell" for those and only then fall back.
+  it("says shell for a launcher row and keeps the agent for a session row", async () => {
+    localStorage.setItem(
+      "grid_v2",
+      JSON.stringify({
+        cells: [
+          { uid: 30, session: IDS.idleA, cwd: "/w" },
+          { uid: 31, session: IDS.idleB, cwd: "/w", agent: "codex" },
+          { uid: 32, session: IDS.blocked, cwd: "/w", launcher: { shell: true, label: "shell" } },
+        ],
+        expanded: 30,
+        page: 0,
+        sortMode: "manual",
+      }),
+    );
+    const w = mount(GridView, {
+      global: { stubs: { TerminalGrid: OrderStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    const rows = w.findComponent(OrderStub).props("listRows");
+    expect(rows.map((r: { agent: string | null }) => r.agent)).toEqual(["claude", "codex", "shell"]);
+    w.unmount();
+  });
 });
 
 // A toolbar stub that surfaces the view-toggle props and can fire the toggle-view event, plus a

--- a/test/src/components/rosterAgent.spec.ts
+++ b/test/src/components/rosterAgent.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { rosterAgent } from "../../../src/components/rosterAgent";
+import { shellLauncher, type Cell } from "../../../src/components/gridTabs";
+
+const SESSION = "11111111-1111-1111-1111-111111111111";
+const cell = (over: Partial<Cell> = {}): Cell => ({ uid: 0, session: SESSION, cwd: "/w", ...over });
+
+describe("rosterAgent", () => {
+  // `Cell.agent` is the ABSENT case for Claude, so this is the one row where the old `?? "claude"`
+  // was right — and the reason the wrong rows were invisible.
+  it("says claude for a session cell that names no agent", () => {
+    expect(rosterAgent(cell())).toBe("claude");
+  });
+
+  it("keeps the agent a session cell was launched as", () => {
+    expect(rosterAgent(cell({ agent: "codex" }))).toBe("codex");
+    expect(rosterAgent(cell({ agent: "grok" }))).toBe("grok");
+  });
+
+  // The two kinds that run the user's own command line. Neither carries an `agent`, so both used to
+  // read as Claude; nothing here looks at what the command is called.
+  it("says shell for a launcher cell", () => {
+    expect(rosterAgent(cell({ launcher: shellLauncher() }))).toBe("shell");
+    expect(rosterAgent(cell({ launcher: { index: 2, label: "codex --yolo" } }))).toBe("shell");
+  });
+
+  it("says shell for a run-command cell, from either source", () => {
+    expect(rosterAgent(cell({ command: { source: "script", index: 0, label: "test", cwd: "/w" } }))).toBe("shell");
+    // A `button` command carries the agent of the SESSION its button belongs to. That is the
+    // context it was resolved against, not what the cell runs — the cell runs a shell command.
+    const button = { source: "button", buttonId: "b1", label: "build", cwd: "/w", session: SESSION, agent: "codex", model: null } as const;
+    expect(rosterAgent(cell({ command: button, agent: "codex" }))).toBe("shell");
+  });
+
+  it("says nothing at all for a cell that has launched nothing", () => {
+    expect(rosterAgent(cell({ session: null }))).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The cockpit roster row wore the agent's **name** in a bordered pill (`codex`, `agy`, `grok`, `mu`) and only for a non-Claude agent. It now wears the same **drawn mark** the Agent Picker and the rate-limit gauge use (`AgentMark.vue`), so one agent looks the same wherever it is named; a shell row gets the picker's `terminal` symbol.

## Why the roster had to learn what a row is NOT

Marking every row makes the default visible, which is where the trap was. `Cell.agent` is absent for Claude **and** for every cell that is not an agent session at all — a launcher chip, a run-command cell, a cell nobody has launched in yet — so the roster's `c.agent ?? "claude"` would have put Anthropic's burst on all of them: a `yarn dev` chip claiming to be a Claude session.

`rosterAgent()` in `GridView.vue` asks the cell's **kind** first:

- a launcher or a command cell is `"shell"` — whatever command line it names, which is the same answer the server records (`spawnLauncherPty`), and nothing here parses that text;
- a session cell keeps its agent (`c.agent ?? "claude"`);
- a cell running nothing answers `null`, and the header marks it with nothing at all — the status dot and the directory already identify the row.

`CockpitRow["agent"]` is `SessionAgent | null` rather than `string`, so the "runs nothing" case is a value the type carries instead of a default someone re-adds.

## Also

- The mark is named for assistive tech (`role="img"` + `aria-label`), which cannot read a drawn glyph; the hover title says the same thing.
- The Material Symbol's ligature text is hidden the way the picker hides its own, so the row's text does not read "terminal".

A custom agent still shows Claude's burst — `TerminalCell` resolves a custom pick to `agent: "claude"` on purpose (a wrapper decides which command line starts Claude Code, not what the session is), so that is the existing model rather than something this PR changes.

## Test plan

- `test/src/components/CockpitHeader.spec.ts` — a mark for every built-in agent and for shell, none when the row runs nothing, the aria name, and no agent NAME printed beside it.
- `test/src/components/GridView.spec.ts` — a launcher row says `shell`, a codex row keeps `codex`, a plain session row says `claude`, driven from persisted state the way a reloaded grid gets it.
- `yarn typecheck`, `yarn lint` (no new warnings), `yarn test` — 9175 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible icons for active agents and terminal sessions, with labels for assistive technologies.
  * Added support for sessions without an assigned agent.
  * Improved grid views to distinguish agent sessions, terminal cells, and inactive cells.

* **Bug Fixes**
  * Corrected roster information so launcher and session entries display the appropriate agent details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->