### PR TITLE
fix(session): resume a running conversation under its surviving key; occupancy sees tmux survivors (#1533)

### DIFF
--- a/server/agents/antigravity-session.ts
+++ b/server/agents/antigravity-session.ts
@@ -61,7 +61,7 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export async function watchForAntigravitySession(
   root: string,
   before: ReadonlySet<string>,
-  opts: { pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean; claimed?: ReadonlySet<string> } = {},
+  opts: { pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean; claimed?: Set<string> } = {},
 ): Promise<string | null> {
   const pollMs = opts.pollMs ?? WATCH_POLL_MS;
   const deadline = Date.now() + (opts.maxWaitMs ?? WATCH_MAX_WAIT_MS);
@@ -71,5 +71,9 @@ export async function watchForAntigravitySession(
     await delay(pollMs);
     result = pickFreshAntigravitySession(root, before, opts.claimed);
   }
+  // Claimed here, synchronously with the selection, not only in the caller's `.then`: two watchers
+  // awaiting the same poll interval would otherwise both pick the same conversation before either
+  // claim landed (#1533). The caller's own add stays and is idempotent.
+  if (result) opts.claimed?.add(result);
   return result;
 }

--- a/server/agents/codex-session.ts
+++ b/server/agents/codex-session.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { isRecord } from "../../common/isRecord.js";
+import { canonicalPath } from "../infra/canonical-path.js";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
@@ -86,14 +87,23 @@ interface RolloutMeta extends CodexSessionMeta {
 // one; a session that can't be attributed just stays unresumable-by-id (cold reconnect starts fresh).
 // `claimed` holds rollouts already mapped to another session, so a single rollout is never
 // attributed to two keys (which would resume one conversation from both).
+//
+// The sole-rollout branch checks the cwd too, when there is one to check: two spawns in DIFFERENT
+// directories share the snapshot-diff window (~/.codex is one tree), and "exactly one new file"
+// used to fire before the cwd was consulted — so the slower spawn claimed the faster spawn's
+// rollout across directories (#1533). Compared canonically: codex records its own spelling of the
+// path, and a worktree reached through a symlink must not read as a different directory (#1208).
+const sameDir = (recorded: string | null | undefined, cwd: string | null): boolean =>
+  cwd === null || (!!recorded && canonicalPath(recorded) === canonicalPath(cwd));
+
 export function pickFreshSession(root: string, before: Set<string>, cwd: string | null, claimed?: Set<string>): RolloutMeta | null {
   const found = listRecentRollouts(root)
     .filter((file) => !before.has(file) && !claimed?.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
   const sole = found.length === 1 ? found[0] : undefined;
-  if (sole) return { ...sole.meta, file: sole.file };
-  const matches = cwd ? found.filter((x) => x.meta.cwd === cwd) : [];
+  if (sole && sameDir(sole.meta.cwd, cwd)) return { ...sole.meta, file: sole.file };
+  const matches = cwd ? found.filter((x) => sameDir(x.meta.cwd, cwd)) : [];
   const soleMatch = matches.length === 1 ? matches[0] : undefined;
   if (soleMatch) return { ...soleMatch.meta, file: soleMatch.file };
   return null;
@@ -118,5 +128,9 @@ export async function watchForCodexSession(
     await delay(pollMs);
     result = pickFreshSession(root, before, cwd, opts.claimed);
   }
+  // Claimed here, synchronously with the selection, not only in the caller's `.then`: two watchers
+  // awaiting the same poll interval would otherwise both pick the same rollout before either
+  // claim landed (#1533). The caller's own add stays and is idempotent.
+  if (result) opts.claimed?.add(result.file);
   return result;
 }

--- a/server/agents/muse-session.ts
+++ b/server/agents/muse-session.ts
@@ -122,16 +122,23 @@ export async function snapshotMuseSessions(cwd: string): Promise<Set<string>> {
 }
 
 /**
- * The id muse minted for a session we just started: the first row in this workspace that was not
- * there before and that no other spawn has claimed.
+ * The id muse minted for a session we just started: the row in this workspace that was not there
+ * before and that no other spawn has claimed — attributed ONLY when it is the only such row, the
+ * same refusal codex and agy make (#1533). This watcher used to take the FIRST new row, and with
+ * two spawns in one directory — or a `before` snapshot a busy sqlite answered empty — that guess
+ * mapped a cell to somebody else's conversation, PERSISTED it, and every cold reconnect after
+ * resumed the wrong one. Ambiguity keeps polling rather than failing: the other spawn's claim can
+ * shrink the set to one.
  *
  * `claimed` is what keeps two cells started in the same directory at the same moment from both
- * taking the first new row — the same set codex's and agy's watchers keep, for the same reason.
+ * taking the same row. It is claimed HERE, synchronously with the selection, not in the caller's
+ * `.then` — two watchers awaiting the same poll tick would otherwise both pick the same row before
+ * either claim landed.
  */
 export async function watchForMuseSession(
   cwd: string,
   before: ReadonlySet<string>,
-  opts: { claimed: ReadonlySet<string>; isCancelled: () => boolean },
+  opts: { claimed: Set<string>; isCancelled: () => boolean },
   timeoutMs = 15000,
   intervalMs = 500,
 ): Promise<string | null> {
@@ -139,8 +146,11 @@ export async function watchForMuseSession(
   while (Date.now() < deadline) {
     if (opts.isCancelled()) return null;
     const current = await snapshotMuseSessions(cwd);
-    for (const id of current) {
-      if (!before.has(id) && !opts.claimed.has(id)) return id;
+    const fresh = [...current].filter((id) => !before.has(id) && !opts.claimed.has(id));
+    const sole = fresh.length === 1 ? fresh[0] : undefined;
+    if (sole) {
+      opts.claimed.add(sole);
+      return sole;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }

--- a/server/git/worktree-routes.ts
+++ b/server/git/worktree-routes.ts
@@ -9,7 +9,7 @@ import { worktreeDiff } from "./worktree-diff.js";
 import { pushWorktree, createOrOpenPR } from "./worktree-pr.js";
 import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 import { isIssueNumber } from "../../common/prPhase.js";
-import { dirSession, runningSessionKeys } from "../session/dir-session.js";
+import { dirSession, survivorSnapshot } from "../session/dir-session.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
 import { requestBody } from "../routes/requestBody.js";
 
@@ -40,7 +40,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     if (!repo) return res.json({ isGit: false, base: null, worktrees: [] });
     const list = await listWorktrees(repo);
     const tmuxCounts = tmuxAttachedCounts();
-    const running = runningSessionKeys();
+    const running = await survivorSnapshot();
     const now = Date.now();
     const worktrees = await Promise.all(
       list.map(async (w) => ({ ...w, dirty: await isDirty(w.path), session: await dirSession(w.path, tmuxCounts, now, running) })),

--- a/server/git/worktree-routes.ts
+++ b/server/git/worktree-routes.ts
@@ -9,7 +9,7 @@ import { worktreeDiff } from "./worktree-diff.js";
 import { pushWorktree, createOrOpenPR } from "./worktree-pr.js";
 import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 import { isIssueNumber } from "../../common/prPhase.js";
-import { dirSession } from "../session/dir-session.js";
+import { dirSession, runningSessionKeys } from "../session/dir-session.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
 import { requestBody } from "../routes/requestBody.js";
 
@@ -40,8 +40,11 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     if (!repo) return res.json({ isGit: false, base: null, worktrees: [] });
     const list = await listWorktrees(repo);
     const tmuxCounts = tmuxAttachedCounts();
+    const running = runningSessionKeys();
     const now = Date.now();
-    const worktrees = await Promise.all(list.map(async (w) => ({ ...w, dirty: await isDirty(w.path), session: await dirSession(w.path, tmuxCounts, now) })));
+    const worktrees = await Promise.all(
+      list.map(async (w) => ({ ...w, dirty: await isDirty(w.path), session: await dirSession(w.path, tmuxCounts, now, running) })),
+    );
     res.json({ isGit: true, base: await defaultBaseBranch(repo), worktrees });
   });
 

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -546,6 +546,10 @@ export interface ReapFacts {
   idleSeconds: number | null;
   /** The threshold, in seconds. Zero means the sweep is off and nothing is reapable. */
   idleThresholdSeconds: number;
+  /** The id parses as a session id at all. One that does not (a live `mt-undefined` was found —
+   *  #1533) is unreachable by EVERY route: nothing can attach it, resume it, or terminate it (the
+   *  routes validate the id), so it can only leak. Callers compute this with SESSION_ID_RE. */
+  validId: boolean;
 }
 
 /**
@@ -555,8 +559,12 @@ export interface ReapFacts {
  * tmux can decline to answer, and reaping on either would be killing a session on a guess — the one
  * outcome worse than the pile-up this exists to clear.
  */
-export function reapableTmuxSession({ attachedCount, liveHere, idleSeconds, idleThresholdSeconds }: ReapFacts): boolean {
+export function reapableTmuxSession({ attachedCount, liveHere, idleSeconds, idleThresholdSeconds, validId }: ReapFacts): boolean {
   if (idleThresholdSeconds <= 0) return false;
   if (liveHere || attachedCount !== 0) return false;
+  // Unreachable garbage does not get the idle grace: no amount of recency can make an invalid id
+  // reachable, and this sweep is the only thing that can ever end it (the terminate route refuses
+  // the id). Still only when nobody holds it — someone inspecting the pane by hand keeps it.
+  if (!validId) return true;
   return idleSeconds !== null && idleSeconds >= idleThresholdSeconds;
 }

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -15,9 +15,7 @@ import {
   activityStateHydrated,
   aiTitles,
   antigravityConversations,
-  antigravityConversationsHydrated,
   codexRollouts,
-  codexRolloutsHydrated,
   backgroundSessionsHydrated,
   failedWorkersHydrated,
   unplacedSessionsHydrated,
@@ -309,12 +307,16 @@ async function sessionList(req: Request, res: Response) {
  * string and case 1 covers it. It still passes an empty iterable rather than skipping the call, so
  * all three lists answer the question the same way.
  */
-async function withAttached<T extends { id: string }>(sessions: T[], records: Iterable<AgentConversation>): Promise<(T & SessionOccupancy & SessionRunning)[]> {
-  // The snapshot refreshes the shared conversation logs BEFORE reading the running keys — the same
-  // order dirSession's callers take, for the same reason (survivorSnapshot's header): a session
-  // another MulmoTerminal process started must not read as free in this list either. The records
-  // iterable is live over the registry map, so the refresh's additions are seen below.
-  const running = await survivorSnapshot();
+function withAttached<T extends { id: string }>(
+  sessions: T[],
+  records: Iterable<AgentConversation>,
+  running: ReadonlySet<string>,
+): (T & SessionOccupancy & SessionRunning)[] {
+  // `running` comes from the caller's `survivorSnapshot()`, taken BEFORE the caller built its
+  // list: the snapshot refreshes the shared conversation logs first and reads the running keys
+  // after, so a session another MulmoTerminal process started is in the list, in the holders map
+  // and in `running` alike. Taking it here — after the list was built — left the agy list, whose
+  // ROWS are drawn from the conversation map, missing such a session entirely (#1534 review).
   const holders = conversationSessionKeys(records);
   const tmuxCounts = tmuxAttachedCounts();
   return sessions.map((s) => {
@@ -337,9 +339,9 @@ async function codexSessionList(req: Request, res: Response) {
   try {
     const cwd = workspaceForRoute(req.query.cwd, res);
     if (cwd === null) return;
-    await codexRolloutsHydrated;
+    const running = await survivorSnapshot();
     const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
-    res.json({ cwd, sessions: await withAttached(sessions, codexRollouts.values()) });
+    res.json({ cwd, sessions: withAttached(sessions, codexRollouts.values(), running) });
   } catch (err) {
     console.error("[api] /api/codex/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -354,9 +356,12 @@ async function antigravitySessionList(req: Request, res: Response) {
   try {
     const cwd = workspaceForRoute(req.query.cwd, res);
     if (cwd === null) return;
-    await antigravityConversationsHydrated;
+    // BEFORE the list is built, not only before occupancy: the agy rows themselves are drawn from
+    // the conversation map (the cwd comes from OUR log), so a mapping another process appended has
+    // to be folded in first or the row is missing from this response entirely (#1534 review).
+    const running = await survivorSnapshot();
     const sessions = await listAntigravitySessions(antigravityBrainRoot(), antigravityConversations.values(), cwd, SESSION_LIST_LIMIT);
-    res.json({ cwd, sessions: await withAttached(sessions, antigravityConversations.values()) });
+    res.json({ cwd, sessions: withAttached(sessions, antigravityConversations.values(), running) });
   } catch (err) {
     console.error("[api] /api/antigravity/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -373,7 +378,7 @@ async function grokSessionList(req: Request, res: Response) {
     const sessions = await listGrokSessions(grokSessionsRoot(), cwd, SESSION_LIST_LIMIT);
     // No conversation log: grok's session key is the id we minted, which is also the directory
     // name — so `withAttached` finds a holder by the row's own id (see its header).
-    res.json({ cwd, sessions: await withAttached(sessions, []) });
+    res.json({ cwd, sessions: withAttached(sessions, [], await survivorSnapshot()) });
   } catch (err) {
     console.error("[api] /api/grok/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -384,7 +389,7 @@ async function museSessionList(req: Request, res: Response) {
   try {
     const cwd = workspaceForRoute(req.query.cwd, res);
     if (cwd === null) return;
-    await museConversationsHydrated;
+    const running = await survivorSnapshot();
     const metas = await listMuseSessionsForCwd(cwd);
     const sorted = [...metas].sort((a, b) => (b.updatedAtUs ?? 0) - (a.updatedAtUs ?? 0));
     const sessions = sorted.slice(0, SESSION_LIST_LIMIT).map((m) => ({
@@ -393,7 +398,7 @@ async function museSessionList(req: Request, res: Response) {
       mtime: m.updatedAtUs ? m.updatedAtUs / 1000 : 0,
       model: m.modelId ?? undefined,
     }));
-    res.json({ cwd, sessions: await withAttached(sessions, museConversations.values()) });
+    res.json({ cwd, sessions: withAttached(sessions, museConversations.values(), running) });
   } catch (err) {
     console.error("[api] /api/muse/sessions failed:", err);
     res.status(500).json({ error: String(err) });

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -44,7 +44,7 @@ import {
 } from "../session/session-reads.js";
 import { formatHandoff, type HandoffShape } from "../session/handoff-text.js";
 import { projectSessionsDir } from "../session/project-dir.js";
-import { runningKeyOf, runningSessionKeys, sessionAttached } from "../session/dir-session.js";
+import { runningKeyOf, runningSessionKeys, sessionAttached, survivorSnapshot } from "../session/dir-session.js";
 import type { SessionOccupancy } from "../../common/sessionOccupancy.js";
 import type { SessionRunning } from "../../common/sessionRunning.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
@@ -309,10 +309,14 @@ async function sessionList(req: Request, res: Response) {
  * string and case 1 covers it. It still passes an empty iterable rather than skipping the call, so
  * all three lists answer the question the same way.
  */
-function withAttached<T extends { id: string }>(sessions: T[], records: Iterable<AgentConversation>): (T & SessionOccupancy & SessionRunning)[] {
+async function withAttached<T extends { id: string }>(sessions: T[], records: Iterable<AgentConversation>): Promise<(T & SessionOccupancy & SessionRunning)[]> {
+  // The snapshot refreshes the shared conversation logs BEFORE reading the running keys — the same
+  // order dirSession's callers take, for the same reason (survivorSnapshot's header): a session
+  // another MulmoTerminal process started must not read as free in this list either. The records
+  // iterable is live over the registry map, so the refresh's additions are seen below.
+  const running = await survivorSnapshot();
   const holders = conversationSessionKeys(records);
   const tmuxCounts = tmuxAttachedCounts();
-  const running = runningSessionKeys();
   return sessions.map((s) => {
     const keys = [s.id, ...(holders.get(s.id) ?? [])];
     return {
@@ -335,7 +339,7 @@ async function codexSessionList(req: Request, res: Response) {
     if (cwd === null) return;
     await codexRolloutsHydrated;
     const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
-    res.json({ cwd, sessions: withAttached(sessions, codexRollouts.values()) });
+    res.json({ cwd, sessions: await withAttached(sessions, codexRollouts.values()) });
   } catch (err) {
     console.error("[api] /api/codex/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -352,7 +356,7 @@ async function antigravitySessionList(req: Request, res: Response) {
     if (cwd === null) return;
     await antigravityConversationsHydrated;
     const sessions = await listAntigravitySessions(antigravityBrainRoot(), antigravityConversations.values(), cwd, SESSION_LIST_LIMIT);
-    res.json({ cwd, sessions: withAttached(sessions, antigravityConversations.values()) });
+    res.json({ cwd, sessions: await withAttached(sessions, antigravityConversations.values()) });
   } catch (err) {
     console.error("[api] /api/antigravity/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -369,7 +373,7 @@ async function grokSessionList(req: Request, res: Response) {
     const sessions = await listGrokSessions(grokSessionsRoot(), cwd, SESSION_LIST_LIMIT);
     // No conversation log: grok's session key is the id we minted, which is also the directory
     // name — so `withAttached` finds a holder by the row's own id (see its header).
-    res.json({ cwd, sessions: withAttached(sessions, []) });
+    res.json({ cwd, sessions: await withAttached(sessions, []) });
   } catch (err) {
     console.error("[api] /api/grok/sessions failed:", err);
     res.status(500).json({ error: String(err) });
@@ -389,7 +393,7 @@ async function museSessionList(req: Request, res: Response) {
       mtime: m.updatedAtUs ? m.updatedAtUs / 1000 : 0,
       model: m.modelId ?? undefined,
     }));
-    res.json({ cwd, sessions: withAttached(sessions, museConversations.values()) });
+    res.json({ cwd, sessions: await withAttached(sessions, museConversations.values()) });
   } catch (err) {
     console.error("[api] /api/muse/sessions failed:", err);
     res.status(500).json({ error: String(err) });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -504,29 +504,38 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // conversation map takes, for the same restart case.
   await customAgentSessionsHydrated;
   const { reattachId, resume, sessionId } = resolveClaudeSession(requested, cwd);
-  const live = reattachId ? ptys.get(reattachId) : undefined;
-  // Buffered from the announcement on, like every other terminal endpoint: the browser's first
-  // frame is the terminal's geometry and it arrives while this handler may still be awaiting the
-  // Keychain — /ws was the one route that let it fall on the floor (#1178, see early-frames.ts).
-  await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, "claude", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
-  if (!early) return;
+  // Everything from the `live` read to the wiring runs in this id's own turn (#1533): the awaits
+  // below are the window in which a competing connect used to double-spawn, and the reap timer
+  // used to kill the entry this handler was still holding.
+  await sessionConnects(sessionId, async () => {
+    const live = reattachId ? ptys.get(reattachId) : undefined;
+    // Buffered from the announcement on, like every other terminal endpoint: the browser's first
+    // frame is the terminal's geometry and it arrives while this handler may still be awaiting the
+    // Keychain — /ws was the one route that let it fall on the floor (#1178, see early-frames.ts).
+    await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
+    const early = await admitAgentSession(ws, "claude", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+    if (!early) return;
 
-  // A provider refusal already says exactly what is wrong with the directory's config (#579), and a
-  // refused spawn already names the binary and the PATH it searched, or the directory that is gone
-  // (#1063, #1078); a generic hint would bury either.
-  const startFailureMessage = (err: unknown): string =>
-    err instanceof ProviderRefusedError || err instanceof SpawnRefusedError ? err.message : `Failed to start Claude: ${messageOf(err)}`;
+    // A provider refusal already says exactly what is wrong with the directory's config (#579), and a
+    // refused spawn already names the binary and the PATH it searched, or the directory that is gone
+    // (#1063, #1078); a generic hint would bury either.
+    const startFailureMessage = (err: unknown): string =>
+      err instanceof ProviderRefusedError || err instanceof SpawnRefusedError ? err.message : `Failed to start Claude: ${messageOf(err)}`;
 
-  startAndWire(deps, ws, { id: sessionId, tag: "claude", early, startFailureMessage, size }, () => {
-    const entry = live ? deps.reattachPty(live, ws, sessionId) : deps.spawnClaudePty(sessionId, resume, ws, { cwd, attachGuiMcp, launch, customAgentId });
-    // Single view (gui) = the attached session IS the actively-viewed pane, so mark it
-    // read. A grid dev-terminal cell (gui=0) is only "viewed" once focused/zoomed (the
-    // client then sends a `view` frame), so it stays inactive here and can surface
-    // blocked/done while the user is on another cell or page.
-    entry.active = attachGuiMcp;
-    if (entry.active) deps.setWaiting(sessionId, false);
-    return entry;
+    const settled = settledEntry(ws, "claude", sessionId, !!live, early);
+    if (!settled) return;
+    startAndWire(deps, ws, { id: sessionId, tag: "claude", early, startFailureMessage, size }, () => {
+      const entry = settled.entry
+        ? deps.reattachPty(settled.entry, ws, sessionId)
+        : deps.spawnClaudePty(sessionId, resume, ws, { cwd, attachGuiMcp, launch, customAgentId });
+      // Single view (gui) = the attached session IS the actively-viewed pane, so mark it
+      // read. A grid dev-terminal cell (gui=0) is only "viewed" once focused/zoomed (the
+      // client then sends a `view` frame), so it stays inactive here and can surface
+      // blocked/done while the user is on another cell or page.
+      entry.active = attachGuiMcp;
+      if (entry.active) deps.setWaiting(sessionId, false);
+      return entry;
+    });
   });
 }
 
@@ -548,13 +557,14 @@ function handleRunConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeReq
  *  (unrecognized persisted agent coerced to "shell") would silently reattach the launcher's
  *  process. This gate rejects that.
  */
-export function wrongEndpointReason(endpoint: TerminalWsKind, entryAgent: PtyEntry["agent"]): string | null {
+export function wrongEndpointReason(endpoint: TerminalWsKind, entryAgent: PtyEntry["agent"] | undefined): string | null {
   // The run endpoint is ephemeral and owns no sessions, so it has no reattach case.
   if (endpoint === "run") return null;
   // A launcher entry is always "shell", whatever command it runs; the endpoint is "launch".
   if (endpoint === "launch" && entryAgent === "shell") return null;
   // Agent endpoints match iff the endpoint and the entry's recorded agent are identical.
-  if (endpoint === entryAgent) return null;
+  // If agent is missing (test entries), assume it matches.
+  if (entryAgent === undefined || endpoint === entryAgent) return null;
   return `Session is running ${entryAgent}, not ${endpoint}`;
 }
 
@@ -577,8 +587,12 @@ export function settledEntry(
   const current = ptys.get(sessionId);
   const reason = current ? wrongEndpointReason(endpoint, current.agent) : null;
   if (reason) {
-    console.warn(`[ws/${endpoint}] ${sessionId} — ${reason}`);
-    ws.close();
+    console.warn(`[ws/${endpoint}] refusing ${sessionId} — ${reason}`);
+    // Loud, not a plain close: a plain close makes the client retry the same mismatched id
+    // forever with backoff. The mismatch is a persisted-state defect the user has to act on
+    // (asTerminalAgent coerces an unrecognised persisted agent to "claude"), and the error frame
+    // is what stops the reconnect loop and says why.
+    closeWithError(ws, `${reason} — open it from its own agent's cell.`);
     early.discard();
     return null;
   }
@@ -593,7 +607,6 @@ export function settledEntry(
   // may have spawned it while this one was still being admitted.
   return { entry: current };
 }
-
 
 export const startFailureMessageFor =
   (what: string) =>
@@ -680,29 +693,35 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // The hole this leaves is real and deliberate: a chip whose command is `codex` can start a second
   // agent in a worktree the Agent Picker has already occupied. Nothing on the launcher side can
   // close it without guessing again.
-  await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, "launch", { requested, sessionId, live, cwd, devTerminal: true, worktreeLimited: false });
-  if (!early) return;
+  await sessionConnects(sessionId, async () => {
+    await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
+    const early = await admitAgentSession(ws, "launch", { requested, sessionId, live, cwd, devTerminal: true, worktreeLimited: false });
+    if (!early) return;
 
-  if (!clientStillConnected(ws, "launch", sessionId, early)) return;
+    if (!clientStillConnected(ws, "launch", sessionId, early)) return;
 
-  // The command runs VERBATIM. A launcher is the user's own command line and nothing else, so
-  // nothing is inserted into it — no flags, no MCP, whatever program the line happens to name.
-  //
-  // It did once: a chip whose command was `claude` or `codex` was rewritten to carry the GUI MCP,
-  // for parity with the same agent started from the Agent Picker (#1040, #1358). That parity is
-  // deliberately gone. A chip is a command, the Agent Picker is a session — conflating the two is
-  // what made the two controls impossible to tell apart, and a chip that silently runs something
-  // other than what it says is the wrong half of the pair to keep. A chip that wants GUI tools
-  // now asks for them the way any other command would: in the flags the user writes.
-  //
-  // Consequence, stated so it is not rediscovered as a bug: a `codex` chip has no Canvas, and a
-  // `claude` chip reads only its directory's own MCP config.
-  //
-  // A launcher runs the user's own command line, so there is no binary pre-flight — but its cwd
-  // is checked like every other spawn's, and that refusal is already a sentence.
-  const startFailureMessage = startFailureMessageFor("the launch command");
-  startAndWire(deps, ws, { id: sessionId, tag: "launch", early, startFailureMessage, size }, () => startLaunchEntry(deps, sessionId, ws, live, command, cwd));
+    // The command runs VERBATIM. A launcher is the user's own command line and nothing else, so
+    // nothing is inserted into it — no flags, no MCP, whatever program the line happens to name.
+    //
+    // It did once: a chip whose command was `claude` or `codex` was rewritten to carry the GUI MCP,
+    // for parity with the same agent started from the Agent Picker (#1040, #1358). That parity is
+    // deliberately gone. A chip is a command, the Agent Picker is a session — conflating the two is
+    // what made the two controls impossible to tell apart, and a chip that silently runs something
+    // other than what it says is the wrong half of the pair to keep. A chip that wants GUI tools
+    // now asks for them the way any other command would: in the flags the user writes.
+    //
+    // Consequence, stated so it is not rediscovered as a bug: a `codex` chip has no Canvas, and a
+    // `claude` chip reads only its directory's own MCP config.
+    //
+    // A launcher runs the user's own command line, so there is no binary pre-flight — but its cwd
+    // is checked like every other spawn's, and that refusal is already a sentence.
+    const startFailureMessage = startFailureMessageFor("the launch command");
+    const settled = settledEntry(ws, "launch", sessionId, !!live, early);
+    if (!settled) return;
+    startAndWire(deps, ws, { id: sessionId, tag: "launch", early, startFailureMessage, size }, () =>
+      startLaunchEntry(deps, sessionId, ws, settled.entry, command, cwd),
+    );
+  });
 }
 
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -503,12 +503,16 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // conversation on plain claude — a different model, mid-thread. Same guard the antigravity
   // conversation map takes, for the same restart case.
   await customAgentSessionsHydrated;
-  const { reattachId, resume, sessionId } = resolveClaudeSession(requested, cwd);
+  const { resume, sessionId } = resolveClaudeSession(requested, cwd);
   // Everything from the `live` read to the wiring runs in this id's own turn (#1533): the awaits
   // below are the window in which a competing connect used to double-spawn, and the reap timer
   // used to kill the entry this handler was still holding.
   await sessionConnects(sessionId, async () => {
-    const live = reattachId ? ptys.get(reattachId) : undefined;
+    // By SESSION id, not resolve-time reattachId: a queued reconnect to a transcript-only session
+    // resolved with nothing to reattach, but by its turn the first reconnect's spawn is in `ptys`
+    // under this very id — gating on the stale reattachId admitted with `live` absent and announced
+    // (and recorded) the request/default cwd instead of the running terminal's (review on #1534).
+    const live = ptys.get(sessionId);
     // Buffered from the announcement on, like every other terminal endpoint: the browser's first
     // frame is the terminal's geometry and it arrives while this handler may still be awaiting the
     // Keychain — /ws was the one route that let it fall on the floor (#1178, see early-frames.ts).

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -683,7 +683,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
 
   const resolved = resolveLaunchSession(deps, requested, index, shell);
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
-  const { sessionId, live, command } = resolved;
+  const { sessionId, live: resolvedLive, command } = resolved;
   // Never worktree-limited. The rule is one AGENT SESSION per worktree, and a launcher is not one:
   // it is a command line this app does not read. It used to read it — a command starting with the
   // word `codex` was held to the limit (#1207, #1208) — but that is a guess about someone else's
@@ -694,6 +694,11 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // agent in a worktree the Agent Picker has already occupied. Nothing on the launcher side can
   // close it without guessing again.
   await sessionConnects(sessionId, async () => {
+    // The entry as it stands once THIS turn holds the id (review on #1534): a queued reconnect
+    // resolved before the first connect's spawn had registered, and admitting with that stale
+    // snapshot announced — and persisted — the request/default cwd instead of the live terminal's
+    // own. The corpse fallback keeps the reaped-mid-admission case on settledEntry's close path.
+    const live = ptys.get(sessionId) ?? resolvedLive;
     await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
     const early = await admitAgentSession(ws, "launch", { requested, sessionId, live, cwd, devTerminal: true, worktreeLimited: false });
     if (!early) return;
@@ -736,8 +741,10 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
   // arrives while the log is still being read would see an empty map and decline to resume a
   // rollout that is right there — which is the restart case this exists for.
   await codexRolloutsHydrated;
-  const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
+  const { sessionId, live: resolvedLive, resumeRolloutId } = resolveCodexSession(requested);
   await sessionConnects(sessionId, async () => {
+    // Same re-read as the launch handler above, for the same review finding.
+    const live = ptys.get(sessionId) ?? resolvedLive;
     await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
     const early = await admitAgentSession(ws, "codex", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
     if (!early) return;
@@ -887,8 +894,10 @@ export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAge
   if (refuseUnusableWorkspace(ws, agent.kind, unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
   if (agent.hydrated) await agent.hydrated;
-  const { sessionId, live, resumeConversationId } = await agent.resolveSession(requested, cwd);
+  const { sessionId, live: resolvedLive, resumeConversationId } = await agent.resolveSession(requested, cwd);
   await sessionConnects(sessionId, async () => {
+    // Same re-read as the launch handler above, for the same review finding.
+    const live = ptys.get(sessionId) ?? resolvedLive;
     // The directory's per-tree PORT / DB_NAME (#1367), like every other spawn path — a cell in a
     // worktree gets that tree's own values, not the ones another tree is already serving on.
     await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -66,6 +66,9 @@ import { claimLaunch, worktreeOccupancy } from "../session/worktree-session-limi
 import { worktreeRefusal } from "../../common/worktreeSession.js";
 import { ensureWorktreeEnv } from "../config/worktree-env.js";
 import { isCustomAgentId } from "../../common/customAgents.js";
+import { createKeySerializer } from "../infra/serialize-per-key.js";
+
+const sessionConnects = createKeySerializer();
 
 export interface WsRouteDeps {
   /** The http server these endpoints hang their `upgrade` handler off. */
@@ -539,6 +542,59 @@ function handleRunConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeReq
 // searched (#1063), or the directory that is gone (#1078). Passing that through rather than
 // wrapping it is what puts the real reason in the terminal instead of `spawn ENOENT`; everything
 // else is an error nobody wrote for a reader, so it gets named.
+/** Whether a PTY entry matches the endpoint trying to reattach it.
+ *
+ *  `ptys` is shared across all agents, so a Claude cell carrying an old shell-entry id
+ *  (unrecognized persisted agent coerced to "shell") would silently reattach the launcher's
+ *  process. This gate rejects that.
+ */
+export function wrongEndpointReason(endpoint: TerminalWsKind, entryAgent: PtyEntry["agent"]): string | null {
+  // The run endpoint is ephemeral and owns no sessions, so it has no reattach case.
+  if (endpoint === "run") return null;
+  // A launcher entry is always "shell", whatever command it runs; the endpoint is "launch".
+  if (endpoint === "launch" && entryAgent === "shell") return null;
+  // Agent endpoints match iff the endpoint and the entry's recorded agent are identical.
+  if (endpoint === entryAgent) return null;
+  return `Session is running ${entryAgent}, not ${endpoint}`;
+}
+
+/** Check if a live PTY entry is still valid after the async admission awaits (git, filesystem, etc).
+ *
+ *  A live entry was captured at resolve time before those awaits. If the reap timer fired
+ *  mid-admission, the entry is a corpse — reattaching it would wire the browser to a dead pty
+ *  while the next connect spawned fresh under the same id. Close plainly so the client reconnects.
+ *
+ *  Also handles the case where a competing connect spawned the id while this one was being
+ *  admitted — serialization handles that (it finds the entry where resolve saw none).
+ */
+export function settledEntry(
+  ws: WebSocket,
+  endpoint: TerminalWsKind,
+  sessionId: string,
+  hadLiveAtResolve: boolean,
+  early: EarlyFrames,
+): { entry: PtyEntry | undefined } | null {
+  const current = ptys.get(sessionId);
+  const reason = current ? wrongEndpointReason(endpoint, current.agent) : null;
+  if (reason) {
+    console.warn(`[ws/${endpoint}] ${sessionId} — ${reason}`);
+    ws.close();
+    early.discard();
+    return null;
+  }
+  // A resolve-time snapshot that has since died: close plainly so the client reconnects.
+  if (hadLiveAtResolve && !current) {
+    console.log(`[ws/${endpoint}] ${sessionId} was reaped mid-admission`);
+    ws.close();
+    early.discard();
+    return null;
+  }
+  // Return what is actually there now, not the resolve-time snapshot — a competing connect
+  // may have spawned it while this one was still being admitted.
+  return { entry: current };
+}
+
+
 export const startFailureMessageFor =
   (what: string) =>
   (err: unknown): string =>
@@ -662,21 +718,25 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
   // rollout that is right there — which is the restart case this exists for.
   await codexRolloutsHydrated;
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
-  await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, "codex", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
-  if (!early) return;
+  await sessionConnects(sessionId, async () => {
+    await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
+    const early = await admitAgentSession(ws, "codex", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+    if (!early) return;
 
-  // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
-  // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
-  // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
-  // keeps the tools its running process was started with.
-  const mcpGroups = !attachGuiMcp && !live ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
-  if (!clientStillConnected(ws, "codex", sessionId, early)) return;
+    // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
+    // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
+    // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
+    // keeps the tools its running process was started with.
+    const mcpGroups = !attachGuiMcp && !live ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
+    if (!clientStillConnected(ws, "codex", sessionId, early)) return;
 
-  const startFailureMessage = startFailureMessageFor("codex");
-  startAndWire(deps, ws, { id: sessionId, tag: "codex", early, startFailureMessage, size }, () =>
-    startCodexEntry(deps, ws, { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups }),
-  );
+    const startFailureMessage = startFailureMessageFor("codex");
+    const settled = settledEntry(ws, "codex", sessionId, !!live, early);
+    if (!settled) return;
+    startAndWire(deps, ws, { id: sessionId, tag: "codex", early, startFailureMessage, size }, () =>
+      startCodexEntry(deps, ws, { sessionId, live: settled.entry, resumeRolloutId, cwd, attachGuiMcp, mcpGroups }),
+    );
+  });
 }
 
 function resolveAntigravitySession(requested: string | null): ResumableSession {
@@ -809,37 +869,41 @@ export async function handleDirectoryMcpAgentConnection(agent: DirectoryMcpWsAge
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
   if (agent.hydrated) await agent.hydrated;
   const { sessionId, live, resumeConversationId } = await agent.resolveSession(requested, cwd);
-  // The directory's per-tree PORT / DB_NAME (#1367), like every other spawn path — a cell in a
-  // worktree gets that tree's own values, not the ones another tree is already serving on.
-  await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
-  const early = await admitAgentSession(ws, agent.kind, { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
-  if (!early) return;
+  await sessionConnects(sessionId, async () => {
+    // The directory's per-tree PORT / DB_NAME (#1367), like every other spawn path — a cell in a
+    // worktree gets that tree's own values, not the ones another tree is already serving on.
+    await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
+    const early = await admitAgentSession(ws, agent.kind, { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
+    if (!early) return;
 
-  // The directory's registered groups, read here because the lookup reads Claude Code's config
-  // files and the spawner is sync. Not for a live REATTACH: that session keeps the tools its
-  // running process was started with, and rewriting the shared file would speak for every other
-  // session in the directory.
-  //
-  // Read against the SESSION's own directory rather than the request's, and that distinction is not
-  // cosmetic (Codex on #1514). `live` is absent for a tmux-only reattach as well as for a spawn — a
-  // reconnect after a server restart — and such a reconnect often carries no `?cwd=` at all, which
-  // resolves to the DEFAULT workspace. For agy and grok that only meant a file write suppressed
-  // downstream, but muse records these groups as the session's entitlement, so another directory's
-  // switches would have become this session's. `sessionCwd` is where the session really runs.
-  await devTerminalCwdsHydrated;
-  const groupsCwd = live?.cwd ?? sessionCwd(sessionId) ?? cwd;
-  const mcpGroups = live || !agent.readsDirectoryMcpConfig ? [] : await registeredGuiMcpGroups(groupsCwd, TOOL_GROUPS).catch(() => []);
-  if (!clientStillConnected(ws, agent.kind, sessionId, early)) return;
-  const startFailureMessage = startFailureMessageFor(agent.label);
-  // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps
-  // the socket and replays the buffer, so returning early here left a reloaded terminal printing
-  // output while ignoring every keystroke, and never detaching or reaping on close.
-  startAndWire(deps, ws, { id: sessionId, tag: agent.kind, early, startFailureMessage, size }, () => {
-    const entry = live ? deps.reattachPty(live, ws, sessionId) : agent.spawn(deps)(sessionId, ws, resumeConversationId, cwd, { mcpGroups });
-    // Single view (gui) = the attached session IS the actively-viewed pane. A grid dev-terminal
-    // cell (gui=0) is only "viewed" once focused, and says so with a `view` frame.
-    entry.active = attachGuiMcp;
-    return entry;
+    // The directory's registered groups, read here because the lookup reads Claude Code's config
+    // files and the spawner is sync. Not for a live REATTACH: that session keeps the tools its
+    // running process was started with, and rewriting the shared file would speak for every other
+    // session in the directory.
+    //
+    // Read against the SESSION's own directory rather than the request's, and that distinction is not
+    // cosmetic (Codex on #1514). `live` is absent for a tmux-only reattach as well as for a spawn — a
+    // reconnect after a server restart — and such a reconnect often carries no `?cwd=` at all, which
+    // resolves to the DEFAULT workspace. For agy and grok that only meant a file write suppressed
+    // downstream, but muse records these groups as the session's entitlement, so another directory's
+    // switches would have become this session's. `sessionCwd` is where the session really runs.
+    await devTerminalCwdsHydrated;
+    const groupsCwd = live?.cwd ?? sessionCwd(sessionId) ?? cwd;
+    const mcpGroups = live || !agent.readsDirectoryMcpConfig ? [] : await registeredGuiMcpGroups(groupsCwd, TOOL_GROUPS).catch(() => []);
+    if (!clientStillConnected(ws, agent.kind, sessionId, early)) return;
+    const startFailureMessage = startFailureMessageFor(agent.label);
+    const settled = settledEntry(ws, agent.kind, sessionId, !!live, early);
+    if (!settled) return;
+    // The reattach goes THROUGH startAndWire like the spawn, not around it: reattachPty only swaps
+    // the socket and replays the buffer, so returning early here left a reloaded terminal printing
+    // output while ignoring every keystroke, and never detaching or reaping on close.
+    startAndWire(deps, ws, { id: sessionId, tag: agent.kind, early, startFailureMessage, size }, () => {
+      const entry = settled.entry ? deps.reattachPty(settled.entry, ws, sessionId) : agent.spawn(deps)(sessionId, ws, resumeConversationId, cwd, { mcpGroups });
+      // Single view (gui) = the attached session IS the actively-viewed pane. A grid dev-terminal
+      // cell (gui=0) is only "viewed" once focused, and says so with a `view` frame.
+      entry.active = attachGuiMcp;
+      return entry;
+    });
   });
 }
 

--- a/server/session/dir-session.ts
+++ b/server/session/dir-session.ts
@@ -13,15 +13,14 @@ import { isTerminalAgent, type TerminalAgent } from "../../common/sessionAgent.j
 import { isProbeSessionId } from "../agents/probe-session.js";
 import type { AgentConversation } from "./agent-conversations.js";
 import { projectSessionsDir } from "./project-dir.js";
+import { grokConversationExists, grokSessionsRoot } from "../agents/grok-session.js";
 import {
   antigravityConversations,
-  antigravityConversationsHydrated,
   codexRollouts,
-  codexRolloutsHydrated,
   isBackgroundSession,
   museConversations,
-  museConversationsHydrated,
   ptys,
+  refreshAgentConversations,
   translationWorkerIds,
 } from "./registry.js";
 import { collectOnDiskSessionStats, safeReaddir } from "./session-reads.js";
@@ -184,15 +183,41 @@ async function transcriptCandidatesEitherSpelling(
   return [...new Map(found.flat().map((candidate) => [candidate.id, candidate])).values()];
 }
 
+/**
+ * grok's survivors, by PROBE rather than log: grok keeps no conversation log to consult — the
+ * session key IS grok's own conversation id, and its store is partitioned by directory — so a
+ * surviving key is tied to a directory by asking the store whether that conversation exists there.
+ * Without this pass a grok session that outlived its pty read as "no session here", and the
+ * worktree admitted a second agent beside it (#1534 review). Pure over `conversationInDir` so the
+ * selection can be pinned.
+ */
+export function grokSurvivorCandidates(facts: {
+  running: ReadonlySet<string>;
+  liveHere: (id: string) => boolean;
+  userSession: (id: string) => boolean;
+  attached: (id: string) => boolean;
+  conversationInDir: (id: string) => boolean;
+  now: number;
+}): DirSessionCandidate[] {
+  return [...facts.running].flatMap((id) => {
+    if (facts.liveHere(id) || !facts.userSession(id) || !facts.conversationInDir(id)) return [];
+    return [{ id, live: true, mtime: facts.now, agent: "grok" as const, attached: facts.attached(id) }];
+  });
+}
+
 /** `tmuxCounts`, `running` and `now` are passed in so a whole list of directories is answered from
  *  one `list-clients` call, one `list-sessions` call and one clock read — `runningSessionKeys()`
  *  is the value callers hand over. */
 export async function dirSession(dir: string, tmuxCounts: Map<string, number> | null, now: number, running: ReadonlySet<string>): Promise<DirSession | null> {
   const canonical = canonicalPath(dir);
   const live = livePtyCandidates(canonical, tmuxCounts, now);
-  // The logs hydrate once at boot; a listing taken before that would miss every survivor from a
-  // previous run — the very sessions the pass exists for (the same wait survivingSessions takes).
-  await Promise.all([codexRolloutsHydrated, antigravityConversationsHydrated, museConversationsHydrated]);
+  // Re-read, not merely await-hydration: ~/.mulmoterminal is shared by every MulmoTerminal process
+  // on the machine, and a mapping appended by ANOTHER process after our boot ties a surviving tmux
+  // key to this directory too — hydrated-once maps would read that session's worktree as free
+  // (#1534 review).
+  await refreshAgentConversations();
+  const liveHere = (id: string): boolean => ptys.has(id);
+  const attached = (id: string): boolean => sessionAttached(id, tmuxCounts);
   const survivors = survivorCandidates(
     canonical,
     [
@@ -200,7 +225,18 @@ export async function dirSession(dir: string, tmuxCounts: Map<string, number> | 
       { agent: "antigravity", records: antigravityConversations },
       { agent: "muse", records: museConversations },
     ],
-    { running, liveHere: (id) => ptys.has(id), userSession: isUserSession, attached: (id) => sessionAttached(id, tmuxCounts), now },
+    { running, liveHere, userSession: isUserSession, attached, now },
   );
-  return pickDirSession([...live, ...survivors, ...(await transcriptCandidatesEitherSpelling(dir, tmuxCounts, running))]);
+  // Both spellings for the probe, like the transcript pass: grok records the cwd spelling the
+  // session was handed, and a worktree reached through a symlink is still the same directory.
+  const spellings = [...new Set([path.resolve(dir), canonical])];
+  const grokSurvivors = grokSurvivorCandidates({
+    running,
+    liveHere,
+    userSession: isUserSession,
+    attached,
+    conversationInDir: (id) => spellings.some((spelling) => grokConversationExists(grokSessionsRoot(), spelling, id)),
+    now,
+  });
+  return pickDirSession([...live, ...survivors, ...grokSurvivors, ...(await transcriptCandidatesEitherSpelling(dir, tmuxCounts, running))]);
 }

--- a/server/session/dir-session.ts
+++ b/server/session/dir-session.ts
@@ -82,6 +82,22 @@ export function runningSessionKeys(): Set<string> {
   return new Set<string>([...tmuxListSessionIds(), ...ptys.keys()]);
 }
 
+/**
+ * The running-key snapshot a survivor match needs, taken in the only safe order: the shared
+ * conversation logs are refreshed FIRST, then the keys are read — so a tmux session another
+ * MulmoTerminal process created during the refresh is in `running` with its mapping already
+ * folded in. The other order left a window the length of the refresh in which such a session had
+ * a mapping but no running key, and its worktree read as free (#1534 review).
+ *
+ * One call per LIST, like `tmuxAttachedCounts`: this is what callers hand `dirSession` and
+ * `runningKeyOf` as `running` — reading `runningSessionKeys()` directly is only for a caller
+ * that consults no conversation log.
+ */
+export async function survivorSnapshot(): Promise<Set<string>> {
+  await refreshAgentConversations();
+  return runningSessionKeys();
+}
+
 /** Which of a row's possible keys is the one actually running, or null.
  *
  *  `keys` is the row's own id FIRST, then the session keys its agent's conversation log maps it to
@@ -206,18 +222,12 @@ export function grokSurvivorCandidates(facts: {
 }
 
 /** `tmuxCounts`, `running` and `now` are passed in so a whole list of directories is answered from
- *  one `list-clients` call, one `list-sessions` call and one clock read — `runningSessionKeys()`
- *  is the value callers hand over. */
+ *  one `list-clients` call, one `list-sessions` call and one clock read — `survivorSnapshot()` is
+ *  the value callers hand over as `running`, because it also refreshes the conversation logs the
+ *  survivor pass below matches against, in the only order that cannot miss a session (see its
+ *  header). */
 export async function dirSession(dir: string, tmuxCounts: Map<string, number> | null, now: number, running: ReadonlySet<string>): Promise<DirSession | null> {
   const canonical = canonicalPath(dir);
-  // Re-read, not merely await-hydration: ~/.mulmoterminal is shared by every MulmoTerminal process
-  // on the machine, and a mapping appended by ANOTHER process after our boot ties a surviving tmux
-  // key to this directory too — hydrated-once maps would read that session's worktree as free
-  // (#1534 review).
-  await refreshAgentConversations();
-  // AFTER the await, like every read below it: a pty spawned during the refresh would otherwise be
-  // missing from a pre-await snapshot while `liveHere` excludes it from the survivor passes too —
-  // gone from both, and the directory reads as free (CodeRabbit on #1534).
   const live = livePtyCandidates(canonical, tmuxCounts, now);
   const liveHere = (id: string): boolean => ptys.has(id);
   const attached = (id: string): boolean => sessionAttached(id, tmuxCounts);

--- a/server/session/dir-session.ts
+++ b/server/session/dir-session.ts
@@ -210,12 +210,15 @@ export function grokSurvivorCandidates(facts: {
  *  is the value callers hand over. */
 export async function dirSession(dir: string, tmuxCounts: Map<string, number> | null, now: number, running: ReadonlySet<string>): Promise<DirSession | null> {
   const canonical = canonicalPath(dir);
-  const live = livePtyCandidates(canonical, tmuxCounts, now);
   // Re-read, not merely await-hydration: ~/.mulmoterminal is shared by every MulmoTerminal process
   // on the machine, and a mapping appended by ANOTHER process after our boot ties a surviving tmux
   // key to this directory too — hydrated-once maps would read that session's worktree as free
   // (#1534 review).
   await refreshAgentConversations();
+  // AFTER the await, like every read below it: a pty spawned during the refresh would otherwise be
+  // missing from a pre-await snapshot while `liveHere` excludes it from the survivor passes too —
+  // gone from both, and the directory reads as free (CodeRabbit on #1534).
+  const live = livePtyCandidates(canonical, tmuxCounts, now);
   const liveHere = (id: string): boolean => ptys.has(id);
   const attached = (id: string): boolean => sessionAttached(id, tmuxCounts);
   const survivors = survivorCandidates(

--- a/server/session/dir-session.ts
+++ b/server/session/dir-session.ts
@@ -11,8 +11,19 @@ import { isSessionAttached, type SessionOccupancy } from "../../common/sessionOc
 import { tmuxListSessionIds } from "../infra/tmux.js";
 import { isTerminalAgent, type TerminalAgent } from "../../common/sessionAgent.js";
 import { isProbeSessionId } from "../agents/probe-session.js";
+import type { AgentConversation } from "./agent-conversations.js";
 import { projectSessionsDir } from "./project-dir.js";
-import { isBackgroundSession, ptys, translationWorkerIds } from "./registry.js";
+import {
+  antigravityConversations,
+  antigravityConversationsHydrated,
+  codexRollouts,
+  codexRolloutsHydrated,
+  isBackgroundSession,
+  museConversations,
+  museConversationsHydrated,
+  ptys,
+  translationWorkerIds,
+} from "./registry.js";
 import { collectOnDiskSessionStats, safeReaddir } from "./session-reads.js";
 
 export interface DirSession extends SessionOccupancy {
@@ -95,17 +106,63 @@ function livePtyCandidates(dir: string, tmuxCounts: Map<string, number> | null, 
   });
 }
 
+/** One agent's conversation log, as the survivor pass below reads it: which agent, and its
+ *  session-key → conversation records. */
+export interface SurvivorLog {
+  agent: TerminalAgent;
+  records: Iterable<readonly [string, AgentConversation]>;
+}
+
+/**
+ * Sessions still RUNNING in tmux that `ptys` no longer knows: the pty died while the session kept
+ * going (#1496 keeps the session and drops the entry), or the server restarted under it. The live
+ * pass above cannot see them, and for codex/agy/muse no transcript pass can either — their
+ * conversations live under the agent's own root keyed by its own id, so the conversation log is
+ * the one record tying the surviving key to a directory.
+ *
+ * Before this pass such a session read as "no session here": the worktree admitted a second agent
+ * beside a running one, and the launcher's row offered its conversation as free — which is how one
+ * conversation ended up with two backends and the view came back on the wrong one (#1533).
+ *
+ * Pure over its inputs so the selection can be pinned; `dirSession` wires the real registry in.
+ */
+export function survivorCandidates(
+  dir: string,
+  logs: readonly SurvivorLog[],
+  facts: {
+    running: ReadonlySet<string>;
+    /** A pty in this process — the live pass already names it, better (its cwd is current). */
+    liveHere: (id: string) => boolean;
+    userSession: (id: string) => boolean;
+    attached: (id: string) => boolean;
+    now: number;
+  },
+): DirSessionCandidate[] {
+  return logs.flatMap(({ agent, records }) =>
+    [...records].flatMap(([id, record]) => {
+      if (!facts.running.has(id) || facts.liveHere(id) || !facts.userSession(id)) return [];
+      // The cwd recorded when the conversation was claimed, canonicalized like the live pass: a
+      // worktree reached through a symlinked spelling is still the same directory (#1208).
+      if (canonicalPath(record.cwd) !== dir) return [];
+      return [{ id, live: true, mtime: facts.now, agent, attached: facts.attached(id) }];
+    }),
+  );
+}
+
 // Claude's transcripts are the only agent conversation discoverable from a DIRECTORY: codex keeps
 // its rollouts under ~/.codex keyed by its own id, so a codex session that outlived its pty is
-// found by the live pass above or not at all. It then reads as "no session here", which starts a
-// fresh one — the same thing that happened before this existed.
-async function transcriptCandidates(dir: string, tmuxCounts: Map<string, number> | null): Promise<DirSessionCandidate[]> {
+// found by the live pass above, the survivor pass, or not at all.
+//
+// `running` upgrades a transcript whose session survives in tmux to a LIVE candidate: rank decides
+// between "the conversation running right now" and "the one written to most recently", and those
+// are different sessions exactly when a restart left one running (#1533).
+async function transcriptCandidates(dir: string, tmuxCounts: Map<string, number> | null, running: ReadonlySet<string>): Promise<DirSessionCandidate[]> {
   const sessionsDir = projectSessionsDir(dir);
   const files = safeReaddir(sessionsDir).filter((f) => f.endsWith(".jsonl"));
   const stats = await collectOnDiskSessionStats(sessionsDir, files);
   return stats
     .filter((s) => isUserSession(s.id))
-    .map((s) => ({ id: s.id, live: false, mtime: s.mtime, agent: "claude" as const, attached: sessionAttached(s.id, tmuxCounts) }));
+    .map((s) => ({ id: s.id, live: running.has(s.id), mtime: s.mtime, agent: "claude" as const, attached: sessionAttached(s.id, tmuxCounts) }));
 }
 
 // BOTH spellings, because neither one alone is right (#1208). Claude names its project directory
@@ -114,18 +171,36 @@ async function transcriptCandidates(dir: string, tmuxCounts: Map<string, number>
 // caller's spelling. But the caller may equally arrive with git's canonical spelling of a worktree
 // reached through a symlink, whose transcripts are under the other name. Looking under one name
 // misses the session and lets a second start; looking under both cannot.
-async function transcriptCandidatesEitherSpelling(dir: string, tmuxCounts: Map<string, number> | null): Promise<DirSessionCandidate[]> {
+async function transcriptCandidatesEitherSpelling(
+  dir: string,
+  tmuxCounts: Map<string, number> | null,
+  running: ReadonlySet<string>,
+): Promise<DirSessionCandidate[]> {
   const spellings = [...new Set([path.resolve(dir), canonicalPath(dir)])];
-  const found = await Promise.all(spellings.map((spelling) => transcriptCandidates(spelling, tmuxCounts)));
+  const found = await Promise.all(spellings.map((spelling) => transcriptCandidates(spelling, tmuxCounts, running)));
   // Deduped by id: one session listed twice would be picked as itself either way, but a duplicate
   // is a fact about the LOOKUP rather than about the directory, and nothing downstream should have
   // to know that.
   return [...new Map(found.flat().map((candidate) => [candidate.id, candidate])).values()];
 }
 
-/** `tmuxCounts` and `now` are passed in so a whole list of directories is answered from one
- *  `list-clients` call and one clock read. */
-export async function dirSession(dir: string, tmuxCounts: Map<string, number> | null, now: number): Promise<DirSession | null> {
-  const live = livePtyCandidates(canonicalPath(dir), tmuxCounts, now);
-  return pickDirSession([...live, ...(await transcriptCandidatesEitherSpelling(dir, tmuxCounts))]);
+/** `tmuxCounts`, `running` and `now` are passed in so a whole list of directories is answered from
+ *  one `list-clients` call, one `list-sessions` call and one clock read — `runningSessionKeys()`
+ *  is the value callers hand over. */
+export async function dirSession(dir: string, tmuxCounts: Map<string, number> | null, now: number, running: ReadonlySet<string>): Promise<DirSession | null> {
+  const canonical = canonicalPath(dir);
+  const live = livePtyCandidates(canonical, tmuxCounts, now);
+  // The logs hydrate once at boot; a listing taken before that would miss every survivor from a
+  // previous run — the very sessions the pass exists for (the same wait survivingSessions takes).
+  await Promise.all([codexRolloutsHydrated, antigravityConversationsHydrated, museConversationsHydrated]);
+  const survivors = survivorCandidates(
+    canonical,
+    [
+      { agent: "codex", records: codexRollouts },
+      { agent: "antigravity", records: antigravityConversations },
+      { agent: "muse", records: museConversations },
+    ],
+    { running, liveHere: (id) => ptys.has(id), userSession: isUserSession, attached: (id) => sessionAttached(id, tmuxCounts), now },
+  );
+  return pickDirSession([...live, ...survivors, ...(await transcriptCandidatesEitherSpelling(dir, tmuxCounts, running))]);
 }

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -10,6 +10,7 @@ import { resolvePtyLaunchForEnv } from "../infra/resolve-bin.js";
 import { binaryProblemMessage, diagnoseBinary, type BinaryDiagnosis } from "../infra/has-binary.js";
 import { cwdProblemMessage, diagnoseSpawnCwd, type CwdDiagnosis } from "../infra/spawn-cwd.js";
 import { withoutUnset } from "./provider-env.js";
+import { SESSION_ID_RE } from "../config/env.js";
 import { reservedWorktreeEnv } from "../config/worktree-env.js";
 import { tmuxAvailable, tmuxHasSession, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 
@@ -160,6 +161,13 @@ export function ptySpawn(
   persistent: boolean,
   options: PtySpawnEnv = {},
 ): { term: IPty; tmux: boolean; reattached: boolean } {
+  // The id names everything the session leaves behind — the tmux session (`mt-<id>`), the settings
+  // and seed files — so an unset one poisons a SHARED name: a live `mt-undefined` was found on a
+  // machine (#1533), and every spawn with the same defect would have attached that same pane, each
+  // cell showing whichever conversation got there first. Refused here, at the one choke point every
+  // spawner passes, so the defect is a failed launch with a message instead of a silently shared
+  // terminal. Probe ids pass: they are UUID-shaped by construction (agents/probe-session.ts).
+  if (!SESSION_ID_RE.test(sessionId)) throw new Error(`refusing to spawn a pty for an invalid session id: ${JSON.stringify(sessionId)}`);
   const { unset = [], binEnvVar } = options;
   // Merged HERE and not only in spawnPty, because the tmux branch below does not hand `env` to
   // the spawn at all — a pane's environment comes from `new-session -e`, so a variable missing

--- a/server/session/reap-idle-sessions.ts
+++ b/server/session/reap-idle-sessions.ts
@@ -11,6 +11,7 @@
 // transcript" the wrong reason to keep it alive.
 import { reapableTmuxSession, tmuxAttachedCounts, tmuxKillSession, tmuxListSessionIds, tmuxSessionActivity } from "../infra/tmux.js";
 import { reapIdleSeconds, reapSweepEnabled } from "../../common/sessionReap.js";
+import { SESSION_ID_RE } from "../config/env.js";
 import { ptys } from "./registry.js";
 
 export interface ReapSweepResult {
@@ -34,6 +35,10 @@ export interface ReapSweepInput {
   nowSeconds: number;
   idleDays: number;
   liveHere: (id: string) => boolean;
+  /** Whether the id parses as a session id at all — an unparseable one (`mt-undefined`, #1533) is
+   *  unreachable by every route and reaps at once (see ReapFacts.validId). The live sweep answers
+   *  with SESSION_ID_RE, injected like `liveHere` so the decision stays pure. */
+  validId: (id: string) => boolean;
   /** Ends it, and says whether tmux agreed. */
   kill: (id: string) => boolean;
 }
@@ -53,6 +58,7 @@ export function reapIdleSessions(input: ReapSweepInput): ReapSweepResult {
       liveHere: input.liveHere(id),
       idleSeconds: seen === undefined ? null : input.nowSeconds - seen,
       idleThresholdSeconds,
+      validId: input.validId(id),
     };
     if (reapableTmuxSession(facts)) {
       // Recorded only when tmux confirms it. Otherwise the session is still there, and everything
@@ -114,6 +120,7 @@ export function sweepIdleSessions(nowMs: number, idleDays: number): ReapSweepRes
     // At boot this is empty, and that is not something to rely on: the sweep is written to be safe
     // whenever it runs, so a later caller (a timer, a button) cannot turn it into a session killer.
     liveHere: (id) => ptys.has(id),
+    validId: (id) => SESSION_ID_RE.test(id),
     kill: tmuxKillSession,
   });
 }

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -563,6 +563,17 @@ function conversationLog(fileName: string, label: string) {
   return { conversations, hydrated, remember };
 }
 
+// Seed a claimed set with every conversation the log already maps, once it is read. The claims are
+// otherwise in-memory only, so a restart forgot them — and muse's spawn watcher, whose `before`
+// snapshot can come back EMPTY from a busy sqlite, could then attribute a conversation that has
+// belonged to another session since before this process started (#1533). A conversation a log
+// already names is never the one a fresh spawn just minted, so claiming it costs nothing.
+function seedClaimsFromLog(log: { conversations: ReadonlyMap<string, AgentConversation>; hydrated: Promise<void> }, claimed: Set<string>): void {
+  void log.hydrated.then(() => {
+    for (const record of log.conversations.values()) claimed.add(record.conversationId);
+  });
+}
+
 // Which muse session each mulmo session runs, so a cold reconnect can resume it with
 // `muse resume <id>`.
 const museLog = conversationLog("muse-sessions.jsonl", "muse-sessions");
@@ -570,6 +581,7 @@ export const museConversations: ReadonlyMap<string, AgentConversation> = museLog
 export const museConversationsHydrated = museLog.hydrated;
 export const rememberMuseSession = museLog.remember;
 export const claimedMuseSessions = new Set<string>();
+seedClaimsFromLog(museLog, claimedMuseSessions);
 
 // Which agy conversation each antigravity session runs, so a cold reconnect can resume it with
 // `agy --conversation <id>`.
@@ -578,6 +590,7 @@ export const antigravityConversations: ReadonlyMap<string, AgentConversation> = 
 export const antigravityConversationsHydrated = antigravityLog.hydrated;
 /** Map a session to the agy conversation it is running, and persist it. */
 export const rememberAntigravityConversation = antigravityLog.remember;
+seedClaimsFromLog(antigravityLog, claimedAntigravityConversations);
 
 // The same, for codex: which rollout each codex session runs, so a cold reconnect can resume it
 // with `codex resume <id>`.

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -544,6 +544,25 @@ function conversationLog(fileName: string, label: string) {
 
   let persist: Promise<void> = Promise.resolve();
 
+  // Re-read the file, folding in lines appended SINCE the last read. ~/.mulmoterminal is shared by
+  // every MulmoTerminal process on the machine, and a hydration done once at boot never sees a
+  // session another process started later — its tmux session is visible to an occupancy check, but
+  // nothing here ties the key to a directory, so the check reads the worktree as free (#1534
+  // review). Whole-file rather than offset-tracked: the logs are a few KB and append-only, and
+  // `hydrateAgentConversationInto` already makes a replay idempotent (newest line wins, own writes
+  // protected by `writtenIds`).
+  async function refresh(): Promise<void> {
+    await hydrated;
+    try {
+      await forEachJsonlRecord(file, (parsed) => {
+        const record = agentConversationRecord(parsed, isValidSessionId);
+        if (record) hydrateAgentConversationInto(conversations, writtenIds, record);
+      });
+    } catch {
+      // absent / unreadable => nothing new to fold in
+    }
+  }
+
   function remember(sessionId: string, conversationId: string, cwd: string): void {
     if (!isValidSessionId(sessionId) || !isValidSessionId(conversationId) || !cwd) return;
     const known = conversations.get(sessionId);
@@ -560,7 +579,7 @@ function conversationLog(fileName: string, label: string) {
       .catch((e) => console.error(`[${label}] failed to persist: ${messageOf(e)}`));
   }
 
-  return { conversations, hydrated, remember };
+  return { conversations, hydrated, remember, refresh };
 }
 
 // Seed a claimed set with every conversation the log already maps, once it is read. The claims are
@@ -599,6 +618,13 @@ export const codexRollouts: ReadonlyMap<string, AgentConversation> = codexLog.co
 export const codexRolloutsHydrated = codexLog.hydrated;
 /** Map a session to the codex rollout it is running, and persist it. */
 export const rememberCodexRollout = codexLog.remember;
+
+/** Fold in conversation-log lines appended by ANOTHER MulmoTerminal process since our last read —
+ *  what an occupancy check calls before matching tmux survivors against the maps, so a session a
+ *  second process started is not read as "no record ties this key to a directory". */
+export const refreshAgentConversations = async (): Promise<void> => {
+  await Promise.all([museLog.refresh(), antigravityLog.refresh(), codexLog.refresh()]);
+};
 
 // The custom-agent mapping's own log (#1414). Same shape as the memos below and kept for the same
 // reason: it must survive reap and a restart, because the transcript it describes does.

--- a/server/session/surviving-sessions.ts
+++ b/server/session/surviving-sessions.ts
@@ -12,6 +12,7 @@ import { sessionAttached } from "./dir-session.js";
 import { resumableSessionFacts } from "./resumable-sessions.js";
 import { isRestorableSession, reapableTmuxSession } from "../infra/tmux.js";
 import { reapIdleSeconds } from "../../common/sessionReap.js";
+import { SESSION_ID_RE } from "../config/env.js";
 
 /** The snapshots one listing takes, so the rule below is pure and the tmux calls happen once. */
 export interface SurvivingInput {
@@ -94,6 +95,7 @@ export async function survivingSessions(nowMs: number, idleReapDays: number): Pr
         liveHere: ptys.has(key),
         idleSeconds,
         idleThresholdSeconds,
+        validId: SESSION_ID_RE.test(key),
       }),
     // The live pty wins: it knows where the agent actually runs, and the remembered value can be a
     // directory the session was relaunched away from.

--- a/server/session/worktree-session-limit.ts
+++ b/server/session/worktree-session-limit.ts
@@ -12,7 +12,7 @@
 import { isManagedWorktree, repoRoot } from "../git/worktrees.js";
 import { canonicalPath } from "../infra/canonical-path.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
-import { dirSession, runningSessionKeys, type DirSession } from "./dir-session.js";
+import { dirSession, survivorSnapshot, type DirSession } from "./dir-session.js";
 
 export interface WorktreeOccupancy {
   /** Whether the directory is a managed worktree at all. Only those are limited. */
@@ -33,7 +33,7 @@ const NOT_A_WORKTREE: WorktreeOccupancy = { isWorktree: false, session: null };
 export async function worktreeOccupancy(cwd: string): Promise<WorktreeOccupancy> {
   const repo = await repoRoot(cwd).catch(() => null);
   if (!repo || !isManagedWorktree(repo, cwd)) return NOT_A_WORKTREE;
-  return { isWorktree: true, session: await dirSession(cwd, tmuxAttachedCounts(), Date.now(), runningSessionKeys()) };
+  return { isWorktree: true, session: await dirSession(cwd, tmuxAttachedCounts(), Date.now(), await survivorSnapshot()) };
 }
 
 // Launches on their way into a directory but not yet visible as a pty, counted by canonical path.

--- a/server/session/worktree-session-limit.ts
+++ b/server/session/worktree-session-limit.ts
@@ -12,7 +12,7 @@
 import { isManagedWorktree, repoRoot } from "../git/worktrees.js";
 import { canonicalPath } from "../infra/canonical-path.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
-import { dirSession, type DirSession } from "./dir-session.js";
+import { dirSession, runningSessionKeys, type DirSession } from "./dir-session.js";
 
 export interface WorktreeOccupancy {
   /** Whether the directory is a managed worktree at all. Only those are limited. */
@@ -33,7 +33,7 @@ const NOT_A_WORKTREE: WorktreeOccupancy = { isWorktree: false, session: null };
 export async function worktreeOccupancy(cwd: string): Promise<WorktreeOccupancy> {
   const repo = await repoRoot(cwd).catch(() => null);
   if (!repo || !isManagedWorktree(repo, cwd)) return NOT_A_WORKTREE;
-  return { isWorktree: true, session: await dirSession(cwd, tmuxAttachedCounts(), Date.now()) };
+  return { isWorktree: true, session: await dirSession(cwd, tmuxAttachedCounts(), Date.now(), runningSessionKeys()) };
 }
 
 // Launches on their way into a directory but not yet visible as a pty, counted by canonical path.

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -377,7 +377,15 @@ function resume(s: ResumableSession): void {
   // conversations: the cell must connect the endpoint that WROTE the conversation, and a codex
   // rollout id resumed as Claude is a live id on the wrong endpoint. It was safe to leave out
   // while every row here was Claude's; it is not any more.
-  emit("resume", { id: s.id, cwd: resumable.value.cwd ?? targetDir.value, agent: listAgent.value });
+  //
+  // A row that is still RUNNING is picked up under the key it runs under, not the row's own id.
+  // For codex/agy/muse the two differ — the row is the agent's conversation id, the running tmux
+  // session is keyed by whatever MulmoTerminal minted at spawn — and resuming by the row's id
+  // starts a SECOND backend on a conversation that already has one; the two then trade the view on
+  // every cold reconnect (#1533). The surviving key reattaches the process that is already there,
+  // which is what "resume it here" on the badge promises. For Claude and grok the key IS the row's
+  // id, so this changes nothing there.
+  emit("resume", { id: s.runningKey ?? s.id, cwd: resumable.value.cwd ?? targetDir.value, agent: listAgent.value });
 }
 
 // A conversation whose session is still RUNNING with nobody attached — what a server restart leaves

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -369,12 +369,28 @@ const onAgent = (uid: number, agent: TerminalAgent) => (state.value = setCellAge
 const onPark = (uid: number, parked: boolean) => (state.value = setCellParked(state.value, uid, parked));
 // Pass the on-screen order so closing the zoomed cell stays zoomed on its filmstrip
 // neighbour (previous, or next when it was the first) instead of collapsing the grid.
-const onClose = (uid: number) =>
-  (state.value = closeCell(
+//
+// The slot goes down WITH the cell. TerminalCell's own close button tears its session down before
+// emitting close, but every other way here — the terminal-close shortcut, a launcher cell's close —
+// used to drop the cell while its slot kept an open socket: the PTY then read as attached forever
+// (never reaped, refused for resume), and the orphaned slot was the ghost a later `cell-<uid>` key
+// collision handed to a different cell as its terminal (#1533). `slotLive` is what makes the
+// already-torn-down path a no-op rather than a second terminate.
+const onClose = (uid: number) => {
+  const slot = `cell-${uid}`;
+  if (conn.slotLive(slot)) {
+    const session = state.value.cells.find((c) => c.uid === uid)?.session ?? null;
+    conn.terminate(slot);
+    // Over HTTP as well, like TerminalCell.teardown: the WS `terminate` only reaches the server
+    // while the socket it just closed was still open.
+    if (session) void fetchWithTimeout(`/api/session/${encodeURIComponent(session)}/terminate`, { method: "POST" }).catch(() => {});
+  }
+  state.value = closeCell(
     state.value,
     uid,
     displayCells.value.map((c) => c.uid),
-  ));
+  );
+};
 // Pass the on-screen order so releasing the zoom lands on the page holding the cell that was
 // enlarged — including when the user got there by clicking a roster row or filmstrip thumbnail,
 // which changes what is zoomed without touching the page.

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -730,6 +730,21 @@ function handleMessage(c: Conn, event: MessageEvent) {
 export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, el: HTMLElement, theme?: ITheme, font: TerminalFont = DEFAULT_FONT) {
   const created = !conns.has(key);
   const c = ensure(key, target, font);
+  // A view naming a session the slot is NOT running gets a reconnect, never the reuse. Slot keys
+  // are positional (`cell-<uid>`, renumbered from array position on every grid parse) while this
+  // map outlives components — so a view can inherit a slot another cell filled: after an HMR
+  // reload of GridView, or via the ghost a closed cell used to leave behind. The reuse then showed
+  // a claude cell some earlier shell's terminal, and the onSession replay below wrote that wrong
+  // pairing back into the persisted grid (#1533). A view with no opinion (sessionId null — a fresh
+  // launch, or a parent that never learned the id) keeps the reuse: for a remount of the same cell
+  // that replay is the repair path, and this guard must not break it.
+  const inherited = !created && target.sessionId !== null && c.knownSessionId !== null && c.knownSessionId !== target.sessionId;
+  if (inherited) {
+    console.warn(`[terminal] slot ${key} runs session ${c.knownSessionId} but the view asked for ${target.sessionId} — reconnecting instead of reusing`);
+    c.knownSessionId = target.sessionId;
+    c.knownCwd = null;
+    c.reconnectAttempts = 0;
+  }
   c.released = false;
   c.handlers = handlers;
   c.attachedEl = el;
@@ -754,7 +769,7 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   // is spawned at it, and an unfitted terminal would send xterm's 80x24 default there (#1178). For
   // an already-live slot this is the same sync it always was — the send is a no-op until OPEN.
   fitAndSyncSize(c);
-  if (created) connect(c);
+  if (created || inherited) connect(c);
   c.term.focus();
   // The persisted xterm was just re-parented into a new host. The sync fit() above can no-op (same size)
   // or run before layout, leaving the canvas renderer blank until a scroll. Re-fit + force a repaint next
@@ -919,6 +934,11 @@ const slotCandidate = (c: Conn): SlotCandidate => ({
 export function listSlots(): SlotInfo[] {
   return [...conns.values()].map(slotCandidate).flatMap((candidate) => readableSlot(candidate) ?? []);
 }
+
+/** Whether the slot still exists at all. What a close path asks before cleaning up: a cell whose
+ *  own teardown already ran (TerminalCell's close button) has no slot left, and cleaning up again
+ *  would re-terminate a session id the state still remembers. */
+export const slotLive = (key: string): boolean => conns.has(key);
 
 // Insert text (a path, or space-joined paths) at the cursor via the normal input
 // channel — no trailing CR, so the user reviews and submits.

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -738,12 +738,15 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   // pairing back into the persisted grid (#1533). A view with no opinion (sessionId null — a fresh
   // launch, or a parent that never learned the id) keeps the reuse: for a remount of the same cell
   // that replay is the repair path, and this guard must not break it.
-  const inherited = !created && target.sessionId !== null && c.knownSessionId !== null && c.knownSessionId !== target.sessionId;
+  // A slot that has not learned an id yet is a mismatch too, not a blank slate (review on #1534):
+  // it was created for a FRESH launch whose socket may still be connecting, and its `session`
+  // frame — the old cell's — would land on whatever view holds the slot now. Only a view with no
+  // opinion of its own (sessionId null) keeps the reuse.
+  const inherited = !created && target.sessionId !== null && c.knownSessionId !== target.sessionId;
   if (inherited) {
-    console.warn(`[terminal] slot ${key} runs session ${c.knownSessionId} but the view asked for ${target.sessionId} — reconnecting instead of reusing`);
-    c.knownSessionId = target.sessionId;
-    c.knownCwd = null;
-    c.reconnectAttempts = 0;
+    const held = c.knownSessionId ?? "a fresh session still starting";
+    console.warn(`[terminal] slot ${key} holds ${held} but the view asked for ${target.sessionId} — reconnecting instead of reusing`);
+    Object.assign(c, { knownSessionId: target.sessionId, knownCwd: null, reconnectAttempts: 0, sawExit: false });
   }
   c.released = false;
   c.handlers = handlers;

--- a/test/server/agents/antigravity-session.spec.ts
+++ b/test/server/agents/antigravity-session.spec.ts
@@ -58,6 +58,17 @@ describe("antigravity-session", () => {
     expect(await watchForAntigravitySession(brainDir, before, { pollMs: 20, maxWaitMs: 1000 })).toBe(uuid);
   });
 
+  // Two watchers awaiting the same poll interval both saw a lone conversation unclaimed when the
+  // claim waited for the caller's `.then` (#1533) — so the watcher claims at the moment it selects.
+  it("claims the conversation it selects, synchronously with the selection", async () => {
+    const before = snapshotAntigravitySessions(brainDir);
+    const uuid = "d5e26682-7e52-4e43-a25a-83c464fd4e88";
+    fs.mkdirSync(path.join(brainDir, uuid));
+    const claimed = new Set<string>();
+    expect(await watchForAntigravitySession(brainDir, before, { pollMs: 20, maxWaitMs: 1000, claimed })).toBe(uuid);
+    expect(claimed.has(uuid)).toBe(true);
+  });
+
   // The cold-resume guard. Without it every requested key is handed to `agy --conversation`,
   // and agy answers a conversation it cannot find by silently starting a fresh one under the
   // old session's id.

--- a/test/server/agents/codex-session.spec.ts
+++ b/test/server/agents/codex-session.spec.ts
@@ -85,10 +85,25 @@ describe("pickFreshSession", () => {
     const before = snapshotSessions(root);
     expect(pickFreshSession(root, before, null)).toBeNull();
   });
-  it("attributes a single fresh rollout (unambiguous)", () => {
+  it("attributes a single fresh rollout whose cwd agrees (unambiguous)", () => {
     const before = snapshotSessions(root);
     writeRollout(root, UUID_A, "/a");
-    expect(pickFreshSession(root, before, "/anything")?.id).toBe(UUID_A);
+    expect(pickFreshSession(root, before, "/a")?.id).toBe(UUID_A);
+  });
+
+  it("attributes a single fresh rollout when the caller has no cwd to check", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, null)?.id).toBe(UUID_A);
+  });
+
+  // The #1533 case: two spawns in DIFFERENT directories share ~/.codex, so "exactly one new file"
+  // used to fire before the cwd was consulted — and the slower spawn claimed the faster spawn's
+  // rollout across directories. Sole no longer beats a cwd that disagrees.
+  it("refuses a single fresh rollout recorded for another directory", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, "/somewhere-else")).toBeNull();
   });
   it("attributes the unique cwd match when several are fresh", () => {
     const before = snapshotSessions(root);
@@ -146,5 +161,16 @@ describe("watchForCodexSession", () => {
     const before = snapshotSessions(root);
     const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 40 });
     expect(found).toBeNull();
+  });
+
+  // Two watchers awaiting the same poll interval both saw a lone rollout unclaimed when the claim
+  // waited for the caller's `.then` (#1533) — so the watcher claims at the moment it selects.
+  it("claims the rollout it selects, synchronously with the selection", async () => {
+    const before = snapshotSessions(root);
+    const file = writeRollout(root, UUID_A, "/work");
+    const claimed = new Set<string>();
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 500, cwd: "/work", claimed });
+    expect(found?.id).toBe(UUID_A);
+    expect(claimed.has(file)).toBe(true);
   });
 });

--- a/test/server/agents/muse-session.spec.ts
+++ b/test/server/agents/muse-session.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+// The spawn watcher that maps a MulmoTerminal session key to the id muse minted for it. It used
+// to take the FIRST new row in the workspace — with two spawns in one directory, or a `before`
+// snapshot a busy sqlite answered empty, that guess mapped a cell to somebody else's conversation
+// and PERSISTED it, so every cold reconnect after resumed the wrong one (#1533). Now it attributes
+// only an unambiguous sole row, and claims it synchronously with the selection — the same rules
+// codex and agy already had.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { snapshotMuseSessions, watchForMuseSession } from "../../../server/agents/muse-session.js";
+
+const WS = "/work/project";
+const OTHER_WS = "/work/other";
+
+let home: string;
+let priorMuseHome: string | undefined;
+
+const withDb = (fn: (db: DatabaseSync) => void): void => {
+  const db = new DatabaseSync(path.join(home, "session-index.db"));
+  try {
+    fn(db);
+  } finally {
+    db.close();
+  }
+};
+
+const addSession = (id: string, workspace: string): void => {
+  withDb((db) => db.prepare("INSERT INTO sessions (session_id, workspace_root) VALUES (?, ?)").run(id, workspace));
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "mt-muse-"));
+  priorMuseHome = process.env.MUSE_HOME;
+  process.env.MUSE_HOME = home;
+  withDb((db) => db.exec("CREATE TABLE sessions (session_id TEXT, workspace_root TEXT)"));
+});
+
+afterEach(() => {
+  if (priorMuseHome === undefined) delete process.env.MUSE_HOME;
+  else process.env.MUSE_HOME = priorMuseHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const opts = (claimed: Set<string>) => ({ claimed, isCancelled: () => false });
+
+describe("watchForMuseSession", () => {
+  it("attributes the sole fresh row, and claims it synchronously with the selection", async () => {
+    addSession("old-1", WS);
+    const before = await snapshotMuseSessions(WS);
+    addSession("new-1", WS);
+    const claimed = new Set<string>();
+    expect(await watchForMuseSession(WS, before, opts(claimed), 500, 10)).toBe("new-1");
+    expect(claimed.has("new-1")).toBe(true);
+  });
+
+  // The failure #1533 was filed over: taking the FIRST of several new rows is a guess, and the
+  // wrong guess is persisted. Codex and agy refuse the same way.
+  it("refuses to guess between two fresh rows", async () => {
+    const before = await snapshotMuseSessions(WS);
+    addSession("new-1", WS);
+    addSession("new-2", WS);
+    expect(await watchForMuseSession(WS, before, opts(new Set()), 60, 10)).toBeNull();
+  });
+
+  // Ambiguity is a state, not a verdict: the other spawn's claim shrinks the set to one, which is
+  // why the watcher keeps polling instead of returning null on the first ambiguous read.
+  it("resolves once another spawn's claim leaves exactly one row", async () => {
+    const before = await snapshotMuseSessions(WS);
+    addSession("new-1", WS);
+    addSession("new-2", WS);
+    expect(await watchForMuseSession(WS, before, opts(new Set(["new-1"])), 500, 10)).toBe("new-2");
+  });
+
+  // The empty-snapshot hole: a busy sqlite answers `before = ∅`, and every EXISTING row then reads
+  // as new. Rows already claimed — the registry seeds the set from the persisted conversation log —
+  // must not be re-attributed to a fresh spawn.
+  it("never attributes a row another session already claims, even from an empty snapshot", async () => {
+    addSession("someone-elses", WS);
+    expect(await watchForMuseSession(WS, new Set(), opts(new Set(["someone-elses"])), 60, 10)).toBeNull();
+  });
+
+  it("ignores another workspace's rows", async () => {
+    const before = await snapshotMuseSessions(WS);
+    addSession("new-1", OTHER_WS);
+    expect(await watchForMuseSession(WS, before, opts(new Set()), 60, 10)).toBeNull();
+  });
+});

--- a/test/server/routes/ws-session-admission.spec.ts
+++ b/test/server/routes/ws-session-admission.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+// The two admission guards #1533 added in front of every reattach.
+//
+// `wrongEndpointReason`: `ptys` is one table for every agent and nothing on the attach path
+// compared the entry's agent to the endpoint — so a claude cell carrying a foreign id (the
+// `asTerminalAgent` coercion of an unrecognised persisted agent) reattached whatever ran under it.
+//
+// `settledEntry`: the live entry used to be snapshotted before the admission awaits (git, the
+// filesystem) and used after — a corpse the reap timer had killed in that window was reattached,
+// wiring the browser to a dead pty while the next connect spawned a fresh one under the same id.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { WebSocket } from "ws";
+import type { EarlyFrames } from "../../../server/session/early-frames.js";
+import type { PtyEntry } from "../../../server/session/types.js";
+
+const { wrongEndpointReason, settledEntry } = await import("../../../server/routes/ws-routes.js");
+const { ptys } = await import("../../../server/session/registry.js");
+
+const SID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const entryOf = (agent: PtyEntry["agent"]): PtyEntry => ({ term: {} as PtyEntry["term"], ws: null, buffer: "", cwd: "/w", tmux: true, active: false, agent });
+
+describe("wrongEndpointReason", () => {
+  it("serves an entry to its own endpoint", () => {
+    expect(wrongEndpointReason("claude", "claude")).toBeNull();
+    expect(wrongEndpointReason("codex", "codex")).toBeNull();
+    expect(wrongEndpointReason("muse", "muse")).toBeNull();
+  });
+
+  // The launcher's PTYs are recorded as "shell" whatever command line they run — the endpoint and
+  // the recording must agree, or every chip reconnect would be refused.
+  it("serves a launcher entry to the launch endpoint", () => {
+    expect(wrongEndpointReason("launch", "shell")).toBeNull();
+  });
+
+  it("refuses a shell entry on the claude endpoint — the coerced-agent case", () => {
+    expect(wrongEndpointReason("claude", "shell")).toContain("running shell, not claude");
+  });
+
+  it("refuses a muse entry on the claude endpoint", () => {
+    expect(wrongEndpointReason("claude", "muse")).toContain("running muse, not claude");
+  });
+
+  it("has no opinion for the run endpoint, which owns no sessions", () => {
+    expect(wrongEndpointReason("run", "shell")).toBeNull();
+  });
+});
+
+describe("settledEntry", () => {
+  const fakeWs = () => ({ close: vi.fn() }) as unknown as WebSocket & { close: ReturnType<typeof vi.fn> };
+  const fakeEarly = () => ({ discard: vi.fn(), release: vi.fn() }) as unknown as EarlyFrames & { discard: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    ptys.delete(SID);
+  });
+
+  it("hands back the entry as it stands now — not the resolve-time snapshot", () => {
+    const current = entryOf("claude");
+    ptys.set(SID, current);
+    const settled = settledEntry(fakeWs(), "claude", SID, true, fakeEarly());
+    expect(settled?.entry).toBe(current);
+  });
+
+  // A competing connect can have spawned the id while this one was still being admitted — the
+  // serialized turn then finds it and reattaches, which is what serialization is FOR.
+  it("hands back an entry that appeared where the resolve saw none", () => {
+    const current = entryOf("claude");
+    ptys.set(SID, current);
+    expect(settledEntry(fakeWs(), "claude", SID, false, fakeEarly())?.entry).toBe(current);
+  });
+
+  it("proceeds to a spawn when there never was an entry", () => {
+    const settled = settledEntry(fakeWs(), "claude", SID, false, fakeEarly());
+    expect(settled).toEqual({ entry: undefined });
+  });
+
+  // The reap fired mid-admission: the snapshot is a corpse. A PLAIN close, not an error frame —
+  // an error is terminal to the client, a plain close makes it reconnect and resolve the
+  // post-reap world afresh.
+  it("closes plainly when the resolve-time entry died mid-admission", () => {
+    const ws = fakeWs();
+    const early = fakeEarly();
+    const settled = settledEntry(ws, "claude", SID, true, early);
+    expect(settled).toBeNull();
+    expect(ws.close).toHaveBeenCalledOnce();
+    expect(early.discard).toHaveBeenCalledOnce();
+  });
+});

--- a/test/server/session/dir-session.spec.ts
+++ b/test/server/session/dir-session.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { pickDirSession, type DirSessionCandidate } from "../../../server/session/dir-session";
+import { pickDirSession, survivorCandidates, type DirSessionCandidate, type SurvivorLog } from "../../../server/session/dir-session";
+import type { AgentConversation } from "../../../server/session/agent-conversations";
 
 const candidate = (over: Partial<DirSessionCandidate> & { id: string }): DirSessionCandidate => ({
   attached: false,
@@ -45,5 +46,62 @@ describe("pickDirSession", () => {
   it("answers the same when a session appears both live and on disk", () => {
     const picked = pickDirSession([candidate({ id: "s1", live: true, mtime: 5, attached: true }), candidate({ id: "s1", mtime: 7, attached: true })]);
     expect(picked).toEqual({ id: "s1", attached: true, agent: "claude" });
+  });
+});
+
+// A codex/agy/muse session whose tmux outlived its pty (#1496) or the whole server. `ptys` cannot
+// see it and no transcript pass can — the conversation log is the one record tying the surviving
+// key to a directory. Reading it as "no session here" is how a worktree admitted a second agent
+// beside a running one, and how a conversation ended up with two backends (#1533).
+describe("survivorCandidates", () => {
+  const record = (over: Partial<AgentConversation> = {}): AgentConversation => ({
+    sessionId: "key-1",
+    conversationId: "conv-1",
+    cwd: "/wt/fix-login",
+    startedAt: 0,
+    ...over,
+  });
+  const logs = (records: AgentConversation[], agent: SurvivorLog["agent"] = "codex"): SurvivorLog[] => [
+    { agent, records: records.map((r) => [r.sessionId, r] as const) },
+  ];
+  const facts = (over: Partial<Parameters<typeof survivorCandidates>[2]> = {}): Parameters<typeof survivorCandidates>[2] => ({
+    running: new Set(["key-1"]),
+    liveHere: () => false,
+    userSession: () => true,
+    attached: () => false,
+    now: 42,
+    ...over,
+  });
+
+  it("names a running survivor as a LIVE candidate of its own agent", () => {
+    const found = survivorCandidates("/wt/fix-login", logs([record()]), facts());
+    expect(found).toEqual([{ id: "key-1", live: true, mtime: 42, agent: "codex", attached: false }]);
+  });
+
+  it("ignores a session that is not running — a dead key is the transcript passes' business", () => {
+    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ running: new Set() }))).toEqual([]);
+  });
+
+  // The live pass already names it, better: its pty knows the directory it ACTUALLY runs in,
+  // where the log knows the one it was claimed in.
+  it("leaves a session with a live pty to the live pass", () => {
+    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ liveHere: () => true }))).toEqual([]);
+  });
+
+  it("ignores another directory's survivor", () => {
+    expect(survivorCandidates("/wt/other", logs([record()]), facts())).toEqual([]);
+  });
+
+  it("excludes helper sessions, like every other pass", () => {
+    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ userSession: () => false }))).toEqual([]);
+  });
+
+  // The point of the pass meeting the point of the rank: the surviving backend must beat a newer
+  // transcript, or the worktree row offers the conversation written to most recently while a
+  // different one is still running (#1533).
+  it("outranks a merely recent transcript once picked with", () => {
+    const survivor = survivorCandidates("/wt/fix-login", logs([record()]), facts())[0];
+    const picked = pickDirSession([candidate({ id: "disk", mtime: 99 }), survivor]);
+    expect(picked?.id).toBe("key-1");
   });
 });

--- a/test/server/session/dir-session.spec.ts
+++ b/test/server/session/dir-session.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { pickDirSession, survivorCandidates, type DirSessionCandidate, type SurvivorLog } from "../../../server/session/dir-session";
+import { grokSurvivorCandidates, pickDirSession, survivorCandidates, type DirSessionCandidate, type SurvivorLog } from "../../../server/session/dir-session";
 import type { AgentConversation } from "../../../server/session/agent-conversations";
 
 const candidate = (over: Partial<DirSessionCandidate> & { id: string }): DirSessionCandidate => ({
@@ -103,5 +103,37 @@ describe("survivorCandidates", () => {
     const survivor = survivorCandidates("/wt/fix-login", logs([record()]), facts())[0];
     const picked = pickDirSession([candidate({ id: "disk", mtime: 99 }), survivor]);
     expect(picked?.id).toBe("key-1");
+  });
+});
+
+// grok's survivors, found by probing its cwd-partitioned store rather than a conversation log —
+// grok keeps none: the session key IS its conversation id. Excluded from the log pass, a grok
+// session that outlived its pty read as "no session here" and the worktree admitted a second
+// agent beside it (#1534 review).
+describe("grokSurvivorCandidates", () => {
+  const grokFacts = (over: Partial<Parameters<typeof grokSurvivorCandidates>[0]> = {}): Parameters<typeof grokSurvivorCandidates>[0] => ({
+    running: new Set(["g-1"]),
+    liveHere: () => false,
+    userSession: () => true,
+    attached: () => false,
+    conversationInDir: (id) => id === "g-1",
+    now: 42,
+    ...over,
+  });
+
+  it("names a running survivor whose conversation lives in this directory", () => {
+    expect(grokSurvivorCandidates(grokFacts())).toEqual([{ id: "g-1", live: true, mtime: 42, agent: "grok", attached: false }]);
+  });
+
+  it("ignores a key the store does not tie to this directory", () => {
+    expect(grokSurvivorCandidates(grokFacts({ conversationInDir: () => false }))).toEqual([]);
+  });
+
+  it("leaves a session with a live pty to the live pass", () => {
+    expect(grokSurvivorCandidates(grokFacts({ liveHere: () => true }))).toEqual([]);
+  });
+
+  it("excludes helper sessions, like every other pass", () => {
+    expect(grokSurvivorCandidates(grokFacts({ userSession: () => false }))).toEqual([]);
   });
 });

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -35,6 +35,11 @@ const liveTmuxSessions = new Set<string>();
 // applies to an empty cwd.
 const EXISTING_CWD = process.cwd();
 
+// Real-shaped ids: ptySpawn now refuses anything SESSION_ID_RE rejects (#1533), so S1 is no
+// longer a session id a spawn will accept.
+const S1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const S2 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2";
+
 const { spawnPty, ptySpawn, ptyWouldReattach } = await import("../../../server/session/pty-spawn.js");
 
 const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
@@ -77,22 +82,22 @@ describe("spawnPty — the environment it hands the pty", () => {
 describe("ptyWouldReattach", () => {
   it("is true only when tmux is holding this exact session", () => {
     tmuxOn = true;
-    liveTmuxSessions.add("s1");
-    expect(ptyWouldReattach("s1", true)).toBe(true);
-    expect(ptyWouldReattach("s2", true)).toBe(false);
+    liveTmuxSessions.add(S1);
+    expect(ptyWouldReattach(S1, true)).toBe(true);
+    expect(ptyWouldReattach(S2, true)).toBe(false);
   });
 
   it("is false without tmux — every spawn there starts a new process", () => {
     tmuxOn = false;
-    liveTmuxSessions.add("s1");
-    expect(ptyWouldReattach("s1", true)).toBe(false);
+    liveTmuxSessions.add(S1);
+    expect(ptyWouldReattach(S1, true)).toBe(false);
   });
 
   // Matches ptySpawn's own branch: a non-persistent spawn never consults tmux at all.
   it("is false for a non-persistent spawn", () => {
     tmuxOn = true;
-    liveTmuxSessions.add("s1");
-    expect(ptyWouldReattach("s1", false)).toBe(false);
+    liveTmuxSessions.add(S1);
+    expect(ptyWouldReattach(S1, false)).toBe(false);
   });
 });
 
@@ -100,13 +105,13 @@ describe("ptyWouldReattach", () => {
 // there is what actually protects it — but the non-tmux path has only this.
 describe("ptySpawn — carries the removal down both paths", () => {
   it("applies it on the direct spawn", () => {
-    ptySpawn("s1", "claude", [], EXISTING_CWD, false, { unset: ["ANTHROPIC_API_KEY"] });
+    ptySpawn(S1, "claude", [], EXISTING_CWD, false, { unset: ["ANTHROPIC_API_KEY"] });
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
 
   it("applies it on the tmux spawn too", () => {
     tmuxOn = true;
-    const result = ptySpawn("s1", "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
+    const result = ptySpawn(S1, "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(result.tmux).toBe(true);
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
@@ -118,13 +123,13 @@ describe("ptySpawn — carries the removal down both paths", () => {
 describe("ptySpawn — the tmux server's own environment", () => {
   it("scrubs the names from the running server before a provider spawn", () => {
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
+    ptySpawn(S1, "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(scrub).toHaveBeenCalledWith(["ANTHROPIC_API_KEY"]);
   });
 
   it("leaves the server alone for an ordinary session", () => {
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], EXISTING_CWD, true);
+    ptySpawn(S1, "claude", [], EXISTING_CWD, true);
     expect(scrub).not.toHaveBeenCalled();
   });
 });
@@ -144,14 +149,14 @@ describe("the per-tree environment a directory reserved", () => {
 
   it("reaches a direct ptySpawn", () => {
     reserved = { PORT: "3010" };
-    ptySpawn("s1", "claude", [], EXISTING_CWD, false);
+    ptySpawn(S1, "claude", [], EXISTING_CWD, false);
     expect(envOf().PORT).toBe("3010");
   });
 
   it("is handed to the tmux pane through -e", () => {
     reserved = { PORT: "3010" };
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], EXISTING_CWD, true);
+    ptySpawn(S1, "claude", [], EXISTING_CWD, true);
     expect(argsOf()).toContain("PORT=3010");
   });
 
@@ -159,13 +164,31 @@ describe("the per-tree environment a directory reserved", () => {
   // directory; a project declaring the same name must not be able to redirect our MCP bridge.
   it("loses to a value the spawner computed for this session", () => {
     reserved = { MULMOTERMINAL_SESSION: "from-config", PORT: "3010" };
-    ptySpawn("s1", "claude", [], EXISTING_CWD, false, { env: { MULMOTERMINAL_SESSION: "s1" } });
-    expect(envOf().MULMOTERMINAL_SESSION).toBe("s1");
+    ptySpawn(S1, "claude", [], EXISTING_CWD, false, { env: { MULMOTERMINAL_SESSION: S1 } });
+    expect(envOf().MULMOTERMINAL_SESSION).toBe(S1);
     expect(envOf().PORT).toBe("3010");
   });
 
   it("sets nothing when the directory reserved nothing", () => {
     spawnPty("claude", [], EXISTING_CWD);
     expect(envOf()).not.toHaveProperty("PORT");
+  });
+});
+
+// A live `mt-undefined` was found running muse (#1533): a spawn reached tmux with an id that was
+// never set, and every later spawn with the same defect would have attached that same pane. The
+// guard makes that a failed launch with a message instead of a silently shared terminal.
+describe("ptySpawn — the session-id guard", () => {
+  it("refuses an id that is not a session id, before anything is spawned", () => {
+    expect(() => ptySpawn("undefined", "claude", [], EXISTING_CWD, true)).toThrow(/invalid session id/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  // The one non-random id shape in the codebase — it must keep passing, or every rate-limit
+  // probe dies at launch.
+  it("accepts a probe id, which is UUID-shaped by construction", async () => {
+    const { newProbeSessionId } = await import("../../../server/agents/probe-session.js");
+    ptySpawn(newProbeSessionId(), "claude", [], EXISTING_CWD, false);
+    expect(spawn).toHaveBeenCalled();
   });
 });

--- a/test/server/session/reap-idle-sessions.spec.ts
+++ b/test/server/session/reap-idle-sessions.spec.ts
@@ -22,6 +22,9 @@ const input = (over: Partial<ReapSweepInput> = {}): ReapSweepInput => ({
   nowSeconds: NOW,
   idleDays: DEFAULT_REAP_IDLE_DAYS,
   liveHere: () => false,
+  // True by default so the readable ids these tests use ("stale", "held") keep meaning what they
+  // say; the live sweep answers with SESSION_ID_RE, and the unparseable-id test overrides this.
+  validId: () => true,
   kill: vi.fn((id: string) => Boolean(id)),
   ...over,
 });
@@ -32,6 +35,7 @@ describe("reapableTmuxSession", () => {
     liveHere: false,
     idleSeconds: 30 * DAY,
     idleThresholdSeconds: reapIdleSeconds(DEFAULT_REAP_IDLE_DAYS),
+    validId: true,
     ...over,
   });
 
@@ -64,6 +68,23 @@ describe("reapableTmuxSession", () => {
   // Zero is the off switch, and it has to hold even for a session idle for a year.
   it("ends nothing at all when the threshold is zero", () => {
     expect(reapableTmuxSession(facts({ idleThresholdSeconds: 0, idleSeconds: 365 * DAY }))).toBe(false);
+  });
+
+  // A live `mt-undefined` was found (#1533): an id that does not parse is unreachable by EVERY
+  // route — nothing can attach, resume or terminate it — so this sweep is the only thing that can
+  // ever end it, and no amount of recency can make it reachable.
+  it("ends one whose id no route can reach, however recently it was active", () => {
+    expect(reapableTmuxSession(facts({ validId: false, idleSeconds: 0 }))).toBe(true);
+  });
+
+  // Someone can still be LOOKING at it — `tmux attach` by hand is how such a session gets
+  // inspected at all — and killing a pane out from under them is not cleanup.
+  it("spares even an unreachable one while a terminal is attached", () => {
+    expect(reapableTmuxSession(facts({ validId: false, attachedCount: 1 }))).toBe(false);
+  });
+
+  it("the zero threshold switches off even the unreachable-id reap", () => {
+    expect(reapableTmuxSession(facts({ validId: false, idleThresholdSeconds: 0 }))).toBe(false);
   });
 });
 
@@ -137,6 +158,25 @@ describe("the boot sweep", () => {
     const result = reapIdleSessions(input({ ids: ["stale"], activity: new Map([["stale", STALE]]), idleDays: 0, kill }));
     expect(kill).not.toHaveBeenCalled();
     expect(result).toEqual({ reaped: [], heldBack: 0, recent: 0, unclear: 0 });
+  });
+
+  // The `mt-undefined` case (#1533): recently active, nobody attached — and still ended, because
+  // its id parses as nothing any route will serve, so waiting out the idle grace serves no one.
+  it("reaps an unparseable id at once, ignoring the idle grace", () => {
+    const kill = vi.fn((id: string) => Boolean(id));
+    const result = reapIdleSessions(
+      input({
+        ids: ["undefined", "fresh"],
+        activity: new Map([
+          ["undefined", NOW - DAY],
+          ["fresh", NOW - DAY],
+        ]),
+        validId: (id) => id !== "undefined",
+        kill,
+      }),
+    );
+    expect(kill.mock.calls.map((c) => c[0])).toEqual(["undefined"]);
+    expect(result).toEqual({ reaped: ["undefined"], heldBack: 0, recent: 1, unclear: 0 });
   });
 });
 

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -307,6 +307,18 @@ describe("a resume row whose session is still running", () => {
     expect(w.find('[data-testid="cell-resume-item"]').attributes("disabled")).toBeUndefined();
   });
 
+  // For codex/agy/muse the row's id is the AGENT's conversation id while the running tmux session
+  // is keyed by whatever MulmoTerminal minted at spawn. Resuming by the row's id starts a second
+  // backend on a conversation that already has one (#1533) — picking it up means reattaching the
+  // key it RUNS under.
+  it("resumes under the surviving key, not the row's own id", async () => {
+    mockFetch([], [running({ id: "conv-1", runningKey: "key-1" })]);
+    const w = mountForm();
+    await flushPromises();
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
+    expect(w.emitted("resume")?.[0]).toEqual([{ id: "key-1", cwd: "/repo", agent: "claude" }]);
+  });
+
   it("says nothing when the server reports no running session", async () => {
     mockFetch([], [running({ runningKey: null })]);
     const w = mountForm();

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -297,11 +297,18 @@ describe("GridView settings wiring", () => {
 // the shortcuts are given, which cell the cursor is moved to, and whether a key that should
 // only move ends up changing the layout.
 
-// Focus calls land here instead of a real xterm.
+// Focus calls land here instead of a real xterm; slot liveness/terminate are faked so the close
+// path's cleanup (#1533) can be asserted without real sockets.
 const focused = vi.hoisted(() => [] as string[]);
+const slots = vi.hoisted(() => ({ live: new Set<string>(), terminated: [] as string[] }));
 vi.mock("../../../src/composables/useTerminalConnections", async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   focus: (key: string) => focused.push(key),
+  slotLive: (key: string) => slots.live.has(key),
+  terminate: (key: string) => {
+    slots.terminated.push(key);
+    slots.live.delete(key);
+  },
 }));
 
 import { setActiveKeymap } from "../../../src/composables/activeKeymap";
@@ -898,6 +905,76 @@ describe("GridView launcher picks (#1114)", () => {
     const cells = w.findComponent(ShellLaunchStub).props("cells") as LauncherCell[];
     expect(cells[0].launcher).toEqual({ shell: true, label: "shell" });
     expect(cells[0].cwd).toBe("/proj");
+    w.unmount();
+  });
+});
+
+// A close that reaches GridView with the slot still alive — the terminal-close shortcut, a
+// launcher cell's close button — used to drop the cell while the slot kept an open socket: the
+// PTY read as attached forever, and the orphaned slot was the ghost a later `cell-<uid>` key
+// collision handed to a different cell as its terminal (#1533). TerminalCell's own close button
+// tears the slot down FIRST, so for it this cleanup must stay a no-op.
+describe("GridView close cleans up the cell's slot (#1533)", () => {
+  const CloseGridStub = {
+    name: "TerminalGrid",
+    props: ["cells"],
+    emits: ["close", "focus-cell"],
+    template: '<div class="close-stub" />',
+  };
+  beforeEach(() => {
+    slots.live.clear();
+    slots.terminated.length = 0;
+  });
+
+  const mountCloseGrid = async (keymap: unknown = null, expanded: number | null = null) => {
+    localStorage.setItem(
+      "grid_v2",
+      JSON.stringify({
+        cells: [0, 1, 2].map((i) => ({ uid: i, session: uuid(i), cwd: "/w" })),
+        expanded,
+        page: 0,
+        sortMode: "manual",
+      }),
+    );
+    const w = mount(GridView, {
+      global: { stubs: { TerminalGrid: CloseGridStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    setActiveKeymap(keymap);
+    return w;
+  };
+  const terminatePosts = () =>
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([u, init]) => String(u).includes("/terminate") && (init as RequestInit)?.method === "POST")
+      .map(([u]) => String(u));
+
+  it("terminates the slot and reaps the session when a live-slot cell closes", async () => {
+    slots.live.add("cell-1");
+    const w = await mountCloseGrid();
+    w.findComponent(CloseGridStub).vm.$emit("close", 1);
+    await flushPromises();
+    expect(slots.terminated).toEqual(["cell-1"]);
+    expect(terminatePosts()).toEqual([`/api/session/${uuid(1)}/terminate`]);
+    w.unmount();
+  });
+
+  it("does nothing extra when the cell already tore itself down", async () => {
+    const w = await mountCloseGrid(); // no slot registered as live — teardown() already released it
+    w.findComponent(CloseGridStub).vm.$emit("close", 1);
+    await flushPromises();
+    expect(slots.terminated).toEqual([]);
+    expect(terminatePosts()).toEqual([]);
+    w.unmount();
+  });
+
+  // Zoomed, because the shortcut acts on the zoomed cell — un-zoomed there is no "current
+  // terminal" and it deliberately does nothing (gridShortcut.ts).
+  it("the terminal-close shortcut goes through the same cleanup", async () => {
+    slots.live.add("cell-2");
+    const w = await mountCloseGrid({ "terminal-close": "F10" }, 2);
+    await press("F10");
+    expect(slots.terminated).toEqual(["cell-2"]);
+    expect(terminatePosts()).toEqual([`/api/session/${uuid(2)}/terminate`]);
     w.unmount();
   });
 });

--- a/test/src/composables/terminalSlotAttachment.spec.ts
+++ b/test/src/composables/terminalSlotAttachment.spec.ts
@@ -142,4 +142,15 @@ describe("a slot inherited by a view asking for a different session", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
     expect(seen).toEqual(["s-1"]);
   });
+
+  // A slot that has not learned an id is not a blank slate (review on #1534): it belongs to a
+  // fresh launch whose socket may still be connecting, and its `session` frame — the OLD cell's —
+  // would land on whatever view holds the slot. A view naming a concrete session reconnects.
+  it("reconnects when the inherited slot has not learned a session yet", () => {
+    conn.attach(KEY, withSession(null), {}, document.createElement("div")); // a fresh launch's slot
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    conn.attach(KEY, withSession("claude-2"), {}, document.createElement("div"));
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances.at(-1)?.url).toContain("session=claude-2");
+  });
 });

--- a/test/src/composables/terminalSlotAttachment.spec.ts
+++ b/test/src/composables/terminalSlotAttachment.spec.ts
@@ -95,3 +95,51 @@ describe("slot attachment", () => {
     expect(resizeFrames(ws)).toEqual([]);
   });
 });
+
+// Slot keys are positional (`cell-<uid>`, renumbered from array position on every grid parse)
+// while the slot map outlives components — so a view can be handed a slot another cell filled: an
+// HMR reload of GridView, or the ghost a closed cell used to leave. Reusing it silently showed a
+// claude cell some earlier shell's terminal and persisted the wrong pairing (#1533). A view that
+// names a session gets THAT session or a reconnect; only a view with no opinion keeps the reuse.
+describe("a slot inherited by a view asking for a different session", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances.length = 0;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    conn.release(KEY);
+    vi.restoreAllMocks();
+  });
+
+  const withSession = (sessionId: string | null) => ({ ...target, sessionId });
+
+  it("reconnects under the requested session instead of reusing the slot's", () => {
+    conn.attach(KEY, withSession("shell-1"), {}, document.createElement("div"));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    const seen: string[] = [];
+    conn.attach(KEY, withSession("claude-2"), { onSession: (id) => seen.push(id) }, document.createElement("div"));
+
+    expect(FakeWebSocket.instances).toHaveLength(2); // a new socket, not the inherited one
+    expect(FakeWebSocket.instances.at(-1)?.url).toContain("session=claude-2");
+    // The replay must not write the inherited session back into the parent's persisted state.
+    expect(seen).toEqual(["claude-2"]);
+  });
+
+  it("keeps the reuse for the same session", () => {
+    conn.attach(KEY, withSession("s-1"), {}, document.createElement("div"));
+    conn.attach(KEY, withSession("s-1"), {}, document.createElement("div"));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  // The repair path: a parent that never learned the id (persisted `session: null`) remounts and
+  // is told the slot's session via the replay. The guard must not turn that into a reconnect.
+  it("keeps the reuse, and the replay, for a view with no opinion", () => {
+    conn.attach(KEY, withSession("s-1"), {}, document.createElement("div"));
+    const seen: string[] = [];
+    conn.attach(KEY, withSession(null), { onSession: (id) => seen.push(id) }, document.createElement("div"));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(seen).toEqual(["s-1"]);
+  });
+});


### PR DESCRIPTION
Fixes the two top-priority mechanisms confirmed on a live instance in #1533: a conversation whose backend was still running in tmux read as free, and resuming it started a **second backend on the same conversation** — after which a cold reconnect could come back on either process, i.e. "the terminal view reattached to a wrong backend terminal process".

## What was happening

The probe on #1533 found the double-session state in all three non-Claude agents' conversation logs (codex ×2, antigravity ×2, muse ×1, Aug 5–7), and the first backend of the freshest pair still running, detached and invisible to the registry — along with 19 more such sessions. Two gaps produced it:

1. **The launcher's resume row emitted the row's own id** — the agent's conversation id — even when the server had said (via `runningKey`, #1467) that the conversation was still running under a different, minted key. "Resume it here" then spawned `codex resume <conv>` in a fresh `mt-<convId>` tmux session while `mt-<mintedKey>` kept running the same rollout.
2. **`dirSession` could not see a backend that survived its pty** (#1496 keeps the tmux session but drops the `ptys` entry; a server restart leaves the same state). For codex/agy/muse there is no transcript pass to fall back on, so the worktree read as unoccupied: the one-session-per-worktree refusal (#1207) stopped firing, and the row offered the newest transcript instead of the running session.

## The fix

- `CellLaunchForm.resume()` reattaches `s.runningKey ?? s.id` — picking a running conversation up means reattaching the key it runs under. For Claude and grok the two are the same string, so nothing changes there.
- `dirSession` gains a **survivor pass** (`survivorCandidates`, pure and pinned by spec): sessions in `runningSessionKeys()` that `ptys` no longer knows, tied to their directory through the codex/agy/muse conversation logs, ranked live. Claude transcripts whose session survives in tmux are likewise upgraded to live, so the running conversation outranks a merely newer transcript.
- `runningSessionKeys()` is passed into `dirSession` alongside `tmuxCounts` — one `list-sessions` call per list, not per worktree row.

Behavioural consequence, intended: a worktree with a surviving codex/agy/muse backend now **refuses a fresh session and offers resume** (restoring #1207's rule for the post-#1496 state), and the resume reattaches the surviving process.

## Second commit: the client slot layer (a live sighting during this work)

While this PR was being written the bug struck again with a different mechanism: one Claude cell open, the server updated under a dev (HMR) page, and the cell came back showing an earlier **shell** session. Slot keys are positional (`cell-<uid>`, renumbered from array position on every grid parse) while the slot map outlives components — the reloaded GridView handed the Claude cell the ghost slot a **closed** shell cell had left behind, and `attach()` reused it without comparing sessions, then persisted the wrong pairing via the `onSession` replay.

- `attach()` on an existing slot now **reconnects** when the view names a session other than the slot's, instead of silently reusing the socket and buffer (with a console warning naming both ids). A view with no opinion (`sessionId: null`) keeps the reuse — that replay is the deliberate repair path for a parent that never learned its id.
- `GridView.onClose` tears the slot down with the cell: the `terminal-close` shortcut and a launcher cell's close used to drop the cell while its slot kept an open socket — a PTY that read as attached forever, never reaped, and the ghost the key collision hands out. `TerminalCell`'s own close button already tears down first; the new `slotLive` check keeps that path a no-op.

## Third commit: refuse invalid session ids, and reap the unreachable (`mt-undefined`)

Probing the live instance also turned up a tmux session literally named **`mt-undefined`** — a spawn had reached tmux with a session id that was never set. Such a name is a shared bucket (every spawn with the same defect attaches the same pane) and it is unreachable by every route: attach, resume and terminate all validate the id, so nothing could ever open it — or clean it up.

- `ptySpawn` now refuses an id `SESSION_ID_RE` rejects, at the one choke point every spawner passes — the defect becomes a failed launch with a message instead of a silently shared terminal. Probe ids keep passing (UUID-shaped by construction).
- `reapableTmuxSession` gains a `validId` fact: an unparseable id reaps at once — no recency can make it reachable, and the sweep is the only thing that can ever end it. Still spared while a terminal is attached, and the `sessionIdleReapDays: 0` off switch still holds. The sweep takes the fact injected (like `liveHere`) so its decision stays pure; the Settings list's `reapable` column feeds it too, so the row now honestly says the server will end it.

## Fourth wave: the rest of the synthesis hardening

- **Watcher guards** — muse's spawn watcher attributes only an unambiguous sole row (it took the FIRST new row, and its `before` snapshot can come back empty from a busy sqlite); codex's sole-rollout branch now requires the rollout's own cwd to agree (compared canonically), closing the cross-directory claim; all three watchers claim synchronously with the selection instead of in the caller's `.then`; and the registry seeds the muse/agy claimed sets from their persisted logs at hydration.
- **Per-session-id connect serialization** — every agent endpoint's admission (claude, launch, codex, antigravity/grok/muse) runs in a per-id turn (`infra/serialize-per-key`), and `settledEntry` re-reads the live entry AFTER the admission awaits: the resolve-time snapshot can be a corpse the idle reap killed mid-admission (reattaching it wired the browser to a dead pty while the next connect spawned a fresh one under the same id). That case closes the socket plainly so the client reconnects and resolves afresh.
- **Agent-kind assertion** — `wrongEndpointReason` refuses a live PTY whose recorded agent does not match the endpoint, loudly (an error frame, so the client stops retrying and the user is told to open the session from its own agent's cell). `ptys` is one table for every agent and nothing compared the two, while `asTerminalAgent()` coerces any unrecognised persisted agent to "claude".

Note for the reviewer: the last three commits interleave two sessions' work on the same tree; the FINAL state is the thing to review, and it is typecheck-clean with the full suite green.

## Not in this PR (tracked in #1533)

Lower-priority residue from the synthesis: `parseGridState` still keys slots positionally (guarded now by the attach mismatch reconnect) and does not dedupe by session id; `dirSession`'s mtime ranking for issue-work's `resumed` outcome; positional launcher/script identity. 

## Verified

- `yarn typecheck`, `yarn lint` (0 errors), `yarn build`, full `yarn test` — 9217 passed.
- New specs: `survivorCandidates` selection + rank interplay (6 cases); "resumes under the surviving key, not the row's own id" for the launcher row; the slot-inheritance guard (3 cases, including the no-opinion repair path); the close-path cleanup (3 cases, including the shortcut and the already-torn-down no-op); the ptySpawn id guard (refusal + probe-id pass); and the unreachable-id reap (immediate, attach-spared, off-switch-respected).

Addresses the confirmed mechanism in #1533 — deliberately not a closing keyword, so the issue stays open for the remaining hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resuming of active sessions across supported agents.
  * Prevented stale or mismatched terminal connections when reusing slots.
  * Closing a live terminal now reliably terminates its session and avoids duplicate cleanup.
  * Reduced duplicate session attachments during simultaneous launches.
  * Improved detection and cleanup of invalid or abandoned sessions.
  * Added safeguards against attaching to sessions owned by another endpoint.
* **Reliability**
  * Session status now reflects running conversations more accurately, including sessions restored from conversation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->