### PR TITLE
fix(session): re-arm codex activity and close live-vs-tmux gaps on restart reattach (#1536)

### DIFF
--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -333,8 +333,8 @@ async function startRunTerminal(deps: WsRouteDeps, ws: WebSocket, url: URL): Pro
 // subprocess (buildHeaderContext for a button command), and the viewer can leave during that
 // window — before any close handler is wired. Spawning then leaks a PTY nobody reaps (/ws/run
 // is ephemeral: no reattach, no reap/grace, so its only kill is the close handler below). Bail
-// if the socket has since closed — the same guard handleClaudeConnection applies after its
-// keychain refresh.
+// if the socket has since closed — the same guard the agent handlers apply after their
+// admission awaits (clientStillConnected).
 export function beginRunTerminal(deps: WsRouteDeps, ws: WebSocket, resolved: { command: string; cwd: string }, size: TerminalSize | null = null): void {
   if (ws.readyState !== ws.OPEN) return;
   let term: IPty;
@@ -460,7 +460,7 @@ function startCodexEntry(deps: WsRouteDeps, ws: WebSocket, start: CodexStart): P
   return deps.spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, { mcpGroups }); // interactive: no seed
 }
 
-async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
+export async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
   // knows the current session's id, even before any file exists.
@@ -519,6 +519,11 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
     await reserveWorktreeEnvForSpawn(cwd, { id: sessionId, live });
     const early = await admitAgentSession(ws, "claude", { requested, sessionId, live, cwd, devTerminal: !attachGuiMcp });
     if (!early) return;
+
+    // Every other agent endpoint asks this after its admission awaits; claude was the one that
+    // did not (#1536), so a client that left mid-admission still got a pty — spawned after the
+    // socket's close event, so the close handler startAndWire installs never fires for it.
+    if (!clientStillConnected(ws, "claude", sessionId, early)) return;
 
     // A provider refusal already says exactly what is wrong with the directory's config (#579), and a
     // refused spawn already names the binary and the PATH it searched, or the directory that is gone
@@ -736,7 +741,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs
 // codex without the GUI MCP and keeps it out of the sidebar; absent (single view) attaches the GUI
 // MCP so codex drives the GUI panel like claude.
-async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
+export async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   const { url, requested, cwd, unusable, size } = wsConnectionContext(req);
   if (refuseUnusableWorkspace(ws, "codex", unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
@@ -756,8 +761,12 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
     // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
     // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
     // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
-    // keeps the tools its running process was started with.
-    const mcpGroups = !attachGuiMcp && !live ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
+    // keeps the tools its running process was started with. BOTH kinds of reattach (#1536): a
+    // tmux-only one — a reconnect after a server restart, where `live` is absent — starts no
+    // process either, and it often carries no `?cwd=` at all, so this read would answer for the
+    // DEFAULT workspace; the argv built from it is discarded by `tmux new-session -A` anyway.
+    // Same predicate reserveWorktreeEnvForSpawn asks, for the same reason.
+    const mcpGroups = !attachGuiMcp && !live && !ptyWouldReattach(sessionId, true) ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
     if (!clientStillConnected(ws, "codex", sessionId, early)) return;
 
     const startFailureMessage = startFailureMessageFor("codex");

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -760,13 +760,20 @@ export async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, re
 
     // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
     // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
-    // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
-    // keeps the tools its running process was started with. BOTH kinds of reattach (#1536): a
-    // tmux-only one — a reconnect after a server restart, where `live` is absent — starts no
-    // process either, and it often carries no `?cwd=` at all, so this read would answer for the
-    // DEFAULT workspace; the argv built from it is discarded by `tmux new-session -A` anyway.
-    // Same predicate reserveWorktreeEnvForSpawn asks, for the same reason.
-    const mcpGroups = !attachGuiMcp && !live && !ptyWouldReattach(sessionId, true) ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
+    // spawn, so the answer has to be read here, before the pty exists. Not for a live reattach,
+    // which keeps the tools its running process was started with.
+    //
+    // Against the SESSION's own directory rather than the request's (#1536) — the same shape the
+    // directory-MCP handler took for #1514: `live` is absent for a tmux-only reattach as well as
+    // for a spawn — a reconnect after a server restart — and such a reconnect often carries no
+    // `?cwd=` at all, which resolves to the DEFAULT workspace. On a real reattach the argv this
+    // builds is discarded by `tmux new-session -A`; it is still read rather than skipped on a
+    // ptyWouldReattach probe, because the tmux session can die between that probe and the spawn's
+    // own — and the fresh codex that fallback starts must not come up with no GUI tools at all
+    // (CodeRabbit on #1538).
+    await devTerminalCwdsHydrated;
+    const groupsCwd = live?.cwd ?? sessionCwd(sessionId) ?? cwd;
+    const mcpGroups = !attachGuiMcp && !live ? await registeredGuiMcpGroups(groupsCwd, TOOL_GROUPS).catch(() => []) : [];
     if (!clientStillConnected(ws, "codex", sessionId, early)) return;
 
     const startFailureMessage = startFailureMessageFor("codex");

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -56,14 +56,21 @@ function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: Cod
 
 // Start tailing; it stops on its own once the session is gone. `startAtEnd` skips a
 // resumed rollout's history — replaying it would flag the cell from turns that finished
-// days ago.
-export function trackCodexActivity(sessionId: string, file: string, startAtEnd: boolean, deps: CodexActivityTrackDeps): void {
+// days ago. `restoreOpenTurn` is the reattach exception to that skip: a turn the file
+// leaves OPEN is what the surviving process is doing right now (see CodexActivityDeps).
+export function trackCodexActivity(
+  sessionId: string,
+  file: string,
+  mode: { startAtEnd: boolean; restoreOpenTurn?: boolean },
+  deps: CodexActivityTrackDeps,
+): void {
   watchCodexActivity({
     fileSize: sizeOf(file),
     readSlice: readSliceOf(file),
     onBoundary: (boundary) => applyBoundary(sessionId, boundary, deps),
     isAlive: deps.isAlive,
-    startAtEnd,
+    startAtEnd: mode.startAtEnd,
+    restoreOpenTurn: mode.restoreOpenTurn ?? false,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   }).catch(() => {}); // a rollout that vanishes mid-session just stops reporting
 }

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -25,11 +25,27 @@ export interface CodexActivityDeps {
    *  first turn isn't missed; a resumed one would otherwise REPLAY every past turn and
    *  leave the cell flagged from history rather than from what is happening now. */
   startAtEnd: boolean;
+  /** Reattach only (with startAtEnd): if the skipped content leaves a turn OPEN — its last
+   *  boundary is a start without an end — report that one boundary before tailing. The
+   *  process behind a reattach is still RUNNING, so an open turn is current fact, not
+   *  history: without this a server restarted mid-turn shows an idle cell until the turn's
+   *  END arrives (#1538 review). A trailing COMPLETED stays unreported — re-flagging a
+   *  days-old finish is the replay startAtEnd exists to prevent. And it must stay false
+   *  for a cold resume, where the process is NEW: a trailing start there means the OLD
+   *  process died mid-turn, and the resumed one is idle. */
+  restoreOpenTurn?: boolean;
   sleep: (ms: number) => Promise<void>;
 }
 
 export async function watchCodexActivity(deps: CodexActivityDeps): Promise<void> {
   let offset = deps.startAtEnd ? await startingOffset(deps) : 0;
+  // Against the SAME offset the tail starts from, so a boundary cannot fall between the
+  // restore read and the first poll — it is either in [0, offset) and restored, or after
+  // and tailed.
+  if (deps.restoreOpenTurn && offset > 0) {
+    const skipped = turnBoundaries((await deps.readSlice(0, offset)).split("\n").filter((l) => l.trim()));
+    if (skipped.at(-1) === "started") deps.onBoundary("started");
+  }
   let pending = "";
   while (deps.isAlive()) {
     await deps.sleep(CODEX_ACTIVITY_POLL_MS);

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -39,14 +39,28 @@ export interface CodexActivityDeps {
 
 export async function watchCodexActivity(deps: CodexActivityDeps): Promise<void> {
   let offset = deps.startAtEnd ? await startingOffset(deps) : 0;
+  let pending = "";
   // Against the SAME offset the tail starts from, so a boundary cannot fall between the
   // restore read and the first poll — it is either in [0, offset) and restored, or after
   // and tailed.
   if (deps.restoreOpenTurn && offset > 0) {
-    const skipped = turnBoundaries((await deps.readSlice(0, offset)).split("\n").filter((l) => l.trim()));
-    if (skipped.at(-1) === "started") deps.onBoundary("started");
+    const skipped = await deps.readSlice(0, offset);
+    // The writer is still ALIVE on this path, so the snapshot can land mid-record. Whatever
+    // follows the last newline is a record still being written: it is carried as the tail's
+    // pending fragment — parsed once its remainder is flushed — never judged as a line here.
+    // Both halves of that matter: a torn task_complete judged here would be ignored AND its
+    // suffix alone is unparseable on the first poll, so the completion would be lost for good
+    // and a restored working flag would stick until some later turn (#1538 review).
+    const lastNewline = skipped.lastIndexOf("\n");
+    pending = skipped.slice(lastNewline + 1);
+    const whole = turnBoundaries(
+      skipped
+        .slice(0, lastNewline + 1)
+        .split("\n")
+        .filter((l) => l.trim()),
+    );
+    if (whole.at(-1) === "started") deps.onBoundary("started");
   }
-  let pending = "";
   while (deps.isAlive()) {
     await deps.sleep(CODEX_ACTIVITY_POLL_MS);
     if (!deps.isAlive()) return;

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -40,7 +40,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
         rememberCodexRollout(sessionId, meta.id, cwd);
         // A rollout only discovered now is one this session just created, so it is read
         // whole: its first turn is in there and hasn't been reported yet.
-        trackCodexActivity(sessionId, meta.file, false, activityDepsFor(sessionId, entry, deps));
+        trackCodexActivity(sessionId, meta.file, { startAtEnd: false }, activityDepsFor(sessionId, entry, deps));
       })
       .catch(() => {});
   }
@@ -101,7 +101,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
       // rollout id itself carries no mapping yet, and one whose cell moved needs the new cwd.
       rememberCodexRollout(sessionId, resumeRolloutId, cwd);
       const file = codexRolloutPath(root, resumeRolloutId);
-      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
+      if (file) trackCodexActivity(sessionId, file, { startAtEnd: true }, activityDepsFor(sessionId, entry, deps));
     } else if (reattached) {
       // A tmux attach picked up a codex that was ALREADY running — a server restart, where
       // `agentResumeId` rightly withholds the resume id so no second codex starts. But the fresh
@@ -109,12 +109,18 @@ export function createCodexSpawner(deps: SpawnDeps) {
       // snapshot — so nothing ever tailed it and the cell's working/waiting flags stayed dead
       // until a cold restart (#1536). Claude survives the same restart via its HTTP hooks; codex
       // has only this tail. The mapping outlived the process in the rollout log (the WS route
-      // awaits its hydration before resolving), so tail it from the end, exactly as a resume
-      // does. No mapping — a rollout never captured before the restart — means there is nothing
-      // to tail: running the watcher would mis-attribute a concurrent session's rollout.
+      // awaits its hydration before resolving), so tail it from the end, as a resume does —
+      // except that a turn the file leaves OPEN is restored: unlike a resume, the process is
+      // still running, so an open turn is what it is doing right now (#1538 review).
       const rolloutId = codexRollouts.get(sessionId)?.conversationId;
       const file = rolloutId ? codexRolloutPath(root, rolloutId) : null;
-      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
+      if (file) trackCodexActivity(sessionId, file, { startAtEnd: true, restoreOpenTurn: true }, activityDepsFor(sessionId, entry, deps));
+      // No mapping — the restart came before the survivor's FIRST turn, so no rollout exists
+      // yet. Its first prompt may still be coming, so run the same appear-watcher a fresh
+      // session gets (attribution is unambiguous-only either way): without it that rollout is
+      // never recorded, activity stays dead, and a later cold reconnect starts a NEW
+      // conversation instead of resuming this one (Codex review on #1538).
+      else captureCodexRollout(sessionId, entry, root, before, cwd);
     } else {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher
       // could overwrite the known id with a mis-attributed concurrent rollout.

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -10,7 +10,7 @@ import { codexGuiMcpServers } from "./mcp-config.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
-import { claimedCodexRollouts, claimFullGuiMcp, ptys, rememberCodexRollout } from "./registry.js";
+import { claimedCodexRollouts, claimFullGuiMcp, codexRollouts, ptys, rememberCodexRollout } from "./registry.js";
 import { ptySpawn, ptyWouldReattach } from "./pty-spawn.js";
 import { ptyStartLine } from "./pty-exit-log.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
@@ -101,6 +101,19 @@ export function createCodexSpawner(deps: SpawnDeps) {
       // rollout id itself carries no mapping yet, and one whose cell moved needs the new cwd.
       rememberCodexRollout(sessionId, resumeRolloutId, cwd);
       const file = codexRolloutPath(root, resumeRolloutId);
+      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
+    } else if (reattached) {
+      // A tmux attach picked up a codex that was ALREADY running — a server restart, where
+      // `agentResumeId` rightly withholds the resume id so no second codex starts. But the fresh
+      // branch below waits for a rollout file to APPEAR, and this session's existed before the
+      // snapshot — so nothing ever tailed it and the cell's working/waiting flags stayed dead
+      // until a cold restart (#1536). Claude survives the same restart via its HTTP hooks; codex
+      // has only this tail. The mapping outlived the process in the rollout log (the WS route
+      // awaits its hydration before resolving), so tail it from the end, exactly as a resume
+      // does. No mapping — a rollout never captured before the restart — means there is nothing
+      // to tail: running the watcher would mis-attribute a concurrent session's rollout.
+      const rolloutId = codexRollouts.get(sessionId)?.conversationId;
+      const file = rolloutId ? codexRolloutPath(root, rolloutId) : null;
       if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
     } else {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher

--- a/test/server/routes/ws-restart-reattach.spec.ts
+++ b/test/server/routes/ws-restart-reattach.spec.ts
@@ -3,8 +3,9 @@
 //
 // After a server restart `ptys` is empty while tmux still holds `mt-<session>` — the state every
 // `!live` test misreads as a fresh spawn. The codex handler read the directory's tool groups on
-// that path (from a request cwd that is often the DEFAULT workspace) and built an MCP argv that
-// `tmux new-session -A` then discarded. And claude was the one agent endpoint that never asked
+// that path from the REQUEST cwd, which a restart reconnect often leaves at the default
+// workspace — another directory's switches, exactly the wrong-cwd read #1514 fixed on the
+// directory-MCP handler. And claude was the one agent endpoint that never asked
 // clientStillConnected after its admission awaits, so a client that left mid-admission still got
 // a pty — spawned after the socket's close event, which no later close handler can reap.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -16,6 +17,8 @@ import type { WebSocket } from "ws";
 const mocks = vi.hoisted(() => ({
   // Whether tmux still holds the requested session — the restart-survivor case.
   tmuxHas: false,
+  // What the dev-terminal cwd log remembers for the session, or null for one it never saw.
+  rememberedCwd: null as string | null,
   // Lets a test simulate the client leaving inside an admission await.
   onEnsureWorktreeEnv: () => {},
 }));
@@ -23,7 +26,7 @@ const mocks = vi.hoisted(() => ({
 const ptys = new Map<string, unknown>();
 vi.mock("../../../server/session/registry.js", () => ({
   ptys,
-  sessionCwd: () => null,
+  sessionCwd: () => mocks.rememberedCwd,
   devTerminalCwdsHydrated: Promise.resolve(),
   antigravityConversations: new Map(),
   antigravityConversationsHydrated: Promise.resolve(),
@@ -103,6 +106,7 @@ beforeEach(() => {
   ptys.clear();
   vi.clearAllMocks();
   mocks.tmuxHas = false;
+  mocks.rememberedCwd = null;
   mocks.onEnsureWorktreeEnv = () => {};
   registeredGuiMcpGroups.mockResolvedValue(["render"]);
   dir = mkdtempSync(path.join(tmpdir(), "mt-ws-restart-"));
@@ -113,18 +117,21 @@ afterEach(() => {
 });
 
 describe("/ws/codex after a server restart (tmux survivor, no live pty)", () => {
-  it("keeps the id, passes no resume id, and looks up no directory groups", async () => {
+  // A restart reconnect often carries no ?cwd= at all, which resolves to the DEFAULT workspace —
+  // so the groups must come from where the session really runs (the remembered cwd, #1514's
+  // shape). Still read rather than skipped: if tmux dies between this handler and the spawn, the
+  // fresh codex that ptySpawn's fallback starts must not come up with no GUI tools at all.
+  it("keeps the id, passes no resume id, and reads the groups from the session's own cwd", async () => {
     mocks.tmuxHas = true;
+    mocks.rememberedCwd = "/where-it-really-runs";
     await handleCodexConnection(makeDeps(), fakeWs() as unknown as WebSocket, request(`&gui=0&session=${SID}`));
-    // The attach ignores whatever argv a group lookup would build, and the request cwd it would
-    // read from is untrustworthy on this path — so the lookup must not happen at all.
-    expect(registeredGuiMcpGroups).not.toHaveBeenCalled();
-    expect(spawnCodexPty).toHaveBeenCalledWith(SID, expect.anything(), null, dir, false, { mcpGroups: [] });
+    expect(registeredGuiMcpGroups).toHaveBeenCalledWith("/where-it-really-runs", expect.anything());
+    expect(spawnCodexPty).toHaveBeenCalledWith(SID, expect.anything(), null, dir, false, { mcpGroups: ["render"] });
   });
 
-  it("still reads the directory's groups for a genuinely fresh grid cell", async () => {
+  it("reads the directory's groups from the request cwd for a genuinely fresh grid cell", async () => {
     await handleCodexConnection(makeDeps(), fakeWs() as unknown as WebSocket, request("&gui=0"));
-    expect(registeredGuiMcpGroups).toHaveBeenCalledTimes(1);
+    expect(registeredGuiMcpGroups).toHaveBeenCalledWith(dir, expect.anything());
     expect(spawnCodexPty).toHaveBeenCalledWith(expect.any(String), expect.anything(), null, dir, false, { mcpGroups: ["render"] });
   });
 });

--- a/test/server/routes/ws-restart-reattach.spec.ts
+++ b/test/server/routes/ws-restart-reattach.spec.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+// The #1536 fixes on the connect path, asserted through the real handlers.
+//
+// After a server restart `ptys` is empty while tmux still holds `mt-<session>` — the state every
+// `!live` test misreads as a fresh spawn. The codex handler read the directory's tool groups on
+// that path (from a request cwd that is often the DEFAULT workspace) and built an MCP argv that
+// `tmux new-session -A` then discarded. And claude was the one agent endpoint that never asked
+// clientStillConnected after its admission awaits, so a client that left mid-admission still got
+// a pty — spawned after the socket's close event, which no later close handler can reap.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { WebSocket } from "ws";
+
+const mocks = vi.hoisted(() => ({
+  // Whether tmux still holds the requested session — the restart-survivor case.
+  tmuxHas: false,
+  // Lets a test simulate the client leaving inside an admission await.
+  onEnsureWorktreeEnv: () => {},
+}));
+
+const ptys = new Map<string, unknown>();
+vi.mock("../../../server/session/registry.js", () => ({
+  ptys,
+  sessionCwd: () => null,
+  devTerminalCwdsHydrated: Promise.resolve(),
+  antigravityConversations: new Map(),
+  antigravityConversationsHydrated: Promise.resolve(),
+  museConversations: new Map(),
+  museConversationsHydrated: Promise.resolve(),
+  codexRollouts: new Map(),
+  codexRolloutsHydrated: Promise.resolve(),
+  customAgentSessionsHydrated: Promise.resolve(),
+  markDevTerminalSession: vi.fn(),
+  markAttachedSessionPlaced: vi.fn(),
+}));
+
+vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/infra/tmux.js")>()),
+  tmuxAvailable: () => true,
+  tmuxHasSession: () => mocks.tmuxHas,
+}));
+
+// The rollout probe walks codex's real sessions root on disk; the resolver must not.
+vi.mock("../../../server/agents/codex-sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/codex-sessions.js")>()),
+  codexRolloutExists: () => false,
+}));
+
+const registeredGuiMcpGroups = vi.fn(() => Promise.resolve(["render"]));
+vi.mock("../../../server/infra/gui-mcp-registration.js", () => ({ registeredGuiMcpGroups }));
+
+vi.mock("../../../server/config/worktree-env.js", () => ({
+  ensureWorktreeEnv: vi.fn(() => {
+    mocks.onEnsureWorktreeEnv();
+    return Promise.resolve({});
+  }),
+  reservedWorktreeEnv: () => ({}),
+}));
+
+// A real occupancy read runs git against the cwd; this spec is about the handlers' shape.
+vi.mock("../../../server/session/worktree-session-limit.js", () => ({
+  claimLaunch: () => ({ release: vi.fn(), contended: false }),
+  worktreeOccupancy: () => Promise.resolve({ isWorktree: false, session: null }),
+}));
+
+const { handleClaudeConnection, handleCodexConnection } = await import("../../../server/routes/ws-routes.js");
+
+const SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02";
+const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
+
+function fakeWs() {
+  const sent: string[] = [];
+  return {
+    sent,
+    readyState: 1,
+    OPEN: 1,
+    send: (raw: string) => sent.push(raw),
+    close: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+  };
+}
+
+const spawnClaudePty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+const spawnCodexPty = vi.fn(() => ({ term: fakeTerm(), active: false }));
+const makeDeps = () =>
+  ({
+    spawnClaudePty,
+    spawnCodexPty,
+    reattachPty: vi.fn(),
+    setWaiting: vi.fn(),
+    handleClientFrame: vi.fn(),
+    handleClientClose: vi.fn(),
+  }) as never;
+
+let dir = "";
+const request = (query = "") => ({ url: `/ws?cwd=${encodeURIComponent(dir)}${query}` });
+
+beforeEach(() => {
+  ptys.clear();
+  vi.clearAllMocks();
+  mocks.tmuxHas = false;
+  mocks.onEnsureWorktreeEnv = () => {};
+  registeredGuiMcpGroups.mockResolvedValue(["render"]);
+  dir = mkdtempSync(path.join(tmpdir(), "mt-ws-restart-"));
+});
+afterEach(() => {
+  ptys.clear();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("/ws/codex after a server restart (tmux survivor, no live pty)", () => {
+  it("keeps the id, passes no resume id, and looks up no directory groups", async () => {
+    mocks.tmuxHas = true;
+    await handleCodexConnection(makeDeps(), fakeWs() as unknown as WebSocket, request(`&gui=0&session=${SID}`));
+    // The attach ignores whatever argv a group lookup would build, and the request cwd it would
+    // read from is untrustworthy on this path — so the lookup must not happen at all.
+    expect(registeredGuiMcpGroups).not.toHaveBeenCalled();
+    expect(spawnCodexPty).toHaveBeenCalledWith(SID, expect.anything(), null, dir, false, { mcpGroups: [] });
+  });
+
+  it("still reads the directory's groups for a genuinely fresh grid cell", async () => {
+    await handleCodexConnection(makeDeps(), fakeWs() as unknown as WebSocket, request("&gui=0"));
+    expect(registeredGuiMcpGroups).toHaveBeenCalledTimes(1);
+    expect(spawnCodexPty).toHaveBeenCalledWith(expect.any(String), expect.anything(), null, dir, false, { mcpGroups: ["render"] });
+  });
+});
+
+describe("/ws (claude) admission", () => {
+  it("spawns nothing for a client that left during the admission awaits", async () => {
+    const ws = fakeWs();
+    mocks.onEnsureWorktreeEnv = () => {
+      ws.readyState = 3; // the client closes while the handler awaits the worktree env
+    };
+    await handleClaudeConnection(makeDeps(), ws as unknown as WebSocket, request());
+    expect(spawnClaudePty).not.toHaveBeenCalled();
+  });
+
+  it("spawns for a client that stayed", async () => {
+    await handleClaudeConnection(makeDeps(), fakeWs() as unknown as WebSocket, request());
+    expect(spawnClaudePty).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -9,7 +9,7 @@ const complete = (turnId = "t1") => line({ type: "event_msg", payload: { type: "
 
 // A fake rollout the test appends to, driving the loop one tick at a time. `sleep`
 // resolves immediately, and the loop is stopped by a tick budget rather than a timer.
-function harness(initial: string, startAtEnd: boolean) {
+function harness(initial: string, startAtEnd: boolean, restoreOpenTurn = false) {
   let content = initial;
   let ticks = 0;
   const maxTicks = 12;
@@ -23,6 +23,7 @@ function harness(initial: string, startAtEnd: boolean) {
     onBoundary: (b) => boundaries.push(b),
     isAlive: () => ticks < maxTicks,
     startAtEnd,
+    restoreOpenTurn,
     sleep: async () => {
       ticks += 1;
       const add = appendAtTick.get(ticks);
@@ -67,6 +68,24 @@ describe("watchCodexActivity", () => {
     h.appendAt(4, complete("new"));
     await h.run();
     expect(h.boundaries).toEqual(["started", "completed"]);
+  });
+
+  // The reattach case (#1538 review): the process behind the file is still RUNNING, so a turn
+  // the skipped content leaves open is what it is doing right now — without restoring it the
+  // cell sits idle until the turn's END arrives. The end itself then comes off the tail.
+  it("restores a turn the skipped content leaves open, then tails its end", async () => {
+    const h = harness(started("mid"), true, true);
+    h.appendAt(3, complete("mid"));
+    await h.run();
+    expect(h.boundaries).toEqual(["started", "completed"]);
+  });
+
+  // A trailing COMPLETED is history, not state: re-reporting it would re-flag the cell (and
+  // re-push) for a turn finished before the restart — the replay startAtEnd exists to prevent.
+  it("restores nothing when the skipped content's last turn is closed", async () => {
+    const h = harness(started("old") + complete("old"), true, true);
+    await h.run();
+    expect(h.boundaries).toEqual([]);
   });
 
   it("joins a record split across two polls", async () => {

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -88,6 +88,18 @@ describe("watchCodexActivity", () => {
     expect(h.boundaries).toEqual([]);
   });
 
+  // The writer is still alive at reattach, so the snapshot can land MID-record. The torn
+  // record must ride the pending fragment into the tail: judged as a line at restore time, a
+  // torn task_complete is ignored there AND unparseable from its suffix alone on the first
+  // poll — the completion is lost for good and the restored working flag sticks (#1538 review).
+  it("assembles a completion record torn by the reattach snapshot, instead of losing it", async () => {
+    const torn = complete("mid");
+    const h = harness(started("mid") + torn.slice(0, 25), true, true);
+    h.appendAt(2, torn.slice(25));
+    await h.run();
+    expect(h.boundaries).toEqual(["started", "completed"]);
+  });
+
   it("joins a record split across two polls", async () => {
     const whole = complete();
     const h = harness("", false);

--- a/test/server/session/spawn-codex.spec.ts
+++ b/test/server/session/spawn-codex.spec.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   // What ptySpawn reports back — the reattached flag IS the case under test.
   reattached: false,
   argv: [] as string[][],
-  tracked: [] as { sessionId: string; file: string; startAtEnd: boolean }[],
+  tracked: [] as { sessionId: string; file: string; mode: unknown }[],
   remembered: [] as { sessionId: string; conversationId: string; cwd: string }[],
   watcherRuns: 0,
   // The hydrated session -> rollout mapping, as the WS route's awaited hydration leaves it.
@@ -51,8 +51,8 @@ vi.mock("../../../server/agents/codex-sessions.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../../server/session/codex-activity-track.js", () => ({
-  trackCodexActivity: vi.fn((sessionId: string, file: string, startAtEnd: boolean) => {
-    mocks.tracked.push({ sessionId, file, startAtEnd });
+  trackCodexActivity: vi.fn((sessionId: string, file: string, mode: unknown) => {
+    mocks.tracked.push({ sessionId, file, mode });
   }),
 }));
 
@@ -96,7 +96,9 @@ describe("createCodexSpawner", () => {
 
   it("tails a resumed rollout from the end, records the mapping, and runs no watcher", () => {
     spawn()(SID, null, ROLLOUT_ID, "/w", false);
-    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, startAtEnd: true }]);
+    // No restoreOpenTurn: the resumed process is NEW, so a turn the old rollout left open is
+    // one the OLD process died inside — the resumed session is idle.
+    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, mode: { startAtEnd: true } }]);
     expect(mocks.remembered).toEqual([{ sessionId: SID, conversationId: ROLLOUT_ID, cwd: "/w" }]);
     expect(mocks.watcherRuns).toBe(0);
     expect(mocks.argv.at(-1)).toContain(ROLLOUT_ID);
@@ -109,7 +111,9 @@ describe("createCodexSpawner", () => {
     mocks.reattached = true;
     mocks.rollouts.set(SID, { sessionId: SID, conversationId: ROLLOUT_ID, cwd: "/w", startedAt: 1 });
     spawn()(SID, null, null, "/w", false);
-    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, startAtEnd: true }]);
+    // restoreOpenTurn: the surviving process may be MID-TURN right now, and tailing from the
+    // end alone would show it idle until that turn's end boundary arrives.
+    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, mode: { startAtEnd: true, restoreOpenTurn: true } }]);
     expect(mocks.watcherRuns).toBe(0);
     expect(mocks.argv.at(-1)).not.toContain("resume");
     // The mapping is already on disk with the cwd the session really runs in; a reattach request's
@@ -117,12 +121,14 @@ describe("createCodexSpawner", () => {
     expect(mocks.remembered).toEqual([]);
   });
 
-  // No mapping means the rollout was never captured before the restart. There is nothing to tail,
-  // and the appear-watcher would mis-attribute a concurrent session's rollout to this one.
-  it("arms nothing on a tmux reattach with no known rollout", () => {
+  // No mapping means the restart came before the survivor's FIRST turn — no rollout exists yet,
+  // but its first prompt may still be coming. The appear-watcher must run exactly as it does for
+  // a fresh session, or that rollout is never recorded and a later cold reconnect starts a new
+  // conversation instead of resuming this one (Codex review on #1538).
+  it("falls back to the appear-watcher on a tmux reattach with no known rollout", () => {
     mocks.reattached = true;
     spawn()(SID, null, null, "/w", false);
     expect(mocks.tracked).toEqual([]);
-    expect(mocks.watcherRuns).toBe(0);
+    expect(mocks.watcherRuns).toBe(1);
   });
 });

--- a/test/server/session/spawn-codex.spec.ts
+++ b/test/server/session/spawn-codex.spec.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+// The three ways spawnCodexPty can meet a rollout, pinned together because the branch between
+// them is what #1536 was: a tmux attach after a server restart took the FRESH branch, whose
+// watcher waits for a rollout file to APPEAR — and the surviving session's file already existed,
+// so nothing ever tailed it and the cell's working/waiting flags stayed dead until a cold
+// restart. Claude survives the same restart via its HTTP hooks; codex has only this tail.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCodexSpawner } from "../../../server/session/spawn-codex.js";
+import { ptys } from "../../../server/session/registry.js";
+import type { SpawnDeps } from "../../../server/session/spawn-deps.js";
+
+const SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01";
+const ROLLOUT_ID = "11111111-2222-4333-8444-555555555555";
+
+const mocks = vi.hoisted(() => ({
+  // What ptySpawn reports back — the reattached flag IS the case under test.
+  reattached: false,
+  argv: [] as string[][],
+  tracked: [] as { sessionId: string; file: string; startAtEnd: boolean }[],
+  remembered: [] as { sessionId: string; conversationId: string; cwd: string }[],
+  watcherRuns: 0,
+  // The hydrated session -> rollout mapping, as the WS route's awaited hydration leaves it.
+  rollouts: new Map<string, { sessionId: string; conversationId: string; cwd: string; startedAt: number }>(),
+}));
+
+vi.mock("../../../server/session/pty-spawn.js", () => ({
+  ptySpawn: vi.fn((_id: string, _bin: string, args: string[]) => {
+    mocks.argv.push(args);
+    return { term: { pid: 1234, onData: vi.fn(), onExit: vi.fn() }, tmux: true, reattached: mocks.reattached };
+  }),
+  ptyWouldReattach: vi.fn(() => mocks.reattached),
+}));
+
+// The watcher polls codex's real sessions root for the session's lifetime, and `remember`
+// appends to the real ~/.mulmoterminal log. Both are stubbed: this file is about which branch
+// the spawner takes, and a unit test must not write a session that never existed into the
+// developer's own state.
+vi.mock("../../../server/agents/codex-session.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/codex-session.js")>()),
+  codexSessionsRoot: () => "/codex-root",
+  snapshotSessions: () => new Set<string>(),
+  watchForCodexSession: vi.fn(() => {
+    mocks.watcherRuns += 1;
+    return new Promise(() => {}); // never resolves — the fresh branch is asserted by the call alone
+  }),
+}));
+
+vi.mock("../../../server/agents/codex-sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/codex-sessions.js")>()),
+  codexRolloutPath: (_root: string, id: string) => `/codex-root/rollout-${id}.jsonl`,
+}));
+
+vi.mock("../../../server/session/codex-activity-track.js", () => ({
+  trackCodexActivity: vi.fn((sessionId: string, file: string, startAtEnd: boolean) => {
+    mocks.tracked.push({ sessionId, file, startAtEnd });
+  }),
+}));
+
+vi.mock("../../../server/session/registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/session/registry.js")>()),
+  codexRollouts: mocks.rollouts,
+  rememberCodexRollout: vi.fn((sessionId: string, conversationId: string, cwd: string) => {
+    mocks.remembered.push({ sessionId, conversationId, cwd });
+  }),
+  claimFullGuiMcp: vi.fn(() => false), // persists a claim log on the real disk
+}));
+
+describe("createCodexSpawner", () => {
+  const dummyDeps = {
+    codexBin: "codex",
+    codexModel: null,
+    outputBufferLimit: 10000,
+    uiPort: "3000",
+    reap: vi.fn(),
+    setWorking: vi.fn(),
+    setWaiting: vi.fn(),
+  } as unknown as SpawnDeps;
+  const spawn = () => createCodexSpawner(dummyDeps).spawnCodexPty;
+
+  beforeEach(() => {
+    ptys.clear();
+    mocks.reattached = false;
+    mocks.argv.length = 0;
+    mocks.tracked.length = 0;
+    mocks.remembered.length = 0;
+    mocks.watcherRuns = 0;
+    mocks.rollouts.clear();
+  });
+
+  it("watches for a fresh session's rollout to appear, and tails nothing yet", () => {
+    spawn()(SID, null, null, "/w", false);
+    expect(mocks.watcherRuns).toBe(1);
+    expect(mocks.tracked).toEqual([]);
+    expect(ptys.get(SID)?.agent).toBe("codex");
+  });
+
+  it("tails a resumed rollout from the end, records the mapping, and runs no watcher", () => {
+    spawn()(SID, null, ROLLOUT_ID, "/w", false);
+    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, startAtEnd: true }]);
+    expect(mocks.remembered).toEqual([{ sessionId: SID, conversationId: ROLLOUT_ID, cwd: "/w" }]);
+    expect(mocks.watcherRuns).toBe(0);
+    expect(mocks.argv.at(-1)).toContain(ROLLOUT_ID);
+  });
+
+  // The #1536 case: a tmux attach after a server restart. The resume id is rightly withheld (a
+  // `codex resume` would start a second process beside the surviving one), so activity has to be
+  // re-armed from the hydrated mapping — from the END, or days-old turns would flag the cell.
+  it("re-arms activity from the hydrated mapping on a tmux reattach, without a resume argv", () => {
+    mocks.reattached = true;
+    mocks.rollouts.set(SID, { sessionId: SID, conversationId: ROLLOUT_ID, cwd: "/w", startedAt: 1 });
+    spawn()(SID, null, null, "/w", false);
+    expect(mocks.tracked).toEqual([{ sessionId: SID, file: `/codex-root/rollout-${ROLLOUT_ID}.jsonl`, startAtEnd: true }]);
+    expect(mocks.watcherRuns).toBe(0);
+    expect(mocks.argv.at(-1)).not.toContain("resume");
+    // The mapping is already on disk with the cwd the session really runs in; a reattach request's
+    // cwd is the least trustworthy value on this path and must not overwrite it.
+    expect(mocks.remembered).toEqual([]);
+  });
+
+  // No mapping means the rollout was never captured before the restart. There is nothing to tail,
+  // and the appear-watcher would mis-attribute a concurrent session's rollout to this one.
+  it("arms nothing on a tmux reattach with no known rollout", () => {
+    mocks.reattached = true;
+    spawn()(SID, null, null, "/w", false);
+    expect(mocks.tracked).toEqual([]);
+    expect(mocks.watcherRuns).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the restart-reattach gaps from #1536. After a MulmoTerminal server restart, `ptys` is empty while tmux still holds `mt-<session>` — the state every bare `!live` test misreads as a fresh spawn. Fixes on that path:

1. **Re-arm codex activity on a tmux-only reattach** (`server/session/spawn-codex.ts`) — the substantive bug. A tmux attach of a surviving codex took the fresh branch, whose watcher waits for a NEW rollout file to appear; the survivor's file already existed, so nothing tailed it and the cell's working/waiting flags (and turn-finished notifications) stayed dead until a cold restart. Now the spawner tails the hydrated mapping's rollout from the end — without a resume id, so no second codex starts beside the surviving one. A survivor with NO mapped rollout (restart before its first turn) falls back to the appear-watcher, so its first prompt's rollout is still captured (Codex review).

2. **Restore an open turn's working flag on reattach** (`server/session/codex-activity-watch.ts`, from CodeRabbit's review) — tailing from the end alone showed a mid-turn survivor as idle until its turn ENDED. `restoreOpenTurn` (reattach only) re-reports a turn the skipped content leaves open — current fact for a still-running process — while a trailing completed stays unreported (no re-flag / re-push for a pre-restart finish) and a cold resume keeps the flag off.

3. **Codex directory tool-group read uses the session's own cwd** (`server/routes/ws-routes.ts`) — a restart reconnect often carries no `?cwd=` at all, so the read answered for the DEFAULT workspace. Now `sessionCwd(sessionId) ?? cwd`, the same shape the directory-MCP handler took for #1514. Deliberately read (not skipped on a `ptyWouldReattach` probe): if tmux dies between that probe and the spawn's own, the fresh-spawn fallback must not come up with no GUI tools (CodeRabbit's race finding).

4. **`clientStillConnected` parity for claude** (`server/routes/ws-routes.ts`) — claude was the one agent endpoint that never asked it after its admission awaits, so a client that left mid-admission still got a pty, spawned after the socket's close event — which no later close handler can reap. Also corrects the `beginRunTerminal` comment that claimed this guard already existed on the claude path.

## Tests

- `test/server/session/spawn-codex.spec.ts` (new) — pins all four rollout branches: fresh (watcher runs), resume (tail from end, no open-turn restore, mapping recorded, `resume` argv), tmux reattach with a hydrated mapping (tail + restore, **no** resume argv, no watcher, mapping not overwritten with the untrustworthy request cwd), and reattach with no mapping (appear-watcher fallback).
- `test/server/session/codex-activity-watch.spec.ts` — two new cases: an open trailing turn is restored then its end tailed; a closed trailing turn restores nothing.
- `test/server/routes/ws-restart-reattach.spec.ts` (new) — drives the real handlers: a codex restart-survivor keeps its id, gets no resume id, and reads groups from the REMEMBERED session cwd (a fresh cell reads from the request cwd); claude spawns nothing for a client that left during the admission awaits, and spawns for one that stayed.

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn test` (9232 passed) all green.

Not in this PR: #1537 (endpoint/agent identity validation for tmux-only attach) — separate PR, per the discussion on #1536.

Fixes #1536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
