### PR TITLE
fix(test): Windows CI を戻す — survivorCandidates の spec に正規化済みの dir を渡す (#1539)

### DIFF
--- a/plans/fix-windows-dir-session-spec.md
+++ b/plans/fix-windows-dir-session-spec.md
@@ -6,7 +6,7 @@ issue: #1539 / 原因を作った PR: #1534
 
 `main` の **Windows (daily)** が #1534 のマージコミット `752961b5` から赤い（直前の `77e0769a` は緑）。
 
-```
+```text
 FAIL test/server/session/dir-session.spec.ts > survivorCandidates
   > names a running survivor as a LIVE candidate of its own agent
       AssertionError: expected [] to deeply equal [ { id: 'key-1', live: true, … } ]

--- a/plans/fix-windows-dir-session-spec.md
+++ b/plans/fix-windows-dir-session-spec.md
@@ -1,0 +1,100 @@
+# Windows CI を戻す — `survivorCandidates` の spec が正規化前のパスを渡していた
+
+issue: #1539 / 原因を作った PR: #1534
+
+## 何が起きていたか
+
+`main` の **Windows (daily)** が #1534 のマージコミット `752961b5` から赤い（直前の `77e0769a` は緑）。
+
+```
+FAIL test/server/session/dir-session.spec.ts > survivorCandidates
+  > names a running survivor as a LIVE candidate of its own agent
+      AssertionError: expected [] to deeply equal [ { id: 'key-1', live: true, … } ]
+  > outranks a merely recent transcript once picked with
+      TypeError: Cannot read properties of undefined (reading 'attached')   ← 1 件目の連鎖
+```
+
+Node 22.x / 24.x の両方。Windows は PR の required check に入っていない（`windows-daily.yaml` は
+`push: [main]` + schedule + `workflow_dispatch`）ので、#1534 は緑のままマージされ、main への
+push で初めて落ちた。
+
+## 根本原因
+
+`survivorCandidates(dir, logs, facts)` は **`dir` を正規化済みで受け取る契約**で、比較は片側だけを
+正規化する:
+
+```ts
+// server/session/dir-session.ts
+if (canonicalPath(record.cwd) !== dir) return [];
+```
+
+呼び出し元 `dirSession` は `canonicalPath(dir)` を渡しているので **プロダクションは正しい**。
+spec だけが生の POSIX リテラルを `dir` に渡していた:
+
+| | POSIX | Windows |
+|---|---|---|
+| `canonicalPath("/wt/fix-login")`（record 側） | `/wt/fix-login` | `D:\wt\fix-login` |
+| spec が渡した `dir` | `"/wt/fix-login"` | `"/wt/fix-login"` |
+| 一致するか | する | **しない** |
+
+`canonicalPath` は存在しないパスでは `path.resolve` にフォールバックするので、POSIX では
+リテラルと同値になり、たまたま通っていた。
+
+## もう一つの害: Windows では 4 件が空振りで緑だった
+
+`survivorCandidates` の spec 6 件のうち 4 件は「`[]` が返ること」を確かめる否定テストなので、
+Windows では **何を渡しても `[]`** = 間違った理由で緑。落ちた 2 件はたまたま肯定テストだった。
+つまり Windows 上ではこの spec 群が実質無効だった。
+
+## 直し方
+
+1. `test/server/session/dir-session.spec.ts` — `dir` 引数を `canonicalPath()` を通した定数
+   （`WORKTREE` / `ELSEWHERE`）にする。**record の `cwd` は生の綴りのまま**にする: ログが実際に
+   保持しているのはそちらで、非対称なままにしておくのが本番と同じ形。
+2. 同 spec に「record の cwd が同じディレクトリを別の綴りで書いている場合も一致する」ケースを追加。
+   両辺が同じリテラルの spec は「本当に比較している」のと「常に同じ答えを返す」のを区別できず、
+   それが今回の失敗が隠れた理由そのものなので、正規化を経由することを固定する。
+   `/wt/other/../fix-login` を使うので symlink を掘らずに済み、Windows でも同じ意味になる。
+3. `test/server/routes/ws-session-admission.spec.ts` — #1534 のレビューで CodeRabbit が指摘した
+   まま未対応だった **`settledEntry` の拒否ブランチ**（error frame + `early.discard()`）を 2 ケース
+   追加。`closeWithError` は OPEN なソケットにしか送らないので、専用の `fakeOpenWs` を足す
+   （既存の `fakeWs` で書くと「フレームを一切送らなくても緑」になる）。
+
+## 同クラスの掃き出し
+
+`canonicalPath` を使うプロダクション側は `codex-session.ts` / `config/worktree-env.ts` /
+`git/worktrees.ts` / `session/dir-session.ts` / `session/worktree-session-limit.ts`。
+
+- `codex-session.ts` の `sameDir` は **両辺**を正規化しているのでリテラル同士でも Windows で一致する
+- 他は spec が実 tmpdir を使っている
+
+→ 片側だけ正規化する非対称な契約を持つのは `survivorCandidates` だけだった。
+
+## 計測のうえ「変更しない」と決めたもの
+
+#1534 のレビューで挙げたコスト懸念は実データで計測した結果、誤差だった:
+
+| 項目 | 実測 |
+|---|---|
+| grok survivor の `existsSync` 480 回（24 running key × 2 綴り × 10 worktree 相当） | 0.54 ms |
+| conversation ログ再読み（実ファイル 1 KB / 4 行）× 10 | 0.036 ms |
+| `tmux list-sessions` 同期 spawn | 7.0 ms / 回 |
+
+効くのは同期 tmux spawn だけで、`/api/worktrees` と WS connect というユーザー操作起点のパスに
+1 回ずつ。ここに短期キャッシュを入れると #1534 が直したばかりのオカレンシー鮮度を削るので、
+入れない。
+
+`GridView.onClose` がセッションを terminate するようになった件も #1534 の意図的な変更
+（TerminalCell の × ボタンと揃える）なので変更しない。
+
+## 検証
+
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
+- **Windows は `workflow_dispatch` でこのブランチに対して実際に回す**。ローカル macOS で緑なのは
+  今回の不具合について何も言わない（元の spec も macOS では緑だった）ので、外部の ground truth に
+  当てる。
+
+## この issue の対象外
+
+#1536 / #1537（#1534 の作者が直後に立てた follow-up。再起動後のエンドポイント検証と codex の
+activity 再アーム）は別途。

--- a/test/server/routes/ws-session-admission.spec.ts
+++ b/test/server/routes/ws-session-admission.spec.ts
@@ -47,6 +47,13 @@ describe("wrongEndpointReason", () => {
 
 describe("settledEntry", () => {
   const fakeWs = () => ({ close: vi.fn() }) as unknown as WebSocket & { close: ReturnType<typeof vi.fn> };
+  // An OPEN socket, because `closeWithError` sends nothing to one that is not — a refusal tested
+  // against the bare `fakeWs` above would pass while delivering no error frame at all.
+  const fakeOpenWs = () =>
+    ({ close: vi.fn(), send: vi.fn(), OPEN: 1, readyState: 1 }) as unknown as WebSocket & {
+      close: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+    };
   const fakeEarly = () => ({ discard: vi.fn(), release: vi.fn() }) as unknown as EarlyFrames & { discard: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
@@ -71,6 +78,29 @@ describe("settledEntry", () => {
   it("proceeds to a spawn when there never was an entry", () => {
     const settled = settledEntry(fakeWs(), "claude", SID, false, fakeEarly());
     expect(settled).toEqual({ entry: undefined });
+  });
+
+  // The branch the other four do not reach: an ERROR frame, not a plain close. A plain close has
+  // the client retry the same mismatched id forever with backoff, and the mismatch is persisted
+  // state only the user can act on — so the frame is what ends the loop and says why.
+  it("refuses a mismatched agent with an error frame, not a plain close", () => {
+    ptys.set(SID, entryOf("muse"));
+    const ws = fakeOpenWs();
+    const early = fakeEarly();
+    expect(settledEntry(ws, "claude", SID, true, early)).toBeNull();
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"type":"error"'));
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining("running muse, not claude"));
+    expect(ws.close).toHaveBeenCalledOnce();
+    expect(early.discard).toHaveBeenCalledOnce();
+  });
+
+  // The mismatch is judged on the entry THIS turn finds, so it fires for one a competing connect
+  // spawned under the id while this connect was being admitted — not only for a resolve-time one.
+  it("refuses a mismatched entry that appeared where the resolve saw none", () => {
+    ptys.set(SID, entryOf("codex"));
+    const ws = fakeOpenWs();
+    expect(settledEntry(ws, "launch", SID, false, fakeEarly())).toBeNull();
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining("running codex, not launch"));
   });
 
   // The reap fired mid-admission: the snapshot is a corpse. A PLAIN close, not an error frame —

--- a/test/server/session/dir-session.spec.ts
+++ b/test/server/session/dir-session.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { grokSurvivorCandidates, pickDirSession, survivorCandidates, type DirSessionCandidate, type SurvivorLog } from "../../../server/session/dir-session";
+import { canonicalPath } from "../../../server/infra/canonical-path";
 import type { AgentConversation } from "../../../server/session/agent-conversations";
 
 const candidate = (over: Partial<DirSessionCandidate> & { id: string }): DirSessionCandidate => ({
@@ -54,6 +55,14 @@ describe("pickDirSession", () => {
 // key to a directory. Reading it as "no session here" is how a worktree admitted a second agent
 // beside a running one, and how a conversation ended up with two backends (#1533).
 describe("survivorCandidates", () => {
+  // The `dir` argument is CANONICAL by contract — `dirSession` hands it `canonicalPath(dir)` and
+  // this pass canonicalizes only the record's side — so the spec has to canonicalize it too. A raw
+  // POSIX literal compared `/wt/fix-login` against Windows's `D:\wt\fix-login`, which made every
+  // case here return nothing: the two positive cases failed, and the four negative ones passed for
+  // the wrong reason (#1539). The RECORD keeps its raw spelling, which is what the log really
+  // holds.
+  const WORKTREE = canonicalPath("/wt/fix-login");
+  const ELSEWHERE = canonicalPath("/wt/other");
   const record = (over: Partial<AgentConversation> = {}): AgentConversation => ({
     sessionId: "key-1",
     conversationId: "conv-1",
@@ -74,33 +83,41 @@ describe("survivorCandidates", () => {
   });
 
   it("names a running survivor as a LIVE candidate of its own agent", () => {
-    const found = survivorCandidates("/wt/fix-login", logs([record()]), facts());
+    const found = survivorCandidates(WORKTREE, logs([record()]), facts());
     expect(found).toEqual([{ id: "key-1", live: true, mtime: 42, agent: "codex", attached: false }]);
   });
 
   it("ignores a session that is not running — a dead key is the transcript passes' business", () => {
-    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ running: new Set() }))).toEqual([]);
+    expect(survivorCandidates(WORKTREE, logs([record()]), facts({ running: new Set() }))).toEqual([]);
   });
 
   // The live pass already names it, better: its pty knows the directory it ACTUALLY runs in,
   // where the log knows the one it was claimed in.
   it("leaves a session with a live pty to the live pass", () => {
-    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ liveHere: () => true }))).toEqual([]);
+    expect(survivorCandidates(WORKTREE, logs([record()]), facts({ liveHere: () => true }))).toEqual([]);
   });
 
   it("ignores another directory's survivor", () => {
-    expect(survivorCandidates("/wt/other", logs([record()]), facts())).toEqual([]);
+    expect(survivorCandidates(ELSEWHERE, logs([record()]), facts())).toEqual([]);
+  });
+
+  // The record holds whatever spelling the spawn was handed, so the match has to survive one — and
+  // a spec whose two sides are the same literal cannot tell a real comparison from one that always
+  // answers the same way, which is exactly how the Windows failure hid (#1539).
+  it("matches a record whose cwd spells the directory another way", () => {
+    const found = survivorCandidates(WORKTREE, logs([record({ cwd: "/wt/other/../fix-login" })]), facts());
+    expect(found.map((c) => c.id)).toEqual(["key-1"]);
   });
 
   it("excludes helper sessions, like every other pass", () => {
-    expect(survivorCandidates("/wt/fix-login", logs([record()]), facts({ userSession: () => false }))).toEqual([]);
+    expect(survivorCandidates(WORKTREE, logs([record()]), facts({ userSession: () => false }))).toEqual([]);
   });
 
   // The point of the pass meeting the point of the rank: the surviving backend must beat a newer
   // transcript, or the worktree row offers the conversation written to most recently while a
   // different one is still running (#1533).
   it("outranks a merely recent transcript once picked with", () => {
-    const survivor = survivorCandidates("/wt/fix-login", logs([record()]), facts())[0];
+    const survivor = survivorCandidates(WORKTREE, logs([record()]), facts())[0];
     const picked = pickDirSession([candidate({ id: "disk", mtime: 99 }), survivor]);
     expect(picked?.id).toBe("key-1");
   });


### PR DESCRIPTION
## Summary

`main` の **Windows (daily)** が #1534 のマージコミット `752961b5` から赤い。原因は #1534 で追加された `survivorCandidates` の spec が **正規化前のパスを `dir` に渡していた**こと。プロダクションコードは正しく、テストのみの移植性バグ。

あわせて、#1534 のレビューで CodeRabbit が指摘したまま未対応だった `settledEntry` の**拒否ブランチ**（error frame）のテストを追加した。

**テストのみの変更**（`test/` 2 ファイル + `plans/`）。プロダクションコードは 1 行も触っていない。

## Items to Confirm / Review

1. **`record.cwd` を生の綴りのままにした判断** — `dir` だけを `canonicalPath()` に通し、record 側はリテラルのままにした。本番と同じ非対称（ログは spawn が渡された綴りを保持し、`dir` は正規化済みで来る）を保つ意図。両方正規化しても緑にはなるが、それだと「比較が効いているか」を確かめられなくなる。
2. **追加した「別綴り」ケースの選び方** — `/wt/other/../fix-login` を使った。symlink を実際に掘らずに `canonicalPath` の正規化を経由でき、Windows でも同じ `D:\wt\fix-login` に落ちる。symlink での実 fs テストにすべきかは判断が分かれるところ。
3. **`fakeOpenWs` を足したこと** — `closeWithError` は `readyState === OPEN` のときしか送らないので、既存の `fakeWs`（`close` のみ）で書くと「フレームを一切送らなくても緑」になる。ここは意図的に別のフェイクにした。
4. **Windows での実証** — このブランチに対して `workflow_dispatch` で Windows (daily) を実際に回して確認する（ローカル macOS が緑なのは今回の不具合について何も言わない — 壊れた spec も macOS では緑だった）。

## User Prompt

- PR #1534 の変更に問題がなかったか、再度しっかり確認してほしい。
- その確認で「バグではないが把握しておくとよい点」として挙げた項目のうち対応できるものと、Windows の CI fix を進めてほしい。

## 何が起きていたか

```
FAIL test/server/session/dir-session.spec.ts > survivorCandidates
  > names a running survivor as a LIVE candidate of its own agent
      AssertionError: expected [] to deeply equal [ { id: 'key-1', live: true, … } ]
  > outranks a merely recent transcript once picked with
      TypeError: Cannot read properties of undefined (reading 'attached')   ← 1 件目の連鎖
Tests  2 failed | 9255 passed | 10 skipped
```

Node 22.x / 24.x の両方で再現。[run 31205147079](https://github.com/receptron/mulmoterminal/actions/runs/31205147079)

Windows は PR の required check に入っていない（`windows-daily.yaml` は `push: [main]` + schedule + `workflow_dispatch`）ため、#1534 は緑のままマージされ、main への push で初めて落ちた。

## 根本原因

`survivorCandidates(dir, logs, facts)` は **`dir` を正規化済みで受け取る契約**で、比較は片側だけを正規化する:

```ts
// server/session/dir-session.ts
if (canonicalPath(record.cwd) !== dir) return [];
```

呼び出し元 `dirSession` は `canonicalPath(dir)` を渡している（= **プロダクションは正しい**）。spec だけが生の POSIX リテラルを渡していた:

| | POSIX | Windows |
|---|---|---|
| `canonicalPath("/wt/fix-login")`（record 側） | `/wt/fix-login` | `D:\wt\fix-login` |
| spec が渡した `dir` | `"/wt/fix-login"` | `"/wt/fix-login"` |
| 一致するか | する | **しない** |

`canonicalPath` は存在しないパスでは `path.resolve` にフォールバックするので、POSIX ではリテラルと同値になり、たまたま通っていた。

## もう一つの害: Windows では 4 件が空振りで緑だった

`survivorCandidates` の spec 6 件のうち 4 件は「`[]` が返ること」を確かめる否定テストなので、Windows では **何を渡しても `[]`** = 間違った理由で緑。落ちた 2 件はたまたま肯定テストだった。つまり Windows 上ではこの spec 群が実質無効だった。これが「別綴り」ケースを足した理由で、両辺が同じリテラルの spec は「本当に比較している」のと「常に同じ答えを返す」のを区別できない。

## 同クラスの掃き出し

`canonicalPath` を使うプロダクション側は `codex-session.ts` / `config/worktree-env.ts` / `git/worktrees.ts` / `session/dir-session.ts` / `session/worktree-session-limit.ts`。

- `codex-session.ts` の `sameDir`（#1534 で追加）は **両辺**を正規化しているのでリテラル同士でも Windows で一致する
- 他は spec が実 tmpdir を使っている

→ 片側だけ正規化する非対称な契約を持つのは `survivorCandidates` だけだった。

## 計測のうえ「変更しない」と決めたもの

#1534 のレビューで挙げたコスト懸念は実データで計測した結果、誤差だった:

| 項目 | 実測 |
|---|---|
| grok survivor の `existsSync` 480 回（24 running key × 2 綴り × 10 worktree 相当） | 0.54 ms |
| conversation ログ再読み（実ファイル 1 KB / 4 行）× 10 | 0.036 ms |
| `tmux list-sessions` 同期 spawn | 7.0 ms / 回 |

効くのは同期 tmux spawn だけで、`/api/worktrees` と WS connect というユーザー操作起点のパスに 1 回ずつ。ここに短期キャッシュを入れると #1534 が直したばかりのオカレンシー鮮度を削るので入れない。

`GridView.onClose` がセッションを terminate するようになった件も #1534 の意図的な変更（TerminalCell の × ボタンと揃える）なので変更しない。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck`（exit 0）/ `yarn build`（exit 0）
- `yarn test` — 637 files passed | **9225 passed** | 45 skipped
- Windows は `workflow_dispatch` でこのブランチに対して実際に回す

## この PR の対象外

#1536 / #1537 は #1534 の作者が直後に立てた follow-up（サーバ再起動後のエンドポイント/エージェント検証、codex の activity 再アーム）。別途対応。

Closes #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows session handling by consistently recognizing equivalent directory path formats.
  * Mismatched session agents are now rejected with an error message and closed connection.
  * Fixed validation for sessions discovered after admission processing begins.

* **Tests**
  * Expanded coverage for survivor sessions, directory states, running sessions, live terminals, helper sessions, and ranking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->