### PR TITLE
fix(session): refuse a provably foreign tmux survivor at the endpoint (#1537)

### DIFF
--- a/server/agents/grok-session.ts
+++ b/server/agents/grok-session.ts
@@ -8,7 +8,7 @@
 // The layout is `~/.grok/sessions/<encoded cwd>/<uuid>/`, partitioned by WORKING DIRECTORY. That
 // partition is why this takes a cwd where the antigravity probe does not: the same id under a
 // different directory is a different lookup, and asking without the cwd cannot be answered.
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -45,4 +45,21 @@ export const grokSessionDir = (root: string, cwd: string, id: string): string =>
  *  resuming from a key that only ever named a MulmoTerminal session. */
 export function grokConversationExists(root: string, cwd: string, id: string): boolean {
   return UUID_RE.test(id) && existsSync(grokSessionDir(root, cwd, id));
+}
+
+/** The same probe with no cwd to ask under: does ANY directory hold a conversation by this id?
+ *  The survivor-identity guard (#1537) asks this of a tmux session that outlived a restart,
+ *  where the request's cwd is the least trustworthy value on the path — often absent and then
+ *  defaulted — so a per-cwd probe would miss the conversation that is right there. One readdir
+ *  over the cwd partitions, the same walk claudeOnDiskSessionIds does over claude's projects.
+ *  A missing root reads as empty: grok never ran, so nothing is held. */
+export function grokConversationExistsInAnyCwd(root: string, id: string): boolean {
+  if (!UUID_RE.test(id)) return false;
+  let cwds: string[];
+  try {
+    cwds = readdirSync(root);
+  } catch {
+    return false;
+  }
+  return cwds.some((encodedCwd) => existsSync(path.join(root, encodedCwd, id)));
 }

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -63,6 +63,7 @@ import { terminalWsKind, type TerminalWsKind } from "./terminal-ws-path.js";
 import { normalizeAgent, parseIndexParam } from "./routeParams.js";
 import { agentResumeId } from "../agents/agent-resume.js";
 import { claimLaunch, worktreeOccupancy } from "../session/worktree-session-limit.js";
+import { foreignTmuxSurvivorReason } from "../session/survivor-agent-guard.js";
 import { worktreeRefusal } from "../../common/worktreeSession.js";
 import { ensureWorktreeEnv } from "../config/worktree-env.js";
 import { isCustomAgentId } from "../../common/customAgents.js";
@@ -235,10 +236,10 @@ async function refuseSecondWorktreeSession(
  * Everything an agent endpoint does between resolving its session and spawning it, in the order
  * the four of them (claude, launch, codex, antigravity) already ran it in.
  *
- * The order is the fragile part: the worktree refusal has to happen BEFORE the browser is told a
- * session id (#1207), and the dev-terminal mark has to be recorded on every attach — new, resumed
- * or reattached — which is what makes this the single choke point for the chat sidebar's exclusion
- * list (see devTerminalSessions).
+ * The order is the fragile part: the survivor-identity refusal and the worktree refusal have to
+ * happen BEFORE the browser is told a session id (#1537, #1207), and the dev-terminal mark has to
+ * be recorded on every attach — new, resumed or reattached — which is what makes this the single
+ * choke point for the chat sidebar's exclusion list (see devTerminalSessions).
  *
  * Returns null when the socket was refused and closed: the caller must return without spawning.
  */
@@ -258,6 +259,20 @@ async function admitAgentSession(
   },
 ): Promise<EarlyFrames | null> {
   const { requested, sessionId, live, cwd, devTerminal, worktreeLimited = true } = session;
+  // A live entry is already agent-checked by settledEntry (wrongEndpointReason); a tmux-only
+  // survivor — a reconnect after a server restart — has no entry to check, and `tmux
+  // new-session -A` would attach whatever runs in the pane under THIS endpoint's identity.
+  // Refused before the browser is told an id, and loudly for settledEntry's reason: the
+  // mismatch is a persisted-state defect the user has to act on, and a plain close would
+  // just retry it forever (#1537).
+  if (!live) {
+    const foreign = await foreignTmuxSurvivorReason(kind, sessionId);
+    if (foreign) {
+      console.warn(`[ws/${kind}] refusing ${sessionId} — ${foreign}`);
+      closeWithError(ws, `${foreign} — open it from its own agent's cell.`);
+      return null;
+    }
+  }
   if (worktreeLimited && (await refuseSecondWorktreeSession(ws, kind, cwd, { requested, sessionId }))) return null;
   if (devTerminal) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   markAttachedSessionPlaced(sessionId, requested);

--- a/server/session/survivor-agent-guard.ts
+++ b/server/session/survivor-agent-guard.ts
@@ -24,7 +24,7 @@ import { claudeOnDiskSessionIds } from "./session-reads.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
-import { grokConversationExists, grokSessionsRoot } from "../agents/grok-session.js";
+import { grokConversationExistsInAnyCwd, grokSessionsRoot } from "../agents/grok-session.js";
 import { ptyWouldReattach } from "./pty-spawn.js";
 import {
   antigravityConversations,
@@ -71,9 +71,25 @@ async function survivorEvidence(): Promise<SurvivorEvidence> {
     codex: (id) => codexRollouts.has(id) || codexRolloutExists(codexSessionsRoot(), id),
     antigravity: (id) => antigravityConversations.has(id) || antigravityConversationExists(antigravityBrainRoot(), id),
     // grok takes `--session-id`, so the key is grok's own conversation id — no mapping exists.
-    grok: (id) => grokConversationExists(grokSessionsRoot(), id),
+    // Probed across every cwd partition: the request's cwd is untrustworthy on this path.
+    grok: (id) => grokConversationExistsInAnyCwd(grokSessionsRoot(), id),
     muse: (id) => museConversations.has(id),
   };
+}
+
+// One snapshot per reconnect burst, not per socket. After a restart every surviving cell
+// reconnects within moments, `sessionConnects` serializes only EQUAL ids, and the claude
+// evidence is a synchronous walk of every project directory — repeated per cell it blocks
+// the event loop exactly when every terminal is trying to come back (Codex review on
+// #1541). Staleness within the window only fails OPEN: evidence appearing mid-burst reads
+// as silence, which attaches as requested — the same answer no-evidence gives. It never
+// manufactures a refusal, and the tmux recheck below owns the pane-died race.
+const EVIDENCE_SNAPSHOT_MS = 5000;
+let snapshot: { at: number; evidence: Promise<SurvivorEvidence> } | null = null;
+function sharedSurvivorEvidence(): Promise<SurvivorEvidence> {
+  const now = Date.now();
+  if (!snapshot || now - snapshot.at > EVIDENCE_SNAPSHOT_MS) snapshot = { at: now, evidence: survivorEvidence() };
+  return snapshot.evidence;
 }
 
 /** The refusal for a connect that would attach a surviving tmux session, or null to proceed.
@@ -81,5 +97,10 @@ async function survivorEvidence(): Promise<SurvivorEvidence> {
  *  itself so a session that died since resolve is a plain spawn, not a refusal. */
 export async function foreignTmuxSurvivorReason(endpoint: TerminalWsKind, sessionId: string): Promise<string | null> {
   if (endpoint === "run" || !ptyWouldReattach(sessionId, true)) return null;
-  return foreignSurvivorReason(endpoint, survivorAgents(sessionId, await survivorEvidence()));
+  const reason = foreignSurvivorReason(endpoint, survivorAgents(sessionId, await sharedSurvivorEvidence()));
+  // Re-asked AFTER the evidence await: the pane can exit while the disk is read, and then
+  // there is no survivor left to protect — the refusal is terminal to the client, so issuing
+  // it on old transcript data would permanently refuse a request that should fall through to
+  // a fresh spawn (Codex review on #1541). Only a still-live pane is worth refusing over.
+  return reason && ptyWouldReattach(sessionId, true) ? reason : null;
 }

--- a/server/session/survivor-agent-guard.ts
+++ b/server/session/survivor-agent-guard.ts
@@ -1,0 +1,85 @@
+// Whether a surviving tmux session may be served to the endpoint asking for it (#1537).
+//
+// A same-process reattach is guarded by wrongEndpointReason, which compares the endpoint
+// against the live PtyEntry's agent. After a server restart there is no entry to compare:
+// `ptys` is empty while tmux still holds `mt-<session>`, the resolvers keep the requested id
+// on tmux liveness alone, and `tmux new-session -A` attaches whatever runs in the pane while
+// IGNORING the argv the endpoint's spawner built. The recreated PtyEntry then records the
+// ENDPOINT's agent — so stale or coerced persisted grid state (asTerminalAgent reads any
+// unrecognised value as "claude") could relabel a surviving codex as claude, and every later
+// same-process guard would trust the wrong label.
+//
+// The rule here is refuse-on-proof, attach-on-silence. What a session belongs to is only
+// knowable from the durable evidence an agent left under the session's own key — a claude
+// transcript, a codex rollout mapping (or the key being a rollout id), agy's and muse's
+// conversation maps, a grok conversation named by the key. A launcher/shell survivor leaves
+// none of those, and neither does an agent session that never reached its first turn.
+// Refusing the unknowable would shut users out of legitimately surviving sessions — a worse
+// failure than the mislabel — so no evidence (or contradictory evidence) attaches as
+// requested. That blind spot is accepted, not overlooked.
+
+import { TERMINAL_AGENTS, type TerminalAgent } from "../../common/sessionAgent.js";
+import type { TerminalWsKind } from "../routes/terminal-ws-path.js";
+import { claudeOnDiskSessionIds } from "./session-reads.js";
+import { codexSessionsRoot } from "../agents/codex-session.js";
+import { codexRolloutExists } from "../agents/codex-sessions.js";
+import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
+import { grokConversationExists, grokSessionsRoot } from "../agents/grok-session.js";
+import { ptyWouldReattach } from "./pty-spawn.js";
+import {
+  antigravityConversations,
+  antigravityConversationsHydrated,
+  codexRollouts,
+  codexRolloutsHydrated,
+  museConversations,
+  museConversationsHydrated,
+} from "./registry.js";
+
+/** Who left durable evidence under a session key, as one predicate per agent. */
+export type SurvivorEvidence = Record<TerminalAgent, (id: string) => boolean>;
+
+/** The agents with evidence for this key. More than one is contradictory — ids are minted
+ *  UUIDs, so two agents claiming one key means the evidence itself is off, and the caller
+ *  treats it as silence rather than picking a side. */
+export function survivorAgents(id: string, evidence: SurvivorEvidence): TerminalAgent[] {
+  return TERMINAL_AGENTS.filter((agent) => evidence[agent](id));
+}
+
+/** The refusal, or null to attach. Only single, unambiguous evidence refuses; the wording
+ *  matches wrongEndpointReason's so the two guards read as one rule from the browser. */
+export function foreignSurvivorReason(endpoint: TerminalWsKind, agents: readonly TerminalAgent[]): string | null {
+  // The run endpoint is ephemeral and owns no sessions; a launcher's survivors are shells
+  // and command lines, for which no evidence exists — its mismatches are exactly the
+  // provable ones (an agent's own key opened as a chip).
+  if (endpoint === "run") return null;
+  if (agents.length !== 1) return null;
+  const survivor = agents[0];
+  if (survivor === endpoint) return null;
+  return `Session belongs to ${survivor}, not ${endpoint}`;
+}
+
+// The real evidence, awaited once per ask: the maps hydrate from disk at boot, and a
+// reconnect racing that read would see empty maps and wave a provable mismatch through —
+// the same wait the codex and antigravity connect paths already take before resolving.
+async function survivorEvidence(): Promise<SurvivorEvidence> {
+  await Promise.all([codexRolloutsHydrated, antigravityConversationsHydrated, museConversationsHydrated]);
+  const claudeOnDisk = claudeOnDiskSessionIds();
+  return {
+    claude: (id) => claudeOnDisk.has(id),
+    // The mapping covers a cell-minted key; the direct probe covers a sidebar resume,
+    // where the key IS the rollout id and the mapping may not have been written yet.
+    codex: (id) => codexRollouts.has(id) || codexRolloutExists(codexSessionsRoot(), id),
+    antigravity: (id) => antigravityConversations.has(id) || antigravityConversationExists(antigravityBrainRoot(), id),
+    // grok takes `--session-id`, so the key is grok's own conversation id — no mapping exists.
+    grok: (id) => grokConversationExists(grokSessionsRoot(), id),
+    muse: (id) => museConversations.has(id),
+  };
+}
+
+/** The refusal for a connect that would attach a surviving tmux session, or null to proceed.
+ *  Asked only when there is no live entry (wrongEndpointReason owns that case); asks tmux
+ *  itself so a session that died since resolve is a plain spawn, not a refusal. */
+export async function foreignTmuxSurvivorReason(endpoint: TerminalWsKind, sessionId: string): Promise<string | null> {
+  if (endpoint === "run" || !ptyWouldReattach(sessionId, true)) return null;
+  return foreignSurvivorReason(endpoint, survivorAgents(sessionId, await survivorEvidence()));
+}

--- a/test/server/agents/grok-session.spec.ts
+++ b/test/server/agents/grok-session.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { encodeGrokCwd, grokSessionDir, grokConversationExists } from "../../../server/agents/grok-session.js";
+import { encodeGrokCwd, grokSessionDir, grokConversationExists, grokConversationExistsInAnyCwd } from "../../../server/agents/grok-session.js";
 
 const ID = "019fcf22-289b-7773-b19c-462d5c08d061";
 const roots: string[] = [];
@@ -63,5 +63,25 @@ describe("grokConversationExists", () => {
     const root = tempRoot();
     mkdirSync(path.join(root, encodeGrokCwd(cwd), "not-a-uuid"), { recursive: true });
     expect(grokConversationExists(root, cwd, "not-a-uuid")).toBe(false);
+  });
+});
+
+// The survivor-identity guard's probe (#1537): after a restart the request's cwd is often the
+// defaulted workspace, so asking under it would miss the conversation that is right there.
+describe("grokConversationExistsInAnyCwd", () => {
+  const cwd = "/Users/satoshi/project";
+
+  it("finds the conversation whichever cwd partition holds it", () => {
+    const root = tempRoot();
+    mkdirSync(grokSessionDir(root, cwd, ID), { recursive: true });
+    expect(grokConversationExistsInAnyCwd(root, ID)).toBe(true);
+  });
+
+  it("is false for an id grok never minted, for a missing root, and for a non-UUID key", () => {
+    const root = tempRoot();
+    mkdirSync(path.join(root, encodeGrokCwd(cwd)), { recursive: true });
+    expect(grokConversationExistsInAnyCwd(root, ID)).toBe(false);
+    expect(grokConversationExistsInAnyCwd(path.join(root, "nope"), ID)).toBe(false);
+    expect(grokConversationExistsInAnyCwd(root, "not-a-uuid")).toBe(false);
   });
 });

--- a/test/server/routes/ws-restart-reattach.spec.ts
+++ b/test/server/routes/ws-restart-reattach.spec.ts
@@ -19,11 +19,14 @@ const mocks = vi.hoisted(() => ({
   tmuxHas: false,
   // What the dev-terminal cwd log remembers for the session, or null for one it never saw.
   rememberedCwd: null as string | null,
+  // The session ids with a claude transcript on disk — the #1537 guard's claude evidence.
+  claudeOnDisk: [] as string[],
   // Lets a test simulate the client leaving inside an admission await.
   onEnsureWorktreeEnv: () => {},
 }));
 
 const ptys = new Map<string, unknown>();
+const codexRollouts = new Map<string, unknown>();
 vi.mock("../../../server/session/registry.js", () => ({
   ptys,
   sessionCwd: () => mocks.rememberedCwd,
@@ -32,11 +35,26 @@ vi.mock("../../../server/session/registry.js", () => ({
   antigravityConversationsHydrated: Promise.resolve(),
   museConversations: new Map(),
   museConversationsHydrated: Promise.resolve(),
-  codexRollouts: new Map(),
+  codexRollouts,
   codexRolloutsHydrated: Promise.resolve(),
   customAgentSessionsHydrated: Promise.resolve(),
   markDevTerminalSession: vi.fn(),
   markAttachedSessionPlaced: vi.fn(),
+}));
+
+// The #1537 guard's other evidence probes walk the developer's real home directories; each is
+// pinned so a survivor's identity in these tests comes only from what a test declares.
+vi.mock("../../../server/session/session-reads.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/session/session-reads.js")>()),
+  claudeOnDiskSessionIds: () => new Set(mocks.claudeOnDisk),
+}));
+vi.mock("../../../server/agents/antigravity-session.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/antigravity-session.js")>()),
+  antigravityConversationExists: () => false,
+}));
+vi.mock("../../../server/agents/grok-session.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/agents/grok-session.js")>()),
+  grokConversationExists: () => false,
 }));
 
 vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
@@ -104,9 +122,11 @@ const request = (query = "") => ({ url: `/ws?cwd=${encodeURIComponent(dir)}${que
 
 beforeEach(() => {
   ptys.clear();
+  codexRollouts.clear();
   vi.clearAllMocks();
   mocks.tmuxHas = false;
   mocks.rememberedCwd = null;
+  mocks.claudeOnDisk = [];
   mocks.onEnsureWorktreeEnv = () => {};
   registeredGuiMcpGroups.mockResolvedValue(["render"]);
   dir = mkdtempSync(path.join(tmpdir(), "mt-ws-restart-"));
@@ -148,6 +168,49 @@ describe("/ws (claude) admission", () => {
 
   it("spawns for a client that stayed", async () => {
     await handleClaudeConnection(makeDeps(), fakeWs() as unknown as WebSocket, request());
+    expect(spawnClaudePty).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The #1537 guard, through the real handlers: a tmux-only survivor has no PtyEntry for
+// wrongEndpointReason to compare, and `tmux new-session -A` attaches whatever runs in the pane
+// while ignoring the argv — so a stale persisted cell could relabel a codex survivor as claude.
+describe("tmux survivor identity (#1537)", () => {
+  const codexEvidence = () => codexRollouts.set(SID, { sessionId: SID, conversationId: "c1", cwd: "/w", startedAt: 1 });
+
+  it("refuses, loudly, a claude reconnect to a survivor codex's evidence claims", async () => {
+    mocks.tmuxHas = true;
+    codexEvidence();
+    const ws = fakeWs();
+    await handleClaudeConnection(makeDeps(), ws as unknown as WebSocket, request(`&session=${SID}`));
+    expect(spawnClaudePty).not.toHaveBeenCalled();
+    // An error frame, not a plain close: a plain close makes the client retry the same
+    // mismatched id forever, and the defect is persisted state the user has to act on.
+    expect(ws.sent.some((frame) => frame.includes("belongs to codex, not claude"))).toBe(true);
+  });
+
+  it("refuses the reverse — a codex reconnect to a survivor with a claude transcript", async () => {
+    mocks.tmuxHas = true;
+    mocks.claudeOnDisk = [SID];
+    const ws = fakeWs();
+    await handleCodexConnection(makeDeps(), ws as unknown as WebSocket, request(`&gui=0&session=${SID}`));
+    expect(spawnCodexPty).not.toHaveBeenCalled();
+    expect(ws.sent.some((frame) => frame.includes("belongs to claude, not codex"))).toBe(true);
+  });
+
+  it("serves a survivor to its own endpoint, evidence agreeing", async () => {
+    mocks.tmuxHas = true;
+    codexEvidence();
+    await handleCodexConnection(makeDeps(), fakeWs() as unknown as WebSocket, request(`&gui=0&session=${SID}`));
+    expect(spawnCodexPty).toHaveBeenCalledTimes(1);
+  });
+
+  // Refuse-on-proof only: a shell/launcher survivor (or an agent that never reached its first
+  // turn) leaves no evidence, and locking users out of a legitimately surviving session would
+  // be worse than the mislabel this guard prevents.
+  it("attaches an evidence-less survivor as requested", async () => {
+    mocks.tmuxHas = true;
+    await handleClaudeConnection(makeDeps(), fakeWs() as unknown as WebSocket, request(`&session=${SID}`));
     expect(spawnClaudePty).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/server/routes/ws-restart-reattach.spec.ts
+++ b/test/server/routes/ws-restart-reattach.spec.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   rememberedCwd: null as string | null,
   // The session ids with a claude transcript on disk — the #1537 guard's claude evidence.
   claudeOnDisk: [] as string[],
+  // Whether grok holds a conversation under the requested key, in any cwd partition.
+  grokHas: false,
   // Lets a test simulate the client leaving inside an admission await.
   onEnsureWorktreeEnv: () => {},
 }));
@@ -54,8 +56,14 @@ vi.mock("../../../server/agents/antigravity-session.js", async (importOriginal) 
 }));
 vi.mock("../../../server/agents/grok-session.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../server/agents/grok-session.js")>()),
-  grokConversationExists: () => false,
+  grokConversationExistsInAnyCwd: () => mocks.grokHas,
 }));
+
+// The guard shares one evidence snapshot per reconnect burst (EVIDENCE_SNAPSHOT_MS). Each test
+// here is its own burst, so the clock steps past the window in beforeEach — otherwise one
+// test's snapshot (its claude transcript set, baked at walk time) answers for the next.
+let nowMs = 0;
+vi.spyOn(Date, "now").mockImplementation(() => nowMs);
 
 vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../server/infra/tmux.js")>()),
@@ -127,7 +135,9 @@ beforeEach(() => {
   mocks.tmuxHas = false;
   mocks.rememberedCwd = null;
   mocks.claudeOnDisk = [];
+  mocks.grokHas = false;
   mocks.onEnsureWorktreeEnv = () => {};
+  nowMs += 60_000;
   registeredGuiMcpGroups.mockResolvedValue(["render"]);
   dir = mkdtempSync(path.join(tmpdir(), "mt-ws-restart-"));
 });
@@ -196,6 +206,15 @@ describe("tmux survivor identity (#1537)", () => {
     await handleCodexConnection(makeDeps(), ws as unknown as WebSocket, request(`&gui=0&session=${SID}`));
     expect(spawnCodexPty).not.toHaveBeenCalled();
     expect(ws.sent.some((frame) => frame.includes("belongs to claude, not codex"))).toBe(true);
+  });
+
+  it("refuses a claude reconnect to a survivor grok's evidence claims", async () => {
+    mocks.tmuxHas = true;
+    mocks.grokHas = true;
+    const ws = fakeWs();
+    await handleClaudeConnection(makeDeps(), ws as unknown as WebSocket, request(`&session=${SID}`));
+    expect(spawnClaudePty).not.toHaveBeenCalled();
+    expect(ws.sent.some((frame) => frame.includes("belongs to grok, not claude"))).toBe(true);
   });
 
   it("serves a survivor to its own endpoint, evidence agreeing", async () => {

--- a/test/server/session/survivor-agent-guard.spec.ts
+++ b/test/server/session/survivor-agent-guard.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+// The #1537 rule: a surviving tmux session is refused to a FOREIGN endpoint only on proof.
+// `tmux new-session -A` attaches whatever runs in the pane while ignoring the argv, so after a
+// server restart a stale persisted cell (asTerminalAgent reads any unrecognised value as
+// "claude") could relabel a surviving codex as claude — and nothing on that path compared
+// anything, because wrongEndpointReason needs a live PtyEntry to compare against.
+import { describe, it, expect } from "vitest";
+import { survivorAgents, foreignSurvivorReason, type SurvivorEvidence } from "../../../server/session/survivor-agent-guard.js";
+
+const noEvidence: SurvivorEvidence = {
+  claude: () => false,
+  codex: () => false,
+  antigravity: () => false,
+  grok: () => false,
+  muse: () => false,
+};
+const only = (agent: keyof SurvivorEvidence): SurvivorEvidence => ({ ...noEvidence, [agent]: () => true });
+
+describe("survivorAgents", () => {
+  it("names the one agent with evidence", () => {
+    expect(survivorAgents("id", only("codex"))).toEqual(["codex"]);
+    expect(survivorAgents("id", only("muse"))).toEqual(["muse"]);
+  });
+
+  it("stays silent with no evidence — the launcher/shell and pre-first-turn blind spot", () => {
+    expect(survivorAgents("id", noEvidence)).toEqual([]);
+  });
+
+  it("reports contradictory evidence as-is, for the caller to treat as silence", () => {
+    expect(survivorAgents("id", { ...only("claude"), codex: () => true })).toEqual(["claude", "codex"]);
+  });
+});
+
+describe("foreignSurvivorReason", () => {
+  it("serves a survivor to its own endpoint", () => {
+    expect(foreignSurvivorReason("claude", ["claude"])).toBeNull();
+    expect(foreignSurvivorReason("codex", ["codex"])).toBeNull();
+    expect(foreignSurvivorReason("grok", ["grok"])).toBeNull();
+  });
+
+  // The #1537 case: a coerced persisted cell reconnects a codex survivor through /ws.
+  it("refuses a provably foreign survivor", () => {
+    expect(foreignSurvivorReason("claude", ["codex"])).toContain("belongs to codex, not claude");
+    expect(foreignSurvivorReason("codex", ["claude"])).toContain("belongs to claude, not codex");
+    expect(foreignSurvivorReason("antigravity", ["muse"])).toContain("belongs to muse, not antigravity");
+  });
+
+  // A chip's survivors are shells and command lines, which leave no evidence — so evidence
+  // under a chip's key can only mean the key names an agent's session.
+  it("refuses an agent's own key opened as a launcher chip", () => {
+    expect(foreignSurvivorReason("launch", ["claude"])).toContain("belongs to claude, not launch");
+  });
+
+  // Refuse-on-proof, attach-on-silence: shutting users out of a legitimately surviving shell
+  // (or an agent session that never reached its first turn) would be worse than the mislabel.
+  it("attaches when there is no evidence", () => {
+    expect(foreignSurvivorReason("claude", [])).toBeNull();
+    expect(foreignSurvivorReason("launch", [])).toBeNull();
+  });
+
+  it("attaches on contradictory evidence rather than picking a side", () => {
+    expect(foreignSurvivorReason("claude", ["claude", "codex"])).toBeNull();
+    expect(foreignSurvivorReason("grok", ["claude", "codex"])).toBeNull();
+  });
+
+  it("has no opinion for the run endpoint, which owns no sessions", () => {
+    expect(foreignSurvivorReason("run", ["claude"])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1537: after a server restart, the endpoint/agent mismatch validation vanished — `settledEntry`'s `wrongEndpointReason` needs a live `PtyEntry` to compare against, `ptys` is empty while tmux still holds `mt-<session>`, the resolvers keep the requested id on tmux liveness alone, and `tmux new-session -A` attaches whatever runs in the pane while **ignoring** the argv the endpoint's spawner built. The recreated `PtyEntry` then records the *endpoint's* agent, so stale or coerced persisted grid state (`asTerminalAgent` reads any unrecognised value as `claude`) could relabel a surviving codex as claude — and every later same-process guard would trust the wrong label.

## The rule: refuse on proof, attach on silence

A new guard (`server/session/survivor-agent-guard.ts`) runs in `admitAgentSession` — the shared choke point for the claude, launch, codex and directory-MCP endpoints — **before the browser is told a session id**, and only when there is no live entry (the live case stays with `wrongEndpointReason`).

- **Evidence**: what an agent left durably under the session's own key — a claude transcript on disk, codex's rollout mapping (or the key itself being a rollout id, the sidebar-resume case), agy's and muse's hydrated conversation maps, a grok conversation named by the key (grok takes `--session-id`, so the key IS its id). The map hydrations are awaited so a reconnect racing boot cannot see empty maps and wave a provable mismatch through.
- **Single foreign evidence → loud refusal** (`closeWithError`), matching `settledEntry`'s behavior and wording — an error frame is what stops the client's reconnect loop, and the mismatch is persisted-state the user has to act on. A launcher chip carrying an agent's key is refused on the same rule: a chip's survivors are shells, which leave no evidence, so evidence under a chip's key can only mean the key names an agent's session.
- **No evidence, or contradictory evidence → attach as requested.** A shell/launcher survivor leaves no trace, and neither does an agent session that never reached its first turn. Refusing the unknowable would lock users out of legitimately surviving sessions — a worse failure than the mislabel — so that blind spot is accepted and documented in the module, not overlooked.

This catches the most likely and most consequential collision (claude↔codex, via the documented `asTerminalAgent` coercion) with the facts the server already persists — no new metadata store.

## Tests

- `test/server/session/survivor-agent-guard.spec.ts` (new) — the pure rule: own-endpoint match, provable mismatch per agent pair, the launcher-chip case, silence and contradiction attaching, `run` having no opinion.
- `test/server/routes/ws-restart-reattach.spec.ts` (extended) — through the real handlers with all evidence probes pinned: a claude reconnect to a codex-claimed survivor is refused with the error frame (no spawn); the reverse refusal; the same survivor served to its own endpoint; and an evidence-less survivor attaching as requested.

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn test` (9249 passed) all green.

Follow-up to #1538 (the #1536 restart-reattach fixes), per the discussion on #1536.

Fixes #1537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sessions from reconnecting to an existing terminal belonging to a different agent.
  * Added safer handling for restarted sessions when ownership evidence is missing, unclear, or contradictory.
  * Ensured inactive sessions continue through the normal session-start flow.
* **Tests**
  * Expanded coverage for cross-agent reconnection, matching sessions, unknown conversations, and invalid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->