### PR TITLE
feat: choose the agent for collection chats, and make workspace skills work on all of them

### DIFF
--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -503,7 +503,7 @@ yourself, add `"work"` to the list** — a configured list is the whole list.
 The header's **Skill** button (the bolt icon) lists the skills available in that directory
 (`<project>/.claude/skills` and `~/.claude/skills`). Working-dir (project) skills come
 first, then user-scope ones. Picking one runs the skill **in the current session**
-(Claude: `/<slug>`; Codex: `Use the "<slug>" skill.`).
+(Claude: `/<slug>`; other agents: `Use the "<slug>" skill.`).
 
 Set `skills` to an allowlist to show **only those slugs, in that order**. **Omit it to
 show everything.**

--- a/docs/guide/en/header.md
+++ b/docs/guide/en/header.md
@@ -276,7 +276,7 @@ The `env staging` on the right-hand cell of the screenshot above is exactly this
 The header's **⚡ Skill** lists the skills available in that directory (the project's
 `.claude/skills` first, then `~/.claude/skills`; alphabetical within each group, and a project
 skill shadows a user one of the same slug). Picking one runs it **in the current session**
-(`/<slug>` for Claude, `Use the "<slug>" skill.` for Codex).
+(`/<slug>` for Claude, `Use the "<slug>" skill.` for the other agents).
 
 ![The Skill menu](../images/header-skill-menu.png)
 

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -483,7 +483,7 @@ MulmoTerminal の「**拡張**」の柱がここ。稼働中ターミナルの�
 
 ### Skill メニューの絞り込み（`skills`）
 
-ヘッダーの **Skill**（雷のアイコン） はそのディレクトリで使えるスキル（`<project>/.claude/skills` と `~/.claude/skills`）を一覧します。working dir（プロジェクト）のスキルが先頭、その後にユーザースコープ。選ぶと**今のセッション**でそのスキルを実行します（Claude は `/<slug>`、Codex は `Use the "<slug>" skill.`）。
+ヘッダーの **Skill**（雷のアイコン） はそのディレクトリで使えるスキル（`<project>/.claude/skills` と `~/.claude/skills`）を一覧します。working dir（プロジェクト）のスキルが先頭、その後にユーザースコープ。選ぶと**今のセッション**でそのスキルを実行します（Claude は `/<slug>`、他のエージェントは `Use the "<slug>" skill.`）。
 
 `skills` を書くと**その slug だけを、その並び順で**表示する許可リストになります。**書かなければ全部**表示。
 

--- a/docs/guide/ja/header.md
+++ b/docs/guide/ja/header.md
@@ -276,7 +276,7 @@ Pull requests** も並びます。ここは固定なので設定では変わり�
 ヘッダーの **⚡ Skill** は、そのディレクトリで使えるスキルを一覧します（プロジェクトの
 `.claude/skills` が先、次に `~/.claude/skills`。それぞれの中はアルファベット順で、同じ slug が
 両方にあればプロジェクト側が勝ちます）。選ぶと**今のセッション**でそれを実行します
-（Claude は `/<slug>`、Codex は `Use the "<slug>" skill.`）。
+（Claude は `/<slug>`、他のエージェントは `Use the "<slug>" skill.`）。
 
 ![Skill メニュー](../images/header-skill-menu.png)
 

--- a/server/agents/antigravity-mcp.ts
+++ b/server/agents/antigravity-mcp.ts
@@ -22,6 +22,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import path from "node:path";
 import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 import { isRecord } from "../../common/isRecord.js";
+import { symlinkFreeWriteTarget } from "../infra/symlink-guard.js";
 import { bridgeCommand, OUR_GUI_SERVER_IDS } from "./gui-mcp-bridge.js";
 import { excludeFromGit } from "./git-exclude.js";
 
@@ -79,6 +80,10 @@ const EXCLUDE_ENTRY = `${CUSTOMIZATION_DIR}/mcp_config.json`;
 // project stops carrying a config for a feature it no longer has switched on.
 export function syncAntigravityMcpConfig(cwd: string, groups: readonly ToolGroup[]): void {
   const file = antigravityMcpConfigFile(cwd);
+  // Same guard as the skills config beside it: a checkout can commit `.agents` or the file
+  // itself as a symlink to somewhere of the repo author's choosing, and every fs call below
+  // follows links (symlink-guard.ts).
+  if (!symlinkFreeWriteTarget(file)) return;
   const existing = readMcpServers(file);
   if (existing === null) return;
   const mcpServers = mergeAntigravityMcpServers(existing, groups);

--- a/server/agents/antigravity-skills.ts
+++ b/server/agents/antigravity-skills.ts
@@ -1,0 +1,77 @@
+// Skill discovery for `agy`, which is the one agent that cannot see `.claude/skills` on its
+// own. claude reads it natively, grok and muse index Claude's skill roots themselves, and codex
+// gets a mirror (codex-skills.ts) — agy instead discovers skills through a JSON config in its
+// workspace customization dir: `.agents/skills.json`, a list of path entries to scan for
+// `<name>/SKILL.md` directories (same format as Claude's).
+//
+// So rather than mirror files a fourth time, we register the roots the other agents already
+// read: the directory's own `.claude/skills` (workspace-relative — agy resolves it against the
+// repo root) and the user-global `~/.claude/skills` (where the bundled mulmoterminal-* skills
+// are installed). The entries point at live directories, so a skill created mid-session — a new
+// collection, say — is visible to the next agy turn with no re-sync step anywhere.
+//
+// Like `.agents/mcp_config.json` (antigravity-mcp.ts), the file is shared by every session in
+// the directory and may be the user's own: their entries and any other fields (`inherits`,
+// fields we do not know) are preserved, and a file we cannot parse is left alone entirely.
+// Unlike the MCP config there is no off-switch and nothing machine-specific in what we add, so
+// entries are only ever ensured present, never removed — deleting a path entry we did not write
+// would break a user's own skill setup with no error anywhere.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
+import { excludeFromGit } from "./git-exclude.js";
+
+/** agy's workspace customization dir — the same one its MCP config lives in. */
+const CUSTOMIZATION_DIR = ".agents";
+
+export const antigravitySkillsConfigFile = (cwd: string): string => path.join(cwd, CUSTOMIZATION_DIR, "skills.json");
+
+/** The skill roots every agy session should scan: the directory's own project skills, and the
+ *  user-global root the bundled skills are installed into. Order is claude's own precedence
+ *  (project first). `~/` is agy's home-relative form, resolved by agy — not by us, so the file
+ *  stays portable across machines if a user does commit it. */
+export const SKILL_ENTRY_PATHS = [".claude/skills", "~/.claude/skills"] as const;
+
+// The merged config, or null for "do not write": the file is not ours to rewrite (not a JSON
+// object, `entries` is not an array) or already carries every root (rewriting anyway would churn
+// the file's mtime and formatting on every spawn for no change). Pure, so the "never lose a
+// user's entry" rule is testable without a filesystem.
+export function mergeAntigravitySkillsConfig(existing: unknown): Record<string, unknown> | null {
+  if (!isRecord(existing)) return null;
+  const raw = Object.prototype.hasOwnProperty.call(existing, "entries") ? existing.entries : [];
+  if (!Array.isArray(raw)) return null;
+  const entries: readonly unknown[] = raw;
+  const present = new Set(entries.map((entry) => (isRecord(entry) && typeof entry.path === "string" ? entry.path : null)));
+  const missing = SKILL_ENTRY_PATHS.filter((p) => !present.has(p));
+  if (missing.length === 0) return null;
+  return { ...existing, entries: [...entries, ...missing.map((p) => ({ path: p }))] };
+}
+
+// Kept out of the user's `git status` — see git-exclude.ts for why it is `.git/info/exclude`
+// and not their `.gitignore`. Excluding has no effect on a skills.json a team already commits
+// (exclude only hides untracked files), which is exactly the behaviour we want for both cases.
+const EXCLUDE_ENTRY = `${CUSTOMIZATION_DIR}/skills.json`;
+
+/** Point this directory's agy sessions at the skill roots. Idempotent, and quiet on failure: a
+ *  read-only project is a reason for agy to have no skills there, not for the session to fail
+ *  to start. */
+export function syncAntigravitySkillsConfig(cwd: string): void {
+  const file = antigravitySkillsConfigFile(cwd);
+  let existing: unknown = {};
+  if (existsSync(file)) {
+    try {
+      existing = JSON.parse(readFileSync(file, "utf8"));
+    } catch {
+      return; // present but not JSON — someone else's file, and rewriting it would lose it
+    }
+  }
+  const merged = mergeAntigravitySkillsConfig(existing);
+  if (merged === null) return;
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify(merged, null, 2) + "\n", "utf8");
+    excludeFromGit(cwd, EXCLUDE_ENTRY);
+  } catch (err) {
+    console.warn(`[antigravity] could not write ${file}: ${err}`);
+  }
+}

--- a/server/agents/antigravity-skills.ts
+++ b/server/agents/antigravity-skills.ts
@@ -19,6 +19,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
+import { symlinkFreeWriteTarget } from "../infra/symlink-guard.js";
 import { excludeFromGit } from "./git-exclude.js";
 
 /** agy's workspace customization dir — the same one its MCP config lives in. */
@@ -57,6 +58,10 @@ const EXCLUDE_ENTRY = `${CUSTOMIZATION_DIR}/skills.json`;
  *  to start. */
 export function syncAntigravitySkillsConfig(cwd: string): void {
   const file = antigravitySkillsConfigFile(cwd);
+  // A checkout can COMMIT `.agents` or `skills.json` as a symlink to a file elsewhere, and the
+  // reads/writes below all follow links — so a cloned repo could point this sync at a file of
+  // the user's own and have it silently rewritten (symlink-guard.ts).
+  if (!symlinkFreeWriteTarget(file)) return;
   let existing: unknown = {};
   if (existsSync(file)) {
     try {

--- a/server/agents/git-exclude.ts
+++ b/server/agents/git-exclude.ts
@@ -4,22 +4,44 @@
 // scope (infra/gui-mcp-registration.ts).
 //
 // Shared by the agents whose GUI MCP registration lands INSIDE the project: agy's
-// `.agents/mcp_config.json` and grok's `.grok/config.toml`.
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+// `.agents/mcp_config.json` and `.agents/skills.json`, and grok's `.grok/config.toml`.
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
+// The `info` directory whose `exclude` file THIS checkout's `git status` reads, or null when
+// there is nothing to resolve (no `.git` here — a session running below the repo root).
+//
+// A plain checkout keeps `.git` as a directory and reads `.git/info/exclude`. A linked WORKTREE
+// keeps `.git` as a FILE naming its private gitdir — and git reads excludes from the COMMON
+// dir, which the `commondir` file inside that gitdir points to (measured on git 2.x: an
+// `info/exclude` placed in the per-worktree gitdir is ignored). That common file is shared by
+// every worktree of the repo, which is fine — the entries we add name the same generated files
+// in each of them. A SUBMODULE's `.git` file names its gitdir under the superproject's
+// `.git/modules/`, which has no `commondir` and IS the dir git reads.
+function gitInfoDir(cwd: string): string | null {
+  const dotGit = path.join(cwd, ".git");
+  const st = statSync(dotGit, { throwIfNoEntry: false });
+  if (!st) return null;
+  if (st.isDirectory()) return path.join(dotGit, "info");
+  const named = /^gitdir:(.*)$/m.exec(readFileSync(dotGit, "utf8"))?.[1];
+  if (!named) return null;
+  const gitdir = path.resolve(cwd, named.trim());
+  const commondir = path.join(gitdir, "commondir");
+  const common = existsSync(commondir) ? path.resolve(gitdir, readFileSync(commondir, "utf8").trim()) : gitdir;
+  return path.join(common, "info");
+}
+
 /**
- * Add `entry` to this repo's `.git/info/exclude`, if there is one. Idempotent.
- *
- * Only when `.git/info` is really there: a worktree or a submodule keeps `.git` as a FILE pointing
- * elsewhere, and a session can also run in a directory below the repo root, where this path means
- * nothing. Both are left alone rather than guessed at — the cost is a line in `git status`, not a
- * broken session.
+ * Add `entry` to the `info/exclude` this checkout's `git status` actually reads, if there is
+ * one. Idempotent. Covers a plain checkout, a linked worktree and a submodule (see
+ * `gitInfoDir`); a directory below the repo root, where `./.git` names nothing, is left alone
+ * rather than guessed at — the cost is a line in `git status`, not a broken session.
  */
 export function excludeFromGit(cwd: string, entry: string): void {
-  const exclude = path.join(cwd, ".git", "info", "exclude");
   try {
-    if (!existsSync(path.dirname(exclude))) return;
+    const info = gitInfoDir(cwd);
+    if (!info || !existsSync(info)) return;
+    const exclude = path.join(info, "exclude");
     const current = existsSync(exclude) ? readFileSync(exclude, "utf8") : "";
     if (current.split("\n").includes(entry)) return;
     writeFileSync(exclude, current + (current === "" || current.endsWith("\n") ? "" : "\n") + entry + "\n", "utf8");

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -98,3 +98,18 @@ export function initWorkspaceSetup(deps: { workspace: string }): void {
     log.info("mirrored skills to codex", { mirrored: result.mirrored.length, skipped: result.skipped.length, removed: result.removed.length });
   });
 }
+
+/** Re-mirror the workspace's skills for a codex session about to start there. The boot-time
+ *  mirror above goes stale the moment a skill is created mid-run — a new collection, say — and
+ *  codex reads the mirror, never the live directory, so without this a restart was the only way
+ *  a codex chat could see a skill made after boot. Gated exactly like boot seeding: only the
+ *  managed workspace's skills belong in the user-global codex root — mirroring an arbitrary
+ *  project's `.claude/skills` there would make its skills fire in every other directory too.
+ *  Quiet on failure for the caller's sake: a mirror that cannot refresh is a session with
+ *  yesterday's skills, not a session that fails to start. */
+export function refreshCodexSkillsMirror(cwd: string): void {
+  if (!isManagedWorkspace(cwd)) return;
+  safeStep("refreshCodexSkillsMirror", () => {
+    syncCodexSkills(path.join(cwd, ".claude", "skills"), codexSkillsRoot());
+  });
+}

--- a/server/infra/symlink-guard.ts
+++ b/server/infra/symlink-guard.ts
@@ -12,7 +12,16 @@ const isSymlink = (p: string): boolean => lstatSync(p, { throwIfNoEntry: false }
 /** True when writing `file` follows no symlink: neither the file nor its parent directory is
  *  one. Missing components are fine — they are about to be created. The parent's own ancestors
  *  are deliberately not walked: the checkout root is the USER'S chosen directory, and links
- *  above it (a symlinked home, `/tmp` on macOS) are their setup, not repo-authored content. */
+ *  above it (a symlinked home, `/tmp` on macOS) are their setup, not repo-authored content.
+ *
+ *  Fails CLOSED on any inspection error: `throwIfNoEntry` suppresses only a missing entry, so
+ *  a parent that exists as a regular FILE still throws (ENOTDIR) from the child's lstat — and
+ *  this guard runs before its callers' own error handling, on the way into a session spawn. A
+ *  path we cannot inspect is a path we do not write. */
 export function symlinkFreeWriteTarget(file: string): boolean {
-  return !isSymlink(path.dirname(file)) && !isSymlink(file);
+  try {
+    return !isSymlink(path.dirname(file)) && !isSymlink(file);
+  } catch {
+    return false;
+  }
 }

--- a/server/infra/symlink-guard.ts
+++ b/server/infra/symlink-guard.ts
@@ -1,0 +1,18 @@
+// A file we GENERATE inside someone else's checkout must never be reached through a symbolic
+// link. A repository can commit `.agents/skills.json` — or the `.agents` directory itself — as
+// a symlink pointing anywhere (an editor config, a dotfile), and the fs write calls follow
+// links, so a routine spawn-time sync would then be reading and overwriting a file OUTSIDE the
+// checkout, chosen by whoever authored the repo the user happened to clone (#1544 review).
+// Checked with lstat, which never follows.
+import { lstatSync } from "node:fs";
+import path from "node:path";
+
+const isSymlink = (p: string): boolean => lstatSync(p, { throwIfNoEntry: false })?.isSymbolicLink() ?? false;
+
+/** True when writing `file` follows no symlink: neither the file nor its parent directory is
+ *  one. Missing components are fine — they are about to be created. The parent's own ancestors
+ *  are deliberately not walked: the checkout root is the USER'S chosen directory, and links
+ *  above it (a symlinked home, `/tmp` on macOS) are their setup, not repo-authored content. */
+export function symlinkFreeWriteTarget(file: string): boolean {
+  return !isSymlink(path.dirname(file)) && !isSymlink(file);
+}

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -4,6 +4,7 @@
 import { antigravityAdapter } from "../agents/antigravity.js";
 import { buildAntigravityArgs } from "../agents/antigravity-args.js";
 import { syncAntigravityMcpConfig } from "../agents/antigravity-mcp.js";
+import { syncAntigravitySkillsConfig } from "../agents/antigravity-skills.js";
 import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravitySession } from "../agents/antigravity-session.js";
 import { startDirectoryMcpPty, syncDirectoryMcpForSpawn, type SpawnDirectoryMcpPty } from "./spawn-directory-mcp.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
@@ -41,6 +42,10 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
     // switches were flipped before this shipped — or with the `claude mcp` CLI directly — needs no
     // second action to work (#1443).
     syncDirectoryMcpForSpawn(sessionId, cwd, mcpGroups, syncAntigravityMcpConfig);
+    // Skills reach agy the same file-in-the-directory way (`.agents/skills.json`) — it cannot
+    // read `.claude/skills` on its own, unlike every other agent hosted here. The entries point
+    // at the live skill roots, so this is registration, not a mirror to keep fresh.
+    syncAntigravitySkillsConfig(cwd);
     // Snapshotted between the sync and the spawn: the capture below tells agy's new conversation
     // from the ones already on disk by the difference, so it must be the world agy is about to find.
     const root = antigravityBrainRoot();

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -17,6 +17,7 @@ import { wireAgentPtyRelay } from "./pty-relay.js";
 import { attachCodexAutoRun } from "./draft-injection.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
+import { refreshCodexSkillsMirror } from "../backends/workspaceSetup.js";
 
 // Bound to ONE pty: `ptys.has(id)` would keep a stale tail alive after a reap-then-
 // respawn under the same id, and both tails would report the same boundaries.
@@ -62,6 +63,11 @@ export function createCodexSpawner(deps: SpawnDeps) {
     } = {},
   ): PtyEntry {
     const { initialPrompt = null, mcpGroups = [] } = options;
+    // codex reads skills from its mirror (~/.codex/skills), not from the workspace's own
+    // `.claude/skills`, and the mirror is otherwise refreshed only at boot — so a skill created
+    // mid-run (a new collection) would stay invisible to codex until a restart. No-op outside
+    // the managed workspace.
+    refreshCodexSkillsMirror(cwd);
     const root = codexSessionsRoot();
     const before = snapshotSessions(root);
     // Two surfaces, the same two claude has:

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -14,6 +14,8 @@ import { useEscapeToClose } from "../composables/useEscapeToClose";
 import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
 import { useShortcuts } from "../composables/useShortcuts";
 import type { Shortcut } from "../../common/shortcuts";
+import { launchAgent } from "../composables/useChatLauncher";
+import { BUILTIN_AGENT_OPTIONS } from "./agentPicker";
 
 // Navigation is the toolbar's job (the Chat tab closes this; Collections / favorite
 // tabs switch what it shows), so the overlay itself carries no chrome — it just fills
@@ -25,9 +27,11 @@ const { view, isOpen, close } = useCollectionBrowse();
 // is where they belong anyway: a favourite IS a collection or a feed, so the row that carries them
 // is the one you are already looking at when you want one.
 //
-// The row previously held the Claude / Codex / Antigravity picker for chats started from here
-// (owner's call to replace it). `launchAgent` still decides which agent a collection action
-// spawns; it is now whatever was last chosen elsewhere, persisted in localStorage.
+// They share the row with the launch-agent dropdown. `launchAgent` decides which agent every
+// collection-started chat spawns (useChatLauncher), and after the old three-button toggle made
+// way for the pins nothing in the UI wrote it — the choice sat frozen at whatever localStorage
+// last held, Claude for anyone who never used the toggle. A dropdown fits beside the pins where
+// the toggle did not, so both fit on the one row now.
 const { shortcuts } = useShortcuts();
 const favActive = (s: Shortcut): boolean => view.value.mode === "detail" && view.value.kind === s.kind && view.value.slug === s.slug;
 
@@ -58,27 +62,41 @@ useEscapeToClose(isOpen, close);
 
 <template>
   <div v-if="isOpen" class="fixed inset-x-0 top-10 bottom-0 z-50 bg-deep flex flex-col" role="region" aria-label="Collections">
-    <!-- Pinned favourites. Hidden entirely when there are none, rather than leaving an empty rule
-         across the top of the view. -->
-    <div v-if="shortcuts.length" class="flex flex-none items-center gap-2.5 border-b border-border px-3 py-1.5 font-sans" role="navigation" aria-label="Pinned">
-      <span class="text-[11px] uppercase tracking-[0.05em] text-dim">Pinned</span>
-      <div class="flex min-w-0 items-center gap-0.5 overflow-x-auto">
-        <!-- ICON ONLY. The name still reaches a screen reader through aria-label, and the pointer
-             through title — dropping the visible text is a density decision, not a decision to
-             ship an unlabelled control. -->
-        <button
-          v-for="s in shortcuts"
-          :key="`${s.kind}:${s.slug}`"
-          type="button"
-          class="flex flex-none cursor-pointer items-center justify-center rounded-[5px] border-0 px-1.5 py-[3px] text-[15px] leading-none"
-          :class="favActive(s) ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
-          :aria-current="favActive(s) ? 'page' : undefined"
-          :aria-label="s.title"
-          :title="s.title"
-          @click="browseGotoDetail(s.kind, s.slug)"
+    <!-- Pinned favourites and the launch-agent picker. The row used to hide itself when nothing
+         was pinned; the picker always has something to show, so the row is always there now. -->
+    <div class="flex flex-none items-center gap-2.5 border-b border-border px-3 py-1.5 font-sans">
+      <template v-if="shortcuts.length">
+        <span class="text-[11px] uppercase tracking-[0.05em] text-dim">Pinned</span>
+        <div class="flex min-w-0 items-center gap-0.5 overflow-x-auto" role="navigation" aria-label="Pinned">
+          <!-- ICON ONLY. The name still reaches a screen reader through aria-label, and the pointer
+               through title — dropping the visible text is a density decision, not a decision to
+               ship an unlabelled control. -->
+          <button
+            v-for="s in shortcuts"
+            :key="`${s.kind}:${s.slug}`"
+            type="button"
+            class="flex flex-none cursor-pointer items-center justify-center rounded-[5px] border-0 px-1.5 py-[3px] text-[15px] leading-none"
+            :class="favActive(s) ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
+            :aria-current="favActive(s) ? 'page' : undefined"
+            :aria-label="s.title"
+            :title="s.title"
+            @click="browseGotoDetail(s.kind, s.slug)"
+          >
+            <span class="material-symbols-outlined" aria-hidden="true">{{ s.icon || "bookmark" }}</span>
+          </button>
+        </div>
+      </template>
+      <div class="ml-auto flex flex-none items-center gap-2">
+        <span class="text-[11px] uppercase tracking-[0.05em] text-dim">Launch with</span>
+        <!-- Not SELECT_CONTROL: that is sized for settings forms (w-full, taller padding); this
+             sits on a thin toolbar row beside py-[3px] chips and matches their height instead. -->
+        <select
+          v-model="launchAgent"
+          aria-label="Agent that chats started from collections run"
+          class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] font-sans text-[12px] text-fg focus:border-accent focus:outline-none"
         >
-          <span class="material-symbols-outlined" aria-hidden="true">{{ s.icon || "bookmark" }}</span>
-        </button>
+          <option v-for="o in BUILTIN_AGENT_OPTIONS" :key="o.agent" :value="o.agent">{{ o.label }}</option>
+        </select>
       </div>
     </div>
     <div class="min-h-0 flex-1">

--- a/src/components/agentPicker.ts
+++ b/src/components/agentPicker.ts
@@ -31,12 +31,15 @@ const OPTIONS: Record<LaunchAgent, Omit<AgentPickerOption, "agent">> = {
   shell: { label: "Shell", title: "A plain shell ($SHELL) — no agent, nothing to configure" },
 };
 
-const BUILTIN_AGENTS: readonly AgentPickerOption[] = TERMINAL_AGENTS.map((agent) => ({ agent, ...OPTIONS[agent] }));
+// Exported on its own for the collection browser's launch picker, which offers ONLY these:
+// spawnBackgroundChat hosts exactly the built-in agents — no shell (a seeded chat needs an
+// agent to send the seed to) and no custom agents (the route builds no custom argv).
+export const BUILTIN_AGENT_OPTIONS: readonly AgentPickerOption[] = TERMINAL_AGENTS.map((agent) => ({ agent, ...OPTIONS[agent] }));
 const SHELL_OPTION: AgentPickerOption = { agent: "shell", ...OPTIONS.shell };
 
 /** The built-in options alone — the whole picker when the user has configured no custom agent,
  *  which is every install by default. */
-export const AGENT_PICKER_OPTIONS: readonly AgentPickerOption[] = [...BUILTIN_AGENTS, SHELL_OPTION];
+export const AGENT_PICKER_OPTIONS: readonly AgentPickerOption[] = [...BUILTIN_AGENT_OPTIONS, SHELL_OPTION];
 
 /**
  * The picker's options for a user who has configured custom agents.
@@ -57,5 +60,5 @@ export function agentPickerOptions(customAgents: readonly CustomAgent[]): readon
     label: agent.label,
     title: `${agent.command} — your own way of starting Claude Code (Claude Code's own arguments are appended)`,
   }));
-  return [...BUILTIN_AGENTS, ...custom, SHELL_OPTION];
+  return [...BUILTIN_AGENT_OPTIONS, ...custom, SHELL_OPTION];
 }

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -27,8 +27,9 @@ import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTim
 
 export type Agent = TerminalAgent;
 
-// Which agent a collection action / chat spawns. Bound to the Claude/Codex/Antigravity toggle in the collection
-// browser (CollectionsBrowseOverlay); persisted in localStorage so the choice survives reloads.
+// Which agent a collection action / chat spawns. Bound to the "Launch with" dropdown in the
+// collection browser (CollectionsBrowseOverlay); persisted in localStorage so the choice
+// survives reloads.
 const LAUNCH_AGENT_KEY = "mt-launch-agent";
 const saved = localStorage.getItem(LAUNCH_AGENT_KEY);
 export const launchAgent = ref<Agent>(asTerminalAgent(saved));

--- a/test/server/agents/antigravity-mcp.spec.ts
+++ b/test/server/agents/antigravity-mcp.spec.ts
@@ -104,4 +104,15 @@ describe("syncAntigravityMcpConfig", () => {
     syncAntigravityMcpConfig(dir, ["render"]);
     expect(fs.readFileSync(file, "utf8")).toBe("not json");
   });
+
+  // Same reason as the skills config beside it (antigravity-skills.spec.ts): a checkout can
+  // commit the file as a symlink, and the sync's writes follow links.
+  it.skipIf(process.platform === "win32")("refuses to write through a symlinked mcp_config.json", () => {
+    const target = path.join(dir, "their-own.json");
+    fs.writeFileSync(target, "{}");
+    fs.mkdirSync(path.dirname(antigravityMcpConfigFile(dir)), { recursive: true });
+    fs.symlinkSync(target, antigravityMcpConfigFile(dir));
+    syncAntigravityMcpConfig(dir, ["render"]);
+    expect(fs.readFileSync(target, "utf8")).toBe("{}");
+  });
 });

--- a/test/server/agents/antigravity-skills.spec.ts
+++ b/test/server/agents/antigravity-skills.spec.ts
@@ -101,6 +101,15 @@ describe("syncAntigravitySkillsConfig", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("{}");
   });
 
+  // `.agents` existing as a regular FILE makes the child lstat throw ENOTDIR (`throwIfNoEntry`
+  // suppresses only missing entries) — the guard must swallow that and skip, not fail the agy
+  // spawn it runs inside (CodeRabbit on #1544).
+  it("skips quietly when .agents is a regular file", () => {
+    fs.writeFileSync(path.join(dir, ".agents"), "not a directory");
+    expect(() => syncAntigravitySkillsConfig(dir)).not.toThrow();
+    expect(fs.readFileSync(path.join(dir, ".agents"), "utf8")).toBe("not a directory");
+  });
+
   it.skipIf(process.platform === "win32")("refuses to write through a symlinked .agents directory", () => {
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ag-outside-"));
     try {

--- a/test/server/agents/antigravity-skills.spec.ts
+++ b/test/server/agents/antigravity-skills.spec.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  antigravitySkillsConfigFile,
+  mergeAntigravitySkillsConfig,
+  syncAntigravitySkillsConfig,
+  SKILL_ENTRY_PATHS,
+} from "../../../server/agents/antigravity-skills.js";
+
+describe("mergeAntigravitySkillsConfig", () => {
+  it("adds both skill roots to an empty config", () => {
+    expect(mergeAntigravitySkillsConfig({})).toEqual({ entries: [{ path: ".claude/skills" }, { path: "~/.claude/skills" }] });
+  });
+
+  // No write when there is nothing to add: the sync runs on every agy spawn, and rewriting an
+  // unchanged file would churn its mtime and normalize the user's formatting each time.
+  it("returns null when every root is already present", () => {
+    const existing = { entries: SKILL_ENTRY_PATHS.map((p) => ({ path: p })) };
+    expect(mergeAntigravitySkillsConfig(existing)).toBeNull();
+  });
+
+  it("keeps the user's own entries, appending ours after them", () => {
+    const merged = mergeAntigravitySkillsConfig({ entries: [{ path: "tools/agents/skills", exclude: ["wip-.*"] }] });
+    expect(merged?.entries).toEqual([{ path: "tools/agents/skills", exclude: ["wip-.*"] }, { path: ".claude/skills" }, { path: "~/.claude/skills" }]);
+  });
+
+  it("adds only the root that is missing", () => {
+    const merged = mergeAntigravitySkillsConfig({ entries: [{ path: ".claude/skills" }] });
+    expect(merged?.entries).toEqual([{ path: ".claude/skills" }, { path: "~/.claude/skills" }]);
+  });
+
+  // `inherits` and any field agy grows later ride along untouched — the file is the user's.
+  it("preserves fields it does not know", () => {
+    const merged = mergeAntigravitySkillsConfig({ inherits: [{ path: "/shared/skills.json" }], future: true });
+    expect(merged).toMatchObject({ inherits: [{ path: "/shared/skills.json" }], future: true });
+  });
+
+  // An entry we cannot read as {path: string} is left in place but never matched — a malformed
+  // entry must not swallow the root we were about to add.
+  it("ignores malformed entries when checking presence", () => {
+    const merged = mergeAntigravitySkillsConfig({ entries: ["not-an-object", { path: 5 }] });
+    expect(merged?.entries).toEqual(["not-an-object", { path: 5 }, { path: ".claude/skills" }, { path: "~/.claude/skills" }]);
+  });
+
+  it("refuses a config that is not an object, or whose entries is not an array", () => {
+    expect(mergeAntigravitySkillsConfig([])).toBeNull();
+    expect(mergeAntigravitySkillsConfig("x")).toBeNull();
+    expect(mergeAntigravitySkillsConfig({ entries: { path: ".claude/skills" } })).toBeNull();
+  });
+});
+
+describe("syncAntigravitySkillsConfig", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ag-skills-"));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const read = (): Record<string, unknown> => JSON.parse(fs.readFileSync(antigravitySkillsConfigFile(dir), "utf8"));
+
+  it("writes .agents/skills.json pointing at both skill roots", () => {
+    syncAntigravitySkillsConfig(dir);
+    expect(read()).toEqual({ entries: [{ path: ".claude/skills" }, { path: "~/.claude/skills" }] });
+  });
+
+  it("is idempotent — a second sync leaves the file byte-identical", () => {
+    syncAntigravitySkillsConfig(dir);
+    const first = fs.readFileSync(antigravitySkillsConfigFile(dir), "utf8");
+    syncAntigravitySkillsConfig(dir);
+    expect(fs.readFileSync(antigravitySkillsConfigFile(dir), "utf8")).toBe(first);
+  });
+
+  it("merges into a user's existing file without losing their entries", () => {
+    fs.mkdirSync(path.dirname(antigravitySkillsConfigFile(dir)), { recursive: true });
+    fs.writeFileSync(antigravitySkillsConfigFile(dir), JSON.stringify({ entries: [{ path: "~/personal-skills" }] }));
+    syncAntigravitySkillsConfig(dir);
+    expect(read().entries).toEqual([{ path: "~/personal-skills" }, { path: ".claude/skills" }, { path: "~/.claude/skills" }]);
+  });
+
+  // Not JSON means it is not a file we wrote, and rewriting it would lose whatever it is.
+  it("leaves an unparseable file untouched", () => {
+    fs.mkdirSync(path.dirname(antigravitySkillsConfigFile(dir)), { recursive: true });
+    fs.writeFileSync(antigravitySkillsConfigFile(dir), "not json");
+    syncAntigravitySkillsConfig(dir);
+    expect(fs.readFileSync(antigravitySkillsConfigFile(dir), "utf8")).toBe("not json");
+  });
+
+  // The user's own repo: the file is generated on spawn, so it must not turn up in git status.
+  it("excludes the file through .git/info/exclude, not their .gitignore", () => {
+    fs.mkdirSync(path.join(dir, ".git", "info"), { recursive: true });
+    syncAntigravitySkillsConfig(dir);
+    expect(fs.readFileSync(path.join(dir, ".git", "info", "exclude"), "utf8")).toContain(".agents/skills.json");
+    expect(fs.existsSync(path.join(dir, ".gitignore"))).toBe(false);
+  });
+});

--- a/test/server/agents/antigravity-skills.spec.ts
+++ b/test/server/agents/antigravity-skills.spec.ts
@@ -89,6 +89,29 @@ describe("syncAntigravitySkillsConfig", () => {
     expect(fs.readFileSync(antigravitySkillsConfigFile(dir), "utf8")).toBe("not json");
   });
 
+  // A checkout can COMMIT skills.json as a symlink to a file elsewhere; the sync's writes
+  // follow links, so without the guard a cloned repo could have a user-owned file silently
+  // rewritten on every agy spawn (#1544 review).
+  it.skipIf(process.platform === "win32")("refuses to write through a symlinked skills.json", () => {
+    const target = path.join(dir, "their-own.json");
+    fs.writeFileSync(target, "{}");
+    fs.mkdirSync(path.dirname(antigravitySkillsConfigFile(dir)), { recursive: true });
+    fs.symlinkSync(target, antigravitySkillsConfigFile(dir));
+    syncAntigravitySkillsConfig(dir);
+    expect(fs.readFileSync(target, "utf8")).toBe("{}");
+  });
+
+  it.skipIf(process.platform === "win32")("refuses to write through a symlinked .agents directory", () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ag-outside-"));
+    try {
+      fs.symlinkSync(outside, path.join(dir, ".agents"));
+      syncAntigravitySkillsConfig(dir);
+      expect(fs.readdirSync(outside)).toHaveLength(0);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   // The user's own repo: the file is generated on spawn, so it must not turn up in git status.
   it("excludes the file through .git/info/exclude, not their .gitignore", () => {
     fs.mkdirSync(path.join(dir, ".git", "info"), { recursive: true });

--- a/test/server/agents/git-exclude.spec.ts
+++ b/test/server/agents/git-exclude.spec.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { excludeFromGit } from "../../../server/agents/git-exclude.js";
+
+describe("excludeFromGit", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "git-exclude-"));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("appends the entry to a plain checkout's .git/info/exclude", () => {
+    fs.mkdirSync(path.join(dir, ".git", "info"), { recursive: true });
+    excludeFromGit(dir, ".agents/skills.json");
+    expect(fs.readFileSync(path.join(dir, ".git", "info", "exclude"), "utf8")).toBe(".agents/skills.json\n");
+  });
+
+  // A linked worktree keeps `.git` as a file naming its private gitdir, and git reads excludes
+  // from the COMMON dir its `commondir` file points to — the per-worktree info/exclude is
+  // ignored (measured; see git-exclude.ts). Before this resolution existed, every agy spawn in
+  // a worktree left `?? .agents/` in git status, which the worktree-removal flow then read as
+  // uncommitted work (#1544 review).
+  it("resolves a worktree's .git file to the common dir's info/exclude", () => {
+    const main = path.join(dir, "main");
+    const wt = path.join(dir, "wt");
+    const gitdir = path.join(main, ".git", "worktrees", "wt");
+    fs.mkdirSync(path.join(main, ".git", "info"), { recursive: true });
+    fs.mkdirSync(gitdir, { recursive: true });
+    fs.writeFileSync(path.join(gitdir, "commondir"), "../..\n");
+    fs.mkdirSync(wt);
+    fs.writeFileSync(path.join(wt, ".git"), `gitdir: ${gitdir}\n`);
+
+    excludeFromGit(wt, ".agents/skills.json");
+
+    expect(fs.readFileSync(path.join(main, ".git", "info", "exclude"), "utf8")).toBe(".agents/skills.json\n");
+    // Nothing lands in the per-worktree gitdir, which git would ignore anyway.
+    expect(fs.existsSync(path.join(gitdir, "info", "exclude"))).toBe(false);
+  });
+
+  // A worktree's `.git` file names the gitdir RELATIVE when the tools that made it did — the
+  // resolution has to happen against the worktree, not the process cwd.
+  it("resolves a relative gitdir in the .git file", () => {
+    const main = path.join(dir, "main");
+    const wt = path.join(dir, "wt");
+    const gitdir = path.join(main, ".git", "worktrees", "wt");
+    fs.mkdirSync(path.join(main, ".git", "info"), { recursive: true });
+    fs.mkdirSync(gitdir, { recursive: true });
+    fs.writeFileSync(path.join(gitdir, "commondir"), "../..\n");
+    fs.mkdirSync(wt);
+    fs.writeFileSync(path.join(wt, ".git"), "gitdir: ../main/.git/worktrees/wt\n");
+
+    excludeFromGit(wt, ".agents/skills.json");
+
+    expect(fs.readFileSync(path.join(main, ".git", "info", "exclude"), "utf8")).toBe(".agents/skills.json\n");
+  });
+
+  // A submodule's gitdir (under the superproject's .git/modules/) has no commondir file and IS
+  // the dir git reads.
+  it("resolves a submodule's .git file to its own gitdir", () => {
+    const gitdir = path.join(dir, "super", ".git", "modules", "sub");
+    const sub = path.join(dir, "super", "sub");
+    fs.mkdirSync(path.join(gitdir, "info"), { recursive: true });
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(sub, ".git"), `gitdir: ${gitdir}\n`);
+
+    excludeFromGit(sub, ".agents/skills.json");
+
+    expect(fs.readFileSync(path.join(gitdir, "info", "exclude"), "utf8")).toBe(".agents/skills.json\n");
+  });
+
+  it("does nothing where there is no .git at all", () => {
+    excludeFromGit(dir, ".agents/skills.json");
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+
+  it("does not add the same entry twice", () => {
+    fs.mkdirSync(path.join(dir, ".git", "info"), { recursive: true });
+    excludeFromGit(dir, ".agents/skills.json");
+    excludeFromGit(dir, ".agents/skills.json");
+    expect(fs.readFileSync(path.join(dir, ".git", "info", "exclude"), "utf8")).toBe(".agents/skills.json\n");
+  });
+});

--- a/test/server/backends/workspaceSetup.spec.ts
+++ b/test/server/backends/workspaceSetup.spec.ts
@@ -1,14 +1,18 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import path from "node:path";
-import { isManagedWorkspace, initWorkspaceSetup } from "../../../server/backends/workspaceSetup.js";
+import { isManagedWorkspace, initWorkspaceSetup, refreshCodexSkillsMirror } from "../../../server/backends/workspaceSetup.js";
 
 // Save/restore MULMOCLAUDE_WORKSPACE_PATH so a test can mark a temp dir as the
-// managed workspace without leaking into sibling tests.
+// managed workspace without leaking into sibling tests. CODEX_HOME likewise, so the
+// mirror-refresh tests never touch the real ~/.codex.
 const ENV_KEY = "MULMOCLAUDE_WORKSPACE_PATH";
+const CODEX_ENV_KEY = "CODEX_HOME";
 let savedEnv: string | undefined;
+let savedCodexEnv: string | undefined;
+let codexHome: string;
 const tempDirs: string[] = [];
 
 function makeTempDir(): string {
@@ -19,12 +23,17 @@ function makeTempDir(): string {
 
 beforeEach(() => {
   savedEnv = process.env[ENV_KEY];
+  savedCodexEnv = process.env[CODEX_ENV_KEY];
   Reflect.deleteProperty(process.env, ENV_KEY);
+  codexHome = makeTempDir();
+  process.env[CODEX_ENV_KEY] = codexHome;
 });
 
 afterEach(() => {
   if (savedEnv === undefined) Reflect.deleteProperty(process.env, ENV_KEY);
   else process.env[ENV_KEY] = savedEnv;
+  if (savedCodexEnv === undefined) Reflect.deleteProperty(process.env, CODEX_ENV_KEY);
+  else process.env[CODEX_ENV_KEY] = savedCodexEnv;
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -79,5 +88,36 @@ describe("initWorkspaceSetup", () => {
     expect(existsSync(path.join(workspace, "data"))).toBe(false);
     expect(existsSync(path.join(workspace, ".claude"))).toBe(false);
     expect(readdirSync(workspace)).toHaveLength(0);
+  });
+});
+
+describe("refreshCodexSkillsMirror", () => {
+  const addSkill = (workspace: string, name: string): void => {
+    const dir = path.join(workspace, ".claude", "skills", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${name}\n---\n`);
+  };
+
+  // The point of the refresh: a skill created AFTER boot reaches codex on the next spawn,
+  // not the next server restart.
+  it("mirrors a skill created after boot into the codex root", () => {
+    const workspace = makeTempDir();
+    process.env[ENV_KEY] = workspace;
+    addSkill(workspace, "made-later");
+
+    refreshCodexSkillsMirror(workspace);
+
+    expect(existsSync(path.join(codexHome, "skills", "made-later", "SKILL.md"))).toBe(true);
+  });
+
+  // An arbitrary project's skills must not land in the user-global codex root, where they
+  // would fire in every other directory's sessions too.
+  it("does nothing outside the managed workspace", () => {
+    const workspace = makeTempDir();
+    addSkill(workspace, "project-local");
+
+    refreshCodexSkillsMirror(workspace);
+
+    expect(existsSync(path.join(codexHome, "skills"))).toBe(false);
   });
 });


### PR DESCRIPTION
Chats started from Collections were Claude-only twice over: nothing in the UI set the agent anymore, and even with another agent chosen, the workspace skills those chats lean on were invisible to some of them. This PR fixes both halves.

## "Launch with" picker (UI)

The old three-button toggle in the collection browser made way for the pinned favourites in fa7da2a9, leaving `launchAgent` with no writer — frozen at whatever localStorage last held, Claude for anyone who never used the toggle. A compact dropdown now shares the row with the pins, offering the built-in agents and only those: `spawnBackgroundChat` hosts exactly them (no shell — a seeded chat needs an agent; no custom agents — the route builds no custom argv). The options derive from `TERMINAL_AGENTS` via the newly-exported `BUILTIN_AGENT_OPTIONS`, so a sixth agent reaches the picker with no second list. The row now shows even with nothing pinned, since the picker always has content.

## Workspace skills on every agent (server)

Audit of the five agents against the real CLIs:

| agent | how it sees skills | status before |
| --- | --- | --- |
| claude | `.claude/skills` + `~/.claude/skills`, native | works |
| grok | indexes Claude's roots natively (`grok inspect`: all 92 workspace skills) | works |
| muse | indexes Claude's roots; project scope gated on trust, which our `--yolo` spawn grants | works |
| codex | mirror in `~/.codex/skills` | stale after boot |
| antigravity | `.agents/skills.json` path entries — nothing wrote one | **no skills at all** |

**agy** (the real gap): every agy spawn now merges two entries into `<cwd>/.agents/skills.json` — `.claude/skills` and `~/.claude/skills` — beside the existing `mcp_config.json` sync, in the new `server/agents/antigravity-skills.ts`. Registration, not a mirror: the entries point at the live roots, so a skill created mid-session is visible to the next agy turn. User entries and unknown fields (`inherits`, …) are preserved, an unparseable file is left alone, nothing is ever removed (there is no off-switch and nothing machine-specific in what we add), no rewrite when nothing is missing, and the file is git-excluded via `.git/info/exclude` — which deliberately has no effect on a skills.json a team already commits.

Verified live in interactive agy sessions (tmux): a probe skill in the workspace's `.claude/skills` was reachable through the generated file both as `/<slug>` and via the exact `Use the "…" skill.` sentence `codexifySkillSeed` sends to non-claude agents. One trap for future readers: agy's **print mode does not load workspace customizations**, so `-p` probes look like failures when nothing is wrong — the interactive mode our PTY spawns loads them fine.

**codex**: the mirror was refreshed only at boot, so a collection skill created mid-run stayed invisible until a server restart. `refreshCodexSkillsMirror(cwd)` now re-syncs on codex spawn — gated to the managed workspace exactly like boot seeding, so an arbitrary project's `.claude/skills` never lands in the user-global codex root where it would fire in every other directory's sessions.

**docs**: the four guide lines (en/ja × config/header) saying skill seeds were Claude/Codex-only now say "other agents".

## Tests

14 new specs: merge semantics + filesystem sync for `antigravity-skills` (12), mirror-refresh gate for codex (2). Full suite: 9266 passed. Lint/typecheck clean.

Known limits: grok and muse rely on the workspace being trusted (true here, untested on a fresh machine); custom agents stay out of the collection picker until the spawn route can build their argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skill discovery and synchronization for additional coding agents.
  * Skills created during active sessions are now available when launching Codex.
  * Added an agent-selection control to collection browsing.

* **Bug Fixes**
  * Improved protection against unsafe symbolic-link configuration writes.
  * Improved Git exclusion support across repositories, worktrees, and submodules.
  * Malformed configurations and synchronization errors no longer block session startup.

* **Documentation**
  * Updated English and Japanese guides with generic skill-running instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->