### PR TITLE
fix(#1549): hold the worktree buttons while they work, and say why they failed

### DIFF
--- a/plans/fix-1549-worktree-button-guard.md
+++ b/plans/fix-1549-worktree-button-guard.md
@@ -1,0 +1,82 @@
+# fix #1549 — a slow button that never says it is working gets pressed again
+
+## What happens
+
+`+ New worktree` in the launcher POSTs `/api/worktrees/create` and changes **nothing** on screen
+while `git worktree add` checks the tree out. On the reporter's ~33,000-file monorepo that is ~6
+seconds of a form identical to the one before the click, with the button still enabled — because
+its only `disabled` test is "is the task field empty", and the field is cleared **after** the
+response lands. Three presses produced `agent/<slug>`, `agent/<slug>-2`, `agent/<slug>-3`:
+`uniqueBranch` takes the free suffix, so every press succeeds.
+
+The same line hides the failure. `if (!res.ok) return;` plus `catch {}` means a 500 shows nothing
+at all — the reporter's real cause (`git worktree add … main` with no local `main`, exit 255) was
+only found by reading the `dist` bundle.
+
+The neighbouring controls in this very form already have the rule: `pickPaths` refuses a second
+call while one is in flight (#1527) and returns the server's sentence (#1447); the `/prs` issue row
+holds itself with `starting` for exactly this reason (#1219). Worktree creation is the entry point
+that got neither.
+
+## The rule, and everywhere it was missing
+
+**A click that shells out must hold itself until it settles, and must say why it failed.** Three
+handlers in the launcher and one in the running cell were missing it — all of them slow (`git
+worktree add` / `remove`, up to four `claude mcp add` calls), all of them silent:
+
+| where | what a second click did |
+|---|---|
+| `CellLaunchForm` `+ New worktree` | **a second worktree** for the same task (#1549) |
+| `CellLaunchForm` worktree row | a second `emit("start")` — the launcher awaits `syncMcpGroupsInto` first |
+| `CellLaunchForm` delete (`wt-del`) | a second `worktree remove` at the same path |
+| `TerminalCell` `Discard & remove` | terminates the pty twice, removes twice |
+
+## What ships
+
+**`src/composables/useBusyAction.ts` (new)** — the rule in one place. `busy` holds the KEY of the
+action in flight (so the pressed control can spin while the others are merely disabled) and `run`
+drops any call arriving while it is set. Exclusive across keys, not per key: these all shell out to
+git in one repository, and `useIssueStart` / `useSessionStop` already hold themselves the same way.
+
+**`CellLaunchForm.vue`**
+
+- all three handlers go through `runWorktreeAction`; `wt-start` and `wt-del` are `disabled` while
+  any of them runs, and the acting control shows `progress_activity` (the spinner the
+  `cell-dir-loading` row already uses) with the label changing to `Creating…`
+- `wt-error` under the section carries the server's own sentence — `{ error }` from create,
+  `{ ok:false, reason }` from remove — the treatment `cell-dir-pick-error` got in #1447
+- `wt-start` gets `enabled:hover:` / `disabled:cursor-not-allowed disabled:opacity-40`, so an
+  empty task name no longer leaves a button that looks pressable and does nothing
+- the delete confirm is not raised at all while another action runs, or the user would answer a
+  dialog for work that is then dropped
+
+**`TerminalCell.vue`** — `Discard & remove` runs through the same composable; the button reads
+`Removing…` and both it and the retry button are held.
+
+**`cellChromeRules.ts`** — `worktreeRequestFailure(body, status)` reads the route's two refusal
+shapes; `dirty` and `not-managed` join the reason table (remove answers them; nothing rendered
+them before).
+
+## Deliberately not done
+
+The route's 500 body is `could not create the worktree (is this a git repo?)` whatever went
+wrong — misleading in the reporter's case, where it **was** a repo and the base branch was
+missing. Surfacing git's own stderr means changing `git()` (which drains and discards stderr on
+purpose) and `createWorktree`'s `null` return, which every caller and a dozen specs read. Out of
+scope here; the UI now shows whatever the server says, so improving that message is a
+self-contained follow-up.
+
+Server-side de-duplication of concurrent creates is also left alone: `agent/<task>` and
+`agent/<task>-2` from two deliberate creates is the documented behaviour, pinned by a spec.
+
+## Files
+
+| file | |
+|---|---|
+| `src/composables/useBusyAction.ts` (new) | one-at-a-time guard, keyed |
+| `src/components/CellLaunchForm.vue` | three handlers guarded, spinner, `wt-error`, disabled styling |
+| `src/components/TerminalCell.vue` | `removeAndClose` guarded + `Removing…` |
+| `src/components/cellChromeRules.ts` | `worktreeRequestFailure`, two more reasons |
+| `test/src/composables/useBusyAction.spec.ts` (new) | second call dropped, released after a throw |
+| `test/src/components/CellLaunchForm.spec.ts` | one POST per press, spinner, error text |
+| `test/src/components/cellChromeRules.spec.ts` | the two refusal shapes |

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -469,10 +469,12 @@ const reportWorktreeFailure = (repoDir: string | null, message: string): void =>
 // worktree may well appear a moment later. Saying otherwise sends the user to look at their network.
 // Reachable — SLOW_COMMAND_TIMEOUT_MS is 60s, and a checkout large enough to make this bug worth
 // fixing is a checkout that can exceed it.
+const errorText = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
 const requestFailureText = (e: unknown): string =>
   e instanceof DOMException && e.name === "AbortError"
     ? "Timed out waiting for git — it may still finish. Re-select this directory to see."
-    : `Could not reach the server: ${e instanceof Error ? e.message : String(e)}`;
+    : `Could not reach the server: ${errorText(e)}`;
 
 // Create a fresh worktree for the typed task and start the selected agent in it.
 //

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -456,7 +456,23 @@ const removeKey = (w: Worktree): string => `remove:${w.path}`;
 // looked identical — and the difference was only findable by reading the shipped bundle.
 const worktreeError = ref<string | null>(null);
 
-const unreachable = (e: unknown): string => `Could not reach the server: ${e instanceof Error ? e.message : String(e)}`;
+// Only if the form is STILL pointed at the repository the action was for. The directory field stays
+// editable for the whole round trip, so a failure reported under whatever the user typed meanwhile
+// is a sentence about somewhere else — #1372's rule, applied to the error line rather than the rows.
+// A successful create deliberately does not ask: the worktree was made because it was asked for, and
+// launching in it is the click being honoured, not a stale answer.
+const reportWorktreeFailure = (repoDir: string | null, message: string): void => {
+  if (isSameDirPath(targetDir.value, repoDir)) worktreeError.value = message;
+};
+
+// A timeout is NOT "could not reach the server": the request landed and git is still working, so the
+// worktree may well appear a moment later. Saying otherwise sends the user to look at their network.
+// Reachable — SLOW_COMMAND_TIMEOUT_MS is 60s, and a checkout large enough to make this bug worth
+// fixing is a checkout that can exceed it.
+const requestFailureText = (e: unknown): string =>
+  e instanceof DOMException && e.name === "AbortError"
+    ? "Timed out waiting for git — it may still finish. Re-select this directory to see."
+    : `Could not reach the server: ${e instanceof Error ? e.message : String(e)}`;
 
 // Create a fresh worktree for the typed task and start the selected agent in it.
 //
@@ -484,20 +500,20 @@ async function requestWorktree(repoDir: string, task: string): Promise<void> {
     );
     const wt = await jsonBody(res);
     if (!res.ok) {
-      worktreeError.value = worktreeRequestFailure(wt, res.status);
+      reportWorktreeFailure(repoDir, worktreeRequestFailure(wt, res.status));
       return;
     }
     // A 200 whose body has no path is not a worktree to launch in, and reporting it as one would
     // start the agent in whatever the field happens to say.
     if (typeof wt.path !== "string") {
-      worktreeError.value = "The server answered without a worktree path.";
+      reportWorktreeFailure(repoDir, "The server answered without a worktree path.");
       return;
     }
     worktreeTask.value = "";
     await syncMcpGroupsInto(wt.path);
     emit("start", wt.path);
   } catch (e) {
-    worktreeError.value = unreachable(e);
+    reportWorktreeFailure(repoDir, requestFailureText(e));
   }
 }
 
@@ -552,10 +568,10 @@ async function requestRemove(repoDir: string | null, w: Worktree): Promise<void>
       },
       SLOW_COMMAND_TIMEOUT_MS,
     );
-    if (!res.ok) worktreeError.value = `${w.task}: ${worktreeRequestFailure(await jsonBody(res), res.status)}`;
+    if (!res.ok) reportWorktreeFailure(repoDir, `${w.task}: ${worktreeRequestFailure(await jsonBody(res), res.status)}`);
     void loadWorktrees(targetDir.value);
   } catch (e) {
-    worktreeError.value = unreachable(e);
+    reportWorktreeFailure(repoDir, requestFailureText(e));
   }
 }
 </script>

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -24,6 +24,7 @@ import AgentMark from "./AgentMark.vue";
 import ModelPicker from "./ModelPicker.vue";
 import { LAUNCH_ROW } from "./launchFormClasses";
 import { jsonBody } from "../jsonBody";
+import { isRecord } from "../../common/isRecord";
 import { filePickerOpen, pickPaths } from "../composables/pickPaths";
 import { useBusyAction } from "../composables/useBusyAction";
 import { useSessionStop } from "../composables/useSessionStop";
@@ -500,20 +501,27 @@ async function requestWorktree(repoDir: string, task: string): Promise<void> {
       },
       SLOW_COMMAND_TIMEOUT_MS,
     );
-    const wt = await jsonBody(res);
     if (!res.ok) {
-      reportWorktreeFailure(repoDir, worktreeRequestFailure(wt, res.status));
+      // A refusal's body may not be JSON at all — a 403 from the origin guard is not — and the
+      // STATUS is already an answer, so absorbing it into `{}` here loses nothing.
+      reportWorktreeFailure(repoDir, worktreeRequestFailure(await jsonBody(res), res.status));
       return;
     }
-    // A 200 whose body has no path is not a worktree to launch in, and reporting it as one would
+    // On a 200 the BODY is the answer, so it must not be absorbed. `fetchWithTimeout` deliberately
+    // keeps its deadline armed across the body, so an aborted read would become `{}` and be
+    // reported as a worktree the server never made — for one that exists. Left to throw, it lands
+    // on the timeout message below instead. This is the trap jsonBody's own doc names (#1300).
+    const body: unknown = await res.json();
+    const path = isRecord(body) ? body.path : undefined;
+    // A 200 that still names no worktree is not one to launch in, and reporting it as one would
     // start the agent in whatever the field happens to say.
-    if (typeof wt.path !== "string") {
+    if (typeof path !== "string") {
       reportWorktreeFailure(repoDir, "The server answered without a worktree path.");
       return;
     }
     worktreeTask.value = "";
-    await syncMcpGroupsInto(wt.path);
-    emit("start", wt.path);
+    await syncMcpGroupsInto(path);
+    emit("start", path);
   } catch (e) {
     reportWorktreeFailure(repoDir, requestFailureText(e));
   }

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -25,7 +25,9 @@ import ModelPicker from "./ModelPicker.vue";
 import { LAUNCH_ROW } from "./launchFormClasses";
 import { jsonBody } from "../jsonBody";
 import { filePickerOpen, pickPaths } from "../composables/pickPaths";
+import { useBusyAction } from "../composables/useBusyAction";
 import { useSessionStop } from "../composables/useSessionStop";
+import { worktreeRequestFailure } from "./cellChromeRules";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
 
 // What an EMPTY grid cell shows: pick a directory, pick what to run in it, and start — or resume
@@ -234,6 +236,9 @@ function forgetForDir(): void {
   forgetScripts();
   forgetWorktrees();
   forgetMcpGroups();
+  // The failure belongs to the repository it was refused in — "no such branch: main" said under a
+  // directory that has one is a sentence about somewhere else.
+  worktreeError.value = null;
 }
 onMounted(() => loadForDir(targetDir.value, listAgent.value));
 
@@ -438,11 +443,35 @@ const allToolGroupNames = computed(() => [...new Set(TOOL_GROUPS.map((group) => 
 
 const worktreeTask = ref("");
 
+// Every worktree control in this section shares one guard, because they all shell out to git in one
+// repository and a second command contends on its index lock. `worktreeBusy` names the control that
+// was actually pressed, so that one spins while the others are merely held (#1549).
+const { busy: worktreeBusy, run: runWorktreeAction } = useBusyAction();
+const CREATE_KEY = "create";
+const openKey = (w: Worktree): string => `open:${w.path}`;
+const removeKey = (w: Worktree): string => `remove:${w.path}`;
+
+// Why the last worktree action failed. Held rather than swallowed: until #1549 a 500 from the
+// create route showed nothing at all, so a missing base branch and a click that never registered
+// looked identical — and the difference was only findable by reading the shipped bundle.
+const worktreeError = ref<string | null>(null);
+
+const unreachable = (e: unknown): string => `Could not reach the server: ${e instanceof Error ? e.message : String(e)}`;
+
 // Create a fresh worktree for the typed task and start the selected agent in it.
+//
+// Held for the whole round trip: `git worktree add` checks out the tree, which is seconds on a
+// large repository, and the task field is only cleared once the answer lands — so without this the
+// form is byte-identical to the one before the click and a second press makes `agent/<task>-2`.
 async function createWorktreeAndLaunch(): Promise<void> {
   const repoDir = targetDir.value;
   const task = worktreeTask.value.trim();
   if (!repoDir || !task) return;
+  await runWorktreeAction(CREATE_KEY, () => requestWorktree(repoDir, task));
+}
+
+async function requestWorktree(repoDir: string, task: string): Promise<void> {
+  worktreeError.value = null;
   try {
     const res = await fetchWithTimeout(
       "/api/worktrees/create",
@@ -453,27 +482,44 @@ async function createWorktreeAndLaunch(): Promise<void> {
       },
       SLOW_COMMAND_TIMEOUT_MS,
     );
-    if (!res.ok) return;
     const wt = await jsonBody(res);
-    if (typeof wt.path === "string") {
-      worktreeTask.value = "";
-      await syncMcpGroupsInto(wt.path);
-      emit("start", wt.path);
+    if (!res.ok) {
+      worktreeError.value = worktreeRequestFailure(wt, res.status);
+      return;
     }
-  } catch {
-    // best-effort — the launcher stays open so the user can retry
+    // A 200 whose body has no path is not a worktree to launch in, and reporting it as one would
+    // start the agent in whatever the field happens to say.
+    if (typeof wt.path !== "string") {
+      worktreeError.value = "The server answered without a worktree path.";
+      return;
+    }
+    worktreeTask.value = "";
+    await syncMcpGroupsInto(wt.path);
+    emit("start", wt.path);
+  } catch (e) {
+    worktreeError.value = unreachable(e);
   }
 }
 
 // One branch, one session: the row continues the worktree's session when it has one and nobody is
 // holding it, and starts a fresh one only when it has none. See common/worktreeSession.ts.
+//
+// Guarded like the create above, and for a reason the row does not look like it has: the launcher
+// waits on `syncMcpGroupsInto` first, which is up to four `claude mcp add` calls, and the row stays
+// on screen for all of them.
 const openWorktree = async (w: Worktree): Promise<void> => {
   const action = worktreeAction(w.session);
   if (action === "busy") return;
-  await syncMcpGroupsInto(w.path);
-  if (action === "resume" && w.session) emit("resume", { id: w.session.id, cwd: w.path, agent: w.session.agent });
-  else emit("start", w.path);
+  await runWorktreeAction(openKey(w), async () => {
+    await syncMcpGroupsInto(w.path);
+    if (action === "resume" && w.session) emit("resume", { id: w.session.id, cwd: w.path, agent: w.session.agent });
+    else emit("start", w.path);
+  });
 };
+
+// A row is not clickable while its worktree is open in another terminal, nor while ANY worktree
+// action is in flight.
+const worktreeRowHeld = (w: Worktree): boolean => worktreeAction(w.session) === "busy" || worktreeBusy.value !== null;
 
 // The hover, which is where the three-way rule is actually readable — the row itself can only
 // afford a word.
@@ -487,9 +533,17 @@ const worktreeTitle = (w: Worktree): string => {
 // discarded silently.
 async function removeWorktree(w: Worktree): Promise<void> {
   const repoDir = targetDir.value;
+  // Asked BEFORE the confirmation rather than left to `runWorktreeAction`: a dialog answered "yes"
+  // for work that is then silently dropped is worse than a button that does not respond.
+  if (worktreeBusy.value !== null) return;
   if (w.dirty && !window.confirm(`"${w.task}" has uncommitted changes. Discard and remove it?`)) return;
+  await runWorktreeAction(removeKey(w), () => requestRemove(repoDir, w));
+}
+
+async function requestRemove(repoDir: string | null, w: Worktree): Promise<void> {
+  worktreeError.value = null;
   try {
-    await fetchWithTimeout(
+    const res = await fetchWithTimeout(
       "/api/worktrees/remove",
       {
         method: "POST",
@@ -498,9 +552,10 @@ async function removeWorktree(w: Worktree): Promise<void> {
       },
       SLOW_COMMAND_TIMEOUT_MS,
     );
+    if (!res.ok) worktreeError.value = `${w.task}: ${worktreeRequestFailure(await jsonBody(res), res.status)}`;
     void loadWorktrees(targetDir.value);
-  } catch {
-    // best-effort
+  } catch (e) {
+    worktreeError.value = unreachable(e);
   }
 }
 </script>
@@ -760,40 +815,61 @@ async function removeWorktree(w: Worktree): Promise<void> {
           spellcheck="false"
           @keydown.enter="createWorktreeAndLaunch"
         />
+        <!-- Held while any worktree action runs, and it says which: `git worktree add` checks out
+             the whole tree, so on a large repository the only thing distinguishing "working" from
+             "the click did nothing" is this label (#1549). -->
         <button
           data-testid="wt-start"
-          class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
-          :disabled="!worktreeTask.trim()"
+          class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
+          :disabled="worktreeBusy !== null || !worktreeTask.trim()"
+          :title="worktreeBusy === CREATE_KEY ? 'Creating the worktree…' : 'Create a worktree for this task and start here'"
           @click="createWorktreeAndLaunch"
         >
-          <span class="material-symbols-outlined" aria-hidden="true">add</span> New worktree
+          <span class="material-symbols-outlined" :class="{ 'animate-spin': worktreeBusy === CREATE_KEY }" aria-hidden="true">{{
+            worktreeBusy === CREATE_KEY ? "progress_activity" : "add"
+          }}</span>
+          {{ worktreeBusy === CREATE_KEY ? "Creating…" : "New worktree" }}
         </button>
       </div>
+      <!-- Until #1549 a refused create showed nothing whatever, so a base branch that is not
+           checked out locally and a click that never registered looked exactly alike. -->
+      <span v-if="worktreeError" data-testid="wt-error" role="alert" class="font-sans text-[11px] leading-snug text-amber">{{ worktreeError }}</span>
       <div v-for="w in worktreeList.worktrees" :key="w.path" class="flex items-center gap-1.5">
         <button
           class="flex-auto min-w-0 text-left rounded-md border bg-elevated font-mono text-[12px] py-[5px] px-2.5 truncate"
-          :class="
-            worktreeAction(w.session) === 'busy'
-              ? 'border-amber text-dim cursor-not-allowed'
-              : 'border-border text-secondary cursor-pointer hover:bg-hover hover:text-fg'
-          "
+          :class="[
+            worktreeAction(w.session) === 'busy' ? 'border-amber text-dim' : 'border-border text-secondary',
+            worktreeRowHeld(w) ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-hover hover:text-fg',
+          ]"
           data-testid="worktree-reuse"
-          :disabled="worktreeAction(w.session) === 'busy'"
+          :disabled="worktreeRowHeld(w)"
           :title="worktreeTitle(w)"
           @click="openWorktree(w)"
         >
           ⎇ {{ w.task }}<span v-if="w.dirty" data-testid="wt-dirty" class="ml-1.5 text-[var(--warn-text,#e0a030)]" title="uncommitted changes">●</span>
           <span v-if="worktreeAction(w.session) === 'busy'" data-testid="wt-busy" class="ml-1.5 font-sans text-[11px] text-amber">in use</span>
           <span v-else-if="worktreeAction(w.session) === 'resume'" data-testid="wt-resume" class="ml-1.5 font-sans text-[11px] text-dim">resume</span>
+          <!-- The row waits on up to four `claude mcp add` calls before the cell launches, and it
+               stays on screen for all of them. -->
+          <span
+            v-if="worktreeBusy === openKey(w)"
+            data-testid="wt-opening"
+            class="material-symbols-outlined ml-1.5 animate-spin align-middle text-[13px]"
+            aria-hidden="true"
+            >progress_activity</span
+          >
         </button>
         <button
           data-testid="wt-del"
-          class="flex-none cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-[13px] hover:bg-[var(--err-hover-bg)]"
-          title="Remove worktree"
+          class="flex-none cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-[13px] enabled:hover:bg-[var(--err-hover-bg)] disabled:cursor-default disabled:opacity-40"
+          :disabled="worktreeBusy !== null"
+          :title="worktreeBusy === removeKey(w) ? 'Removing the worktree…' : 'Remove worktree'"
           aria-label="Remove worktree"
           @click="removeWorktree(w)"
         >
-          <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+          <span class="material-symbols-outlined" :class="{ 'animate-spin': worktreeBusy === removeKey(w) }" aria-hidden="true">{{
+            worktreeBusy === removeKey(w) ? "progress_activity" : "delete"
+          }}</span>
         </button>
       </div>
     </div>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -806,6 +806,9 @@ async function close() {
     teardown();
     return;
   }
+  // The header's own close button is not covered by the overlay. Re-entering while a removal runs
+  // would clear the error the removal is about to write.
+  if (closeBusy.value !== null) return;
   closeError.value = null;
   closeConfirm.value = true;
   // Refresh dirty/ahead before the Remove button is enabled, so a fast click can't
@@ -814,7 +817,13 @@ async function close() {
   await loadDiff();
   closeChecking.value = false;
 }
+
+// Nothing dismisses the confirmation once the removal has started. The pty is terminated before the
+// route is even called, so a dialog that closes here would claim the worktree was kept while it is
+// being deleted — and would take its failure off the screen with it (Codex and CodeRabbit, #1550).
+// Guarded in the shared function rather than on the button, because Escape reaches it too.
 function cancelClose() {
+  if (closeBusy.value !== null) return;
   closeConfirm.value = false;
   closeChecking.value = false;
   closeError.value = null;
@@ -1611,9 +1620,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               </p>
               <p v-else class="m-0 font-sans text-[12px] text-dim">Keep the worktree to reuse it later, or remove it.</p>
               <div class="flex flex-wrap gap-1.5">
+                <!-- Held during a removal: by then the pty is gone and the branch is being
+                     deleted, so "keep" is a promise this cannot make. -->
                 <button
                   data-testid="ccx-keep"
-                  class="cursor-pointer rounded-md border border-accent bg-elevated px-3 py-1.5 font-sans text-[12px] text-fg hover:bg-hover hover:text-fg"
+                  class="cursor-pointer rounded-md border border-accent bg-elevated px-3 py-1.5 font-sans text-[12px] text-fg enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
+                  :disabled="closeBusy !== null"
                   @click="teardown"
                 >
                   Keep worktree
@@ -1648,7 +1660,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                   {{ closeBusy === REMOVE_KEY ? "Removing…" : "Retry" }}
                 </button>
                 <button
-                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  data-testid="ccx-close-cell"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
+                  :disabled="closeBusy !== null"
                   @click="teardown"
                 >
                   Close cell

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -3,6 +3,7 @@ import { ref, computed, nextTick, watch, onMounted, onUnmounted, useTemplateRef 
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+import { useBusyAction } from "../composables/useBusyAction";
 import { useCellChrome } from "../composables/useCellChrome";
 import { useGitStatus } from "../composables/useGitStatus";
 import { useWorkItem } from "../composables/useWorkItem";
@@ -66,7 +67,7 @@ import { runRoundTable, liveRoundTableDeps, memberFromTarget, type TableMember }
 import { roundTableMessage } from "../composables/roundTableRules";
 import RoundTableMenu from "./RoundTableMenu.vue";
 import { outcomeMessage } from "../composables/exchangeRules";
-import { worktreeFailureMessage } from "./cellChromeRules";
+import { worktreeFailureMessage, worktreeRequestFailure } from "./cellChromeRules";
 import { isRecord } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
@@ -819,12 +820,30 @@ function cancelClose() {
   closeError.value = null;
 }
 
+// `git worktree remove` on a large repository takes seconds, and the confirmation stays on screen
+// for all of them — so the button holds itself and says so, rather than terminating the pty and
+// firing a second removal on the next impatient click (#1549's rule, same route).
+const { busy: closeBusy, run: runCloseAction } = useBusyAction();
+const REMOVE_KEY = "remove";
+
+// The three things this one button is doing at any moment: waiting for an accurate dirty/ahead
+// count, running the removal, or offering it.
+const removeButtonLabel = computed(() => {
+  if (closeChecking.value) return "Checking…";
+  if (closeBusy.value === REMOVE_KEY) return "Removing…";
+  return hasUnsaved.value ? "Discard & remove" : "Remove worktree";
+});
+
 async function removeAndClose() {
   const dir = cwd.value;
   if (!dir) {
     teardown();
     return;
   }
+  await runCloseAction(REMOVE_KEY, () => requestRemove(dir));
+}
+
+async function requestRemove(dir: string) {
   closeError.value = null;
   termRef.value?.terminate(); // free the worktree dir first (Windows locks a process's cwd)
   try {
@@ -838,7 +857,7 @@ async function removeAndClose() {
       SLOW_COMMAND_TIMEOUT_MS,
     );
     if (res.ok) return teardown();
-    closeError.value = "Couldn't remove the worktree — it may need manual cleanup.";
+    closeError.value = `Couldn't remove the worktree: ${worktreeRequestFailure(await jsonBody(res), res.status)} — it may need manual cleanup.`;
   } catch {
     closeError.value = "Couldn't reach the server to remove the worktree.";
   }
@@ -1601,15 +1620,16 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                 </button>
                 <button
                   data-testid="ccx-remove"
-                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-                  :disabled="closeChecking"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary enabled:hover:border-err-text enabled:hover:bg-[var(--err-hover-bg)] enabled:hover:text-err-text disabled:cursor-default disabled:opacity-40"
+                  :disabled="closeChecking || closeBusy !== null"
                   @click="removeAndClose"
                 >
-                  {{ closeChecking ? "Checking…" : hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}
+                  {{ removeButtonLabel }}
                 </button>
                 <button
                   data-testid="ccx-cancel"
-                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
+                  :disabled="closeBusy !== null"
                   @click="cancelClose"
                 >
                   Cancel
@@ -1621,10 +1641,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               <div class="flex flex-wrap gap-1.5">
                 <button
                   data-testid="ccx-remove"
-                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary enabled:hover:border-err-text enabled:hover:bg-[var(--err-hover-bg)] enabled:hover:text-err-text disabled:cursor-default disabled:opacity-40"
+                  :disabled="closeBusy !== null"
                   @click="removeAndClose"
                 >
-                  Retry
+                  {{ closeBusy === REMOVE_KEY ? "Removing…" : "Retry" }}
                 </button>
                 <button
                   class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"

--- a/src/components/cellChromeRules.ts
+++ b/src/components/cellChromeRules.ts
@@ -7,6 +7,10 @@ const REASON_MESSAGES = new Map<string, string>([
   ["no-remote", "No git remote (origin) configured"],
   ["no-forge", "Push succeeded — this remote is on a forge MulmoTerminal cannot open a request on; do it there"],
   ["push-failed", "Push failed"],
+  // Removal's two refusals. The launcher sends `force` for a worktree its list showed as dirty, so
+  // `dirty` is the one that became dirty since — which is exactly when the user needs telling.
+  ["dirty", "It has uncommitted changes — reload the list and confirm again"],
+  ["not-managed", "Not a worktree MulmoTerminal created, so it will not remove it"],
   ["failed", "Failed"],
 ]);
 
@@ -16,6 +20,16 @@ const REASON_MESSAGES = new Map<string, string>([
 // sentence belongs.
 export function worktreeFailureMessage(reason?: string | null): string {
   return REASON_MESSAGES.get(reason ?? "") ?? "Failed";
+}
+
+// What a refused worktree REQUEST says. The routes answer a failure in two shapes — `{ error }`
+// from create and from every argument check, `{ ok:false, reason }` from remove/push/pr — and the
+// sentence naming the cause lives in a different key in each. Showing it at all is #1447's rule:
+// a button that swallows the server's reason is a button that "does nothing".
+export function worktreeRequestFailure(body: Record<string, unknown>, status: number): string {
+  if (typeof body.error === "string" && body.error) return body.error;
+  if (typeof body.reason === "string" && body.reason) return worktreeFailureMessage(body.reason);
+  return `The request failed (HTTP ${status}).`;
 }
 
 // Which cell the zoom transition should fly, given the expanded cell before and after.

--- a/src/composables/useBusyAction.ts
+++ b/src/composables/useBusyAction.ts
@@ -1,0 +1,34 @@
+// One slow, side-effecting click at a time.
+//
+// A button whose handler shells out — `git worktree add` checks out the whole tree, seconds on a
+// large repository — stays pressable for the entire round trip unless something says otherwise,
+// and a screen that does not change is indistinguishable from a click that did nothing. So it is
+// pressed again: #1549 got three worktrees for one task, because every press succeeded.
+//
+// The rule is not new here — `pickPaths` refuses a second dialog (#1527), the /prs issue row holds
+// itself with `starting` (#1219), `useSessionStop` with `stopping` — it just had no shared home,
+// which is how the worktree buttons ended up without it.
+import { ref } from "vue";
+
+export function useBusyAction() {
+  // The KEY of the action in flight, rather than a flag: several controls share one guard, and the
+  // one that was actually pressed is the one that should show the progress. Null means idle.
+  const busy = ref<string | null>(null);
+
+  // Exclusive across keys, not per key. Every caller so far runs git in ONE repository, where two
+  // concurrent commands contend on the index lock; and "the form is doing something" is a state a
+  // user can read, where "these two buttons are live and that one is not" is not.
+  async function run(key: string, action: () => Promise<void>): Promise<void> {
+    if (busy.value !== null) return;
+    busy.value = key;
+    try {
+      await action();
+    } finally {
+      // Released even when the action threw, or one failure would leave the form dead with no way
+      // back short of a reload.
+      busy.value = null;
+    }
+  }
+
+  return { busy, run };
+}

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -1071,6 +1071,55 @@ describe("creating a worktree", () => {
     expect(w.find('[data-testid="wt-error"]').exists()).toBe(false);
   });
 
+  // Raised by Codex on #1550. `fetchWithTimeout` keeps its deadline armed across the BODY, so a
+  // read that aborts after a 200 used to be absorbed into `{}` and reported as "the server answered
+  // without a worktree path" — for a worktree that exists. The absorption is still right on a
+  // refusal, where the STATUS is the answer and the body may not be JSON at all.
+  it("reports an unreadable 200 body as a timeout, not as a worktree that was never made", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/create")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new DOMException("The operation was aborted.", "AbortError");
+          },
+        };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+    }) as unknown as typeof fetch;
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    const text = w.find('[data-testid="wt-error"]').text();
+    expect(text).toContain("Timed out");
+    expect(text).not.toContain("without a worktree path");
+    expect(w.emitted("start")).toBeUndefined();
+  });
+
+  it("still reads a refusal whose body is not JSON at all (a 403 from the origin guard)", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/create")) {
+        return {
+          ok: false,
+          status: 403,
+          json: async () => {
+            throw new SyntaxError("Unexpected token '<'");
+          },
+        };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+    }) as unknown as typeof fetch;
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    expect(w.find('[data-testid="wt-error"]').text()).toContain("403");
+  });
+
   // `fetchWithTimeout` gives up at 60s, which a checkout large enough to make #1549 worth fixing can
   // exceed — and git carries on regardless. "Could not reach the server" would send the user to look
   // at their network for a worktree that is about to appear.

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -911,3 +911,195 @@ describe("the folder button when the host has no file dialog", () => {
     expect(pickError(w).exists()).toBe(false);
   });
 });
+
+// #1549: `git worktree add` checks out the whole tree — around six seconds on the reporter's
+// 33,000-file monorepo — and the form was byte-identical to the one before the click for all of it.
+// The button's only `disabled` test was "is the task field empty", and the field is cleared once
+// the ANSWER lands, so it stayed live; `uniqueBranch` takes the next free suffix, so every extra
+// press succeeded. Three presses, three worktrees: agent/<task>, -2, -3.
+describe("creating a worktree", () => {
+  /** Everything answers as usual, but the create waits until the test lets it finish. */
+  function mockHeldCreate(answer: { ok: boolean; status?: number; body: unknown }, worktrees: WorktreeRow[] = []) {
+    const bodies: string[] = [];
+    let finish: () => void = () => {};
+    const held = new Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>((resolve) => {
+      finish = () => resolve({ ok: answer.ok, status: answer.status ?? (answer.ok ? 200 : 500), json: async () => answer.body });
+    });
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/create")) {
+        bodies.push(String(init?.body ?? ""));
+        return held;
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    return { finish, bodies };
+  }
+
+  const startButton = (w: ReturnType<typeof mountForm>) => w.find('[data-testid="wt-start"]');
+
+  /** Type a task name and press the button, leaving the create in flight. */
+  async function beginCreate(w: ReturnType<typeof mountForm>, task = "fix login") {
+    await w.find('[data-testid="wt-task"]').setValue(task);
+    await startButton(w).trigger("click");
+    await flushPromises();
+  }
+
+  it("holds the button and says it is working while the worktree is being cut", async () => {
+    const { finish } = mockHeldCreate({ ok: true, body: { path: "/wt/fix-login", branch: "agent/fix-login" } });
+    const w = mountForm();
+    await flushPromises();
+    await w.find('[data-testid="wt-task"]').setValue("fix login");
+    expect(startButton(w).attributes("disabled")).toBeUndefined();
+    await startButton(w).trigger("click");
+    await flushPromises();
+    expect(startButton(w).attributes("disabled")).toBeDefined();
+    expect(startButton(w).text()).toContain("Creating…");
+    finish();
+    await flushPromises();
+    expect(w.emitted("start")?.at(-1)).toEqual(["/wt/fix-login"]);
+    expect(startButton(w).text()).toContain("New worktree");
+  });
+
+  // The Enter key is the OTHER way in and the input is never disabled, so the guard has to live in
+  // the handler rather than only on the button — which is what makes this a fix and not a coat of
+  // paint.
+  it("creates exactly one worktree however many times it is asked", async () => {
+    const { finish, bodies } = mockHeldCreate({ ok: true, body: { path: "/wt/fix-login" } });
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    await w.find('[data-testid="wt-task"]').trigger("keydown.enter");
+    await startButton(w).trigger("click");
+    await flushPromises();
+    expect(bodies).toHaveLength(1);
+    finish();
+    await flushPromises();
+    expect(bodies).toHaveLength(1);
+    expect(w.emitted("start")).toHaveLength(1);
+  });
+
+  // The task name stays put on a failure: it is what the retry needs, and clearing it would make a
+  // refused create look like one that worked.
+  it("shows what the server said instead of nothing at all", async () => {
+    const { finish } = mockHeldCreate({ ok: false, status: 500, body: { error: "fatal: Not a valid object name: 'main'." } });
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    finish();
+    await flushPromises();
+    expect(w.find('[data-testid="wt-error"]').text()).toContain("Not a valid object name");
+    expect(w.emitted("start")).toBeUndefined();
+    expect(startButton(w).attributes("disabled")).toBeUndefined();
+  });
+
+  // A 200 with no path is not a worktree to launch in, and treating it as one would start the agent
+  // in whatever the directory field happens to say.
+  it("refuses to launch on an answer that names no worktree", async () => {
+    const { finish } = mockHeldCreate({ ok: true, body: { branch: "agent/fix-login" } });
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    finish();
+    await flushPromises();
+    expect(w.emitted("start")).toBeUndefined();
+    expect(w.find('[data-testid="wt-error"]').exists()).toBe(true);
+  });
+
+  // One guard for the whole section: these all shell out to git in one repository, where a second
+  // command contends on the index lock.
+  it("holds the existing worktrees' own buttons while a create runs", async () => {
+    const { finish } = mockHeldCreate({ ok: true, body: { path: "/wt/fix-login" } }, [worktree({ session: null })]);
+    const w = mountForm();
+    await flushPromises();
+    expect(w.find('[data-testid="wt-del"]').attributes("disabled")).toBeUndefined();
+    await beginCreate(w);
+    expect(w.find('[data-testid="wt-del"]').attributes("disabled")).toBeDefined();
+    expect(w.find('[data-testid="worktree-reuse"]').attributes("disabled")).toBeDefined();
+    finish();
+    await flushPromises();
+    expect(w.find('[data-testid="wt-del"]').attributes("disabled")).toBeUndefined();
+  });
+
+  it("does not offer the button at all with no task name", async () => {
+    mockFetch();
+    const w = mountForm();
+    await flushPromises();
+    expect(startButton(w).attributes("disabled")).toBeDefined();
+    expect(startButton(w).classes()).toContain("disabled:opacity-40");
+  });
+
+  // The failure belongs to the repository it was refused in, and the section comes BACK for the
+  // next directory — so a message kept in state would reappear under a repo it says nothing true
+  // about. Waited out in real time, like the debounce spec below: what matters is the state after
+  // the new directory's lists land, not that a timer was scheduled.
+  it("drops the failure when the field moves to another repository", async () => {
+    const { finish } = mockHeldCreate({ ok: false, status: 500, body: { error: "fatal: Not a valid object name: 'main'." } });
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    finish();
+    await flushPromises();
+    expect(w.find('[data-testid="wt-error"]').exists()).toBe(true);
+    await w.setProps({ dir: "/elsewhere" });
+    for (let waited_ms = 0; waited_ms < 3000; waited_ms += 25) {
+      if (w.find('[data-testid="cell-worktrees"]').exists()) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await flushPromises();
+    }
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true); // the section is back…
+    expect(w.find('[data-testid="wt-error"]').exists()).toBe(false); // …without the other repo's failure
+  });
+});
+
+// The delete beside each row is the same shape of button on the same slow route, and had the same
+// nothing: no guard, no progress, and `catch {}` over the answer.
+describe("removing a worktree", () => {
+  function mockHeldRemove(answer: { ok: boolean; status?: number; body: unknown }) {
+    let finish: () => void = () => {};
+    let calls = 0;
+    const held = new Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>((resolve) => {
+      finish = () => resolve({ ok: answer.ok, status: answer.status ?? (answer.ok ? 200 : 500), json: async () => answer.body });
+    });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/remove")) {
+        calls += 1;
+        return held;
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [worktree({ session: null })] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    return { finish, calls: () => calls };
+  }
+
+  it("removes once however many times the button is pressed, and shows which row it is on", async () => {
+    const { finish, calls } = mockHeldRemove({ ok: true, body: { ok: true } });
+    const w = mountForm();
+    await flushPromises();
+    const del = () => w.find('[data-testid="wt-del"]');
+    await del().trigger("click");
+    await flushPromises();
+    expect(del().attributes("disabled")).toBeDefined();
+    expect(del().text()).toContain("progress_activity");
+    await del().trigger("click");
+    await flushPromises();
+    expect(calls()).toBe(1);
+    finish();
+    await flushPromises();
+    expect(del().text()).toContain("delete");
+  });
+
+  it("says why a removal was refused", async () => {
+    const { finish } = mockHeldRemove({ ok: false, status: 409, body: { ok: false, reason: "dirty" } });
+    const w = mountForm();
+    await flushPromises();
+    await w.find('[data-testid="wt-del"]').trigger("click");
+    finish();
+    await flushPromises();
+    expect(w.find('[data-testid="wt-error"]').text()).toContain("uncommitted changes");
+  });
+});

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -1052,6 +1052,42 @@ describe("creating a worktree", () => {
     expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true); // the section is back…
     expect(w.find('[data-testid="wt-error"]').exists()).toBe(false); // …without the other repo's failure
   });
+
+  // The harder half of the same rule: the field is editable for the whole round trip, so a refusal
+  // can LAND after the move. Clearing on the change is not enough — the answer has to know which
+  // repository it was about. (Observed during review, not flagged by either bot.)
+  it("does not report a refusal that lands after the field has moved on", async () => {
+    const { finish } = mockHeldCreate({ ok: false, status: 500, body: { error: "fatal: Not a valid object name: 'main'." } });
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    await w.setProps({ dir: "/elsewhere" }); // typed while the create is still in flight
+    finish();
+    for (let waited_ms = 0; waited_ms < 3000; waited_ms += 25) {
+      if (w.find('[data-testid="cell-worktrees"]').exists()) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await flushPromises();
+    }
+    expect(w.find('[data-testid="wt-error"]').exists()).toBe(false);
+  });
+
+  // `fetchWithTimeout` gives up at 60s, which a checkout large enough to make #1549 worth fixing can
+  // exceed — and git carries on regardless. "Could not reach the server" would send the user to look
+  // at their network for a worktree that is about to appear.
+  it("says a timeout is a timeout, not an unreachable server", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/create")) throw new DOMException("The operation was aborted.", "AbortError");
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees: [] }) };
+      return { ok: true, json: async () => ({ cwd: "/repo", sessions: [] }) };
+    }) as unknown as typeof fetch;
+    const w = mountForm();
+    await flushPromises();
+    await beginCreate(w);
+    const text = w.find('[data-testid="wt-error"]').text();
+    expect(text).toContain("Timed out");
+    expect(text).not.toContain("Could not reach");
+  });
 });
 
 // The delete beside each row is the same shape of button on the same slow route, and had the same

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1761,6 +1761,40 @@ describe("TerminalCell", () => {
     expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
   });
 
+  // Raised by Codex and CodeRabbit on #1550: the removal terminates the pty BEFORE it calls the
+  // route, so a dialog that can still be dismissed offers to "keep" a worktree that is already
+  // being deleted — and takes the failure off the screen on its way out.
+  it("lets nothing dismiss the confirmation once the removal has started", async () => {
+    const gate = deferred<{ ok: boolean; status: number; json: () => Promise<unknown> }>();
+    globalThis.fetch = vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/remove")) return gate.promise;
+      if (u.includes("/api/worktrees/diff")) return Promise.resolve({ ok: true, json: async () => cleanWtDiff });
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await flushPromises();
+    await w.find('[data-testid="ccx-remove"]').trigger("click");
+    await flushPromises();
+
+    expect(w.find('[data-testid="ccx-keep"]').attributes("disabled")).toBeDefined();
+    await w.find('[data-testid="ccx-keep"]').trigger("click");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await w.find(".cell-close").trigger("click"); // the header button is not under the overlay
+    await flushPromises();
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(false);
+
+    // …and the failure it was hiding stays put, on a confirmation that is dismissible again.
+    gate.resolve({ ok: false, status: 500, json: async () => ({ ok: false, reason: "failed" }) });
+    await flushPromises();
+    expect(w.find('[data-testid="ccx-warn"]').text()).toContain("Couldn't remove");
+    expect(w.find('[data-testid="ccx-close-cell"]').attributes("disabled")).toBeUndefined();
+  });
+
   it("keeps the confirm open with an error when the remove fails (no false success)", async () => {
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1727,6 +1727,40 @@ describe("TerminalCell", () => {
     expect(w.find('[data-testid="ccx-remove"]').attributes("disabled")).toBeUndefined(); // released
   });
 
+  // #1549's rule, on the same route: `git worktree remove` runs for seconds with the confirmation
+  // still on screen, and the button said nothing — so a second click terminated the pty again and
+  // fired a second removal at a path the first one was already taking apart.
+  it("holds Remove (Removing…) for the whole removal, and posts it once", async () => {
+    const gate = deferred<{ ok: boolean; status: number; json: () => Promise<unknown> }>();
+    let removes = 0;
+    globalThis.fetch = vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/remove")) {
+        removes += 1;
+        return gate.promise;
+      }
+      if (u.includes("/api/worktrees/diff")) return Promise.resolve({ ok: true, json: async () => cleanWtDiff });
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await flushPromises(); // the close() diff refresh releases the button
+    const remove = () => w.find('[data-testid="ccx-remove"]');
+    await remove().trigger("click");
+    await flushPromises();
+    expect(remove().attributes("disabled")).toBeDefined();
+    expect(remove().text()).toBe("Removing…");
+    expect(w.find('[data-testid="ccx-cancel"]').attributes("disabled")).toBeDefined();
+    await remove().trigger("click");
+    await flushPromises();
+    expect(removes).toBe(1);
+    gate.resolve({ ok: true, status: 200, json: async () => ({ ok: true }) });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
+  });
+
   it("keeps the confirm open with an error when the remove fails (no false success)", async () => {
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);

--- a/test/src/components/cellChromeRules.spec.ts
+++ b/test/src/components/cellChromeRules.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { flipTargetUid, shouldFlipZoom, worktreeFailureMessage } from "../../../src/components/cellChromeRules";
+import { flipTargetUid, shouldFlipZoom, worktreeFailureMessage, worktreeRequestFailure } from "../../../src/components/cellChromeRules";
 
 describe("worktreeFailureMessage", () => {
   it.each([
@@ -29,6 +29,25 @@ describe("worktreeFailureMessage", () => {
   // "function Object() { [native code] }" where a sentence belongs.
   it.each([["constructor"], ["toString"], ["__proto__"], ["hasOwnProperty"]])("does not resolve %s through the prototype chain", (reason) => {
     expect(worktreeFailureMessage(reason)).toBe("Failed");
+  });
+});
+
+// The worktree routes refuse in two shapes and the sentence naming the cause lives in a different
+// key in each. Reading only one of them is how #1549's create failure showed nothing at all.
+describe("worktreeRequestFailure", () => {
+  it("prefers the server's own sentence", () => {
+    expect(worktreeRequestFailure({ error: "fatal: Not a valid object name: 'main'." }, 500)).toBe("fatal: Not a valid object name: 'main'.");
+  });
+
+  it("explains a `reason` refusal in words", () => {
+    expect(worktreeRequestFailure({ ok: false, reason: "dirty" }, 409)).toContain("uncommitted changes");
+    expect(worktreeRequestFailure({ ok: false, reason: "not-managed" }, 409)).toContain("MulmoTerminal created");
+  });
+
+  // A body absorbed into `{}` (a 403 from the origin guard, a truncated response) still has to say
+  // that the click FAILED — the whole point is that silence is indistinguishable from doing nothing.
+  it.each([[{}], [{ error: "" }], [{ reason: 42 }]])("names the status when the body says nothing usable: %j", (body) => {
+    expect(worktreeRequestFailure(body, 403)).toContain("403");
   });
 });
 

--- a/test/src/composables/useBusyAction.spec.ts
+++ b/test/src/composables/useBusyAction.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+
+import { useBusyAction } from "../../../src/composables/useBusyAction";
+
+// The guard #1549 was missing: `git worktree add` runs for seconds with nothing on screen changing,
+// so the button gets pressed again — and every press succeeded, one worktree each.
+describe("useBusyAction", () => {
+  /** A promise the test decides when to settle, standing in for the round trip. */
+  function gate() {
+    let release: () => void = () => {};
+    let fail: (e: Error) => void = () => {};
+    const promise = new Promise<void>((resolve, reject) => {
+      release = resolve;
+      fail = reject;
+    });
+    return { promise, release, fail };
+  }
+
+  it("runs the first call and names it", async () => {
+    const { busy, run } = useBusyAction();
+    const first = gate();
+    expect(busy.value).toBeNull();
+    const running = run("create", () => first.promise);
+    expect(busy.value).toBe("create");
+    first.release();
+    await running;
+    expect(busy.value).toBeNull();
+  });
+
+  it("drops a second call while one is in flight", async () => {
+    const { run } = useBusyAction();
+    const first = gate();
+    let secondRan = false;
+    const running = run("create", () => first.promise);
+    await run("create", async () => {
+      secondRan = true;
+    });
+    expect(secondRan).toBe(false);
+    first.release();
+    await running;
+  });
+
+  // Exclusive across keys, not per key: the callers all shell out to git in ONE repository, where
+  // two commands contend on the index lock.
+  it("drops a DIFFERENT action while one is in flight", async () => {
+    const { run } = useBusyAction();
+    const first = gate();
+    let removeRan = false;
+    const running = run("create", () => first.promise);
+    await run("remove:/wt/x", async () => {
+      removeRan = true;
+    });
+    expect(removeRan).toBe(false);
+    first.release();
+    await running;
+  });
+
+  // A failure that left the flag set would leave the form dead with no way back short of a reload —
+  // and a failed create is exactly when the user wants to press it again.
+  it("releases after the action throws, and lets the retry through", async () => {
+    const { busy, run } = useBusyAction();
+    await expect(
+      run("create", () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(busy.value).toBeNull();
+    let retried = false;
+    await run("create", async () => {
+      retried = true;
+    });
+    expect(retried).toBe(true);
+  });
+
+  it("takes the next call once the first settles", async () => {
+    const { run } = useBusyAction();
+    const first = gate();
+    const running = run("create", () => first.promise);
+    first.release();
+    await running;
+    let secondRan = false;
+    await run("create", async () => {
+      secondRan = true;
+    });
+    expect(secondRan).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`+ New worktree` in the launcher POSTed `/api/worktrees/create` and changed **nothing** on screen for the whole round trip. Its only `disabled` test was "is the task field empty", and the field is cleared once the **answer** lands — so on a large repository (the reporter's is ~33,000 files, ~6s per checkout) the form was identical to the one before the click and the button stayed live. Each extra press succeeded, because `uniqueBranch` takes the next free suffix: `agent/<task>`, `-2`, `-3`.

The same line hid the failure. `if (!res.ok) return;` plus `catch {}` meant a 500 showed nothing at all — the reporter's actual cause (`git worktree add … main` with no local `main`) was only findable by reading the shipped `dist` bundle.

This adds **one guard for the whole worktree section** and gives every control in it a visible working state and a readable failure.

| where | what a second click used to do |
|---|---|
| `+ New worktree` | **a second worktree** for the same task (the issue) |
| a worktree row | a second `emit("start")` — the row waits on up to four `claude mcp add` calls first |
| the delete beside a row | a second `git worktree remove` at the same path |
| the running cell's `Discard & remove` | terminated the pty again and removed twice |

## Items to Confirm / Review

1. **The guard is exclusive across the section, not per button.** Creating holds the delete buttons and the rows too. Reasoning: they all shell out to git in one repository, where two commands contend on the index lock; and "the form is busy" is a state a user can read, where "these two are live and that one is not" is not. Same shape as `useIssueStart`'s `starting` (#1219) and `useSessionStop`'s `stopping`.
2. **Disabled cursor.** The issue suggested `cursor-not-allowed`; I used `disabled:cursor-default disabled:opacity-40` to match the two buttons immediately beside it in the same form (`cell-dir-go`, `cell-dir-pick` from #1527). Happy to switch all three to `cursor-not-allowed` instead if the "refused" reading is preferred — but they should agree.
3. **The server's 500 message is unchanged and still generic**: `could not create the worktree (is this a git repo?)`, which is misleading in the reporter's case — it *was* a repo, the base branch was missing. Surfacing git's real stderr means changing `git()` (which drains and discards stderr deliberately) and `createWorktree`'s `null` return, read by every caller and a dozen specs. Left as a self-contained follow-up; the UI now shows whatever the server does say.
4. **Server-side de-duplication is deliberately not added.** `agent/<task>` + `agent/<task>-2` from two intentional creates is documented behaviour with a spec pinning it.
5. `TerminalCell`'s `Cancel` is now also held during a removal. The removal has already terminated the pty by then, so cancelling would leave the confirmation dismissed over a half-removed worktree.

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1549
> たしかにそうだ。ボタンロックしてloading spinner みたいなのをまわしたほうがよいかも。ここ以外でも必要そうなのは直してね

## What ships

**`src/composables/useBusyAction.ts` (new)** — the rule in one place. `busy` holds the *key* of the action in flight, so the pressed control can spin while the others are merely disabled; `run` drops any call arriving while it is set, and releases in `finally` so a failure does not leave the form dead.

**`CellLaunchForm.vue`**
- create / open-row / delete all go through `runWorktreeAction`
- the acting control shows `progress_activity` (the spinner the `cell-dir-loading` row already uses); the create button's label becomes `Creating…`
- new `wt-error` line carries the server's own sentence — `{ error }` from create, `{ ok:false, reason }` from remove — and is dropped when the field moves to another repository, since the failure was about the previous one
- `wt-start` / `wt-del` get `enabled:hover:` + `disabled:` styling, so an empty task name no longer leaves a button that looks pressable and does nothing
- the delete confirmation is not raised at all while another action runs — a dialog answered "yes" for work that is then dropped is worse than a button that does not respond

**`TerminalCell.vue`** — `Discard & remove` runs through the same composable and reads `Removing…`; it, `Cancel` and the error-state `Retry` are held.

**`cellChromeRules.ts`** — `worktreeRequestFailure(body, status)` reads the routes' two refusal shapes; `dirty` and `not-managed` join the reason table (remove answers them; nothing rendered them before).

## Verification

`yarn format` / `lint` / `typecheck` / `build` / `test` (9314 passed) all green.

Beyond the specs, driven in a **real browser against a real dev server** (scratch `HOME` + `MULMOTERMINAL_HOME`, a throwaway git repo, the create/remove routes delayed 3.5–4s to stand in for the 33k-file monorepo):

- **create**: button `disabled=true`, label `progress_activity / Creating…`; four further clicks plus three Enter presses in the (never-disabled) task field over the 4s window → **1 request**, and `git worktree list` afterwards shows exactly one `agent/fix-login`, no `-2`
- **failure**: with the route returning `{"error":"fatal: Not a valid object name: 'main'."}`, that exact sentence appears under the section, the button is released, and the task name is kept for the retry
- **remove**: delete icon becomes the spinner, the row and the create button are held, four clicks → **1 request**, row gone afterwards
- no `pageerror` / console errors throughout

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate worktree creation and removal requests during slow operations.
  * Disabled conflicting controls and added progress indicators while actions are running.
  * Improved worktree error messages, including server-provided refusal details and network failures.
  * Cleared outdated errors when switching repositories or directories.
  * Preserved task input after unsuccessful worktree creation.
* **Improvements**
  * Resume actions now retain the selected agent and active session where available.
* **Tests**
  * Added coverage for concurrency protection, loading states, validation, retries, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->