### PR TITLE
feat(#1551): grey the whole cell and spin over it while its worktree is removed

### DIFF
--- a/plans/feat-1551-cell-removing-overlay.md
+++ b/plans/feat-1551-cell-removing-overlay.md
@@ -1,0 +1,43 @@
+# feat #1551 — a cell being removed should look like a cell being removed
+
+## The gap #1550 left
+
+#1550 made the removal button hold itself and read `Removing…`. That is a 12px label inside a
+dialog. Meanwhile the **cell** — its header, its directory chip, its terminal — carries on looking
+exactly like a live cell for the several seconds `git worktree remove` takes on a large repository.
+So the whole screen still says "nothing happened", which is the complaint #1549 was about, one
+layer out.
+
+## What ships
+
+**While `closeBusy === REMOVE_KEY`:**
+
+1. **The whole cell fades**, header included, through the mechanism parked cells already use
+   (`SUNK_CELL` = `opacity-40` on `.cell-inner`, which wraps every child — see `cellParked.ts`).
+   One computed yields the class for **either** reason, because two opacity utilities on one
+   element are settled by Tailwind's output order rather than by intent — the rule `SUNK_CELL`'s
+   own comment sets.
+2. **One spinner over the whole cell**, as a **sibling** of `.cell-inner` rather than a child: a
+   busy indicator inside the layer it is dimming would be dimmed by it. `absolute inset-0` on the
+   cell root therefore covers the header too, which the close-confirm overlay never did (that is
+   why #1550 needed a re-entry guard on `close()`).
+3. **The confirmation dialog is replaced, not faded.** Every one of its controls is already
+   disabled during the removal, and a dialog of dead buttons at 40% is noise where a spinner is an
+   answer. It comes **back** — with the failure — if the removal fails, which is the behaviour
+   #1550 shipped and this must not lose.
+
+Nothing else changes: the dismissal guards from #1550 (`cancelClose`, `close`, the disabled
+controls) all stay, because they are what makes the confirmation return intact on a failure.
+
+## Not in scope
+
+The launcher's own `wt-del` row already shows its spinner in place (#1550) and is a row in a list,
+not a cell — there is no cell to grey out. Left alone.
+
+## Files
+
+| file | |
+|---|---|
+| `src/components/cellParked.ts` | `SUNK_CELL` gains a second caller; comment says so |
+| `src/components/TerminalCell.vue` | the dim computed, the busy overlay, the dialog's `v-if` |
+| `test/src/components/TerminalCell.spec.ts` | the overlay appears and covers, the dialog returns with its error on failure |

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -835,11 +835,16 @@ function cancelClose() {
 const { busy: closeBusy, run: runCloseAction } = useBusyAction();
 const REMOVE_KEY = "remove";
 
+// `git worktree remove` runs for seconds on a large repository, and until #1551 the only thing
+// saying so was a 12px label inside the dialog — the cell itself, header and all, went on looking
+// live. This is what fades it and puts the spinner over it.
+const removingWorktree = computed(() => closeBusy.value === REMOVE_KEY);
+
 // The three things this one button is doing at any moment: waiting for an accurate dirty/ahead
 // count, running the removal, or offering it.
 const removeButtonLabel = computed(() => {
   if (closeChecking.value) return "Checking…";
-  if (closeBusy.value === REMOVE_KEY) return "Removing…";
+  if (removingWorktree.value) return "Removing…";
   return hasUnsaved.value ? "Discard & remove" : "Remove worktree";
 });
 
@@ -913,7 +918,10 @@ const headerStatusClass = computed(() => HEADER_STATUS[status.value]);
 // bring it back — that is how you look at a parked session without waking it.
 const parked = computed(() => props.parked === true);
 const sunk = computed(() => isCellSunk(parked.value, status.value));
-const sunkClass = computed(() => (sunk.value ? SUNK_CELL : ""));
+// Both reasons the cell body is faded — set aside, and on its way out (#1551) — resolved to ONE
+// class. Two opacity utilities on one element are settled by Tailwind's output order rather than
+// by intent, which is the rule SUNK_CELL's own comment sets.
+const fadedClass = computed(() => (sunk.value || removingWorktree.value ? SUNK_CELL : ""));
 const togglePark = () => emit("park", !parked.value);
 // Typing into it is the un-parking gesture. Guarded on `parked` so an awake cell does not ask the
 // grid to rewrite its state on every keystroke.
@@ -1185,7 +1193,20 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
          one property covers the whole cell. Opacity alone: the status branches own the borders,
          backgrounds and ink, and two utilities for one property are settled by Tailwind's
          output order rather than by intent. -->
-    <div class="cell-inner" :class="[CELL_INNER, sunkClass]">
+    <!-- A worktree being deleted, over the WHOLE cell — a sibling of `.cell-inner` rather than a
+         child, so it is not dimmed by the layer it is dimming, and so it reaches the header, which
+         the close-confirm overlay inside never did. -->
+    <div
+      v-if="removingWorktree"
+      data-testid="cell-removing"
+      class="absolute inset-0 z-[30] flex flex-col items-center justify-center gap-2 bg-[color-mix(in_srgb,var(--bg-base)_70%,transparent)]"
+      role="status"
+      :aria-label="`Removing worktree ${headerDir}`"
+    >
+      <span class="material-symbols-outlined animate-spin text-[30px] text-secondary" aria-hidden="true">progress_activity</span>
+      <span class="max-w-full truncate px-3 font-sans text-[12px] text-secondary">Removing {{ headerDir }}…</span>
+    </div>
+    <div class="cell-inner" :class="[CELL_INNER, fadedClass]">
       <template v-if="launched">
         <!-- Filmstrip thumbnail: the same roster header (CockpitHeader) — the dir colour is applied
            regardless of status (status is the dot + badge), so a thumbnail reads as its directory
@@ -1604,8 +1625,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
           </div>
         </div>
+        <!-- Replaced, not faded, while the removal runs: every control in here is already disabled
+             by then, and a dialog of dead buttons is noise where the spinner above is an answer. It
+             comes BACK with the failure if the removal fails — which is what the dismissal guards
+             below exist to protect (#1550). -->
         <div
-          v-if="closeConfirm"
+          v-if="closeConfirm && !removingWorktree"
           data-testid="cell-close-confirm"
           class="absolute inset-0 z-[25] flex items-center justify-center bg-[color-mix(in_srgb,var(--bg-base)_82%,transparent)] p-4"
           role="dialog"

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1206,7 +1206,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       <span class="material-symbols-outlined animate-spin text-[30px] text-secondary" aria-hidden="true">progress_activity</span>
       <span class="max-w-full truncate px-3 font-sans text-[12px] text-secondary">Removing {{ headerDir }}…</span>
     </div>
-    <div class="cell-inner" :class="[CELL_INNER, fadedClass]">
+    <!-- `inert` while the removal runs, not just faded: the veil above stops the mouse and nothing
+         else, so Tab still walked into the header buttons and the terminal's own textarea behind
+         it, and a screen reader still read a cell that is being deleted (Codex, #1552).
+         `|| undefined` rather than the boolean — `inert` is Booleanish to Vue, so `false` reaches
+         the DOM as inert="false", which is an inert element (the trap TerminalGrid's zoom-main
+         hit on #1333). -->
+    <div class="cell-inner" :class="[CELL_INNER, fadedClass]" :inert="removingWorktree || undefined">
       <template v-if="launched">
         <!-- Filmstrip thumbnail: the same roster header (CockpitHeader) — the dir colour is applied
            regardless of status (status is the dot + badge), so a thumbnail reads as its directory

--- a/src/components/cellParked.ts
+++ b/src/components/cellParked.ts
@@ -26,7 +26,8 @@ export function isCellSunk(parked: boolean, status: AttentionStatus): boolean {
 // Opacity ALONE. Every status branch in TerminalCell (CELL_STATUS / HEADER_STATUS / DOT_STATUS)
 // names its own border, background and ink, and two utilities setting one property are resolved
 // by Tailwind's output order rather than by intent — so the sunk look may only use a property
-// none of them touch.
+// none of them touch. That rule is why a cell being REMOVED (#1551) shares this one class rather
+// than adding a second opacity of its own: same property, so one caller has to win.
 export const SUNK_CELL = "opacity-40";
 
 // The dot while sunk. A second complete map rather than a conditional edit of DOT_STATUS, so

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
 import { CELL_CHIP_BTN, CELL_CHIP_ICON } from "../../../src/components/cellChromeClasses";
+import { SUNK_CELL } from "../../../src/components/cellParked";
 import { TOOL_GROUPS } from "../../../common/toolGroups";
 
 // Capture the "sessions" pub/sub callback and the reconnect handler so tests can push
@@ -1750,20 +1751,55 @@ describe("TerminalCell", () => {
     const remove = () => w.find('[data-testid="ccx-remove"]');
     await remove().trigger("click");
     await flushPromises();
-    expect(remove().attributes("disabled")).toBeDefined();
-    expect(remove().text()).toBe("Removing…");
-    expect(w.find('[data-testid="ccx-cancel"]').attributes("disabled")).toBeDefined();
-    await remove().trigger("click");
+    // The dialog hands over to the whole-cell spinner (#1551), so the second click has no button
+    // left to land on — the handler's own guard is what the count below is really testing.
+    expect(w.find('[data-testid="cell-removing"]').exists()).toBe(true);
+    await w.find(".cell-close").trigger("click");
     await flushPromises();
     expect(removes).toBe(1);
     gate.resolve({ ok: true, status: 200, json: async () => ({ ok: true }) });
     await flushPromises();
     expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-removing"]').exists()).toBe(false);
+  });
+
+  // #1551: the button read `Removing…` while the cell around it — header, chips, terminal — went on
+  // looking live for the several seconds `git worktree remove` takes. The whole cell now says so.
+  it("greys the whole cell and spins over it while the worktree is being removed", async () => {
+    const gate = deferred<{ ok: boolean; status: number; json: () => Promise<unknown> }>();
+    globalThis.fetch = vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/remove")) return gate.promise;
+      if (u.includes("/api/worktrees/diff")) return Promise.resolve({ ok: true, json: async () => cleanWtDiff });
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-inner").classes()).not.toContain(SUNK_CELL);
+
+    await w.find('[data-testid="ccx-remove"]').trigger("click");
+    await flushPromises();
+    const busy = w.find('[data-testid="cell-removing"]');
+    expect(busy.exists()).toBe(true);
+    expect(busy.text()).toContain("Removing");
+    expect(busy.attributes("role")).toBe("status");
+    // The body fades through the same one class parked cells use, and the spinner sits OUTSIDE it —
+    // a busy indicator inside the layer it is dimming would be dimmed by it.
+    expect(w.find(".cell-inner").classes()).toContain(SUNK_CELL);
+    expect(w.find(".cell-inner").find('[data-testid="cell-removing"]').exists()).toBe(false);
+    // …and it covers the header, which the confirmation overlay never did.
+    expect(busy.classes()).toContain("inset-0");
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);
   });
 
   // Raised by Codex and CodeRabbit on #1550: the removal terminates the pty BEFORE it calls the
-  // route, so a dialog that can still be dismissed offers to "keep" a worktree that is already
-  // being deleted — and takes the failure off the screen on its way out.
+  // route, so anything that dismisses the confirmation mid-flight takes the failure off the screen
+  // with it. Since #1551 the dialog hands over to the busy overlay, so the buttons are gone — but
+  // `cancelClose` still has to refuse, or Escape would clear `closeConfirm` underneath and the
+  // failure would come back to a confirmation that is no longer rendered.
   it("lets nothing dismiss the confirmation once the removal has started", async () => {
     const gate = deferred<{ ok: boolean; status: number; json: () => Promise<unknown> }>();
     globalThis.fetch = vi.fn((url: string) => {
@@ -1780,17 +1816,18 @@ describe("TerminalCell", () => {
     await w.find('[data-testid="ccx-remove"]').trigger("click");
     await flushPromises();
 
-    expect(w.find('[data-testid="ccx-keep"]').attributes("disabled")).toBeDefined();
-    await w.find('[data-testid="ccx-keep"]').trigger("click");
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     await w.find(".cell-close").trigger("click"); // the header button is not under the overlay
     await flushPromises();
-    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-removing"]').exists()).toBe(true);
     expect(w.find('[data-testid="cell-launch"]').exists()).toBe(false);
 
-    // …and the failure it was hiding stays put, on a confirmation that is dismissible again.
+    // …and the failure lands on a confirmation that is back, un-faded and dismissible again.
     gate.resolve({ ok: false, status: 500, json: async () => ({ ok: false, reason: "failed" }) });
     await flushPromises();
+    expect(w.find('[data-testid="cell-removing"]').exists()).toBe(false);
+    expect(w.find(".cell-inner").classes()).not.toContain(SUNK_CELL);
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true);
     expect(w.find('[data-testid="ccx-warn"]').text()).toContain("Couldn't remove");
     expect(w.find('[data-testid="ccx-close-cell"]').attributes("disabled")).toBeUndefined();
   });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1779,6 +1779,9 @@ describe("TerminalCell", () => {
     await w.find(".cell-close").trigger("click");
     await flushPromises();
     expect(w.find(".cell-inner").classes()).not.toContain(SUNK_CELL);
+    // Absent, NOT `inert="false"` — Vue treats it as Booleanish, and an element carrying
+    // inert="false" is inert (the trap TerminalGrid's zoom-main hit on #1333).
+    expect(w.find(".cell-inner").attributes("inert")).toBeUndefined();
 
     await w.find('[data-testid="ccx-remove"]').trigger("click");
     await flushPromises();
@@ -1790,6 +1793,10 @@ describe("TerminalCell", () => {
     // a busy indicator inside the layer it is dimming would be dimmed by it.
     expect(w.find(".cell-inner").classes()).toContain(SUNK_CELL);
     expect(w.find(".cell-inner").find('[data-testid="cell-removing"]').exists()).toBe(false);
+    // The veil stops the mouse and nothing else, so the body is made inert too — otherwise Tab
+    // walks into the header buttons and xterm's textarea behind it, and a screen reader reads a
+    // cell that is being deleted (Codex, #1552).
+    expect(w.find(".cell-inner").attributes("inert")).toBeDefined();
     // …and it covers the header, which the confirmation overlay never did.
     expect(busy.classes()).toContain("inset-0");
     expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);


### PR DESCRIPTION
## Summary

#1550 made the removal button hold itself and read `Removing…`. That is a 12px label inside a dialog — meanwhile the **cell** (header, chips, terminal) went on looking completely live for the several seconds `git worktree remove` takes on a large repository. So the screen still said "nothing happened", which is #1549's complaint one layer out.

While the removal runs:

- **the whole cell fades**, header included, through the same one class parked cells already use (`SUNK_CELL` = `opacity-40` on `.cell-inner`, which wraps every child)
- **one spinner sits over it**, centred, naming what is going: `Removing ⎇ demo-repo (fix-login)…`
- **the confirmation dialog is replaced**, not faded

## Items to Confirm / Review

1. **The spinner is a SIBLING of `.cell-inner`, not a child.** Two reasons, both load-bearing: a busy indicator inside the layer it is dimming would be dimmed by it (40%), and only a sibling at the cell root reaches the **header** — the close-confirm overlay is inside `.cell-inner` and never did, which is why #1550 needed a re-entry guard on `close()`.
2. **One class for the fade, not two.** `sunkClass` became `fadedClass`, yielding `SUNK_CELL` for *either* reason (parked, or removing). Adding a second opacity utility on the same element would be settled by Tailwind's output order rather than by intent — the rule `SUNK_CELL`'s own comment sets, now noted there.
3. **Replacing the dialog rather than fading it** is a judgement call. Every control in it is already disabled during the removal, so a dialog of dead buttons at 40% is noise where a spinner is an answer. It comes **back**, with its reason, if the removal fails — the dismissal guards from #1550 are what keep that true and are unchanged. The #1550 spec that asserted the dialog stays visible mid-removal has been rewritten against the new shape, and still proves what it was written for: Escape and the header close button must not clear `closeConfirm` underneath, or the failure would return to a confirmation that is no longer rendered.
4. **Not in scope:** the launcher's `wt-del` row already shows its spinner in place (#1550) and is a row in a list — there is no cell to grey out.

## User Prompt

> つづけてworktreeをとじるときに削除するけど、それもUI変化しないでなかなか閉じないので分かりづらい。そのセル全体をグレイアウトしてスピナーを回そう

## Verification

`format` / `lint` / `typecheck` / `build` / `test` all exit 0 (9319 passing).

Driven in a **real browser against a real dev server** (scratch `HOME` + `MULMOTERMINAL_HOME`, a throwaway git repo, the remove route delayed 6s to stand in for a large repository) — the actual flow, worktree created from the launcher and the cell closed from its own header:

- `.cell-inner` computed `opacity` = **0.4**; the overlay's own = **1**
- overlay bounding box `1082×744` against the cell's `1084×746` — the whole cell, border in
- text: `Removing ⎇ demo-repo (fix-login)…`, `role="status"`
- the confirmation is gone while it runs, and the launcher is back once it finishes
- no `pageerror`, no console errors

Screenshot: the header, the `connecting` chip and the terminal are all visibly dimmed behind a single crisp spinner.

Closes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear in-progress state when removing a worktree, including a full-cell spinner and faded appearance.
  * Disabled cell interactions and prevented repeated removal attempts while removal is underway.
* **Bug Fixes**
  * Restored the close confirmation dialog when worktree removal fails, allowing the action to be retried.
* **Tests**
  * Expanded coverage for removal progress, disabled states, completion, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->