### PR TITLE
fix: start the agent the phone asked for, instead of the launcher form (#1535)

### DIFF
--- a/plans/fix-1535-phone-agent-autostart.md
+++ b/plans/fix-1535-phone-agent-autostart.md
@@ -1,0 +1,89 @@
+# fix #1535 — the phone's claude / codex launch stops at the launcher form
+
+## Symptom
+
+From mulmoserver, "+ → claude" (or codex) opens a cell on the desktop grid, but it is the EMPTY
+cell-creation screen — the same thing the header `+` button opens. Nothing starts, and nothing
+starts later. `shell` works.
+
+## Which side
+
+Neither mulmoserver nor mulmoterminal's server. Both are correct:
+
+- `server/backends/remoteHost/launchTerminal.ts` validates the agent and publishes
+  `{ agent, cwd }` on `LAUNCH_TERMINAL_CHANNEL` (verified by its spec).
+- `src/App.vue` receives it and calls `openTerminalAt(cwd, null, agent)`.
+
+The bug is in the browser, in what the grid builds from that agent —
+`CELL_FOR_AGENT` in `src/components/GridView.vue`:
+
+```ts
+claude: (cwd) => ({ session: null, cwd }),
+codex:  (cwd) => ({ session: null, cwd, agent: "codex" }),
+```
+
+A cell with no session, no command and no launcher IS the empty launcher —
+`isLaunchCell()` in `gridTabs.ts` says so, and `TerminalCell` renders `CellLaunchForm`
+whenever `initialSessionId === null` (`launched = ref(props.initialSessionId !== null)`).
+So the phone's request produced a launch form with the agent PRE-SELECTED and the dir
+pre-filled, waiting for someone to press Start.
+
+`shell` works because `shellCell()` carries a `launcher`, which is a running cell.
+
+It never worked: 34841e80 (#831) introduced the mapping in this shape, its comment
+("Claude is the plain default") describes a persisted, already-running cell rather than a
+fresh one, and no browser-side test covers the channel end to end.
+
+## Why a new field is needed
+
+There is no way to say "a Claude cell that is starting" in `Cell` today. A fresh Claude launch
+from the UI is a purely LOCAL transition inside `TerminalCell` (`launchIn()` sets `launched`,
+bumps `connectKey`, and the server-generated session id arrives afterwards). The grid only ever
+learns about it when the id comes back. So the grid cannot express what it wants here, and the
+cell has nothing to act on.
+
+Rejected: giving the agent cells a `launcher`. A launcher cell runs a command on the launcher PTY
+path (`agent: "shell"`, no `--mcp-config`, no session accounting) — CLAUDE.md is explicit that a
+launcher must run the user's command verbatim and must not become an agent spawn path.
+
+## Change
+
+1. `src/components/gridTabs.ts`
+   - `Cell.autoStart?: true` — one-shot, ephemeral: "this cell already knows what it runs; start it
+     on mount instead of showing the launcher".
+   - It counts as OCCUPIED (`isOccupied`), so `switchPage` does not discard it as an abandoned
+     trailing launch cell in the window before its session id arrives, and `addCell` does not
+     cancel it. `isLaunchCell` becomes `!isOccupied`, which it already was term for term.
+   - `setSession` strips it: once a session exists the flag has done its job, and an emptied cell
+     left holding it would count as occupied forever.
+2. `src/components/GridView.vue` — every `CELL_FOR_AGENT` entry except `shell` carries
+   `autoStart: true`.
+3. `src/components/TerminalCell.vue` — `autoStart?: boolean` prop; on mount, when it is set, the
+   cell has no session and a cwd is known, call `launchIn(props.initialCwd)`. Once, on mount —
+   never a watcher: closing the session (`teardown`) puts this same component back on the launch
+   form without unmounting, and a watcher would restart it under the user.
+4. `src/components/TerminalGrid.vue` — pass it through.
+
+## Tests
+
+- `test/src/components/gridTabs.spec.ts`: an auto-start cell is occupied / not the launch cell `+`
+  cancels / survives `switchPage`; `setSession` clears the flag.
+- `test/src/components/phoneLaunchAgent.spec.ts` (new): the two halves the report ran through — the
+  real `TerminalCell` renders a terminal rather than `CellLaunchForm` and connects on the requested
+  agent's endpoint, and `openTerminalAt` (the seam `App.vue` calls for the published request) opens
+  a running cell for every kind in `LAUNCH_AGENTS`, `shell` still as a launcher. The end-to-end
+  assertion whose absence let this ship.
+- 13 of the new assertions verified RED against the unfixed code.
+
+## Verified against the running app, not only the specs
+
+`yarn dev` on isolated ports under a scratch `HOME` (so the real config is untouched), driven with
+Playwright, calling `openTerminalAt(dir, null, agent)` in the page — exactly what `App.vue` does
+with the published request:
+
+- before (fix stashed, `claude`): a SECOND cell-creation form, 0 terminals — the report, reproduced.
+- after (`claude`): 1 terminal, Claude Code's trust prompt in `~/proj-a`.
+- after (`codex`): 1 terminal, codex's own trust prompt — so it reached the codex endpoint, not
+  Claude's.
+
+No console errors in any run.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -21,6 +21,7 @@ import {
   runCommand,
   runScriptInNewCell,
   insertCellAfter,
+  revealCell,
   shellCell,
   sessionCell,
   launchInCell,
@@ -447,10 +448,16 @@ const CELL_FOR_AGENT: Record<LaunchAgent, (cwd: string) => Omit<Cell, "uid">> = 
 };
 const cellForAgent = (cwd: string, agent: LaunchAgent | undefined): Omit<Cell, "uid"> => (agent ? CELL_FOR_AGENT[agent](cwd) : shellCell(cwd));
 
+// `revealCell` after the insert, not instead of its page: what starts a cell is MOUNTING, and a
+// cell mounts only on the page the grid shows. insertCellAfter can only page by the manual index
+// — ordering needs the live status and the directory priorities, which only this component has.
 const openNewTerminal = ({ cwd, afterSlotKey, agent }: NewTerminalRequest) => {
   const match = afterSlotKey?.match(SLOT_UID_RE);
   const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
-  state.value = insertCellAfter(state.value, afterUid, cellForAgent(cwd, agent));
+  const uid = state.value.nextUid; // insertCellAfter gives the new cell this one
+  const placed = insertCellAfter(state.value, afterUid, cellForAgent(cwd, agent));
+  const order = orderCells(placed.cells, statusForSort.value, placed.sortMode, priorityByCwd.value).map((c) => c.uid);
+  state.value = revealCell(placed, uid, order);
 };
 const detachNewTerminal = () => {
   offNewTerminal?.();

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -429,16 +429,21 @@ let offNewTerminal: (() => void) | null = null;
 // marked with `agent`, and Claude is the plain default. The session id arrives from the server once
 // the cell opens its socket, so they all persist and reconnect like any other cell.
 //
+// `autoStart` is what makes an agent cell RUN. Without it these are indistinguishable from the
+// empty launcher — no session, no command, no launcher — so the phone's request (#831) opened the
+// cell-creation form with the agent pre-picked and waited for someone at the desktop to press
+// Start, which is exactly what #1535 reported. A shell needs none of it: its launcher runs on sight.
+//
 // A Record over LAUNCH_AGENTS rather than an if-chain: the chain ended in `shellCell`, so adding an
 // agent to that list without a case here silently opened a SHELL under its name. Now it does not
 // compile.
 const CELL_FOR_AGENT: Record<LaunchAgent, (cwd: string) => Omit<Cell, "uid">> = {
   shell: (cwd) => shellCell(cwd),
-  claude: (cwd) => ({ session: null, cwd }),
-  codex: (cwd) => ({ session: null, cwd, agent: "codex" }),
-  antigravity: (cwd) => ({ session: null, cwd, agent: "antigravity" }),
-  grok: (cwd) => ({ session: null, cwd, agent: "grok" }),
-  muse: (cwd) => ({ session: null, cwd, agent: "muse" }),
+  claude: (cwd) => ({ session: null, cwd, autoStart: true }),
+  codex: (cwd) => ({ session: null, cwd, agent: "codex", autoStart: true }),
+  antigravity: (cwd) => ({ session: null, cwd, agent: "antigravity", autoStart: true }),
+  grok: (cwd) => ({ session: null, cwd, agent: "grok", autoStart: true }),
+  muse: (cwd) => ({ session: null, cwd, agent: "muse", autoStart: true }),
 };
 const cellForAgent = (cwd: string, agent: LaunchAgent | undefined): Omit<Cell, "uid"> => (agent ? CELL_FOR_AGENT[agent](cwd) : shellCell(cwd));
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -99,6 +99,9 @@ const props = defineProps<
     initialCwd: string | null;
     // The persisted agent for this cell; absent (or "claude") resumes as a normal Claude session.
     initialAgent?: TerminalAgent | null | undefined;
+    // Start `initialAgent` in `initialCwd` on mount rather than opening the launcher form. Set by
+    // the grid for a cell it already knows what to run — the phone's launch request (#831).
+    autoStart?: boolean;
     defaultCwd: string | null;
     presets: CwdPreset[];
     // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
@@ -494,6 +497,15 @@ function startPickedAgent(dir: string | null) {
   if (pickedAgent.value === "shell") emit("launch", { launcher: shellLauncher(), cwd: dir });
   else launchIn(dir);
 }
+
+// The cell was opened with its agent and directory already decided (the phone's launch request),
+// so start it rather than showing the launcher for someone at the desktop to press Start.
+//
+// On MOUNT, once — never a watcher on the prop. Closing a session returns this same component to
+// the launch form without unmounting it (`teardown`), so a watcher would relaunch under the user.
+onMounted(() => {
+  if (props.autoStart && !launched.value && props.initialCwd) launchIn(props.initialCwd);
+});
 
 // Attach to a session the form listed, in the cwd those rows were fetched for (not the
 // possibly-changed input).

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1208,6 +1208,7 @@ watch(
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
           :initial-agent="cell.agent"
+          :auto-start="cell.autoStart === true"
           :presets="presets"
           :launchers="launchers"
           :custom-agents="customAgents ?? []"

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -54,7 +54,10 @@ export interface Cell {
   // someone to press Start. The phone's launch request (#831) is the only thing that sets it: the
   // grid has to say WHAT the cell runs, because a fresh agent launch is otherwise a local
   // transition inside TerminalCell and the grid learns of it only when the session id arrives.
-  // One-shot and ephemeral — cleared by setSession, and never persisted.
+  //
+  // One-shot: `setSession` drops it once the cell has answered. It never survives a RELOAD either
+  // — parseGridState rebuilds each cell field by field and does not carry it — though, like every
+  // other in-flight field, it is written to localStorage in the meantime rather than stripped.
   autoStart?: true;
 }
 // How the grid orders its cells. "manual": the user's hand-arranged order (the move buttons);
@@ -165,7 +168,8 @@ export function launchInCell(state: GridState, uid: number, launcher: CellLaunch
 
 // Insert a brand-new cell immediately AFTER the cell that triggered it, so the header
 // "new terminal" button and the Run button open next to the current cell rather than at
-// the end. Falls back to appending when `afterUid` is gone. Jumps to the new cell's page.
+// the end. Falls back to appending when `afterUid` is gone. Jumps to the new cell's page —
+// its MANUAL page, which is what the user sees only in manual mode; see revealCell.
 export function insertCellAfter(state: GridState, afterUid: number, cell: Omit<Cell, "uid">): GridState {
   if (runningCount(state.cells) >= MAX_TERMINALS) return state;
   const idx = state.cells.findIndex((c) => c.uid === afterUid);
@@ -174,6 +178,20 @@ export function insertCellAfter(state: GridState, afterUid: number, cell: Omit<C
   const cells = [...state.cells.slice(0, at), { ...cell, uid }, ...state.cells.slice(at)];
   const expanded = zoomedUid(state) !== null ? uid : state.expanded;
   return { ...state, cells, nextUid: state.nextUid + 1, page: Math.floor(at / PAGE_SIZE), expanded };
+}
+
+// Page the grid at whatever page actually SHOWS `uid`, given the display order.
+//
+// "auto" and "priority" order the whole list before paging (visibleOrdered), so a cell's manual
+// index and the page it appears on are different questions — and insertCellAfter can only answer
+// the first, since ordering needs live status and per-directory priority that a pure transform
+// here is not given. On a grid of more than one page that gap leaves the new cell on a page the
+// grid is not showing, and an unrendered cell never MOUNTS: its launcher, its command, or the
+// agent an `autoStart` cell was opened for is then never started at all (Codex on #1557).
+//
+// `order` is the uid order the grid renders — orderCells over the state this is called with.
+export function revealCell(state: GridState, uid: number, order: readonly number[]): GridState {
+  return { ...state, page: pageHolding(order, uid, state.page) };
 }
 
 // The Run button opened a script in a spare cell next to the cell that triggered it.

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -50,6 +50,12 @@ export interface Cell {
   // way (#992). Stored as the ABSENCE of the key when not parked, for the same reason `agent`
   // is — only an absent key survives the JSON a persisted cell round-trips.
   parked?: true;
+  // Start `agent` in `cwd` as soon as the cell mounts, instead of opening the launcher form for
+  // someone to press Start. The phone's launch request (#831) is the only thing that sets it: the
+  // grid has to say WHAT the cell runs, because a fresh agent launch is otherwise a local
+  // transition inside TerminalCell and the grid learns of it only when the session id arrives.
+  // One-shot and ephemeral — cleared by setSession, and never persisted.
+  autoStart?: true;
 }
 // How the grid orders its cells. "manual": the user's hand-arranged order (the move buttons);
 // "auto": attention-first, recomputed from each cell's live status; "priority": the rank each
@@ -72,9 +78,11 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 export const pageCount = (cellCount: number) => Math.max(1, Math.ceil(cellCount / PAGE_SIZE));
 export const pageSlice = <T>(cells: T[], page: number) => cells.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 // A cell occupies a slot when it runs a Claude session, a command, OR a launcher; only
-// those count toward the cap. A launch cell is empty: no session, command, or launcher.
-const isOccupied = (c: Cell) => c.session !== null || c.command != null || c.launcher != null;
-const isLaunchCell = (c: Cell | undefined) => !!c && c.session === null && c.command == null && c.launcher == null;
+// those count toward the cap. A cell told to auto-start counts too, in the window before its
+// session id arrives: it is about to run, and `switchPage` discards a trailing LAUNCH cell.
+// A launch cell is the other side of that — the empty launcher, waiting to be told what to run.
+const isOccupied = (c: Cell) => c.session !== null || c.command != null || c.launcher != null || c.autoStart === true;
+const isLaunchCell = (c: Cell | undefined) => !!c && !isOccupied(c);
 export const runningCount = (cells: Cell[]) => cells.filter(isOccupied).length;
 
 const clampPage = (s: GridState): GridState => ({ ...s, page: Math.min(Math.max(0, Math.floor(s.page)), pageCount(s.cells.length) - 1) });
@@ -109,7 +117,10 @@ export function cancelableLaunchUid(state: GridState): number | null {
 }
 
 export function setSession(state: GridState, uid: number, id: string | null): GridState {
-  const cells = state.cells.map((c) => (c.uid === uid ? { ...c, session: id } : c));
+  // Drop the one-shot auto-start flag: the cell has answered. Left set, a cell whose session is
+  // later closed would keep counting as occupied while sitting on the launcher form.
+  const started = ({ autoStart: _consumed, ...rest }: Cell): Cell => ({ ...rest, session: id });
+  const cells = state.cells.map((c) => (c.uid === uid ? started(c) : c));
   const expanded = id === null && state.expanded === uid ? null : state.expanded;
   return { ...state, cells, expanded };
 }

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -512,6 +512,37 @@ describe("setSession / setCwd / toggleExpand", () => {
   });
 });
 
+// `autoStart` is a cell the grid already knows what to run — the phone's launch request (#831).
+// Between the request and the server's session id it is the only thing telling the rest of the
+// grid that this cell is not an abandoned launcher, which is what #1535 turned on.
+describe("autoStart (a cell told to run on mount)", () => {
+  const starting = (uid: number): Cell => ({ uid, session: null, cwd: "/w", autoStart: true });
+
+  it("counts toward the cap like any other running cell", () => {
+    expect(runningCount([cell(0, U(0)), starting(1), cell(2)])).toBe(2);
+  });
+
+  // The one that costs the terminal: flipping pages before the session id lands would otherwise
+  // delete the cell the phone just asked for, as an abandoned trailing launcher.
+  it("survives a page switch", () => {
+    expect(switchPage(make([...running(9), starting(9)], { page: 1 }), 0).cells).toHaveLength(10);
+  });
+
+  it("is not the launch cell '+' cancels", () => {
+    expect(cancelableLaunchUid(make([...running(2), starting(2)]))).toBeNull();
+    expect(addCell(make([...running(2), starting(2)])).cells).toHaveLength(4); // appended, not cancelled
+  });
+
+  // One-shot: the cell has answered. Left set, closing that session later would leave an empty
+  // launcher permanently counted as occupied.
+  it("is cleared once the session arrives", () => {
+    const s = setSession(make([starting(0)]), 0, U(5));
+    expect(s.cells[0].session).toBe(U(5));
+    expect(s.cells[0].autoStart).toBeUndefined();
+    expect("autoStart" in s.cells[0]).toBe(false); // absent, not undefined — it round-trips through JSON
+  });
+});
+
 // `agent` is how a reloaded cell knows to reconnect via /ws/codex, and Claude is the ABSENT
 // case — so switching back to it has to REMOVE the key. A persisted grid round-trips through
 // JSON, where `agent: undefined` and no key are indistinguishable on the way out but only the

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -16,6 +16,7 @@ import {
   runCommand,
   runScriptInNewCell,
   insertCellAfter,
+  revealCell,
   shellCell,
   sessionCell,
   launchInCell,
@@ -509,6 +510,28 @@ describe("setSession / setCwd / toggleExpand", () => {
   it("always allows collapsing, even down to one cell", () => {
     const stranded = make([cell(0, U(0)), cell(1)], { expanded: 0 });
     expect(toggleExpand(stranded, 0).expanded).toBeNull();
+  });
+});
+
+// What starts a cell is MOUNTING, and a cell mounts only on the page the grid shows — so for an
+// auto-start cell the page is not cosmetic. insertCellAfter can only page by the manual index.
+describe("revealCell (page at where the cell is actually shown)", () => {
+  const ten = () => make(running(10), { page: 1 });
+
+  it("pages at the cell's position in the DISPLAY order, not its manual one", () => {
+    const manualLast = ten();
+    const reordered = [9, ...Array.from({ length: 9 }, (_, i) => i)]; // uid 9 sorted to the front
+    expect(revealCell(manualLast, 9, reordered).page).toBe(0);
+  });
+
+  it("agrees with the manual page when nothing was re-ordered", () => {
+    const order = Array.from({ length: 10 }, (_, i) => i);
+    expect(revealCell(ten(), 9, order).page).toBe(1);
+  });
+
+  // A uid the order doesn't carry (a full grid refused the insert) must not move the user.
+  it("leaves the page alone for a uid the order does not hold", () => {
+    expect(revealCell(ten(), 99, [0, 1, 2]).page).toBe(1);
   });
 });
 

--- a/test/src/components/phoneLaunchAgent.spec.ts
+++ b/test/src/components/phoneLaunchAgent.spec.ts
@@ -1,0 +1,150 @@
+// The phone asks the desktop grid to open a terminal in a session's directory (#831). Every kind
+// in LAUNCH_AGENTS has to actually RUN — a `shell` did while `claude` and `codex` stopped at the
+// cell-creation form, waiting for someone at the desktop to press Start (#1535).
+//
+// The two halves the report ran through are pinned here: what the GRID builds from the requested
+// agent, and what the CELL does with it on mount. The mapping was green in isolation on both sides
+// before — a cell with no session, no command and no launcher IS the empty launcher, and nothing
+// said so.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { LAUNCH_AGENTS, type LaunchAgent } from "../../../common/launchAgent";
+import { openTerminalAt } from "../../../src/composables/useNewTerminal";
+import { router } from "../../../src/router";
+import type { Cell } from "../../../src/components/gridTabs";
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+// The live terminal, reduced to the props that say WHERE it connected and as WHAT.
+vi.mock("../../../src/components/Terminal.vue", () => ({
+  default: {
+    name: "TerminalView",
+    props: ["sessionId", "connectKey", "cwd", "agent", "launcher", "hideHeader"],
+    template: '<div class="stub-term" />',
+  },
+}));
+
+// Module scope, not inside a test: the import is the slow part and collection has no per-test
+// budget (#1314).
+const TerminalCell = (await import("../../../src/components/TerminalCell.vue")).default;
+const GridView = (await import("../../../src/components/GridView.vue")).default;
+
+const CWD = "/w/proj";
+const LAUNCH_FORM = '[data-testid="cell-launch"]';
+
+beforeEach(() => {
+  localStorage.clear();
+  globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/api/config")) {
+      return { ok: true, json: async () => ({ cwd: "/w", home: "/w", cwdPresets: [], launchers: [], prRepos: [], userMcpServers: [] }) } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  }) as typeof fetch;
+});
+
+const mountCell = (props: { autoStart?: boolean; initialCwd?: string | null; initialAgent?: "claude" | "codex" }) =>
+  mount(TerminalCell, {
+    props: {
+      uid: 1,
+      expanded: false,
+      zoomed: false,
+      initialSessionId: null,
+      initialCwd: CWD,
+      defaultCwd: "/w",
+      presets: [],
+      home: "/w",
+      cancellable: false,
+      openSessionIds: [],
+      openCwds: [],
+      ...props,
+    },
+  });
+
+describe("a cell the grid already knows what to run", () => {
+  it("starts it on mount instead of opening the launcher form", async () => {
+    const w = mountCell({ autoStart: true });
+    await flushPromises();
+    expect(w.find(LAUNCH_FORM).exists()).toBe(false);
+    expect(w.find(".stub-term").exists()).toBe(true);
+  });
+
+  // The control, and the whole of #1535: the SAME cell without the flag is the empty launcher.
+  it("opens the launcher form when it is not told to start", async () => {
+    const w = mountCell({});
+    await flushPromises();
+    expect(w.find(LAUNCH_FORM).exists()).toBe(true);
+    expect(w.find(".stub-term").exists()).toBe(false);
+  });
+
+  it("starts a FRESH session in the requested directory", async () => {
+    const w = mountCell({ autoStart: true });
+    await flushPromises();
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.props("sessionId")).toBeNull(); // the server generates the id for a new session
+    expect(term.props("cwd")).toBe(CWD);
+  });
+
+  // A codex request that connected on Claude's endpoint would attach the wrong agent to a real
+  // session — the reason `agent` rides on the cell at all.
+  it("connects on the requested agent's endpoint", async () => {
+    const w = mountCell({ autoStart: true, initialAgent: "codex" });
+    await flushPromises();
+    expect(w.findComponent({ name: "TerminalView" }).props("agent")).toBe("codex");
+  });
+
+  it("tells the grid which agent it started, so a reload reconnects to the same endpoint", async () => {
+    const w = mountCell({ autoStart: true, initialAgent: "codex" });
+    await flushPromises();
+    expect(w.emitted("agent")?.[0]).toEqual(["codex"]);
+  });
+
+  // Nothing sets the flag without a directory today (the host refuses a session it has no cwd for),
+  // but starting a process in a guessed directory is the wrong way to fail if one ever does.
+  it("falls back to the launcher form when no directory is known", async () => {
+    const w = mountCell({ autoStart: true, initialCwd: null });
+    await flushPromises();
+    expect(w.find(LAUNCH_FORM).exists()).toBe(true);
+  });
+});
+
+// What the grid builds from the request. Driven through openTerminalAt — the seam App.vue calls
+// when the host publishes on LAUNCH_TERMINAL_CHANNEL — so this covers the mapping the phone hits.
+const GridStub = { name: "TerminalGrid", props: ["cells", "listRows", "expandedUid", "reorderable"], template: '<div class="grid-stub" />' };
+const ToolbarStub = { name: "AppToolbar", emits: ["settings"], template: "<div />" };
+
+const mountGrid = async () => {
+  await router.push("/terminals");
+  const w = mount(GridView, { global: { stubs: { TerminalGrid: GridStub, AppToolbar: ToolbarStub, SettingsModal: true } } });
+  await flushPromises();
+  return w;
+};
+const cellsOf = (w: Awaited<ReturnType<typeof mountGrid>>): Cell[] => w.findComponent(GridStub).props("cells");
+const openedFor = async (agent: LaunchAgent) => {
+  const w = await mountGrid();
+  openTerminalAt(CWD, null, agent);
+  await flushPromises();
+  const cell = cellsOf(w).find((c) => c.cwd === CWD);
+  w.unmount();
+  return cell;
+};
+
+describe("the grid's answer to a phone launch request", () => {
+  // Every kind, from the list itself: a new agent added to LAUNCH_AGENTS without a running cell
+  // here is the same silent failure, and it would ship the same way.
+  it.each(LAUNCH_AGENTS.filter((a) => a !== "shell"))("opens a running %s cell, not the launcher", async (agent) => {
+    const cell = await openedFor(agent);
+    expect(cell).toBeDefined();
+    expect(cell?.autoStart).toBe(true);
+    expect(cell?.agent).toBe(agent === "claude" ? undefined : agent);
+  });
+
+  // The one kind that already worked, and it must not start going through the agent path: a
+  // launcher runs the user's command verbatim on /ws/launch.
+  it("still opens a shell as a launcher cell", async () => {
+    const cell = await openedFor("shell");
+    expect(cell?.launcher).toEqual({ shell: true, label: "shell" });
+    expect(cell?.autoStart).toBeUndefined();
+  });
+});

--- a/test/src/components/phoneLaunchAgent.spec.ts
+++ b/test/src/components/phoneLaunchAgent.spec.ts
@@ -11,10 +11,16 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { LAUNCH_AGENTS, type LaunchAgent } from "../../../common/launchAgent";
 import { openTerminalAt } from "../../../src/composables/useNewTerminal";
 import { router } from "../../../src/router";
-import type { Cell } from "../../../src/components/gridTabs";
+import { PAGE_SIZE, type Cell } from "../../../src/components/gridTabs";
 
 vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+// Every pre-existing cell is mid-turn ("working"), which sorts BEHIND a brand-new idle one in
+// auto mode — the condition under which the grid's display order and the manual order disagree.
+const BUSY = vi.hoisted(() => ({ ids: Array.from({ length: 10 }, (_, i) => `${String(i).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`) }));
+vi.mock("../../../src/composables/useGridActivity", () => ({
+  useGridActivity: () => ({ activity: new Map(BUSY.ids.map((id) => [id, { working: true, waiting: false, event: null }])) }),
 }));
 // The live terminal, reduced to the props that say WHERE it connected and as WHAT.
 vi.mock("../../../src/components/Terminal.vue", () => ({
@@ -146,5 +152,35 @@ describe("the grid's answer to a phone launch request", () => {
     const cell = await openedFor("shell");
     expect(cell?.launcher).toEqual({ shell: true, label: "shell" });
     expect(cell?.autoStart).toBeUndefined();
+  });
+});
+
+// A cell only starts when it MOUNTS, and it only mounts while it is on the page the grid shows.
+// insertCellAfter pages by the cell's index in the MANUAL list — which is the page the user sees
+// only in manual mode. "auto" and "priority" re-order the whole list before paging, so on a grid
+// of more than one page the new cell could be shown on a page the grid had just navigated away
+// from, and nothing would ever start it (Codex on #1557).
+describe("the phone's request on a re-ordered, multi-page grid", () => {
+  const seedBusyGrid = () =>
+    localStorage.setItem(
+      "grid_v2",
+      JSON.stringify({
+        cells: BUSY.ids.map((session, uid) => ({ uid, session, cwd: "/w" })),
+        expanded: null,
+        page: 0,
+        sortMode: "auto",
+      }),
+    );
+
+  it("leaves the grid on the page that actually shows the new cell", async () => {
+    seedBusyGrid();
+    const w = await mountGrid();
+    openTerminalAt(CWD, null, "claude");
+    await flushPromises();
+    // The 10 working cells sort behind it, so the new idle cell is FIRST in display order —
+    // page 0 — while its manual index (10) says page 1.
+    expect(cellsOf(w).map((c) => c.cwd)).toContain(CWD);
+    expect(w.findComponent(GridStub).props("cells").length).toBeLessThanOrEqual(PAGE_SIZE);
+    w.unmount();
   });
 });

--- a/test/src/composables/terminalSlotAttachment.spec.ts
+++ b/test/src/composables/terminalSlotAttachment.spec.ts
@@ -143,6 +143,18 @@ describe("a slot inherited by a view asking for a different session", () => {
     expect(seen).toEqual(["s-1"]);
   });
 
+  // The same cell paging away and back before its id arrives — the window an auto-start cell
+  // (the phone's launch request, #1535) lives in. BOTH sides have no opinion: the slot has not
+  // learned an id and the remounted view is a fresh launch, so this must stay the reuse. A
+  // reconnect here would spawn a SECOND agent and orphan the first, which is what the cell's
+  // relaunch-on-mount was reviewed as doing (CodeRabbit on #1557) — it does not.
+  it("keeps the reuse when neither the slot nor the remounted view knows the session yet", () => {
+    conn.attach(KEY, withSession(null), {}, document.createElement("div"));
+    conn.detach(KEY, null);
+    conn.attach(KEY, withSession(null), {}, document.createElement("div"));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
   // A slot that has not learned an id is not a blank slate (review on #1534): it belongs to a
   // fresh launch whose socket may still be connecting, and its `session` frame — the OLD cell's —
   // would land on whatever view holds the slot. A view naming a concrete session reconnects.


### PR DESCRIPTION
## Summary

A `claude` or `codex` launch from the phone opened a cell on the desktop grid and stopped at the **empty cell-creation form** — agent pre-picked, directory filled in, waiting for someone at the desktop to press Start. `shell` worked. Nothing started if left alone.

The grid is what was wrong; both hosts were correct. A cell with **no session, no command and no launcher IS the empty launcher** (`isLaunchCell()` says so, and `TerminalCell` renders `CellLaunchForm` whenever it mounts without a session id) — and that is exactly what `CELL_FOR_AGENT` built for every agent kind.

`Cell.autoStart` (one-shot, ephemeral) is the missing way for the grid to say "this cell already knows what it runs; start it". `TerminalCell` consumes it on mount.

## Items to Confirm / Review

1. **A new field on `Cell` is the design call.** There was no way to express "a Claude cell that is STARTING": a fresh agent launch is a local transition inside `TerminalCell` (`launchIn` sets `launched`, bumps `connectKey`; the server generates the id afterwards), so the grid learns of it only when the id comes back. Giving the agent cells a `launcher` instead was **rejected** — that runs the user's command verbatim on the launcher PTY (`agent: "shell"`, no `--mcp-config`), which CLAUDE.md is explicit a launcher must stay and an agent spawn must not become.
2. **`autoStart` counts as OCCUPIED** (`isOccupied`). In the window before the session id arrives it is the only thing telling `switchPage` that a trailing cell is not an abandoned launcher to discard, and telling `+` not to cancel it. `isLaunchCell` becomes `!isOccupied`, which it already was term for term.
3. **`setSession` strips the flag.** Otherwise a cell whose session is later closed sits counted as occupied on an empty launcher form forever. Assert-worthy detail: it is removed as a KEY, not set to `undefined`.
4. **Consumed on MOUNT, once — deliberately not a watcher.** Closing a session (`teardown`) returns the same component to the launch form *without unmounting it*, so a watcher would relaunch under the user.
5. **The no-cwd fallback** (`props.initialCwd` required) is belt-and-braces: the host already refuses a session it has no directory for. Starting a process in a guessed directory seemed the wrong way to fail.
6. The comment above `CELL_FOR_AGENT` is worth a read — it now says why a `shell` needs none of this.

## User Prompt

> あー、これほんとうだ。起動してないな。直せる？serverとterminalのどっちの問題だ？？
> https://github.com/receptron/mulmoterminal/issues/1535

（続き: 「たぶんなおった！！れびゅーかなPRだ」）

## Which side was it

Neither mulmoserver nor mulmoterminal's server:

- `server/backends/remoteHost/launchTerminal.ts` validates the agent, looks the session's directory up and publishes `{ agent, cwd }` on `LAUNCH_TERMINAL_CHANNEL` — pinned by its own spec.
- `src/App.vue` receives it and calls `openTerminalAt(cwd, null, agent)`.

The browser is where it stopped, in `CELL_FOR_AGENT` (`src/components/GridView.vue`):

```ts
claude: (cwd) => ({ session: null, cwd }),
codex:  (cwd) => ({ session: null, cwd, agent: "codex" }),
```

It never worked. #831 (34841e80) shipped the mapping in this shape — its comment "Claude is the plain default" describes a persisted, already-running cell rather than a fresh one — and no test covered the channel end to end.

## Changes

| file | change |
| --- | --- |
| `src/components/gridTabs.ts` | `Cell.autoStart?: true`; it counts as occupied; `setSession` clears it |
| `src/components/GridView.vue` | every `CELL_FOR_AGENT` entry except `shell` carries `autoStart: true` |
| `src/components/TerminalCell.vue` | `autoStart` prop; `onMounted` → `launchIn(initialCwd)` |
| `src/components/TerminalGrid.vue` | pass it through |
| `plans/fix-1535-phone-agent-autostart.md` | design note |

## Tests

- `test/src/components/gridTabs.spec.ts` — the flag's lifecycle: occupied, survives `switchPage`, not the launch cell `+` cancels, cleared by `setSession`.
- `test/src/components/phoneLaunchAgent.spec.ts` (new) — the two halves the report ran through: the **real** `TerminalCell` renders a terminal rather than `CellLaunchForm` and connects on the requested agent's endpoint; and `openTerminalAt` (the seam `App.vue` calls) opens a running cell for **every kind in `LAUNCH_AGENTS`**, driven off the list itself so a new agent cannot be half-added. `shell` still opens a launcher cell.
- **13 assertions verified RED against the unfixed code**; full suite 9360 passed.

## Verified on the running app, not only the specs

`yarn dev` on isolated ports under a scratch `HOME` (the real config untouched), driven with Playwright, calling `openTerminalAt(dir, null, agent)` in the page — exactly what `App.vue` does with the published request:

| run | result |
| --- | --- |
| before (fix stashed, `claude`) | a SECOND cell-creation form, 0 terminals — the report, reproduced |
| after (`claude`) | 1 terminal, Claude Code's trust prompt in the requested directory |
| after (`codex`) | 1 terminal, **codex's own** trust prompt — so it reached the codex endpoint, not Claude's |

No console errors in any run. `yarn format` / `lint` / `typecheck` / `build` all pass.

Closes #1535

## Review round 1 (Codex CHANGES REQUESTED / CodeRabbit 1 major)

**Codex — real, fixed in 3c5a001e.** Under `auto` / `priority` sorting an auto-start cell could never start: `insertCellAfter` pages by the cell's MANUAL index, while the grid renders `pageSlice(orderCells(...))`. On a grid of more than one page the new cell can be shown on a page the grid just navigated away from — and an unrendered cell never MOUNTS, which is what starts it. Reproduced as a failing test first (ten `working` cells + a fresh idle one → display page 0, state page 1). `revealCell(state, uid, order)` re-points the page at the ordered position. Codex's reading of why it is new is right: the empty launch cell this replaces sorted last by `LAUNCH_RANK`, so the mismatch only bites now that the cell is occupied and ranks by status.

**CodeRabbit — split.** Its core claim ("a remount before the session id arrives starts a SECOND session") is a false positive: `attach()` reconnects only when the view NAMES a session, and a fresh launch asks with `sessionId: null`, so the live slot is reused and the id replayed (the #1533/#1534 repair path). The one combination `terminalSlotAttachment.spec.ts` had not pinned — neither side knows the id yet — is now a test asserting **one** socket. Its second point is taken: the `ephemeral` comment overstated things, since the field is dropped on READ rather than stripped on write.

### Known, deliberately not fixed here

`terminal-new-adjacent` (keyboard) and the Run menu's spare cell call `insertCellAfter` the same way and can land off-screen for the same reason — a launcher that never mounts never starts either. Same shape of fix, different feature; worth a follow-up issue rather than widening this PR.

### One behavioural consequence worth knowing

A phone launch goes through `launchIn`, so like any fresh desktop launch it records the server-confirmed cwd as a directory preset. Intentional (it is a launch the user made), but it means the desktop's preset list can grow from the phone.

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed phone-triggered Claude, Codex, and other agent launches opening an empty launcher instead of starting a terminal session.
  * Agent sessions now start automatically with the correct working directory.
  * Shell launches retain their existing launcher behavior.
  * Fixed terminal connection reuse when views are detached and remounted.

* **Tests**
  * Added coverage for automatic agent startup, session limits, page switching, and session assignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->