### PR TITLE
feat(collections): resolve a root per request and leave the engine none

### DIFF
--- a/plans/feat-collections-project-root.md
+++ b/plans/feat-collections-project-root.md
@@ -100,6 +100,14 @@ we are not re-binding, we are passing arguments.
 Zero callers, and it is precisely the helper a future contributor would reach for — at which
 point containment is silently checked against the wrong root. Delete it, or make it take a root.
 
+### U5. `skillsStagingDir` must be able to say "there is no staging here" *(required — see §6.5)*
+
+`CollectionHost.paths.skillsStagingDir: (root) => string` cannot express "this root has no
+staging tree", and the engine reads staging **first** for `source === "project"` collections
+(`skillAssets.ts:55`). Widen it to `(root) => string | null` and skip the staging base when null.
+
+MulmoClaude returns a string for its one workspace and is unaffected.
+
 ### Not upstream
 
 - **Route shapes** — the collection HTTP routes are host-owned (MulmoTerminal mounts its own in
@@ -205,6 +213,52 @@ With a project root, the questions are:
 
 None of these need upstream changes; they are the options the host passes.
 
+### 6.5. Skill staging is a WORKSPACE mechanism and must not follow into project roots
+
+The workspace does not let the agent write `.claude/skills/` directly. It writes drafts to
+`data/skills/<slug>/`, and `@mulmoclaude/core/skill-bridge` mirrors a **fixed allowlist** —
+`SKILL.md`, `schema.json`, `templates/<path>` — into `.claude/skills/<slug>/`. Everything else
+(README, assets, arbitrary nesting) stays staging-side. The bridge exists because of the
+`.claude/` permission gate, not because staging is a nicer layout.
+
+**A regular project folder has no such gate: the agent writes `<project>/.claude/skills/<slug>/`
+directly, and there must be no staging tree there.**
+
+This is not just a preference — the engine actively prefers staging:
+
+```ts
+// skillAssets.ts:55 — a `source: "project"` collection reads staging FIRST
+const bases = collection.source === "project"
+  ? [path.join(skillsStagingDir(workspaceRoot), safeSlug), collection.skillDir]
+  : [collection.skillDir];
+```
+
+A project root's collections are exactly `source: "project"`. So a stray
+`<project>/data/skills/<slug>/` — copied from a workspace, or written by an agent that learned the
+workspace convention — **silently shadows the committed skill**: two `schema.json` in one repo, and
+the one that is not the committed one wins. It also breaks §11 (the clone would carry a second copy
+of the definition, and which one is live depends on a directory nobody meant to commit).
+
+**What to do**
+
+- Upstream **U5**: let `skillsStagingDir` return `null`; the engine then uses `[collection.skillDir]`
+  alone.
+- In MulmoTerminal, return the staging path **only for the managed workspace**. The predicate
+  already exists — `isManagedWorkspace()` in `server/backends/workspaceSetup.ts`, which is what
+  gates workspace-only seeding today.
+- Do **not** wire a skill-bridge for project roots. There is nothing to bridge.
+
+**How this qualifies D7 (§6.4).** The workspace stays "just another project" *for root resolution* —
+`resolveProjectRoot` still returns a plain root with no discriminator. What differs is not identity
+but **whether the root sits behind the `.claude/` permission gate**, and that belongs to the
+skill-WRITE path, not to the resolver. Keep the distinction there and it stays one branch in one
+place instead of a `kind` field spreading through every caller.
+
+**Note on MulmoTerminal today**: MT declares `skillsStagingDir` for the engine but wires **no
+bridge** — there is no PostToolUse mirror here (that was the deferred PR5). So MT reads a staging
+tree it never writes; the declaration exists so a workspace MulmoClaude staged into is read the same
+way by both hosts. Whether MT needs the bridge for the workspace at all is §10.
+
 ### 6.4. The shared workspace is one project among many *(decided)*
 
 For collections there is **no workspace special case**: `~/mulmoclaude` is a directory with
@@ -238,6 +292,7 @@ separate change, deliberately not bundled here.
 | **Live-update pings crossing projects** | U1 |
 | Drift from MulmoClaude's API | paths unchanged; project rides as an optional param (§5) |
 | A project directory with no `.claude/skills` | empty list, not an error — same as an empty workspace |
+| **A stray `data/skills/<slug>/` in a project shadowing the committed skill** | U5 + return staging only for the managed workspace (§6.5) |
 
 ## 7b. The collection watcher is single-root, and it fails quietly
 
@@ -287,13 +342,14 @@ project selector ships, or "my project's collection never rings" becomes the fir
 | # | Work | Where | Ships on its own? |
 |---|---|---|---|
 | 1 | U1 payload root + U2 strict mode + U3 cleanup, published | MulmoClaude / core | yes (no behaviour change there) |
-| 2 | `resolveProjectRoot()` + known-projects validation | MulmoTerminal | no |
-| 3 | Thread root through all routes; turn strict mode on | MulmoTerminal | yes — still workspace-only, but now explicit |
+| 2 | `resolveProjectRoot()` + known-projects validation | MulmoTerminal | **DONE** (the known-projects list is phase 5; a `project` parameter is refused, not ignored) |
+| 3 | Thread root through all routes; turn strict mode on | MulmoTerminal | **DONE** — still workspace-only, but now explicit |
 | 4 | Re-key tokens / caches / channels by `(root, slug)` | MulmoTerminal | yes |
 | 5 | `?project=` parameter + client project selector | MulmoTerminal | **yes — this is the feature landing** |
 | 6 | Merge-semantics decisions from §6 made real | MulmoTerminal | with 5 |
 | 7 | Self-containment check (§11.4) | MulmoTerminal | yes — useful even before 5 |
 | 8 | Watcher per root, or accept workspace-only bells (§7b) | MT + possibly upstream | decide before 5 ships |
+| 9 | No skill staging outside the managed workspace (§6.5, needs U5) | upstream + MT | with 5 |
 
 Phase 3 is worth shipping alone: it changes no behaviour but removes every implicit root, which
 is what makes phase 5 safe.
@@ -318,6 +374,9 @@ is what makes phase 5 safe.
    repo? Refusal is safer for clone parity and worse for the "global collection everywhere" case.
 6. Should `generateItemId()` be widened upstream (32 bits → 128), or is `primaryKey` guidance
    enough?
+7. Does MulmoTerminal need the skill-bridge for the managed workspace at all (§6.5)? It declares
+   the staging path but mirrors nothing, so an agent authoring a collection skill in the workspace
+   from MT writes a draft that never becomes active here.
 
 ## 11. Self-contained projects — clone parity
 

--- a/server/backends/calendarPush.ts
+++ b/server/backends/calendarPush.ts
@@ -15,7 +15,8 @@
 //   POST /api/collections/:slug/calendar-push   →  CollectionPushResult
 import type { Express, Request, Response } from "express";
 import { pushCalendarForCollection } from "@mulmoclaude/core/google";
-import { getWorkspaceRoot, loadCollection } from "@mulmoclaude/core/collection/server";
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+import { resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { toCollectionPushResult } from "./calendarPushResult.js";
 import { hostLogger } from "./hostLogger.js";
 
@@ -30,16 +31,19 @@ export interface CalendarPushRouteDeps {
    *  built to be tested is a route nobody tests. `object` rather than `unknown` because
    *  `unknown | null` collapses to `unknown`, which would drop "or null" from the contract
    *  the route reads. `loadCollection` satisfies this. */
-  findCollection: (slug: string) => Promise<object | null>;
+  findCollection: (slug: string, scope: ProjectScope) => Promise<object | null>;
   push: typeof pushCalendarForCollection;
-  workspaceRoot: () => string;
+  /** The root this request runs against. ONE source for it: the engine lookup and the push
+   *  must agree, and a second reader is how they drift. Read per REQUEST, not at mount — the
+   *  routes go up before the collection host is configured, and (since core 3.0.0) that host
+   *  has no ambient root to read later either. */
+  scope: (req: Request) => ProjectScope;
 }
 
 const liveDeps: CalendarPushRouteDeps = {
   findCollection: loadCollection,
   push: pushCalendarForCollection,
-  // Read per request, not at mount: the collection host is configured after the routes go up.
-  workspaceRoot: getWorkspaceRoot,
+  scope: resolveProjectRoot,
 };
 
 /** Mount POST /api/collections/:slug/calendar-push — backs the collection view's Push
@@ -50,7 +54,8 @@ export function mountCalendarPushRoutes(app: Express, deps: CalendarPushRouteDep
     try {
       // A slug that names nothing is the one genuine 404 here: there is no collection to
       // report a push result for, and the view distinguishes 404 from a generic failure.
-      if (!(await deps.findCollection(slug))) {
+      const scope = deps.scope(req);
+      if (!(await deps.findCollection(slug, scope))) {
         res.status(404).json({ error: `collection '${slug}' not found` });
         return;
       }
@@ -63,7 +68,7 @@ export function mountCalendarPushRoutes(app: Express, deps: CalendarPushRouteDep
       // reports the bare `HTTP 400` and drops the body, which would turn a fixable setup
       // problem into a page-level "HTTP 400" beside no explanation at all. Reunifying the
       // two means teaching `fetchJson` to read the body — tracked separately.
-      const body = toCollectionPushResult(await deps.push(slug, deps.workspaceRoot()));
+      const body = toCollectionPushResult(await deps.push(slug, scope.workspaceRoot));
       hostLogger.info("calendar-push", "pushed via collection route", {
         slug,
         created: body.created,

--- a/server/backends/collectionActionGuards.ts
+++ b/server/backends/collectionActionGuards.ts
@@ -10,6 +10,7 @@
 import type { Response } from "express";
 import { collectionWritable, readOnlyRefusal, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
 import { actionVisible, type ActionWithWhen, type CollectionAction, type CollectionItem } from "@mulmoclaude/core/collection";
+import type { ProjectScope } from "../infra/project-root.js";
 
 // The action's state gate, rebuilt so core's exact-optional parameter accepts it: the schema
 // parse yields a `when: undefined` / `require: undefined` KEY, which that type rejects.
@@ -53,8 +54,9 @@ export const resolveActionableRecord = async (
   collection: LoadedCollection,
   action: CollectionAction,
   itemId: string,
+  scope: ProjectScope,
 ): Promise<CollectionItem | null> => {
-  const record = await storeFor(collection).read(itemId);
+  const record = await storeFor(collection, scope).read(itemId);
   if (!record) {
     res.status(404).json({ error: `item '${itemId}' not found` });
     return null;

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -14,6 +14,7 @@
 import { configureCollectionWatchers, startCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
 import type { CollectionNotificationAdapter } from "@mulmoclaude/core/collection-watchers";
 import { buildNavigateTarget, buildPluginData, priorityToSeverity, readEntry } from "./collectionNotifierAdapter.js";
+import { workspaceScope } from "../infra/project-root.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[collection-watchers] ${message}`, data ?? ""),
@@ -35,6 +36,14 @@ const adapter: CollectionNotificationAdapter = {
  *  watcher failure must not abort startup, so the caller attaches `.catch`. */
 export async function startCollectionCompletionWatchers(): Promise<void> {
   configureCollectionWatchers({ adapter, log });
-  await startCollectionWatchers();
+  // The root is passed EXPLICITLY. The engine host runs in explicit-root mode, so a watcher
+  // started without one would throw `COLLECTION_ROOT_REQUIRED` on its first discovery — and
+  // because the caller is fire-and-forget with a `.catch`, that failure would not stop the
+  // server, it would just log once and leave every collection bell silently dead.
+  //
+  // One root per process is the watcher's own contract (a second start for a DIFFERENT root
+  // throws `WATCHER_ROOT_CONFLICT`); serving a project's collections means
+  // `await stopCollectionWatchers()` first. See plans/feat-collections-project-root.md §7b.
+  await startCollectionWatchers({ discoveryOpts: workspaceScope() });
   log.info("collection completion watchers started");
 }

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -31,7 +31,6 @@ import {
   buildActionSeedPrompt,
   buildCollectionActionSeedPrompt,
   promptPathsFor,
-  getWorkspaceRoot,
   toSummary,
   toDetail,
   validateCollectionRecords,
@@ -59,11 +58,11 @@ import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } 
 // Mobile custom-view builder — shared with the remote-host channel handlers so
 // the desktop phone-frame preview renders the EXACT artifact the phone receives.
 import {
-  buildRemoteView,
-  mutateRemoteView,
+  buildRemoteViewFor,
+  mutateRemoteViewFor,
   remoteViewFailureMessage,
   mutateRemoteViewFailureMessage,
-  remoteViewItems,
+  remoteViewItemsFor,
   remoteViewItemsFailureMessage,
 } from "./remoteView.js";
 import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from "./viewToken.js";
@@ -71,6 +70,7 @@ import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from
 // action so a view can never do more than the agent's own data plane.
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
+import { initProjectRoots, projectRootsConfigured, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
 import { isRecord } from "../../common/isRecord.js";
 import { requestBody } from "../routes/requestBody.js";
@@ -89,16 +89,20 @@ export const userSkillsDir = (): string => path.join(os.homedir(), ".claude", "s
 /** `<root>/.claude/skills` — project scope. */
 export const projectSkillsDir = (root: string): string => path.join(root, ".claude", "skills");
 
-// The shared workspace root, captured at init so the registry import route can pass
-// it to the engine (importRegistry takes it explicitly; the read side reads the host).
-let workspaceRoot: string | null = null;
-
 /** Wire the collection engine to the shared workspace. Call once at boot, before
- *  any collection route is hit. The path layout mirrors MulmoClaude verbatim. */
+ *  any collection route is hit. The path layout mirrors MulmoClaude verbatim.
+ *
+ *  EXPLICIT-ROOT MODE: the host binds `workspaceRoot: null`, declaring that every call
+ *  names its own root (`resolveProjectRoot`). Under that binding the engine's
+ *  `getWorkspaceRoot()` THROWS rather than falling back, so a call site that forgets its
+ *  root fails loudly here instead of silently reading whichever root happened to be bound —
+ *  which on a host with one root per project is the difference between an error and another
+ *  project's data. The workspace itself is bound through `initProjectRoots`, which is what
+ *  every scope still resolves to today. */
 export function initCollectionsBackend(deps: { workspace: string }): void {
-  workspaceRoot = deps.workspace;
+  initProjectRoots({ workspace: deps.workspace });
   configureCollectionHost({
-    workspaceRoot: deps.workspace,
+    workspaceRoot: null,
     log,
     paths: {
       // ~/.claude/skills — user scope (read-only).
@@ -154,8 +158,8 @@ type ResolvedCollection = NonNullable<Awaited<ReturnType<typeof loadCollection>>
 
 /** Load a collection, answering 404 when the slug is unknown. A null return means
  *  the response is already sent — the caller must return immediately. */
-async function resolveCollection(res: Response, slug: string): Promise<ResolvedCollection | null> {
-  const collection = await loadCollection(slug);
+async function resolveCollection(res: Response, slug: string, scope: ProjectScope): Promise<ResolvedCollection | null> {
+  const collection = await loadCollection(slug, scope);
   if (!collection) res.status(404).json({ error: `collection '${slug}' not found` });
   return collection;
 }
@@ -186,8 +190,13 @@ type CollectionWriteFn = NonNullable<ReturnType<typeof storeFor>["write"]>;
 /** The collection's write function plus a validated body record, or null after
  *  sending the 405 (read-only) / 400 (bad body) response. Shared by the create and
  *  update routes, which each then call `write` their own way. */
-function resolveWriteTarget(res: Response, collection: ResolvedCollection, body: unknown): { write: CollectionWriteFn; record: CollectionItem } | null {
-  const write = storeFor(collection).write;
+function resolveWriteTarget(
+  res: Response,
+  collection: ResolvedCollection,
+  body: unknown,
+  scope: ProjectScope,
+): { write: CollectionWriteFn; record: CollectionItem } | null {
+  const write = storeFor(collection, scope).write;
   if (!write) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return null;
@@ -281,7 +290,7 @@ const VIEW_WRITE_MODES: readonly ViewWriteMode[] = ["merge", "upsert", "create"]
 // row comes back in `rejected` with an actionable `problem` instead of persisting.
 type ViewItemWriteResult = { writtenId: string } | { rejected: { id: string; problem: string } };
 
-async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode: ViewWriteMode): Promise<ViewItemWriteResult> {
+async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode: ViewWriteMode, scope: ProjectScope): Promise<ViewItemWriteResult> {
   const record = extractRecord(raw);
   if (!record) return { rejected: { id: "", problem: "item must be a JSON object" } };
   const { singleton, primaryKey } = collection.schema;
@@ -293,7 +302,7 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   }
   // Reads and writes go through the collection's STORE (file, sqlite, …);
   // presence of `write` IS the writability check (core 0.25 storage seam).
-  const store = storeFor(collection);
+  const store = storeFor(collection, scope);
   const { write } = store;
   if (!write) return { rejected: { id: itemId, problem: readOnlyRefusal(collection.slug) } };
   let toWrite: CollectionItem;
@@ -332,16 +341,17 @@ function csvParam(value: unknown): string[] | undefined {
 
 // Discover tab: the merged curated-registry catalog (every configured registry's
 // index.json, fetched + cached server-side).
-const registryListHandler: RequestHandler = async (_req, res) => {
-  res.json(await listRegistry());
+const registryListHandler: RequestHandler = async (req, res) => {
+  res.json(await listRegistry(resolveProjectRoot(req)));
 };
 
 // Discover tab: install a registry collection into the shared workspace.
 const registryImportHandler: RequestHandler = async (req, res) => {
-  if (!workspaceRoot) {
+  if (!projectRootsConfigured()) {
     res.status(503).json({ error: "collections backend not initialized" });
     return;
   }
+  const { workspaceRoot } = resolveProjectRoot(req);
   const body = requestBody(req.body);
   const author = typeof body.author === "string" ? body.author : "";
   const slug = typeof body.slug === "string" ? body.slug : "";
@@ -361,9 +371,10 @@ const registryImportHandler: RequestHandler = async (req, res) => {
 // Delete one custom view: drop it from the schema + unlink its HTML. Refuses
 // user-scope / preset collections (read-only), like collection delete.
 const viewDeleteHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
-  const result = await deleteCustomView(collection, req.params.viewId);
+  const result = await deleteCustomView(collection, req.params.viewId, scope);
   if (result.kind !== "ok") {
     res.status(result.kind === "not-found" ? 404 : 403).json({ error: `view delete refused (${result.kind})` });
     return;
@@ -375,9 +386,10 @@ const viewDeleteHandler: RequestHandler<{ slug: string; viewId: string }> = asyn
 // copy. Only project-scope, non-preset collections are deletable; a refusal
 // (preset / user-scope / unsafe path) comes back as 403 with the reason.
 const collectionDeleteHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
-  const result = await deleteCollection(collection);
+  const result = await deleteCollection(collection, scope);
   if (result.kind !== "ok") {
     res.status(403).json({ error: deleteCollectionRefusalMessage(result) });
     return;
@@ -386,8 +398,8 @@ const collectionDeleteHandler: RequestHandler<{ slug: string }> = async (req, re
 };
 
 // List skill-backed collections for the index + toolbar.
-const listHandler: RequestHandler = async (_req, res) => {
-  const collections = await discoverCollections();
+const listHandler: RequestHandler = async (req, res) => {
+  const collections = await discoverCollections(resolveProjectRoot(req));
   res.json({ collections: collections.map(toSummary) });
 };
 
@@ -395,22 +407,23 @@ const listHandler: RequestHandler = async (_req, res) => {
 // never stored); the /collections Map tab builds its graph from these with the
 // shared `buildOntologyGraph` client-side. Port of MulmoClaude's
 // GET /api/collections/ontology (mulmoclaude PR #2218).
-const ontologyHandler: RequestHandler = async (_req, res) => {
-  res.json({ entries: await buildWorkspaceOntology() });
+const ontologyHandler: RequestHandler = async (req, res) => {
+  res.json({ entries: await buildWorkspaceOntology(resolveProjectRoot(req)) });
 };
 
 // A collection's live schema + records by slug. Backs both the card's own load
 // (CollectionView reads `status` for 404 → not-found) and ref/embed resolution.
 const detailHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
-  const items = await storeFor(collection).list();
+  const items = await storeFor(collection, scope).list();
   // Best-effort validation: a malformed record is silently skipped at read
   // time, so surface the problems here too and let the view offer a Repair
   // button. Never let validation failure turn a successful detail into a 500.
   let issues: RecordIssue[] = [];
   try {
-    issues = await validateCollectionRecords(collection);
+    issues = await validateCollectionRecords(collection, scope);
   } catch (err) {
     log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
   }
@@ -426,10 +439,11 @@ async function resolveWriteRequest(
   res: Response,
   slug: string,
   body: unknown,
+  scope: ProjectScope,
 ): Promise<{ collection: ResolvedCollection; target: { write: CollectionWriteFn; record: CollectionItem } } | null> {
-  const collection = await resolveCollection(res, slug);
+  const collection = await resolveCollection(res, slug, scope);
   if (!collection) return null;
-  const target = resolveWriteTarget(res, collection, body);
+  const target = resolveWriteTarget(res, collection, body, scope);
   if (!target) return null;
   return { collection, target };
 }
@@ -438,7 +452,7 @@ async function resolveWriteRequest(
 // Create a record. The id is the schema's primaryKey value from the body, or a
 // generated one; a singleton collection pins every create to its fixed id.
 const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const resolved = await resolveWriteRequest(res, req.params.slug, req.body);
+  const resolved = await resolveWriteRequest(res, req.params.slug, req.body, resolveProjectRoot(req));
   if (!resolved) return;
   const { collection, target } = resolved;
   const itemId = resolveCreateItemId(collection.schema, target.record) ?? generateItemId();
@@ -459,7 +473,7 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
 // Update a record. The primaryKey is pinned to the URL itemId (the body can't
 // smuggle a different id). Singletons only accept their one fixed id.
 const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = async (req, res) => {
-  const resolved = await resolveWriteRequest(res, req.params.slug, req.body);
+  const resolved = await resolveWriteRequest(res, req.params.slug, req.body, resolveProjectRoot(req));
   if (!resolved) return;
   const { collection, target } = resolved;
   const { singleton, primaryKey } = collection.schema;
@@ -483,9 +497,10 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
 
 // Delete a record.
 const itemDeleteHandler: RequestHandler<{ slug: string; itemId: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
-  const deleteStore = storeFor(collection).delete;
+  const deleteStore = storeFor(collection, scope).delete;
   if (!deleteStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
@@ -517,10 +532,11 @@ const respondForMutateAction = async (
   action: CollectionMutateAction,
   itemId: string,
   body: { params?: unknown } | undefined,
+  scope: ProjectScope,
 ): Promise<void> => {
   const raw = body?.params;
   const params = isRecord(raw) ? raw : {};
-  const outcome = await applyMutateAction(collection, action, itemId, params);
+  const outcome = await applyMutateAction(collection, action, itemId, params, scope);
   if (!outcome.ok) {
     // `itemId` is caller-controlled (a route param) — strip CR/LF so a crafted
     // id can't forge log lines.
@@ -543,31 +559,33 @@ const respondForMutateAction = async (
 
 // Per-record action (e.g. Repair / enrich this record).
 const itemActionHandler: RequestHandler<{ slug: string; itemId: string; actionId: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
   const action = resolveItemAction(res, collection, req.params.actionId);
   if (!action) return;
-  const record = await resolveActionableRecord(res, collection, action, req.params.itemId);
+  const record = await resolveActionableRecord(res, collection, action, req.params.itemId, scope);
   if (!record) return;
   // `kind: "mutate"` needs no template / seed / LLM — the host applies the
   // declarative write itself (`when` was just enforced above, same
   // visibility-is-authorization rule as the seeded kinds).
   if (action.kind === "mutate") {
     if (refuseReadOnlyCollection(res, collection)) return;
-    await respondForMutateAction(res, collection, action, req.params.itemId, isRecord(req.body) ? req.body : undefined);
+    await respondForMutateAction(res, collection, action, req.params.itemId, isRecord(req.body) ? req.body : undefined, scope);
     return;
   }
   const template = await readActionTemplateOr500(res, collection, action);
   if (template === null) return;
   // Pass the collection paths so the seed prompt carries the <collection_paths>
   // block — the skill template needs skillDir/dataPath to find its files.
-  const paths = promptPathsFor(collection, getWorkspaceRoot());
+  const paths = promptPathsFor(collection, scope.workspaceRoot);
   res.json({ prompt: buildActionSeedPrompt(record, template, paths), role: action.role });
 };
 
 // Collection-level action (operates over all records).
 const collectionActionHandler: RequestHandler<{ slug: string; actionId: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
   const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
   if (!action) {
@@ -583,8 +601,8 @@ const collectionActionHandler: RequestHandler<{ slug: string; actionId: string }
   try {
     const template = await readActionTemplateOr500(res, collection, action);
     if (template === null) return;
-    const allItems = await storeFor(collection).list();
-    const paths = promptPathsFor(collection, getWorkspaceRoot());
+    const allItems = await storeFor(collection, scope).list();
+    const paths = promptPathsFor(collection, scope.workspaceRoot);
     res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template, paths), role: action.role });
   } catch (err) {
     log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
@@ -601,11 +619,12 @@ const collectionActionHandler: RequestHandler<{ slug: string; actionId: string }
 // path-safe reader. The frontend renders it sandboxed (token injected).
 const viewFileHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   const viewId = typeof req.query.id === "string" ? req.query.id : "";
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
   const view = resolveView(res, collection, viewId);
   if (!view) return;
-  const html = await readCustomViewHtml(collection, view.file);
+  const html = await readCustomViewHtml(collection, view.file, scope);
   if (html === null) {
     res.status(404).json({ error: `view file '${view.file}' not found` });
     return;
@@ -629,9 +648,10 @@ const remoteViewHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   const { slug } = req.params;
   const viewId = typeof req.query.id === "string" ? req.query.id : "";
   const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-  const collection = await resolveCollection(res, slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, slug, scope);
   if (!collection) return;
-  const result = await buildRemoteView(collection, viewId, locale);
+  const result = await buildRemoteViewFor(scope)(collection, viewId, locale);
   if (result.kind !== "ok") {
     const notFound = result.kind === "view-not-found" || result.kind === "file-missing";
     res.status(notFound ? 404 : 400).json({ error: remoteViewFailureMessage(result, slug) });
@@ -655,9 +675,10 @@ const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> 
     res.status(400).json({ error: "invalid mutate request — expected { op: 'update'|'delete', id, patch? }" });
     return;
   }
-  const collection = await resolveCollection(res, slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, slug, scope);
   if (!collection) return;
-  const result = await mutateRemoteView(collection, viewId, request);
+  const result = await mutateRemoteViewFor(scope)(collection, viewId, request);
   if (mutateWriteApplied(result)) {
     // The write applied; only its response blew the byte budget. Report success (not a 4xx
     // that reads as a failed edit and strands stale data) and tell the client to re-fetch.
@@ -679,9 +700,10 @@ const remoteViewItemsHandler: RequestHandler<{ slug: string; viewId: string }> =
   const { slug, viewId } = req.params;
   const fields = normalizeFields(csvParam(req.query.fields));
   const request = { offset: clampViewOffset(req.query.offset), limit: clampViewLimit(req.query.limit), ...(fields ? { fields } : {}) };
-  const collection = await resolveCollection(res, slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, slug, scope);
   if (!collection) return;
-  const result = await remoteViewItems(collection, viewId, request);
+  const result = await remoteViewItemsFor(scope)(collection, viewId, request);
   if (result.kind !== "ok") {
     res.status(result.kind === "view-not-found" ? 404 : 400).json({ error: remoteViewItemsFailureMessage(result, slug) });
     return;
@@ -699,7 +721,7 @@ const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
     res.status(400).json({ error: "`viewId` is required" });
     return;
   }
-  const collection = await resolveCollection(res, slug);
+  const collection = await resolveCollection(res, slug, resolveProjectRoot(req));
   if (!collection) return;
   const view = resolveView(res, collection, viewId);
   if (!view) return;
@@ -728,9 +750,10 @@ const viewDataCors = (_req: Request, res: Response, next: NextFunction): void =>
 // Scoped read: the view's enriched records as `{ items }` — the shape custom views
 // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
 const viewDataGetHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
-  const items = await enrichItems(collection, await storeFor(collection).list());
+  const items = await enrichItems(collection, await storeFor(collection, scope).list(), scope);
   res.json({ items });
 };
 
@@ -741,7 +764,8 @@ const viewDataGetHandler: RequestHandler<{ slug: string }> = async (req, res) =>
 // response envelope is `{ written, rejected }` — `written` is the id of each stored
 // record, `rejected` a `{ id, problem }` per row that failed — the shape views read.
 const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, req.params.slug, scope);
   if (!collection) return;
   if (refuseReadOnlyCollection(res, collection)) return;
   const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
@@ -760,7 +784,7 @@ const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) =>
   const written: string[] = [];
   const rejected: Array<{ id: string; problem: string }> = [];
   for (const raw of body.items) {
-    const outcome = await writeViewItem(collection, raw, mode);
+    const outcome = await writeViewItem(collection, raw, mode, scope);
     if ("writtenId" in outcome) written.push(outcome.writtenId);
     else rejected.push(outcome.rejected);
   }

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -16,9 +16,10 @@ import type { CollectionItem, CollectionMutateAction } from "@mulmoclaude/core/c
 import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
 // The same thumbnail resolver the mobile view's image inlining uses, so a desktop
 // view's <img> and the phone's inlined one are the same bytes.
-import { resolveThumbnail } from "./thumbnailStore.js";
+import { thumbnailResolverFor } from "./thumbnailStore.js";
 import { makeViewActionRateLimiter, ONE_MINUTE_MS, VIEW_ACTION_RATE_LIMIT_PER_MINUTE, VIEW_IMAGE_RATE_LIMIT_PER_MINUTE } from "./viewRateLimit.js";
 import { requireViewToken } from "./viewToken.js";
+import { resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { hostLogger } from "./hostLogger.js";
 import { isRecord } from "../../common/isRecord.js";
 
@@ -28,7 +29,7 @@ const log = hostLogger;
  *  its mutate executor, and the two middlewares the whole view-data family shares. */
 export interface CustomViewRouteDeps {
   /** Load a collection, answering 404 itself; null means the response was sent. */
-  resolveCollection: (res: Response, slug: string) => Promise<LoadedCollection | null>;
+  resolveCollection: (res: Response, slug: string, scope: ProjectScope) => Promise<LoadedCollection | null>;
   /** Locate a declared custom view, answering 404 itself; null means sent. */
   resolveView: (res: Response, collection: LoadedCollection, viewId: string) => { i18n?: string | undefined } | null;
   /** Apply a mutate action and answer with the written record (or its refusal). */
@@ -38,6 +39,7 @@ export interface CustomViewRouteDeps {
     action: CollectionMutateAction,
     itemId: string,
     body: { params?: unknown } | undefined,
+    scope: ProjectScope,
   ) => Promise<void>;
   /** Wrap a handler so a throw becomes a logged 500. */
   guarded: <P extends Record<string, string>>(op: string, handler: RequestHandler<P>) => RequestHandler<P>;
@@ -77,7 +79,8 @@ const makeI18nHandler =
   async (req, res) => {
     const viewId = typeof req.query.id === "string" ? req.query.id : "";
     const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-    const collection = await deps.resolveCollection(res, req.params.slug);
+    const i18nScope = resolveProjectRoot(req);
+    const collection = await deps.resolveCollection(res, req.params.slug, i18nScope);
     if (!collection) return;
     const view = deps.resolveView(res, collection, viewId);
     if (!view) return;
@@ -86,7 +89,7 @@ const makeI18nHandler =
       res.json({ locale: "", dict: {} });
       return;
     }
-    res.json(await readCustomViewI18n(collection, view.i18n, locale));
+    res.json(await readCustomViewI18n(collection, view.i18n, locale, i18nScope));
   };
 
 // Scoped image read: resolve one record-referenced image path into a downscaled
@@ -97,7 +100,8 @@ const makeI18nHandler =
 const makeImageHandler =
   (deps: CustomViewRouteDeps): RequestHandler<{ slug: string }> =>
   async (req, res) => {
-    const collection = await deps.resolveCollection(res, req.params.slug);
+    const scope = resolveProjectRoot(req);
+    const collection = await deps.resolveCollection(res, req.params.slug, scope);
     if (!collection) return;
     const relPath = typeof req.query.path === "string" ? req.query.path : "";
     if (relPath.length === 0) {
@@ -105,12 +109,12 @@ const makeImageHandler =
       return;
     }
     try {
-      const items = await storeFor(collection).list();
+      const items = await storeFor(collection, scope).list();
       if (!isAuthorizedImagePath(collection.schema, items, relPath)) {
         res.status(404).json({ error: "path is not a current value of this collection's image fields" });
         return;
       }
-      const dataUrl = await resolveThumbnail(relPath, clampImageMaxEdge(req.query.maxEdge));
+      const dataUrl = await thumbnailResolverFor(scope)(relPath, clampImageMaxEdge(req.query.maxEdge));
       if (dataUrl === null) {
         res.status(404).json({ error: "image could not be resolved" });
         return;
@@ -132,7 +136,8 @@ const makeImageHandler =
 const makeActionHandler =
   (deps: CustomViewRouteDeps): RequestHandler<{ slug: string; actionId: string }> =>
   async (req, res) => {
-    const collection = await deps.resolveCollection(res, req.params.slug);
+    const mutateScope = resolveProjectRoot(req);
+    const collection = await deps.resolveCollection(res, req.params.slug, mutateScope);
     if (!collection) return;
     const action = resolveItemAction(res, collection, req.params.actionId);
     if (!action) return;
@@ -147,8 +152,8 @@ const makeActionHandler =
       res.status(400).json({ error: "`itemId` is required (the record's primary-key value)" });
       return;
     }
-    if (!(await resolveActionableRecord(res, collection, action, itemId))) return;
-    await deps.respondForMutateAction(res, collection, action, itemId, body);
+    if (!(await resolveActionableRecord(res, collection, action, itemId, mutateScope))) return;
+    await deps.respondForMutateAction(res, collection, action, itemId, body, mutateScope);
   };
 
 // Per-minute budgets, keyed by IP + slug. Two buckets on purpose: a gallery's

--- a/server/backends/feeds.ts
+++ b/server/backends/feeds.ts
@@ -73,7 +73,7 @@ export function mountFeedsRoutes(app: Express): void {
   });
 
   app.post("/api/collections/:slug/refresh", async (req: Request<{ slug: string }>, res: Response) => {
-    const collection = await loadCollection(req.params.slug);
+    const collection = await loadCollection(req.params.slug, { workspaceRoot });
     if (!collection) {
       res.status(404).json({ error: `collection '${req.params.slug}' not found` });
       return;

--- a/server/backends/remoteHost/handlers/getCollection.ts
+++ b/server/backends/remoteHost/handlers/getCollection.ts
@@ -12,6 +12,7 @@
 // stubbed; the default export wires the real engine functions. Mirrors
 // MulmoClaude's server/remoteHost/handlers/getCollection.ts.
 import { loadCollection, storeFor, toDetail, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import { workspaceScope } from "../../../infra/project-root.js";
 import type { CollectionItem } from "@mulmoclaude/core/collection";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
@@ -36,4 +37,8 @@ export const createGetCollection =
     return pageResult(deps.toDetail(collection), all, offset, limit);
   };
 
-export const getCollection = createGetCollection({ loadCollection, listRecords: (collection) => storeFor(collection).list(), toDetail });
+export const getCollection = createGetCollection({
+  loadCollection: (slug) => loadCollection(slug, workspaceScope()),
+  listRecords: (collection) => storeFor(collection, workspaceScope()).list(),
+  toDetail,
+});

--- a/server/backends/remoteHost/handlers/getFeed.ts
+++ b/server/backends/remoteHost/handlers/getFeed.ts
@@ -38,4 +38,4 @@ export const createGetFeed =
   };
 
 export const getFeedFor = (workspaceRoot: string): CommandHandlers["getFeed"] =>
-  createGetFeed({ listFeeds, listRecords: (collection) => storeFor(collection).list(), toDetail, workspaceRoot });
+  createGetFeed({ listFeeds, listRecords: (collection) => storeFor(collection, { workspaceRoot }).list(), toDetail, workspaceRoot });

--- a/server/backends/remoteHost/handlers/getRemoteView.ts
+++ b/server/backends/remoteHost/handlers/getRemoteView.ts
@@ -4,16 +4,18 @@
 // postMessage bootstrap) — the phone renders the artifact verbatim.
 import { loadCollection } from "@mulmoclaude/core/collection/server";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
-import { buildRemoteView, remoteViewFailureMessage } from "../../remoteView.js";
+import { buildRemoteViewFor, remoteViewFailureMessage } from "../../remoteView.js";
+import { workspaceScope } from "../../../infra/project-root.js";
 import { readString } from "../../../../common/readString.js";
 
 export const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObject) => {
   const slug = readString(params.slug);
   const viewId = readString(params.viewId);
   const locale = typeof params.locale === "string" ? params.locale : "";
-  const collection = await loadCollection(slug);
+  const scope = workspaceScope();
+  const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
-  const result = await buildRemoteView(collection, viewId, locale);
+  const result = await buildRemoteViewFor(scope)(collection, viewId, locale);
   if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
   return toJsonObject({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
 };

--- a/server/backends/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/backends/remoteHost/handlers/getRemoteViewItems.ts
@@ -7,7 +7,8 @@ import { loadCollection } from "@mulmoclaude/core/collection/server";
 import { normalizeFields } from "@mulmoclaude/core/remote-view";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset } from "../collectionPage.js";
-import { remoteViewItems, remoteViewItemsFailureMessage } from "../../remoteView.js";
+import { remoteViewItemsFor, remoteViewItemsFailureMessage } from "../../remoteView.js";
+import { workspaceScope } from "../../../infra/project-root.js";
 import { jsonPayload } from "../jsonPayload.js";
 import { readString } from "../../../../common/readString.js";
 
@@ -16,9 +17,10 @@ export const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (
   const viewId = readString(params.viewId);
   const fields = normalizeFields(params.fields);
   const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), ...(fields ? { fields } : {}) };
-  const collection = await loadCollection(slug);
+  const scope = workspaceScope();
+  const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
-  const result = await remoteViewItems(collection, viewId, request);
+  const result = await remoteViewItemsFor(scope)(collection, viewId, request);
   if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
   // Converted rather than asserted (see ../jsonPayload.ts): `RemoteViewPage` has no index
   // signature at all, so it does not even overlap `JsonObject` — which is why this used to need a

--- a/server/backends/remoteHost/handlers/listCollections.ts
+++ b/server/backends/remoteHost/handlers/listCollections.ts
@@ -3,9 +3,10 @@
 // Mirrors GET /api/collections/list → { collections: CollectionSummary[] }. Feeds
 // (source "feed") are excluded — they are served by listFeeds.
 import { discoverCollections, toSummary } from "@mulmoclaude/core/collection/server";
+import { workspaceScope } from "../../../infra/project-root.js";
 import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
 
 export const listCollections: CommandHandlers["listCollections"] = async () => {
-  const collections = (await discoverCollections()).filter((collection) => collection.source !== "feed").map(toSummary);
+  const collections = (await discoverCollections(workspaceScope())).filter((collection) => collection.source !== "feed").map(toSummary);
   return toJsonObject({ collections });
 };

--- a/server/backends/remoteHost/handlers/listSkills.ts
+++ b/server/backends/remoteHost/handlers/listSkills.ts
@@ -10,7 +10,7 @@ import { discoverSkillNames } from "../skills.js";
 export const createListSkills =
   (workspace: string): CommandHandlers["listSkills"] =>
   async () => {
-    const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections()]);
+    const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections({ workspaceRoot: workspace })]);
     const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
     return toJsonObject({ skills: names.filter((name) => !collectionSlugs.has(name)) });
   };

--- a/server/backends/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/backends/remoteHost/handlers/mutateRemoteView.ts
@@ -6,7 +6,8 @@
 import { loadCollection } from "@mulmoclaude/core/collection/server";
 import { normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
-import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../remoteView.js";
+import { mutateRemoteViewFor, mutateRemoteViewFailureMessage } from "../../remoteView.js";
+import { workspaceScope } from "../../../infra/project-root.js";
 import { mutateWriteApplied } from "../../mutateStatus.js";
 import { jsonPayload } from "../jsonPayload.js";
 import { readString } from "../../../../common/readString.js";
@@ -16,9 +17,10 @@ export const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = asy
   const viewId = readString(params.viewId);
   const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
   if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
-  const collection = await loadCollection(slug);
+  const scope = workspaceScope();
+  const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
-  const result = await mutateRemoteView(collection, viewId, request);
+  const result = await mutateRemoteViewFor(scope)(collection, viewId, request);
   // The write applied but its response blew the byte budget — report success (+refetch),
   // not a thrown error the phone shows as a failed edit while keeping stale data (#747).
   if (mutateWriteApplied(result)) {

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -36,7 +36,8 @@ import {
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionCustomView, CollectionItem, CollectionSchema } from "@mulmoclaude/core/collection";
 
-import { resolveThumbnail } from "./thumbnailStore.js";
+import { thumbnailResolverFor } from "./thumbnailStore.js";
+import type { ProjectScope } from "../infra/project-root.js";
 
 // Resolves a workspace image path to a downscaled JPEG `data:` URL, or null when
 // it can't (path escapes the workspace, missing, or undecodable).
@@ -91,7 +92,11 @@ export const createBuildRemoteView =
     return { kind: "ok", view: { id: view.id, label: view.label, ...(view.icon ? { icon: view.icon } : {}), target: "mobile" }, srcdoc, bytes };
   };
 
-export const buildRemoteView = createBuildRemoteView({ readCustomViewHtml, readCustomViewI18n });
+/** Bound to one project root. The engine reads (view HTML, i18n, records, thumbnails) all
+ *  resolve against the scope the REQUEST named — binding at construction is what keeps the
+ *  root next to the call instead of threading it through every dep signature. */
+export const buildRemoteViewFor = (scope: ProjectScope) =>
+  createBuildRemoteView({ readCustomViewHtml: (collection, file) => readCustomViewHtml(collection, file, scope), readCustomViewI18n });
 
 /** The message a failure kind nobody wrote a branch for gets.
  *
@@ -218,7 +223,12 @@ async function updateViaView(
   return { kind: "ok", op: "update", item };
 }
 
-export const mutateRemoteView = createMutateRemoteView({ storeFor, enrichItems, resolveThumbnail });
+export const mutateRemoteViewFor = (scope: ProjectScope) =>
+  createMutateRemoteView({
+    storeFor: (collection) => storeFor(collection, scope),
+    enrichItems: (collection, items) => enrichItems(collection, items, scope),
+    resolveThumbnail: thumbnailResolverFor(scope),
+  });
 
 // ── Item pages (getItems) ──
 // A mobile view's record page: derive computed fields → slice/project (the same
@@ -299,7 +309,12 @@ export const createRemoteViewItems =
     return { kind: "ok", page, inlined, omitted };
   };
 
-export const remoteViewItems = createRemoteViewItems({ listRecords: (collection) => storeFor(collection).list(), enrichItems, resolveThumbnail });
+export const remoteViewItemsFor = (scope: ProjectScope) =>
+  createRemoteViewItems({
+    listRecords: (collection) => storeFor(collection, scope).list(),
+    enrichItems: (collection, items) => enrichItems(collection, items, scope),
+    resolveThumbnail: thumbnailResolverFor(scope),
+  });
 
 /** Message per non-ok item-page kind, thrown by the channel handler. */
 export function remoteViewItemsFailureMessage(result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): string {

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -96,7 +96,13 @@ export const createBuildRemoteView =
  *  resolve against the scope the REQUEST named — binding at construction is what keeps the
  *  root next to the call instead of threading it through every dep signature. */
 export const buildRemoteViewFor = (scope: ProjectScope) =>
-  createBuildRemoteView({ readCustomViewHtml: (collection, file) => readCustomViewHtml(collection, file, scope), readCustomViewI18n });
+  createBuildRemoteView({
+    readCustomViewHtml: (collection, file) => readCustomViewHtml(collection, file, scope),
+    // Bound too, and not by symmetry: a view that declares `i18n` reads it through this dep,
+    // and an unbound one falls back to the ambient root — which under explicit-root mode is a
+    // throw, so a TRANSLATED mobile view would fail to build while an untranslated one worked.
+    readCustomViewI18n: (collection, file, locale) => readCustomViewI18n(collection, file, locale, scope),
+  });
 
 /** The message a failure kind nobody wrote a branch for gets.
  *

--- a/server/backends/thumbnailStore.ts
+++ b/server/backends/thumbnailStore.ts
@@ -13,6 +13,7 @@ import { readFile, stat } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 
 import { getWorkspaceRoot } from "@mulmoclaude/core/collection/server";
+import type { ProjectScope } from "../infra/project-root.js";
 
 import { containedPath, realContainedWithin } from "../files/pathContainment.js";
 
@@ -69,14 +70,14 @@ export function clearThumbnailCache(): void {
  *  `null` when the path escapes the workspace, is missing, or can't be decoded —
  *  the caller then leaves the field as its original path (a placeholder in the
  *  view). `maxEdge` should already be clamped by the caller (`clampImageMaxEdge`). */
-export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize) {
+export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize, rootOf: () => string = getWorkspaceRoot) {
   return async function resolveThumbnail(relPath: string, maxEdge: number): Promise<string | null> {
     if (typeof relPath !== "string" || relPath.length === 0) return null;
     let root: string;
     try {
       // .native, for the Windows 8.3 reason in files/pathContainment.ts. fs/promises has no
       // native variant, so this is the sync call.
-      root = realpathSync.native(getWorkspaceRoot());
+      root = realpathSync.native(rootOf());
     } catch {
       return null;
     }
@@ -104,4 +105,8 @@ export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize) {
   };
 }
 
-export const resolveThumbnail = createThumbnailResolver();
+/** A resolver bound to one project root. There is deliberately no ambient
+ *  `resolveThumbnail`: the containment check below IS the security boundary, so the root it
+ *  checks against must be the root the request resolved, never whatever the engine happens to
+ *  have bound. Under explicit-root mode an ambient one would throw anyway. */
+export const thumbnailResolverFor = (scope: ProjectScope) => createThumbnailResolver(sharpResize, () => scope.workspaceRoot);

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -6,9 +6,11 @@
 // there is no passthrough router — the route calls the handler directly.
 //
 // MulmoTerminal's deps binding:
-//   - workspaceRoot: omitted — the engine falls back to the collection host
-//     configured at boot (initCollectionsBackend → configureCollectionHost),
-//     the same root every collection REST route uses.
+//   - workspaceRoot: a GETTER over the bound workspace, not a captured string. The tool
+//     is built at module scope — before boot binds anything — so a value read here would
+//     be `undefined`, and under the engine's explicit-root binding that is a throw rather
+//     than a fallback. The getter defers the read to the call, which is when a root exists.
+//     (This is the agent's data plane, which has no request: it operates on the workspace.)
 //   - bundledHelpsDir: workspace-setup's helpsAssetDir, so `schemaDocs`
 //     serves the bundled collection-authoring reference even when the
 //     workspace has no config/helps copy (only managed workspaces are seeded).
@@ -18,8 +20,14 @@
 import type { ToolDefinition } from "gui-chat-protocol";
 import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
+import { workspaceScope } from "./project-root.js";
 
-const tool = makeManageCollectionTool({ bundledHelpsDir: helpsAssetDir });
+const tool = makeManageCollectionTool({
+  bundledHelpsDir: helpsAssetDir,
+  get workspaceRoot(): string {
+    return workspaceScope().workspaceRoot;
+  },
+});
 
 /** The bound handler the dispatch route calls. Returns the tool's narration
  *  string (JSON for the read/write actions) — no GUI `data`, matching

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -1,0 +1,75 @@
+// Which root a request operates against — the one choke point four subsystems will
+// share (collections now; accounting, wiki and resources later, see
+// plans/project-architecture.md D4).
+//
+// WHY THIS EXISTS BEFORE IT DOES ANYTHING INTERESTING. Every root today resolves to the
+// shared workspace, so this file changes no behaviour. What it buys is that the ~30 engine
+// call sites now name a root explicitly instead of falling through to the engine's ambient
+// default, which lets `configureCollectionHost` run in EXPLICIT-ROOT mode
+// (`workspaceRoot: null`): a call that forgets its root throws `COLLECTION_ROOT_REQUIRED`
+// instead of silently resolving against whichever workspace happened to be bound. On a host
+// with one root that difference is invisible; on a host with one root PER PROJECT it is the
+// difference between an error and quietly reading another project's data.
+//
+// Serving a second root is deliberately NOT wired here yet. When it is, the resolution order
+// is: an explicit project parameter on the request (validated against the known-projects
+// list) → the session's cwd → the workspace. The validation is not optional and not a detail:
+// `resolveDataDir` only guarantees containment WITHIN the root it is handed, so the root
+// itself is the trust boundary. A client-supplied path would turn every collection route into
+// an arbitrary-directory reader, which is why the extension point below takes an opaque id
+// resolved through directories we already know rather than a path.
+import type { Request } from "express";
+
+/** A root, in the shape the collection engine's options already take, so it can be passed
+ *  straight through as `opts` rather than unpacked at every call site. */
+export interface ProjectScope {
+  workspaceRoot: string;
+}
+
+let workspace: string | null = null;
+
+/** Bind the shared workspace. Call once at boot, before any route resolves a scope. */
+export function initProjectRoots(deps: { workspace: string }): void {
+  workspace = deps.workspace;
+}
+
+/** Whether the binding is in place. Routes that answered 503 for "backend not initialized"
+ *  before this module existed keep answering 503, rather than throwing into a 500. */
+export function projectRootsConfigured(): boolean {
+  return workspace !== null;
+}
+
+/** Test-only: drop the binding so a spec can assert the unconfigured failure. */
+export function resetProjectRootsForTesting(): void {
+  workspace = null;
+}
+
+function requireWorkspace(): string {
+  if (workspace === null) {
+    throw new Error("project roots are not configured — call initProjectRoots({ workspace }) at boot");
+  }
+  return workspace;
+}
+
+/** The shared workspace, for callers that have no request: boot paths, the agent tool
+ *  dispatch, the completion watchers. Separate from `resolveProjectRoot` so those callers
+ *  read as what they are — "the workspace" — rather than as a request that lost its `req`. */
+export function workspaceScope(): ProjectScope {
+  return { workspaceRoot: requireWorkspace() };
+}
+
+/** The root this request operates against — the workspace, today.
+ *
+ *  A `project` parameter is REFUSED rather than ignored. Ignoring it would mean a client that
+ *  asks for one project and is served another, with nothing anywhere saying so — the same
+ *  silent-wrong-root failure explicit-root mode exists to remove, just moved onto the wire.
+ *  A build that cannot honour the request should say so. */
+export function resolveProjectRoot(req: Request): ProjectScope {
+  const requested = typeof req.query.project === "string" ? req.query.project.trim() : "";
+  if (requested !== "") {
+    // The value is caller-controlled and lands in a log line via `guarded`; strip CR/LF so a
+    // crafted id cannot forge one.
+    throw new Error(`project scoping is not enabled on this server (received project '${requested.replace(/[\r\n]/g, " ")}')`);
+  }
+  return { workspaceRoot: requireWorkspace() };
+}

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -19,6 +19,7 @@
 // an arbitrary-directory reader, which is why the extension point below takes an opaque id
 // resolved through directories we already know rather than a path.
 import type { Request } from "express";
+import { describeValue } from "../../common/readString.js";
 
 /** A root, in the shape the collection engine's options already take, so it can be passed
  *  straight through as `opts` rather than unpacked at every call site. */
@@ -65,11 +66,15 @@ export function workspaceScope(): ProjectScope {
  *  silent-wrong-root failure explicit-root mode exists to remove, just moved onto the wire.
  *  A build that cannot honour the request should say so. */
 export function resolveProjectRoot(req: Request): ProjectScope {
-  const requested = typeof req.query.project === "string" ? req.query.project.trim() : "";
-  if (requested !== "") {
-    // The value is caller-controlled and lands in a log line via `guarded`; strip CR/LF so a
-    // crafted id cannot forge one.
-    throw new Error(`project scoping is not enabled on this server (received project '${requested.replace(/[\r\n]/g, " ")}')`);
+  // PRESENCE is the test, not the value's shape. `?project=a&project=b` arrives as an array
+  // and `?project[x]=y` as an object, so a `typeof === "string"` check would let both through
+  // as "absent" and quietly serve the workspace — the exact silent substitution this refuses.
+  // An empty `?project=` is refused for the same reason: the client meant to name one.
+  if (Object.hasOwn(req.query, "project")) {
+    // Caller-controlled, and it lands in a log line via `guarded`; `describeValue` renders a
+    // non-string shape without interpolating it, and CR/LF is stripped so no id can forge one.
+    const described = describeValue(req.query.project).replace(/[\r\n]/g, " ");
+    throw new Error(`project scoping is not enabled on this server (received project: ${described})`);
   }
   return { workspaceRoot: requireWorkspace() };
 }

--- a/test/server/backends/calendarPush.spec.ts
+++ b/test/server/backends/calendarPush.spec.ts
@@ -13,6 +13,8 @@ import type { CalendarPushOutcome } from "@mulmoclaude/core/google";
 
 import { mountCalendarPushRoutes, type CalendarPushRouteDeps } from "../../../server/backends/calendarPush.js";
 import { PUSH_NOT_DECLARED_ERROR, PUSH_NOT_LINKED_ERROR } from "../../../server/backends/calendarPushResult.js";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { makeTempDir } from "../../support/tempDir";
 
 const PUSHED: CalendarPushOutcome = {
   kind: "pushed",
@@ -22,9 +24,20 @@ const PUSHED: CalendarPushOutcome = {
 const stubDeps = (over: Partial<CalendarPushRouteDeps> = {}): CalendarPushRouteDeps => ({
   findCollection: vi.fn(async () => ({ slug: "meetings" })),
   push: vi.fn(async () => PUSHED),
-  workspaceRoot: () => "/ws",
+  scope: () => ({ workspaceRoot: "/ws" }),
   ...over,
 });
+
+// The LIVE deps, mounted the way server startup mounts them. The stubs above prove the
+// status/field split; they cannot prove the wiring, and that is precisely where this route
+// broke once: `liveDeps` read the engine's ambient root, which explicit-root mode removed, so
+// every push 500'd while every stubbed test stayed green.
+const appWithLiveDeps = () => {
+  const app = express();
+  app.use(express.json());
+  mountCalendarPushRoutes(app);
+  return app;
+};
 
 const appWith = (deps: CalendarPushRouteDeps) => {
   const app = express();
@@ -44,11 +57,22 @@ describe("mountCalendarPushRoutes", () => {
     expect(deps.push).toHaveBeenCalledWith("meetings", "/ws");
   });
 
-  // Read per request, not captured at mount: the collection host is configured after the
-  // routes go up, so a root read at mount time would be the empty string forever.
-  it("reads the workspace root per request", async () => {
+  // The wiring test. An unknown slug is the cheapest request that still runs the live deps
+  // end to end: it resolves the root and calls the real `loadCollection`, so a root the route
+  // cannot obtain surfaces as a 500 here instead of shipping.
+  it("serves a request through the live deps without losing the root", async () => {
+    initCollectionsBackend({ workspace: makeTempDir("mt-calendar-push-") });
+    const res = await request(appWithLiveDeps()).post("/api/collections/nope/calendar-push").send({});
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("'nope' not found");
+  });
+
+  // Resolved per request, not captured at mount: the routes go up before the collection host
+  // is configured, and since core 3.0.0 that host has no ambient root to read later either —
+  // a root captured at mount would be wrong forever, and now unobtainable as well.
+  it("resolves the root per request", async () => {
     let root = "/before";
-    const deps = stubDeps({ workspaceRoot: () => root });
+    const deps = stubDeps({ scope: () => ({ workspaceRoot: root }) });
     await push(deps);
     root = "/after";
     await push(deps);

--- a/test/server/backends/thumbnailStore.spec.ts
+++ b/test/server/backends/thumbnailStore.spec.ts
@@ -12,14 +12,15 @@ import { makeTempDir } from "../../support/tempDir";
 const stubResize = async (input: Buffer, maxEdge: number) => Buffer.from(`RESIZED:${maxEdge}:${input.length}`);
 
 describe("thumbnail resolver", () => {
-  const resolve = createThumbnailResolver(stubResize);
+  // The root is passed EXPLICITLY, as production does (`thumbnailResolverFor(scope)`): the
+  // engine host runs in explicit-root mode, so there is no ambient root to fall back to.
   let ws = "";
+  const resolve = createThumbnailResolver(stubResize, () => ws);
 
   beforeAll(() => {
     ws = makeTempDir("mt-thumb-");
     mkdirSync(path.join(ws, "data"), { recursive: true });
     writeFileSync(path.join(ws, "data", "pic.png"), Buffer.from([1, 2, 3, 4]));
-    // Sets the workspace root the resolver reads via getWorkspaceRoot().
     initCollectionsBackend({ workspace: ws });
   });
 
@@ -50,10 +51,13 @@ describe("thumbnail resolver", () => {
   it("caches by (path, mtime, maxEdge) so a repeated page doesn't re-decode", async () => {
     clearThumbnailCache();
     let calls = 0;
-    const counting = createThumbnailResolver(async (_buf, edge) => {
-      calls += 1;
-      return Buffer.from(`X:${edge}`);
-    });
+    const counting = createThumbnailResolver(
+      async (_buf, edge) => {
+        calls += 1;
+        return Buffer.from(`X:${edge}`);
+      },
+      () => ws,
+    );
     await counting("data/pic.png", 256);
     await counting("data/pic.png", 256);
     expect(calls).toBe(1);

--- a/test/server/infra/projectRoot.spec.ts
+++ b/test/server/infra/projectRoot.spec.ts
@@ -38,9 +38,18 @@ describe("project roots", () => {
     expect(() => resolveProjectRoot(anyRequest)).toThrow(/not configured/);
   });
 
-  it("refuses a project parameter rather than silently serving the workspace", () => {
+  // Presence, not shape. Express turns `?project=a&project=b` into an array and
+  // `?project[x]=y` into an object, so a `typeof === "string"` guard would read both as
+  // "absent" and serve the workspace — the silent substitution this refuses. An empty
+  // `?project=` counts too: the client meant to name one.
+  it.each([
+    ["a plain id", "some-project"],
+    ["repeated parameters", ["a", "b"]],
+    ["a bracketed object", { x: "y" }],
+    ["an empty value", ""],
+  ])("refuses %s rather than silently serving the workspace", (_label, project) => {
     initProjectRoots({ workspace: ws });
-    expect(() => resolveProjectRoot(requestWith({ project: "some-project" }))).toThrow(/not enabled/);
+    expect(() => resolveProjectRoot(requestWith({ project }))).toThrow(/not enabled/);
   });
 
   it("resolves every request to the bound workspace", () => {

--- a/test/server/infra/projectRoot.spec.ts
+++ b/test/server/infra/projectRoot.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+//
+// Pins the guarantee the root-threading buys, which is otherwise invisible: after
+// `initCollectionsBackend`, the collection engine has NO ambient root. Every call names its
+// own, and one that forgets throws instead of resolving against whichever root happened to be
+// bound. On a single-workspace host that difference never shows; on a host with one root per
+// project it is the difference between an error and another project's data — so the binding is
+// asserted here rather than left to be re-derived from a `null` literal in the wiring.
+import { describe, it, expect, beforeEach } from "vitest";
+import { getWorkspaceRoot } from "@mulmoclaude/core/collection/server";
+
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import {
+  initProjectRoots,
+  projectRootsConfigured,
+  resolveProjectRoot,
+  resetProjectRootsForTesting,
+  workspaceScope,
+} from "../../../server/infra/project-root.js";
+import { makeTempDir } from "../../support/tempDir";
+
+// Only `resolveProjectRoot`'s parameter type is exercised, so a bare object is the whole
+// request this needs — building an express Request here would assert nothing extra.
+const requestWith = (query: Record<string, unknown> = {}) => ({ query }) as Parameters<typeof resolveProjectRoot>[0];
+const anyRequest = requestWith();
+
+describe("project roots", () => {
+  let ws = "";
+
+  beforeEach(() => {
+    resetProjectRootsForTesting();
+    ws = makeTempDir("mt-project-root-");
+  });
+
+  it("is unconfigured until a workspace is bound", () => {
+    expect(projectRootsConfigured()).toBe(false);
+    expect(() => workspaceScope()).toThrow(/not configured/);
+    expect(() => resolveProjectRoot(anyRequest)).toThrow(/not configured/);
+  });
+
+  it("refuses a project parameter rather than silently serving the workspace", () => {
+    initProjectRoots({ workspace: ws });
+    expect(() => resolveProjectRoot(requestWith({ project: "some-project" }))).toThrow(/not enabled/);
+  });
+
+  it("resolves every request to the bound workspace", () => {
+    initProjectRoots({ workspace: ws });
+    expect(projectRootsConfigured()).toBe(true);
+    expect(resolveProjectRoot(anyRequest)).toEqual({ workspaceRoot: ws });
+    expect(workspaceScope()).toEqual({ workspaceRoot: ws });
+  });
+
+  // The regression pin. Binding a STRING root here would restore the silent fallback and every
+  // test above would still pass — this is the only assertion that would notice.
+  it("leaves the collection engine with no ambient root to fall back to", () => {
+    initCollectionsBackend({ workspace: ws });
+    expect(() => getWorkspaceRoot()).toThrow(/explicit-root mode/);
+    // …while the host still knows the workspace, which is what every call passes today.
+    expect(workspaceScope()).toEqual({ workspaceRoot: ws });
+  });
+});


### PR DESCRIPTION
Phase 2+3 of `plans/feat-collections-project-root.md`. **Behaviour is unchanged** — every request still resolves to the shared workspace — but the collection engine no longer has an ambient root to fall back to, which is what makes serving a second one safe.

## What changed

`configureCollectionHost` now binds `workspaceRoot: null` (core 3.0.0's explicit-root mode), so `getWorkspaceRoot()` **throws** instead of guessing. Every engine call names its root through the new `server/infra/project-root.ts` — one choke point, shared with accounting / wiki / resources later, so phase 5 changes one function rather than the ~30 call sites this touched.

## Why the ceremony for a no-op

With one root, a forgotten `opts.workspaceRoot` resolves correctly by accident. With one root **per project** it is not a crash — it reads or writes another project's data: tests green, types green, nothing logged. Turning the fallback into a throw is the only way to know the threading is complete.

It immediately earned that: two call sites this change had missed showed up as test failures rather than as silence.

- the custom-view **i18n** read
- the **thumbnail resolver's containment check** — which is a security boundary, so it must check against the root the request resolved, never whatever happened to be bound

## Shapes worth a look in review

- **Injected-dep modules are bound per scope**, not given a scope parameter: `buildRemoteViewFor(scope)`, `mutateRemoteViewFor(scope)`, `remoteViewItemsFor(scope)`, `thumbnailResolverFor(scope)`. The root ends up next to the engine call, and no dep interface — or its specs — had to change.
- **`manageCollection`'s binding takes the root as a getter.** The tool is built at module scope, before boot binds anything, so a captured value would be `undefined` — which under the new binding is a throw, not a fallback.
- **The completion watchers are started with an explicit root.** Without one they would throw `COLLECTION_ROOT_REQUIRED` on first discovery, and since the caller is fire-and-forget with a `.catch`, that would not stop the server — it would leave every collection bell silently dead.
- **`resolveProjectRoot` refuses a `?project=` parameter rather than ignoring it.** Ignoring it would serve one project while the client asked for another, with nothing saying so — the same silent-wrong-root failure this PR removes, moved onto the wire. Serving it is phase 5.

## The regression pin

`test/server/infra/projectRoot.spec.ts` asserts that after `initCollectionsBackend` the engine throws on `getWorkspaceRoot()`. Binding a string root again would restore the silent fallback and **every other test would still pass** — this is the only assertion that would notice.

## Also lands

The §6.5 note written before this work: skill staging (`data/skills` → `.claude/skills`) is a **workspace** mechanism and must not follow into project roots — the engine reads staging *first* for `source: "project"` collections, so a stray tree there would shadow the committed skill. That needs an upstream change (U5) and is not in this PR.

## Gate

`yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — **9412 passed / 45 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal