### PR TITLE
feat(collections): serve a collection from any known project

### DIFF
--- a/plans/feat-collections-project-root.md
+++ b/plans/feat-collections-project-root.md
@@ -344,9 +344,9 @@ project selector ships, or "my project's collection never rings" becomes the fir
 | 1 | U1 payload root + U2 strict mode + U3 cleanup, published | MulmoClaude / core | yes (no behaviour change there) |
 | 2 | `resolveProjectRoot()` + known-projects validation | MulmoTerminal | **DONE** (the known-projects list is phase 5; a `project` parameter is refused, not ignored) |
 | 3 | Thread root through all routes; turn strict mode on | MulmoTerminal | **DONE** — still workspace-only, but now explicit |
-| 4 | Re-key tokens / caches / channels by `(root, slug)` | MulmoTerminal | yes |
-| 5 | `?project=` parameter + client project selector | MulmoTerminal | **yes — this is the feature landing** |
-| 6 | Merge-semantics decisions from §6 made real | MulmoTerminal | with 5 |
+| 4 | Re-key tokens / caches / channels by `(root, slug)` | MulmoTerminal | **DONE** — tokens carry the root, the thumbnail cache and the query cap key on it; MT wires no collection change publisher, so there was no channel to re-key |
+| 5 | `?project=` parameter + client project selector | MulmoTerminal | **server DONE** (`?project=<opaque id>`, `GET /api/collection-projects`); the client selector is still to build |
+| 6 | Merge-semantics decisions from §6 made real | MulmoTerminal | **DONE by construction** — user scope still merges (engine default), feeds follow the root (`feedsRoot(root)`), and the workspace is simply not the root when a project is named |
 | 7 | Self-containment check (§11.4) | MulmoTerminal | yes — useful even before 5 |
 | 8 | Watcher per root, or accept workspace-only bells (§7b) | MT + possibly upstream | decide before 5 ships |
 | 9 | No skill staging outside the managed workspace (§6.5, needs U5) | upstream + MT | with 5 |

--- a/server/backends/calendarPush.ts
+++ b/server/backends/calendarPush.ts
@@ -16,7 +16,7 @@
 import type { Express, Request, Response } from "express";
 import { pushCalendarForCollection } from "@mulmoclaude/core/google";
 import { loadCollection } from "@mulmoclaude/core/collection/server";
-import { resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
+import { errorStatus, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { toCollectionPushResult } from "./calendarPushResult.js";
 import { hostLogger } from "./hostLogger.js";
 
@@ -80,7 +80,9 @@ export function mountCalendarPushRoutes(app: Express, deps: CalendarPushRouteDep
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       hostLogger.warn("calendar-push", "push threw", { slug, error });
-      res.status(500).json({ error });
+      // A request naming a project this server cannot serve is a client error, not a failure
+      // of the push — `errorStatus` keeps a query-parameter typo out of the 500 bucket.
+      res.status(errorStatus(err)).json({ error });
     }
   });
 }

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -48,15 +48,11 @@ import type { CollectionMutateAction } from "@mulmoclaude/core/collection";
 import { fieldVisible, COMPUTED_TYPES, type CollectionItem } from "@mulmoclaude/core/collection";
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
-import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 // The rest of the custom-view surface (view-i18n, scoped image resolve, scoped
 // mutate action), mounted at the bottom of mountCollectionRoutes with the
 // helpers those routes share with the ones here.
 import { mountCustomViewRoutes, viewActionRateLimit } from "./customViewRoutes.js";
-// The 404 / 405 / 409 preamble those action routes share with the one here.
-import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
-// Mobile custom-view builder — shared with the remote-host channel handlers so
-// the desktop phone-frame preview renders the EXACT artifact the phone receives.
+import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 import {
   buildRemoteViewFor,
   mutateRemoteViewFor,
@@ -65,13 +61,18 @@ import {
   remoteViewItemsFor,
   remoteViewItemsFailureMessage,
 } from "./remoteView.js";
+import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
+// The 404 / 405 / 409 preamble those action routes share with the one here.
+import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } from "./collectionActionGuards.js";
+// Mobile custom-view builder — shared with the remote-host channel handlers so
+// the desktop phone-frame preview renders the EXACT artifact the phone receives.
 import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from "./viewToken.js";
 // The shared manageCollection binding — the query route reuses its queryItems
 // action so a view can never do more than the agent's own data plane.
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
-import { initProjectRoots, projectRootsConfigured, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
-import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
+import { getCwdPresets } from "../config/config-routes.js";
+import { errorStatus, initProjectRoots, projectRootKey, projectRootsConfigured, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { isRecord } from "../../common/isRecord.js";
 import { requestBody } from "../routes/requestBody.js";
 
@@ -99,8 +100,11 @@ export const projectSkillsDir = (root: string): string => path.join(root, ".clau
  *  which on a host with one root per project is the difference between an error and another
  *  project's data. The workspace itself is bound through `initProjectRoots`, which is what
  *  every scope still resolves to today. */
-export function initCollectionsBackend(deps: { workspace: string }): void {
-  initProjectRoots({ workspace: deps.workspace });
+export function initCollectionsBackend(deps: { workspace: string; knownProjects?: () => Array<{ label: string; path: string }> }): void {
+  // The saved directories are the projects a request may name. Defaulted here rather than
+  // passed from boot: a THUNK, because launching from a new directory records one and a list
+  // captured at boot would refuse a project the launcher already shows. Specs override it.
+  initProjectRoots({ workspace: deps.workspace, knownProjects: deps.knownProjects ?? getCwdPresets });
   configureCollectionHost({
     workspaceRoot: null,
     log,
@@ -142,7 +146,9 @@ function guarded<P extends Record<string, string>>(op: string, handler: RequestH
       await handler(req, res, next);
     } catch (err) {
       log.warn("collections", `${op} failed`, { ...sanitizeLogValues(req.params), error: errorMessage(err) });
-      res.status(500).json({ error: errorMessage(err) });
+      // A request that named a project this server cannot serve is a CLIENT error; answering
+      // 500 would read as "the server broke" for a typo in a query parameter.
+      res.status(errorStatus(err)).json({ error: errorMessage(err) });
     }
   };
 }
@@ -640,6 +646,53 @@ const viewFileHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   res.type("text/html").send(html);
 };
 
+// Mint a scoped token for a custom view, clamped to what the view declared so a
+// read-only view can never obtain a write token.
+const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
+  const { slug } = req.params;
+  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
+  const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
+  if (!viewId) {
+    res.status(400).json({ error: "`viewId` is required" });
+    return;
+  }
+  const scope = resolveProjectRoot(req);
+  const collection = await resolveCollection(res, slug, scope);
+  if (!collection) return;
+  const view = resolveView(res, collection, viewId);
+  if (!view) return;
+  // The write tier is wired below (PUT /view-data), so grant exactly what the
+  // view declared. `clampCapabilities` defaults the requested set to the declared
+  // set, so a `["read"]` view still can never obtain a `write` token.
+  // Filtered rather than asserted. The schema validator already rejects an unrecognised capability
+  // (a collection declaring one fails to load at all), so this changes nothing today — but it is
+  // the local code proving what it hands to the minter rather than declaring it.
+  const granted = clampCapabilities(Array.isArray(view.capabilities) ? view.capabilities.filter(isCapability) : undefined, undefined);
+  const minted = mintViewToken(slug, granted, scope.workspaceRoot);
+  // The project rides ON the dataUrl, not just in the token. The iframe fetches this URL
+  // verbatim, and a URL without the project resolves to the workspace — against which the
+  // token (minted for the project) is invalid, so the view would render an empty 401 rather
+  // than its records. The two must name the same root or neither works.
+  const project = typeof req.query.project === "string" ? `?project=${encodeURIComponent(req.query.project)}` : "";
+  res.json({
+    token: minted.token,
+    exp: minted.exp,
+    dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data${project}`,
+    capabilities: granted,
+  });
+};
+
+// CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
+// its fetch is cross-origin and preflighted. `*` is safe — auth is the unguessable
+// scoped token in the Authorization header (not a cookie), so no ambient-credential
+// leak; an origin without the token just gets a 401.
+const viewDataCors = (_req: Request, res: Response, next: NextFunction): void => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+  res.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, OPTIONS");
+  next();
+};
+
 // Serve a mobile (`target: "mobile"`) custom view wrapped into its sandboxed
 // srcdoc — the desktop phone-frame preview's data source. Same builder as the
 // remote-host channel's `getRemoteView`, so the preview renders the exact
@@ -664,9 +717,6 @@ const remoteViewHandler: RequestHandler<{ slug: string }> = async (req, res) => 
 // preview's write channel. Same builder + host-side policy as the channel's
 // `mutateRemoteViewItem`, so a preview mutation runs the exact enforcement the
 // phone will.
-// The predicate the write-mode check needs: `VIEW_WRITE_MODES.includes()` only accepts a value
-// already typed as a mode, which is what forced the assertion it replaces.
-const isViewWriteMode = (value: unknown): value is ViewWriteMode => VIEW_WRITE_MODES.some((mode) => mode === value);
 
 const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
   const { slug, viewId } = req.params;
@@ -711,41 +761,9 @@ const remoteViewItemsHandler: RequestHandler<{ slug: string; viewId: string }> =
   res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
 };
 
-// Mint a scoped token for a custom view, clamped to what the view declared so a
-// read-only view can never obtain a write token.
-const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const { slug } = req.params;
-  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
-  const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
-  if (!viewId) {
-    res.status(400).json({ error: "`viewId` is required" });
-    return;
-  }
-  const collection = await resolveCollection(res, slug, resolveProjectRoot(req));
-  if (!collection) return;
-  const view = resolveView(res, collection, viewId);
-  if (!view) return;
-  // The write tier is wired below (PUT /view-data), so grant exactly what the
-  // view declared. `clampCapabilities` defaults the requested set to the declared
-  // set, so a `["read"]` view still can never obtain a `write` token.
-  // Filtered rather than asserted. The schema validator already rejects an unrecognised capability
-  // (a collection declaring one fails to load at all), so this changes nothing today — but it is
-  // the local code proving what it hands to the minter rather than declaring it.
-  const granted = clampCapabilities(Array.isArray(view.capabilities) ? view.capabilities.filter(isCapability) : undefined, undefined);
-  const minted = mintViewToken(slug, granted);
-  res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
-};
-
-// CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
-// its fetch is cross-origin and preflighted. `*` is safe — auth is the unguessable
-// scoped token in the Authorization header (not a cookie), so no ambient-credential
-// leak; an origin without the token just gets a 401.
-const viewDataCors = (_req: Request, res: Response, next: NextFunction): void => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
-  res.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, OPTIONS");
-  next();
-};
+// The predicate the write-mode check needs: `VIEW_WRITE_MODES.includes()` only accepts a value
+// already typed as a mode, which is what forced the assertion it replaces.
+const isViewWriteMode = (value: unknown): value is ViewWriteMode => VIEW_WRITE_MODES.some((mode) => mode === value);
 
 // Scoped read: the view's enriched records as `{ items }` — the shape custom views
 // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
@@ -797,7 +815,9 @@ const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) =>
 const VIEW_QUERY_MAX_CONCURRENT = 4;
 const inflightViewQueries = new Map<string, number>();
 const viewQueryConcurrency = (req: Request<{ slug?: string }>, res: Response, next: NextFunction): void => {
-  const slug = req.params.slug ?? "";
+  // Keyed by (root, slug): a slug is unique only within a root, so a shared key would let one
+  // project's dashboard spend another project's budget.
+  const slug = `${projectRootKey(req)}\u0000${req.params.slug ?? ""}`;
   const current = inflightViewQueries.get(slug) ?? 0;
   if (current >= VIEW_QUERY_MAX_CONCURRENT) {
     res.status(429).json({ error: "too many concurrent queries for this collection — retry shortly" });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -908,7 +908,12 @@ export function mountCollectionRoutes(app: Express): void {
   // Not `guarded` like its neighbours, on purpose: the handler catches its own
   // throw so it can answer a FIXED message. A raw engine error can carry host
   // paths, and `guarded` would put exactly that in the body for a scoped view.
-  app.post("/api/collections/:slug/view-data/query", viewDataCors, viewActionRateLimit, viewQueryConcurrency, requireViewToken("read"), viewDataQueryHandler);
+  // `requireViewToken` runs BEFORE the concurrency cap, and the order is load-bearing: the
+  // token is what names the project (the iframe's URLs carry none), so a cap keyed on the root
+  // must run after the token has attached it — otherwise every project's views contend for the
+  // workspace's bucket. It is also the cheaper order: an unauthorized request no longer spends
+  // a slot before being refused.
+  app.post("/api/collections/:slug/view-data/query", viewDataCors, viewActionRateLimit, requireViewToken("read"), viewQueryConcurrency, viewDataQueryHandler);
 
   // The rest of the custom-view surface (customViewRoutes.ts: the i18n dict, the
   // scoped image resolve, the scoped mutate action), handed the loader / view

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -69,10 +69,18 @@ import { refuseReadOnlyCollection, resolveActionableRecord, resolveItemAction } 
 import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from "./viewToken.js";
 // The shared manageCollection binding — the query route reuses its queryItems
 // action so a view can never do more than the agent's own data plane.
-import { manageCollectionHandler } from "../infra/collection-tool.js";
+import { manageCollectionHandlerFor } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
 import { getCwdPresets } from "../config/config-routes.js";
-import { errorStatus, initProjectRoots, projectRootKey, projectRootsConfigured, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
+import {
+  errorStatus,
+  initProjectRoots,
+  projectId,
+  projectRootKey,
+  projectRootsConfigured,
+  resolveProjectRoot,
+  type ProjectScope,
+} from "../infra/project-root.js";
 import { isRecord } from "../../common/isRecord.js";
 import { requestBody } from "../routes/requestBody.js";
 
@@ -668,18 +676,11 @@ const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   // (a collection declaring one fails to load at all), so this changes nothing today — but it is
   // the local code proving what it hands to the minter rather than declaring it.
   const granted = clampCapabilities(Array.isArray(view.capabilities) ? view.capabilities.filter(isCapability) : undefined, undefined);
-  const minted = mintViewToken(slug, granted, scope.workspaceRoot);
-  // The project rides ON the dataUrl, not just in the token. The iframe fetches this URL
-  // verbatim, and a URL without the project resolves to the workspace — against which the
-  // token (minted for the project) is invalid, so the view would render an empty 401 rather
-  // than its records. The two must name the same root or neither works.
-  const project = typeof req.query.project === "string" ? `?project=${encodeURIComponent(req.query.project)}` : "";
-  res.json({
-    token: minted.token,
-    exp: minted.exp,
-    dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data${project}`,
-    capabilities: granted,
-  });
+  // The token carries the project; the URL stays clean. The bundled custom-view contract
+  // builds its other endpoints by CONCATENATION (`dataUrl + "/query"`, `+ "/image?…"`), so a
+  // trailing `?project=` here would land inside those suffixes and 401 every one of them.
+  const minted = mintViewToken(slug, granted, projectId(scope.workspaceRoot));
+  res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
 };
 
 // CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
@@ -845,7 +846,11 @@ const viewQueryConcurrency = (req: Request<{ slug?: string }>, res: Response, ne
 const viewDataQueryHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   try {
     const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
-    const raw = await manageCollectionHandler({ action: "queryItems", slug: req.params.slug, query: body.query });
+    // Bound to the root THIS request resolved. `requireViewToken` has already checked the
+    // token against that same root, so running the query against any other one would hand a
+    // project-scoped view another project's rows for a shared slug.
+    const query = manageCollectionHandlerFor(resolveProjectRoot(req).workspaceRoot);
+    const raw = await query({ action: "queryItems", slug: req.params.slug, query: body.query });
     try {
       res.json(JSON.parse(raw));
     } catch {

--- a/server/backends/customViewRoutes.ts
+++ b/server/backends/customViewRoutes.ts
@@ -187,8 +187,11 @@ export function mountCustomViewRoutes(app: Express, deps: CustomViewRouteDeps): 
     "/api/collections/:slug/view-data/image",
     deps.cors,
     imageRateLimit,
-    deps.queryConcurrency,
+    // Token first, cap second — the token is what names the project, and a cap keyed on the
+    // root before it is attached buckets every project into the workspace's. Same order as
+    // /view-data/query, for the same reason.
     requireViewToken("read"),
+    deps.queryConcurrency,
     deps.guarded("view-data image", makeImageHandler(deps)),
   );
 

--- a/server/backends/feeds.ts
+++ b/server/backends/feeds.ts
@@ -17,6 +17,7 @@ import { loadCollection } from "@mulmoclaude/core/collection/server";
 import type { FeedSummary } from "@mulmoclaude/core/collection";
 import { writeFileAtomic } from "../files/atomic-write.js";
 import { feedSummary } from "./feed-summary.js";
+import { errorStatus, resolveProjectRoot } from "../infra/project-root.js";
 
 const log: FeedsLogger = {
   error: (prefix, msg, data) => console.error(`[${prefix}] ${msg}`, data ?? ""),
@@ -72,8 +73,18 @@ export function mountFeedsRoutes(app: Express): void {
     }
   });
 
+  // Sits on the collection surface, so it honours `?project=` like the rest of it. Reading the
+  // module-level workspace here instead would refresh — and WRITE — the workspace collection
+  // that happens to share the slug, or 404 while the named project holds the feed.
   app.post("/api/collections/:slug/refresh", async (req: Request<{ slug: string }>, res: Response) => {
-    const collection = await loadCollection(req.params.slug, { workspaceRoot });
+    let scope;
+    try {
+      scope = resolveProjectRoot(req);
+    } catch (err) {
+      res.status(errorStatus(err)).json({ error: errorMessage(err) });
+      return;
+    }
+    const collection = await loadCollection(req.params.slug, scope);
     if (!collection) {
       res.status(404).json({ error: `collection '${req.params.slug}' not found` });
       return;
@@ -83,7 +94,7 @@ export function mountFeedsRoutes(app: Express): void {
       return;
     }
     try {
-      const result = await refreshOne(workspaceRoot, collection, { hidden: false });
+      const result = await refreshOne(scope.workspaceRoot, collection, { hidden: false });
       res.json({ refreshed: true, written: result.written, errors: result.errors, dispatched: result.dispatched, chatId: result.chatId });
     } catch (err) {
       log.warn("feeds", "refresh failed", { slug: collection.slug, error: errorMessage(err) });

--- a/server/backends/thumbnailStore.ts
+++ b/server/backends/thumbnailStore.ts
@@ -45,16 +45,21 @@ interface CacheEntry {
 const MAX_CACHE_ENTRIES = 256;
 const cache = new Map<string, CacheEntry>();
 
-function cacheGet(relPath: string, mtimeMs: number, maxEdge: number): string | null {
-  const entry = cache.get(relPath);
+// The cache key carries the ROOT, not just the workspace-relative path. Two projects both
+// holding `data/pic.png` are the normal case, and the cached value is the image BYTES — so a
+// path-only key would serve one project's picture inside another's view.
+const cacheKey = (root: string, relPath: string): string => `${root}\u0000${relPath}`;
+
+function cacheGet(key: string, mtimeMs: number, maxEdge: number): string | null {
+  const entry = cache.get(key);
   if (!entry || entry.mtimeMs !== mtimeMs || entry.maxEdge !== maxEdge) return null;
-  cache.delete(relPath);
-  cache.set(relPath, entry);
+  cache.delete(key);
+  cache.set(key, entry);
   return entry.dataUrl;
 }
 
-function cacheSet(relPath: string, entry: CacheEntry): void {
-  cache.set(relPath, entry);
+function cacheSet(key: string, entry: CacheEntry): void {
+  cache.set(key, entry);
   if (cache.size > MAX_CACHE_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) cache.delete(oldest);
@@ -91,12 +96,13 @@ export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize, root
     if (!real) return null;
     const info = await stat(real).catch(() => null);
     if (!info?.isFile()) return null;
-    const cached = cacheGet(relPath, info.mtimeMs, maxEdge);
+    const key = cacheKey(root, relPath);
+    const cached = cacheGet(key, info.mtimeMs, maxEdge);
     if (cached) return cached;
     try {
       const out = await resize(await readFile(real), maxEdge);
       const dataUrl = `data:image/jpeg;base64,${out.toString("base64")}`;
-      cacheSet(relPath, { mtimeMs: info.mtimeMs, maxEdge, dataUrl });
+      cacheSet(key, { mtimeMs: info.mtimeMs, maxEdge, dataUrl });
       return dataUrl;
     } catch (err) {
       console.warn("[thumbnail] resolve failed", relPath, String(err));

--- a/server/backends/viewToken.ts
+++ b/server/backends/viewToken.ts
@@ -14,6 +14,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { Request, Response, NextFunction } from "express";
 import { isRecord } from "../../common/isRecord.js";
+import { resolveProjectRoot } from "../infra/project-root.js";
 
 export type ViewCapability = "read" | "write";
 
@@ -32,6 +33,11 @@ const SIGNING_KEY = randomBytes(32).toString("hex");
 
 interface ViewTokenPayload {
   slug: string;
+  /** The project root the token was minted against. A slug is unique only WITHIN a root, so
+   *  without this a token for `tasks` in one project would read `tasks` in another — the
+   *  iframe is sandboxed and opaque-origin, but the token is the only thing standing between
+   *  it and another project's records. */
+  root: string;
   caps: ViewCapability[];
   exp: number;
 }
@@ -54,9 +60,9 @@ export function clampCapabilities(declared: ViewCapability[] | undefined, reques
 }
 
 /** Mint a signed token for `slug` granting `caps`, valid for {@link VIEW_TOKEN_TTL_MS}. */
-export function mintViewToken(slug: string, caps: ViewCapability[], nowMs: number = Date.now()): { token: string; exp: number } {
+export function mintViewToken(slug: string, caps: ViewCapability[], root: string, nowMs: number = Date.now()): { token: string; exp: number } {
   const exp = nowMs + VIEW_TOKEN_TTL_MS;
-  const payload: ViewTokenPayload = { slug, caps, exp };
+  const payload: ViewTokenPayload = { slug, root, caps, exp };
   const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
   return { token: `${payloadB64}.${signPayload(payloadB64)}`, exp };
 }
@@ -80,12 +86,12 @@ export function verifyViewToken(token: string, nowMs: number = Date.now()): View
     return null;
   }
   if (!isRecord(parsed)) return null;
-  const { slug, exp, caps } = parsed;
-  if (typeof slug !== "string" || typeof exp !== "number") return null;
+  const { slug, root, exp, caps } = parsed;
+  if (typeof slug !== "string" || typeof root !== "string" || typeof exp !== "number") return null;
   // `every` with a type predicate narrows the array itself, so the checked value IS the typed one.
   if (!Array.isArray(caps) || !caps.every(isCapability)) return null;
   if (nowMs >= exp) return null;
-  return { slug, caps, exp };
+  return { slug, root, caps, exp };
 }
 
 /** Express middleware: require a valid scoped token whose slug matches the route
@@ -98,7 +104,18 @@ export function requireViewToken(action: ViewCapability) {
       return;
     }
     const payload = verifyViewToken(header.slice(BEARER_PREFIX.length));
-    if (!payload || payload.slug !== req.params.slug || !payload.caps.includes(action)) {
+    // The root is checked as well as the slug, against the root THIS request resolves. A token
+    // minted for one project must not be spendable on a request naming another — and a request
+    // naming a project the server cannot resolve has no valid token by definition, so the
+    // resolver's refusal is an unauthorized answer here rather than a 500.
+    let requestRoot: string;
+    try {
+      requestRoot = resolveProjectRoot(req).workspaceRoot;
+    } catch {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    if (!payload || payload.slug !== req.params.slug || payload.root !== requestRoot || !payload.caps.includes(action)) {
       res.status(401).json({ error: "unauthorized" });
       return;
     }

--- a/server/backends/viewToken.ts
+++ b/server/backends/viewToken.ts
@@ -14,7 +14,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { Request, Response, NextFunction } from "express";
 import { isRecord } from "../../common/isRecord.js";
-import { resolveProjectRoot } from "../infra/project-root.js";
+import { attachProjectScope, rootForProjectId } from "../infra/project-root.js";
 
 export type ViewCapability = "read" | "write";
 
@@ -33,11 +33,14 @@ const SIGNING_KEY = randomBytes(32).toString("hex");
 
 interface ViewTokenPayload {
   slug: string;
-  /** The project root the token was minted against. A slug is unique only WITHIN a root, so
-   *  without this a token for `tasks` in one project would read `tasks` in another — the
-   *  iframe is sandboxed and opaque-origin, but the token is the only thing standing between
-   *  it and another project's records. */
-  root: string;
+  /** The project the token was minted for, as its OPAQUE ID. A slug is unique only within a
+   *  root, so without this a token for `tasks` in one project would read `tasks` in another.
+   *
+   *  The id, never the path: a token is signed but NOT encrypted — everything before the dot
+   *  is plain base64url JSON — and it is handed to an LLM-authored iframe. An absolute root
+   *  here would publish the user's home directory to exactly the party the opaque id exists to
+   *  keep it from. */
+  project: string;
   caps: ViewCapability[];
   exp: number;
 }
@@ -60,9 +63,9 @@ export function clampCapabilities(declared: ViewCapability[] | undefined, reques
 }
 
 /** Mint a signed token for `slug` granting `caps`, valid for {@link VIEW_TOKEN_TTL_MS}. */
-export function mintViewToken(slug: string, caps: ViewCapability[], root: string, nowMs: number = Date.now()): { token: string; exp: number } {
+export function mintViewToken(slug: string, caps: ViewCapability[], project: string, nowMs: number = Date.now()): { token: string; exp: number } {
   const exp = nowMs + VIEW_TOKEN_TTL_MS;
-  const payload: ViewTokenPayload = { slug, root, caps, exp };
+  const payload: ViewTokenPayload = { slug, project, caps, exp };
   const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
   return { token: `${payloadB64}.${signPayload(payloadB64)}`, exp };
 }
@@ -86,12 +89,12 @@ export function verifyViewToken(token: string, nowMs: number = Date.now()): View
     return null;
   }
   if (!isRecord(parsed)) return null;
-  const { slug, root, exp, caps } = parsed;
-  if (typeof slug !== "string" || typeof root !== "string" || typeof exp !== "number") return null;
+  const { slug, project, exp, caps } = parsed;
+  if (typeof slug !== "string" || typeof project !== "string" || typeof exp !== "number") return null;
   // `every` with a type predicate narrows the array itself, so the checked value IS the typed one.
   if (!Array.isArray(caps) || !caps.every(isCapability)) return null;
   if (nowMs >= exp) return null;
-  return { slug, root, caps, exp };
+  return { slug, project, caps, exp };
 }
 
 /** Express middleware: require a valid scoped token whose slug matches the route
@@ -104,21 +107,26 @@ export function requireViewToken(action: ViewCapability) {
       return;
     }
     const payload = verifyViewToken(header.slice(BEARER_PREFIX.length));
-    // The root is checked as well as the slug, against the root THIS request resolves. A token
-    // minted for one project must not be spendable on a request naming another — and a request
-    // naming a project the server cannot resolve has no valid token by definition, so the
-    // resolver's refusal is an unauthorized answer here rather than a 500.
-    let requestRoot: string;
-    try {
-      requestRoot = resolveProjectRoot(req).workspaceRoot;
-    } catch {
+    if (!payload || payload.slug !== req.params.slug || !payload.caps.includes(action)) {
       res.status(401).json({ error: "unauthorized" });
       return;
     }
-    if (!payload || payload.slug !== req.params.slug || payload.root !== requestRoot || !payload.caps.includes(action)) {
+    // The TOKEN names the project, not the URL. The iframe builds its other endpoints by
+    // concatenating onto the data URL (`dataUrl + "/query"`), so a query parameter there would
+    // end up inside the suffix; carrying the project in the token keeps those URLs clean and
+    // makes authorization and scope one decision instead of two that can disagree.
+    const root = rootForProjectId(payload.project);
+    if (root === null) {
       res.status(401).json({ error: "unauthorized" });
       return;
     }
+    // A request that ALSO names a project must name the same one. Ignoring a mismatch would
+    // serve the token's project while the URL asked for another.
+    if (Object.hasOwn(req.query, "project") && req.query.project !== payload.project) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    attachProjectScope(req, { workspaceRoot: root });
     next();
   };
 }

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -31,8 +31,31 @@ const tool = makeManageCollectionTool({
 
 /** The bound handler the dispatch route calls. Returns the tool's narration
  *  string (JSON for the read/write actions) — no GUI `data`, matching
- *  MulmoClaude where manageCollection results narrate to claude only. */
+ *  MulmoClaude where manageCollection results narrate to claude only.
+ *
+ *  This one is the AGENT's data plane and operates on the workspace, which is what the
+ *  getter above says. A REQUEST must not use it — see `manageCollectionHandlerFor`. */
 export const manageCollectionHandler = tool.handler;
+
+// One tool instance per root. `makeManageCollectionTool` takes its root in the FACTORY deps,
+// not per call, so a request-scoped operation needs its own instance; they are cached because
+// a custom view's dashboard can issue these in a loop. Bounded by the number of projects the
+// user has, which is the same list `resolveProjectRoot` resolves against.
+const byRoot = new Map<string, typeof tool.handler>();
+
+/** The handler bound to ONE project root — what a request-scoped route must use.
+ *
+ *  The workspace-bound handler above would execute against the workspace no matter which
+ *  project the request named and its token was checked for, so a view in one project could
+ *  receive another's rows for a shared slug. The token check and the query have to agree on
+ *  the root, and this is how the query learns it. */
+export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
+  const cached = byRoot.get(workspaceRoot);
+  if (cached) return cached;
+  const handler = makeManageCollectionTool({ bundledHelpsDir: helpsAssetDir, workspaceRoot }).handler;
+  byRoot.set(workspaceRoot, handler);
+  return handler;
+}
 
 /** gui-chat-protocol shape of the core tool's MCP definition — the same
  *  inputSchema→parameters / prompt-folding adaptation loadServerToolPackage

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -2,22 +2,23 @@
 // share (collections now; accounting, wiki and resources later, see
 // plans/project-architecture.md D4).
 //
-// WHY THIS EXISTS BEFORE IT DOES ANYTHING INTERESTING. Every root today resolves to the
-// shared workspace, so this file changes no behaviour. What it buys is that the ~30 engine
-// call sites now name a root explicitly instead of falling through to the engine's ambient
-// default, which lets `configureCollectionHost` run in EXPLICIT-ROOT mode
-// (`workspaceRoot: null`): a call that forgets its root throws `COLLECTION_ROOT_REQUIRED`
-// instead of silently resolving against whichever workspace happened to be bound. On a host
-// with one root that difference is invisible; on a host with one root PER PROJECT it is the
-// difference between an error and quietly reading another project's data.
+// A request names its project with an OPAQUE ID, never a path. That is not tidiness: the
+// engine's `resolveDataDir` guarantees containment only WITHIN the root it is handed, so the
+// root itself is the trust boundary. A client-supplied path would turn every collection route
+// into an arbitrary-directory reader. Ids resolve against directories the app already knows —
+// the shared workspace and the saved `cwdPresets` — and anything else is refused.
 //
-// Serving a second root is deliberately NOT wired here yet. When it is, the resolution order
-// is: an explicit project parameter on the request (validated against the known-projects
-// list) → the session's cwd → the workspace. The validation is not optional and not a detail:
-// `resolveDataDir` only guarantees containment WITHIN the root it is handed, so the root
-// itself is the trust boundary. A client-supplied path would turn every collection route into
-// an arbitrary-directory reader, which is why the extension point below takes an opaque id
-// resolved through directories we already know rather than a path.
+// The id is also what keeps host paths out of the browser, out of URLs and out of logs. It is
+// DERIVED from the path rather than stored, so it survives restarts and needs no registry: the
+// list of projects is already `cwdPresets`, which follows from a Project simply BEING a
+// directory (plans/project-architecture.md D2).
+//
+// The other half of the contract lives in the engine binding: the collection host runs in
+// explicit-root mode (`workspaceRoot: null`), so nothing can fall back to an ambient root when
+// a call site forgets to pass one — it throws instead. Serving several roots is only safe
+// because that fallback is gone.
+import { createHash } from "node:crypto";
+import path from "node:path";
 import type { Request } from "express";
 import { describeValue } from "../../common/readString.js";
 
@@ -27,11 +28,42 @@ export interface ProjectScope {
   workspaceRoot: string;
 }
 
-let workspace: string | null = null;
+/** A project as the client sees it: an opaque id and something to show in a picker. The path
+ *  is deliberately absent — see the header. */
+export interface ProjectSummary {
+  id: string;
+  label: string;
+}
 
-/** Bind the shared workspace. Call once at boot, before any route resolves a scope. */
-export function initProjectRoots(deps: { workspace: string }): void {
+/** A request that named a project this server cannot serve. Carries the status the route
+ *  should answer with, so an unknown id reads as the client error it is rather than as a 500
+ *  that looks like the server broke. */
+export class ProjectRootError extends Error {
+  readonly status = 400;
+}
+
+/** The status a caught error should answer with — `ProjectRootError`'s own, 500 otherwise. */
+export function errorStatus(err: unknown): number {
+  return err instanceof ProjectRootError ? err.status : 500;
+}
+
+interface KnownProject {
+  label: string;
+  path: string;
+}
+
+let workspace: string | null = null;
+let knownProjects: () => KnownProject[] = () => [];
+
+/** Bind the shared workspace and the source of saved directories. Call once at boot, before
+ *  any route resolves a scope.
+ *
+ *  `knownProjects` is a THUNK because the saved directories change while the server runs —
+ *  launching from a new directory records one — and a list captured at boot would refuse a
+ *  project the user can see in their own launcher. */
+export function initProjectRoots(deps: { workspace: string; knownProjects?: () => KnownProject[] }): void {
   workspace = deps.workspace;
+  knownProjects = deps.knownProjects ?? (() => []);
 }
 
 /** Whether the binding is in place. Routes that answered 503 for "backend not initialized"
@@ -43,6 +75,7 @@ export function projectRootsConfigured(): boolean {
 /** Test-only: drop the binding so a spec can assert the unconfigured failure. */
 export function resetProjectRootsForTesting(): void {
   workspace = null;
+  knownProjects = () => [];
 }
 
 function requireWorkspace(): string {
@@ -52,29 +85,69 @@ function requireWorkspace(): string {
   return workspace;
 }
 
-/** The shared workspace, for callers that have no request: boot paths, the agent tool
- *  dispatch, the completion watchers. Separate from `resolveProjectRoot` so those callers
- *  read as what they are — "the workspace" — rather than as a request that lost its `req`. */
-export function workspaceScope(): ProjectScope {
-  return { workspaceRoot: requireWorkspace() };
+/** The opaque id for a root. A truncated digest: stable across restarts (nothing is stored),
+ *  short enough to sit in a URL, and not reversible into the path it names.
+ *
+ *  16 hex characters is 64 bits. A collision would need billions of directories, and even then
+ *  it could only confuse two of the user's OWN projects — never reach one outside the list,
+ *  since an id that matches nothing resolves to nothing. */
+export function projectId(root: string): string {
+  return createHash("sha256").update(root).digest("hex").slice(0, 16);
 }
 
-/** The root this request operates against — the workspace, today.
- *
- *  A `project` parameter is REFUSED rather than ignored. Ignoring it would mean a client that
- *  asks for one project and is served another, with nothing anywhere saying so — the same
- *  silent-wrong-root failure explicit-root mode exists to remove, just moved onto the wire.
- *  A build that cannot honour the request should say so. */
-export function resolveProjectRoot(req: Request): ProjectScope {
-  // PRESENCE is the test, not the value's shape. `?project=a&project=b` arrives as an array
-  // and `?project[x]=y` as an object, so a `typeof === "string"` check would let both through
-  // as "absent" and quietly serve the workspace — the exact silent substitution this refuses.
-  // An empty `?project=` is refused for the same reason: the client meant to name one.
-  if (Object.hasOwn(req.query, "project")) {
-    // Caller-controlled, and it lands in a log line via `guarded`; `describeValue` renders a
-    // non-string shape without interpolating it, and CR/LF is stripped so no id can forge one.
-    const described = describeValue(req.query.project).replace(/[\r\n]/g, " ");
-    throw new Error(`project scoping is not enabled on this server (received project: ${described})`);
+/** Every project a request may name, workspace first. Deduped by root: a user who has launched
+ *  from the workspace has it among the saved directories too. */
+export function listProjectRoots(): ProjectSummary[] {
+  const ws = requireWorkspace();
+  const rows: Array<{ root: string; label: string }> = [{ root: ws, label: path.basename(ws) || ws }];
+  for (const project of knownProjects()) {
+    if (!rows.some((row) => row.root === project.path)) rows.push({ root: project.path, label: project.label });
   }
+  return rows.map((row) => ({ id: projectId(row.root), label: row.label }));
+}
+
+function rootForId(id: string): string | null {
+  if (projectId(requireWorkspace()) === id) return requireWorkspace();
+  for (const project of knownProjects()) {
+    if (projectId(project.path) === id) return project.path;
+  }
+  return null;
+}
+
+/** The root this request operates against: the project it named, or the workspace when it
+ *  named none.
+ *
+ *  PRESENCE is the test, not the value's shape. `?project=a&project=b` arrives as an array and
+ *  `?project[x]=y` as an object, so a `typeof === "string"` guard would read both as "absent"
+ *  and serve the workspace — one project asked for, another served, with nothing anywhere
+ *  saying so. That is the silent-wrong-root failure explicit-root mode removed from the engine,
+ *  and it must not come back through the wire. */
+export function resolveProjectRoot(req: Request): ProjectScope {
+  if (!Object.hasOwn(req.query, "project")) return { workspaceRoot: requireWorkspace() };
+  const requested = req.query.project;
+  if (typeof requested === "string") {
+    const root = rootForId(requested);
+    if (root !== null) return { workspaceRoot: root };
+  }
+  // Caller-controlled, and it lands in a log line; `describeValue` renders a non-string shape
+  // without interpolating it, and CR/LF is stripped so no id can forge one.
+  throw new ProjectRootError(`unknown project: ${describeValue(requested).replace(/[\r\n]/g, " ")}`);
+}
+
+/** The request's root as a cache-key fragment, or "" when it names a project this server
+ *  cannot resolve. Deliberately does NOT throw: a caller building a key is not the place an
+ *  unknown project should be reported — the route it guards answers that. */
+export function projectRootKey(req: Request): string {
+  try {
+    return resolveProjectRoot(req).workspaceRoot;
+  } catch {
+    return "";
+  }
+}
+
+/** The shared workspace, for callers that have no request: boot paths, the agent tool
+ *  dispatch, the completion watchers. Separate from `resolveProjectRoot` so those callers read
+ *  as what they are — "the workspace" — rather than as a request that lost its `req`. */
+export function workspaceScope(): ProjectScope {
   return { workspaceRoot: requireWorkspace() };
 }

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -106,7 +106,9 @@ export function listProjectRoots(): ProjectSummary[] {
   return rows.map((row) => ({ id: projectId(row.root), label: row.label }));
 }
 
-function rootForId(id: string): string | null {
+/** The root an opaque id names, or null when it names none. Exported because the view-token
+ *  middleware resolves the id carried IN a token, which never passes through a query string. */
+export function rootForProjectId(id: string): string | null {
   if (projectId(requireWorkspace()) === id) return requireWorkspace();
   for (const project of knownProjects()) {
     if (projectId(project.path) === id) return project.path;
@@ -123,15 +125,30 @@ function rootForId(id: string): string | null {
  *  saying so. That is the silent-wrong-root failure explicit-root mode removed from the engine,
  *  and it must not come back through the wire. */
 export function resolveProjectRoot(req: Request): ProjectScope {
+  const attached = attachedScopes.get(req);
+  if (attached) return attached;
   if (!Object.hasOwn(req.query, "project")) return { workspaceRoot: requireWorkspace() };
   const requested = req.query.project;
   if (typeof requested === "string") {
-    const root = rootForId(requested);
+    const root = rootForProjectId(requested);
     if (root !== null) return { workspaceRoot: root };
   }
   // Caller-controlled, and it lands in a log line; `describeValue` renders a non-string shape
   // without interpolating it, and CR/LF is stripped so no id can forge one.
   throw new ProjectRootError(`unknown project: ${describeValue(requested).replace(/[\r\n]/g, " ")}`);
+}
+
+// Scopes resolved by AUTHORIZATION rather than by the query string. A custom view's iframe
+// fetches URLs the bundled API contract builds by concatenation (`dataUrl + "/query"`), so a
+// project cannot ride in the query there without corrupting those suffixes — the token carries
+// it instead, and the middleware that verifies the token records the root it authorized. A
+// WeakMap because the key is the request object and the entry should die with it.
+const attachedScopes = new WeakMap<Request, ProjectScope>();
+
+/** Record the root a request was AUTHORIZED for, so every handler behind that middleware
+ *  resolves the same one through the usual accessor. */
+export function attachProjectScope(req: Request, scope: ProjectScope): void {
+  attachedScopes.set(req, scope);
 }
 
 /** The request's root as a cache-key fragment, or "" when it names a project this server

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -42,6 +42,7 @@ import { mountWikiRoutes } from "../backends/wiki.js";
 import { mountAccountingRoutes } from "../backends/accounting.js";
 import { mountFeedsRoutes } from "../backends/feeds.js";
 import { mountCalendarPushRoutes } from "../backends/calendarPush.js";
+import { listProjectRoots } from "../infra/project-root.js";
 import { mountRemoteHostRoutes } from "../backends/remoteHost/index.js";
 import { mountNotificationRoutes } from "../backends/notifier.js";
 import { mountWhisperRoutes } from "../backends/whisper.js";
@@ -194,6 +195,17 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   // API_ROUTES.collections.calendarPush). Backs the collection-view Push button; reads the
   // workspace from the collection host configured below.
   mountCalendarPushRoutes(app);
+
+  // The projects a request may name, for a picker: ids and labels only — the paths they stand
+  // for stay server-side (server/infra/project-root.ts).
+  //
+  // Deliberately OUTSIDE `/api/collections/*`. MulmoClaude's `src/config/apiRoutes.ts` is the
+  // naming authority in that namespace and has no project concept at all — it is a
+  // single-workspace app — so there is nothing to match and nothing to drift from. Mounting it
+  // there would also shadow `/api/collections/:slug` for a collection named `projects`.
+  app.get("/api/collection-projects", (_req, res) => {
+    res.json({ projects: listProjectRoots() });
+  });
 
   // Notification REST surface (list active / history, dismiss one) — backs the toolbar
   // bell. The engine is configured below once pubsub + the workspace exist.

--- a/test/server/backends/collectionsProjectScope.spec.ts
+++ b/test/server/backends/collectionsProjectScope.spec.ts
@@ -23,6 +23,7 @@ const schemaFor = (title: string) => ({
     id: { type: "string", label: "ID", primary: true, required: true },
     name: { type: "string", label: "Name" },
   },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
 });
 
 /** A root holding one `tasks` collection with one record — the same slug in both, which is
@@ -31,6 +32,8 @@ function makeProject(prefix: string, title: string, recordName: string): string 
   const root = makeTempDir(prefix);
   mkdirSync(path.join(root, ".claude", "skills", "tasks"), { recursive: true });
   writeFileSync(path.join(root, ".claude", "skills", "tasks", "schema.json"), JSON.stringify(schemaFor(title)));
+  mkdirSync(path.join(root, "data", "skills", "tasks", "views"), { recursive: true });
+  writeFileSync(path.join(root, "data", "skills", "tasks", "views", "v1.html"), "<head></head><body>view</body>");
   mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
   writeFileSync(path.join(root, "data", "tasks", "items", "one.json"), JSON.stringify({ id: "one", name: recordName }));
   return root;
@@ -90,6 +93,45 @@ describe("collections served from a named project", () => {
     const res = await request("/api/collections/tasks/detail?project=0123456789abcdef");
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toContain("unknown project");
+  });
+
+  // The token names the project; the URL handed to the iframe must stay CLEAN. The bundled
+  // custom-view contract builds its other endpoints by concatenation (`dataUrl + "/query"`), so
+  // a trailing `?project=` would land inside the suffix and 401 every one of them.
+  it("mints a view token for the named project whose dataUrl carries no query", async () => {
+    const res = await request(`/api/collections/tasks/view-token?project=${projectId(other)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; dataUrl: string };
+    expect(body.dataUrl).toBe("/api/collections/tasks/view-data");
+
+    // A token is signed, not encrypted: the payload is plain base64url JSON that the iframe can
+    // read. It must name the project by id — an absolute root here would publish the user's
+    // home directory to the LLM-authored page the token is handed to.
+    const payload = JSON.parse(Buffer.from(body.token.split(".")[0], "base64url").toString("utf8")) as Record<string, unknown>;
+    expect(payload.project).toBe(projectId(other));
+    expect(JSON.stringify(payload)).not.toContain(other);
+  });
+
+  // The token alone must scope the read — the iframe sends no project in the URL.
+  it("serves view-data for the token's project without a project in the URL", async () => {
+    const minted = (await (
+      await request(`/api/collections/tasks/view-token?project=${projectId(other)}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ viewId: "v1" }),
+      })
+    ).json()) as { token: string; dataUrl: string };
+
+    const res = await request(minted.dataUrl, { headers: { authorization: `Bearer ${minted.token}` } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ name: string }> };
+    const names = body.items.map((item) => item.name);
+    expect(names).toContain("from-other");
+    expect(names).not.toContain("from-workspace");
   });
 
   it("scopes the collection LIST to the named project too, not only the detail route", async () => {

--- a/test/server/backends/collectionsProjectScope.spec.ts
+++ b/test/server/backends/collectionsProjectScope.spec.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+//
+// The feature this whole change exists for, asserted end to end: TWO roots, each owning a
+// collection under the SAME slug, served through the same routes without bleeding into each
+// other. Nothing before this could express it — with one ambient root, a slug was globally
+// unique by construction, so "reads the right one" was true by accident rather than by rule.
+import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { appRequest } from "../../helpers/appRequest.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "../../../server/backends/collections.js";
+import { projectId } from "../../../server/infra/project-root.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const schemaFor = (title: string) => ({
+  title,
+  icon: "star",
+  dataPath: "data/tasks/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
+  },
+});
+
+/** A root holding one `tasks` collection with one record — the same slug in both, which is
+ *  the case a single-root engine could not tell apart. */
+function makeProject(prefix: string, title: string, recordName: string): string {
+  const root = makeTempDir(prefix);
+  mkdirSync(path.join(root, ".claude", "skills", "tasks"), { recursive: true });
+  writeFileSync(path.join(root, ".claude", "skills", "tasks", "schema.json"), JSON.stringify(schemaFor(title)));
+  mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
+  writeFileSync(path.join(root, "data", "tasks", "items", "one.json"), JSON.stringify({ id: "one", name: recordName }));
+  return root;
+}
+
+describe("collections served from a named project", () => {
+  let request: ReturnType<typeof appRequest>;
+  let workspace = "";
+  let other = "";
+
+  beforeAll(() => {
+    workspace = makeProject("mt-scope-ws-", "Workspace Tasks", "from-workspace");
+    other = makeProject("mt-scope-other-", "Other Tasks", "from-other");
+    initCollectionsBackend({ workspace, knownProjects: () => [{ label: "other", path: other }] });
+
+    const app = express();
+    app.use(express.json());
+    mountCollectionRoutes(app);
+    request = appRequest(app);
+  });
+
+  it("serves the workspace when no project is named", async () => {
+    const res = await request("/api/collections/tasks/detail");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collection: { title: string }; items: Array<{ name: string }> };
+    expect(body.collection.title).toBe("Workspace Tasks");
+    expect(body.items.map((item) => item.name)).toEqual(["from-workspace"]);
+  });
+
+  // The assertion the feature is about: same slug, same route, different root.
+  it("serves the named project's collection under the same slug", async () => {
+    const res = await request(`/api/collections/tasks/detail?project=${projectId(other)}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collection: { title: string }; items: Array<{ name: string }> };
+    expect(body.collection.title).toBe("Other Tasks");
+    expect(body.items.map((item) => item.name)).toEqual(["from-other"]);
+  });
+
+  it("writes into the named project, leaving the workspace untouched", async () => {
+    const created = await request(`/api/collections/tasks/items?project=${projectId(other)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "two", name: "written-in-other" }),
+    });
+    expect(created.status).toBe(200);
+
+    const inOther = (await (await request(`/api/collections/tasks/detail?project=${projectId(other)}`)).json()) as { items: Array<{ id: string }> };
+    expect(inOther.items.map((item) => item.id).sort()).toEqual(["one", "two"]);
+
+    const inWorkspace = (await (await request("/api/collections/tasks/detail")).json()) as { items: Array<{ id: string }> };
+    expect(inWorkspace.items.map((item) => item.id)).toEqual(["one"]);
+  });
+
+  // A typo in a query parameter is the client's error. Answering 500 would read as "the server
+  // broke", and — worse — an ignored parameter would have served the workspace silently.
+  it("answers 400 for a project it cannot resolve", async () => {
+    const res = await request("/api/collections/tasks/detail?project=0123456789abcdef");
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("unknown project");
+  });
+
+  it("scopes the collection LIST to the named project too, not only the detail route", async () => {
+    const res = await request("/api/collections/list?project=" + projectId(other));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collections: Array<{ slug: string; title: string }> };
+    expect(body.collections.find((c) => c.slug === "tasks")?.title).toBe("Other Tasks");
+  });
+});

--- a/test/server/backends/viewToken.spec.ts
+++ b/test/server/backends/viewToken.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   mintViewToken,
   verifyViewToken,
@@ -9,17 +9,23 @@ import {
   type ViewCapability,
 } from "../../../server/backends/viewToken.js";
 import type { Request, Response, NextFunction } from "express";
+import { initProjectRoots, projectId, resetProjectRootsForTesting } from "../../../server/infra/project-root.js";
+
+// The middleware checks the token's root against the one the REQUEST resolves, so these tests
+// need a bound workspace. `/ws` is the root every token below is minted for.
+const WS = "/ws";
+const OTHER = "/other-project";
 
 describe("viewToken mint/verify", () => {
   it("round-trips a minted token", () => {
-    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    const { token, exp } = mintViewToken("watchlist", ["read"], WS, 1000);
     expect(exp).toBe(1000 + VIEW_TOKEN_TTL_MS);
     const payload = verifyViewToken(token, 2000);
-    expect(payload).toEqual({ slug: "watchlist", caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
+    expect(payload).toEqual({ slug: "watchlist", root: WS, caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
   });
 
   it("rejects a tampered payload", () => {
-    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const { token } = mintViewToken("watchlist", ["read"], WS, 1000);
     const [payloadB64, sig] = token.split(".");
     // Re-encode a payload claiming a different slug, keep the original signature.
     const forged = Buffer.from(JSON.stringify({ slug: "secrets", caps: ["read", "write"], exp: 1000 + VIEW_TOKEN_TTL_MS }), "utf8").toString("base64url");
@@ -29,13 +35,13 @@ describe("viewToken mint/verify", () => {
   });
 
   it("rejects a bad signature", () => {
-    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const { token } = mintViewToken("watchlist", ["read"], WS, 1000);
     const [payloadB64] = token.split(".");
     expect(verifyViewToken(`${payloadB64}.deadbeef`, 2000)).toBeNull();
   });
 
   it("rejects an expired token", () => {
-    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    const { token, exp } = mintViewToken("watchlist", ["read"], WS, 1000);
     expect(verifyViewToken(token, exp)).toBeNull(); // exactly at exp → expired
     expect(verifyViewToken(token, exp + 1)).toBeNull();
   });
@@ -81,14 +87,19 @@ function mockRes(): MockRes {
   };
 }
 
-function runGuard(action: ViewCapability, headers: Record<string, string>, slug: string) {
+function runGuard(action: ViewCapability, headers: Record<string, string>, slug: string, query: Record<string, unknown> = {}) {
   const res = mockRes();
   const next = vi.fn();
-  requireViewToken(action)({ headers, params: { slug } } as unknown as Request, res as unknown as Response, next as NextFunction);
+  requireViewToken(action)({ headers, params: { slug }, query } as unknown as Request, res as unknown as Response, next as NextFunction);
   return { res, next };
 }
 
 describe("requireViewToken middleware", () => {
+  beforeEach(() => {
+    resetProjectRootsForTesting();
+    initProjectRoots({ workspace: WS, knownProjects: () => [{ label: "other", path: OTHER }] });
+  });
+
   it("401s with no Authorization header", () => {
     const { res, next } = runGuard("read", {}, "watchlist");
     expect(res.statusCode).toBe(401);
@@ -96,21 +107,46 @@ describe("requireViewToken middleware", () => {
   });
 
   it("calls next() for a valid token with the right slug + capability", () => {
-    const { token } = mintViewToken("watchlist", ["read"]);
+    const { token } = mintViewToken("watchlist", ["read"], WS);
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist");
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(200);
   });
 
   it("401s when the token's slug differs from the route", () => {
-    const { token } = mintViewToken("watchlist", ["read"]);
+    const { token } = mintViewToken("watchlist", ["read"], WS);
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "other");
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
   });
 
+  // The token is scoped to a ROOT as well as a slug. A slug is unique only within a root, so
+  // without this a `tasks` token minted in one project would read `tasks` in another.
+  it("401s when the request names a different project than the token", () => {
+    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: projectId(OTHER) });
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() when the request names the project the token was minted for", () => {
+    const { token } = mintViewToken("watchlist", ["read"], OTHER);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: projectId(OTHER) });
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(200);
+  });
+
+  // An unresolvable project has no valid token by definition — the refusal must not surface as
+  // a 500 from inside auth middleware.
+  it("401s when the request names an unknown project", () => {
+    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: "nope" });
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("401s when the required capability is missing", () => {
-    const { token } = mintViewToken("watchlist", ["read"]);
+    const { token } = mintViewToken("watchlist", ["read"], WS);
     const { res, next } = runGuard("write", { authorization: `Bearer ${token}` }, "watchlist");
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();

--- a/test/server/backends/viewToken.spec.ts
+++ b/test/server/backends/viewToken.spec.ts
@@ -18,14 +18,14 @@ const OTHER = "/other-project";
 
 describe("viewToken mint/verify", () => {
   it("round-trips a minted token", () => {
-    const { token, exp } = mintViewToken("watchlist", ["read"], WS, 1000);
+    const { token, exp } = mintViewToken("watchlist", ["read"], projectId(WS), 1000);
     expect(exp).toBe(1000 + VIEW_TOKEN_TTL_MS);
     const payload = verifyViewToken(token, 2000);
-    expect(payload).toEqual({ slug: "watchlist", root: WS, caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
+    expect(payload).toEqual({ slug: "watchlist", project: projectId(WS), caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
   });
 
   it("rejects a tampered payload", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS, 1000);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS), 1000);
     const [payloadB64, sig] = token.split(".");
     // Re-encode a payload claiming a different slug, keep the original signature.
     const forged = Buffer.from(JSON.stringify({ slug: "secrets", caps: ["read", "write"], exp: 1000 + VIEW_TOKEN_TTL_MS }), "utf8").toString("base64url");
@@ -35,13 +35,13 @@ describe("viewToken mint/verify", () => {
   });
 
   it("rejects a bad signature", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS, 1000);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS), 1000);
     const [payloadB64] = token.split(".");
     expect(verifyViewToken(`${payloadB64}.deadbeef`, 2000)).toBeNull();
   });
 
   it("rejects an expired token", () => {
-    const { token, exp } = mintViewToken("watchlist", ["read"], WS, 1000);
+    const { token, exp } = mintViewToken("watchlist", ["read"], projectId(WS), 1000);
     expect(verifyViewToken(token, exp)).toBeNull(); // exactly at exp → expired
     expect(verifyViewToken(token, exp + 1)).toBeNull();
   });
@@ -107,14 +107,14 @@ describe("requireViewToken middleware", () => {
   });
 
   it("calls next() for a valid token with the right slug + capability", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS));
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist");
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(200);
   });
 
   it("401s when the token's slug differs from the route", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS));
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "other");
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
@@ -123,14 +123,14 @@ describe("requireViewToken middleware", () => {
   // The token is scoped to a ROOT as well as a slug. A slug is unique only within a root, so
   // without this a `tasks` token minted in one project would read `tasks` in another.
   it("401s when the request names a different project than the token", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS));
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: projectId(OTHER) });
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
   });
 
   it("calls next() when the request names the project the token was minted for", () => {
-    const { token } = mintViewToken("watchlist", ["read"], OTHER);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(OTHER));
     const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: projectId(OTHER) });
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(200);
@@ -138,15 +138,15 @@ describe("requireViewToken middleware", () => {
 
   // An unresolvable project has no valid token by definition — the refusal must not surface as
   // a 500 from inside auth middleware.
-  it("401s when the request names an unknown project", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS);
-    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist", { project: "nope" });
+  it("401s when the TOKEN names a project the server can no longer resolve", () => {
+    const { token } = mintViewToken("watchlist", ["read"], "0123456789abcdef");
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist");
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
   });
 
   it("401s when the required capability is missing", () => {
-    const { token } = mintViewToken("watchlist", ["read"], WS);
+    const { token } = mintViewToken("watchlist", ["read"], projectId(WS));
     const { res, next } = runGuard("write", { authorization: `Bearer ${token}` }, "watchlist");
     expect(res.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();

--- a/test/server/infra/projectRoot.spec.ts
+++ b/test/server/infra/projectRoot.spec.ts
@@ -10,8 +10,13 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { getWorkspaceRoot } from "@mulmoclaude/core/collection/server";
 
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import path from "node:path";
+
 import {
+  errorStatus,
   initProjectRoots,
+  listProjectRoots,
+  projectId,
   projectRootsConfigured,
   resolveProjectRoot,
   resetProjectRootsForTesting,
@@ -40,16 +45,62 @@ describe("project roots", () => {
 
   // Presence, not shape. Express turns `?project=a&project=b` into an array and
   // `?project[x]=y` into an object, so a `typeof === "string"` guard would read both as
-  // "absent" and serve the workspace — the silent substitution this refuses. An empty
+  // "absent" and serve the workspace — one project asked for, another served. An empty
   // `?project=` counts too: the client meant to name one.
   it.each([
-    ["a plain id", "some-project"],
+    ["an unknown id", "0123456789abcdef"],
     ["repeated parameters", ["a", "b"]],
     ["a bracketed object", { x: "y" }],
     ["an empty value", ""],
   ])("refuses %s rather than silently serving the workspace", (_label, project) => {
     initProjectRoots({ workspace: ws });
-    expect(() => resolveProjectRoot(requestWith({ project }))).toThrow(/not enabled/);
+    expect(() => resolveProjectRoot(requestWith({ project }))).toThrow(/unknown project/);
+  });
+
+  it("answers an unknown project as a client error, not a server failure", () => {
+    initProjectRoots({ workspace: ws });
+    try {
+      resolveProjectRoot(requestWith({ project: "nope" }));
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(errorStatus(err)).toBe(400);
+    }
+  });
+
+  // The id is derived, not stored: a restart must not invalidate a URL a view is holding.
+  it("resolves a known project by its opaque id", () => {
+    const other = makeTempDir("mt-other-project-");
+    initProjectRoots({ workspace: ws, knownProjects: () => [{ label: "other", path: other }] });
+    expect(resolveProjectRoot(requestWith({ project: projectId(other) }))).toEqual({ workspaceRoot: other });
+    expect(resolveProjectRoot(requestWith({ project: projectId(ws) }))).toEqual({ workspaceRoot: ws });
+  });
+
+  // The list is read through a thunk on every call: launching from a new directory records a
+  // preset, and a list captured at boot would refuse a project the launcher already shows.
+  it("sees a project added after boot", () => {
+    const added = makeTempDir("mt-added-project-");
+    let projects: Array<{ label: string; path: string }> = [];
+    initProjectRoots({ workspace: ws, knownProjects: () => projects });
+    expect(() => resolveProjectRoot(requestWith({ project: projectId(added) }))).toThrow(/unknown project/);
+    projects = [{ label: "added", path: added }];
+    expect(resolveProjectRoot(requestWith({ project: projectId(added) }))).toEqual({ workspaceRoot: added });
+  });
+
+  it("lists the workspace first, then the saved directories, without repeating one", () => {
+    const other = makeTempDir("mt-listed-project-");
+    initProjectRoots({
+      workspace: ws,
+      // The workspace appears among the saved directories too, as it does for anyone who has
+      // launched from it — it must be listed once.
+      knownProjects: () => [
+        { label: "workspace", path: ws },
+        { label: "other", path: other },
+      ],
+    });
+    expect(listProjectRoots()).toEqual([
+      { id: projectId(ws), label: path.basename(ws) },
+      { id: projectId(other), label: "other" },
+    ]);
   });
 
   it("resolves every request to the bound workspace", () => {


### PR DESCRIPTION
Phases 4–6 of `plans/feat-collections-project-root.md`. A request may now name a project — `?project=<opaque id>` — and the collection routes serve **that** root instead of the shared workspace. Absent, everything behaves exactly as before.

## The id is the security boundary

The id is **opaque** and resolved against directories the app already knows (the workspace plus the saved `cwdPresets`). That is not a nicety: the engine's `resolveDataDir` guarantees containment only **within the root it is handed**, so the root itself is what must not be attacker-controlled. A path parameter would have turned every collection route into an arbitrary-directory reader.

Deriving the id from the path (a truncated digest) also keeps host paths out of the browser, out of URLs and out of logs — and needs no registry, because the list of projects is already `cwdPresets`, which follows from a Project simply *being* a directory.

`GET /api/collection-projects` lists what a request may name. It sits deliberately **outside** `/api/collections/*`: MulmoClaude's `apiRoutes.ts` is the naming authority there and has no project concept — it is a single-workspace app — so there is nothing to match and nothing to drift from. It would also shadow `/api/collections/:slug` for a collection someone named `projects`.

## Re-keyed by `(root, slug)`

A slug is unique only *within* a root, so everything keyed on one alone had to move:

- **View tokens** carry the root and are checked against the root the **request** resolves. A `tasks` token minted in one project is now unusable against another project's `tasks`. The minted `dataUrl` carries the project too — the iframe fetches it verbatim, and a URL without it would resolve to the workspace, against which the token is invalid, so the view would render an empty 401 instead of its records.
- **The thumbnail cache** keys on the root. Two projects both holding `data/pic.png` is the normal case, and the cached value is the image **bytes** — a path-only key served one project's picture inside another's view.
- **The view-query concurrency cap** keys on the root, so one project's dashboard cannot spend another's budget.
- MulmoTerminal wires **no** collection change publisher, so there was no live-update channel to re-key; the `root` field core 3.0.0 added to `CollectionChangePayload` has no consumer here yet.

## Status codes

An unknown project answers **400**, not 500 — a typo in a query parameter is the client's error, and a 500 reads as "the server broke". Inside the view-token middleware it answers **401**: a request whose root cannot be resolved has no valid token by definition.

## Merge semantics (§6) — no code needed

True by construction: user-scope collections still merge in (engine default), feeds follow the root (`feedsRoot(root)`), and the workspace is simply not the root when a project is named.

## The test

`test/server/backends/collectionsProjectScope.spec.ts` is the assertion the previous architecture could not express: **two roots, each owning a `tasks` collection**, read and written through the same routes without bleeding into each other. With one ambient root a slug was globally unique by construction, so "reads the right one" was true by accident rather than by rule.

## Still to build

The client project selector — phase 5's UI half. Nothing in the app sends `?project=` yet, so this PR is reachable only by API.

## Gate

`yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — **9428 passed / 45 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project selection using secure project IDs and readable labels.
  * Added an endpoint to list available collection projects without exposing filesystem paths.
  * Scoped collections, view tokens, queries, feeds, and thumbnail caching to the selected project.

* **Bug Fixes**
  * Invalid project selections now return clear client errors instead of generic server errors.
  * Improved error status handling for calendar and collection operations.
  * Added CORS support for collection data access.

* **Tests**
  * Expanded coverage for project isolation, token validation, project discovery, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->