### PR TITLE
feat(collections): staging is workspace-only, and the agent is told so

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mulmoclaude/accounting-plugin": "^2.1.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.0.0",
-    "@mulmoclaude/core": "^3.0.1",
+    "@mulmoclaude/core": "^3.1.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -72,6 +72,7 @@ import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from
 import { manageCollectionHandlerFor } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
 import { getCwdPresets } from "../config/config-routes.js";
+import { isManagedWorkspace } from "./workspaceSetup.js";
 import {
   errorStatus,
   initProjectRoots,
@@ -123,8 +124,18 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       projectSkillsDir,
       // <root>/feeds — feed registry root.
       feedsRoot: (root) => path.join(root, "feeds"),
-      // <root>/data/skills — project-skills staging.
-      skillsStagingDir: (root) => path.join(root, "data", "skills"),
+      // <root>/data/skills — project-skills staging, and ONLY for the managed workspace.
+      //
+      // Staging exists to route around the `.claude/` permission gate: the agent writes drafts
+      // to a plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`.
+      // A project folder has no such gate and MulmoTerminal runs no bridge, so a staging tree
+      // there is not merely unused — the engine reads it FIRST for a project-scope collection,
+      // so a stray file would shadow the committed skill, and it is a second copy of the
+      // definition in a repo that is supposed to be self-contained.
+      //
+      // `null` is what core 3.1.0 added for exactly this: the engine then skips the staging
+      // base rather than being handed a path that must never match.
+      skillsStagingDir: (root) => (isManagedWorkspace(root) ? path.join(root, "data", "skills") : null),
       // Workspace-relative archive dir (removed collections move here).
       archiveDir: "archive",
       // <root>/config/collections-registries.json — extra Discover registries

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -20,6 +20,7 @@ import { mkdirSync } from "node:fs";
 import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { syncCodexSkills, codexSkillsRoot } from "../agents/codex-skills.js";
 import { isSamePath } from "../infra/path-within.js";
+import { canonicalPath } from "../infra/canonical-path.js";
 
 // Console-backed logger, matching the prefix style other backends use.
 const log = {
@@ -41,7 +42,13 @@ export function isManagedWorkspace(workspace: string): boolean {
   // isSamePath, not `===`: the workspace arrives from the launcher's --cwd, so on Windows it
   // can name the managed directory in a different casing than os.homedir() spells it, and a
   // raw compare would silently skip seeding.
-  return isSamePath(workspace, managedWorkspacePath());
+  const managed = managedWorkspacePath();
+  // Lexical first, so an answer that already matched keeps matching byte for byte. Then through
+  // REALPATH, because `isSamePath` resolves `.`/`..` and casing but not symlinks: a managed
+  // workspace that is a symlink, launched by its physical target (or the reverse), read as "not
+  // the workspace" — which since core 3.1.0 means no staging dir and the project-style authoring
+  // guide, i.e. the workspace quietly losing its staged views and being told to write elsewhere.
+  return isSamePath(workspace, managed) || isSamePath(canonicalPath(workspace), canonicalPath(managed));
 }
 
 // Run one seeding step in isolation: a filesystem edge case (EACCES/ENOSPC/path

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -21,6 +21,7 @@ import type { ToolDefinition } from "gui-chat-protocol";
 import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { workspaceScope } from "./project-root.js";
+import { isManagedWorkspace } from "../backends/workspaceSetup.js";
 
 const tool = makeManageCollectionTool({
   bundledHelpsDir: helpsAssetDir,
@@ -52,7 +53,20 @@ const byRoot = new Map<string, typeof tool.handler>();
 export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
   const cached = byRoot.get(workspaceRoot);
   if (cached) return cached;
-  const handler = makeManageCollectionTool({ bundledHelpsDir: helpsAssetDir, workspaceRoot }).handler;
+  const handler = makeManageCollectionTool({
+    bundledHelpsDir: helpsAssetDir,
+    workspaceRoot,
+    // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`, mirrored
+    // by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent writes a
+    // draft nothing mirrors and nothing discovers — it does as instructed and produces a
+    // collection that does not exist, with no error anywhere.
+    //
+    // The engine also derives the variant from `skillsStagingDir` returning null, so this agrees
+    // with the host binding rather than overriding it. Passed anyway: two levers that must agree
+    // are worth stating at both ends, and this one says WHY the root has no staging rather than
+    // leaving it to be inferred from a path that came back empty.
+    stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
+  }).handler;
   byRoot.set(workspaceRoot, handler);
   return handler;
 }

--- a/test/server/backends/collectionStaging.spec.ts
+++ b/test/server/backends/collectionStaging.spec.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+//
+// `data/skills` is a WORKSPACE mechanism. It exists to route around the `.claude/` permission
+// gate — the agent writes drafts to a plain data dir and a bridge mirrors the allowlisted files
+// into `.claude/skills` — and MulmoTerminal runs no bridge outside the managed workspace.
+//
+// Two things follow, and both are asserted here because both fail silently: a project folder must
+// get NO staging dir at all (core 3.1.0's `null`), and the guide the agent is served must not tell
+// it to author there — an agent that obeys writes a draft nothing mirrors and nothing discovers,
+// producing a collection that does not exist with no error anywhere.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection/server";
+
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { manageCollectionHandlerFor } from "../../../server/infra/collection-tool.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const SCHEMA = {
+  title: "Tasks",
+  icon: "star",
+  dataPath: "data/tasks/items",
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+};
+
+/** A root with the collection in the place a PROJECT keeps it — the skill dir. */
+function makeProject(prefix: string, viewBody: string): string {
+  const root = makeTempDir(prefix);
+  mkdirSync(path.join(root, ".claude", "skills", "tasks", "views"), { recursive: true });
+  writeFileSync(path.join(root, ".claude", "skills", "tasks", "schema.json"), JSON.stringify(SCHEMA));
+  writeFileSync(path.join(root, ".claude", "skills", "tasks", "views", "v1.html"), viewBody);
+  mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
+  return root;
+}
+
+describe("skill staging is workspace-only", () => {
+  const savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  let workspace = "";
+  let project = "";
+
+  // ONE binding for the file: `configureCollectionHost` refuses a second call with a different
+  // host, deliberately — silently redirecting later filesystem work to another workspace would be
+  // a bug, not a feature. So the roots are built once and each test writes only its own files.
+  beforeAll(() => {
+    workspace = makeProject("mt-staging-ws-", "<body>workspace view</body>");
+    project = makeProject("mt-staging-proj-", "<body>project view</body>");
+    // `isManagedWorkspace` compares against this, so a temp dir can stand in for ~/mulmoclaude.
+    process.env.MULMOCLAUDE_WORKSPACE_PATH = workspace;
+    initCollectionsBackend({ workspace, knownProjects: () => [{ label: "project", path: project }] });
+  });
+
+  afterAll(() => {
+    if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+    else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
+  });
+
+  // The regression that matters. The engine reads staging FIRST for a project-scope collection,
+  // so before `null` a stray file there won — silently, and in a repo where the committed skill
+  // is the one git carries.
+  it("does not let a stray data/skills view shadow the committed one", async () => {
+    mkdirSync(path.join(project, "data", "skills", "tasks", "views"), { recursive: true });
+    writeFileSync(path.join(project, "data", "skills", "tasks", "views", "v1.html"), "<body>STRAY</body>");
+
+    const collection = await loadCollection("tasks", { workspaceRoot: project });
+    if (!collection) throw new Error("fixture collection did not load");
+    const html = await readCustomViewHtml(collection, "views/v1.html", { workspaceRoot: project });
+    expect(html).toContain("project view");
+    expect(html).not.toContain("STRAY");
+  });
+
+  // …while the workspace still resolves through staging, which is the layout its bridge produces.
+  it("still prefers the workspace's staging copy", async () => {
+    mkdirSync(path.join(workspace, "data", "skills", "tasks", "views"), { recursive: true });
+    writeFileSync(path.join(workspace, "data", "skills", "tasks", "views", "v1.html"), "<body>STAGED</body>");
+    // The staging tree is authoritative there only when it holds the schema too — the same
+    // condition the bridge satisfies when it mirrors a draft.
+    writeFileSync(path.join(workspace, "data", "skills", "tasks", "schema.json"), JSON.stringify(SCHEMA));
+
+    const collection = await loadCollection("tasks", { workspaceRoot: workspace });
+    if (!collection) throw new Error("fixture collection did not load");
+    const html = await readCustomViewHtml(collection, "views/v1.html", { workspaceRoot: workspace });
+    expect(html).toContain("STAGED");
+  });
+
+  // The other half: the instructions the agent reads.
+  // Asserted on the INSTRUCTION, not on the string: the direct variant still says the words
+  // "data/skills" — in the sentence telling the agent never to write there.
+  it("serves an authoring guide that names the right directory for each root", async () => {
+    const docs = (root: string) => manageCollectionHandlerFor(root)({ action: "schemaDocs", topic: "Anatomy of a collection skill" });
+
+    const forProject = await docs(project);
+    expect(forProject).toContain("Author under `.claude/skills/<slug>/`");
+    expect(forProject).not.toContain("Author under `data/skills/<slug>/`");
+
+    const forWorkspace = await docs(workspace);
+    expect(forWorkspace).toContain("Author under `data/skills/<slug>/`");
+    expect(forWorkspace).not.toContain("Author under `.claude/skills/<slug>/`");
+  });
+});

--- a/test/server/backends/collectionStaging.spec.ts
+++ b/test/server/backends/collectionStaging.spec.ts
@@ -9,12 +9,13 @@
 // it to author there — an agent that obeys writes a draft nothing mirrors and nothing discovers,
 // producing a collection that does not exist with no error anywhere.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, symlinkSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection/server";
 
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
 import { manageCollectionHandlerFor } from "../../../server/infra/collection-tool.js";
+import { isManagedWorkspace } from "../../../server/backends/workspaceSetup.js";
 import { makeTempDir } from "../../support/tempDir";
 
 const SCHEMA = {
@@ -60,6 +61,17 @@ describe("skill staging is workspace-only", () => {
   // The regression that matters. The engine reads staging FIRST for a project-scope collection,
   // so before `null` a stray file there won — silently, and in a repo where the committed skill
   // is the one git carries.
+  // A managed workspace is often reached by a symlink (`~/mulmoclaude` pointing elsewhere), and
+  // the launcher may name it by either spelling. A lexical comparison read the physical path as
+  // "not the workspace", which since core 3.1.0 means no staging dir and the project authoring
+  // guide — the workspace quietly losing its staged views and being told to write elsewhere.
+  it("recognises the managed workspace through a symlink", async () => {
+    const link = path.join(makeTempDir("mt-staging-link-"), "workspace-link");
+    symlinkSync(workspace, link, "dir");
+    expect(isManagedWorkspace(link)).toBe(true);
+    expect(isManagedWorkspace(realpathSync(link))).toBe(true);
+  });
+
   it("does not let a stray data/skills view shadow the committed one", async () => {
     mkdirSync(path.join(project, "data", "skills", "tasks", "views"), { recursive: true });
     writeFileSync(path.join(project, "data", "skills", "tasks", "views", "v1.html"), "<body>STRAY</body>");

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import express from "express";
 import sharp from "sharp";
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -65,6 +65,9 @@ const SCHEMA = {
 };
 
 let request: ReturnType<typeof appRequest>;
+// Saved and restored: the assignment below mutates the WORKER's environment, which outlives this
+// suite even though vitest isolates the module registry.
+let savedWorkspaceEnv: string | undefined;
 
 beforeAll(async () => {
   const ws = makeTempDir("mt-col-");
@@ -194,6 +197,7 @@ beforeAll(async () => {
   // the staging layout the skill-bridge produces — and staging is workspace-only since core
   // 3.1.0. So the temp dir has to actually BE the managed workspace, or `skillsStagingDir`
   // returns null for it and the staged views are invisible.
+  savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
   process.env.MULMOCLAUDE_WORKSPACE_PATH = ws;
   initCollectionsBackend({ workspace: ws });
 
@@ -201,6 +205,11 @@ beforeAll(async () => {
   app.use(express.json());
   mountCollectionRoutes(app);
   request = appRequest(app);
+});
+
+afterAll(() => {
+  if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
 });
 
 describe("GET /api/collections/list", () => {

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -189,6 +189,12 @@ beforeAll(async () => {
 
   // Point the collection host at the fixture. vitest isolates modules
   // per test file, so this configure is fresh for this worker.
+  //
+  // The fixture models the MANAGED workspace — its views live under `data/skills/<slug>/views`,
+  // the staging layout the skill-bridge produces — and staging is workspace-only since core
+  // 3.1.0. So the temp dir has to actually BE the managed workspace, or `skillsStagingDir`
+  // returns null for it and the staged views are invisible.
+  process.env.MULMOCLAUDE_WORKSPACE_PATH = ws;
   initCollectionsBackend({ workspace: ws });
 
   const app = express();

--- a/test/server/backends/system-tasks.spec.ts
+++ b/test/server/backends/system-tasks.spec.ts
@@ -11,9 +11,13 @@ const WORKLOG_OFF = { enabled: false, intervalHours: 6 };
 const build = (worklog = WORKLOG_OFF) => buildSystemTasks({ workspaceRoot: "/ws", worklog, spawnChat: () => {} });
 
 describe("buildSystemTasks", () => {
-  it("registers both shared engines", () => {
+  // The feed-refresh id carries its ROOT since core 3.1.0 — the task def is per root, so two
+  // roots would otherwise register one id and the second would replace the first. MulmoTerminal
+  // registers one (the workspace) today, and does not persist system-task state, so there is no
+  // stale row from the old id to clean up.
+  it("registers both shared engines, the feed refresh keyed by its root", () => {
     const ids = build().map((task) => task.id);
-    expect(ids).toContain("system:feed-refresh");
+    expect(ids).toContain("system:feed-refresh:/ws");
     expect(ids).toContain("system:google-calendar-sync");
   });
 

--- a/test/server/backends/workspaceSetup.spec.ts
+++ b/test/server/backends/workspaceSetup.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import path from "node:path";
+import { realpathSync } from "node:fs";
 import { isManagedWorkspace, initWorkspaceSetup, refreshCodexSkillsMirror } from "../../../server/backends/workspaceSetup.js";
 
 // Save/restore MULMOCLAUDE_WORKSPACE_PATH so a test can mark a temp dir as the
@@ -46,11 +47,23 @@ describe("isManagedWorkspace", () => {
     expect(isManagedWorkspace(makeTempDir())).toBe(false);
   });
 
-  // The workspace arrives from the launcher's --cwd, so its casing is the user's. On
-  // Windows that still names the managed directory; on POSIX it names a different one, and
-  // seeding must stay out of it.
-  it("compares by the platform's own casing rule", () => {
-    expect(isManagedWorkspace(path.join(homedir(), "MULMOCLAUDE"))).toBe(process.platform === "win32");
+  // The workspace arrives from the launcher's --cwd, so its casing is the user's. The question
+  // is whether that spelling names the managed directory, and the answer is the FILESYSTEM's,
+  // not the platform's: macOS is POSIX and case-insensitive by default, so there `MULMOCLAUDE`
+  // is the same directory and seeding into it is correct rather than a spill.
+  //
+  // Probed rather than assumed, because it varies per volume — a case-sensitive APFS volume on
+  // the same Mac answers the other way.
+  it("compares by the filesystem's own casing rule", () => {
+    const probe = makeTempDir();
+    const caseInsensitive = ((): boolean => {
+      try {
+        return realpathSync.native(probe.toUpperCase()) === realpathSync.native(probe);
+      } catch {
+        return false;
+      }
+    })();
+    expect(isManagedWorkspace(path.join(homedir(), "MULMOCLAUDE"))).toBe(process.platform === "win32" || caseInsensitive);
   });
 
   it("honors MULMOCLAUDE_WORKSPACE_PATH (resolved compare)", () => {

--- a/test/server/backends/workspaceSetup.spec.ts
+++ b/test/server/backends/workspaceSetup.spec.ts
@@ -47,23 +47,27 @@ describe("isManagedWorkspace", () => {
     expect(isManagedWorkspace(makeTempDir())).toBe(false);
   });
 
-  // The workspace arrives from the launcher's --cwd, so its casing is the user's. The question
-  // is whether that spelling names the managed directory, and the answer is the FILESYSTEM's,
-  // not the platform's: macOS is POSIX and case-insensitive by default, so there `MULMOCLAUDE`
-  // is the same directory and seeding into it is correct rather than a spill.
+  // The workspace arrives from the launcher's --cwd, so its casing is the user's. The question is
+  // whether that spelling names the managed directory, and the answer is the FILESYSTEM's, not
+  // the platform's: macOS is POSIX and case-insensitive by default, so there `MULMOCLAUDE` is the
+  // same directory and seeding into it is correct rather than a spill.
   //
-  // Probed rather than assumed, because it varies per volume — a case-sensitive APFS volume on
-  // the same Mac answers the other way.
+  // Measured on the SAME directory it asserts about, and one that EXISTS. An earlier version
+  // probed a temp dir and asserted about `~/MULMOCLAUDE`: two different volumes on a CI runner,
+  // where the home directory also has no managed workspace at all — and a path whose leaf does
+  // not exist keeps the casing it was written with, so the probe and the assertion disagreed.
   it("compares by the filesystem's own casing rule", () => {
-    const probe = makeTempDir();
+    const dir = makeTempDir();
+    process.env[ENV_KEY] = dir;
+    const shouted = path.join(path.dirname(dir), path.basename(dir).toUpperCase());
     const caseInsensitive = ((): boolean => {
       try {
-        return realpathSync.native(probe.toUpperCase()) === realpathSync.native(probe);
+        return realpathSync.native(shouted) === realpathSync.native(dir);
       } catch {
         return false;
       }
     })();
-    expect(isManagedWorkspace(path.join(homedir(), "MULMOCLAUDE"))).toBe(process.platform === "win32" || caseInsensitive);
+    expect(isManagedWorkspace(shouted)).toBe(process.platform === "win32" || caseInsensitive);
   });
 
   it("honors MULMOCLAUDE_WORKSPACE_PATH (resolved compare)", () => {

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -20,7 +20,15 @@ vi.mock("node:fs", () => {
     mkdir: vi.fn(async () => undefined),
     writeFile: vi.fn(async () => undefined),
   };
-  return { promises, default: { promises } };
+  // `realpathSync` is in the graph because the spawn path now resolves which directory a seeded
+  // chat runs in, and the managed-workspace check canonicalises through symlinks to answer it.
+  // Identity, not a stub returning nothing: these tests care about the route's wiring, and a
+  // realpath that invented a different path would move the answer without saying so.
+  const realpathSync = Object.assign(
+    vi.fn((p: string) => p),
+    { native: vi.fn((p: string) => p) },
+  );
+  return { promises, realpathSync, default: { promises, realpathSync } };
 });
 
 const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,10 +1912,10 @@
     js-yaml "^5.2.3"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.0.1.tgz#50b3e5b46058b8fe9b5b842b0f006f41433d309d"
-  integrity sha512-mJkIUUJLy8HnDHAl+HwRmTuKrMfSeD938/RdSjhEz8O+pJHj+mqRCV1cX6OuV127w3SGF3j1aYMmnQ98WhPEBA==
+"@mulmoclaude/core@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.1.0.tgz#e5b11cbbde784a46b92672b19bf42876766b9813"
+  integrity sha512-1C9UgjOnppPyp2Z76N915rUjrA4ffRt7Q2k8nHTy4qOYwK86NRaTegSdvQYo1kdA/NJTC75BTUbNkHgMgn0nFw==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"


### PR DESCRIPTION
Takes `@mulmoclaude/core@3.1.0` and wires the two halves of the promise that `data/skills` belongs to the managed workspace and nowhere else.

## The binding

`skillsStagingDir` returns the staging path only for the managed workspace and **`null`** for every other root — which 3.1.0 added for exactly this.

Staging exists to route around the `.claude/` permission gate: the agent writes drafts to a plain data dir and a bridge mirrors the allowlisted files across. A project folder has **neither gate nor bridge**, and the engine reads staging *first* for a project-scope collection — so a stray `data/skills/<slug>/` shadowed the committed skill, in a repo whose whole point is to be self-contained.

## The instructions

`manageCollection`'s `schemaDocs` is what the agent reads before authoring, and it said:

> **Author under `data/skills/<slug>/`, NEVER `.claude/skills/<slug>/`**

Correct in the workspace. Outside it, silently fatal: the agent obeys, nothing mirrors the draft, discovery never sees it, and **the collection simply does not exist — with no error anywhere**. The guide is now root-appropriate.

`stagedSkillAuthoring` agrees with the staging binding rather than overriding it (the engine derives the variant from either), and is passed anyway because two levers that must agree are worth stating at both ends.

## Two existing specs moved with the behaviour

Both moves are the point rather than bookkeeping:

- **`collections.spec.ts`** models the *managed* workspace — its views sit in the staging layout the bridge produces — so its temp dir now has to actually **be** that workspace. Before this, "the fixture is a workspace" was a claim no code checked.
- **`system-tasks.spec.ts`** — 3.1.0 keys the feed-refresh task id by root (`system:feed-refresh:<root>`), since a per-root def would otherwise have two roots registering one id. MulmoTerminal registers one and persists no system-task state, so there is no stale row from the old id to clean up.

## New spec

`collectionStaging.spec.ts` pins both halves, because both fail silently:

- a stray `data/skills` view in a project does **not** shadow the committed one, while the workspace still prefers its staging copy;
- the authoring guide names `.claude/skills` for a project root and `data/skills` for the workspace — asserted on the *instruction*, since the direct variant still contains the words "data/skills", in the sentence telling the agent never to write there.

## Gate

`yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — **9433 passed / 45 skipped**.

Branched off `main`, so it is independent of #1573 (the Collections pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved skill handling across workspace types.
  - Managed workspaces now use staged skills from `data/skills`.
  - Project workspaces prioritize committed skills from `.claude/skills`.
  - Collection authoring guidance reflects the correct skill location.

- **Bug Fixes**
  - Prevented project collections from using stray staged skill files.
  - Improved workspace detection for symlinked paths.
  - Improved workspace-specific task registration to avoid stale shared state.

- **Maintenance**
  - Updated the core package dependency to the latest compatible release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->