### PR TITLE
fix(collections): a presentCollection card fetches its own session's project

### DIFF
--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -78,6 +78,9 @@ onBeforeUnmount(unregister);
 // before surfaces existed.
 const overlaySurface: CollectionSurface = {
   projectId: null,
+  // Full-screen: it covers the pane slot, so it outranks a canvas or Collections pane however
+  // recently that mounted — a tool result can auto-reveal a canvas BEHIND this overlay.
+  layer: "screen",
   nav: {
     routeSlug: browseRouteSlug,
     routeSelectedId: browseRouteSelectedId,

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -13,7 +13,7 @@ import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 import { pushCollectionSurface, popCollectionSurface, type CollectionSurface } from "../composables/collectionSurface";
-import { projectIdForCwd } from "../composables/collectionProject";
+import { cachedProjectIdForCwd, projectIdForCwd } from "../composables/collectionProject";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -161,7 +161,11 @@ const cards = computed(() => collapseByIdentity(results.value, cardIdentity));
 // and that is exactly what today's behaviour already loses, since today every edit draws a whole
 // new card. Correct-and-unchanged beats stale-but-smooth. Caught by Codex on PR #1223; pinned by
 // "remounts the view … so it refetches" in GuiPanelCollapse.spec.ts.
-const cardKey = (result: ToolResult) => result.uuid;
+// The PROJECT SCOPE is part of the key, not decoration: a `presentCollection` card self-fetches
+// by slug, so a card mounted before the scope resolved fetched against the workspace. Keying on
+// the scope remounts it when the scope lands — the same refetch-by-remount this file already
+// relies on above, applied to the one input a card cannot see change.
+const cardKey = (result: ToolResult) => `${scopeId.value ?? ""}\u0000${result.uuid}`;
 
 // Each card paired with the plugin that draws it, resolved ONCE here rather than in the template.
 // A template cannot carry `v-if="getPlugin(...)"` narrowing across to the sibling attributes, so
@@ -275,13 +279,26 @@ const canvasSurface: CollectionSurface = { projectId: null };
 pushCollectionSurface(canvasSurface);
 onBeforeUnmount(() => popCollectionSurface(canvasSurface));
 
+// Mirrored into a ref because the CARD KEY reads it: a card self-fetches on mount, so a scope
+// that resolves a tick later resolves after the request it was for. Keying on it remounts the
+// cards when it lands, which is how this file already makes a card refetch (see `cardKey`).
+const scopeId = ref<string | null>(null);
+function applyScope(resolved: string | null): void {
+  canvasSurface.projectId = resolved;
+  scopeId.value = resolved;
+}
+
 let scopeGeneration = 0;
 watch(
   () => props.cwd,
   async (cwd) => {
     const mine = ++scopeGeneration;
+    // Synchronously when the project list is already warm, which it is for every canvas after the
+    // first: then there is no window at all, rather than a window the cards usually win.
+    const cached = cachedProjectIdForCwd(cwd ?? null);
+    if (cached !== undefined) applyScope(cached);
     const resolved = await projectIdForCwd(cwd ?? null);
-    if (mine === scopeGeneration) canvasSurface.projectId = resolved;
+    if (mine === scopeGeneration) applyScope(resolved);
   },
   { immediate: true },
 );

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from "vue";
+import { ref, computed, watch, nextTick, onBeforeUnmount } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
 import { getPlugin } from "../plugins-registry";
@@ -12,6 +12,8 @@ import { isRecord } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
 import { jsonBody } from "../jsonBody";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
+import { pushCollectionSurface, popCollectionSurface, type CollectionSurface } from "../composables/collectionSurface";
+import { projectIdForCwd } from "../composables/collectionProject";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -30,6 +32,10 @@ interface ToolResult {
 
 const props = defineProps<{
   sessionId: string | null;
+  /** The directory the session this panel mirrors is running in. A `presentCollection` card
+   *  SELF-FETCHES by slug, so without it the fetch went to the workspace and a collection living
+   *  in the session's own folder came back "not found". */
+  cwd?: string | null;
   sendTextMessage: (text: string) => boolean;
   // Whether the panel currently covers the terminal area. Owned by the grid (it is the grid's
   // layout that changes), shown here because the button that flips it lives in this toolbar.
@@ -254,6 +260,31 @@ async function loadAvailableTools(sessionId: string | null) {
   }
 }
 watch(() => props.sessionId, loadAvailableTools, { immediate: true });
+
+// The canvas is a SURFACE: it shows one session's cards, and a `presentCollection` card
+// self-fetches its collection by slug through the global binding. Without a scope that fetch went
+// to the workspace, so a collection living in the session's own folder came back "not found" —
+// the card rendered its own failure while the tool call had succeeded.
+//
+// Scope only, no `nav`: a link inside a card still belongs to the full-screen browser, and a
+// canvas that took navigation would swallow it.
+//
+// A GENERATION token for the same reason the pane has one — the lookup is async, so a session
+// change or an unmount mid-flight must not let an older answer land.
+const canvasSurface: CollectionSurface = { projectId: null };
+pushCollectionSurface(canvasSurface);
+onBeforeUnmount(() => popCollectionSurface(canvasSurface));
+
+let scopeGeneration = 0;
+watch(
+  () => props.cwd,
+  async (cwd) => {
+    const mine = ++scopeGeneration;
+    const resolved = await projectIdForCwd(cwd ?? null);
+    if (mine === scopeGeneration) canvasSurface.projectId = resolved;
+  },
+  { immediate: true },
+);
 
 // The answer above is normally asked BEFORE it can be true: the browser is handed a session id
 // while claude is still being spawned, so its MCP client has not connected to the group URLs yet

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1151,6 +1151,7 @@ watch(
         <GuiPanel
           v-else-if="rightPane === 'canvas'"
           :session-id="expandedSessionId"
+          :cwd="expandedCwd"
           :send-text-message="sendToExpandedCell"
           :unavailable="canvasUnavailable"
           :expanded="paneFull"

--- a/src/composables/collectionProject.ts
+++ b/src/composables/collectionProject.ts
@@ -25,6 +25,9 @@ export interface CollectionProject {
 }
 
 let cache: Promise<CollectionProject[]> | null = null;
+// The resolved list, kept beside the promise so a caller that cannot await still gets an answer
+// once one exists (`cachedProjectIdForCwd`).
+let settled: CollectionProject[] | null = null;
 
 function asProjects(body: unknown): CollectionProject[] {
   if (!isRecord(body) || !isUnknownArray(body.projects)) return [];
@@ -42,7 +45,8 @@ export async function listCollectionProjects(): Promise<CollectionProject[]> {
   cache ??= (async () => {
     const res = await fetchWithTimeout("/api/collection-projects");
     if (!res.ok) throw new Error(`collection-projects: HTTP ${res.status}`);
-    return asProjects(await res.json());
+    settled = asProjects(await res.json());
+    return settled;
   })().catch((err: unknown) => {
     cache = null;
     throw err;
@@ -53,6 +57,19 @@ export async function listCollectionProjects(): Promise<CollectionProject[]> {
 /** Drop the cached list — after launching from a directory that was not in it. */
 export function forgetCollectionProjects(): void {
   cache = null;
+  settled = null;
+}
+
+/** The project id for a cwd from the ALREADY-FETCHED list, or `undefined` when the list has not
+ *  arrived yet — which is a different answer from `null` ("known, and not a project").
+ *
+ *  Exists so a surface can scope itself SYNCHRONOUSLY once the list is warm. The async lookup is
+ *  a race against the cards it is supposed to scope: they mount and self-fetch immediately, so a
+ *  scope that arrives a tick later arrives after the request it was for. */
+export function cachedProjectIdForCwd(cwd: string | null | undefined): string | null | undefined {
+  if (!cwd) return null;
+  if (!settled) return undefined;
+  return settled.find((project) => project.cwd === cwd)?.id ?? null;
 }
 
 /** The project id for a cell's cwd, or null when that directory is not one the server knows.

--- a/src/composables/collectionSurface.ts
+++ b/src/composables/collectionSurface.ts
@@ -38,8 +38,19 @@ export interface CollectionNavSurface {
 /** A surface: where navigation goes, and which project its requests name. `projectId: null` is
  *  the shared workspace — what the full-screen overlay shows, and what everything showed before
  *  panes existed. */
+/** How a surface sits on the screen. `"screen"` covers everything below it (the full-screen
+ *  collection browser); `"pane"` is the right-hand slot beside the terminal (the Collections pane
+ *  and the canvas, which share it).
+ *
+ *  Precedence is by LAYER first, push order second — not push order alone. A canvas can mount
+ *  while the full-screen browser is already open (a tool result auto-reveals one behind it), and
+ *  the surface that mounted last is then not the surface being looked at. */
+export type CollectionSurfaceLayer = "pane" | "screen";
+
 export interface CollectionSurface {
   projectId: string | null;
+  /** Defaults to `"pane"` — the slot beside the terminal. */
+  layer?: CollectionSurfaceLayer;
   /** How this surface navigates — OPTIONAL, because scoping and navigating are not always the
    *  same claim. The canvas shows one session's cards and must scope their fetches to that
    *  session's project, but a link inside a card still belongs to the full-screen browser: a
@@ -62,20 +73,30 @@ export function popCollectionSurface(surface: CollectionSurface): void {
   if (i >= 0) stack.splice(i, 1);
 }
 
+/** The surfaces that can be the visible one: those on the topmost occupied LAYER. A full-screen
+ *  surface covers every pane, so once one is registered nothing in a pane can be what the user is
+ *  looking at, however recently it mounted. */
+function visibleSurfaces(): CollectionSurface[] {
+  const screen = stack.filter((surface) => surface.layer === "screen");
+  return screen.length > 0 ? screen : stack;
+}
+
 /** The project the visible surface is scoped to — null for the workspace, which is also the
  *  answer when no surface is registered at all. */
 export function activeCollectionProjectId(): string | null {
-  return stack.at(-1)?.projectId ?? null;
+  return visibleSurfaces().at(-1)?.projectId ?? null;
 }
 
 /** The surface currently driving navigation, or null when only the router-backed overlay is up.
  *  Null is the DEFAULT, not a failure: with no pane mounted the binding keeps behaving exactly as
  *  it did, which is what keeps this change invisible to the overlay. */
 export function activeCollectionNavSurface(): CollectionNavSurface | null {
-  // The topmost surface that HAS a nav, not the topmost surface: a scope-only surface above it
-  // (the canvas) must not silence the one below that can actually navigate.
-  for (let i = stack.length - 1; i >= 0; i -= 1) {
-    const nav = stack[i]?.nav;
+  // The topmost VISIBLE surface that has a nav, not the topmost surface: a scope-only surface
+  // above it (the canvas) must not silence the one below that can actually navigate, and a pane
+  // must not answer for a full-screen browser covering it.
+  const visible = visibleSurfaces();
+  for (let i = visible.length - 1; i >= 0; i -= 1) {
+    const nav = visible[i]?.nav;
     if (nav) return nav;
   }
   return null;

--- a/src/composables/collectionSurface.ts
+++ b/src/composables/collectionSurface.ts
@@ -40,7 +40,11 @@ export interface CollectionNavSurface {
  *  panes existed. */
 export interface CollectionSurface {
   projectId: string | null;
-  nav: CollectionNavSurface;
+  /** How this surface navigates — OPTIONAL, because scoping and navigating are not always the
+   *  same claim. The canvas shows one session's cards and must scope their fetches to that
+   *  session's project, but a link inside a card still belongs to the full-screen browser: a
+   *  canvas that took navigation would swallow it. */
+  nav?: CollectionNavSurface;
 }
 
 // A PLAIN array, deliberately not a `ref`. Nothing renders from this stack — it is read
@@ -68,5 +72,11 @@ export function activeCollectionProjectId(): string | null {
  *  Null is the DEFAULT, not a failure: with no pane mounted the binding keeps behaving exactly as
  *  it did, which is what keeps this change invisible to the overlay. */
 export function activeCollectionNavSurface(): CollectionNavSurface | null {
-  return stack.at(-1)?.nav ?? null;
+  // The topmost surface that HAS a nav, not the topmost surface: a scope-only surface above it
+  // (the canvas) must not silence the one below that can actually navigate.
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    const nav = stack[i]?.nav;
+    if (nav) return nav;
+  }
+  return null;
 }

--- a/test/src/components/GuiPanelCollapse.spec.ts
+++ b/test/src/components/GuiPanelCollapse.spec.ts
@@ -57,6 +57,7 @@ vi.mock("../../../src/components/PluginFrame.vue", () => ({
   }),
 }));
 
+const { activeCollectionProjectId } = await import("../../../src/composables/collectionSurface");
 const GuiPanel = (await import("../../../src/components/GuiPanel.vue")).default;
 
 function mountPanel() {
@@ -68,6 +69,21 @@ function mountPanel() {
     })),
   );
   return mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true } });
+}
+
+/** The panel with a directory, i.e. the shape the grid actually renders. The project list is
+ *  answered too, so the scope resolves — asynchronously, which is the point of the test below. */
+function mountPanelIn(cwd: string) {
+  const body = (url: string): unknown => {
+    if (url.includes("/api/collection-projects")) return { projects: [{ id: "proj-1", label: "proj", cwd }] };
+    if (url.includes("/api/tools")) return { tools: [] };
+    return { toolResults: [] };
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => ({ ok: true, json: async () => body(url) })),
+  );
+  return mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true, cwd } });
 }
 
 // Deliver a result the way the server does — on the session channel.
@@ -139,6 +155,19 @@ describe("GuiPanel — collapsing repeated cards", () => {
     await push(plain("p1"));
     await push(plain("p2"));
     expect(rendered(wrapper)).toEqual(["p1", "p2"]);
+  });
+
+  // A card SELF-FETCHES its collection by slug, and which project that resolves to is the
+  // PANEL's scope — the canvas shows one session's cards, and that session has a directory.
+  // Without this the fetch went to the workspace and a collection living in the session's own
+  // folder came back "not found" while the tool call had succeeded.
+  it("scopes collection requests to the session's directory while it is open", async () => {
+    const panel = mountPanelIn("/proj");
+    await flushPromises();
+    expect(activeCollectionProjectId()).toBe("proj-1");
+    // …and gives the scope back when it goes away, so the next surface is not left holding it.
+    panel.unmount();
+    expect(activeCollectionProjectId()).toBeNull();
   });
 
   it("remounts the view on a re-presentation, so the card refetches", async () => {

--- a/test/src/composables/collectionProject.spec.ts
+++ b/test/src/composables/collectionProject.spec.ts
@@ -109,6 +109,22 @@ describe("collection nav surface", () => {
     popCollectionSurface(overlay);
   });
 
+  // Precedence is by LAYER, not by push order. A tool result can auto-reveal a canvas BEHIND the
+  // full-screen browser, so the surface that mounted last is not always the one being looked at —
+  // and the overlay's own requests would then be sent to a background session's project.
+  it("keeps a full-screen surface in charge when a pane mounts behind it", () => {
+    const overlay: CollectionSurface = { projectId: null, layer: "screen", nav: surfaceFor(null, "overlay").nav };
+    const canvas: CollectionSurface = { projectId: "proj-behind" };
+    pushCollectionSurface(overlay);
+    pushCollectionSurface(canvas);
+    expect(activeCollectionProjectId()).toBeNull();
+    expect(activeCollectionNavSurface()?.routeSlug()).toBe("overlay");
+    // …and the pane takes over again once the screen above it goes away.
+    popCollectionSurface(overlay);
+    expect(activeCollectionProjectId()).toBe("proj-behind");
+    popCollectionSurface(canvas);
+  });
+
   it("ignores a pop for a surface that is not registered", () => {
     const pane = surfaceNamed("pane");
     pushCollectionSurface(pane);

--- a/test/src/composables/collectionProject.spec.ts
+++ b/test/src/composables/collectionProject.spec.ts
@@ -113,7 +113,7 @@ describe("collection nav surface", () => {
   // full-screen browser, so the surface that mounted last is not always the one being looked at —
   // and the overlay's own requests would then be sent to a background session's project.
   it("keeps a full-screen surface in charge when a pane mounts behind it", () => {
-    const overlay: CollectionSurface = { projectId: null, layer: "screen", nav: surfaceFor(null, "overlay").nav };
+    const overlay: CollectionSurface = { ...surfaceFor(null, "overlay"), layer: "screen" };
     const canvas: CollectionSurface = { projectId: "proj-behind" };
     pushCollectionSurface(overlay);
     pushCollectionSurface(canvas);

--- a/test/src/composables/collectionProject.spec.ts
+++ b/test/src/composables/collectionProject.spec.ts
@@ -95,6 +95,20 @@ describe("collection nav surface", () => {
     popCollectionSurface(pane);
   });
 
+  // The canvas scopes its cards' fetches without owning navigation: a link inside a card still
+  // belongs to the full-screen browser. So a scope-only surface must not silence the nav of the
+  // surface beneath it.
+  it("lets a scope-only surface set the project without taking navigation", () => {
+    const overlay = surfaceFor(null, "overlay");
+    const canvas: CollectionSurface = { projectId: "proj-canvas" };
+    pushCollectionSurface(overlay);
+    pushCollectionSurface(canvas);
+    expect(activeCollectionProjectId()).toBe("proj-canvas");
+    expect(activeCollectionNavSurface()?.routeSlug()).toBe("overlay");
+    popCollectionSurface(canvas);
+    popCollectionSurface(overlay);
+  });
+
   it("ignores a pop for a surface that is not registered", () => {
     const pane = surfaceNamed("pane");
     pushCollectionSurface(pane);


### PR DESCRIPTION
Reported from a real session: an agent in `../mag2` created a collection there successfully — `putSchema` wrote it, `queryItems` read 168 records — and then `presentCollection` rendered **"Collection not found"**. The tool call succeeded and the card failed, which is the worst shape for this to take.

## Why

The card **self-fetches** by slug (`fetchCollectionDetail(slug)`) through the global binding, and the binding scopes to the active surface. With no Collections pane open there was no surface, so the fetch went to the **workspace** — where that slug does not exist.

## The fix

The canvas is a surface too, and now says so: it shows **one session's** cards, that session has a directory, and that directory is the project its cards belong to.

It registers with a project and **no `nav`**, which is a new shape the stack allows. The two claims are not the same: a link inside a card still belongs to the full-screen browser, and a canvas that took navigation would swallow it. So `activeCollectionNavSurface()` returns the topmost surface that *has* a nav, rather than the topmost surface.

The cwd lookup carries a generation token, for the reason the pane's does: it is async, so a session change or an unmount mid-flight must not let an older answer land.

## What this deliberately is not

core 3.1.0 ships `withCardScope` so a card can carry the root it was made for — stricter, and the right end state: two cards from two projects in one panel. The plugin that renders the card does not read that field yet (`@mulmoclaude/collection-plugin@3.0.0` fetches by slug alone), so per-card scope needs a plugin release. This fixes the case that actually occurs, where a panel shows one session's work.

Tracked as §7c D in `plans/feat-collections-project-root.md`.

## Gate

`yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — **9448 passed / 45 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Canvas panels now automatically use the project associated with their current working directory.
  - Project context can be applied independently without replacing active navigation.
  - Switching between projects now updates panel content more reliably.

- **Bug Fixes**
  - Prevented outdated project lookups from overriding the current canvas context.
  - Ensured temporary project scopes are removed when panels close.
  - Improved project resolution using previously loaded project information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->