### PR TITLE
Collections: per-root watchers, project-aware completion bells, and the dead pane button

### DIFF
--- a/common/collectionNotifyTarget.ts
+++ b/common/collectionNotifyTarget.ts
@@ -19,6 +19,12 @@ export interface CollectionNotifyTarget {
   slug: string;
   /** Absent on a collection-level bell — those can't accent a specific record. */
   itemId?: string | undefined;
+  /** The record's project, as the opaque id the API takes. ABSENT MEANS THE WORKSPACE — both
+   *  because that is what a workspace bell has always written and because it is the only thing
+   *  MulmoClaude, which has one root, can write. A slug is unique within a root and nowhere
+   *  else, so a reader that ignores this accents the same-named record of whichever project is
+   *  on screen. */
+  project?: string | undefined;
 }
 
 /** Narrow a notification's opaque `pluginData` to its collection navigate target,
@@ -31,7 +37,11 @@ export function collectionNotifyTargetOf(pluginData: unknown): CollectionNotifyT
   if (!isRecord(action)) return null;
   const { target } = action;
   if (!isRecord(target)) return null;
-  const { view, slug, itemId } = target;
+  const { view, slug, itemId, project } = target;
   if (view !== COLLECTION_NOTIFY_VIEW || typeof slug !== "string" || slug.length === 0) return null;
-  return { slug, itemId: typeof itemId === "string" && itemId.length > 0 ? itemId : undefined };
+  return {
+    slug,
+    itemId: typeof itemId === "string" && itemId.length > 0 ? itemId : undefined,
+    project: typeof project === "string" && project.length > 0 ? project : undefined,
+  };
 }

--- a/plans/HANDOFF-collections-projects.md
+++ b/plans/HANDOFF-collections-projects.md
@@ -35,8 +35,8 @@ uses. Confirmed present in the installed package:
   `stagedSkillAuthoring` — **both wired**
 - **`startCollectionWatchers` mounts one generation PER ROOT, concurrently**, each stamping its
   root on payloads and driving bells whose ids carry it; `stopCollectionWatchers({ workspaceRoot })`
-  stops exactly one — **not wired**
-- `buildNavigateTarget(slug, itemId, root?)` — the adapter receives the root — **not used**
+  stops exactly one — **wired** (§3.1)
+- `buildNavigateTarget(slug, itemId, root?)` — the adapter receives the root — **used** (§3.2)
 - `withCardScope` for per-card project — **blocked, see §3.3**
 - `feedRefreshTaskDef({ workspaceRoot })` with a per-root task id — MT registers one, for the
   workspace only
@@ -79,34 +79,61 @@ PRs and they were nearly all one of the following.
 
 ## 3. What is left
 
-Ordered by how much it hurts today.
+Ordered by how much it hurts today. §3.1 and §3.2 are now done — kept here, marked, because what
+was decided about them (which roots get a watcher, and why the adapter must not import server
+infra) is what the next reader needs.
 
-### 3.1 Per-root watchers — the one with live consequences
+### 3.1 Per-root watchers — DONE
 
-`server/backends/collectionWatchers.ts` starts ONE generation, for the workspace. The collection
-created in mag2 declares `completionField` / `completionDoneValues`, so it is asking for a feature
-that cannot fire:
+`server/backends/collectionWatchers.ts` now mounts **one generation per known project** — the
+workspace and every saved `cwdPresets` directory — instead of one for the workspace. So a
+project's collections get their completion bells and their live refresh on a direct file write,
+which is the canonical authoring path.
 
-- **no completion bells** for a project's collections;
-- **no live refresh** when an agent writes records directly — and that is the CANONICAL authoring
-  path (the watcher's own header says so: a direct file write has no other producer, so open views
-  would never refresh).
+- **"Open" means "a project this server serves"**, not "a project on screen". A completion bell is
+  the notification that the user is NOT looking, so scoping the watchers to the open Collections
+  pane would mean a bell can only ring while its collection is already visible. The inotify cost is
+  bounded by discovery: a root with no collections mounts no watcher.
+- The watched set is reconciled by a **60s poll** (`syncCollectionWatcherRoots`, exported so a
+  caller that knows the list just changed can pull the pass forward). A poll because
+  `listProjectRoots` reads a live thunk over `cwdPresets` and nothing emits when it changes.
+- A root that fails to start does not stop the roots after it, is warned about **once**, and is
+  retried on the next pass. Errors carry their `code` (`COLLECTION_ROOT_REQUIRED` distinguishes a
+  wiring bug in this file from one directory's problem).
+- `WATCHER_ROOT_CONFLICT` is no longer thrown by core 3.1.0 — a second root mounts a second
+  generation. `feat-collections-project-root.md` §7b describes the 3.0.0 contract and is now
+  historical on that point.
 
-Core already supports it (see §1). The MT work is to start a generation for each project the user
-has open and stop it when they close it — `stopCollectionWatchers({ workspaceRoot })` releases one.
-The contract, including the error codes to branch on (`WATCHER_ROOT_CONFLICT`,
-`COLLECTION_ROOT_REQUIRED`) and why the failure is silent if you get it wrong, is
-`feat-collections-project-root.md` §7b.
+Not done: nothing calls `syncCollectionWatcherRoots` when a directory is recorded, so a project
+launched for the first time waits up to a minute for its watcher. Config writes go through several
+paths (`POST /api/config`, `cli-init`) and the poll covers them all.
 
-Decide what "open" means — the Collections pane's project is the obvious trigger; watching every
-known project would spend inotify handles on directories nobody is looking at.
+### 3.2 Notification deep links — DONE
 
-### 3.2 Notification deep links (§7c C, MT half)
+A bell now carries its project, as the **opaque id**, both in the URL
+(`/collections/<slug>?selected=<itemId>&project=<id>`) and on `action.target.project`.
 
-`server/backends/collectionNotifierAdapter.ts` builds `/collections/<slug>` with no project, so a
-bell from a project collection opens the workspace's collection of that slug. Core now passes the
-root as the third argument to `buildNavigateTarget`. The client route must accept a project too.
-The id is opaque — do not put a path in a URL.
+- `buildNavigateTarget` / `buildPluginData` take the project, and
+  **`collectionWatchers.ts` resolves root → id** (`projectIdForRoot`, new in `project-root.ts`).
+  The adapter stays free of server infra deliberately: `test/src/utils/collectionNotified.spec.ts`
+  imports it, so pulling `node:crypto` in through it puts Node's globals into a DOM-typed project
+  and `window.setTimeout` stops returning a number — a real, confusing typecheck failure.
+- **Cross-app parity holds where it is observable**: the id is omitted for the workspace, so the
+  only link MulmoClaude can produce or receive is byte-for-byte what it was.
+- The client half: `browseRouteProjectId()` reads it from the route query, the browse pushes
+  **carry** the open project (a ref hop inside a project stays in it) while a bell passes its own
+  explicitly (`null` for a workspace bell, so it does not inherit an open project), and
+  `CollectionsBrowseOverlay`'s surface takes its `projectId` from the route via a getter. The
+  plugin views are **keyed** by project so a same-path project switch refetches.
+- `collectionNotifiedSeverities` now matches the project too. That is not theoretical: with a
+  `primaryKey` schema the record id is drawn from the data, so the same record in two projects has
+  the SAME id and an unscoped reader accents the wrong card reliably rather than rarely.
+
+Still open (upstream): MT publishes ROOTED bell ids while MulmoClaude publishes root-less ones for
+the same workspace. Core's sweep handles it asymmetrically — MT's rooted sweep clears a root-less
+entry (`drop-legacy`) and republishes, while MulmoClaude's root-less sweep `skip`s a rooted one, so
+alternating between the apps can leave a stale bell MulmoClaude will not clear. Pre-existing since
+#1571, by upstream design, and worth confirming with MulmoClaude before anyone "fixes" it here.
 
 ### 3.3 Per-card project scope (§7c D remainder) — blocked
 
@@ -129,7 +156,8 @@ must be an opaque id, and the artifact stays host-built.
 
 `server/backends/system-tasks.ts` registers `feedRefreshTaskDef({ workspaceRoot })` once. A
 project's feeds therefore never refresh on their schedule. Core's task def is root-parameterised
-with a per-root id, so registering one per watched project is the shape.
+with a per-root id, so registering one per watched project is the shape — and "which roots" is
+now answered by §3.1: `listProjectRoots()`, reconciled by the same kind of pass.
 
 ### 3.6 The self-containment check (phase 7)
 
@@ -138,12 +166,27 @@ clone?" — user-scope dependencies, a sqlite store in a git repo (unmergeable),
 by `.gitignore`, a missing `primaryKey`. Cheap, no upstream dependency, and it is the difference
 between the guarantee holding and appearing to hold until someone else pulls.
 
-### 3.7 Never done: a live browser check
+### 3.7 A live browser check — still owed, and it already cost one dead button
 
 The Collections pane shipped without one. The pane's height, the plugin views inside the shadow
 root, and the nav containment are exactly what a test suite does not see. Note that this instance
 serves compiled `dist/` with no HMR — a UI change needs `yarn build` and a server restart before it
 is visible.
+
+**What the first hand-press found (2026-08-09):** the "Show this folder's collections" button had
+never worked. `CellChromeButtons` emitted `toggle-collections`, but `cellChromeBinding`'s
+`chromeEvents` object — which every cell binds with a single `v-on` — had no key for it, and
+`GridCellEmits` did not declare it. So the emit was dropped inside the cell and `TerminalGrid`'s
+handler waited for something nothing ever sent. Fixed by adding the event to both, plus
+`cellShellEvents`.
+
+Two things made it survive: an unlistened Vue emit is legal, so `typecheck` was clean; and the
+existing "forwards every chrome event" test listed the events BY HAND from the same wrong set of
+four. The replacement (`test/src/components/cellChromeForwarding.spec.ts`) derives the expectation
+from `CellChromeButtons`' own runtime `emits`, so the next button is covered the day it is added.
+
+The general lesson for the rest of this list: server-side correctness here has been verified by
+curl and by specs at every step, and none of that says the feature is reachable.
 
 ---
 

--- a/plans/feat-collections-project-root.md
+++ b/plans/feat-collections-project-root.md
@@ -331,6 +331,12 @@ project selector ships, or "my project's collection never rings" becomes the fir
 - **Branch on `err.code`, not message text.** Both codes are exported. Our call site
   (`startCollectionCompletionWatchers`, fire-and-forget with `.catch`) otherwise lands both on
   one log line and we cannot tell "forgot the root" from "another project is running".
+- **SUPERSEDED BY core 3.1.0 (shipped):** `startCollectionWatchers` mounts one generation PER
+  ROOT concurrently, `WATCHER_ROOT_CONFLICT` is no longer thrown, and bell ids carry the root, so
+  two projects owning one slug hold two distinct bells. MulmoTerminal wires it in
+  `server/backends/collectionWatchers.ts` — see `HANDOFF-collections-projects.md` §3.1. The
+  paragraph below is the 3.0.0 contract, kept for the reasoning behind the identity change:
+
 - **Still one root at a time.** Concurrency was deliberately deferred: bell identity is
   `completionLegacyId(slug, itemId)` and `buildNavigateTarget(slug, itemId)`, a HOST-FACING
   contract carried through the notifier file we SHARE with MulmoClaude. Two roots owning one slug
@@ -360,11 +366,12 @@ spawns in `CLAUDE_CWD`, while the seed prompt's `<collection_paths>` are built f
 root. The agent is handed a project's paths and dropped in the workspace — the two disagree in a
 way that reads as a broken template rather than a wrong cwd.
 
-**C. Notification deep links.** `buildNavigateTarget(slug, itemId)` yields
+**C. Notification deep links.** ~~`buildNavigateTarget(slug, itemId)` yields
 `/collections/<slug>` with no project, so a bell from a project collection opens the workspace's
-collection of that slug. Worse, the bell's identity is `completionLegacyId(slug, itemId)` in a
-notifier file SHARED with MulmoClaude — so this one is the cross-app identity change §7b names,
-not a local fix.
+collection of that slug.~~ **DONE.** core 3.1.0 made the identity change this paragraph called
+for — `completionLegacyId` encodes the root, and the adapter receives it — and MulmoTerminal now
+turns that root into an opaque project id on the link, the target and the card accent. See
+`HANDOFF-collections-projects.md` §3.2, including the one parity asymmetry it leaves.
 
 **D. Canvas cards.** `presentCollection` / `seedCollectionCanvas` render through the global
 binding, which reads the ambient `activeProjectId` — set only while a Collections pane is open. A

--- a/server/backends/collectionNotifierAdapter.ts
+++ b/server/backends/collectionNotifierAdapter.ts
@@ -19,7 +19,7 @@ export interface LegacyNotifierPluginData {
   legacyId: string;
   kind: "todo";
   priority: "normal" | "high";
-  action: { type: "navigate"; target: { view: "collections"; slug: string; itemId: string } };
+  action: { type: "navigate"; target: { view: "collections"; slug: string; itemId: string; project?: string } };
 }
 
 export function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
@@ -30,11 +30,30 @@ export function isLegacyNotifierPluginData(value: unknown): value is LegacyNotif
 
 /** Deep-link the bell row navigates to: `/collections/<slug>?selected=<itemId>` (the
  *  documented record permalink). Dot-segment slugs would normalise out of the route,
- *  so fall back to the index — matches MulmoClaude's builder. */
-export function buildNavigateTarget(slug: string, itemId: string): string {
+ *  so fall back to the index — matches MulmoClaude's builder.
+ *
+ *  `project` is the record's project as an OPAQUE ID — never a path: this string is written to
+ *  a file two apps read and rendered into a URL in a browser. A slug is unique WITHIN a root and
+ *  nowhere else, so without it a bell from a project's `tasks` opens the workspace's `tasks`:
+ *  the same row, the same title, the wrong records, and nothing anywhere saying so.
+ *
+ *  RESOLVED BY THE CALLER (collectionWatchers.ts), which is handed the ROOT by the engine. This
+ *  file stays free of server infra deliberately — a `test/src` spec imports it to build a
+ *  fixture, and pulling `node:crypto` in through here puts Node's globals into a DOM-typed
+ *  project, where `window.setTimeout` stops returning a number.
+ *
+ *  CROSS-APP PARITY IS PRESERVED where it is observable: the caller passes nothing for the
+ *  WORKSPACE, so the workspace link — the only one MulmoClaude can produce or receive — is
+ *  byte-for-byte what it was. Built by concatenation rather than URLSearchParams for the same
+ *  reason: the latter encodes a space as `+` where MulmoClaude's builder writes `%20`. */
+export function buildNavigateTarget(slug: string, itemId: string, project?: string): string {
   if (slug === "." || slug === "..") return "/collections";
   const base = `/collections/${encodeURIComponent(slug)}`;
-  return itemId ? `${base}?selected=${encodeURIComponent(itemId)}` : base;
+  const query: string[] = [];
+  // `selected` FIRST: it is what the pre-project link carried, so the common case is unchanged.
+  if (itemId) query.push(`selected=${encodeURIComponent(itemId)}`);
+  if (project) query.push(`project=${encodeURIComponent(project)}`);
+  return query.length > 0 ? `${base}?${query.join("&")}` : base;
 }
 
 // high → urgent (red), normal → nudge (amber). Never "info" — the engine forbids
@@ -43,14 +62,26 @@ export function priorityToSeverity(priority: CompletionPriority): NotifierSeveri
   return priority === "high" ? "urgent" : "nudge";
 }
 
-export function buildPluginData(input: { legacyId: string; slug: string; itemId: string; priority: CompletionPriority }): LegacyNotifierPluginData {
-  const { legacyId, slug, itemId, priority } = input;
+export function buildPluginData(input: {
+  legacyId: string;
+  slug: string;
+  itemId: string;
+  priority: CompletionPriority;
+  /** The record's project, as the same opaque id `buildNavigateTarget` takes. Absent for the
+   *  workspace. It rides on the target as well as in the URL because the UI narrows this shape
+   *  to decide which record card to accent (common/collectionNotifyTarget.ts), and a slug-only
+   *  target accents the same-named record of whichever project is on screen. */
+  project?: string | undefined;
+}): LegacyNotifierPluginData {
+  const { legacyId, slug, itemId, priority, project } = input;
   return {
     legacy: true,
     legacyId,
     kind: "todo",
     priority: priority === "high" ? "high" : "normal",
-    action: { type: "navigate", target: { view: COLLECTION_NOTIFY_VIEW, slug, itemId } },
+    // The key is OMITTED rather than set to undefined for a workspace bell: this object is
+    // serialised into a file MulmoClaude also reads, and an absent key is what it wrote.
+    action: { type: "navigate", target: { view: COLLECTION_NOTIFY_VIEW, slug, itemId, ...(project ? { project } : {}) } },
   };
 }
 

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -106,6 +106,46 @@ async function startRoot(root: string): Promise<void> {
   }
 }
 
+/** Warn ONCE that a root would not release, so a stop that keeps failing does not fill the log
+ *  at one line a minute. */
+function warnStopFailure(root: string, err: unknown): void {
+  if (failedStops.has(root)) return;
+  failedStops.add(root);
+  log.warn("collection watchers failed to stop for a root — retrying next pass", {
+    root,
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+/** Release one root's generation, forgetting it only once the package confirms it is gone.
+ *
+ *  STAYS TRACKED ON FAILURE. The package deletes the generation on the LAST line of its stop, so
+ *  a throw can leave one alive — and forgetting the root here would forget the only handle the
+ *  next pass has to try again with, leaving a project the server no longer serves watching its
+ *  files and publishing bells for the rest of the process's life. A repeat stop is idempotent
+ *  (an already-released root is a no-op), so retrying costs nothing. */
+async function releaseRoot(root: string): Promise<void> {
+  try {
+    // Scoped stop: it releases exactly this root's generation and leaves every other project
+    // running. A bare `stopCollectionWatchers()` stops them ALL.
+    await stopCollectionWatchers({ workspaceRoot: root });
+  } catch (err) {
+    warnStopFailure(root, err);
+    return;
+  }
+  watchedRoots.delete(root);
+  failedRoots.delete(root);
+  failedStops.delete(root);
+}
+
+/** Drop the retry bookkeeping a pass has made moot: a root that left the list has no start left
+ *  to retry, and one that came BACK while its stop was failing is wanted again — so its pending
+ *  warning is spent and it must warn afresh if it ever fails to stop later. */
+function forgetSpentRetries(desired: Set<string>): void {
+  for (const root of failedRoots) if (!desired.has(root)) failedRoots.delete(root);
+  for (const root of failedStops) if (desired.has(root)) failedStops.delete(root);
+}
+
 /** Reconcile the mounted generations against the current project list: mount one per root the
  *  server now serves, and release the ones it no longer does.
  *
@@ -115,40 +155,9 @@ async function startRoot(root: string): Promise<void> {
  *  `WATCHER_ROOT_CONFLICT` is no longer thrown (the export remains for hosts that catch it). */
 async function runRootSync(): Promise<void> {
   const desired = new Set(desiredRoots());
-  for (const root of [...watchedRoots]) {
-    if (desired.has(root)) continue;
-    try {
-      // Scoped stop: it releases exactly this root's generation and leaves every other
-      // project running. A bare `stopCollectionWatchers()` stops them ALL.
-      await stopCollectionWatchers({ workspaceRoot: root });
-    } catch (err) {
-      // STAY TRACKED. The package deletes the generation on its LAST line, so a throw can
-      // leave one alive — and forgetting the root here would be forgetting the only handle
-      // the next pass has to try again with, leaving a project the server no longer serves
-      // watching its files and publishing bells for the rest of the process's life. A repeat
-      // stop is idempotent (an already-released root is a no-op), so retrying costs nothing.
-      if (!failedStops.has(root)) {
-        failedStops.add(root);
-        log.warn("collection watchers failed to stop for a root — retrying next pass", {
-          root,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      continue;
-    }
-    watchedRoots.delete(root);
-    failedRoots.delete(root);
-    failedStops.delete(root);
-  }
-  for (const root of desired) {
-    if (watchedRoots.has(root)) continue;
-    await startRoot(root);
-  }
-  // A root that dropped off the list has nothing left to retry.
-  for (const root of [...failedRoots]) if (!desired.has(root)) failedRoots.delete(root);
-  // A root that came BACK onto the list while its stop was failing is wanted again, so the
-  // pending-stop warning is spent — it must warn afresh if it ever fails to stop later.
-  for (const root of [...failedStops]) if (desired.has(root)) failedStops.delete(root);
+  for (const root of [...watchedRoots]) if (!desired.has(root)) await releaseRoot(root);
+  for (const root of desired) if (!watchedRoots.has(root)) await startRoot(root);
+  forgetSpentRetries(desired);
 }
 
 /** Reconcile the watched roots now. Exported so a caller that KNOWS the project list just

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -11,39 +11,168 @@
 // whose `readEntry` recognises ANY legacy entry by its marker. Then MulmoTerminal's
 // reconciler recognises a bell MulmoClaude already published (same legacyId) and won't
 // add a duplicate — and vice-versa. Diverging here is what produced double bells.
-import { configureCollectionWatchers, startCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
+import path from "node:path";
+import { configureCollectionWatchers, startCollectionWatchers, stopCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
 import type { CollectionNotificationAdapter } from "@mulmoclaude/core/collection-watchers";
 import { buildNavigateTarget, buildPluginData, priorityToSeverity, readEntry } from "./collectionNotifierAdapter.js";
-import { workspaceScope } from "../infra/project-root.js";
+import { listProjectRoots, projectIdForRoot } from "../infra/project-root.js";
+import { isRecord } from "../../common/isRecord.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[collection-watchers] ${message}`, data ?? ""),
   warn: (message: string, data?: Record<string, unknown>) => console.warn(`[collection-watchers] ${message}`, data ?? ""),
 };
 
+/** The record's ROOT as the opaque project id the client can ask for, or undefined for the
+ *  workspace and for a root this server does not serve as a project — the two cases whose link
+ *  is the plain, pre-project one. Resolved HERE rather than inside the adapter helpers so those
+ *  stay free of server infra: a `test/src` spec imports them, and reaching `node:crypto` through
+ *  them puts Node's globals into a DOM-typed project. */
+function projectIdFor(root: string | undefined): string | undefined {
+  return root === undefined ? undefined : (projectIdForRoot(root) ?? undefined);
+}
+
 const adapter: CollectionNotificationAdapter = {
   // MulmoClaude's collection bells publish under its legacy namespace; match it so
   // the shared notifier treats both apps' bells as the same entry.
   pluginPkg: "todo",
   priorityToSeverity,
-  buildNavigateTarget,
-  buildPluginData,
+  // The engine hands these the ROOT the record lives under (core 3.1.0). It becomes an opaque
+  // id on the way into the bell, so two projects owning the same slug deep-link to their own.
+  buildNavigateTarget: (slug, itemId, root) => buildNavigateTarget(slug, itemId, projectIdFor(root)),
+  buildPluginData: ({ legacyId, slug, itemId, priority, root }) => buildPluginData({ legacyId, slug, itemId, priority, project: projectIdFor(root) }),
   readEntry,
 };
 
+/** How often the watched set is reconciled against the projects the server knows.
+ *
+ *  A POLL, because `listProjectRoots` reads a live thunk over `cwdPresets` and nothing
+ *  emits when that list changes — launching a terminal from a new directory records one
+ *  deep inside the session code. A minute is well under "the user goes looking for the
+ *  bell", and a pass over an unchanged list starts and stops nothing. */
+const ROOT_SYNC_INTERVAL_MS = 60_000;
+
+// The roots a generation is currently mounted for, in `path.resolve` form — the same
+// canonicalisation the package applies at its own claim, so this set and its generation map
+// agree on what "already watching" means and a trailing slash cannot mount a second one.
+const watchedRoots = new Set<string>();
+// Roots whose last start FAILED, so the retry every sync pass does not repeat the warning
+// once a minute forever (a project on an unmounted volume would otherwise fill the log).
+const failedRoots = new Set<string>();
+let syncTimer: NodeJS.Timeout | null = null;
+// Sync passes are SERIALISED rather than single-flighted: a pass triggered while one is
+// running must still run, because it may be the one that sees a newly recorded project.
+let queue: Promise<void> = Promise.resolve();
+
+function errorCode(err: unknown): string | undefined {
+  return isRecord(err) && typeof err.code === "string" ? err.code : undefined;
+}
+
+/** Every root that should have a watcher: the workspace and every saved project directory.
+ *
+ *  WHY ALL OF THEM rather than "the one the user is looking at": a completion bell is the
+ *  notification that the user is NOT looking. Scoping the watchers to the open Collections
+ *  pane would mean a project's bell can only ring while its collection is already on screen,
+ *  which is the one moment it is not needed. The cost is bounded — discovery mounts a watcher
+ *  only for a root that actually HAS collections, and most project directories have none. */
+function desiredRoots(): string[] {
+  return listProjectRoots().map((project) => path.resolve(project.cwd));
+}
+
+async function startRoot(root: string): Promise<void> {
+  try {
+    // The root is passed EXPLICITLY. The engine host runs in explicit-root mode, so a watcher
+    // started without one throws `COLLECTION_ROOT_REQUIRED` on its first discovery.
+    await startCollectionWatchers({ discoveryOpts: { workspaceRoot: root } });
+    watchedRoots.add(root);
+    if (failedRoots.delete(root)) log.info("collection watchers recovered", { root });
+  } catch (err) {
+    // Branch on the CODE, not the message: "this call forgot its root" is a wiring bug in
+    // this file, while anything else is that one directory's problem and must not stop the
+    // roots after it in the loop. Both used to land on one log line at the boot call site.
+    const code = errorCode(err);
+    if (!failedRoots.has(root)) {
+      failedRoots.add(root);
+      log.warn("collection watchers failed to start for a root — its completion bells are off", {
+        root,
+        code: code ?? "none",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/** Reconcile the mounted generations against the current project list: mount one per root the
+ *  server now serves, and release the ones it no longer does.
+ *
+ *  Core 3.1.0 mounts a generation PER ROOT concurrently — each with its own watcher set,
+ *  timers and single-flight slots, stamping its root on the bell ids it publishes, which is
+ *  what stops two projects' `tasks` collections from deduping into one bell.
+ *  `WATCHER_ROOT_CONFLICT` is no longer thrown (the export remains for hosts that catch it). */
+async function runRootSync(): Promise<void> {
+  const desired = new Set(desiredRoots());
+  for (const root of [...watchedRoots]) {
+    if (desired.has(root)) continue;
+    try {
+      // Scoped stop: it releases exactly this root's generation and leaves every other
+      // project running. A bare `stopCollectionWatchers()` stops them ALL.
+      await stopCollectionWatchers({ workspaceRoot: root });
+    } catch (err) {
+      log.warn("collection watchers failed to stop for a root", { root, error: err instanceof Error ? err.message : String(err) });
+    }
+    watchedRoots.delete(root);
+    failedRoots.delete(root);
+  }
+  for (const root of desired) {
+    if (watchedRoots.has(root)) continue;
+    await startRoot(root);
+  }
+  // A root that dropped off the list has nothing left to retry.
+  for (const root of [...failedRoots]) if (!desired.has(root)) failedRoots.delete(root);
+}
+
+/** Reconcile the watched roots now. Exported so a caller that KNOWS the project list just
+ *  changed can pull the next pass forward instead of waiting out the poll. */
+export function syncCollectionWatcherRoots(): Promise<void> {
+  queue = queue.catch(() => {}).then(runRootSync);
+  return queue;
+}
+
 /** Configure the adapter + mount the watchers. Fire-and-forget at boot AFTER
  *  initCollectionsBackend (the engine host) + initNotifier (the delivery sink); a
- *  watcher failure must not abort startup, so the caller attaches `.catch`. */
+ *  watcher failure must not abort startup, so the caller attaches `.catch`.
+ *
+ *  Per-root failures are already contained (see `startRoot`), so what reaches that `.catch`
+ *  is only a failure of the pass itself — reading the project list at all. */
 export async function startCollectionCompletionWatchers(): Promise<void> {
   configureCollectionWatchers({ adapter, log });
-  // The root is passed EXPLICITLY. The engine host runs in explicit-root mode, so a watcher
-  // started without one would throw `COLLECTION_ROOT_REQUIRED` on its first discovery — and
-  // because the caller is fire-and-forget with a `.catch`, that failure would not stop the
-  // server, it would just log once and leave every collection bell silently dead.
-  //
-  // One root per process is the watcher's own contract (a second start for a DIFFERENT root
-  // throws `WATCHER_ROOT_CONFLICT`); serving a project's collections means
-  // `await stopCollectionWatchers()` first. See plans/feat-collections-project-root.md §7b.
-  await startCollectionWatchers({ discoveryOpts: workspaceScope() });
-  log.info("collection completion watchers started");
+  await syncCollectionWatcherRoots();
+  if (syncTimer === null) {
+    syncTimer = setInterval(() => {
+      void syncCollectionWatcherRoots().catch((err: unknown) => {
+        log.warn("collection watcher root sync failed", { error: err instanceof Error ? err.message : String(err) });
+      });
+    }, ROOT_SYNC_INTERVAL_MS);
+    // Never hold the process open for the poll — same as the package's own timers.
+    syncTimer.unref();
+  }
+  log.info("collection completion watchers started", { roots: watchedRoots.size });
+}
+
+/** Stop every generation and the poll. For test teardown (a leaked timer or watcher crosses
+ *  into the next spec file) and for a host that shuts the subsystem down. */
+export async function stopCollectionCompletionWatchers(): Promise<void> {
+  if (syncTimer !== null) {
+    clearInterval(syncTimer);
+    syncTimer = null;
+  }
+  await queue.catch(() => {});
+  await stopCollectionWatchers();
+  watchedRoots.clear();
+  failedRoots.clear();
+}
+
+/** Test-only: which roots currently have a generation mounted. */
+export function watchedCollectionRootsForTesting(): string[] {
+  return [...watchedRoots];
 }

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -59,6 +59,10 @@ const watchedRoots = new Set<string>();
 // Roots whose last start FAILED, so the retry every sync pass does not repeat the warning
 // once a minute forever (a project on an unmounted volume would otherwise fill the log).
 const failedRoots = new Set<string>();
+// Roots whose scoped STOP failed, for the same warn-once reason. Separate from `failedRoots`
+// because the two are opposite states: one is not watching and wants to be, the other is still
+// watching and must not be.
+const failedStops = new Set<string>();
 let syncTimer: NodeJS.Timeout | null = null;
 // Sync passes are SERIALISED rather than single-flighted: a pass triggered while one is
 // running must still run, because it may be the one that sees a newly recorded project.
@@ -118,10 +122,23 @@ async function runRootSync(): Promise<void> {
       // project running. A bare `stopCollectionWatchers()` stops them ALL.
       await stopCollectionWatchers({ workspaceRoot: root });
     } catch (err) {
-      log.warn("collection watchers failed to stop for a root", { root, error: err instanceof Error ? err.message : String(err) });
+      // STAY TRACKED. The package deletes the generation on its LAST line, so a throw can
+      // leave one alive — and forgetting the root here would be forgetting the only handle
+      // the next pass has to try again with, leaving a project the server no longer serves
+      // watching its files and publishing bells for the rest of the process's life. A repeat
+      // stop is idempotent (an already-released root is a no-op), so retrying costs nothing.
+      if (!failedStops.has(root)) {
+        failedStops.add(root);
+        log.warn("collection watchers failed to stop for a root — retrying next pass", {
+          root,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      continue;
     }
     watchedRoots.delete(root);
     failedRoots.delete(root);
+    failedStops.delete(root);
   }
   for (const root of desired) {
     if (watchedRoots.has(root)) continue;
@@ -129,6 +146,9 @@ async function runRootSync(): Promise<void> {
   }
   // A root that dropped off the list has nothing left to retry.
   for (const root of [...failedRoots]) if (!desired.has(root)) failedRoots.delete(root);
+  // A root that came BACK onto the list while its stop was failing is wanted again, so the
+  // pending-stop warning is spent — it must warn afresh if it ever fails to stop later.
+  for (const root of [...failedStops]) if (desired.has(root)) failedStops.delete(root);
 }
 
 /** Reconcile the watched roots now. Exported so a caller that KNOWS the project list just
@@ -170,6 +190,7 @@ export async function stopCollectionCompletionWatchers(): Promise<void> {
   await stopCollectionWatchers();
   watchedRoots.clear();
   failedRoots.clear();
+  failedStops.clear();
 }
 
 /** Test-only: which roots currently have a generation mounted. */

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -112,6 +112,29 @@ export function listProjectRoots(): ProjectSummary[] {
   return rows.map((row) => ({ id: projectId(row.root), label: row.label, cwd: row.root }));
 }
 
+/** The opaque id for a ROOT the server serves, or null when it serves none — which is also
+ *  the answer for the WORKSPACE, deliberately: the workspace is what a request naming no
+ *  project gets, so a link into it carries no id and stays byte-identical to the one this app
+ *  built before projects existed (and to MulmoClaude's, which has only that root).
+ *
+ *  The inverse of `rootForProjectId`, and matched against the SAME list it resolves against —
+ *  by RESOLVED path, not by string equality. Hashing the caller's root directly would mint an
+ *  id that resolves to nothing: `cwdPresets` holds the path as the user saved it while the
+ *  collection engine hands back a `path.resolve`d form, so a trailing slash or a `.` segment
+ *  would be a different digest of the same directory.
+ *
+ *  Exported for the completion-bell adapter, whose deep link has to name a project the client
+ *  can then ask for. */
+export function projectIdForRoot(root: string): string | null {
+  if (workspace === null) return null;
+  const target = path.resolve(root);
+  if (path.resolve(workspace) === target) return null;
+  for (const project of knownProjects()) {
+    if (path.resolve(project.path) === target) return projectId(project.path);
+  }
+  return null;
+}
+
 /** The root an opaque id names, or null when it names none. Exported because the view-token
  *  middleware resolves the id carried IN a token, which never passes through a query string. */
 export function rootForProjectId(id: string): string | null {

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -5,7 +5,7 @@
 // inside a PluginFrame shadow root with the collection styles, exactly like the chat
 // card. Opened by the toolbar launcher / index cards / ref hops via the binding's nav
 // capabilities (collectionUi.ts).
-import { onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { CollectionsIndexView, CollectionView, FeedsView } from "@mulmoclaude/collection-plugin/vue";
 import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
@@ -16,6 +16,7 @@ import { pushCollectionSurface, popCollectionSurface, type CollectionSurface } f
 import {
   browseGotoIndex,
   browseNavigateToRecord,
+  browseRouteProjectId,
   browseRouteSlug,
   browseRouteSelectedId,
   browseIsFeedRoute,
@@ -73,11 +74,18 @@ onBeforeUnmount(unregister);
 // pane's project. Registering restores the invariant the stack is for — the innermost VISIBLE
 // surface owns scope and navigation.
 //
-// `projectId: null` is the workspace, which is what this overlay has always shown. Its nav
-// delegates to `useCollectionBrowse`, i.e. the router, which is what the binding fell through to
-// before surfaces existed.
+// The project comes from the ROUTE, and null — the workspace — is what every way of opening this
+// overlay still produces. Only one thing puts a project in that URL: a completion bell whose
+// record lives in one (server/backends/collectionNotifierAdapter.ts). A GETTER because the stack
+// is read imperatively at the moment a request is built, so the surface must answer for the page
+// on screen NOW rather than for the one it was pushed on.
+//
+// Its nav delegates to `useCollectionBrowse`, i.e. the router, which is what the binding fell
+// through to before surfaces existed.
 const overlaySurface: CollectionSurface = {
-  projectId: null,
+  get projectId() {
+    return browseRouteProjectId();
+  },
   // Full-screen: it covers the pane slot, so it outranks a canvas or Collections pane however
   // recently that mounted — a tool result can auto-reveal a canvas BEHIND this overlay.
   layer: "screen",
@@ -100,6 +108,9 @@ watch(
   { immediate: true },
 );
 onBeforeUnmount(() => popCollectionSurface(overlaySurface));
+
+// Remount key for the plugin views — see the template.
+const projectKey = computed(() => browseRouteProjectId() ?? "workspace");
 
 useEscapeToClose(isOpen, close);
 </script>
@@ -151,9 +162,13 @@ useEscapeToClose(isOpen, close);
                the collection list under the Feeds button — the plugin ships FeedsView for exactly
                this and nothing here was using it. Detail is shared: CollectionView asks the binding
                (`isFeedRoute`) which kind it is showing. -->
-          <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" />
-          <CollectionsIndexView v-else-if="view.mode === 'index'" />
-          <CollectionView v-else-if="view.mode === 'detail'" />
+          <!-- KEYED BY PROJECT. The views fetch on mount and follow the route's SLUG; switching
+               project changes only the query, so without this a bell for another project's
+               `tasks` while the workspace's `tasks` is open would re-scope the requests and
+               render none of them. -->
+          <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" :key="projectKey" />
+          <CollectionsIndexView v-else-if="view.mode === 'index'" :key="projectKey" />
+          <CollectionView v-else-if="view.mode === 'detail'" :key="projectKey" />
         </div>
       </PluginFrame>
     </div>

--- a/src/components/cellChromeBinding.ts
+++ b/src/components/cellChromeBinding.ts
@@ -21,7 +21,13 @@ export interface CellChromeProps {
   canvasAvailable: boolean;
 }
 
-export type CellChromeEvent = "toggle-expand" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "close";
+// EVERY event CellChromeButtons can raise, minus the ones a cell binds itself (`toggle-park`,
+// which only a session terminal has). A button whose event is missing HERE is dead: the cell
+// binds `v-on="chromeEvents"`, so an emit with no entry is dropped silently — the grid's own
+// handler waits for something nothing ever sends it. That is what happened to the collections
+// button, which shipped in #1573 and never once opened the pane. `cellChromeEventsAreComplete`
+// in the spec pins the two lists together so the next button cannot repeat it.
+export type CellChromeEvent = "toggle-expand" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "toggle-collections" | "close";
 
 // Bound as two objects rather than spelled out in each template.
 //
@@ -49,6 +55,7 @@ export function cellChromeBinding(
       "toggle-files": () => emit("toggle-files"),
       "toggle-canvas": () => emit("toggle-canvas"),
       "toggle-tools": () => emit("toggle-tools"),
+      "toggle-collections": () => emit("toggle-collections"),
       close,
     },
   };
@@ -68,6 +75,7 @@ export function cellShellEvents(emit: {
     "toggle-files": () => emit("toggle-files"),
     "toggle-canvas": () => emit("toggle-canvas"),
     "toggle-tools": () => emit("toggle-tools"),
+    "toggle-collections": () => emit("toggle-collections"),
     close: () => emit("close"),
     move: (dir: -1 | 1) => emit("move", dir),
   };

--- a/src/components/gridCell.ts
+++ b/src/components/gridCell.ts
@@ -45,7 +45,7 @@ export interface GridCellEmits {
   // `open-canvas` is the unread-canvas chip on an UN-expanded cell: enlarge me AND open the
   // pane, in one gesture. Distinct from `toggle-canvas`, which toggles the pane on the cell
   // that is already enlarged.
-  (e: "toggle-expand" | "close" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "open-canvas"): void;
+  (e: "toggle-expand" | "close" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "toggle-collections" | "open-canvas"): void;
   // Swap this cell left (-1) or right (+1) in manual sort mode.
   (e: "move", dir: -1 | 1): void;
   // Report activity up so the grid can attention-sort in auto mode.

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -290,7 +290,9 @@ configureCollectionUi({
   // `useNotifications()` is a module singleton and its init is idempotent, so calling
   // it per invocation costs nothing after the first (and keeps the pubsub subscription
   // out of this module's import).
-  notifiedSeverities: (slug: string) => collectionNotifiedSeverities(useNotifications().active.value, slug),
+  // Scoped to the SURFACE's project: the bell is app-wide and carries records from every
+  // watched root, so a pane showing one project must not accent from another's.
+  notifiedSeverities: (slug: string) => collectionNotifiedSeverities(useNotifications().active.value, slug, activeCollectionProjectId()),
 
   // ── runtime translation: POST /api/translation (hidden-chat LLM). Enables the
   //    new-collection starter modal's localized cards; omitted ⇒ English fallback. ──

--- a/src/composables/useCollectionBrowse.ts
+++ b/src/composables/useCollectionBrowse.ts
@@ -47,26 +47,50 @@ function pathFor(kind: ShortcutKind, slug?: string): string {
   return slug ? `${base}/${encodeURIComponent(slug)}` : base;
 }
 
+/** The project the open page is showing, or null for the workspace.
+ *
+ *  IT LIVES IN THE URL, unlike the open record: a project is not a modal, it is which
+ *  collections the page is listing, and a link that arrives without it lands on a different
+ *  collection of the same name. That is exactly what a completion bell from a project sends —
+ *  the deep link it carries is the only way this overlay is ever asked for a non-workspace
+ *  project (server/backends/collectionNotifierAdapter.ts). An OPAQUE ID, never a path. */
+export function browseRouteProjectId(): string | null {
+  const project = router.currentRoute.value.query.project;
+  return typeof project === "string" && project.length > 0 ? project : null;
+}
+
+/** The query a push should carry: the project asked for, else the one already open — so a ref
+ *  hop or an index click made INSIDE a project stays in it instead of silently falling back to
+ *  the workspace halfway through a browse. */
+function queryFor(projectId?: string | null): Record<string, string> {
+  const project = projectId === undefined ? browseRouteProjectId() : projectId;
+  return project ? { project } : {};
+}
+
 /** Open the index for a kind (collections / feeds). */
-export function browseGotoIndex(kind: ShortcutKind): void {
+export function browseGotoIndex(kind: ShortcutKind, projectId?: string | null): void {
   clearRecord();
-  void router.push({ path: pathFor(kind), state: overlayOriginState() });
+  void router.push({ path: pathFor(kind), query: queryFor(projectId), state: overlayOriginState() });
 }
 
 /** Open one collection / feed's detail page. */
-export function browseGotoDetail(kind: ShortcutKind, slug: string): void {
+export function browseGotoDetail(kind: ShortcutKind, slug: string, projectId?: string | null): void {
   clearRecord();
-  void router.push({ path: pathFor(kind, slug), state: overlayOriginState() });
+  void router.push({ path: pathFor(kind, slug), query: queryFor(projectId), state: overlayOriginState() });
 }
 
-/** A ref/embed hop into another collection, optionally deep-linking a record. */
-export function browseNavigateToRecord(targetSlug: string, recordId?: string): void {
+/** A ref/embed hop into another collection, optionally deep-linking a record.
+ *
+ *  `projectId` is passed by the ONE caller that knows a project other than the open one: a
+ *  completion bell, whose record may live in a project this page is not showing. A ref hop
+ *  passes nothing and stays where it is — a reference is resolved within its own root. */
+export function browseNavigateToRecord(targetSlug: string, recordId?: string, projectId?: string | null): void {
   // Ref hops are collection→collection. The sync path watcher clears the record
   // during the push, so (re)apply the record AFTER navigation settles on the target
   // path. Always assign — a hop to the CURRENT page (no path change → no watcher
   // fire) with no recordId must still close any stale modal, not reuse it.
   const targetPath = pathFor("collection", targetSlug);
-  void router.push({ path: targetPath, state: overlayOriginState() }).then(() => {
+  void router.push({ path: targetPath, query: queryFor(projectId), state: overlayOriginState() }).then(() => {
     state.recordPath = recordId ? targetPath : null;
     state.selectedId = recordId ?? null;
   });

--- a/src/composables/useCollectionBrowse.ts
+++ b/src/composables/useCollectionBrowse.ts
@@ -14,32 +14,50 @@ import { overlayOriginState, overlayReturnPath } from "./overlayOrigin";
 type BrowseView = { mode: "closed" } | { mode: "index"; kind: ShortcutKind } | { mode: "detail"; kind: ShortcutKind; slug: string; selectedId: string | null };
 
 // The only retained state: which record's modal is open, KEYED by the exact detail
-// PATH it belongs to (so /collections/foo and /feeds/foo never share a record, even
+// PAGE it belongs to (so /collections/foo and /feeds/foo never share a record, even
 // with overlapping slugs). Records are intentionally not addressable — opening one
 // never touches the URL.
-const state = reactive<{ recordPath: string | null; selectedId: string | null }>({ recordPath: null, selectedId: null });
+const state = reactive<{ pageKey: string | null; selectedId: string | null }>({ pageKey: null, selectedId: null });
+
+/** What "the same page" means for a record: the path AND the project.
+ *
+ *  THE PROJECT IS PART OF THE KEY, not decoration. Two projects' `/collections/tasks` are the
+ *  same path, so keying on the path alone lets a record modal survive a project change made by
+ *  browser Back/Forward or a hand-typed URL — the one navigation this module does not route
+ *  itself. With a `primaryKey` schema the ids are drawn from the data, so the surviving id
+ *  frequently EXISTS in the project navigated to, and the modal then shows a different record
+ *  of the same name rather than failing visibly.
+ *
+ *  A newline separates the two because a path cannot contain one, so no path-and-project pair
+ *  can spell another. */
+function pageKeyFor(path: string, projectId: string | null): string {
+  return `${path}\n${projectId ?? ""}`;
+}
+
+function currentPageKey(): string {
+  return pageKeyFor(router.currentRoute.value.path, browseRouteProjectId());
+}
 
 function clearRecord(): void {
-  state.recordPath = null;
+  state.pageKey = null;
   state.selectedId = null;
 }
 
 // Leaving a detail page — by ANY means: a toolbar push, browser Back/Forward, or a
 // hand-typed URL — drops the open record, honoring the "records are not history"
 // contract (a later return to the same URL must not revive a stale modal). A single
-// SYNC watcher on the path is the one place this happens, so individual nav callers
+// SYNC watcher on the page key is the one place this happens, so individual nav callers
 // (showChat / showGrid / showAccounting / …) don't each have to remember to clear.
 // flush:"sync" fires the clear during navigation, strictly before router.push's
 // promise resolves — so browseNavigateToRecord's post-push .then re-set always wins.
-watch(
-  () => router.currentRoute.value.path,
-  () => clearRecord(),
-  { flush: "sync" },
-);
+//
+// It watches the KEY rather than the path so a project switch that keeps the path counts as
+// leaving the page, which it is.
+watch(currentPageKey, () => clearRecord(), { flush: "sync" });
 
-// The open record for the page currently on screen (null once the path no longer matches).
+// The open record for the page currently on screen (null once the page no longer matches).
 function recordOnCurrentPage(): string | null {
-  return state.recordPath !== null && state.recordPath === router.currentRoute.value.path ? state.selectedId : null;
+  return state.pageKey !== null && state.pageKey === currentPageKey() ? state.selectedId : null;
 }
 
 function pathFor(kind: ShortcutKind, slug?: string): string {
@@ -91,7 +109,7 @@ export function browseNavigateToRecord(targetSlug: string, recordId?: string, pr
   // fire) with no recordId must still close any stale modal, not reuse it.
   const targetPath = pathFor("collection", targetSlug);
   void router.push({ path: targetPath, query: queryFor(projectId), state: overlayOriginState() }).then(() => {
-    state.recordPath = recordId ? targetPath : null;
+    state.pageKey = recordId ? currentPageKey() : null;
     state.selectedId = recordId ?? null;
   });
 }
@@ -115,7 +133,7 @@ export function browseIsFeedRoute(): boolean {
 
 /** Set/clear the open record (the modal deep-link) on the current page, no history. */
 export function browseSetSelectedId(itemId: string | null): void {
-  state.recordPath = itemId ? router.currentRoute.value.path : null;
+  state.pageKey = itemId ? currentPageKey() : null;
   state.selectedId = itemId;
 }
 

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -71,10 +71,14 @@ let changesDuringFetch: LiveChange<NotifierEntry>[] | null = null;
 // newest answer may be applied — an older one describes a moment already overtaken.
 let latestFetch = 0;
 
-/** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>`) into its
- *  parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
- *  patterns). Returns null for anything that isn't a collection target. */
-export function parseCollectionTarget(target: string | undefined): { slug: string; itemId?: string | undefined } | null {
+/** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>&project=<id>`) into
+ *  its parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
+ *  patterns). Returns null for anything that isn't a collection target.
+ *
+ *  `project` is the opaque project id the bell was published with, absent for the workspace
+ *  (and always absent on a link MulmoClaude wrote — it has one root). Without it the row would
+ *  open the same-named collection of whichever project is on screen. */
+export function parseCollectionTarget(target: string | undefined): { slug: string; itemId?: string | undefined; project?: string | undefined } | null {
   if (!target) return null;
   const prefix = "/collections/";
   if (!target.startsWith(prefix)) return null;
@@ -83,18 +87,22 @@ export function parseCollectionTarget(target: string | undefined): { slug: strin
   const rawSlug = queryAt === -1 ? rest : rest.slice(0, queryAt);
   if (!rawSlug) return null;
   let itemId: string | undefined;
+  let project: string | undefined;
   if (queryAt !== -1) {
     // URLSearchParams.get() returns an already-decoded value — decoding again would
     // throw "URI malformed" on a valid id containing a literal "%" (e.g. "100% done").
-    const selected = new URLSearchParams(rest.slice(queryAt + 1)).get("selected");
+    const query = new URLSearchParams(rest.slice(queryAt + 1));
+    const selected = query.get("selected");
     if (selected) itemId = selected;
+    const named = query.get("project");
+    if (named) project = named;
   }
   // The slug was string-sliced (not via URLSearchParams), so it is still encoded.
   // A malformed escape (e.g. "%E0%A4%A") makes decodeURIComponent throw; since this
   // runs from the row-click handler, treat a bad slug as non-actionable (return null)
   // rather than letting it crash activation.
   try {
-    return { slug: decodeURIComponent(rawSlug), itemId };
+    return { slug: decodeURIComponent(rawSlug), itemId, project };
   } catch {
     return null;
   }
@@ -210,7 +218,10 @@ export function useNotifications() {
   function activate(entry: NotifierEntry): boolean {
     const parsed = parseCollectionTarget(entry.navigateTarget);
     if (!parsed) return false;
-    browseNavigateToRecord(parsed.slug, parsed.itemId);
+    // The bell's OWN project, passed explicitly rather than left to the open page: a bell is
+    // app-wide and its record may live in a project the browser is not currently showing —
+    // `null` for a workspace bell, which must not inherit an open project either.
+    browseNavigateToRecord(parsed.slug, parsed.itemId, parsed.project ?? null);
     return true;
   }
 

--- a/src/utils/collectionNotified.ts
+++ b/src/utils/collectionNotified.ts
@@ -28,15 +28,24 @@ export interface NotifiedEntryLike {
   severity?: string | undefined;
 }
 
-/** itemId → worst active severity, for records of `slug`. Entries without a concrete
- *  `itemId` are skipped (a collection-level bell can't point at one card), and when a
- *  record has several bells the highest severity wins so the accent matches the most
- *  urgent one. */
-export function collectionNotifiedSeverities(entries: readonly NotifiedEntryLike[], slug: string): Map<string, NotifiedSeverity> {
+/** itemId → worst active severity, for records of `slug` IN `projectId`. Entries without a
+ *  concrete `itemId` are skipped (a collection-level bell can't point at one card), and when a
+ *  record has several bells the highest severity wins so the accent matches the most urgent one.
+ *
+ *  `projectId` is the project the view being accented is showing — `null`/omitted for the
+ *  workspace, which is also what a bell with no project on its target means. It is matched
+ *  rather than ignored because a slug is unique within a root only: two projects' `tasks` are
+ *  different collections, and with a `primaryKey` schema their record ids are not even unlikely
+ *  to coincide — they are drawn from the data (an ISBN, an email address), so a shared record
+ *  in two projects has the SAME id, and ignoring the project accents the wrong card reliably
+ *  rather than rarely. */
+export function collectionNotifiedSeverities(entries: readonly NotifiedEntryLike[], slug: string, projectId?: string | null): Map<string, NotifiedSeverity> {
   const out = new Map<string, NotifiedSeverity>();
+  const project = projectId ?? null;
   for (const entry of entries) {
     const target = collectionNotifyTargetOf(entry.pluginData);
     if (!target || target.slug !== slug || !target.itemId) continue;
+    if ((target.project ?? null) !== project) continue;
     const severity = asSeverity(entry.severity);
     const existing = out.get(target.itemId);
     if (!existing || SEVERITY_RANK[severity] > SEVERITY_RANK[existing]) out.set(target.itemId, severity);

--- a/test/server/backends/collectionNotifierAdapter.spec.ts
+++ b/test/server/backends/collectionNotifierAdapter.spec.ts
@@ -15,6 +15,18 @@ import {
 // deep-link builder — the three places a divergence would silently double a bell or
 // misroute a click.
 
+describe("buildPluginData carries the project", () => {
+  it("puts a named project on the navigate target", () => {
+    const data = buildPluginData({ legacyId: "x", slug: "tasks", itemId: "i", priority: "normal", project: "p1" });
+    expect(data.action.target).toEqual({ view: "collections", slug: "tasks", itemId: "i", project: "p1" });
+  });
+
+  it("OMITS the key for the workspace — the shape MulmoClaude writes and reads", () => {
+    const data = buildPluginData({ legacyId: "x", slug: "tasks", itemId: "i", priority: "normal" });
+    expect(Object.hasOwn(data.action.target, "project")).toBe(false);
+  });
+});
+
 describe("buildPluginData -> readEntry round-trip", () => {
   it("preserves a high priority", () => {
     const data = buildPluginData({ legacyId: "todo:a/b", slug: "a", itemId: "b", priority: "high" });
@@ -87,6 +99,16 @@ describe("buildNavigateTarget", () => {
 
   it("percent-encodes reserved characters in slug and itemId", () => {
     expect(buildNavigateTarget("a b/c", "x?y&z")).toBe("/collections/a%20b%2Fc?selected=x%3Fy%26z");
+  });
+
+  it("names the project after the record, so two roots' same-named collections deep-link apart", () => {
+    expect(buildNavigateTarget("tasks", "abc", "p1")).toBe("/collections/tasks?selected=abc&project=p1");
+    expect(buildNavigateTarget("tasks", "", "p1")).toBe("/collections/tasks?project=p1");
+  });
+
+  it("is byte-identical to the pre-project link when no project is named (the workspace)", () => {
+    expect(buildNavigateTarget("tasks", "abc", undefined)).toBe("/collections/tasks?selected=abc");
+    expect(buildNavigateTarget("tasks", "abc", "")).toBe("/collections/tasks?selected=abc");
   });
 });
 

--- a/test/server/backends/collectionWatchers.spec.ts
+++ b/test/server/backends/collectionWatchers.spec.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The package is mocked: this spec is about WHICH roots the host mounts a generation for and
+// how it recovers, not about the watcher itself (that is core's own suite). `vi.mock` is
+// hoisted, so the module under test can be imported at the top like any other.
+vi.mock("@mulmoclaude/core/collection-watchers", () => ({
+  configureCollectionWatchers: vi.fn(),
+  startCollectionWatchers: vi.fn(async () => {}),
+  stopCollectionWatchers: vi.fn(async () => {}),
+}));
+
+import { configureCollectionWatchers, startCollectionWatchers, stopCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
+import {
+  startCollectionCompletionWatchers,
+  stopCollectionCompletionWatchers,
+  syncCollectionWatcherRoots,
+  watchedCollectionRootsForTesting,
+} from "../../../server/backends/collectionWatchers.js";
+import { initProjectRoots, resetProjectRootsForTesting } from "../../../server/infra/project-root.js";
+
+const WORKSPACE = "/srv/ws";
+let projects: Array<{ label: string; path: string }> = [];
+
+const startedRoots = (): string[] => vi.mocked(startCollectionWatchers).mock.calls.map((call) => String(call[0]?.discoveryOpts?.workspaceRoot ?? ""));
+
+beforeEach(() => {
+  vi.mocked(configureCollectionWatchers).mockClear();
+  vi.mocked(startCollectionWatchers).mockReset().mockResolvedValue(undefined);
+  vi.mocked(stopCollectionWatchers).mockReset().mockResolvedValue(undefined);
+  projects = [];
+  initProjectRoots({ workspace: WORKSPACE, knownProjects: () => projects });
+});
+
+afterEach(async () => {
+  await stopCollectionCompletionWatchers();
+  resetProjectRootsForTesting();
+});
+
+describe("startCollectionCompletionWatchers", () => {
+  it("mounts one generation per known project, workspace included, each with its root", async () => {
+    projects = [
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ];
+    await startCollectionCompletionWatchers();
+    expect(configureCollectionWatchers).toHaveBeenCalledTimes(1);
+    expect(startedRoots().sort()).toEqual(["/srv/mag2", "/srv/site", WORKSPACE]);
+  });
+
+  it("passes an EXPLICIT root on every start — the engine host would otherwise throw", async () => {
+    await startCollectionCompletionWatchers();
+    for (const call of vi.mocked(startCollectionWatchers).mock.calls) {
+      expect(call[0]?.discoveryOpts?.workspaceRoot).toBeTruthy();
+    }
+  });
+});
+
+describe("syncCollectionWatcherRoots", () => {
+  it("mounts a project recorded after boot, without restarting the ones already running", async () => {
+    await startCollectionCompletionWatchers();
+    expect(startedRoots()).toEqual([WORKSPACE]);
+
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    await syncCollectionWatcherRoots();
+    expect(startedRoots()).toEqual([WORKSPACE, "/srv/mag2"]);
+  });
+
+  it("releases exactly the root that left the list, by name", async () => {
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    await startCollectionCompletionWatchers();
+
+    projects = [];
+    await syncCollectionWatcherRoots();
+    // Scoped, not the bare form: a bare stop would take the workspace's generation down too.
+    expect(stopCollectionWatchers).toHaveBeenCalledWith({ workspaceRoot: "/srv/mag2" });
+    expect(watchedCollectionRootsForTesting()).toEqual([WORKSPACE]);
+  });
+
+  it("treats two spellings of one directory as one root", async () => {
+    projects = [{ label: "mag2", path: "/srv/mag2/" }];
+    await startCollectionCompletionWatchers();
+    projects = [{ label: "mag2", path: "/srv/mag2/./" }];
+    await syncCollectionWatcherRoots();
+    expect(startedRoots()).toEqual([WORKSPACE, "/srv/mag2"]);
+  });
+
+  it("keeps the other roots when one fails, and retries it on the next pass", async () => {
+    projects = [
+      { label: "gone", path: "/srv/gone" },
+      { label: "mag2", path: "/srv/mag2" },
+    ];
+    vi.mocked(startCollectionWatchers).mockImplementation(async (opts) => {
+      if (opts?.discoveryOpts?.workspaceRoot === "/srv/gone") throw new Error("ENOENT");
+    });
+    await startCollectionCompletionWatchers();
+    // The failure did not stop the loop: the roots after it are watched.
+    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", WORKSPACE]);
+
+    vi.mocked(startCollectionWatchers).mockResolvedValue(undefined);
+    await syncCollectionWatcherRoots();
+    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/gone", "/srv/mag2", WORKSPACE]);
+  });
+
+  it("does not re-mount a root that is already running", async () => {
+    await startCollectionCompletionWatchers();
+    await syncCollectionWatcherRoots();
+    await syncCollectionWatcherRoots();
+    expect(startedRoots()).toEqual([WORKSPACE]);
+  });
+
+  it("serialises overlapping passes rather than dropping the later one", async () => {
+    await startCollectionCompletionWatchers();
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    const first = syncCollectionWatcherRoots();
+    projects = [
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ];
+    const second = syncCollectionWatcherRoots();
+    await Promise.all([first, second]);
+    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", "/srv/site", WORKSPACE]);
+  });
+});

--- a/test/server/backends/collectionWatchers.spec.ts
+++ b/test/server/backends/collectionWatchers.spec.ts
@@ -167,5 +167,7 @@ describe("syncCollectionWatcherRoots", () => {
     projects = [{ label: "mag2", path: "/srv/mag2" }];
     await syncCollectionWatcherRoots();
     expect(vi.mocked(startCollectionWatchers).mock.calls.length).toBe(startsAfterBoot);
+    // The teardown stops everything through the same mock, so leave it able to succeed.
+    vi.mocked(stopCollectionWatchers).mockResolvedValue(undefined);
   });
 });

--- a/test/server/backends/collectionWatchers.spec.ts
+++ b/test/server/backends/collectionWatchers.spec.ts
@@ -166,7 +166,7 @@ describe("syncCollectionWatcherRoots", () => {
     // starting it again would be mounting a second one over a live tree.
     projects = [{ label: "mag2", path: "/srv/mag2" }];
     await syncCollectionWatcherRoots();
-    expect(vi.mocked(startCollectionWatchers).mock.calls.length).toBe(startsAfterBoot);
+    expect(vi.mocked(startCollectionWatchers).mock.calls).toHaveLength(startsAfterBoot);
     // The teardown stops everything through the same mock, so leave it able to succeed.
     vi.mocked(stopCollectionWatchers).mockResolvedValue(undefined);
   });

--- a/test/server/backends/collectionWatchers.spec.ts
+++ b/test/server/backends/collectionWatchers.spec.ts
@@ -111,14 +111,61 @@ describe("syncCollectionWatcherRoots", () => {
 
   it("serialises overlapping passes rather than dropping the later one", async () => {
     await startCollectionCompletionWatchers();
+    // The first pass is held INSIDE its start, so it has provably already read the project list
+    // before the second pass is queued. Without the gate both passes read the list after it was
+    // widened, and an implementation that simply DROPPED the second pass would pass this test.
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const inFlight = new Promise<void>((resolve) => (entered = resolve));
+    vi.mocked(startCollectionWatchers).mockImplementationOnce(async () => {
+      entered();
+      await gate;
+    });
+
     projects = [{ label: "mag2", path: "/srv/mag2" }];
     const first = syncCollectionWatcherRoots();
+    await inFlight;
+
     projects = [
       { label: "mag2", path: "/srv/mag2" },
       { label: "site", path: "/srv/site" },
     ];
     const second = syncCollectionWatcherRoots();
+    release();
     await Promise.all([first, second]);
     expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", "/srv/site", WORKSPACE]);
+  });
+
+  // The package deletes its generation on the LAST line of its stop, so a throw can leave one
+  // alive. Forgetting the root here would forget the only handle a later pass could retry with,
+  // and the project would keep watching files and publishing bells forever.
+  it("keeps a root tracked when its stop fails, and retries the stop next pass", async () => {
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    await startCollectionCompletionWatchers();
+
+    vi.mocked(stopCollectionWatchers).mockRejectedValueOnce(new Error("EBUSY"));
+    projects = [];
+    await syncCollectionWatcherRoots();
+    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", WORKSPACE]);
+
+    await syncCollectionWatcherRoots();
+    expect(vi.mocked(stopCollectionWatchers)).toHaveBeenCalledTimes(2);
+    expect(watchedCollectionRootsForTesting()).toEqual([WORKSPACE]);
+  });
+
+  it("does not re-mount a root whose stop failed — it is still watching", async () => {
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    await startCollectionCompletionWatchers();
+    const startsAfterBoot = vi.mocked(startCollectionWatchers).mock.calls.length;
+
+    vi.mocked(stopCollectionWatchers).mockRejectedValue(new Error("EBUSY"));
+    projects = [];
+    await syncCollectionWatcherRoots();
+    // Back on the list before the stop ever succeeded: the generation never went away, so
+    // starting it again would be mounting a second one over a live tree.
+    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    await syncCollectionWatcherRoots();
+    expect(vi.mocked(startCollectionWatchers).mock.calls.length).toBe(startsAfterBoot);
   });
 });

--- a/test/server/infra/projectRoot.spec.ts
+++ b/test/server/infra/projectRoot.spec.ts
@@ -17,6 +17,7 @@ import {
   initProjectRoots,
   listProjectRoots,
   projectId,
+  projectIdForRoot,
   projectRootsConfigured,
   resolveProjectRoot,
   resetProjectRootsForTesting,
@@ -35,6 +36,33 @@ describe("project roots", () => {
   beforeEach(() => {
     resetProjectRootsForTesting();
     ws = makeTempDir("mt-project-root-");
+  });
+
+  it("resolves a root back to the id the client can ask for", () => {
+    const proj = path.join(ws, "mag2");
+    initProjectRoots({ workspace: ws, knownProjects: () => [{ label: "mag2", path: proj }] });
+    const id = projectIdForRoot(proj);
+    expect(id).toBe(projectId(proj));
+    // The whole point of building it this way: the id resolves back through the route's own path.
+    expect(resolveProjectRoot(requestWith({ project: id })).workspaceRoot).toBe(proj);
+  });
+
+  it("answers null for the workspace — the root a request naming no project already gets", () => {
+    initProjectRoots({ workspace: ws });
+    expect(projectIdForRoot(ws)).toBeNull();
+  });
+
+  it("matches a root by RESOLVED path, so a differently spelled one still gets its id", () => {
+    const proj = path.join(ws, "mag2");
+    initProjectRoots({ workspace: ws, knownProjects: () => [{ label: "mag2", path: proj }] });
+    expect(projectIdForRoot(path.join(proj, "."))).toBe(projectId(proj));
+    expect(projectIdForRoot(`${proj}/`)).toBe(projectId(proj));
+  });
+
+  it("answers null for a directory the server does not serve, and before it is configured", () => {
+    expect(projectIdForRoot(ws)).toBeNull();
+    initProjectRoots({ workspace: ws });
+    expect(projectIdForRoot(path.join(ws, "elsewhere"))).toBeNull();
   });
 
   it("is unconfigured until a workspace is bound", () => {

--- a/test/src/components/CommandCell.spec.ts
+++ b/test/src/components/CommandCell.spec.ts
@@ -75,16 +75,19 @@ describe("CommandCell", () => {
   // rather than five hand-written `@` lines. A key that binding gets wrong is a button that
   // silently does nothing, and canvas/tools had no cell-level coverage at all — so all five are
   // asserted, not just the two that already were.
-  it("forwards every chrome event, including the canvas and tools toggles", async () => {
+  it("forwards every chrome event, including the canvas, tools and collections toggles", async () => {
     const w = mount(CommandCell, { props: { expanded: true, filesOpen: false, canvasAvailable: true, command: COMMAND, home: "/work" } });
     await w.find('[aria-label="Show files"]').trigger("click");
     await w.find('[aria-label="Show canvas"]').trigger("click");
     await w.find('[aria-label="Show tools"]').trigger("click");
+    await w.find('[aria-label="Show this folder\'s collections"]').trigger("click");
     await w.find('[aria-label="Restore terminal"]').trigger("click");
     await w.find('[aria-label="Close terminal"]').trigger("click");
     expect(w.emitted("toggle-files")).toHaveLength(1);
     expect(w.emitted("toggle-canvas")).toHaveLength(1);
     expect(w.emitted("toggle-tools")).toHaveLength(1);
+    // The one this list was missing while the button was dead — see cellChromeForwarding.spec.
+    expect(w.emitted("toggle-collections")).toHaveLength(1);
     expect(w.emitted("toggle-expand")).toHaveLength(1);
     expect(w.emitted("close")).toHaveLength(1);
   });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1961,6 +1961,18 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-actions .cell-close").exists()).toBe(true);
   });
 
+  // The whole chain, on the cell the user actually presses it on: button -> CellChromeButtons'
+  // emit -> the cell's chromeEvents object -> the cell's own emit -> the grid, which opens the
+  // pane. It was broken at the third step from #1573 until the button was first tried by hand:
+  // `chromeEvents` had no `toggle-collections` key, so the emit was dropped inside the cell and
+  // nothing reached the grid. See cellChromeForwarding.spec for why the list is derived now.
+  it("forwards the collections toggle out of an enlarged cell, so the grid can open the pane", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
+    await flushPromises();
+    await w.find(`[aria-label="Show this folder's collections"]`).trigger("click");
+    expect(w.emitted("toggle-collections")).toHaveLength(1);
+  });
+
   it("shows the restore label + icon when the cell is expanded", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
     await flushPromises();

--- a/test/src/components/cellChromeForwarding.spec.ts
+++ b/test/src/components/cellChromeForwarding.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import CellChromeButtons from "../../../src/components/CellChromeButtons.vue";
+import { cellChromeBinding, cellShellEvents, type CellChromeEvent } from "../../../src/components/cellChromeBinding";
+
+// A cell binds the chrome buttons with ONE object (`v-on="chromeEvents"`), so an event the
+// buttons can raise but that object has no key for is dropped where nothing can see it: the
+// button clicks, the grid's handler waits for something that never arrives, and typecheck is
+// happy because an unlistened emit is legal Vue.
+//
+// That is not hypothetical. The collections button shipped in #1573 emitting `toggle-collections`
+// while `cellChromeBinding` mapped four events and `GridCellEmits` declared five — so "Show this
+// folder's collections" never once opened the pane, through a green suite that included a
+// "forwards every chrome event" test whose list was TYPED BY HAND from the same wrong set.
+//
+// Hence: the expectation is DERIVED from the component's own declared emits. A new button is
+// covered the day it is added, and a hand-maintained list cannot agree with itself into a
+// second silent dead button.
+const declaredEmits = (CellChromeButtons as unknown as { emits?: string[] }).emits ?? [];
+
+// Events a CELL binds itself rather than through the shared object, with the reason. `toggle-park`
+// exists only on a session terminal (the command and launcher cells never render the button), so
+// TerminalCell wires it explicitly beside `v-on="chromeEvents"`.
+const SELF_BOUND = new Set(["toggle-park"]);
+
+const forwarded = (keys: string[]): Set<string> => new Set([...keys, ...SELF_BOUND]);
+
+describe("cellChromeBinding forwards every event the chrome buttons can raise", () => {
+  it("declares emits at runtime, so this spec is comparing against something real", () => {
+    // Guards the derivation itself: if the SFC compiler stopped emitting the array, every
+    // assertion below would pass vacuously against an empty list.
+    expect(declaredEmits).toContain("toggle-collections");
+    expect(declaredEmits.length).toBeGreaterThan(5);
+  });
+
+  it("maps each one in chromeEvents — the binding TerminalCell and CellShell use", () => {
+    const { chromeEvents } = cellChromeBinding({ expanded: true }, () => {});
+    expect(forwarded(Object.keys(chromeEvents))).toEqual(new Set(declaredEmits));
+  });
+
+  it("maps each one in cellShellEvents — the binding the command and launcher cells use", () => {
+    const events = cellShellEvents(() => {});
+    // `move` is the shell's own, not a chrome button's, so it is the one extra key here.
+    expect(forwarded(Object.keys(events).filter((key) => key !== "move"))).toEqual(new Set(declaredEmits));
+  });
+
+  it("re-emits each event under its OWN name rather than a near-miss", () => {
+    const emit = vi.fn();
+    const { chromeEvents } = cellChromeBinding({ expanded: true }, emit);
+    for (const [name, handler] of Object.entries(chromeEvents)) {
+      emit.mockClear();
+      handler();
+      expect(emit).toHaveBeenCalledWith(name as CellChromeEvent);
+    }
+  });
+
+  it("still routes close through the caller's own handler", () => {
+    const emit = vi.fn();
+    const close = vi.fn();
+    cellChromeBinding({ expanded: true }, emit, close).chromeEvents.close();
+    expect(close).toHaveBeenCalledTimes(1);
+    // TerminalCell's close confirms before tearing a live session down — it must not ALSO emit.
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/test/src/composables/useCollectionBrowse.spec.ts
+++ b/test/src/composables/useCollectionBrowse.spec.ts
@@ -11,6 +11,7 @@ import {
   browseRouteSlug,
   browseRouteSelectedId,
   browseIsFeedRoute,
+  browseRouteProjectId,
   browseClose,
 } from "../../../src/composables/useCollectionBrowse";
 
@@ -156,5 +157,51 @@ describe("useCollectionBrowse over the router", () => {
     await flushPromises();
     expect(browseRouteSelectedId()).toBeUndefined();
     expect(useCollectionBrowse().view.value).toMatchObject({ slug: "foo", selectedId: null });
+  });
+});
+
+// The project lives in the URL because it decides WHICH collections the page is listing —
+// unlike the open record, which is a modal and deliberately not addressable. A completion bell
+// from a project is the only thing that puts one there today.
+describe("the project a browse page is scoped to", () => {
+  it("is null on every ordinary open", async () => {
+    browseGotoIndex("collection");
+    await flushPromises();
+    expect(browseRouteProjectId()).toBeNull();
+  });
+
+  it("rides in the query when a bell names one, and comes back out", async () => {
+    browseNavigateToRecord("tasks", "t1", "p1");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/collections/tasks");
+    expect(router.currentRoute.value.query.project).toBe("p1");
+    expect(browseRouteProjectId()).toBe("p1");
+    expect(browseRouteSelectedId()).toBe("t1");
+  });
+
+  it("is CARRIED by a nav made inside a project — a ref hop must not fall back to the workspace", async () => {
+    browseNavigateToRecord("tasks", "t1", "p1");
+    await flushPromises();
+    browseNavigateToRecord("people");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/collections/people");
+    expect(browseRouteProjectId()).toBe("p1");
+
+    browseGotoDetail("collection", "notes");
+    await flushPromises();
+    expect(browseRouteProjectId()).toBe("p1");
+
+    browseGotoIndex("collection");
+    await flushPromises();
+    expect(browseRouteProjectId()).toBe("p1");
+  });
+
+  it("is DROPPED when a workspace bell names null explicitly, rather than inheriting the open one", async () => {
+    browseNavigateToRecord("tasks", "t1", "p1");
+    await flushPromises();
+    browseNavigateToRecord("tasks", "t2", null);
+    await flushPromises();
+    expect(browseRouteProjectId()).toBeNull();
+    expect(browseRouteSelectedId()).toBe("t2");
   });
 });

--- a/test/src/composables/useCollectionBrowse.spec.ts
+++ b/test/src/composables/useCollectionBrowse.spec.ts
@@ -196,6 +196,44 @@ describe("the project a browse page is scoped to", () => {
     expect(browseRouteProjectId()).toBe("p1");
   });
 
+  // The record modal is keyed by the PAGE, and two projects' /collections/tasks are one path.
+  // Browser Back and a hand-typed URL are the navigations this module does not route itself, so
+  // they are the ones that reach a project change with the path unmoved — and with a primaryKey
+  // schema the surviving id often EXISTS in the project landed on, so the modal shows a
+  // different record of the same name instead of failing visibly.
+  it("drops the open record when only the project changes (Back / a hand-typed URL)", async () => {
+    browseNavigateToRecord("tasks", "t1", "p1");
+    await flushPromises();
+    expect(browseRouteSelectedId()).toBe("t1");
+
+    // Same path, project gone — what Back onto the workspace page looks like to the router.
+    await router.push({ path: "/collections/tasks" });
+    await flushPromises();
+    expect(browseRouteProjectId()).toBeNull();
+    expect(browseRouteSelectedId()).toBeUndefined();
+  });
+
+  it("drops it in the other direction too — workspace record, then a project URL", async () => {
+    browseNavigateToRecord("tasks", "t1");
+    await flushPromises();
+    expect(browseRouteSelectedId()).toBe("t1");
+
+    await router.push({ path: "/collections/tasks", query: { project: "p1" } });
+    await flushPromises();
+    expect(browseRouteSelectedId()).toBeUndefined();
+  });
+
+  it("does not revive a record when the same project page is returned to", async () => {
+    browseNavigateToRecord("tasks", "t1", "p1");
+    await flushPromises();
+    await router.push({ path: "/collections/people", query: { project: "p1" } });
+    await flushPromises();
+    await router.push({ path: "/collections/tasks", query: { project: "p1" } });
+    await flushPromises();
+    // Records are not history: coming back to the exact same page must not restore the modal.
+    expect(browseRouteSelectedId()).toBeUndefined();
+  });
+
   it("is DROPPED when a workspace bell names null explicitly, rather than inheriting the open one", async () => {
     browseNavigateToRecord("tasks", "t1", "p1");
     await flushPromises();

--- a/test/src/composables/useNotifications.spec.ts
+++ b/test/src/composables/useNotifications.spec.ts
@@ -25,6 +25,15 @@ describe("parseCollectionTarget", () => {
     expect(parseCollectionTarget("/collections/todo?selected=item-1")).toEqual({ slug: "todo", itemId: "item-1" });
   });
 
+  it("parses the project the bell was published with", () => {
+    expect(parseCollectionTarget("/collections/todo?selected=item-1&project=p1")).toEqual({ slug: "todo", itemId: "item-1", project: "p1" });
+    expect(parseCollectionTarget("/collections/todo?project=p1")).toEqual({ slug: "todo", itemId: undefined, project: "p1" });
+  });
+
+  it("leaves the project undefined on a workspace link (and on one MulmoClaude wrote)", () => {
+    expect(parseCollectionTarget("/collections/todo?selected=item-1")?.project).toBeUndefined();
+  });
+
   it("parses a bare slug with no record", () => {
     expect(parseCollectionTarget("/collections/todo")).toEqual({ slug: "todo", itemId: undefined });
   });

--- a/test/src/utils/collectionNotified.spec.ts
+++ b/test/src/utils/collectionNotified.spec.ts
@@ -59,3 +59,31 @@ describe("collectionNotifiedSeverities", () => {
     expect(collectionNotifiedSeverities([published], "tasks").get("t1")).toBe("urgent");
   });
 });
+
+// A bell is app-wide and now carries records from every watched root. The project on its
+// target is what keeps a project's bell off the workspace's identically-named card — and with
+// a `primaryKey` schema the ids are drawn from the data, so the same record in two projects has
+// the SAME id and an unscoped reader accents the wrong card reliably, not rarely.
+describe("collectionNotifiedSeverities scopes by project", () => {
+  const inProject = (project: string | undefined, itemId: string): NotifiedEntryLike => ({
+    severity: "urgent",
+    pluginData: buildPluginData({ legacyId: `todo:tasks/${itemId}`, slug: "tasks", itemId, priority: "high", project }),
+  });
+
+  it("accents only the project's own records", () => {
+    const entries = [inProject("p1", "shared"), inProject("p2", "other")];
+    expect([...collectionNotifiedSeverities(entries, "tasks", "p1")]).toEqual([["shared", "urgent"]]);
+    expect([...collectionNotifiedSeverities(entries, "tasks", "p2")]).toEqual([["other", "urgent"]]);
+  });
+
+  it("treats an absent project on the target as the workspace, matched by null or omission", () => {
+    const workspaceBell = [inProject(undefined, "t1")];
+    expect(collectionNotifiedSeverities(workspaceBell, "tasks", null).get("t1")).toBe("urgent");
+    expect(collectionNotifiedSeverities(workspaceBell, "tasks").get("t1")).toBe("urgent");
+    expect(collectionNotifiedSeverities(workspaceBell, "tasks", "p1").size).toBe(0);
+  });
+
+  it("keeps a project's bell off the workspace view of the same slug and id", () => {
+    expect(collectionNotifiedSeverities([inProject("p1", "t1")], "tasks", null).size).toBe(0);
+  });
+});


### PR DESCRIPTION
Picks up `plans/HANDOFF-collections-projects.md` §3.1 and §3.2, and fixes a bug the first hand-press of the feature found.

## 1. Per-root watchers (§3.1)

The completion watcher mounted ONE generation, for the workspace, so a collection in a project folder got **no completion bells and no live refresh** when an agent wrote a record directly — which is the canonical authoring path. The collection created in `~/git/ai/mag2` declares `completionField`, i.e. it asks for a feature that could not fire.

core 3.1.0 already supports this (a generation per root, concurrently; `WATCHER_ROOT_CONFLICT` is no longer thrown; `stopCollectionWatchers({ workspaceRoot })` releases exactly one). This wires it: one generation per root the server serves — the workspace plus every saved `cwdPresets` directory.

- **"Open" means "served by this server", not "on screen".** A completion bell is the notification that the user is *not* looking, so scoping the watchers to the visible Collections pane would let a bell ring only while its collection is already up. Bounded by discovery: a root with no collections mounts no watcher.
- Reconciled by a **60s poll**, because `listProjectRoots` reads a live thunk over `cwdPresets` and nothing emits when it changes. `syncCollectionWatcherRoots` is exported so a caller that knows it changed can pull the pass forward.
- A root that fails does not stop the roots after it, warns **once**, carries its error `code`, and retries next pass.

## 2. A bell opens the project it came from (§3.2)

`buildNavigateTarget` produced `/collections/<slug>` with no project, so a bell from a project's `tasks` opened the workspace's `tasks` — same row, same title, wrong records. The bell now carries its project as the **opaque id**, in the URL and on `action.target.project`.

- Root→id resolution lives in `collectionWatchers.ts`, **not** the adapter: a `test/src` spec imports the adapter, and reaching `node:crypto` through it puts Node's globals into a DOM-typed project, where `window.setTimeout` stops returning a number and an unrelated component fails to typecheck.
- **Cross-app parity holds where it is observable**: the id is omitted for the workspace, so the only link MulmoClaude can produce or receive is byte-for-byte what it was. Concatenated rather than built with `URLSearchParams`, which writes a space as `+` where MulmoClaude's builder writes `%20`.
- Client: the project rides in the route query, browse pushes carry the open project (a ref hop stays in its project) while a bell passes its own explicitly, the overlay's surface reads it through a getter, and the plugin views are keyed on it so a same-path project switch refetches.
- `collectionNotifiedSeverities` matches project too — with a `primaryKey` schema the record id is drawn from the data, so the same record in two projects has the **same** id and an unscoped reader accents the wrong card reliably, not rarely.

## 3. The "Show this folder's collections" button never worked

Reported from the running app. It has done nothing since it shipped in #1573.

`CellChromeButtons` emits `toggle-collections`, but `cellChromeBinding`'s `chromeEvents` — the single object every cell binds with `v-on` — had no key for it, and `GridCellEmits` did not declare it. The emit was dropped inside the cell; `TerminalGrid`'s handler waited for something nothing ever sent.

Two things let it survive a green suite: an unlistened Vue emit is legal, so `typecheck` was clean; and the existing "forwards every chrome event" test listed the events **by hand** from the same wrong set of four, so it agreed with the bug. The replacement derives the expectation from `CellChromeButtons`' own runtime `emits`, so the next button is covered the day it is added.

## Verification

- `yarn format / lint / typecheck / build / test` — 9481 passing, 0 lint errors.
- Removing the button fix fails the three new tests (checked, not assumed).
- Server side confirmed against the running instance: `/api/collection-projects` lists mag2, and `/api/collections/list?project=<id>` returns its `newsletters` collection.
- **Not verified in a browser.** The pane's height, the plugin views inside the shadow root and the nav containment are exactly what the suite does not see — which is how §3 got here in the first place. `plans/HANDOFF-collections-projects.md` §3.7 now says so with this as the example.

## Left for later

Nothing calls `syncCollectionWatcherRoots` at the moment a directory is recorded, so a first-time project waits up to a minute for its watcher; the config writers are several and the poll covers them all. And MT publishes *rooted* bell ids while MulmoClaude publishes root-less ones for the same workspace — core's sweep handles that asymmetrically, so alternating between the apps can strand a bell MulmoClaude will `skip` rather than clear. Pre-existing since #1571, by upstream design, and recorded in the handoff to confirm with MulmoClaude rather than "fix" here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection monitoring now supports multiple project roots concurrently, with automatic synchronization and isolated recovery.
  * Collection links and notifications preserve project context, including encoded deep links and project-specific navigation.
  * Collection browsing and plugin views update correctly when switching projects.
  * Added support for toggling Collections from cell controls.
* **Bug Fixes**
  * Notification severity indicators are now scoped to the active project, preventing cross-project highlights.
* **Documentation**
  * Updated project-root watcher and notification handoff documentation.
* **Tests**
  * Expanded coverage for project navigation, watcher reconciliation, notification links, and Collections toggle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->