### PR TITLE
fix: catch scheduled tasks up after the server was off (#1581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,8 +693,9 @@ work. It reads and reconciles progress against `vision.md` / `milestones.md` (cr
 empty ones if absent) so a long-running goal isn't forgotten.
 
 A run due while the server was **off** is not lost: built-in scheduled tasks record their
-runs in `config/scheduler/state.json` and **catch up at startup** — one run covering
-everything since the last, so several missed windows don't become several batches. Whether
+runs in `config/scheduler/state.json` and **catch up at startup**, each by its own missed-run
+policy. The worklog's is `run-once` — a single run covering everything since the last, so
+several missed windows don't become several batches summarising the same period. Whether
 they ran, and when they run next, is in `GET /api/scheduler/tasks`; the history is in
 `GET /api/scheduler/logs` (`?taskId=&since=&limit=`, newest first) and on disk under
 `data/scheduler/logs/`.

--- a/README.md
+++ b/README.md
@@ -692,6 +692,13 @@ and not built*. The window is **since the last run** (tracked in
 work. It reads and reconciles progress against `vision.md` / `milestones.md` (creating
 empty ones if absent) so a long-running goal isn't forgotten.
 
+A run due while the server was **off** is not lost: built-in scheduled tasks record their
+runs in `config/scheduler/state.json` and **catch up at startup** — one run covering
+everything since the last, so several missed windows don't become several batches. Whether
+they ran, and when they run next, is in `GET /api/scheduler/tasks`; the history is in
+`GET /api/scheduler/logs` (`?taskId=&since=&limit=`, newest first) and on disk under
+`data/scheduler/logs/`.
+
 Output lands in the wiki: one **weekly page** per ISO week
 (`data/wiki/pages/dev-log-YYYY-www.md` — filenames are lowercase, or the wiki can't open
 them), each tagged `worklog`. To browse them, open the **作業ログ 一覧** hub page

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -113,8 +113,8 @@ until there's a concrete need.
 scheduled tasks.
 
 **What MulmoTerminal has:** the engine, plus the same persistence adapter since
-#1581 — system tasks catch up at startup for windows missed while the server was
-off, every run is recorded, and the read-only routes (`GET /api/scheduler/tasks`
+issue #1581 — system tasks catch up at startup for windows missed while the server
+was off, every run is recorded, and the read-only routes (`GET /api/scheduler/tasks`
 with each task's state, `GET /api/scheduler/logs`) mirror MulmoClaude's shapes.
 What is missing is the write half: creating or changing a task means editing
 `config/scheduler/tasks.json` by hand (or asking the agent to edit it, which

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -112,11 +112,13 @@ until there's a concrete need.
 **What MulmoClaude has:** routes and a panel to create / edit / delete
 scheduled tasks.
 
-**What MulmoTerminal has:** the engine only. Tasks in
-`config/scheduler/tasks.json` load at boot and fire correctly, but the sole
-route is a read-only `GET /api/scheduler/tasks` — creating or changing a task
-means editing the JSON by hand (or asking the agent to edit it, which works
-fine and is the current de-facto CRUD).
+**What MulmoTerminal has:** the engine, plus the same persistence adapter since
+#1581 — system tasks catch up at startup for windows missed while the server was
+off, every run is recorded, and the read-only routes (`GET /api/scheduler/tasks`
+with each task's state, `GET /api/scheduler/logs`) mirror MulmoClaude's shapes.
+What is missing is the write half: creating or changing a task means editing
+`config/scheduler/tasks.json` by hand (or asking the agent to edit it, which
+works fine and is the current de-facto CRUD), and there is no tasks view.
 
 **Picking it up means:** write routes over the same validated
 `buildUserTaskDefinitions` path, plus a small tasks view. Pure convenience on

--- a/plans/fix-1581-scheduler-catchup.md
+++ b/plans/fix-1581-scheduler-catchup.md
@@ -1,0 +1,78 @@
+# fix #1581 — system tasks need persistence + startup catch-up
+
+## What is broken
+
+`initUserTaskScheduler` (`server/backends/scheduler.ts`) creates a task-manager and calls
+`registerTask()` for system tasks and user tasks alike. It never calls
+`configureScheduler()` / `initScheduler()` from `@mulmoclaude/core/scheduler`, so there is
+no state file, no execution log, and no catch-up.
+
+The task-manager's `isDue()` fires an interval schedule only on UTC-midnight-aligned
+boundaries. A 6-hour worklog can therefore fire only during the one tick minute at
+00:00 / 06:00 / 12:00 / 18:00 UTC. A server started with `npx` — off overnight, asleep,
+restarted — misses that minute and the run is skipped **forever**: nothing records that a
+window passed, so nothing can make it up. The reporter had `worklogEnabled: true` for days
+with no page, no state file and no error.
+
+## What MulmoClaude does (the target)
+
+`server/index.ts:1246` → `server/events/scheduler-adapter.ts` → `initScheduler()`:
+
+1. loads `config/scheduler/state.json` (per-task `lastRunAt`),
+2. `computeCatchUpPlan()` enumerates every window missed since `lastRunAt`,
+3. runs them per the task's `missedRunPolicy` (`skip` / `run-once` / `run-all`, capped at 24),
+4. registers the tasks on the task-manager for ongoing ticks,
+5. records every run — state + a log line under `data/scheduler/logs/`.
+
+User and skill tasks there are NOT caught up (they register directly on the task-manager),
+but each run is recorded through `recordExternalRun` so history and last/next-run exist.
+
+## Plan
+
+Adopt that path. The shared package is already a dependency (`@mulmoclaude/core@^3.0.0`,
+`@receptron/task-scheduler@^1.0.3`) and `feedRefreshTaskDef()` / `googleCalendarSyncTaskDef()`
+already return the richer `SystemTaskDef` — this host was throwing the extra fields away.
+
+1. **`server/backends/scheduler-adapter.ts`** (new) — bind `configureScheduler` to this host's
+   workspace root, `writeFileAtomic` and logger, mirroring MulmoClaude's file of the same name.
+2. **Seed never-run tasks before `initScheduler` loads the state file**
+   (`server/backends/scheduler-state-seed.ts`, new). `computeCatchUpPlan` treats a task with no
+   state as "just registered" and catches nothing up — and since nothing is then written, the
+   next boot is "just registered" again. A 6-hour task on a laptop would stay in that loop
+   forever, which is the reported bug surviving its own fix. Seeding `lastRunAt` = boot time
+   (with `totalRuns: 0`, so nothing claims a run happened) starts the accounting, and the boot
+   after a missed window catches it up. Seeding runs BEFORE `initScheduler` because the adapter
+   holds the state map in memory and rewrites the whole file on each save — a later external
+   write would be clobbered.
+3. **`worklogSystemTask` returns `SystemTaskDef`** — `name` + `missedRunPolicy: run-once`.
+   `run-once` because the batch's own window is `[lastRunAt, now]` from
+   `config/scheduler/worklog-state.json`: one catch-up run covers everything missed.
+4. **`initUserTaskScheduler`** registers user tasks directly (as MulmoClaude does) and hands the
+   system tasks to `initScheduler`, fire-and-forget so a slow catch-up cannot block boot.
+5. **User-task runs are recorded** (`server/backends/scheduled-run.ts`, new) via
+   `recordExternalRun`, keyed `user.<id>`. MulmoTerminal has the same completion-hook seam
+   MulmoClaude uses (`server/session/completion-hooks.ts`), so the recorded verdict is the
+   turn's real outcome, not merely "dispatch succeeded". `spawnScheduledWorker` gains an
+   `onComplete` hook — the map holds ONE hook per session, so the recorder has to share the
+   existing `markFailedWorker` one rather than register a second and silently replace it.
+6. **API**: `GET /api/scheduler/tasks` returns system + user tasks with their execution state and
+   an `origin` tag, and `GET /api/scheduler/logs` (`since` / `taskId` / `limit`, capped 500) is
+   added — both shaped exactly like MulmoClaude's `server/api/routes/schedulerTasks.ts`, which is
+   the naming authority. Task CRUD stays out (a separate parity item).
+
+## Deliberately not in scope
+
+- Task CRUD routes and a tasks UI (`docs/mulmoclaude-parity.md` item 2).
+- The interval-anchoring quirk itself: catch-up windows are epoch-anchored while `isDue` is
+  UTC-midnight-anchored. They agree for any interval dividing 24 h (1, 2, 3, 4, 6, 8, 12, 24);
+  an interval like 5 h ticks only at 00:00 UTC and is otherwise reached by catch-up at boot.
+  That lives in the shared engine and affects MulmoClaude identically.
+
+## Verification
+
+- Specs for: seeding (first boot writes state, second boot with a missed window catches up,
+  a task that already has state is left alone), `SystemTaskDef` shape of the worklog task,
+  user-task run recording, and the two routes.
+- `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`.
+- Manual: enable the worklog with a 1-hour interval, let a window pass with the server down,
+  restart, and confirm the catch-up run fires and `config/scheduler/state.json` advances.

--- a/server/backends/scheduled-run.ts
+++ b/server/backends/scheduled-run.ts
@@ -1,28 +1,34 @@
-// Dispatch one user task's chat and record the run — the counterpart of MulmoClaude's
+// Dispatch a scheduled task's chat and record the run — the counterpart of MulmoClaude's
 // `server/workspace/skills/scheduled-run.ts`, so both hosts write the same state and history for
 // a task registered directly on the task-manager (user tasks get no catch-up in either host;
 // what they get is a record of every run).
 //
 // The verdict is the turn's REAL outcome, not "the spawn returned": a scheduled chat can still
 // fail its first turn, and recording at dispatch would file that as a successful 8 ms run.
-import { recordExternalRun, type TaskSchedule, type TaskTrigger } from "@mulmoclaude/core/scheduler";
+import { recordExternalRun, TASK_TRIGGERS, type TaskSchedule, type TaskTrigger } from "@mulmoclaude/core/scheduler";
 import { messageOf } from "../errors.js";
 
 /** Spawn a scheduled chat, returning its session id. `onComplete` fires once, when the session's
  *  turn finishes or its teardown reports failure. Throws when the spawn itself fails. */
 export type ScheduledChatSpawn = (message: string, onComplete?: (outcome: { didError: boolean }, chatSessionId: string) => void | Promise<void>) => string;
 
-export interface ScheduledDispatch {
-  /** Task-manager id (`user.<id>`) — the key its state and log entries are filed under. */
+export interface ScheduledTaskMeta {
+  /** Task-manager id (`user.<id>`, `system.worklog`) — the key its state and log entries are
+   *  filed under. */
   id: string;
   name: string;
   schedule: TaskSchedule;
+}
+
+export interface ScheduledDispatch extends ScheduledTaskMeta {
   message: string;
   trigger: TaskTrigger;
   spawnChat: ScheduledChatSpawn;
 }
 
-/** Dispatch the task's chat, recording either the dispatch failure or the turn's outcome.
+const didNotComplete = (name: string): string => `${name} run did not complete successfully`;
+
+/** Dispatch a USER task's chat, recording either the dispatch failure or the turn's outcome.
  *  Rethrows a dispatch failure so the task-manager tick logs it too. */
 export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<string> {
   const startedAt = new Date().toISOString();
@@ -31,30 +37,49 @@ export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<st
     // No register-before-dispatch dance is needed here (MulmoClaude's `startChat` is async and can
     // finish before it returns): this spawn is synchronous and registers the hook itself.
     return dispatch.spawnChat(dispatch.message, (outcome, chatSessionId) =>
-      recordRun(dispatch, startedAt, startMs, outcome.didError ? `${dispatch.name} run did not complete successfully` : null, chatSessionId),
+      recordRun(dispatch, dispatch.trigger, startedAt, startMs, outcome.didError ? didNotComplete(dispatch.name) : null, chatSessionId),
     );
   } catch (err) {
-    await recordRun(dispatch, startedAt, startMs, messageOf(err), undefined);
+    await recordRun(dispatch, dispatch.trigger, startedAt, startMs, messageOf(err), undefined);
     throw err;
   }
 }
 
+/** Spawn a SYSTEM task's chat, filing a failure against the task when its turn finally ends.
+ *
+ *  Such a task's `run` must NOT await that outcome, and this is the reason: the tick loop drops
+ *  every tick that overlaps a still-running one, so a batch that takes minutes would silence the
+ *  whole scheduler — feed refresh and calendar sync included — for its duration. So `run` returns
+ *  at the spawn, the persistence adapter files that as the run, and a turn that then dies is
+ *  filed here rather than left reading "success". The cost is one extra `totalRuns` on a failed
+ *  run, which is the cheaper of the two wrong numbers. */
+export function spawnSystemChat(task: ScheduledTaskMeta, message: string, spawnChat: ScheduledChatSpawn): void {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+  // Reported as `scheduled` even for a catch-up run: `SystemTaskDef.run` takes no context, so
+  // which trigger fired it is not knowable here.
+  spawnChat(message, (outcome, chatSessionId) =>
+    outcome.didError ? recordRun(task, TASK_TRIGGERS.scheduled, startedAt, startMs, didNotComplete(task.name), chatSessionId) : undefined,
+  );
+}
+
 /** Persist one run's state + history entry. `runError` null = success. */
 async function recordRun(
-  dispatch: ScheduledDispatch,
+  task: ScheduledTaskMeta,
+  trigger: TaskTrigger,
   startedAt: string,
   startMs: number,
   runError: string | null,
   chatSessionId: string | undefined,
 ): Promise<void> {
   await recordExternalRun({
-    id: dispatch.id,
-    name: dispatch.name,
-    schedule: dispatch.schedule,
+    id: task.id,
+    name: task.name,
+    schedule: task.schedule,
     scheduledFor: startedAt,
     startedAt,
     durationMs: Date.now() - startMs,
-    trigger: dispatch.trigger,
+    trigger,
     errorMessage: runError,
     chatSessionId,
   });

--- a/server/backends/scheduled-run.ts
+++ b/server/backends/scheduled-run.ts
@@ -1,0 +1,61 @@
+// Dispatch one user task's chat and record the run — the counterpart of MulmoClaude's
+// `server/workspace/skills/scheduled-run.ts`, so both hosts write the same state and history for
+// a task registered directly on the task-manager (user tasks get no catch-up in either host;
+// what they get is a record of every run).
+//
+// The verdict is the turn's REAL outcome, not "the spawn returned": a scheduled chat can still
+// fail its first turn, and recording at dispatch would file that as a successful 8 ms run.
+import { recordExternalRun, type TaskSchedule, type TaskTrigger } from "@mulmoclaude/core/scheduler";
+import { messageOf } from "../errors.js";
+
+/** Spawn a scheduled chat, returning its session id. `onComplete` fires once, when the session's
+ *  turn finishes or its teardown reports failure. Throws when the spawn itself fails. */
+export type ScheduledChatSpawn = (message: string, onComplete?: (outcome: { didError: boolean }, chatSessionId: string) => void | Promise<void>) => string;
+
+export interface ScheduledDispatch {
+  /** Task-manager id (`user.<id>`) — the key its state and log entries are filed under. */
+  id: string;
+  name: string;
+  schedule: TaskSchedule;
+  message: string;
+  trigger: TaskTrigger;
+  spawnChat: ScheduledChatSpawn;
+}
+
+/** Dispatch the task's chat, recording either the dispatch failure or the turn's outcome.
+ *  Rethrows a dispatch failure so the task-manager tick logs it too. */
+export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<string> {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+  try {
+    // No register-before-dispatch dance is needed here (MulmoClaude's `startChat` is async and can
+    // finish before it returns): this spawn is synchronous and registers the hook itself.
+    return dispatch.spawnChat(dispatch.message, (outcome, chatSessionId) =>
+      recordRun(dispatch, startedAt, startMs, outcome.didError ? `${dispatch.name} run did not complete successfully` : null, chatSessionId),
+    );
+  } catch (err) {
+    await recordRun(dispatch, startedAt, startMs, messageOf(err), undefined);
+    throw err;
+  }
+}
+
+/** Persist one run's state + history entry. `runError` null = success. */
+async function recordRun(
+  dispatch: ScheduledDispatch,
+  startedAt: string,
+  startMs: number,
+  runError: string | null,
+  chatSessionId: string | undefined,
+): Promise<void> {
+  await recordExternalRun({
+    id: dispatch.id,
+    name: dispatch.name,
+    schedule: dispatch.schedule,
+    scheduledFor: startedAt,
+    startedAt,
+    durationMs: Date.now() - startMs,
+    trigger: dispatch.trigger,
+    errorMessage: runError,
+    chatSessionId,
+  });
+}

--- a/server/backends/scheduler-adapter.ts
+++ b/server/backends/scheduler-adapter.ts
@@ -1,0 +1,39 @@
+// System-task scheduling with persistence + startup catch-up — the half of the scheduler that
+// survives the server being off. Thin host binding over `@mulmoclaude/core/scheduler`, the same
+// shape as MulmoClaude's `server/events/scheduler-adapter.ts`: the engine (state file, missed-
+// window plan, execution log) is the shared package; this file injects THIS host's workspace
+// root, atomic writer and logger.
+//
+// Without it, a task fires only if the process happens to be alive during the one tick minute
+// its UTC window lands on, and a missed window is skipped forever with nothing recorded (#1581).
+import { configureScheduler, initScheduler, type ITaskManager, type SchedulerLogger, type SystemTaskDef } from "@mulmoclaude/core/scheduler";
+import { writeFileAtomic } from "../files/atomic-write.js";
+import { seedSchedulerState } from "./scheduler-state-seed.js";
+
+/** Point the package at this host. Sets module state and touches no disk, so it is safe to call
+ *  on every boot — including one with no tasks at all, where the read-only routes still have to
+ *  answer and a user task still has to be able to record its run. */
+export function configureSchedulerAdapter(workspace: string, log: SchedulerLogger): void {
+  configureScheduler({
+    workspaceRoot: workspace,
+    // The `uniqueTmp` option is what this writer already does unconditionally.
+    writeFileAtomic: (filePath: string, content: string) => writeFileAtomic(filePath, content),
+    log,
+  });
+}
+
+/** Seed first-run state, run the catch-up plan, and register the system tasks for ongoing ticks.
+ *  Requires `configureSchedulerAdapter` first.
+ *
+ *  Awaiting this delays nothing but the system tasks: `initScheduler` runs the catch-up plan
+ *  inline and a caught-up feed refresh can take a while, so callers keep it off the boot path. */
+export async function startSystemTaskScheduler(deps: {
+  taskManager: ITaskManager;
+  workspace: string;
+  tasks: SystemTaskDef[];
+  log: SchedulerLogger;
+}): Promise<void> {
+  const seeded = await seedSchedulerState(deps.workspace, deps.tasks, new Date());
+  if (seeded.length > 0) deps.log.info("seeded first-run state", { tasks: seeded.join(", ") });
+  await initScheduler(deps.taskManager, deps.tasks);
+}

--- a/server/backends/scheduler-state-seed.ts
+++ b/server/backends/scheduler-state-seed.ts
@@ -51,13 +51,18 @@ function nextWindowIso(schedule: TaskSchedule, now: Date): string | null {
   return next === null ? null : new Date(next).toISOString();
 }
 
-/** Give every task the map has never seen a starting point. Returns the ids seeded — pure
- *  apart from the map it fills, so the boot behaviour is testable without a filesystem. */
+/** Give every task without a starting point one. Returns the ids seeded — pure apart from the
+ *  map it fills, so the boot behaviour is testable without a filesystem.
+ *
+ *  Keyed on `lastRunAt`, not on the entry existing: an entry that somehow has none is stuck in
+ *  the same never-caught-up loop, and the rest of its fields (run counts, last error) are still
+ *  worth keeping. */
 export function seedStates(states: StateMap, tasks: readonly SeedTask[], now: Date): string[] {
   const seeded: string[] = [];
   for (const task of tasks) {
-    if (states.has(task.id)) continue;
-    states.set(task.id, { ...emptyState(task.id), lastRunAt: now.toISOString(), nextScheduledAt: nextWindowIso(task.schedule, now) });
+    const current = states.get(task.id);
+    if (current && current.lastRunAt !== null) continue;
+    states.set(task.id, { ...(current ?? emptyState(task.id)), lastRunAt: now.toISOString(), nextScheduledAt: nextWindowIso(task.schedule, now) });
     seeded.push(task.id);
   }
   return seeded;

--- a/server/backends/scheduler-state-seed.ts
+++ b/server/backends/scheduler-state-seed.ts
@@ -1,0 +1,82 @@
+// A system task with NO state entry gets no catch-up: `computeCatchUpPlan` reads a missing
+// entry as "just registered" and enumerates nothing — and because nothing is then written,
+// the next boot reads it as just-registered again. That loop is #1581 surviving its own fix:
+// a 6-hour task on a laptop that is never up at a UTC window would still never run once.
+//
+// Seeding `lastRunAt` with the boot time starts the window accounting, so the boot AFTER a
+// missed window catches it up. `totalRuns` stays 0 — nothing here claims a run happened.
+//
+// Seeding must land BEFORE `initScheduler`: the adapter loads this file into memory once and
+// rewrites the whole map on every save, so a later external write is clobbered by the next run.
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  SCHEDULE_TYPES,
+  emptyState,
+  loadState,
+  nextWindowAfter,
+  saveState,
+  type StateDeps,
+  type StateMap,
+  type TaskSchedule as CoreSchedule,
+} from "@receptron/task-scheduler";
+import type { TaskSchedule } from "@mulmoclaude/core/scheduler";
+import { writeFileAtomic } from "../files/atomic-write.js";
+
+const MS_PER_SECOND = 1000;
+
+export interface SeedTask {
+  id: string;
+  schedule: TaskSchedule;
+}
+
+/** Mirrors the adapter's own location (`SCHEDULER_CONFIG_DIR` + `state.json`), which the
+ *  package does not export. Both hosts read the same file for the same workspace. */
+export function schedulerStateFilePath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, "config", "scheduler", "state.json");
+}
+
+/** The host-schedule shape the task-manager takes, in the window library's terms. */
+function toCoreSchedule(schedule: TaskSchedule): CoreSchedule {
+  if (schedule.type === SCHEDULE_TYPES.interval) {
+    return { type: SCHEDULE_TYPES.interval, intervalSec: Math.round(schedule.intervalMs / MS_PER_SECOND) };
+  }
+  return schedule;
+}
+
+/** When this schedule next fires, for the API to show before the first run ever happens. */
+function nextWindowIso(schedule: TaskSchedule, now: Date): string | null {
+  const next = nextWindowAfter(toCoreSchedule(schedule), now.getTime() + 1);
+  return next === null ? null : new Date(next).toISOString();
+}
+
+/** Give every task the map has never seen a starting point. Returns the ids seeded — pure
+ *  apart from the map it fills, so the boot behaviour is testable without a filesystem. */
+export function seedStates(states: StateMap, tasks: readonly SeedTask[], now: Date): string[] {
+  const seeded: string[] = [];
+  for (const task of tasks) {
+    if (states.has(task.id)) continue;
+    states.set(task.id, { ...emptyState(task.id), lastRunAt: now.toISOString(), nextScheduledAt: nextWindowIso(task.schedule, now) });
+    seeded.push(task.id);
+  }
+  return seeded;
+}
+
+function stateDeps(): StateDeps {
+  return {
+    readFile: (filePath: string) => readFile(filePath, "utf-8"),
+    writeFileAtomic: (filePath: string, content: string) => writeFileAtomic(filePath, content),
+    exists: existsSync,
+  };
+}
+
+/** Read the state file, seed the tasks missing from it, write it back. Returns the ids
+ *  seeded (empty when every task already had one — the steady state after the first boot). */
+export async function seedSchedulerState(workspaceRoot: string, tasks: readonly SeedTask[], now: Date): Promise<string[]> {
+  const filePath = schedulerStateFilePath(workspaceRoot);
+  const states = await loadState(filePath, stateDeps());
+  const seeded = seedStates(states, tasks, now);
+  if (seeded.length > 0) await saveState(filePath, states, stateDeps());
+  return seeded;
+}

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -150,9 +150,8 @@ export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: S
  *  The tick loop starts whenever ANY task exists — so a system task alone (no user tasks) still
  *  drives its schedule. Returns the user-task count.
  *
- *  Boot never waits on the adapter: its catch-up runs every window missed while the server was
- *  off, which for a caught-up feed refresh is real work. The TICK LOOP does wait for it, but
- *  only so far — see startTicking. */
+ *  Nothing waits on the adapter: its catch-up runs every window missed while the server was off,
+ *  which for a caught-up feed refresh is real work — see startTicking for what that costs. */
 export function initUserTaskScheduler(deps: { workspace: string; spawnChat: ScheduledChatSpawn; systemTasks?: SystemTaskDef[] }): number {
   const userDefs = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
   const systemTasks = deps.systemTasks ?? [];
@@ -165,36 +164,25 @@ export function initUserTaskScheduler(deps: { workspace: string; spawnChat: Sche
   return userDefs.length;
 }
 
-// How long the tick loop waits for the adapter before starting without it. One tick: long
-// enough that the normal case (seed + a catch-up run) is always inside it, short enough that a
-// wedged catch-up costs at most one tick rather than every tick.
-const ADAPTER_START_GRACE_MS = 60_000;
-
-/** Start the tick loop once the registry is COMPLETE. The adapter registers its tasks only after
- *  seeding and running the catch-up plan, so starting first leaves ticks that see no system task
- *  at all — and a window passing in that gap then waits for the next boot to be noticed.
+/** Start the tick loop as soon as anything is registered, and let the adapter register its own
+ *  tasks behind it.
  *
- *  Bounded, though: a catch-up run is real work over the network, and waiting on one that never
- *  returns would mean the user's own tasks never tick either. `start()` ignores a second call, so
- *  whichever of the two happens first wins. A failed adapter start also starts the loop — the
- *  user tasks are registered and due regardless. */
+ *  Which window to risk, since both cannot be protected: the adapter registers only after seeding
+ *  and running its catch-up plan, so ticking first means those ticks see no system task — while a
+ *  loop that waits for it fires no USER task meanwhile. Codex flagged each side in turn, and what
+ *  settles it is the asymmetry between the two kinds. A user task is one-shot — "remind me at
+ *  09:00", with no catch-up in either host — so a window it misses is never run at all. A system
+ *  task's WORK survives either way: the worklog's window is [lastRunAt, now] from its own state
+ *  file, and the feed / calendar engines re-derive what is due from their own markers. So the
+ *  loop starts now, and a window landing inside a slow catch-up costs a system task one run
+ *  rather than costing someone a reminder. */
 function startTicking(taskManager: ITaskManager, deps: { workspace: string; systemTasks: SystemTaskDef[]; userTaskCount: number }): void {
   if (deps.systemTasks.length + deps.userTaskCount === 0) return;
-  if (deps.systemTasks.length === 0) {
-    taskManager.start();
-    return;
-  }
-  const graceTimer = setTimeout(() => {
-    log.warn("adapter still starting — ticking without the system tasks for now");
-    taskManager.start();
-  }, ADAPTER_START_GRACE_MS);
-  graceTimer.unref();
-  void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: deps.systemTasks, log })
-    .catch((err: unknown) => log.error("system task scheduler failed to start", { error: String(err) }))
-    .finally(() => {
-      clearTimeout(graceTimer);
-      taskManager.start();
-    });
+  taskManager.start();
+  if (deps.systemTasks.length === 0) return;
+  void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: deps.systemTasks, log }).catch((err: unknown) =>
+    log.error("system task scheduler failed to start", { error: String(err) }),
+  );
 }
 
 /** One user task as the API returns it: the persisted entry, tagged with its origin and

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -19,7 +19,7 @@ import path from "node:path";
 import type { Express, Request, Response } from "express";
 import { SCHEDULE_TYPES, TASK_ORIGINS, TASK_TRIGGERS, type TaskLogEntry } from "@receptron/task-scheduler";
 import { createTaskManager, getSchedulerLogs, getSchedulerTasks, getSchedulerTaskState } from "@mulmoclaude/core/scheduler";
-import type { SystemTaskDef, TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
+import type { ITaskManager, SystemTaskDef, TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
 import { readTextFile } from "../infra/read-text-file.js";
 import { isRecord } from "../../common/isRecord.js";
 import { configureSchedulerAdapter, startSystemTaskScheduler } from "./scheduler-adapter.js";
@@ -159,14 +159,24 @@ export function initUserTaskScheduler(deps: { workspace: string; spawnChat: Sche
   // Before anything can record a run — including a user task, which reaches the same state file.
   configureSchedulerAdapter(deps.workspace, log);
   for (const definition of userDefs) taskManager.registerTask(definition);
-  if (systemTasks.length + userDefs.length > 0) {
-    taskManager.start();
-    void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: systemTasks, log }).catch((err: unknown) =>
-      log.error("system task scheduler failed to start", { error: String(err) }),
-    );
-  }
+  startTicking(taskManager, { workspace: deps.workspace, systemTasks, userTaskCount: userDefs.length });
   log.info("scheduler started", { userTasks: userDefs.length, systemTasks: systemTasks.length });
   return userDefs.length;
+}
+
+/** Start the tick loop once the registry is COMPLETE. The adapter registers its tasks only after
+ *  seeding and running the catch-up plan, so starting first leaves ticks that see no system task
+ *  at all — and a window passing in that gap then waits for the next boot to be noticed.
+ *  A failed adapter start still starts the loop: the user tasks are registered and due. */
+function startTicking(taskManager: ITaskManager, deps: { workspace: string; systemTasks: SystemTaskDef[]; userTaskCount: number }): void {
+  if (deps.systemTasks.length + deps.userTaskCount === 0) return;
+  if (deps.systemTasks.length === 0) {
+    taskManager.start();
+    return;
+  }
+  void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: deps.systemTasks, log })
+    .catch((err: unknown) => log.error("system task scheduler failed to start", { error: String(err) }))
+    .finally(() => taskManager.start());
 }
 
 /** One user task as the API returns it: the persisted entry, tagged with its origin and

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -6,22 +6,24 @@
 // schema is uninvolved; the only link is the prompt text.
 //
 // The tick/scheduling ENGINE is the shared package; the run-binding is
-// MulmoTerminal-specific: spawnChat = spawnClaudePty (a visible background session).
-// Tasks are registered directly on the task-manager (matching MulmoClaude's user
-// tasks) — they fire forward on schedule, with no system-task persistence/catch-up.
+// MulmoTerminal-specific: spawnChat = spawnClaudePty (a background worker session).
 //
-// System tasks may be passed in via `systemTasks` and are registered alongside the
-// user tasks on the same task-manager (one tick loop). feed-refresh now IS wired this
-// way — its def comes from the shared @mulmoclaude/core/feeds (`feedRefreshTaskDef`),
-// supplied by server/index.ts. journal / chat-index stay MulmoClaude-only (their run
-// logic isn't in the shared package).
+// The two kinds of task are registered differently, exactly as in MulmoClaude:
+//   - SYSTEM tasks (`systemTasks`, from system-tasks.ts) go through the persistence
+//     adapter — state file, startup catch-up for windows missed while the server was
+//     off, execution log. See scheduler-adapter.ts.
+//   - USER tasks register straight on the task-manager and fire forward only, but every
+//     run is recorded (scheduled-run.ts) so history and last/next-run exist for them too.
+// Both share one task-manager, so one tick loop drives everything.
 import path from "node:path";
 import type { Express, Request, Response } from "express";
-import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
-import { createTaskManager } from "@mulmoclaude/core/scheduler";
-import type { TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
+import { SCHEDULE_TYPES, TASK_ORIGINS, TASK_TRIGGERS, type TaskLogEntry } from "@receptron/task-scheduler";
+import { createTaskManager, getSchedulerLogs, getSchedulerTasks, getSchedulerTaskState } from "@mulmoclaude/core/scheduler";
+import type { SystemTaskDef, TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
 import { readTextFile } from "../infra/read-text-file.js";
 import { isRecord } from "../../common/isRecord.js";
+import { configureSchedulerAdapter, startSystemTaskScheduler } from "./scheduler-adapter.js";
+import { fireScheduledChat, type ScheduledChatSpawn } from "./scheduled-run.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[scheduler] ${message}`, data ?? ""),
@@ -70,6 +72,12 @@ function tasksFilePath(workspace: string): string {
   return path.join(workspace, "config", "scheduler", "tasks.json");
 }
 
+/** The task-manager id a user task registers under — the key its state and log entries
+ *  are filed under, so the API has to ask for it by the same name. */
+export function userTaskManagerId(taskId: string): string {
+  return `user.${taskId}`;
+}
+
 /** Read the user tasks file. Returns [] for a missing file or malformed JSON (a bad
  *  file must not abort scheduling — it just means no user tasks). */
 export function loadUserTasks(workspace: string): unknown[] {
@@ -96,7 +104,7 @@ export function loadUserTasks(workspace: string): unknown[] {
  *  schedule, and binds each surviving task's run to a fresh chat seeded with its
  *  prompt. Takes `unknown[]` because the array comes straight from JSON.parse — a
  *  bad element (`null`, a primitive) must be skipped, not throw (non-fatal). */
-export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: (message: string) => void): TaskDefinition[] {
+export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: ScheduledChatSpawn): TaskDefinition[] {
   const definitions: TaskDefinition[] = [];
   for (const entry of tasks) {
     if (!isRecord(entry)) {
@@ -122,38 +130,86 @@ export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: (
     }
     const prompt = rawPrompt.trim();
     const name = typeof entry.name === "string" ? entry.name : id;
+    const schedule = entry.schedule;
     definitions.push({
-      id: `user.${id}`,
+      id: userTaskManagerId(id),
       description: `User task: ${name}`,
-      schedule: entry.schedule,
+      schedule,
       run: async () => {
         log.info("running user task", { id, name });
-        spawnChat(prompt);
+        await fireScheduledChat({ id: userTaskManagerId(id), name, schedule, message: prompt, trigger: TASK_TRIGGERS.scheduled, spawnChat });
       },
     });
   }
   return definitions;
 }
 
-/** Wire the scheduler: load user tasks, register the enabled+valid ones plus any
- *  host `systemTasks` (e.g. feed-refresh) on one task-manager, and start the tick loop.
- *  `spawnChat` is the user-task run-binding (spawns a visible chat seeded with the
- *  prompt). The tick loop starts whenever ANY task is registered — so a system task
- *  alone (no user tasks) still drives its schedule. Returns the user-task count. */
-export function initUserTaskScheduler(deps: { workspace: string; spawnChat: (message: string) => void; systemTasks?: TaskDefinition[] }): number {
+/** Wire the scheduler: load user tasks, register the enabled+valid ones on the task-manager,
+ *  hand any host `systemTasks` (e.g. feed-refresh) to the persistence adapter, and start the
+ *  tick loop. `spawnChat` is the run-binding (spawns a background chat seeded with the prompt).
+ *  The tick loop starts whenever ANY task exists — so a system task alone (no user tasks) still
+ *  drives its schedule. Returns the user-task count.
+ *
+ *  The adapter's catch-up is deliberately NOT awaited: it runs every window missed while the
+ *  server was off, which for a caught-up feed refresh is real work, and boot must not wait. */
+export function initUserTaskScheduler(deps: { workspace: string; spawnChat: ScheduledChatSpawn; systemTasks?: SystemTaskDef[] }): number {
   const userDefs = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
   const systemTasks = deps.systemTasks ?? [];
   const taskManager = createTaskManager({ log });
-  for (const definition of [...systemTasks, ...userDefs]) taskManager.registerTask(definition);
-  if (systemTasks.length + userDefs.length > 0) taskManager.start();
+  // Before anything can record a run — including a user task, which reaches the same state file.
+  configureSchedulerAdapter(deps.workspace, log);
+  for (const definition of userDefs) taskManager.registerTask(definition);
+  if (systemTasks.length + userDefs.length > 0) {
+    taskManager.start();
+    void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: systemTasks, log }).catch((err: unknown) =>
+      log.error("system task scheduler failed to start", { error: String(err) }),
+    );
+  }
   log.info("scheduler started", { userTasks: userDefs.length, systemTasks: systemTasks.length });
   return userDefs.length;
 }
 
-/** Read-only REST surface: list the user tasks (backs a future tasks UI). CRUD is a
- *  later PR; existing tasks run without it. */
+/** One user task as the API returns it: the persisted entry, tagged with its origin and
+ *  carrying the execution state the adapter files under its task-manager id. A malformed
+ *  entry is passed through untouched — the list is a mirror of the file, not a validator. */
+function userTaskWithState(entry: unknown): unknown {
+  if (!isRecord(entry) || typeof entry.id !== "string") return entry;
+  return { ...entry, origin: TASK_ORIGINS.user, state: getSchedulerTaskState(userTaskManagerId(entry.id)) };
+}
+
+/** Positive integer query param, capped. Anything else reads as "unset". */
+function positiveIntQuery(value: unknown, max: number): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, max) : undefined;
+}
+
+function stringQuery(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+const MAX_LOG_LIMIT = 500;
+
+/** Read-only REST surface, shaped like MulmoClaude's `server/api/routes/schedulerTasks.ts`:
+ *  every registered task with its execution state, and the execution log. Task CRUD is a
+ *  separate parity item; tasks written to `tasks.json` by hand or by the agent run without it. */
 export function mountSchedulerRoutes(app: Express, deps: { workspace: string }): void {
   app.get("/api/scheduler/tasks", (_req: Request, res: Response) => {
-    res.json({ tasks: loadUserTasks(deps.workspace) });
+    const systemTasks = getSchedulerTasks().map((task) => ({ ...task, origin: TASK_ORIGINS.system }));
+    res.json({ tasks: [...systemTasks, ...loadUserTasks(deps.workspace).map(userTaskWithState)] });
+  });
+
+  app.get("/api/scheduler/logs", async (req: Request, res: Response) => {
+    try {
+      const logs: TaskLogEntry[] = await getSchedulerLogs({
+        since: stringQuery(req.query.since),
+        taskId: stringQuery(req.query.taskId),
+        limit: positiveIntQuery(req.query.limit, MAX_LOG_LIMIT),
+      });
+      res.json({ logs });
+    } catch (err) {
+      log.warn("failed to read scheduler logs", { error: String(err) });
+      res.status(500).json({ error: "failed to read scheduler logs" });
+    }
   });
 }

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -150,8 +150,9 @@ export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: S
  *  The tick loop starts whenever ANY task exists — so a system task alone (no user tasks) still
  *  drives its schedule. Returns the user-task count.
  *
- *  The adapter's catch-up is deliberately NOT awaited: it runs every window missed while the
- *  server was off, which for a caught-up feed refresh is real work, and boot must not wait. */
+ *  Boot never waits on the adapter: its catch-up runs every window missed while the server was
+ *  off, which for a caught-up feed refresh is real work. The TICK LOOP does wait for it, but
+ *  only so far — see startTicking. */
 export function initUserTaskScheduler(deps: { workspace: string; spawnChat: ScheduledChatSpawn; systemTasks?: SystemTaskDef[] }): number {
   const userDefs = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
   const systemTasks = deps.systemTasks ?? [];

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -164,19 +164,36 @@ export function initUserTaskScheduler(deps: { workspace: string; spawnChat: Sche
   return userDefs.length;
 }
 
+// How long the tick loop waits for the adapter before starting without it. One tick: long
+// enough that the normal case (seed + a catch-up run) is always inside it, short enough that a
+// wedged catch-up costs at most one tick rather than every tick.
+const ADAPTER_START_GRACE_MS = 60_000;
+
 /** Start the tick loop once the registry is COMPLETE. The adapter registers its tasks only after
  *  seeding and running the catch-up plan, so starting first leaves ticks that see no system task
  *  at all — and a window passing in that gap then waits for the next boot to be noticed.
- *  A failed adapter start still starts the loop: the user tasks are registered and due. */
+ *
+ *  Bounded, though: a catch-up run is real work over the network, and waiting on one that never
+ *  returns would mean the user's own tasks never tick either. `start()` ignores a second call, so
+ *  whichever of the two happens first wins. A failed adapter start also starts the loop — the
+ *  user tasks are registered and due regardless. */
 function startTicking(taskManager: ITaskManager, deps: { workspace: string; systemTasks: SystemTaskDef[]; userTaskCount: number }): void {
   if (deps.systemTasks.length + deps.userTaskCount === 0) return;
   if (deps.systemTasks.length === 0) {
     taskManager.start();
     return;
   }
+  const graceTimer = setTimeout(() => {
+    log.warn("adapter still starting — ticking without the system tasks for now");
+    taskManager.start();
+  }, ADAPTER_START_GRACE_MS);
+  graceTimer.unref();
   void startSystemTaskScheduler({ taskManager, workspace: deps.workspace, tasks: deps.systemTasks, log })
     .catch((err: unknown) => log.error("system task scheduler failed to start", { error: String(err) }))
-    .finally(() => taskManager.start());
+    .finally(() => {
+      clearTimeout(graceTimer);
+      taskManager.start();
+    });
 }
 
 /** One user task as the API returns it: the persisted entry, tagged with its origin and

--- a/server/backends/system-tasks.ts
+++ b/server/backends/system-tasks.ts
@@ -1,12 +1,13 @@
 import { feedRefreshTaskDef } from "@mulmoclaude/core/feeds/server";
 import { googleCalendarSyncTaskDef } from "@mulmoclaude/core/google";
-import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
+import type { SystemTaskDef } from "@mulmoclaude/core/scheduler";
 import { worklogSystemTask } from "./worklog.js";
+import type { ScheduledChatSpawn } from "./scheduled-run.js";
 
 export interface SystemTaskDeps {
   workspaceRoot: string;
   worklog: { enabled: boolean; intervalHours: number };
-  spawnChat: (message: string) => void;
+  spawnChat: ScheduledChatSpawn;
 }
 
 // The system tasks a standalone MulmoTerminal registers — the ones that must keep running with no
@@ -24,10 +25,15 @@ export interface SystemTaskDeps {
 //
 // Extracted from index.ts so the list is a value a spec can read. It went months missing the
 // calendar task with nothing to notice (#1191).
-export function buildSystemTasks(deps: SystemTaskDeps): TaskDefinition[] {
+//
+// `SystemTaskDef`, not `TaskDefinition`: the extra `name` + `missedRunPolicy` are what the
+// persistence adapter needs to catch a task up after the server was off. Both core factories
+// already returned them — this host used to throw them away, so nothing was ever caught up
+// and a missed window was skipped forever (#1581).
+export function buildSystemTasks(deps: SystemTaskDeps): SystemTaskDef[] {
   return [
     feedRefreshTaskDef({ workspaceRoot: deps.workspaceRoot }),
     googleCalendarSyncTaskDef({ workspaceRoot: deps.workspaceRoot }),
     worklogSystemTask({ ...deps.worklog, spawnChat: deps.spawnChat }),
-  ].filter((task): task is TaskDefinition => task !== null);
+  ].filter((task): task is SystemTaskDef => task !== null);
 }

--- a/server/backends/worklog.ts
+++ b/server/backends/worklog.ts
@@ -7,7 +7,7 @@
 // user only has to flip the flag. See plans/feat-worklog-vision.md (#351).
 import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { SystemTaskDef } from "@mulmoclaude/core/scheduler";
-import type { ScheduledChatSpawn } from "./scheduled-run.js";
+import { spawnSystemChat, type ScheduledChatSpawn } from "./scheduled-run.js";
 
 const HOUR_MS = 3_600_000;
 
@@ -69,14 +69,17 @@ export const WORKLOG_PROMPT = `あなたは開発作業ログのバッチです�
 export function worklogSystemTask(deps: { enabled: boolean; intervalHours: number; spawnChat: ScheduledChatSpawn }): SystemTaskDef | null {
   if (!deps.enabled) return null;
   const intervalMs = Math.max(1, Math.round(deps.intervalHours)) * HOUR_MS;
-  return {
+  const task = {
     id: "system.worklog",
     name: "Dev worklog",
     description: "Periodic cross-clone dev worklog → weekly wiki pages",
     schedule: { type: SCHEDULE_TYPES.interval, intervalMs },
     missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
-    run: async () => {
-      deps.spawnChat(WORKLOG_PROMPT);
-    },
+  } as const;
+  return {
+    ...task,
+    // Returns at the spawn and files a failure later — see spawnSystemChat for why awaiting the
+    // batch here would stop the whole tick loop for its duration.
+    run: async () => spawnSystemChat(task, WORKLOG_PROMPT, deps.spawnChat),
   };
 }

--- a/server/backends/worklog.ts
+++ b/server/backends/worklog.ts
@@ -5,14 +5,16 @@
 // into one summary — into weekly wiki pages, and reconciles progress against
 // vision/milestones. The batch self-scaffolds the wiki pages and its state file, so a
 // user only has to flip the flag. See plans/feat-worklog-vision.md (#351).
-import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
-import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
+import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import type { SystemTaskDef } from "@mulmoclaude/core/scheduler";
+import type { ScheduledChatSpawn } from "./scheduled-run.js";
 
 const HOUR_MS = 3_600_000;
 
-// The run window is [lastRunAt, now], NOT a fixed interval: user/system tasks aren't
-// caught up, so a missed or slept-through run can leave a >intervalHours gap that a
-// fixed window would silently drop. lastRunAt is the high-water mark in worklog-state.json.
+// The run window is [lastRunAt, now], NOT a fixed interval: a run can be late (the server was
+// off and the scheduler caught it up at boot) or cover several missed windows at once, and a
+// fixed window would silently drop the difference. lastRunAt is the high-water mark in
+// worklog-state.json — the batch's own file, separate from the scheduler's state.json.
 export const WORKLOG_PROMPT = `あなたは開発作業ログのバッチです。カレントディレクトリ（ワークスペース = CLAUDE_CWD）で以下を実行してください。
 
 【最重要・セキュリティ / 信頼境界】
@@ -61,13 +63,18 @@ export const WORKLOG_PROMPT = `あなたは開発作業ログのバッチです�
 
 // Build the built-in worklog system task, or null when disabled. `intervalHours` sets
 // the cadence; the actual run window is still [lastRunAt, now] (see WORKLOG_PROMPT).
-export function worklogSystemTask(deps: { enabled: boolean; intervalHours: number; spawnChat: (message: string) => void }): TaskDefinition | null {
+//
+// `run-once` on a missed window: one catch-up run covers everything since lastRunAt, so
+// several missed windows must NOT become several batches all summarising the same period.
+export function worklogSystemTask(deps: { enabled: boolean; intervalHours: number; spawnChat: ScheduledChatSpawn }): SystemTaskDef | null {
   if (!deps.enabled) return null;
   const intervalMs = Math.max(1, Math.round(deps.intervalHours)) * HOUR_MS;
   return {
     id: "system.worklog",
+    name: "Dev worklog",
     description: "Periodic cross-clone dev worklog → weekly wiki pages",
     schedule: { type: SCHEDULE_TYPES.interval, intervalMs },
+    missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
     run: async () => {
       deps.spawnChat(WORKLOG_PROMPT);
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -852,16 +852,18 @@ setInterval(refreshDecisionDigests, DECISION_DIGEST_INTERVAL_MS).unref();
 
 // A user's scheduled task runs as a BACKGROUND WORKER — see scheduled-chat.ts for why, and for
 // what follows from it (no grid cell, but a failed one still says so).
-function spawnScheduledChat(message: string): void {
+//
+// A failed spawn is left to throw: whichever scheduler dispatched it records the failure and
+// logs it. Swallowing it here is how a task that never once started looked exactly like a task
+// that had not come due yet.
+function spawnScheduledChat(message: string, onComplete?: (outcome: { didError: boolean }, sessionId: string) => void | Promise<void>): string {
   const sessionId = randomUUID();
-  try {
-    spawnScheduledWorker(sessionId, {
-      spawn: (id) => spawnClaudePty(id, null, null, { initialPrompt: message }),
-      retain: (id) => scheduledSessions.register(id),
-    });
-  } catch (err) {
-    console.error(`[scheduler] failed to spawn chat for a scheduled task: ${messageOf(err)}`);
-  }
+  spawnScheduledWorker(sessionId, {
+    spawn: (id) => spawnClaudePty(id, null, null, { initialPrompt: message }),
+    retain: (id) => scheduledSessions.register(id),
+    onComplete,
+  });
+  return sessionId;
 }
 try {
   // Which tasks and why: system-tasks.ts. Both hosts are already configured above

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -214,8 +214,9 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   // bell. The engine is configured below once pubsub + the workspace exist.
   mountNotificationRoutes(app);
 
-  // Scheduler REST surface (read-only list of user cron tasks) — backs a future tasks
-  // UI. The tasks themselves are loaded + started below, once the spawn infra exists.
+  // Scheduler REST surface (read-only): every registered task with its execution state, and the
+  // run log. Backs a future tasks UI, and answers "did the worklog ever actually run?" today.
+  // The tasks themselves are loaded + started below, once the spawn infra exists.
   mountSchedulerRoutes(app, { workspace: CLAUDE_CWD });
 
   // Raw file serving (GET /api/files/raw?path=[&cwd=]) — backs collection image/file

--- a/server/session/scheduled-chat.ts
+++ b/server/session/scheduled-chat.ts
@@ -28,6 +28,11 @@ export interface ScheduledChatDeps {
   spawn: (sessionId: string) => void;
   /** Put it on the scheduled-session retention — nothing else would ever end it. */
   retain: (sessionId: string) => void;
+  /** Told the outcome once the turn finishes (or its teardown reports failure), for the
+   *  scheduler to record the run. Threaded through here rather than registered by the caller
+   *  because the hook map holds exactly ONE hook per session: a second registration would
+   *  replace the failed-worker mark below instead of running alongside it. */
+  onComplete?: ((outcome: { didError: boolean }, sessionId: string) => void | Promise<void>) | undefined;
 }
 
 /**
@@ -48,7 +53,8 @@ export function spawnScheduledWorker(sessionId: string, deps: ScheduledChatDeps)
   // run while they are away is exactly that, with the phone the only way they would hear about it
   // (Codex, PR #1196). Marked after the spawn, like the hook below.
   markUserScheduledSession(sessionId);
-  registerCompletionHook(sessionId, ({ didError }) => {
-    if (didError) markFailedWorker(sessionId);
+  registerCompletionHook(sessionId, async (outcome) => {
+    if (outcome.didError) markFailedWorker(sessionId);
+    await deps.onComplete?.(outcome, sessionId);
   });
 }

--- a/test/server/backends/scheduler-adapter.spec.ts
+++ b/test/server/backends/scheduler-adapter.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+// The wiring, against the REAL @mulmoclaude/core/scheduler and a real workspace on disk —
+// no mocks, because the thing #1581 got wrong was precisely the handoff to that package.
+// A stub task-manager stands in for the tick loop; catch-up does not go through it.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import { resetSchedulerForTesting, type ITaskManager, type SystemTaskDef, type TaskDefinition } from "@mulmoclaude/core/scheduler";
+import { configureSchedulerAdapter, startSystemTaskScheduler } from "../../../server/backends/scheduler-adapter.js";
+import { schedulerStateFilePath, seedSchedulerState } from "../../../server/backends/scheduler-state-seed.js";
+
+const HOUR_MS = 3_600_000;
+const silent = { info: () => {}, warn: () => {}, error: () => {} };
+
+const tempDirs: string[] = [];
+function makeWorkspace(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-sched-adapter-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Records what would have been registered for ongoing ticks. */
+function stubTaskManager(): { manager: ITaskManager; registered: string[] } {
+  const registered: string[] = [];
+  const manager: ITaskManager = {
+    registerTask: (def: TaskDefinition) => void registered.push(def.id),
+    removeTask: () => {},
+    updateSchedule: () => true,
+    start: () => {},
+    stop: () => {},
+    tick: async () => {},
+    listTasks: () => [],
+  };
+  return { manager, registered };
+}
+
+function worklogTask(runs: string[]): SystemTaskDef {
+  return {
+    id: "system.worklog",
+    name: "Dev worklog",
+    description: "test",
+    schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 6 * HOUR_MS },
+    missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
+    run: async () => void runs.push("ran"),
+  };
+}
+
+afterEach(() => {
+  resetSchedulerForTesting();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("startSystemTaskScheduler", () => {
+  it("does not fire a task on the boot that first registers it", async () => {
+    const workspace = makeWorkspace();
+    const runs: string[] = [];
+    const { manager, registered } = stubTaskManager();
+
+    configureSchedulerAdapter(workspace, silent);
+    await startSystemTaskScheduler({ taskManager: manager, workspace, tasks: [worklogTask(runs)], log: silent });
+
+    expect(runs).toEqual([]); // enabling a task is not a reason to run it
+    expect(registered).toEqual(["system.worklog"]); // but it ticks from here on
+  });
+
+  // The reported bug, end to end: the server was down through the task's UTC window. Before
+  // this wiring nothing recorded that the window had passed, so the run was skipped forever.
+  it("runs a window the server was down for, once, on the next boot", async () => {
+    const workspace = makeWorkspace();
+    const runs: string[] = [];
+    const { manager } = stubTaskManager();
+    // An earlier boot, a day ago — four 6-hour windows have passed since.
+    await seedSchedulerState(workspace, [worklogTask(runs)], new Date(Date.now() - 24 * HOUR_MS));
+
+    configureSchedulerAdapter(workspace, silent);
+    await startSystemTaskScheduler({ taskManager: manager, workspace, tasks: [worklogTask(runs)], log: silent });
+
+    expect(runs).toEqual(["ran"]); // run-once: one batch covers everything missed
+    const state: Record<string, { lastRunAt: string; totalRuns: number }> = JSON.parse(await readFile(schedulerStateFilePath(workspace), "utf-8"));
+    expect(state["system.worklog"].totalRuns).toBe(1);
+    // And the clock has moved to the window that ran, so the next boot owes nothing.
+    expect(new Date(state["system.worklog"].lastRunAt).getTime()).toBeGreaterThan(Date.now() - 7 * HOUR_MS);
+  });
+
+  it("writes an execution log entry the API can read back", async () => {
+    const workspace = makeWorkspace();
+    const runs: string[] = [];
+    const { manager } = stubTaskManager();
+    await seedSchedulerState(workspace, [worklogTask(runs)], new Date(Date.now() - 24 * HOUR_MS));
+
+    configureSchedulerAdapter(workspace, silent);
+    await startSystemTaskScheduler({ taskManager: manager, workspace, tasks: [worklogTask(runs)], log: silent });
+
+    // Read whichever daily file it landed in rather than computing today's name — a run that
+    // straddles UTC midnight would otherwise fail this test and nothing else.
+    const logsDir = path.join(workspace, "data", "scheduler", "logs");
+    const [logFile] = await readdir(logsDir);
+    const logLine: { taskId: string; trigger: string; result: string } = JSON.parse((await readFile(path.join(logsDir, logFile), "utf-8")).trim());
+    expect(logLine).toMatchObject({ taskId: "system.worklog", trigger: "catch-up", result: "success" });
+  });
+});

--- a/test/server/backends/scheduler-state-seed.spec.ts
+++ b/test/server/backends/scheduler-state-seed.spec.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+// #1581. The catch-up engine reads a task with no state entry as "just registered" and
+// enumerates no missed windows — and nothing is written, so the next boot reads it the same
+// way. A 6-hour task on a machine that is never up at a UTC window therefore never ran once,
+// with no state file, no log and no error. The seed is what breaks that loop.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { computeCatchUpPlan, MISSED_RUN_POLICIES, SCHEDULE_TYPES, type StateMap } from "@receptron/task-scheduler";
+import { schedulerStateFilePath, seedSchedulerState, seedStates } from "../../../server/backends/scheduler-state-seed.js";
+
+const HOUR_MS = 3_600_000;
+const BOOT = new Date("2026-08-10T04:30:00.000Z");
+const SEVEN_HOURS_LATER = new Date(BOOT.getTime() + 7 * HOUR_MS);
+const WORKLOG = { id: "system.worklog", schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 6 * HOUR_MS } } as const;
+
+// The same task in the catch-up library's terms (seconds, plus the policy the adapter passes).
+const catchUpTask = {
+  id: WORKLOG.id,
+  name: "Dev worklog",
+  schedule: { type: SCHEDULE_TYPES.interval, intervalSec: 6 * 60 * 60 },
+  missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
+  enabled: true,
+} as const;
+
+const tempDirs: string[] = [];
+const makeWorkspace = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-seed-"));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("seedStates", () => {
+  it("starts the window accounting without claiming a run happened", () => {
+    const states: StateMap = new Map();
+
+    expect(seedStates(states, [WORKLOG], BOOT)).toEqual([WORKLOG.id]);
+
+    const seeded = states.get(WORKLOG.id);
+    expect(seeded?.lastRunAt).toBe(BOOT.toISOString());
+    expect(seeded?.totalRuns).toBe(0);
+    expect(seeded?.lastRunResult).toBeNull();
+    // 04:30 UTC on a 6-hour cadence — the next epoch-aligned window is 06:00.
+    expect(seeded?.nextScheduledAt).toBe("2026-08-10T06:00:00.000Z");
+  });
+
+  it("leaves a task that has already run alone", () => {
+    const ranAt = "2026-08-09T18:00:00.000Z";
+    const states: StateMap = new Map([
+      [
+        WORKLOG.id,
+        {
+          taskId: WORKLOG.id,
+          lastRunAt: ranAt,
+          lastRunResult: null,
+          lastRunDurationMs: null,
+          lastErrorMessage: null,
+          consecutiveFailures: 0,
+          totalRuns: 3,
+          nextScheduledAt: null,
+        },
+      ],
+    ]);
+
+    expect(seedStates(states, [WORKLOG], BOOT)).toEqual([]);
+    expect(states.get(WORKLOG.id)?.lastRunAt).toBe(ranAt);
+  });
+});
+
+describe("what the seed buys: a window missed with the server down is caught up", () => {
+  it("un-seeded — the bug: no state, so nothing is ever owed", () => {
+    const plan = computeCatchUpPlan([catchUpTask], new Map(), SEVEN_HOURS_LATER.getTime());
+    expect(plan.runs).toEqual([]);
+  });
+
+  it("seeded — the 06:00 window the server slept through comes back as a catch-up run", () => {
+    const states: StateMap = new Map();
+    seedStates(states, [WORKLOG], BOOT);
+
+    const plan = computeCatchUpPlan([catchUpTask], states, SEVEN_HOURS_LATER.getTime());
+
+    expect(plan.runs.map((run) => run.context.scheduledFor)).toEqual(["2026-08-10T06:00:00.000Z"]);
+    expect(plan.runs[0].context.trigger).toBe("catch-up");
+  });
+});
+
+describe("seedSchedulerState", () => {
+  it("writes the state file the adapter reads, then has nothing left to do", async () => {
+    const workspace = makeWorkspace();
+
+    expect(await seedSchedulerState(workspace, [WORKLOG], BOOT)).toEqual([WORKLOG.id]);
+    const written: Record<string, { lastRunAt: string }> = JSON.parse(await readFile(schedulerStateFilePath(workspace), "utf-8"));
+    expect(written[WORKLOG.id].lastRunAt).toBe(BOOT.toISOString());
+
+    // Second boot: the entry is there, so the clock is not reset — which is the whole point.
+    expect(await seedSchedulerState(workspace, [WORKLOG], SEVEN_HOURS_LATER)).toEqual([]);
+    const reread: Record<string, { lastRunAt: string }> = JSON.parse(await readFile(schedulerStateFilePath(workspace), "utf-8"));
+    expect(reread[WORKLOG.id].lastRunAt).toBe(BOOT.toISOString());
+  });
+});

--- a/test/server/backends/scheduler-state-seed.spec.ts
+++ b/test/server/backends/scheduler-state-seed.spec.ts
@@ -71,6 +71,31 @@ describe("seedStates", () => {
     expect(seedStates(states, [WORKLOG], BOOT)).toEqual([]);
     expect(states.get(WORKLOG.id)?.lastRunAt).toBe(ranAt);
   });
+
+  // An entry with no lastRunAt is in the same never-caught-up loop as no entry at all, so it
+  // gets a starting point — without discarding what the entry already knows.
+  it("gives an entry that has no starting point one, keeping its history", () => {
+    const states: StateMap = new Map([
+      [
+        WORKLOG.id,
+        {
+          taskId: WORKLOG.id,
+          lastRunAt: null,
+          lastRunResult: null,
+          lastRunDurationMs: null,
+          lastErrorMessage: "boom",
+          consecutiveFailures: 2,
+          totalRuns: 5,
+          nextScheduledAt: null,
+        },
+      ],
+    ]);
+
+    expect(seedStates(states, [WORKLOG], BOOT)).toEqual([WORKLOG.id]);
+    expect(states.get(WORKLOG.id)?.lastRunAt).toBe(BOOT.toISOString());
+    expect(states.get(WORKLOG.id)?.totalRuns).toBe(5);
+    expect(states.get(WORKLOG.id)?.consecutiveFailures).toBe(2);
+  });
 });
 
 describe("what the seed buys: a window missed with the server down is caught up", () => {

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -239,11 +239,38 @@ describe("initUserTaskScheduler", () => {
       systemTasks: [sysTask("system:feed-refresh")],
     });
     expect(count).toBe(0); // zero USER tasks
-    expect(startMock).toHaveBeenCalledTimes(1); // started despite zero user tasks
     // System tasks are NOT registered directly any more — registering them there is what left
     // them with no state and no catch-up (#1581).
     expect(registerTaskMock).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledWith(expect.anything(), [expect.objectContaining({ id: "system:feed-refresh" })]));
+    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1)); // started despite zero user tasks
+  });
+
+  // The adapter registers its tasks only after seeding and catch-up. A tick in that gap would
+  // see no system task at all, and the window it fell in would wait for the next boot.
+  it("does not tick until the system tasks are registered", async () => {
+    let finishInit: () => void = () => {};
+    initSchedulerMock.mockImplementationOnce(() => new Promise<void>((resolve) => (finishInit = resolve)));
+
+    initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: spawnOk, systemTasks: [sysTask("system:feed-refresh")] });
+
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalled());
+    expect(startMock).not.toHaveBeenCalled();
+    finishInit();
+    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+  });
+
+  // ...but a broken adapter must not leave the user's own tasks dead in the water.
+  it("still ticks when the adapter fails to start", async () => {
+    initSchedulerMock.mockRejectedValueOnce(new Error("disk full"));
+
+    initUserTaskScheduler({
+      workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, prompt: "go" }]),
+      spawnChat: spawnOk,
+      systemTasks: [sysTask("system:feed-refresh")],
+    });
+
+    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
   });
 
   it("does not start the tick loop when there are no tasks at all", () => {
@@ -269,8 +296,8 @@ describe("initUserTaskScheduler", () => {
     });
     expect(count).toBe(1); // one user task
     expect(registerTaskMock.mock.calls.map((call) => (call[0] as TaskDefinition).id)).toEqual(["user.a"]);
-    expect(startMock).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
   });
 
   // The seed is what makes catch-up reachable at all: a task with no state entry is read as

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -260,7 +260,24 @@ describe("initUserTaskScheduler", () => {
     await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
   });
 
-  // ...but a broken adapter must not leave the user's own tasks dead in the water.
+  // ...but not forever. A catch-up run is network work; one that never returns must cost a tick,
+  // not every tick, or the user's own tasks never fire either.
+  it("ticks without the system tasks if the adapter is still starting a tick later", async () => {
+    vi.useFakeTimers();
+    try {
+      initSchedulerMock.mockImplementationOnce(() => new Promise<void>(() => {})); // never settles
+      initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: spawnOk, systemTasks: [sysTask("system:feed-refresh")] });
+
+      vi.advanceTimersByTime(59_000);
+      expect(startMock).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2_000);
+      expect(startMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ...and a broken adapter must not leave the user's own tasks dead in the water either.
   it("still ticks when the adapter fails to start", async () => {
     initSchedulerMock.mockRejectedValueOnce(new Error("disk full"));
 

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -250,7 +250,7 @@ describe("initUserTaskScheduler", () => {
   // user task's window is one-shot (no catch-up in either host), so a tick it misses is a
   // reminder that never fires. A system task registered a moment late loses at most one run, and
   // its work is covered by the next one. Both sides of this were flagged in review, in turn.
-  it("ticks without waiting for the adapter's catch-up to finish", () => {
+  it("ticks without waiting for the adapter's catch-up to finish", async () => {
     initSchedulerMock.mockImplementationOnce(() => new Promise<void>(() => {})); // never settles
 
     initUserTaskScheduler({
@@ -259,7 +259,11 @@ describe("initUserTaskScheduler", () => {
       systemTasks: [sysTask("system:feed-refresh")],
     });
 
-    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledTimes(1); // already ticking, with the adapter still going
+    // Then let the adapter reach `initScheduler` before this test ends. Not decoration: the seed
+    // ahead of it is real file I/O, and a call still in flight lands in a LATER test's counts —
+    // which is how this file went green here and red on the slower CI runner.
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledTimes(1));
   });
 
   // And a broken adapter must not leave the user's own tasks dead in the water either.
@@ -272,7 +276,9 @@ describe("initUserTaskScheduler", () => {
       systemTasks: [sysTask("system:feed-refresh")],
     });
 
-    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+    expect(startMock).toHaveBeenCalledTimes(1);
+    // Same reason as above: don't leave the rejected adapter start in flight into the next test.
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledTimes(1));
   });
 
   it("does not start the tick loop when there are no tasks at all", () => {

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -2,21 +2,49 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { appRequest } from "../../helpers/appRequest.js";
-import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
+import type { SystemTaskDef, TaskDefinition } from "@mulmoclaude/core/scheduler";
 import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "../../../server/backends/scheduler.js";
 
-// Mock the shared task-manager so initUserTaskScheduler's registration + start calls
-// are observable without starting real interval timers.
-const { registerTaskMock, startMock } = vi.hoisted(() => ({ registerTaskMock: vi.fn(), startMock: vi.fn() }));
+// Mock the shared scheduler package so registration, the tick loop and the persistence adapter
+// are observable without real timers or a real catch-up run. The SEED is deliberately left
+// real — it writes into the temp workspace, and it is the half of #1581 this host owns.
+const {
+  registerTaskMock,
+  startMock,
+  configureSchedulerMock,
+  initSchedulerMock,
+  recordExternalRunMock,
+  getSchedulerTasksMock,
+  getSchedulerTaskStateMock,
+  getSchedulerLogsMock,
+} = vi.hoisted(() => ({
+  registerTaskMock: vi.fn(),
+  startMock: vi.fn(),
+  configureSchedulerMock: vi.fn(),
+  initSchedulerMock: vi.fn(async () => {}),
+  recordExternalRunMock: vi.fn(async () => {}),
+  getSchedulerTasksMock: vi.fn(() => [] as unknown[]),
+  getSchedulerTaskStateMock: vi.fn((taskId: string) => ({ taskId, totalRuns: 0 })),
+  getSchedulerLogsMock: vi.fn(async () => [] as unknown[]),
+}));
 vi.mock("@mulmoclaude/core/scheduler", () => ({
   createTaskManager: () => ({ registerTask: registerTaskMock, start: startMock }),
+  configureScheduler: configureSchedulerMock,
+  initScheduler: initSchedulerMock,
+  recordExternalRun: recordExternalRunMock,
+  getSchedulerTasks: getSchedulerTasksMock,
+  getSchedulerTaskState: getSchedulerTaskStateMock,
+  getSchedulerLogs: getSchedulerLogsMock,
 }));
 
 const tempDirs: string[] = [];
+const SESSION_ID = "11111111-1111-1111-1111-111111111111";
+const spawnOk = () => SESSION_ID;
 
 function makeWorkspace(tasks?: unknown): string {
   const workspace = mkdtempSync(path.join(tmpdir(), "mt-sched-"));
@@ -35,10 +63,14 @@ afterEach(() => {
 
 describe("buildUserTaskDefinitions", () => {
   let spawned: string[];
-  const spawnChat = (message: string) => spawned.push(message);
+  const spawnChat = (message: string) => {
+    spawned.push(message);
+    return SESSION_ID;
+  };
 
   beforeEach(() => {
     spawned = [];
+    recordExternalRunMock.mockClear();
   });
 
   it("registers only enabled tasks with a valid id, prompt, and schedule", () => {
@@ -86,6 +118,35 @@ describe("buildUserTaskDefinitions", () => {
 
     expect(spawned).toEqual(["nudge me"]);
   });
+
+  // User tasks get no catch-up in either host — what they get is a record of every run, so a
+  // task that fired (or failed to) can be told apart from one that never came due (#1581).
+  it("records the turn's outcome under the task-manager id, not merely the dispatch", async () => {
+    const tasks = [{ id: "a", name: "Nudge", schedule: { type: "daily", time: "11:00" }, prompt: "go" }];
+    let reportOutcome: ((outcome: { didError: boolean }, sessionId: string) => void | Promise<void>) | undefined;
+    const spawnWithHook = (_message: string, onComplete?: (outcome: { didError: boolean }, sessionId: string) => void | Promise<void>) => {
+      reportOutcome = onComplete;
+      return SESSION_ID;
+    };
+
+    await buildUserTaskDefinitions(tasks, spawnWithHook)[0].run({ taskId: "user.a", now: new Date(0) });
+    expect(recordExternalRunMock).not.toHaveBeenCalled(); // the turn has not finished yet
+    await reportOutcome?.({ didError: true }, SESSION_ID);
+
+    expect(recordExternalRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "user.a", name: "Nudge", chatSessionId: SESSION_ID, errorMessage: expect.stringContaining("did not complete") }),
+    );
+  });
+
+  it("records a spawn that threw, and lets the failure reach the tick log", async () => {
+    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, prompt: "go" }];
+    const throwing = () => {
+      throw new Error("claude missing");
+    };
+
+    await expect(buildUserTaskDefinitions(tasks, throwing)[0].run({ taskId: "user.a", now: new Date(0) })).rejects.toThrow("claude missing");
+    expect(recordExternalRunMock).toHaveBeenCalledWith(expect.objectContaining({ id: "user.a", errorMessage: "claude missing", chatSessionId: undefined }));
+  });
 });
 
 describe("loadUserTasks", () => {
@@ -108,58 +169,121 @@ describe("loadUserTasks", () => {
 });
 
 describe("mountSchedulerRoutes", () => {
-  it("GET /api/scheduler/tasks lists the persisted tasks", async () => {
+  beforeEach(() => {
+    getSchedulerTasksMock.mockReturnValue([]);
+    getSchedulerLogsMock.mockClear();
+  });
+
+  it("GET /api/scheduler/tasks lists the persisted tasks with their execution state", async () => {
     const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "go" }];
-    const workspace = makeWorkspace(tasks);
     const app = express();
-    mountSchedulerRoutes(app, { workspace });
+    mountSchedulerRoutes(app, { workspace: makeWorkspace(tasks) });
 
     const res = await appRequest(app)("/api/scheduler/tasks");
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ tasks });
+    expect(await res.json()).toEqual({ tasks: [{ ...tasks[0], origin: "user", state: { taskId: "user.a", totalRuns: 0 } }] });
+  });
+
+  // The reported symptom was as much "no way to tell whether it ever ran" as the missed run:
+  // the old route answered from tasks.json only, so a system task appeared nowhere at all.
+  it("GET /api/scheduler/tasks includes the system tasks the adapter runs", async () => {
+    getSchedulerTasksMock.mockReturnValue([{ id: "system.worklog", name: "Dev worklog", state: { taskId: "system.worklog", totalRuns: 2 } }]);
+    const app = express();
+    mountSchedulerRoutes(app, { workspace: makeWorkspace() });
+
+    // No tasks.json in this workspace, so the system task is the whole list.
+    expect(await (await appRequest(app)("/api/scheduler/tasks")).json()).toEqual({
+      tasks: [expect.objectContaining({ id: "system.worklog", origin: "system" })],
+    });
+  });
+
+  it("GET /api/scheduler/logs passes the filters through, capping the limit", async () => {
+    const app = express();
+    mountSchedulerRoutes(app, { workspace: makeWorkspace() });
+
+    const res = await appRequest(app)("/api/scheduler/logs?taskId=system.worklog&limit=9000&since=2026-01-01T00:00:00.000Z");
+    expect(res.status).toBe(200);
+    expect(getSchedulerLogsMock).toHaveBeenCalledWith({ taskId: "system.worklog", limit: 500, since: "2026-01-01T00:00:00.000Z" });
+  });
+
+  it("GET /api/scheduler/logs reads an absent filter as unset, not as a bad request", async () => {
+    const app = express();
+    mountSchedulerRoutes(app, { workspace: makeWorkspace() });
+
+    await appRequest(app)("/api/scheduler/logs?limit=notanumber");
+    expect(getSchedulerLogsMock).toHaveBeenCalledWith({ taskId: undefined, limit: undefined, since: undefined });
   });
 });
 
 describe("initUserTaskScheduler", () => {
-  const sysTask = (id: string): TaskDefinition => ({
+  const sysTask = (id: string): SystemTaskDef => ({
     id,
+    name: id,
+    description: id,
     schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60 * 60 * 1000 },
+    missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
     run: async () => {},
   });
 
   beforeEach(() => {
     registerTaskMock.mockClear();
     startMock.mockClear();
+    initSchedulerMock.mockClear();
+    configureSchedulerMock.mockClear();
   });
 
-  it("registers system tasks and starts the tick loop even with zero user tasks", () => {
-    // makeWorkspace() with no tasks.json → zero user tasks (the standalone feed-refresh case).
+  it("hands the system tasks to the persistence adapter and starts the tick loop with zero user tasks", async () => {
     const count = initUserTaskScheduler({
       workspace: makeWorkspace(),
-      spawnChat: () => {},
+      spawnChat: spawnOk,
       systemTasks: [sysTask("system:feed-refresh")],
     });
     expect(count).toBe(0); // zero USER tasks
-    expect(registerTaskMock).toHaveBeenCalledTimes(1);
-    expect(registerTaskMock).toHaveBeenCalledWith(expect.objectContaining({ id: "system:feed-refresh" }));
     expect(startMock).toHaveBeenCalledTimes(1); // started despite zero user tasks
+    // System tasks are NOT registered directly any more — registering them there is what left
+    // them with no state and no catch-up (#1581).
+    expect(registerTaskMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledWith(expect.anything(), [expect.objectContaining({ id: "system:feed-refresh" })]));
   });
 
   it("does not start the tick loop when there are no tasks at all", () => {
-    initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: () => {} });
+    initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: spawnOk });
     expect(registerTaskMock).not.toHaveBeenCalled();
     expect(startMock).not.toHaveBeenCalled();
+    expect(initSchedulerMock).not.toHaveBeenCalled();
   });
 
-  it("registers both system and user tasks on the one manager", () => {
+  // Configured even then: the read-only routes and any later run recording reach the same
+  // module-level config, and it touches no disk.
+  it("configures the adapter for the workspace either way", () => {
+    const workspace = makeWorkspace();
+    initUserTaskScheduler({ workspace, spawnChat: spawnOk });
+    expect(configureSchedulerMock).toHaveBeenCalledWith(expect.objectContaining({ workspaceRoot: workspace }));
+  });
+
+  it("registers the user tasks on the manager and the system tasks through the adapter", async () => {
     const count = initUserTaskScheduler({
       workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "go" }]),
-      spawnChat: () => {},
+      spawnChat: spawnOk,
       systemTasks: [sysTask("system:feed-refresh")],
     });
     expect(count).toBe(1); // one user task
-    const ids = registerTaskMock.mock.calls.map((call) => (call[0] as TaskDefinition).id);
-    expect(ids).toEqual(expect.arrayContaining(["system:feed-refresh", "user.a"]));
+    expect(registerTaskMock.mock.calls.map((call) => (call[0] as TaskDefinition).id)).toEqual(["user.a"]);
     expect(startMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledTimes(1));
+  });
+
+  // The seed is what makes catch-up reachable at all: a task with no state entry is read as
+  // "just registered" every boot, so a 6-hour worklog on a laptop never runs once (#1581).
+  it("seeds first-run state for the system tasks before the adapter loads it", async () => {
+    const workspace = makeWorkspace();
+    initUserTaskScheduler({ workspace, spawnChat: spawnOk, systemTasks: [sysTask("system.worklog")] });
+
+    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalled());
+    const state: Record<string, { lastRunAt: string | null; totalRuns: number }> = JSON.parse(
+      await readFile(path.join(workspace, "config", "scheduler", "state.json"), "utf-8"),
+    );
+    expect(state["system.worklog"].lastRunAt).not.toBeNull();
+    expect(state["system.worklog"].totalRuns).toBe(0); // seeded, not claimed to have run
   });
 });

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -242,42 +242,27 @@ describe("initUserTaskScheduler", () => {
     // System tasks are NOT registered directly any more — registering them there is what left
     // them with no state and no catch-up (#1581).
     expect(registerTaskMock).not.toHaveBeenCalled();
+    expect(startMock).toHaveBeenCalledTimes(1); // started despite zero user tasks
     await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledWith(expect.anything(), [expect.objectContaining({ id: "system:feed-refresh" })]));
-    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1)); // started despite zero user tasks
   });
 
-  // The adapter registers its tasks only after seeding and catch-up. A tick in that gap would
-  // see no system task at all, and the window it fell in would wait for the next boot.
-  it("does not tick until the system tasks are registered", async () => {
-    let finishInit: () => void = () => {};
-    initSchedulerMock.mockImplementationOnce(() => new Promise<void>((resolve) => (finishInit = resolve)));
+  // The tick loop must not wait for the adapter's seed + catch-up, however long that takes: a
+  // user task's window is one-shot (no catch-up in either host), so a tick it misses is a
+  // reminder that never fires. A system task registered a moment late loses at most one run, and
+  // its work is covered by the next one. Both sides of this were flagged in review, in turn.
+  it("ticks without waiting for the adapter's catch-up to finish", () => {
+    initSchedulerMock.mockImplementationOnce(() => new Promise<void>(() => {})); // never settles
 
-    initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: spawnOk, systemTasks: [sysTask("system:feed-refresh")] });
+    initUserTaskScheduler({
+      workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, prompt: "go" }]),
+      spawnChat: spawnOk,
+      systemTasks: [sysTask("system:feed-refresh")],
+    });
 
-    await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalled());
-    expect(startMock).not.toHaveBeenCalled();
-    finishInit();
-    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+    expect(startMock).toHaveBeenCalledTimes(1);
   });
 
-  // ...but not forever. A catch-up run is network work; one that never returns must cost a tick,
-  // not every tick, or the user's own tasks never fire either.
-  it("ticks without the system tasks if the adapter is still starting a tick later", async () => {
-    vi.useFakeTimers();
-    try {
-      initSchedulerMock.mockImplementationOnce(() => new Promise<void>(() => {})); // never settles
-      initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: spawnOk, systemTasks: [sysTask("system:feed-refresh")] });
-
-      vi.advanceTimersByTime(59_000);
-      expect(startMock).not.toHaveBeenCalled();
-      vi.advanceTimersByTime(2_000);
-      expect(startMock).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  // ...and a broken adapter must not leave the user's own tasks dead in the water either.
+  // And a broken adapter must not leave the user's own tasks dead in the water either.
   it("still ticks when the adapter fails to start", async () => {
     initSchedulerMock.mockRejectedValueOnce(new Error("disk full"));
 
@@ -313,8 +298,8 @@ describe("initUserTaskScheduler", () => {
     });
     expect(count).toBe(1); // one user task
     expect(registerTaskMock.mock.calls.map((call) => (call[0] as TaskDefinition).id)).toEqual(["user.a"]);
+    expect(startMock).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(initSchedulerMock).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
   });
 
   // The seed is what makes catch-up reachable at all: a task with no state entry is read as

--- a/test/server/backends/system-tasks.spec.ts
+++ b/test/server/backends/system-tasks.spec.ts
@@ -8,17 +8,26 @@ import { describe, it, expect } from "vitest";
 import { buildSystemTasks } from "../../../server/backends/system-tasks.js";
 
 const WORKLOG_OFF = { enabled: false, intervalHours: 6 };
-const build = (worklog = WORKLOG_OFF) => buildSystemTasks({ workspaceRoot: "/ws", worklog, spawnChat: () => {} });
+const build = (worklog = WORKLOG_OFF) => buildSystemTasks({ workspaceRoot: "/ws", worklog, spawnChat: () => "11111111-1111-1111-1111-111111111111" });
 
 describe("buildSystemTasks", () => {
   // The feed-refresh id carries its ROOT since core 3.1.0 — the task def is per root, so two
   // roots would otherwise register one id and the second would replace the first. MulmoTerminal
-  // registers one (the workspace) today, and does not persist system-task state, so there is no
-  // stale row from the old id to clean up.
+  // registers one (the workspace) today. State is persisted from #1581 onward, but nothing was
+  // ever written under the OLD id, so there is no stale row to clean up.
   it("registers both shared engines, the feed refresh keyed by its root", () => {
     const ids = build().map((task) => task.id);
     expect(ids).toContain("system:feed-refresh:/ws");
     expect(ids).toContain("system:google-calendar-sync");
+  });
+
+  // The whole list has to be takeable by the persistence adapter, not just the worklog: a def
+  // missing either field cannot be caught up after the server was off (#1581).
+  it("every task carries a name and a missed-run policy", () => {
+    for (const task of build({ enabled: true, intervalHours: 6 })) {
+      expect(task.name.length).toBeGreaterThan(0);
+      expect(task.missedRunPolicy.length).toBeGreaterThan(0);
+    }
   });
 
   // Off is the default, so the list must not carry a null through to registerTask.

--- a/test/server/backends/worklog.spec.ts
+++ b/test/server/backends/worklog.spec.ts
@@ -3,10 +3,19 @@ import { describe, it, expect, vi } from "vitest";
 import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { worklogSystemTask, WORKLOG_PROMPT } from "../../../server/backends/worklog.js";
 
+// Only the run recorder is needed here; the rest of the package is untouched by this file.
+const { recordExternalRunMock } = vi.hoisted(() => ({ recordExternalRunMock: vi.fn(async () => {}) }));
+vi.mock("@mulmoclaude/core/scheduler", () => ({
+  recordExternalRun: recordExternalRunMock,
+  TASK_TRIGGERS: { scheduled: "scheduled", catchUp: "catch-up", manual: "manual" },
+}));
+
 const HOUR_MS = 3_600_000;
 
+const SESSION_ID = "11111111-1111-1111-1111-111111111111";
+
 describe("worklogSystemTask", () => {
-  const noop = () => "11111111-1111-1111-1111-111111111111";
+  const noop = () => SESSION_ID;
 
   it("returns null when disabled (no system task registered)", () => {
     expect(worklogSystemTask({ enabled: false, intervalHours: 6, spawnChat: noop })).toBeNull();
@@ -37,7 +46,40 @@ describe("worklogSystemTask", () => {
     const spawnChat = vi.fn(noop);
     const task = worklogSystemTask({ enabled: true, intervalHours: 6, spawnChat });
     await task?.run();
-    expect(spawnChat).toHaveBeenCalledWith(WORKLOG_PROMPT);
+    expect(spawnChat).toHaveBeenCalledWith(WORKLOG_PROMPT, expect.any(Function));
+  });
+
+  // run() resolves at the spawn — awaiting the batch would stall the tick loop for its whole
+  // length — so the adapter files that as a successful run. A turn that then dies is filed here,
+  // rather than leaving the scheduler reading "success" for a batch that never wrote a page.
+  describe("a worker that fails after it was spawned", () => {
+    const runAndReport = async (didError: boolean) => {
+      recordExternalRunMock.mockClear();
+      let report: ((outcome: { didError: boolean }, sessionId: string) => void | Promise<void>) | undefined;
+      const spawnChat = (_message: string, onComplete?: (outcome: { didError: boolean }, sessionId: string) => void | Promise<void>) => {
+        report = onComplete;
+        return SESSION_ID;
+      };
+      await worklogSystemTask({ enabled: true, intervalHours: 6, spawnChat })?.run();
+      await report?.({ didError }, SESSION_ID);
+    };
+
+    it("is recorded against the task, with the session that failed", async () => {
+      await runAndReport(true);
+      expect(recordExternalRunMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "system.worklog",
+          name: "Dev worklog",
+          chatSessionId: SESSION_ID,
+          errorMessage: expect.stringContaining("did not complete"),
+        }),
+      );
+    });
+
+    it("records nothing extra when the turn finished — the adapter already filed it", async () => {
+      await runAndReport(false);
+      expect(recordExternalRunMock).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/test/server/backends/worklog.spec.ts
+++ b/test/server/backends/worklog.spec.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
-import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { worklogSystemTask, WORKLOG_PROMPT } from "../../../server/backends/worklog.js";
 
 const HOUR_MS = 3_600_000;
 
 describe("worklogSystemTask", () => {
-  const noop = () => {};
+  const noop = () => "11111111-1111-1111-1111-111111111111";
 
   it("returns null when disabled (no system task registered)", () => {
     expect(worklogSystemTask({ enabled: false, intervalHours: 6, spawnChat: noop })).toBeNull();
@@ -24,10 +24,19 @@ describe("worklogSystemTask", () => {
     expect(task?.schedule).toEqual({ type: SCHEDULE_TYPES.interval, intervalMs: 24 * HOUR_MS });
   });
 
+  // #1581: without these two fields the persistence adapter cannot take the task, so a window
+  // missed while the server was off was skipped forever. `run-once` and not `run-all` because
+  // the batch's own window is [lastRunAt, now] — one run already covers every missed window.
+  it("carries what the catch-up adapter needs: a name and run-once on a missed window", () => {
+    const task = worklogSystemTask({ enabled: true, intervalHours: 6, spawnChat: noop });
+    expect(task?.name).toBe("Dev worklog");
+    expect(task?.missedRunPolicy).toBe(MISSED_RUN_POLICIES.runOnce);
+  });
+
   it("run() spawns a chat seeded with the worklog prompt", async () => {
-    const spawnChat = vi.fn();
+    const spawnChat = vi.fn(noop);
     const task = worklogSystemTask({ enabled: true, intervalHours: 6, spawnChat });
-    await task?.run({ taskId: "system.worklog", now: new Date(0) });
+    await task?.run();
     expect(spawnChat).toHaveBeenCalledWith(WORKLOG_PROMPT);
   });
 });

--- a/test/server/session/scheduled-chat.spec.ts
+++ b/test/server/session/scheduled-chat.spec.ts
@@ -78,6 +78,19 @@ describe("a scheduled task's chat", () => {
     expect(registry.isFailedWorker(ID)).toBe(false);
   });
 
+  // The scheduler records the run from this, and the map holds ONE hook per session: registering
+  // a second from the caller would REPLACE the failed-worker mark above rather than run beside it.
+  it("tells the dispatcher the outcome, without losing the failed-worker mark", async () => {
+    const { registry, spawnScheduledWorker, runCompletionHook } = await fresh();
+    const seen: { didError: boolean; sessionId: string }[] = [];
+    spawnScheduledWorker(ID, { ...noop, onComplete: (outcome, sessionId) => void seen.push({ ...outcome, sessionId }) });
+
+    await runCompletionHook(ID, { didError: true });
+
+    expect(seen).toEqual([{ didError: true, sessionId: ID }]);
+    expect(registry.isFailedWorker(ID)).toBe(true);
+  });
+
   it("spawns and retains, in that order", async () => {
     // Retention exists because nothing else would ever end this session; registering a session
     // that failed to spawn would put a dead id on it.


### PR DESCRIPTION
## Summary

System tasks (dev worklog / feed refresh / calendar sync) were registered directly on the
task-manager, which fires an interval schedule only on UTC-midnight-aligned boundaries. A
6-hour task could therefore run only during the one tick minute at 00/06/12/18 UTC, and a
server that was off, asleep or restarting through that minute skipped the run **forever** —
nothing recorded that a window had passed, and nothing in the UI or API could say so.

They now go through `@mulmoclaude/core/scheduler`'s persistence adapter, the same path
MulmoClaude uses: state file, startup catch-up per each task's `missedRunPolicy`, execution
log. User tasks keep firing forward only (as in MulmoClaude), but every run is now recorded
with the turn's real outcome, and the read-only routes report all of it.

Closes #1581.

## Items to Confirm / Review

1. **Seeding first-run state is an addition to MulmoClaude's design, not a copy of it.**
   `computeCatchUpPlan` reads a task with no state entry as "just registered" and enumerates
   nothing — and since nothing is then written, the next boot reads it the same way. Without
   the seed the reported bug survives its own fix. The seed writes `lastRunAt` = boot time
   with `totalRuns: 0`, so nothing claims a run happened. It must run **before**
   `initScheduler`, because the adapter holds the state map in memory and rewrites the whole
   file on each save. **MulmoClaude has the same gap** (masked there by hourly tasks) — worth
   deciding whether this belongs upstream in the shared package.
2. **Every boot with a task now writes into the workspace**: `config/scheduler/state.json`
   plus a `data/scheduler/logs/` directory under `CLAUDE_CWD`. Feed refresh and calendar sync
   are always registered, so this is every boot in practice. Consistent with the existing
   workspace layout (`config/scheduler/tasks.json`, `data/wiki/`), but it is new files
   appearing in a user's project directory.
3. **Catch-up now runs work at startup.** A feed refresh whose window passed while the server
   was down fires at boot, which for an `ingest.kind: "agent"` collection dispatches a hidden
   worker. That is the intended meaning of catch-up and the engines soft-dedup on their own
   markers (`lastFetchedAt` / `lastSyncedAt`), but it is a behaviour change at startup.
4. **`spawnScheduledChat` no longer swallows a failed spawn.** It throws, and the dispatcher
   records and logs it. Previously a task that never once started was indistinguishable from
   one that had not come due.
5. **`GET /api/scheduler/tasks` changed shape** (additively): entries now carry `origin` and
   `state`, and system tasks appear in the list. Nothing in this repo consumed the route.
6. **Not in scope**: task CRUD routes and a tasks UI (`docs/mulmoclaude-parity.md` item 2),
   and the interval-anchoring quirk in the shared engine — catch-up windows are epoch-anchored
   while `isDue` is UTC-midnight-anchored. They agree for any interval dividing 24 h; an odd
   one like 5 h ticks only at 00:00 UTC and is otherwise reached by catch-up at boot.

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1581
> mulmoclaude だと task がうまくキューにはいるかなにかで、その時間 PC が起動して無くても動くように作ったはずだけど、mulmoterminal ではどうなっている？できれば mulmoclaude と同じ実装にしたい

Scope was then confirmed as full parity: catch-up, the read-only API surface with execution
state and logs, and run recording for user tasks.

## What MulmoClaude does, and what this host was missing

| | MulmoClaude | MulmoTerminal (before) | MulmoTerminal (this PR) |
|---|---|---|---|
| System tasks | `initScheduler()` — state, catch-up, log | `registerTask()` — nothing persisted | `initScheduler()`, same as MulmoClaude |
| Missed window | replayed per `missedRunPolicy` | skipped forever | replayed (`run-once` for the worklog) |
| User tasks | fire forward, run recorded | fire forward, nothing recorded | fire forward, run recorded |
| API | tasks + state, logs | tasks from `tasks.json` only | tasks + state, logs |

## Implementation

- **`server/backends/scheduler-adapter.ts`** (new) — binds `configureScheduler` to this host's
  workspace root, `writeFileAtomic` and logger, and drives seed → `initScheduler`. Mirrors
  MulmoClaude's file of the same name. Catch-up is not awaited on the boot path.
- **`server/backends/scheduler-state-seed.ts`** (new) — item 1 above.
- **`server/backends/scheduled-run.ts`** (new) — dispatch + record for user tasks, the
  counterpart of MulmoClaude's `scheduled-run.ts`. The verdict comes from the completion hook,
  so it is the turn's outcome rather than "the spawn returned".
- **`worklogSystemTask` returns `SystemTaskDef`** — `name` + `missedRunPolicy: run-once`.
  `run-once` because the batch's own window is `[lastRunAt, now]` from
  `config/scheduler/worklog-state.json`: one catch-up run already covers everything missed,
  and `run-all` would spawn several batches summarising the same period. The two core
  factories already returned `SystemTaskDef`; this host was discarding the extra fields.
- **`spawnScheduledWorker` gains an `onComplete` hook.** The hook map holds exactly ONE hook
  per session, so the recorder had to share the existing failed-worker hook rather than
  register a second and silently replace it.
- **Routes** shaped like MulmoClaude's `server/api/routes/schedulerTasks.ts`:
  `GET /api/scheduler/tasks` (system + user, each with `origin` and `state`) and
  `GET /api/scheduler/logs` (`since` / `taskId` / `limit`, capped at 500).

## Verification

- `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — 9536
  passing.
- `test/server/backends/scheduler-adapter.spec.ts` runs the **real** shared package against a
  real workspace on disk: a first boot registers without firing; a second boot after 24 h down
  fires exactly one catch-up run, advances `state.json`, and writes a
  `trigger: "catch-up", result: "success"` log entry.
- `test/server/backends/scheduler-state-seed.spec.ts` pins the bug and the fix side by side:
  `computeCatchUpPlan` owes nothing on an unseeded task and owes the slept-through 06:00
  window on a seeded one.

Plan: `plans/fix-1581-scheduler-catchup.md`.

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled tasks now record execution status, history, timing, errors, and session details.
  * Missed scheduled runs are consolidated into a catch-up run when the server starts.
  * Scheduler task status, execution history, and log locations are available through read-only routes.
  * Worklog catch-up runs cover the full missed interval.

* **Documentation**
  * Updated scheduler behavior, parity documentation, and implementation planning details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->