### PR TITLE
Collections: the portability check in the pane, phone scope preparation, and the first live browser check

### DIFF
--- a/common/collectionPortability.ts
+++ b/common/collectionPortability.ts
@@ -47,9 +47,9 @@ export interface SelfContainmentReport {
   findings: SelfContainmentFinding[];
 }
 
-/** The severity IS narrowed, unlike the code: it decides how the row is rendered, so an
- *  unrecognised one has no styling to fall back to. A predicate rather than a list membership
- *  test, so the narrowing is the type system's rather than an assertion's. */
+/** The severity IS narrowed, unlike the code: it decides how the row is rendered AND whether the
+ *  finding is a blocker, so an unrecognised one cannot be shown honestly. A predicate rather than
+ *  a list membership test, so the narrowing is the type system's rather than an assertion's. */
 export function isSelfContainmentSeverity(value: unknown): value is SelfContainmentSeverity {
   return value === "blocker" || value === "warning" || value === "info";
 }
@@ -72,7 +72,13 @@ export function asSelfContainmentReport(body: unknown): SelfContainmentReport | 
   const parsed: SelfContainmentFinding[] = [];
   for (const entry of findings) {
     const finding = asFinding(entry);
-    if (finding) parsed.push(finding);
+    // ONE UNREADABLE FINDING REJECTS THE WHOLE REPORT. Skipping it would be the worse failure:
+    // if the dropped finding was the only blocker, the caller is handed `findings: []` and tells
+    // the user "nothing to fix — it travels" about a collection that does not. A report we cannot
+    // fully read is not a clean bill of health, and "could not run the check" is the honest
+    // answer — visible and actionable, where a false all-clear is neither.
+    if (!finding) return null;
+    parsed.push(finding);
   }
   return { slug, portable, findings: parsed };
 }

--- a/common/collectionPortability.ts
+++ b/common/collectionPortability.ts
@@ -1,0 +1,78 @@
+// "Would this collection survive a clone?" — the wire shape, shared because BOTH sides decide
+// from it: the server produces the report (server/backends/collectionSelfContainment.ts) and the
+// Collections pane renders it, colouring by severity and blocking on `portable`.
+//
+// In `common/` rather than mirrored, for the reason the layout rule gives: a second copy of a
+// union is how a writer and a reader drift while both keep compiling. The RULES stay server-side
+// — they read the filesystem and shell out to git — and only their result crosses.
+import { isRecord } from "./isRecord.js";
+import { isUnknownArray } from "./isUnknownArray.js";
+
+/** Why a collection would not survive a clone. Stable strings — a client branches on these, and
+ *  the prose is free to be rewritten without breaking it. */
+export type SelfContainmentCode =
+  /** The skill lives in `~/.claude/skills`, i.e. on this machine and not in the repo. */
+  | "user-scope"
+  /** Records are one SQLite file: git cannot merge it. */
+  | "sqlite-store"
+  /** Records are rows of a CSV read through DuckDB — a runtime the clone must also have. */
+  | "csv-runtime"
+  /** Something the records need is git-ignored: the schema travels, they do not. */
+  | "data-ignored"
+  /** No `primaryKey`, so ids are 4 random bytes and two machines can mint the same one. */
+  | "no-primary-key"
+  /** The project is not a git repo, so there is nothing to clone and most checks do not apply. */
+  | "not-a-repo";
+
+/** `blocker` stops the clone working; `warning` costs something on the other machine; `info` is
+ *  context. Only a blocker makes `portable` false. */
+export type SelfContainmentSeverity = "blocker" | "warning" | "info";
+
+export interface SelfContainmentFinding {
+  /** One of `SelfContainmentCode` in practice, typed as a plain string on the WIRE on purpose: a
+   *  newer server may report a code this build has never heard of, and narrowing here would drop
+   *  a real finding behind a version skew. Nothing branches on it — the pane renders `message`
+   *  and colours by `severity` — so widening costs nothing. A spec pins that everything the
+   *  server produces IS in the union. */
+  code: string;
+  severity: SelfContainmentSeverity;
+  /** What breaks on the other machine, in the terms the person will see it. */
+  message: string;
+}
+
+export interface SelfContainmentReport {
+  slug: string;
+  /** True when nothing BLOCKS the clone. Warnings can still be present. */
+  portable: boolean;
+  findings: SelfContainmentFinding[];
+}
+
+/** The severity IS narrowed, unlike the code: it decides how the row is rendered, so an
+ *  unrecognised one has no styling to fall back to. A predicate rather than a list membership
+ *  test, so the narrowing is the type system's rather than an assertion's. */
+export function isSelfContainmentSeverity(value: unknown): value is SelfContainmentSeverity {
+  return value === "blocker" || value === "warning" || value === "info";
+}
+
+function asFinding(value: unknown): SelfContainmentFinding | null {
+  if (!isRecord(value)) return null;
+  const { code, severity, message } = value;
+  if (typeof code !== "string" || typeof message !== "string") return null;
+  if (!isSelfContainmentSeverity(severity)) return null;
+  return { code, severity, message };
+}
+
+/** Narrow a fetched body to the report, or null when it is not one. The body arrives as
+ *  `unknown` — a truncated response, an error page, an older server — so every level is checked
+ *  rather than trusted. */
+export function asSelfContainmentReport(body: unknown): SelfContainmentReport | null {
+  if (!isRecord(body)) return null;
+  const { slug, portable, findings } = body;
+  if (typeof slug !== "string" || typeof portable !== "boolean" || !isUnknownArray(findings)) return null;
+  const parsed: SelfContainmentFinding[] = [];
+  for (const entry of findings) {
+    const finding = asFinding(entry);
+    if (finding) parsed.push(finding);
+  }
+  return { slug, portable, findings: parsed };
+}

--- a/plans/HANDOFF-collections-projects.md
+++ b/plans/HANDOFF-collections-projects.md
@@ -144,13 +144,31 @@ the field. **This needs a collection-plugin release built against core 3.1.0.** 
 surface-level scoping covers the real case (one panel, one session's work); what is missing is two
 cards from two projects in the same panel.
 
-### 3.4 The phone (§7c E)
+### 3.4 The phone (§7c E) — PREPARATION DONE
 
-`server/backends/remoteHost/handlers/*` are bound to `workspaceScope()`, so a project's
-collections do not exist on the phone. Preparation is specified in
-`../mulmoclaude/plans/feat-collection-multi-root-2.md` §8: handlers should resolve a scope from
-params defaulting to the host root (so adding the parameter later changes no handler), the scope
-must be an opaque id, and the artifact stays host-built.
+The command handlers no longer hard-code the workspace. `server/backends/remoteHost/commandScope.ts`
+resolves a scope from the command's params, defaulting to the host's root, and every collection /
+feed / skill handler calls it — so the day a phone gains a project picker, the picker is the only
+new thing (`../mulmoclaude/plans/feat-collection-multi-root-2.md` §8, item 3).
+
+**No behaviour changed**: nothing sends `project` yet, so every command resolves the same root it
+did before.
+
+- The param name and reader are core's (`COMMAND_SCOPE_PARAM`, `readCommandScope`) — the wire name
+  was already reserved upstream, so nothing here invents one.
+- **An opaque id, never a path.** A path in a command would publish the user's home directory over
+  the wire and make every handler an arbitrary-directory reader; the id resolves against the
+  server's own list, and a spec pins that a real path is REFUSED.
+- **A named-but-unknown project THROWS**, which is a deliberate divergence from the wording on
+  core's `readCommandScope` ("fall back to the default"). Falling back would serve the workspace's
+  records to a phone that asked for a project's — the silent wrong-root answer the HTTP side
+  answers 400 for. An ABSENT scope still defaults, which is what that rule is really about.
+- `getCollection` and `getFeed` build their deps once, so the scope is threaded through the deps
+  per call rather than captured at construction — the one shape a later `project` param could not
+  have changed.
+
+Still missing (deliberately, per §8): the phone-side picker, and a command that lets it LEARN the
+`{ id, label }` list.
 
 ### 3.5 Per-root scheduled feed refresh — BLOCKED UPSTREAM (attempted, reverted)
 
@@ -210,8 +228,49 @@ Two decisions worth keeping:
 - **Unknown is not clean.** `dataDirIgnored` is `boolean | null`, and `null` (no repo, no git)
   reports nothing rather than clearing the collection.
 
-Not done: nothing SURFACES it yet — no button, no agent tool, no creation-time hook. The route is
-the seam a UI would use, and the rules are a pure function anything can call.
+**Surfaced in the Collections pane** (a strip below the plugin's views, outside its shadow root):
+a "Survives a clone?" button while a collection is open, then the findings, coloured by severity.
+A BUTTON rather than something computed on open, because the answer changes without the collection
+changing — a `.gitignore` line lands, `git init` runs, the skill moves into the project.
+
+The wire shape lives in `common/collectionPortability.ts`, since both sides decide from it. The
+finding's `code` is a plain `string` there on purpose: a newer server may report one this build has
+never heard of, and narrowing would drop a real finding behind a version skew. `severity` IS
+narrowed — it decides how the row renders. A spec pins that the server only ever produces a
+documented code.
+
+Still missing: an agent-facing form (a tool or a skill step), and a creation-time hook. §11.4 asked
+for "collection-creation time and as a command"; this is the command half.
+
+### 3.7 A live browser check — DONE for the overlay, still owed for the pane
+
+**How it is run** (repeatable, and it touches neither the live config nor a real project): start a
+server from this checkout with `HOME` pointed at a scratch dir holding its own
+`.mulmoterminal/config.json`, `CLAUDE_CWD` at an empty scratch workspace, and `PORT` on a free
+port. Drive Chromium with the Playwright already installed in a sibling checkout
+(`../mulmoclaude/node_modules/playwright`) — this repo gains no dependency. The scratch project is
+a real git repo with one collection whose `data/` is gitignored, so the portability rules have
+something true to say.
+
+**What it proved (2026-08-09), none of which a unit test can see:**
+
+- The per-root watchers mount for real: the boot log says
+  `collection completion watchers started { roots: 2 }` and a watcher for the scratch project's own
+  collection. §3.1 had never been observed in a live process.
+- `/collections` shows "No collections installed" for the empty workspace, while
+  `/collections?project=<id>` shows the PROJECT's collection, and
+  `/collections/<slug>?project=<id>` shows its records. That is the project query, the surface
+  scoping and the plugin's fetch, working together inside the shadow root.
+- Zero console errors and zero page errors across all three routes.
+
+**What it did NOT reach.** The Collections PANE — and therefore the portability strip and the
+button-visibility rule — needs a cell whose session reports the `data` MCP group, i.e. a real agent
+session. Nothing in this harness can conjure one, and spawning a paid agent was not something to do
+unasked. The pane's own behaviour is covered by component specs; what remains unobserved is its
+height, the plugin views inside ITS shadow root, and the strip's layout beneath them.
+
+The original lesson stands: server-side correctness was verified by curl and by specs at every
+step, and none of that said the feature was reachable.
 
 ### 3.8 The Collections button only where the tools are (added 2026-08-09)
 
@@ -229,30 +288,10 @@ Two consequences to keep in mind:
 - **A cell with no session gets no button** — no MCP client, no groups. That is the honest answer,
   but it also hides the pane on a launcher or command cell whose DIRECTORY does have collections.
 - **The pane has no close control of its own**, so the button is its only way out. It therefore
-  stays visible while the pane is open regardless of the groups (`collectionsOpenable`) — remove
-  that clause and the pane is stranded for the life of the cell.
-
-### 3.7 A live browser check — still owed, and it already cost one dead button
-
-The Collections pane shipped without one. The pane's height, the plugin views inside the shadow
-root, and the nav containment are exactly what a test suite does not see. Note that this instance
-serves compiled `dist/` with no HMR — a UI change needs `yarn build` and a server restart before it
-is visible.
-
-**What the first hand-press found (2026-08-09):** the "Show this folder's collections" button had
-never worked. `CellChromeButtons` emitted `toggle-collections`, but `cellChromeBinding`'s
-`chromeEvents` object — which every cell binds with a single `v-on` — had no key for it, and
-`GridCellEmits` did not declare it. So the emit was dropped inside the cell and `TerminalGrid`'s
-handler waited for something nothing ever sent. Fixed by adding the event to both, plus
-`cellShellEvents`.
-
-Two things made it survive: an unlistened Vue emit is legal, so `typecheck` was clean; and the
-existing "forwards every chrome event" test listed the events BY HAND from the same wrong set of
-four. The replacement (`test/src/components/cellChromeForwarding.spec.ts`) derives the expectation
-from `CellChromeButtons`' own runtime `emits`, so the next button is covered the day it is added.
-
-The general lesson for the rest of this list: server-side correctness here has been verified by
-curl and by specs at every step, and none of that says the feature is reachable.
+  stays visible while the pane is open regardless of the groups. That clause lives in
+  `CellChromeButtons` beside the `v-if` it guards (moved there on review), where `rightPane` is
+  THAT cell's pane rather than the one the grid happens to be showing — remove it and an open pane
+  is stranded for the life of the cell.
 
 ---
 

--- a/server/backends/collectionSelfContainment.ts
+++ b/server/backends/collectionSelfContainment.ts
@@ -21,33 +21,11 @@ import { loadCollection } from "@mulmoclaude/core/collection/server";
 import type { Express, Request, Response } from "express";
 import { errorStatus, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
 import { isRecord } from "../../common/isRecord.js";
+// The wire shape is shared: the Collections pane renders this report and colours by severity, so
+// a second copy of the union here is how the two would drift while both keep compiling.
+import type { SelfContainmentFinding, SelfContainmentReport } from "../../common/collectionPortability.js";
 
 const run = promisify(execFile);
-
-/** Why a collection would not survive a clone. Stable strings — a client branches on these, and
- *  the prose is free to be rewritten. */
-export type SelfContainmentCode =
-  /** The skill lives in `~/.claude/skills`, i.e. on this machine and not in the repo. */
-  | "user-scope"
-  /** Records are one SQLite file: git cannot merge it. */
-  | "sqlite-store"
-  /** Records are rows of a CSV read through DuckDB — a runtime the clone must also have. */
-  | "csv-runtime"
-  /** The data directory is git-ignored: the schema travels, the records do not. */
-  | "data-ignored"
-  /** No `primaryKey`, so ids are 4 random bytes and two machines can mint the same one. */
-  | "no-primary-key"
-  /** The project is not a git repo, so there is nothing to clone and most checks do not apply. */
-  | "not-a-repo";
-
-export type SelfContainmentSeverity = "blocker" | "warning" | "info";
-
-export interface SelfContainmentFinding {
-  code: SelfContainmentCode;
-  severity: SelfContainmentSeverity;
-  /** What breaks on the other machine, in the terms the person will see it. */
-  message: string;
-}
 
 /** Everything the verdict depends on, separated from how it is discovered — so the rules can be
  *  exercised without a git repo and a workspace on disk, and so each rule reads as one line. */
@@ -63,13 +41,6 @@ export interface SelfContainmentFacts {
    *  Null when it could not be established — not a repo, or git is not on PATH. Null is NOT
    *  "fine": it is "unknown", and the check says nothing rather than clearing it. */
   dataDirIgnored: boolean | null;
-}
-
-export interface SelfContainmentReport {
-  slug: string;
-  /** True when nothing BLOCKS the clone. Warnings can still be present. */
-  portable: boolean;
-  findings: SelfContainmentFinding[];
 }
 
 /** The rules, in the order someone should act on them. Pure. */

--- a/server/backends/remoteHost/commandScope.ts
+++ b/server/backends/remoteHost/commandScope.ts
@@ -1,0 +1,45 @@
+// Which project a phone's command operates on.
+//
+// PREPARATION, not a feature: no client sends the parameter yet, and every command below
+// resolves the host's own workspace exactly as it did before this file existed. It is written now
+// because the parts that are hard to change later are the ones being written today — the day a
+// phone gains a project picker, the only new thing should be the picker
+// (../mulmoclaude/plans/feat-collection-multi-root-2.md §8, and the contract on core's
+// `COMMAND_SCOPE_PARAM`).
+//
+// Three rules the handlers inherit by using this:
+//
+// 1. **AN OPAQUE ID, NEVER A PATH.** The phone is a genuinely remote client, so an absolute root
+//    in a command, an artifact or a token publishes the user's home directory over the wire. The
+//    id is resolved HERE, against the list the server owns (`rootForProjectId`), and a path never
+//    travels in either direction.
+// 2. **The artifact stays host-built.** A remote view's srcdoc, its inlined thumbnails and its
+//    token are assembled on the host, so the phone never resolves a path itself. That is what
+//    makes (1) hold without trusting the client — see remoteView.ts.
+// 3. **Handlers resolve a scope; they do not hard-code one.** Hence this call replacing an inline
+//    `workspaceScope()` at each site, even though today the two are the same value.
+import { readCommandScope } from "@mulmoclaude/core/remote-host";
+import type { JsonObject } from "@mulmoclaude/core/remote-host";
+import { rootForProjectId, workspaceScope, type ProjectScope } from "../../infra/project-root.js";
+
+/** The scope a command runs in: the project it named, or the host's workspace when it named none.
+ *
+ *  A NAMED-BUT-UNKNOWN project THROWS, and that is a deliberate divergence from the wording on
+ *  core's `readCommandScope` ("must fall back to the default"). Falling back would serve the
+ *  workspace's `tasks` to a phone that asked for a project's `tasks` — same command, same shape,
+ *  different records, nothing anywhere saying so. That silent wrong-root answer is the failure
+ *  this whole feature removed on the HTTP side (`resolveProjectRoot` answers 400), and the phone
+ *  must not reintroduce it. An absent scope still defaults, which is what core's rule is really
+ *  about and what keeps today's behaviour identical.
+ *
+ *  `fallback` is the host root the caller was constructed with, for the handlers that receive one
+ *  by injection rather than reading it globally. */
+export function scopeFromCommand(params: JsonObject, fallback?: string): ProjectScope {
+  const requested = readCommandScope(params);
+  if (requested === undefined) return fallback === undefined ? workspaceScope() : { workspaceRoot: fallback };
+  const root = rootForProjectId(requested);
+  // The id is opaque and client-supplied, so it is not echoed into the message: a value that
+  // reaches a log or a phone's error toast is one more thing travelling that need not.
+  if (root === null) throw new Error("unknown project");
+  return { workspaceRoot: root };
+}

--- a/server/backends/remoteHost/getCollection.spec.ts
+++ b/server/backends/remoteHost/getCollection.spec.ts
@@ -8,9 +8,22 @@
 // The store-seam test is the one this file exists for (#1488): records must come
 // from `listRecords` (storeFor(...).list() in production), never from a dataDir
 // read, or a CSV/SQLite-backed collection pages as empty on the phone.
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { createGetCollection, type GetCollectionDeps } from "./handlers/getCollection.js";
+import { initProjectRoots, resetProjectRootsForTesting } from "../../infra/project-root.js";
+
+// The handler RESOLVES its scope per call now (commandScope.ts) instead of capturing the
+// workspace in its deps, so the roots binding has to exist — the same binding boot installs. A
+// handler that reaches it unconfigured should fail loudly rather than invent a root, which is why
+// this is set up here rather than defaulted away inside the resolver.
+beforeEach(() => {
+  initProjectRoots({ workspace: "/srv/ws" });
+});
+
+afterEach(() => {
+  resetProjectRootsForTesting();
+});
 
 const records = (count: number) => Array.from({ length: count }, (_unused, index) => ({ id: `r${index}` }));
 

--- a/server/backends/remoteHost/handlers/getCollection.ts
+++ b/server/backends/remoteHost/handlers/getCollection.ts
@@ -12,7 +12,8 @@
 // stubbed; the default export wires the real engine functions. Mirrors
 // MulmoClaude's server/remoteHost/handlers/getCollection.ts.
 import { loadCollection, storeFor, toDetail, type LoadedCollection } from "@mulmoclaude/core/collection/server";
-import { workspaceScope } from "../../../infra/project-root.js";
+import { scopeFromCommand } from "../commandScope.js";
+import type { ProjectScope } from "../../../infra/project-root.js";
 import type { CollectionItem } from "@mulmoclaude/core/collection";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
@@ -21,7 +22,7 @@ import { readString } from "../../../../common/readString.js";
 export interface GetCollectionDeps {
   loadCollection: typeof loadCollection;
   /** Store-aware records loader (file records or a dataSource CSV's rows). */
-  listRecords: (collection: LoadedCollection) => Promise<CollectionItem[]>;
+  listRecords: (collection: LoadedCollection, scope: ProjectScope) => Promise<CollectionItem[]>;
   toDetail: typeof toDetail;
 }
 
@@ -31,14 +32,18 @@ export const createGetCollection =
     const slug = readString(params.slug);
     const offset = clampOffset(params.offset);
     const limit = clampLimit(params.limit);
-    const collection = await deps.loadCollection(slug);
+    // Resolved PER CALL and threaded into both engine calls, rather than baked into the deps at
+    // construction: the deps are built once, so a scope captured there is the one thing a later
+    // `project` param could not change (../commandScope.ts).
+    const scope = scopeFromCommand(params);
+    const collection = await deps.loadCollection(slug, scope);
     if (!collection) throw new Error(`collection '${slug}' not found`);
-    const all = deriveItems(collection.schema, await deps.listRecords(collection));
+    const all = deriveItems(collection.schema, await deps.listRecords(collection, scope));
     return pageResult(deps.toDetail(collection), all, offset, limit);
   };
 
 export const getCollection = createGetCollection({
-  loadCollection: (slug) => loadCollection(slug, workspaceScope()),
-  listRecords: (collection) => storeFor(collection, workspaceScope()).list(),
+  loadCollection,
+  listRecords: (collection, scope) => storeFor(collection, scope).list(),
   toDetail,
 });

--- a/server/backends/remoteHost/handlers/getFeed.ts
+++ b/server/backends/remoteHost/handlers/getFeed.ts
@@ -16,12 +16,15 @@ import { listFeeds } from "@mulmoclaude/core/feeds/server";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
 import { readString } from "../../../../common/readString.js";
+import { scopeFromCommand } from "../commandScope.js";
+import type { ProjectScope } from "../../../infra/project-root.js";
 
 export interface GetFeedDeps {
   listFeeds: typeof listFeeds;
   /** Store-aware records loader (file records or a dataSource CSV's rows). */
-  listRecords: (collection: LoadedCollection) => Promise<CollectionItem[]>;
+  listRecords: (collection: LoadedCollection, scope: ProjectScope) => Promise<CollectionItem[]>;
   toDetail: typeof toDetail;
+  /** The host's own root — the DEFAULT a command that names no project resolves to. */
   workspaceRoot: string;
 }
 
@@ -31,11 +34,13 @@ export const createGetFeed =
     const slug = readString(params.slug);
     const offset = clampOffset(params.offset);
     const limit = clampLimit(params.limit);
-    const feed = (await deps.listFeeds(deps.workspaceRoot)).find((entry) => entry.slug === slug);
+    // Resolved per call, defaulting to the injected root (../commandScope.ts).
+    const scope = scopeFromCommand(params, deps.workspaceRoot);
+    const feed = (await deps.listFeeds(scope.workspaceRoot)).find((entry) => entry.slug === slug);
     if (!feed) throw new Error(`feed '${slug}' not found`);
-    const all = deriveItems(feed.schema, await deps.listRecords(feed));
+    const all = deriveItems(feed.schema, await deps.listRecords(feed, scope));
     return pageResult(deps.toDetail(feed), all, offset, limit);
   };
 
 export const getFeedFor = (workspaceRoot: string): CommandHandlers["getFeed"] =>
-  createGetFeed({ listFeeds, listRecords: (collection) => storeFor(collection, { workspaceRoot }).list(), toDetail, workspaceRoot });
+  createGetFeed({ listFeeds, listRecords: (collection, scope) => storeFor(collection, scope).list(), toDetail, workspaceRoot });

--- a/server/backends/remoteHost/handlers/getRemoteView.ts
+++ b/server/backends/remoteHost/handlers/getRemoteView.ts
@@ -5,14 +5,15 @@
 import { loadCollection } from "@mulmoclaude/core/collection/server";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { buildRemoteViewFor, remoteViewFailureMessage } from "../../remoteView.js";
-import { workspaceScope } from "../../../infra/project-root.js";
+import { scopeFromCommand } from "../commandScope.js";
 import { readString } from "../../../../common/readString.js";
 
 export const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObject) => {
   const slug = readString(params.slug);
   const viewId = readString(params.viewId);
   const locale = typeof params.locale === "string" ? params.locale : "";
-  const scope = workspaceScope();
+  // The project this command names, or the host's workspace when it names none (../commandScope.ts).
+  const scope = scopeFromCommand(params);
   const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await buildRemoteViewFor(scope)(collection, viewId, locale);

--- a/server/backends/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/backends/remoteHost/handlers/getRemoteViewItems.ts
@@ -8,7 +8,7 @@ import { normalizeFields } from "@mulmoclaude/core/remote-view";
 import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
 import { clampLimit, clampOffset } from "../collectionPage.js";
 import { remoteViewItemsFor, remoteViewItemsFailureMessage } from "../../remoteView.js";
-import { workspaceScope } from "../../../infra/project-root.js";
+import { scopeFromCommand } from "../commandScope.js";
 import { jsonPayload } from "../jsonPayload.js";
 import { readString } from "../../../../common/readString.js";
 
@@ -17,7 +17,8 @@ export const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (
   const viewId = readString(params.viewId);
   const fields = normalizeFields(params.fields);
   const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), ...(fields ? { fields } : {}) };
-  const scope = workspaceScope();
+  // The project this command names, or the host's workspace when it names none (../commandScope.ts).
+  const scope = scopeFromCommand(params);
   const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await remoteViewItemsFor(scope)(collection, viewId, request);

--- a/server/backends/remoteHost/handlers/listCollections.ts
+++ b/server/backends/remoteHost/handlers/listCollections.ts
@@ -3,10 +3,10 @@
 // Mirrors GET /api/collections/list → { collections: CollectionSummary[] }. Feeds
 // (source "feed") are excluded — they are served by listFeeds.
 import { discoverCollections, toSummary } from "@mulmoclaude/core/collection/server";
-import { workspaceScope } from "../../../infra/project-root.js";
-import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { scopeFromCommand } from "../commandScope.js";
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 
-export const listCollections: CommandHandlers["listCollections"] = async () => {
-  const collections = (await discoverCollections(workspaceScope())).filter((collection) => collection.source !== "feed").map(toSummary);
+export const listCollections: CommandHandlers["listCollections"] = async (params: JsonObject) => {
+  const collections = (await discoverCollections(scopeFromCommand(params))).filter((collection) => collection.source !== "feed").map(toSummary);
   return toJsonObject({ collections });
 };

--- a/server/backends/remoteHost/handlers/listFeeds.ts
+++ b/server/backends/remoteHost/handlers/listFeeds.ts
@@ -2,16 +2,19 @@
 //
 // Feed registry with retrieval kind / schedule / last-fetch time (read-only).
 import { listFeeds, readFeedState } from "@mulmoclaude/core/feeds/server";
-import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { feedSummary } from "../../feed-summary.js";
+import { scopeFromCommand } from "../commandScope.js";
 
 export const createListFeeds =
   (workspace: string): CommandHandlers["listFeeds"] =>
-  async () => {
-    const feeds = await listFeeds(workspace);
+  async (params: JsonObject) => {
+    // The injected workspace is the DEFAULT, not the only answer — see ../commandScope.ts.
+    const { workspaceRoot: root } = scopeFromCommand(params, workspace);
+    const feeds = await listFeeds(root);
     const summaries = [];
     for (const feed of feeds) {
-      const state = await readFeedState(workspace, feed);
+      const state = await readFeedState(root, feed);
       summaries.push(feedSummary(feed, state.lastFetchedAt));
     }
     return toJsonObject({ feeds: summaries });

--- a/server/backends/remoteHost/handlers/listSkills.ts
+++ b/server/backends/remoteHost/handlers/listSkills.ts
@@ -4,13 +4,16 @@
 // slugs are subtracted — a skill dir that ships a schema.json is a collection served by
 // listCollections, so it must not double-list here (mirrors MulmoClaude's listSkills).
 import { discoverCollections } from "@mulmoclaude/core/collection/server";
-import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { discoverSkillNames } from "../skills.js";
+import { scopeFromCommand } from "../commandScope.js";
 
 export const createListSkills =
   (workspace: string): CommandHandlers["listSkills"] =>
-  async () => {
-    const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections({ workspaceRoot: workspace })]);
+  async (params: JsonObject) => {
+    // The injected workspace is the DEFAULT, not the only answer — see ../commandScope.ts.
+    const scope = scopeFromCommand(params, workspace);
+    const [names, collections] = await Promise.all([discoverSkillNames(scope), discoverCollections(scope)]);
     const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
     return toJsonObject({ skills: names.filter((name) => !collectionSlugs.has(name)) });
   };

--- a/server/backends/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/backends/remoteHost/handlers/mutateRemoteView.ts
@@ -7,7 +7,7 @@ import { loadCollection } from "@mulmoclaude/core/collection/server";
 import { normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { mutateRemoteViewFor, mutateRemoteViewFailureMessage } from "../../remoteView.js";
-import { workspaceScope } from "../../../infra/project-root.js";
+import { scopeFromCommand } from "../commandScope.js";
 import { mutateWriteApplied } from "../../mutateStatus.js";
 import { jsonPayload } from "../jsonPayload.js";
 import { readString } from "../../../../common/readString.js";
@@ -17,7 +17,8 @@ export const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = asy
   const viewId = readString(params.viewId);
   const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
   if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
-  const scope = workspaceScope();
+  // The project this command names, or the host's workspace when it names none (../commandScope.ts).
+  const scope = scopeFromCommand(params);
   const collection = await loadCollection(slug, scope);
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await mutateRemoteViewFor(scope)(collection, viewId, request);

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -14,6 +14,8 @@ import { collectionShadowCss } from "../collectionShadowCss";
 import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
 import { pushCollectionSurface, popCollectionSurface, type CollectionNavSurface, type CollectionSurface } from "../composables/collectionSurface";
 import { projectIdForCwd } from "../composables/collectionProject";
+import { fetchWithTimeout } from "../utils/fetchWithTimeout";
+import { asSelfContainmentReport, type SelfContainmentReport, type SelfContainmentSeverity } from "../../common/collectionPortability";
 import type { ShortcutKind } from "../../common/shortcuts";
 
 const props = defineProps<{ cwd: string | null }>();
@@ -81,6 +83,57 @@ watch(
 
 const unknownDirectory = computed(() => !resolving.value && projectId.value === null);
 
+// ── "would this collection survive a clone?" ──
+//
+// The check is surfaced HERE and nowhere else, because here is the only place someone is looking
+// at one collection of one project — which is exactly the pair the question is about. It is a
+// button rather than something computed on open: the answer changes without the collection
+// changing (a `.gitignore` line lands, `git init` runs, the skill moves into the project), so
+// asking on every render would be both wrong and chatty, and asking never is how #1582 shipped a
+// check nothing could reach.
+const report = ref<SelfContainmentReport | null>(null);
+const checking = ref(false);
+const checkFailed = ref(false);
+
+/** The open collection, or undefined on the index — the check is per collection. */
+const openSlug = computed(() => (view.value.mode === "detail" && view.value.kind === "collection" ? view.value.slug : undefined));
+
+// Leaving the collection drops its report: a verdict that outlived the thing it was about would
+// read as this collection's.
+watch(openSlug, () => {
+  report.value = null;
+  checkFailed.value = false;
+});
+
+async function checkPortability(): Promise<void> {
+  const slug = openSlug.value;
+  if (!slug || checking.value) return;
+  checking.value = true;
+  checkFailed.value = false;
+  report.value = null;
+  try {
+    // THIS PANE's project, not the ambient surface's: an overlay opened over this pane is the
+    // active surface, and the question is about the collection on screen here.
+    const scoped = projectId.value === null ? "" : `?project=${encodeURIComponent(projectId.value)}`;
+    const res = await fetchWithTimeout(`/api/collections/${encodeURIComponent(slug)}/self-containment${scoped}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const parsed = asSelfContainmentReport(await res.json());
+    if (!parsed) throw new Error("unrecognised report");
+    // A slower earlier answer must not land on a collection the user has since left.
+    if (openSlug.value === slug) report.value = parsed;
+  } catch {
+    if (openSlug.value === slug) checkFailed.value = true;
+  } finally {
+    checking.value = false;
+  }
+}
+
+const SEVERITY_CLASS: Record<SelfContainmentSeverity, string> = {
+  blocker: "text-err-text",
+  warning: "text-amber",
+  info: "text-dim",
+};
+
 // Register this pane's shadow root as the record-modal teleport target — same getRootNode()
 // trick as CollectionsBrowseOverlay, which is where the comment explaining it lives.
 const probe = ref<HTMLElement>();
@@ -110,14 +163,45 @@ onBeforeUnmount(unregister);
     <div v-else-if="unknownDirectory" class="p-3 font-sans text-[12px] text-dim">
       This directory has no collections yet. Collections live in <code>.claude/skills</code> under the folder the cell is open in.
     </div>
-    <div v-else class="min-h-0 flex-1">
-      <PluginFrame :css="collectionShadowCss" height="100%">
-        <div ref="probe" style="height: 100%">
-          <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" />
-          <CollectionsIndexView v-else-if="view.mode === 'index'" />
-          <CollectionView v-else />
+    <template v-else>
+      <div class="min-h-0 flex-1">
+        <PluginFrame :css="collectionShadowCss" height="100%">
+          <div ref="probe" style="height: 100%">
+            <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" />
+            <CollectionsIndexView v-else-if="view.mode === 'index'" />
+            <CollectionView v-else />
+          </div>
+        </PluginFrame>
+      </div>
+      <!-- The portability check, on a strip of its own below the plugin's own surface: it is the
+           HOST's question about the collection (does it survive a clone), not part of the
+           collection's data, and it must not be inside the shadow root the package styles. -->
+      <div v-if="openSlug" class="flex-none border-t border-border px-2.5 py-1.5 font-sans">
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent disabled:cursor-default disabled:opacity-60"
+            :disabled="checking"
+            :aria-busy="checking"
+            title="Check whether this collection would still work after a git clone on another machine"
+            @click="checkPortability"
+          >
+            {{ checking ? "Checking…" : "Survives a clone?" }}
+          </button>
+          <span v-if="checkFailed" class="text-[11px] text-err-text">Could not run the check.</span>
+          <span v-else-if="report && report.findings.length === 0" class="text-[11px] text-dim">Nothing to fix — it travels.</span>
+          <span v-else-if="report" class="text-[11px]" :class="report.portable ? 'text-amber' : 'text-err-text'">
+            {{ report.portable ? "Travels, with caveats" : "Would not survive a clone" }}
+          </span>
         </div>
-      </PluginFrame>
-    </div>
+        <!-- The MESSAGE, not the code: each one says what breaks on the other machine, which is
+             the part that tells someone what to do about it. -->
+        <ul v-if="report && report.findings.length" class="mt-1.5 flex list-none flex-col gap-1 p-0">
+          <li v-for="finding in report.findings" :key="finding.code" class="text-[11px] leading-[1.4]" :class="SEVERITY_CLASS[finding.severity]">
+            {{ finding.message }}
+          </li>
+        </ul>
+      </div>
+    </template>
   </div>
 </template>

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -207,19 +207,28 @@ onBeforeUnmount(unregister);
           >
             {{ checking ? "Checking…" : "Survives a clone?" }}
           </button>
-          <span v-if="checkFailed" class="text-[11px] text-err-text">Could not run the check.</span>
-          <span v-else-if="report && report.findings.length === 0" class="text-[11px] text-dim">Nothing to fix — it travels.</span>
-          <span v-else-if="report" class="text-[11px]" :class="report.portable ? 'text-amber' : 'text-err-text'">
-            {{ report.portable ? "Travels, with caveats" : "Would not survive a clone" }}
-          </span>
         </div>
-        <!-- The MESSAGE, not the code: each one says what breaks on the other machine, which is
-             the part that tells someone what to do about it. -->
-        <ul v-if="report && report.findings.length" class="mt-1.5 flex list-none flex-col gap-1 p-0">
-          <li v-for="finding in report.findings" :key="finding.code" class="text-[11px] leading-[1.4]" :class="SEVERITY_CLASS[finding.severity]">
-            {{ finding.message }}
-          </li>
-        </ul>
+        <!-- A LIVE REGION, and always present rather than rendered with the result: focus stays on
+             the button across the whole check, so a verdict that merely appears is a verdict a
+             screen-reader user is never told. `polite` because it answers something they asked
+             for and interrupts nothing. It wraps the findings too — the list IS the answer, not a
+             decoration on it. -->
+        <div role="status" aria-live="polite" class="mt-1">
+          <span v-if="checkFailed" class="text-[11px] text-err-text">Could not run the check.</span>
+          <!-- `portable` decides FIRST. A report can be non-portable with no findings this build
+               can read (a newer server disqualifying on something it does not describe here), and
+               "nothing to fix" is the one thing that must never be said about it. -->
+          <span v-else-if="report && !report.portable" class="text-[11px] text-err-text">Would not survive a clone</span>
+          <span v-else-if="report && report.findings.length === 0" class="text-[11px] text-dim">Nothing to fix — it travels.</span>
+          <span v-else-if="report" class="text-[11px] text-amber">Travels, with caveats</span>
+          <!-- The MESSAGE, not the code: each one says what breaks on the other machine, which is
+               the part that tells someone what to do about it. -->
+          <ul v-if="report && report.findings.length" class="mt-1.5 flex list-none flex-col gap-1 p-0">
+            <li v-for="finding in report.findings" :key="finding.code" class="text-[11px] leading-[1.4]" :class="SEVERITY_CLASS[finding.severity]">
+              {{ finding.message }}
+            </li>
+          </ul>
+        </div>
       </div>
     </template>
   </div>

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -75,6 +75,9 @@ watch(
     projectId.value = resolved;
     resolving.value = false;
     surface.projectId = resolved;
+    // The project half of the report's identity just changed, so anything in flight is about a
+    // pair that is no longer on screen — including a check for a slug that exists in BOTH.
+    invalidateCheck();
     // Reset the view: a slug open in one directory need not exist in the next.
     nav.gotoIndex("collection");
   },
@@ -98,16 +101,31 @@ const checkFailed = ref(false);
 /** The open collection, or undefined on the index — the check is per collection. */
 const openSlug = computed(() => (view.value.mode === "detail" && view.value.kind === "collection" ? view.value.slug : undefined));
 
-// Leaving the collection drops its report: a verdict that outlived the thing it was about would
-// read as this collection's.
-watch(openSlug, () => {
+// A GENERATION token, like the project lookup above it, and for a reason a slug comparison cannot
+// cover: the pair this report describes is (project, collection), and BOTH can change under an
+// in-flight request. Comparing the slug alone lets project A's verdict land on project B's
+// identically-named collection — the same-slug-in-two-roots collision this whole feature is
+// about, arriving through a race instead of through a path.
+let checkGeneration = 0;
+
+/** Abandon any in-flight check and drop what it was about. Also releases `checking`: the user is
+ *  now looking at a different (project, collection) and must be able to ask about THAT one while
+ *  the superseded request is still out. */
+function invalidateCheck(): void {
+  checkGeneration += 1;
   report.value = null;
   checkFailed.value = false;
-});
+  checking.value = false;
+}
+
+// Leaving the collection drops its report: a verdict that outlived the thing it was about would
+// read as this collection's. The project half is invalidated in the cwd watcher above.
+watch(openSlug, invalidateCheck);
 
 async function checkPortability(): Promise<void> {
   const slug = openSlug.value;
   if (!slug || checking.value) return;
+  const mine = ++checkGeneration;
   checking.value = true;
   checkFailed.value = false;
   report.value = null;
@@ -119,12 +137,13 @@ async function checkPortability(): Promise<void> {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const parsed = asSelfContainmentReport(await res.json());
     if (!parsed) throw new Error("unrecognised report");
-    // A slower earlier answer must not land on a collection the user has since left.
-    if (openSlug.value === slug) report.value = parsed;
+    if (mine === checkGeneration) report.value = parsed;
   } catch {
-    if (openSlug.value === slug) checkFailed.value = true;
+    if (mine === checkGeneration) checkFailed.value = true;
   } finally {
-    checking.value = false;
+    // Only the CURRENT check owns the flag — a superseded one clearing it would end the spinner
+    // for a request that is still out.
+    if (mine === checkGeneration) checking.value = false;
   }
 }
 

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -147,6 +147,17 @@ async function checkPortability(): Promise<void> {
   }
 }
 
+/** Whether to TELL the user it travels — the report's verdict, corrected by a blocker this build
+ *  can read.
+ *
+ *  `portable` and the findings can contradict each other, and the two directions want opposite
+ *  treatment. A non-portable report with no readable reason is trusted: a newer server may
+ *  disqualify on something this build cannot describe, and refusing to say so would replace a
+ *  wrong answer with none. A portable report carrying a BLOCKER is not trusted: the contradiction
+ *  is visible from here, and of the two readings the safe one is the blocker — a false "it
+ *  travels" is discovered by someone else, on another machine, days later. */
+const travels = computed(() => report.value !== null && report.value.portable && !report.value.findings.some((finding) => finding.severity === "blocker"));
+
 const SEVERITY_CLASS: Record<SelfContainmentSeverity, string> = {
   blocker: "text-err-text",
   warning: "text-amber",
@@ -215,10 +226,10 @@ onBeforeUnmount(unregister);
              decoration on it. -->
         <div role="status" aria-live="polite" class="mt-1">
           <span v-if="checkFailed" class="text-[11px] text-err-text">Could not run the check.</span>
-          <!-- `portable` decides FIRST. A report can be non-portable with no findings this build
-               can read (a newer server disqualifying on something it does not describe here), and
-               "nothing to fix" is the one thing that must never be said about it. -->
-          <span v-else-if="report && !report.portable" class="text-[11px] text-err-text">Would not survive a clone</span>
+          <!-- The VERDICT decides first (see `travels`): a report can be non-portable with no
+               finding this build can read, and "nothing to fix" is the one thing that must never
+               be said about it — nor may "it travels" be said over a blocker we CAN read. -->
+          <span v-else-if="report && !travels" class="text-[11px] text-err-text">Would not survive a clone</span>
           <span v-else-if="report && report.findings.length === 0" class="text-[11px] text-dim">Nothing to fix — it travels.</span>
           <span v-else-if="report" class="text-[11px] text-amber">Travels, with caveats</span>
           <!-- The MESSAGE, not the code: each one says what breaks on the other machine, which is

--- a/test/common/collectionPortability.spec.ts
+++ b/test/common/collectionPortability.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+//
+// The reader for a report the PANE renders a verdict from. What it must never do is turn a
+// response it cannot fully read into a clean bill of health.
+import { describe, it, expect } from "vitest";
+import { asSelfContainmentReport, isSelfContainmentSeverity } from "../../common/collectionPortability";
+
+const ok = {
+  slug: "notes",
+  portable: false,
+  findings: [{ code: "data-ignored", severity: "blocker", message: "The records are excluded by .gitignore." }],
+};
+
+describe("asSelfContainmentReport", () => {
+  it("reads a well-formed report", () => {
+    expect(asSelfContainmentReport(ok)).toEqual(ok);
+  });
+
+  it("keeps a code it has never heard of — a newer server's finding still says something", () => {
+    const body = { ...ok, findings: [{ code: "invented-later", severity: "warning", message: "Something new." }] };
+    expect(asSelfContainmentReport(body)?.findings[0]?.code).toBe("invented-later");
+  });
+
+  // The failure this rejection exists to prevent: drop the unreadable finding and a report whose
+  // ONLY blocker was that finding comes back as `findings: []`, which the pane renders as
+  // "nothing to fix — it travels" about a collection that does not.
+  it("REJECTS the whole report when a finding is unreadable, rather than dropping it", () => {
+    const cases = [
+      { ...ok, findings: [{ code: "data-ignored", severity: "catastrophic", message: "x" }] },
+      { ...ok, findings: [{ code: "data-ignored", severity: "blocker" }] },
+      { ...ok, findings: [{ code: 7, severity: "blocker", message: "x" }] },
+      { ...ok, findings: [ok.findings[0], null] },
+      { ...ok, findings: [ok.findings[0], { code: "x", severity: "nope", message: "y" }] },
+    ];
+    for (const body of cases) expect(asSelfContainmentReport(body)).toBeNull();
+  });
+
+  it("rejects a body that is not a report at all", () => {
+    for (const body of [null, undefined, "no", 7, {}, { slug: "a" }, { slug: "a", portable: "yes", findings: [] }, { slug: "a", portable: true }]) {
+      expect(asSelfContainmentReport(body)).toBeNull();
+    }
+  });
+
+  it("accepts an empty findings list — that IS the clean answer", () => {
+    expect(asSelfContainmentReport({ slug: "notes", portable: true, findings: [] })).toEqual({ slug: "notes", portable: true, findings: [] });
+  });
+});
+
+describe("isSelfContainmentSeverity", () => {
+  it("admits exactly the three the pane can render", () => {
+    expect(["blocker", "warning", "info"].every(isSelfContainmentSeverity)).toBe(true);
+    expect([undefined, null, "", "BLOCKER", "critical", 1].some(isSelfContainmentSeverity)).toBe(false);
+  });
+});

--- a/test/server/backends/collectionSelfContainment.spec.ts
+++ b/test/server/backends/collectionSelfContainment.spec.ts
@@ -9,13 +9,9 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import {
-  isPortable,
-  selfContainmentFactsFor,
-  selfContainmentFindings,
-  type SelfContainmentCode,
-  type SelfContainmentFacts,
-} from "../../../server/backends/collectionSelfContainment.js";
+import { isPortable, selfContainmentFactsFor, selfContainmentFindings, type SelfContainmentFacts } from "../../../server/backends/collectionSelfContainment.js";
+// The wire types are shared with the pane that renders the report.
+import type { SelfContainmentCode } from "../../../common/collectionPortability.js";
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
 import { makeTempDir } from "../../support/tempDir";
 
@@ -28,8 +24,12 @@ const PORTABLE: SelfContainmentFacts = {
   dataDirIgnored: false,
 };
 
-const codes = (facts: Partial<SelfContainmentFacts>): SelfContainmentCode[] =>
-  selfContainmentFindings({ ...PORTABLE, ...facts }).map((finding) => finding.code);
+const codes = (facts: Partial<SelfContainmentFacts>): string[] => selfContainmentFindings({ ...PORTABLE, ...facts }).map((finding) => finding.code);
+
+// The wire type widens `code` to a plain string so a newer server's finding is not dropped by an
+// older client. That widening must not become licence for THIS server to invent one: every code
+// it can produce is pinned to the documented union here.
+const KNOWN_CODES: readonly SelfContainmentCode[] = ["user-scope", "sqlite-store", "csv-runtime", "data-ignored", "no-primary-key", "not-a-repo"];
 
 const verdict = (facts: Partial<SelfContainmentFacts>): boolean => isPortable(selfContainmentFindings({ ...PORTABLE, ...facts }));
 
@@ -94,6 +94,15 @@ describe("selfContainmentFindings", () => {
       "sqlite-store",
       "no-primary-key",
     ]);
+  });
+
+  it("only ever produces a documented code", () => {
+    const everyFinding = [
+      ...selfContainmentFindings({ source: "user", storageKind: "sqlite", hasPrimaryKey: false, inGitRepo: true, dataDirIgnored: true }),
+      ...selfContainmentFindings({ source: "project", storageKind: "csv", hasPrimaryKey: true, inGitRepo: false, dataDirIgnored: null }),
+    ];
+    expect(everyFinding.length).toBeGreaterThan(4);
+    for (const finding of everyFinding) expect(KNOWN_CODES).toContain(finding.code);
   });
 
   it("names what breaks on the other machine, not just the rule", () => {

--- a/test/server/backends/remoteHost/commandScope.spec.ts
+++ b/test/server/backends/remoteHost/commandScope.spec.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+//
+// §3.4 is PREPARATION: no phone sends `project` yet, so the behaviour that matters most here is
+// the one that must not change — every command still resolves the host's workspace. The rest pins
+// the contract the phone will be held to when the picker lands, because the parts that are hard to
+// change later are the ones written today.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+
+import { scopeFromCommand } from "../../../../server/backends/remoteHost/commandScope.js";
+import { initProjectRoots, projectId, resetProjectRootsForTesting } from "../../../../server/infra/project-root.js";
+
+const WORKSPACE = "/srv/ws";
+const PROJECT = "/srv/mag2";
+
+beforeEach(() => {
+  initProjectRoots({ workspace: WORKSPACE, knownProjects: () => [{ label: "mag2", path: PROJECT }] });
+});
+
+afterEach(() => {
+  resetProjectRootsForTesting();
+});
+
+describe("scopeFromCommand", () => {
+  it("resolves the host's workspace when a command names no project — today's every command", () => {
+    expect(scopeFromCommand({})).toEqual({ workspaceRoot: WORKSPACE });
+  });
+
+  it("prefers the caller's injected root as the default, for the handlers built with one", () => {
+    // listFeeds / listSkills / getFeed receive the root by injection rather than reading it
+    // globally; the default must be THEIRS, or a factory pointed elsewhere silently drifts.
+    expect(scopeFromCommand({}, "/srv/other")).toEqual({ workspaceRoot: "/srv/other" });
+  });
+
+  it("resolves a named project by its OPAQUE id", () => {
+    expect(scopeFromCommand({ project: projectId(PROJECT) })).toEqual({ workspaceRoot: PROJECT });
+  });
+
+  // The phone is a genuinely remote client: a path in a command would publish the user's home
+  // directory over the wire, and accepting one would make every handler an arbitrary-directory
+  // reader. Only an id the server can resolve against its own list is accepted.
+  it("refuses a PATH, even a real one", () => {
+    expect(() => scopeFromCommand({ project: PROJECT })).toThrow(/unknown project/);
+    expect(() => scopeFromCommand({ project: WORKSPACE })).toThrow(/unknown project/);
+    expect(() => scopeFromCommand({ project: path.join(PROJECT, "..") })).toThrow(/unknown project/);
+  });
+
+  // The divergence from core's `readCommandScope` wording, asserted so it is a decision rather
+  // than a drift: falling back would serve the workspace's records to a phone that asked for a
+  // project's, which is the silent wrong-root answer this feature exists to remove.
+  it("THROWS for a project it cannot resolve, rather than serving the workspace", () => {
+    expect(() => scopeFromCommand({ project: "deadbeefdeadbeef" })).toThrow(/unknown project/);
+  });
+
+  it("does not echo the requested id back in the error", () => {
+    expect(() => scopeFromCommand({ project: "s3cret-looking-id" })).toThrow(/^(?!.*s3cret).*$/);
+  });
+
+  // A non-string is "absent", not an error: core's own reader normalises it that way, and a
+  // command with a malformed scope must land on the default rather than on a guess.
+  it("treats a non-string or empty scope as absent", () => {
+    expect(scopeFromCommand({ project: "" })).toEqual({ workspaceRoot: WORKSPACE });
+    expect(scopeFromCommand({ project: 7 })).toEqual({ workspaceRoot: WORKSPACE });
+    expect(scopeFromCommand({ project: null })).toEqual({ workspaceRoot: WORKSPACE });
+    expect(scopeFromCommand({ project: ["a", "b"] })).toEqual({ workspaceRoot: WORKSPACE });
+  });
+
+  it("resolves the workspace by id too, so a phone may name it explicitly", () => {
+    expect(scopeFromCommand({ project: projectId(WORKSPACE) })).toEqual({ workspaceRoot: WORKSPACE });
+  });
+});

--- a/test/src/components/CollectionsPanePortability.spec.ts
+++ b/test/src/components/CollectionsPanePortability.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// The plugin's Vue surfaces pull a large module graph and render inside a shadow root; none of
+// that is what this spec is about (the HOST's portability strip below them is). Stubbed at the
+// module boundary so the pane mounts as itself.
+vi.mock("@mulmoclaude/collection-plugin/vue", () => ({
+  CollectionsIndexView: { name: "CollectionsIndexView", template: "<div />" },
+  CollectionView: { name: "CollectionView", template: "<div />" },
+  FeedsView: { name: "FeedsView", template: "<div />" },
+  // collectionUi.ts binds the package at import time; the pane pulls that module in for its
+  // teleport-target helpers, so the mock has to answer for it too.
+  configureCollectionUi: () => {},
+}));
+vi.mock("../../../src/components/PluginFrame.vue", () => ({
+  default: { name: "PluginFrame", template: "<div><slot /></div>" },
+}));
+
+// The pane resolves its project from the server's list; this cell's cwd IS a known project.
+vi.mock("../../../src/composables/collectionProject", () => ({
+  projectIdForCwd: async (cwd: string | null) => (cwd === "/srv/mag2" ? "p1" : null),
+}));
+
+// Imported at module scope on purpose — an `await import` inside a test bills the whole module
+// graph against that test's timeout (CLAUDE.md).
+const CollectionsPane = (await import("../../../src/components/CollectionsPane.vue")).default;
+const { activeCollectionNavSurface } = await import("../../../src/composables/collectionSurface");
+
+const REPORT = {
+  slug: "newsletters",
+  portable: false,
+  findings: [
+    { code: "data-ignored", severity: "blocker", message: "The data directory is excluded by .gitignore, so the records do not travel." },
+    { code: "no-primary-key", severity: "warning", message: "No primaryKey is declared, so record ids are 4 random bytes." },
+  ],
+};
+
+let lastUrl = "";
+function mockFetch(body: unknown, ok = true) {
+  lastUrl = "";
+  globalThis.fetch = vi.fn((url: string) => {
+    lastUrl = String(url);
+    return Promise.resolve({ ok, status: ok ? 200 : 500, json: async () => body });
+  }) as unknown as typeof fetch;
+}
+
+/** Mount the pane and open a collection in it. The pane registers itself as the collection nav
+ *  SURFACE while mounted, and that is how the plugin's own views move it — so the test drives the
+ *  same seam rather than reaching into the component. (Wrappers auto-unmount after each test, so
+ *  the surface a later test finds is its own.) */
+async function mountOnCollection(slug = "newsletters") {
+  const wrapper = mount(CollectionsPane, { props: { cwd: "/srv/mag2" } });
+  await flushPromises();
+  const nav = activeCollectionNavSurface();
+  if (!nav) throw new Error("the pane did not register a nav surface");
+  nav.gotoDetail("collection", slug);
+  await flushPromises();
+  return { wrapper, nav };
+}
+
+describe("CollectionsPane portability strip", () => {
+  beforeEach(() => {
+    mockFetch(REPORT);
+  });
+
+  it("offers nothing while the pane is on the index — the question is per collection", async () => {
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/mag2" } });
+    await flushPromises();
+    expect(w.find("button").exists()).toBe(false);
+  });
+
+  it("says so when the directory is not a project the server knows", async () => {
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/unknown" } });
+    await flushPromises();
+    expect(w.text()).toContain("This directory has no collections yet");
+    expect(w.find("button").exists()).toBe(false);
+  });
+
+  it("asks the server for THIS pane's project, and renders what breaks on the other machine", async () => {
+    const { wrapper: w } = await mountOnCollection();
+    const button = w.find("button");
+    expect(button.exists()).toBe(true);
+    await button.trigger("click");
+    await flushPromises();
+
+    expect(lastUrl).toBe("/api/collections/newsletters/self-containment?project=p1");
+    expect(w.text()).toContain("Would not survive a clone");
+    // The MESSAGE, not the code — it is the part that says what to do.
+    expect(w.text()).toContain("excluded by .gitignore");
+    expect(w.text()).toContain("4 random bytes");
+  });
+
+  it("reports a clean collection without inventing a finding row", async () => {
+    mockFetch({ slug: "newsletters", portable: true, findings: [] });
+    const { wrapper: w } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Nothing to fix");
+    expect(w.findAll("li")).toHaveLength(0);
+  });
+
+  it("says the check failed rather than showing a verdict it does not have", async () => {
+    mockFetch({}, false);
+    const { wrapper: w } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Could not run the check");
+    expect(w.text()).not.toContain("survive");
+  });
+
+  // A verdict that outlived the collection it was about would read as the new one's.
+  it("drops the report when the pane moves to another collection", async () => {
+    const { wrapper: w, nav } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Would not survive a clone");
+
+    nav.gotoDetail("collection", "other");
+    await flushPromises();
+    expect(w.text()).not.toContain("Would not survive a clone");
+  });
+});

--- a/test/src/components/CollectionsPanePortability.spec.ts
+++ b/test/src/components/CollectionsPanePortability.spec.ts
@@ -17,8 +17,9 @@ vi.mock("../../../src/components/PluginFrame.vue", () => ({
 }));
 
 // The pane resolves its project from the server's list; this cell's cwd IS a known project.
+const PROJECT_OF: Record<string, string> = { "/srv/mag2": "p1", "/srv/other": "p2" };
 vi.mock("../../../src/composables/collectionProject", () => ({
-  projectIdForCwd: async (cwd: string | null) => (cwd === "/srv/mag2" ? "p1" : null),
+  projectIdForCwd: async (cwd: string | null) => (cwd === null ? null : (PROJECT_OF[cwd] ?? null)),
 }));
 
 // Imported at module scope on purpose — an `await import` inside a test bills the whole module
@@ -106,6 +107,41 @@ describe("CollectionsPane portability strip", () => {
     await flushPromises();
     expect(w.text()).toContain("Could not run the check");
     expect(w.text()).not.toContain("survive");
+  });
+
+  // The pair a report describes is (project, collection), and BOTH can change under an in-flight
+  // request. A slug-only guard lets project A's verdict land on project B's identically-named
+  // collection — the same-slug-in-two-roots collision this feature is about, arriving through a
+  // race rather than through a path.
+  it("drops a verdict fetched for the previous project when the same slug is reopened", async () => {
+    // A fetch the test releases by hand, so the pane can be moved while it is out.
+    let release!: (body: unknown) => void;
+    const inFlight = new Promise<unknown>((resolve) => (release = resolve));
+    globalThis.fetch = vi.fn(
+      () => inFlight.then((body) => ({ ok: true, status: 200, json: async () => body })) as unknown as Promise<Response>,
+    ) as unknown as typeof fetch;
+
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/mag2" } });
+    await flushPromises();
+    const navA = activeCollectionNavSurface();
+    navA?.gotoDetail("collection", "notes");
+    await flushPromises();
+    await w.find("button").trigger("click");
+
+    // The cell walks to another project, and the user opens ITS collection of the same name.
+    await w.setProps({ cwd: "/srv/other" });
+    await flushPromises();
+    activeCollectionNavSurface()?.gotoDetail("collection", "notes");
+    await flushPromises();
+
+    // Now project A's answer arrives.
+    release({ slug: "notes", portable: false, findings: [{ code: "data-ignored", severity: "blocker", message: "A's problem, not B's." }] });
+    await flushPromises();
+
+    expect(w.text()).not.toContain("A's problem");
+    expect(w.text()).not.toContain("Would not survive a clone");
+    // And the superseded request must not have left the button spinning.
+    expect(w.find("button").text()).toBe("Survives a clone?");
   });
 
   // A verdict that outlived the collection it was about would read as the new one's.

--- a/test/src/components/CollectionsPanePortability.spec.ts
+++ b/test/src/components/CollectionsPanePortability.spec.ts
@@ -100,6 +100,35 @@ describe("CollectionsPane portability strip", () => {
     expect(w.findAll("li")).toHaveLength(0);
   });
 
+  // `portable` is the verdict; the findings are its reasons. A build that cannot read the reason
+  // must still not contradict the verdict — "nothing to fix" is the one thing that may never be
+  // said about a report that says the collection does not travel.
+  it("never says 'nothing to fix' about a report whose verdict is not portable", async () => {
+    mockFetch({ slug: "newsletters", portable: false, findings: [] });
+    const { wrapper: w } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Would not survive a clone");
+    expect(w.text()).not.toContain("Nothing to fix");
+  });
+
+  // Focus stays on the button across the whole check, so a verdict that merely APPEARS is one a
+  // screen-reader user is never told. The region has to exist before the result lands, or the
+  // insertion is not announced at all.
+  it("announces the result through a live region that is present before it arrives", async () => {
+    const { wrapper: w } = await mountOnCollection();
+    const region = w.find('[role="status"]');
+    expect(region.exists()).toBe(true);
+    expect(region.attributes("aria-live")).toBe("polite");
+    expect(region.text()).toBe("");
+
+    await w.find("button").trigger("click");
+    await flushPromises();
+    // The findings are inside it too: the list IS the answer, not a decoration on it.
+    expect(w.find('[role="status"]').text()).toContain("Would not survive a clone");
+    expect(w.find('[role="status"]').text()).toContain("excluded by .gitignore");
+  });
+
   it("says the check failed rather than showing a verdict it does not have", async () => {
     mockFetch({}, false);
     const { wrapper: w } = await mountOnCollection();

--- a/test/src/components/CollectionsPanePortability.spec.ts
+++ b/test/src/components/CollectionsPanePortability.spec.ts
@@ -112,6 +112,37 @@ describe("CollectionsPane portability strip", () => {
     expect(w.text()).not.toContain("Nothing to fix");
   });
 
+  // The mirror case, and the one where the client can SEE the contradiction: of the two readings
+  // the safe one is the blocker, because a false "it travels" is discovered by someone else, on
+  // another machine, days later.
+  it("does not call it portable over a blocker it can read", async () => {
+    mockFetch({
+      slug: "newsletters",
+      portable: true,
+      findings: [{ code: "sqlite-store", severity: "blocker", message: "Records are one SQLite file; git cannot merge it." }],
+    });
+    const { wrapper: w } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Would not survive a clone");
+    expect(w.text()).not.toContain("Travels, with caveats");
+    // The reason is still shown — the correction is to the headline, not to the report.
+    expect(w.text()).toContain("git cannot merge it");
+  });
+
+  it("still says 'with caveats' when the findings are only warnings", async () => {
+    mockFetch({
+      slug: "newsletters",
+      portable: true,
+      findings: [{ code: "no-primary-key", severity: "warning", message: "No primaryKey is declared." }],
+    });
+    const { wrapper: w } = await mountOnCollection();
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("Travels, with caveats");
+    expect(w.text()).not.toContain("Would not survive");
+  });
+
   // Focus stays on the button across the whole check, so a verdict that merely APPEARS is one a
   // screen-reader user is never told. The region has to exist before the result lands, or the
   // insertion is not announced at all.


### PR DESCRIPTION
Picks up `plans/HANDOFF-collections-projects.md` §3.6 (the surfacing half), §3.4 and §3.7.

## 1. "Survives a clone?" in the Collections pane (§3.6)

#1582 shipped the rules and a route and **nothing that could reach them**. Now there is a strip below the plugin's views — outside its shadow root, because this is the host's question about the collection, not part of the collection's data.

- A **button**, not something computed on open: the answer changes without the collection changing (a `.gitignore` line lands, `git init` runs, the skill moves into the project).
- It asks about **this pane's** project, not the ambient surface's — an overlay opened over the pane is the active surface, while the question is about the collection on screen here.
- A slower earlier answer is dropped if the user has moved on, and leaving the collection drops the report: a verdict that outlived what it was about would read as the new collection's.
- The wire shape moves to `common/collectionPortability.ts`. The finding's `code` is a plain `string` there **on purpose** — a newer server may report one this build has never heard of, and narrowing would drop a real finding behind a version skew. `severity` **is** narrowed (it decides how the row renders), through a predicate rather than an assertion. A spec pins that this server only ever produces a documented code, so the widening is not licence to invent one.

Still missing: an agent-facing form and a creation-time hook. §11.4 asked for "creation time and as a command"; this is the command half.

## 2. The phone's handlers resolve a scope (§3.4)

**Preparation only — no behaviour changes.** Nothing sends the parameter yet, so every command resolves the same root it did before. It is written now because the day a phone gains a project picker, the picker should be the only new thing (`../mulmoclaude/plans/feat-collection-multi-root-2.md` §8, item 3).

- The param name and reader are **core's own** (`COMMAND_SCOPE_PARAM`, `readCommandScope`) — no wire name invented here.
- **An opaque id, never a path.** A path in a command would publish the user's home directory over the wire and turn every handler into an arbitrary-directory reader. A spec pins that a real path is refused.
- **A named-but-unknown project throws** — a deliberate divergence from the wording on core's `readCommandScope` ("fall back to the default"), flagged here as CLAUDE.md asks. Falling back would serve the workspace's records to a phone that asked for a project's: the silent wrong-root answer the HTTP side answers 400 for. An *absent* scope still defaults, which is what that rule is really about.
- `getCollection` / `getFeed` build their deps once, so the scope is threaded through **per call** rather than captured at construction — the one shape a later `project` param could not have changed.

## 3. The first live browser check (§3.7)

**How to run it**, recorded in the plan: a server from this checkout with `HOME` pointed at a scratch config and `CLAUDE_CWD` at an empty scratch workspace, driven with the Playwright already installed in a sibling checkout. It touches neither the live config nor a real project, and **this repo gains no dependency**.

What it proved, none of which a unit test can see:

- The **per-root watchers mount in a live process** — `collection completion watchers started { roots: 2 }`, plus a watcher for the scratch project's own collection. §3.1 shipped in #1580 and had never been observed running.
- `/collections` shows "No collections installed" for the empty workspace, while `/collections?project=<id>` shows the **project's** collection and `/collections/<slug>?project=<id>` shows its records — the project query, the surface scoping and the plugin's fetch working together **inside the shadow root**.
- Zero console errors and zero page errors across all three routes.

**What it did not reach**: the Collections pane itself — and therefore the new strip and the button-visibility rule — needs a cell whose session reports the `data` MCP group, i.e. a real agent session. Nothing in the harness can conjure one and spawning a paid agent unasked was not something to do. Said plainly in the plan rather than left reading as "verified".

## Verification

`yarn format / lint / typecheck / build / test` — 9533 passing, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project-scoped collection, feed, skill, and remote-view operations.
  - Added portability checks to collections, displaying status and self-containment findings.
  - Added validation for portability reports and findings.

- **Bug Fixes**
  - Prevented stale portability results from appearing when switching collections or projects.
  - Improved handling of unknown, malformed, or invalid project selections.

- **Tests**
  - Expanded coverage for project scoping, portability checks, report validation, and collection navigation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->