### PR TITLE
Collections: the agent hears the portability verdict, the phone can list projects, and a new project's watchers start at once

### DIFF
--- a/common/pathSegments.ts
+++ b/common/pathSegments.ts
@@ -1,0 +1,23 @@
+// Splitting a filesystem path into its parts, on EITHER separator.
+//
+// `path.sep` is not the answer here: these paths come from a config file and from a saved
+// directory list, so a Windows path can be read on a mac (a synced config, a bug report, a test
+// fixture) and a POSIX one on Windows. Code that splits on "/" alone does not fail loudly on
+// `C:\Users\me\project` — it returns the WHOLE STRING as one segment, which is how a "label"
+// becomes an absolute path.
+//
+// That is a privacy contract in one place: the phone's project listing sends a label and never a
+// path, precisely so a command or an artifact cannot publish the user's home directory. A
+// one-separator split turns that guarantee off on Windows without changing a line of the code
+// that states it.
+
+/** The non-empty parts of a path, splitting on `/` and `\` alike. A drive letter (`C:`) stays a
+ *  segment of its own — it is not a directory name, and nothing here wants it as one. */
+export function pathSegments(value: string): string[] {
+  return value.split(/[/\\]+/).filter((segment) => segment.length > 0);
+}
+
+/** The last part of a path — its directory or file name — or the input when it has none. */
+export function lastSegment(value: string): string {
+  return pathSegments(value).at(-1) ?? value;
+}

--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -41,16 +41,40 @@ grouped in `handlers/terminalSession.ts`.
 | `startChat` | `message`, `attachments?` | `{ started: true, chatId }` |
 | `listIssues` | — | `{ repos: RepoIssueRows[] }` |
 | `startIssueWork` | `repo`, `issue`, `run?` | `{ started: true, sessionId, branch, issue, outcome, ran }` |
-| `listFeeds` | — | `{ feeds }` |
-| `getFeed` | `slug`, `offset?`, `limit?` | the feed page |
-| `listCollections` | — | `{ collections }` (feed-backed ones excluded) |
-| `getCollection` | `slug`, `offset?`, `limit?` | one page of the collection's items |
+| `listFeeds` | `project?` | `{ feeds }` |
+| `getFeed` | `slug`, `project?`, `offset?`, `limit?` | the feed page |
+| `listCollectionProjects` | — | `{ projects: { id, label }[] }` — workspace first |
+| `listCollections` | `project?` | `{ collections }` (feed-backed ones excluded) |
+| `getCollection` | `slug`, `project?`, `offset?`, `limit?` | one page of the collection's items |
 | `listShortcuts` | — | `{ shortcuts }` |
-| `listSkills` | — | `{ skills }` (collection slugs excluded) |
+| `listSkills` | `project?` | `{ skills }` (collection slugs excluded) |
 | `listAccountingBooks` | — | `{ books: { id, name }[] }` |
-| `getRemoteView` | `slug`, `viewId`, `locale?` | `{ view, srcdoc, bytes }` |
-| `getRemoteViewItems` | `slug`, `viewId`, `offset?`, `limit?`, `fields?` | `{ page, inlined, omitted }` |
-| `mutateRemoteViewItem` | `slug`, `viewId`, `op`, `id`, `patch?` | `{ op, item }` / `{ op, id }` |
+| `getRemoteView` | `slug`, `viewId`, `project?`, `locale?` | `{ view, srcdoc, bytes }` |
+| `getRemoteViewItems` | `slug`, `viewId`, `project?`, `offset?`, `limit?`, `fields?` | `{ page, inlined, omitted }` |
+| `mutateRemoteViewItem` | `slug`, `viewId`, `project?`, `op`, `id`, `patch?` | `{ op, item }` / `{ op, id }` |
+
+### Which project a command means (`project`)
+
+A collection lives in a **directory**, and the host serves several: its own workspace plus every
+directory the user has saved. Every command above that reads collections, feeds or skills accepts
+an optional **`project`**, and `listCollectionProjects` is how the phone learns the ids to put in
+it.
+
+Three rules, and they are the contract rather than this host's preference:
+
+1. **The value is an OPAQUE ID, never a path.** The phone is a genuinely remote client — an
+   absolute root in a command or an artifact publishes the user's home directory over the wire.
+   Ids come from `listCollectionProjects` and are resolved host-side against the list the host
+   owns; a path is refused even when it names a real project.
+2. **Omitting it means the host's own workspace**, which is what every command meant before this
+   parameter existed. A phone that never sends it behaves exactly as it always did.
+3. **An id the host cannot resolve is an ERROR, not a fallback.** Serving the workspace's records
+   to a request that named a project would be the same slug, the same shape and different records,
+   with nothing saying so. Re-fetch the list and retry rather than treating the answer as the
+   project's.
+
+The ids are derived from the directory, not stored, so they survive a host restart — but they are
+not a name: a project the user removes stops resolving, which is the error in (3).
 
 The three `*RemoteView*` commands serve a collection's **mobile custom views**. The host wraps
 each view into its sandboxed `srcdoc` (CSP + postMessage bootstrap) and the phone renders that

--- a/plans/HANDOFF-collections-projects.md
+++ b/plans/HANDOFF-collections-projects.md
@@ -104,9 +104,10 @@ which is the canonical authoring path.
   generation. `feat-collections-project-root.md` §7b describes the 3.0.0 contract and is now
   historical on that point.
 
-Not done: nothing calls `syncCollectionWatcherRoots` when a directory is recorded, so a project
-launched for the first time waits up to a minute for its watcher. Config writes go through several
-paths (`POST /api/config`, `cli-init`) and the poll covers them all.
+The poll is now the FALLBACK, not the only path: `POST /api/config` reports when the saved-directory
+list actually moved (by path — a relabel is the same directory) and `app-routes.ts` pulls the sync
+forward. `cli-init` writes before the server runs, so it needs nothing. The callback is injected
+rather than imported, so the config module stays config-shaped.
 
 ### 3.2 Notification deep links — DONE
 
@@ -167,8 +168,14 @@ did before.
   per call rather than captured at construction — the one shape a later `project` param could not
   have changed.
 
-Still missing (deliberately, per §8): the phone-side picker, and a command that lets it LEARN the
-`{ id, label }` list.
+`listCollectionProjects` completes the host half: the handlers could already resolve a project a
+command NAMES, and this is how the phone learns which ids exist. It carries id + label and
+deliberately NOT the cwd the browser listing has — the browser needs the path to match a project to
+a cell it is already showing, and the phone, being genuinely remote, must not be handed one.
+`docs/remote-host-protocol.md` documents the parameter, the listing, and the three rules (opaque
+id; omitted means the workspace; an unresolvable id is an error, not a fallback).
+
+Still missing, and it is not in this repo: the phone's own project picker.
 
 ### 3.5 Per-root scheduled feed refresh — BLOCKED UPSTREAM (attempted, reverted)
 
@@ -239,8 +246,19 @@ never heard of, and narrowing would drop a real finding behind a version skew. `
 narrowed — it decides how the row renders. A spec pins that the server only ever produces a
 documented code.
 
-Still missing: an agent-facing form (a tool or a skill step), and a creation-time hook. §11.4 asked
-for "collection-creation time and as a command"; this is the command half.
+**The agent gets it too**, on the one action that can change the answer: a successful `putSchema`
+carries the findings back as a `portability` field beside `written: true`
+(`server/infra/collectionToolPortability.ts`). The agent is the one that chose the storage kind or
+dropped the `primaryKey`, and it is holding the file open at the moment that is cheapest to fix.
+
+Quiet by construction: a clean collection is not mentioned, a refusal (which is PROSE the agent is
+meant to act on) is passed through untouched, every other action is left alone rather than spending
+a git call per listing, and a failure of the check itself changes nothing about the write.
+
+Still missing: a creation-time hook. There is nowhere to put one — creation is a plain file write
+the engine never sees (`putSchema` refuses an unknown collection and tells the agent to create it
+by writing SKILL.md + schema.json), so the first moment the host can speak is the schema edit that
+follows. §11.4's "at collection-creation time" is answered by that, not by a hook.
 
 ### 3.7 A live browser check — DONE for the overlay, still owed for the pane
 

--- a/server/backends/remoteHost/handlers/index.ts
+++ b/server/backends/remoteHost/handlers/index.ts
@@ -19,6 +19,7 @@ import { getRemoteView } from "./getRemoteView.js";
 import { createIssueWorkHandlers } from "./issueWork.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
 import { createListAccountingBooks } from "./listAccountingBooks.js";
+import { listCollectionProjects } from "./listCollectionProjects.js";
 import { listCollections } from "./listCollections.js";
 import { createListFeeds } from "./listFeeds.js";
 import { createListShortcuts } from "./listShortcuts.js";
@@ -35,6 +36,9 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
 
   return {
     listCollections,
+    // How the phone LEARNS which projects it may name — the other half of the scope the
+    // collection handlers already resolve (../commandScope.ts).
+    listCollectionProjects,
     getCollection,
     getRemoteView,
     getRemoteViewItems,

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -38,13 +38,45 @@ const MAX_BORROWED_SEGMENTS = 2;
  *  still collide after `MAX_BORROWED_SEGMENTS`, the id's first characters break the tie — ugly,
  *  but ugly and distinct beats pretty and ambiguous. */
 function disambiguated(projects: ProjectSummary[]): { id: string; label: string }[] {
-  const named = projects.map((project) => ({ ...project, label: pathFreeLabel(project) }));
+  const named = projects.map((project) => ({ id: project.id, cwd: project.cwd, label: pathFreeLabel(project) }));
   const counts = new Map<string, number>();
   for (const project of named) counts.set(project.label, (counts.get(project.label) ?? 0) + 1);
   return named.map((project) => ({
     id: project.id,
     label: (counts.get(project.label) ?? 0) > 1 ? distinguish(project, named) : project.label,
   }));
+}
+
+/** The shortest tail of `cwd` that no other project shares, or the (already path-free) label plus
+ *  an id fragment.
+ *
+ *  Every candidate is checked before it is returned, including the last one: this is the final
+ *  thing between a config file full of arbitrary strings and a wire that promises no paths, so it
+ *  ends by proving the answer rather than by trusting where the answer came from. */
+function distinguish(project: SafeProject, projects: SafeProject[]): string {
+  // BOTH separators: splitting on "/" alone leaves `C:\Users\me\project` as ONE segment, so the
+  // "tail" would be the whole absolute path — the no-path rule silently off on Windows.
+  const tailOf = (cwd: string, depth: number) => pathSegments(cwd).slice(-depth).join("/");
+  for (let depth = 2; depth <= MAX_BORROWED_SEGMENTS + 1; depth += 1) {
+    const tail = tailOf(project.cwd, depth);
+    // A tail can fail in two ways, and BOTH have been shipped here: it can be a location in its
+    // own right (a drive letter is a segment like any other), or it can be EMPTY — a filesystem
+    // root has no segments to borrow, so the "distinguishing" label was a blank string.
+    if (tail.length === 0 || looksLikePath(tail)) continue;
+    const shared = projects.some((other) => other.id !== project.id && tailOf(other.cwd, depth) === tail);
+    if (!shared) return tail;
+  }
+  // `project.label` is `pathFreeLabel`'s output, not the saved string — the type says so, which is
+  // the point: a reader should not have to trace where it came from to know it is safe.
+  return `${project.label} (${project.id.slice(0, 6)})`;
+}
+
+/** A project whose label has already been through `pathFreeLabel`. A nominal type would be
+ *  heavier than this is worth; the name is what tells `distinguish` what it is holding. */
+interface SafeProject {
+  id: string;
+  cwd: string;
+  label: string;
 }
 
 /** A label with no path in it — ENFORCED here rather than assumed of what is stored.
@@ -55,14 +87,11 @@ function disambiguated(projects: ProjectSummary[]): { id: string; label: string 
  *  the protocol promises never receives one, publishing the user's home directory over the wire.
  *
  *  The no-path rule is this listing's to keep. A label that looks like a path is replaced by the
- *  directory's own name, which is what the label was supposed to be. */
+ *  directory's own name, and the FALLBACK is checked too, because it can fail the same test: a
+ *  project at a filesystem root has no name to fall back to. */
 function pathFreeLabel(project: ProjectSummary): string {
   const label = project.label.trim();
   if (label.length > 0 && !looksLikePath(label)) return label;
-  // The FALLBACK is checked too, because it can fail the same test: a project at a filesystem
-  // root has no directory name to fall back to — `lastSegment("/")` is `"/"` and a Windows drive
-  // root is `"C:"`. Both would walk straight past the check just made, which is the whole reason
-  // this is one function and not a check followed by a trusting `else`.
   const derived = lastSegment(project.cwd).trim();
   return derived.length > 0 && !looksLikePath(derived) ? derived : ROOT_LABEL;
 }
@@ -72,28 +101,11 @@ function pathFreeLabel(project: ProjectSummary): string {
  *  sharing a label. */
 const ROOT_LABEL = "root";
 
-/** A separator, a home-relative `~`, or a drive letter — the three ways a label carries location
- *  rather than a name. Deliberately broad: a false positive costs a nicer label, a false negative
- *  costs the guarantee. */
+/** A separator, a home-relative `~`, or a drive letter — the ways a label carries location rather
+ *  than a name. Deliberately broad: a false positive costs a nicer label, a false negative costs
+ *  the guarantee. */
 function looksLikePath(label: string): boolean {
   return (
     label.includes("\\") || label.startsWith("~") || label.startsWith("/") || /^[a-z]:/i.test(label) || label.split("/").some((part) => /^[a-z]:$/i.test(part))
   );
-}
-
-/** The shortest tail of `cwd` that no other project shares, or the label plus an id fragment. */
-function distinguish(project: ProjectSummary, projects: ProjectSummary[]): string {
-  // BOTH separators: splitting on "/" alone leaves `C:\\Users\\me\\project` as ONE segment, so the
-  // "tail" would be the whole absolute path — the no-path rule silently off on Windows.
-  const tailOf = (cwd: string, depth: number) => pathSegments(cwd).slice(-depth).join("/");
-  for (let depth = 2; depth <= MAX_BORROWED_SEGMENTS + 1; depth += 1) {
-    const tail = tailOf(project.cwd, depth);
-    // The borrowed segments are RAW path parts, so the tail can be a location in its own right —
-    // a drive letter (`C:`) is a segment like any other. Checked here rather than trusted,
-    // because this is the last thing between the config and the wire.
-    if (looksLikePath(tail)) continue;
-    const shared = projects.some((other) => other.id !== project.id && tailOf(other.cwd, depth) === tail);
-    if (!shared) return tail;
-  }
-  return `${project.label} (${project.id.slice(0, 6)})`;
 }

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -15,7 +15,7 @@
 // parameter and hoping.
 import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
 import { listProjectRoots, type ProjectSummary } from "../../../infra/project-root.js";
-import { pathSegments } from "../../../../common/pathSegments.js";
+import { lastSegment, pathSegments } from "../../../../common/pathSegments.js";
 
 export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () => toJsonObject({ projects: disambiguated(listProjectRoots()) });
 
@@ -38,12 +38,34 @@ const MAX_BORROWED_SEGMENTS = 2;
  *  still collide after `MAX_BORROWED_SEGMENTS`, the id's first characters break the tie — ugly,
  *  but ugly and distinct beats pretty and ambiguous. */
 function disambiguated(projects: ProjectSummary[]): { id: string; label: string }[] {
+  const named = projects.map((project) => ({ ...project, label: pathFreeLabel(project) }));
   const counts = new Map<string, number>();
-  for (const project of projects) counts.set(project.label, (counts.get(project.label) ?? 0) + 1);
-  return projects.map((project) => ({
+  for (const project of named) counts.set(project.label, (counts.get(project.label) ?? 0) + 1);
+  return named.map((project) => ({
     id: project.id,
-    label: (counts.get(project.label) ?? 0) > 1 ? distinguish(project, projects) : project.label,
+    label: (counts.get(project.label) ?? 0) > 1 ? distinguish(project, named) : project.label,
   }));
+}
+
+/** A label with no path in it — ENFORCED here rather than assumed of what is stored.
+ *
+ *  `cwdPresets` labels are arbitrary strings: hand-edited, or written by an older version, or set
+ *  to the directory itself. One that IS a path (`/Users/alice/work/private`) is perfectly unique,
+ *  so nothing else on this path would look at it twice — and it would go out verbatim to a phone
+ *  the protocol promises never receives one, publishing the user's home directory over the wire.
+ *
+ *  The no-path rule is this listing's to keep. A label that looks like a path is replaced by the
+ *  directory's own name, which is what the label was supposed to be. */
+function pathFreeLabel(project: ProjectSummary): string {
+  const label = project.label.trim();
+  return label.length > 0 && !looksLikePath(label) ? label : lastSegment(project.cwd);
+}
+
+/** A separator, a home-relative `~`, or a drive letter — the three ways a label carries location
+ *  rather than a name. Deliberately broad: a false positive costs a nicer label, a false negative
+ *  costs the guarantee. */
+function looksLikePath(label: string): boolean {
+  return label.includes("/") || label.includes("\\") || label.startsWith("~") || /^[a-z]:/i.test(label);
 }
 
 /** The shortest tail of `cwd` that no other project shares, or the label plus an id fragment. */

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -58,14 +58,27 @@ function disambiguated(projects: ProjectSummary[]): { id: string; label: string 
  *  directory's own name, which is what the label was supposed to be. */
 function pathFreeLabel(project: ProjectSummary): string {
   const label = project.label.trim();
-  return label.length > 0 && !looksLikePath(label) ? label : lastSegment(project.cwd);
+  if (label.length > 0 && !looksLikePath(label)) return label;
+  // The FALLBACK is checked too, because it can fail the same test: a project at a filesystem
+  // root has no directory name to fall back to — `lastSegment("/")` is `"/"` and a Windows drive
+  // root is `"C:"`. Both would walk straight past the check just made, which is the whole reason
+  // this is one function and not a check followed by a trusting `else`.
+  const derived = lastSegment(project.cwd).trim();
+  return derived.length > 0 && !looksLikePath(derived) ? derived : ROOT_LABEL;
 }
+
+/** What a project with no directory name of its own is called. Ambiguous between two roots by
+ *  construction — which `disambiguated` then resolves, exactly as it does for any other pair
+ *  sharing a label. */
+const ROOT_LABEL = "root";
 
 /** A separator, a home-relative `~`, or a drive letter — the three ways a label carries location
  *  rather than a name. Deliberately broad: a false positive costs a nicer label, a false negative
  *  costs the guarantee. */
 function looksLikePath(label: string): boolean {
-  return label.includes("/") || label.includes("\\") || label.startsWith("~") || /^[a-z]:/i.test(label);
+  return (
+    label.includes("\\") || label.startsWith("~") || label.startsWith("/") || /^[a-z]:/i.test(label) || label.split("/").some((part) => /^[a-z]:$/i.test(part))
+  );
 }
 
 /** The shortest tail of `cwd` that no other project shares, or the label plus an id fragment. */
@@ -75,6 +88,10 @@ function distinguish(project: ProjectSummary, projects: ProjectSummary[]): strin
   const tailOf = (cwd: string, depth: number) => pathSegments(cwd).slice(-depth).join("/");
   for (let depth = 2; depth <= MAX_BORROWED_SEGMENTS + 1; depth += 1) {
     const tail = tailOf(project.cwd, depth);
+    // The borrowed segments are RAW path parts, so the tail can be a location in its own right —
+    // a drive letter (`C:`) is a segment like any other. Checked here rather than trusted,
+    // because this is the last thing between the config and the wire.
+    if (looksLikePath(tail)) continue;
     const shared = projects.some((other) => other.id !== project.id && tailOf(other.cwd, depth) === tail);
     if (!shared) return tail;
   }

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -15,6 +15,7 @@
 // parameter and hoping.
 import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
 import { listProjectRoots, type ProjectSummary } from "../../../infra/project-root.js";
+import { pathSegments } from "../../../../common/pathSegments.js";
 
 export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () => toJsonObject({ projects: disambiguated(listProjectRoots()) });
 
@@ -47,7 +48,9 @@ function disambiguated(projects: ProjectSummary[]): { id: string; label: string 
 
 /** The shortest tail of `cwd` that no other project shares, or the label plus an id fragment. */
 function distinguish(project: ProjectSummary, projects: ProjectSummary[]): string {
-  const tailOf = (cwd: string, depth: number) => cwd.split("/").filter(Boolean).slice(-depth).join("/");
+  // BOTH separators: splitting on "/" alone leaves `C:\\Users\\me\\project` as ONE segment, so the
+  // "tail" would be the whole absolute path — the no-path rule silently off on Windows.
+  const tailOf = (cwd: string, depth: number) => pathSegments(cwd).slice(-depth).join("/");
   for (let depth = 2; depth <= MAX_BORROWED_SEGMENTS + 1; depth += 1) {
     const tail = tailOf(project.cwd, depth);
     const shared = projects.some((other) => other.id !== project.id && tailOf(other.cwd, depth) === tail);

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -1,0 +1,20 @@
+// listCollectionProjects command handler.
+//
+// The other half of the project scope (../commandScope.ts): the handlers can already RESOLVE a
+// project a command names, and this is how the phone LEARNS which ones there are. A picker needs
+// `{ id, label }` pairs from the host and can invent neither.
+//
+// Mirrors GET /api/collection-projects, minus the `cwd`. The browser is handed each project's
+// path because it has to MATCH a project to a cell it is already showing, and it knows every
+// cell's cwd anyway. The phone has no such need and is a genuinely remote client, so the path
+// stays here: an absolute root in a command or an artifact publishes the user's home directory
+// over the wire, and the id is what the host resolves against its own list.
+//
+// The workspace is included and leads the list, as it does in the HTTP listing — a phone that
+// wants "the host's own collections" names it like any other project rather than by omitting the
+// parameter and hoping.
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { listProjectRoots } from "../../../infra/project-root.js";
+
+export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () =>
+  toJsonObject({ projects: listProjectRoots().map((project) => ({ id: project.id, label: project.label })) });

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -14,7 +14,44 @@
 // wants "the host's own collections" names it like any other project rather than by omitting the
 // parameter and hoping.
 import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
-import { listProjectRoots } from "../../../infra/project-root.js";
+import { listProjectRoots, type ProjectSummary } from "../../../infra/project-root.js";
 
-export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () =>
-  toJsonObject({ projects: listProjectRoots().map((project) => ({ id: project.id, label: project.label })) });
+export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () => toJsonObject({ projects: disambiguated(listProjectRoots()) });
+
+/** How many parent directories a duplicated label may borrow to become distinct. Two is enough to
+ *  separate `~/mulmoclaude` from `~/git/ai/mulmoclaude`, which is the real case; a cap is what
+ *  keeps this from walking up to the home directory and sending the whole path after all. */
+const MAX_BORROWED_SEGMENTS = 2;
+
+/** Labels a person can tell apart, without sending a path.
+ *
+ *  Two saved directories can carry the SAME label — `cwdPresets` dedupes by path, and an
+ *  auto-derived label is just the basename, so a repo and its clone are both "mulmoclaude" (this
+ *  is the author's own config). The browser never had to care: its listing carries each project's
+ *  `cwd` and it matches them to cells. The phone deliberately gets no path, so two identical rows
+ *  would be two rows it cannot choose between — the picker would be a coin toss.
+ *
+ *  A duplicate therefore borrows the least it needs from its parent directories: `git/ai/mulmo…`
+ *  is enough to tell two clones apart and is NOT the absolute root the no-path rule is about (the
+ *  rule exists so a command or an artifact never publishes the user's home directory). If two
+ *  still collide after `MAX_BORROWED_SEGMENTS`, the id's first characters break the tie — ugly,
+ *  but ugly and distinct beats pretty and ambiguous. */
+function disambiguated(projects: ProjectSummary[]): { id: string; label: string }[] {
+  const counts = new Map<string, number>();
+  for (const project of projects) counts.set(project.label, (counts.get(project.label) ?? 0) + 1);
+  return projects.map((project) => ({
+    id: project.id,
+    label: (counts.get(project.label) ?? 0) > 1 ? distinguish(project, projects) : project.label,
+  }));
+}
+
+/** The shortest tail of `cwd` that no other project shares, or the label plus an id fragment. */
+function distinguish(project: ProjectSummary, projects: ProjectSummary[]): string {
+  const tailOf = (cwd: string, depth: number) => cwd.split("/").filter(Boolean).slice(-depth).join("/");
+  for (let depth = 2; depth <= MAX_BORROWED_SEGMENTS + 1; depth += 1) {
+    const tail = tailOf(project.cwd, depth);
+    const shared = projects.some((other) => other.id !== project.id && tailOf(other.cwd, depth) === tail);
+    if (!shared) return tail;
+  }
+  return `${project.label} (${project.id.slice(0, 6)})`;
+}

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,7 +2,7 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, copyFileSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { existsSync, copyFileSync, openSync, closeSync, unlinkSync, statSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
@@ -722,54 +722,92 @@ export function serializableAppConfig(config: AppConfig, unknownKeys: Record<str
 // windows at once — which is how the whole list was lost once already (a client-side version of
 // the same race). So the critical section is claimed with a lock file rather than hoped over.
 const LOCK_SUFFIX = ".lock";
-// Long enough that no honest read-modify-write is still holding it, short enough that a crash
-// does not wedge the config for a session. Everything inside the lock is synchronous file I/O.
-const LOCK_STALE_MS = 5_000;
+// A critical section here is synchronous file I/O — microseconds. So a lock still held after
+// SECONDS is not a slow writer, it is a crashed one, and it is broken rather than obeyed: a crash
+// must not wedge the config for the rest of the session.
+const LOCK_STALE_MS = 2_000;
+// Deliberately LONGER than the stale window, so a lock left by a crash is always broken inside
+// the wait instead of timing out. A timeout therefore means real contention, never wreckage.
+const LOCK_WAIT_MS = 3_000;
 const LOCK_RETRY_MS = 15;
-const LOCK_WAIT_MS = 2_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const hasErrnoCode = (err: unknown): err is { code: string } => isRecord(err) && typeof err.code === "string";
+
+/** Thrown when the lock could not be taken. Its own class so a route can answer "retry" rather
+ *  than reporting a generic failure for something that will very likely work in a moment. */
+export class ConfigLockTimeout extends Error {
+  constructor(file: string) {
+    super(`config is being written by another process (${path.basename(file)}) — try again`);
+    this.name = "ConfigLockTimeout";
+  }
+}
+
 /** Take the config lock, run `critical`, and release it — whatever `critical` does.
  *
- *  If the lock cannot be taken within `LOCK_WAIT_MS` the work runs ANYWAY, because the failure
- *  modes are not symmetric: proceeding risks the narrow race this exists to close, while
- *  refusing loses the user's action outright and leaves a wedged lock file permanently fatal.
- *  A stale lock (older than `LOCK_STALE_MS`, i.e. left by a crash) is broken rather than waited
- *  out, for the same reason. */
+ *  IT NEVER RUNS `critical` WITHOUT THE LOCK. An earlier version proceeded on timeout, on the
+ *  reasoning that losing the user's action is worse than a narrow race; that was wrong twice
+ *  over. The action is not lost — the caller gets a retryable error, and the one caller that
+ *  matters (recording a launched directory) retries on the next launch. And "a narrow race" is
+ *  precisely the bug this exists to close: this writer would read the old config while the holder
+ *  is still inside its own read-modify-write, and overwrite it. A rare silent deletion of someone
+ *  else's data is worse than a visible "try again". */
 export async function withConfigLock<T>(file: string, critical: () => T): Promise<T> {
   const lockPath = `${file}${LOCK_SUFFIX}`;
   const deadline = Date.now() + LOCK_WAIT_MS;
   let held = false;
-  while (Date.now() < deadline) {
-    try {
-      // `wx` is the claim: it fails if the file exists, which is what makes this a lock rather
-      // than a note that someone once intended to hold one.
-      closeSync(openSync(lockPath, "wx"));
-      held = true;
-      break;
-    } catch {
-      if (staleLock(lockPath)) {
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // Someone else broke it first — either way the next attempt can claim it.
-        }
-        continue;
-      }
-      await sleep(LOCK_RETRY_MS);
-    }
+  while (!held && Date.now() < deadline) {
+    held = tryClaim(lockPath);
+    if (!held) await sleep(LOCK_RETRY_MS);
   }
+  if (!held) throw new ConfigLockTimeout(file);
   try {
     return critical();
   } finally {
-    if (held) {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Already gone (a stale-breaker beat us to it). Nothing to undo.
+    }
+  }
+}
+
+/** One attempt at the claim. True when this call now holds the lock.
+ *
+ *  Every failure is classified rather than lumped into "someone else has it":
+ *
+ *  - **EEXIST** is the only real contention. If the holder is older than `LOCK_STALE_MS` it
+ *    crashed, so the lock is broken; otherwise the caller waits.
+ *  - **ENOENT** is a first-ever write — `~/.mulmoterminal` does not exist yet. Reading that as
+ *    contention made a fresh install wait out the whole timeout and then refuse to save anything.
+ *  - **anything else** (a read-only directory, a permissions problem) will not become true by
+ *    waiting, so it is raised immediately instead of costing the caller the full timeout first. */
+function tryClaim(lockPath: string): boolean {
+  try {
+    // `wx` is the claim: it fails if the file exists, which is what makes this a lock rather than
+    // a note that someone once intended to hold one.
+    closeSync(openSync(lockPath, "wx"));
+    return true;
+  } catch (err) {
+    const code = hasErrnoCode(err) ? err.code : "";
+    if (code === "ENOENT") {
+      mkdirSync(path.dirname(lockPath), { recursive: true });
+      return tryClaim(lockPath);
+    }
+    if (code !== "EEXIST") throw err;
+    // A stale lock is broken here, not waited out; the next attempt claims it. A FAILED unlink
+    // deliberately falls through to the caller's wait rather than retrying at full speed — the
+    // claim would fail the same way and `staleLock` would say the same thing.
+    if (staleLock(lockPath)) {
       try {
         unlinkSync(lockPath);
+        return tryClaim(lockPath);
       } catch {
-        // Already gone (a stale-breaker beat us to it). Nothing to undo.
+        // Someone else broke it first, or we may not remove it at all.
       }
     }
+    return false;
   }
 }
 

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,7 +2,7 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, copyFileSync } from "node:fs";
+import { existsSync, copyFileSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
@@ -708,6 +708,78 @@ export function serializableAppConfig(config: AppConfig, unknownKeys: Record<str
   const known = toPublicAppConfig(config);
   const extras = Object.entries(unknownKeys).filter(([key]) => !Object.hasOwn(known, key));
   return Object.fromEntries([...Object.entries(known), ...extras]);
+}
+
+// ── serializing a read-modify-write ACROSS PROCESSES ──────────────────────────────────────────
+//
+// One machine runs several mulmoterminals (several checkouts, side by side) and they share ONE
+// config.json. `writeFileAtomicSync` makes each write all-or-nothing, which stops a truncated
+// file — it does nothing about two processes that both READ the old list, each add their own
+// directory, and each write: the second rename replaces the first process's addition, and a
+// saved directory is gone with no error anywhere.
+//
+// The window is small, and it is exactly the window a user hits by launching a terminal in two
+// windows at once — which is how the whole list was lost once already (a client-side version of
+// the same race). So the critical section is claimed with a lock file rather than hoped over.
+const LOCK_SUFFIX = ".lock";
+// Long enough that no honest read-modify-write is still holding it, short enough that a crash
+// does not wedge the config for a session. Everything inside the lock is synchronous file I/O.
+const LOCK_STALE_MS = 5_000;
+const LOCK_RETRY_MS = 15;
+const LOCK_WAIT_MS = 2_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Take the config lock, run `critical`, and release it — whatever `critical` does.
+ *
+ *  If the lock cannot be taken within `LOCK_WAIT_MS` the work runs ANYWAY, because the failure
+ *  modes are not symmetric: proceeding risks the narrow race this exists to close, while
+ *  refusing loses the user's action outright and leaves a wedged lock file permanently fatal.
+ *  A stale lock (older than `LOCK_STALE_MS`, i.e. left by a crash) is broken rather than waited
+ *  out, for the same reason. */
+export async function withConfigLock<T>(file: string, critical: () => T): Promise<T> {
+  const lockPath = `${file}${LOCK_SUFFIX}`;
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  let held = false;
+  while (Date.now() < deadline) {
+    try {
+      // `wx` is the claim: it fails if the file exists, which is what makes this a lock rather
+      // than a note that someone once intended to hold one.
+      closeSync(openSync(lockPath, "wx"));
+      held = true;
+      break;
+    } catch {
+      if (staleLock(lockPath)) {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Someone else broke it first — either way the next attempt can claim it.
+        }
+        continue;
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+  try {
+    return critical();
+  } finally {
+    if (held) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Already gone (a stale-breaker beat us to it). Nothing to undo.
+      }
+    }
+  }
+}
+
+function staleLock(lockPath: string): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS;
+  } catch {
+    // Vanished between the failed claim and this check — not stale, just gone.
+    return false;
+  }
 }
 
 // Persist the whole config; returns false on any write failure so the caller can

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,8 +2,9 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, copyFileSync, openSync, closeSync, unlinkSync, statSync, mkdirSync } from "node:fs";
+import { existsSync, copyFileSync } from "node:fs";
 import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
 import {
@@ -27,7 +28,6 @@ import { isCustomAgentId, type CustomAgent } from "../../common/customAgents.js"
 import { DEFAULT_PUSH_KINDS, PUSH_KINDS, type PushKind } from "../../common/pushKinds.js";
 import { DEFAULT_SOUND_KINDS, NOTIFY_KINDS, type NotifyKind } from "../../common/notifyKinds.js";
 import { parsePresetRef } from "../../common/notifySounds.js";
-import { isRecord } from "../../common/isRecord.js";
 import { MODEL_ID_ALLOWED } from "../../common/modelIds.js";
 import { sanitizeKeymap, type Keymap } from "../../common/keymap.js";
 import { sanitizeCockpitLines, DEFAULT_COCKPIT_LINES, type CockpitLines } from "../../common/cockpitLines.js";
@@ -708,116 +708,6 @@ export function serializableAppConfig(config: AppConfig, unknownKeys: Record<str
   const known = toPublicAppConfig(config);
   const extras = Object.entries(unknownKeys).filter(([key]) => !Object.hasOwn(known, key));
   return Object.fromEntries([...Object.entries(known), ...extras]);
-}
-
-// ── serializing a read-modify-write ACROSS PROCESSES ──────────────────────────────────────────
-//
-// One machine runs several mulmoterminals (several checkouts, side by side) and they share ONE
-// config.json. `writeFileAtomicSync` makes each write all-or-nothing, which stops a truncated
-// file — it does nothing about two processes that both READ the old list, each add their own
-// directory, and each write: the second rename replaces the first process's addition, and a
-// saved directory is gone with no error anywhere.
-//
-// The window is small, and it is exactly the window a user hits by launching a terminal in two
-// windows at once — which is how the whole list was lost once already (a client-side version of
-// the same race). So the critical section is claimed with a lock file rather than hoped over.
-const LOCK_SUFFIX = ".lock";
-// A critical section here is synchronous file I/O — microseconds. So a lock still held after
-// SECONDS is not a slow writer, it is a crashed one, and it is broken rather than obeyed: a crash
-// must not wedge the config for the rest of the session.
-const LOCK_STALE_MS = 2_000;
-// Deliberately LONGER than the stale window, so a lock left by a crash is always broken inside
-// the wait instead of timing out. A timeout therefore means real contention, never wreckage.
-const LOCK_WAIT_MS = 3_000;
-const LOCK_RETRY_MS = 15;
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const hasErrnoCode = (err: unknown): err is { code: string } => isRecord(err) && typeof err.code === "string";
-
-/** Thrown when the lock could not be taken. Its own class so a route can answer "retry" rather
- *  than reporting a generic failure for something that will very likely work in a moment. */
-export class ConfigLockTimeout extends Error {
-  constructor(file: string) {
-    super(`config is being written by another process (${path.basename(file)}) — try again`);
-    this.name = "ConfigLockTimeout";
-  }
-}
-
-/** Take the config lock, run `critical`, and release it — whatever `critical` does.
- *
- *  IT NEVER RUNS `critical` WITHOUT THE LOCK. An earlier version proceeded on timeout, on the
- *  reasoning that losing the user's action is worse than a narrow race; that was wrong twice
- *  over. The action is not lost — the caller gets a retryable error, and the one caller that
- *  matters (recording a launched directory) retries on the next launch. And "a narrow race" is
- *  precisely the bug this exists to close: this writer would read the old config while the holder
- *  is still inside its own read-modify-write, and overwrite it. A rare silent deletion of someone
- *  else's data is worse than a visible "try again". */
-export async function withConfigLock<T>(file: string, critical: () => T): Promise<T> {
-  const lockPath = `${file}${LOCK_SUFFIX}`;
-  const deadline = Date.now() + LOCK_WAIT_MS;
-  let held = false;
-  while (!held && Date.now() < deadline) {
-    held = tryClaim(lockPath);
-    if (!held) await sleep(LOCK_RETRY_MS);
-  }
-  if (!held) throw new ConfigLockTimeout(file);
-  try {
-    return critical();
-  } finally {
-    try {
-      unlinkSync(lockPath);
-    } catch {
-      // Already gone (a stale-breaker beat us to it). Nothing to undo.
-    }
-  }
-}
-
-/** One attempt at the claim. True when this call now holds the lock.
- *
- *  Every failure is classified rather than lumped into "someone else has it":
- *
- *  - **EEXIST** is the only real contention. If the holder is older than `LOCK_STALE_MS` it
- *    crashed, so the lock is broken; otherwise the caller waits.
- *  - **ENOENT** is a first-ever write — `~/.mulmoterminal` does not exist yet. Reading that as
- *    contention made a fresh install wait out the whole timeout and then refuse to save anything.
- *  - **anything else** (a read-only directory, a permissions problem) will not become true by
- *    waiting, so it is raised immediately instead of costing the caller the full timeout first. */
-function tryClaim(lockPath: string): boolean {
-  try {
-    // `wx` is the claim: it fails if the file exists, which is what makes this a lock rather than
-    // a note that someone once intended to hold one.
-    closeSync(openSync(lockPath, "wx"));
-    return true;
-  } catch (err) {
-    const code = hasErrnoCode(err) ? err.code : "";
-    if (code === "ENOENT") {
-      mkdirSync(path.dirname(lockPath), { recursive: true });
-      return tryClaim(lockPath);
-    }
-    if (code !== "EEXIST") throw err;
-    // A stale lock is broken here, not waited out; the next attempt claims it. A FAILED unlink
-    // deliberately falls through to the caller's wait rather than retrying at full speed — the
-    // claim would fail the same way and `staleLock` would say the same thing.
-    if (staleLock(lockPath)) {
-      try {
-        unlinkSync(lockPath);
-        return tryClaim(lockPath);
-      } catch {
-        // Someone else broke it first, or we may not remove it at all.
-      }
-    }
-    return false;
-  }
-}
-
-function staleLock(lockPath: string): boolean {
-  try {
-    return Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS;
-  } catch {
-    // Vanished between the failed claim and this check — not stale, just gone.
-    return false;
-  }
 }
 
 // Persist the whole config; returns false on any write failure so the caller can

--- a/server/config/config-lock.ts
+++ b/server/config/config-lock.ts
@@ -5,6 +5,7 @@
 // it when — and that file is already well over its line budget.
 import path from "node:path";
 import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
 import { openSync, closeSync, unlinkSync, statSync, mkdirSync, writeSync, readFileSync } from "node:fs";
 import { isRecord } from "../../common/isRecord.js";
 
@@ -49,13 +50,13 @@ export class ConfigLockTimeout extends Error {
  *  precisely the bug this exists to close: this writer would read the old config while the holder
  *  is still inside its own read-modify-write, and overwrite it. A rare silent deletion of someone
  *  else's data is worse than a visible "try again". */
-export async function withConfigLock<T>(file: string, critical: () => T): Promise<T> {
+export async function withConfigLock<T>(file: string, critical: () => T | Promise<T>): Promise<T> {
   const lockPath = `${file}${LOCK_SUFFIX}`;
   const deadline = Date.now() + LOCK_WAIT_MS;
   // What identifies THIS claim inside the lock file, so the release can tell "still mine" from
   // "someone reclaimed it". The pid alone is not enough — one process can hold the lock twice in
   // sequence, and the second claim must not be releasable by the first.
-  const token = `${process.pid}:${randomUUID()}`;
+  const token = `${hostname()}:${process.pid}:${randomUUID()}`;
   let held = false;
   while (!held && Date.now() < deadline) {
     held = tryClaim(lockPath, token);
@@ -63,7 +64,11 @@ export async function withConfigLock<T>(file: string, critical: () => T): Promis
   }
   if (!held) throw new ConfigLockTimeout(file);
   try {
-    return critical();
+    // AWAITED inside the lock. Every caller today is synchronous, but a `critical` that returned
+    // a promise would otherwise release the lock the moment it was CREATED — the section would
+    // run outside the protection it asked for, which is worse than not locking at all because it
+    // looks locked.
+    return await critical();
   } finally {
     release(lockPath, token);
   }
@@ -125,10 +130,10 @@ function tryClaim(lockPath: string, token: string): boolean {
       return tryClaim(lockPath, token);
     }
     if (code !== "EEXIST") throw err;
-    // A stale lock is broken here, not waited out; the next attempt claims it. A FAILED unlink
-    // deliberately falls through to the caller's wait rather than retrying at full speed — the
-    // claim would fail the same way and `staleLock` would say the same thing.
-    if (staleLock(lockPath)) {
+    // A lock whose owner is gone is broken here, not waited out; the next attempt claims it. A
+    // FAILED unlink deliberately falls through to the caller's wait rather than retrying at full
+    // speed — the claim would fail the same way and `breakable` would say the same thing.
+    if (breakable(lockPath)) {
       try {
         unlinkSync(lockPath);
         return tryClaim(lockPath, token);
@@ -140,11 +145,63 @@ function tryClaim(lockPath: string, token: string): boolean {
   }
 }
 
-function staleLock(lockPath: string): boolean {
+/** Whether a lock may be taken from whoever wrote it.
+ *
+ *  AGE ALONE IS NOT ENOUGH, and this is the correction that matters: `mtime` says when the lock
+ *  was created, not whether its owner is still inside. Breaking it on age took it from a live
+ *  writer that was merely slow — paused, or blocked in synchronous filesystem I/O — and a second
+ *  writer then entered the read-modify-write the first was still in the middle of. That is the
+ *  overlap this whole file exists to prevent, reintroduced by its own recovery path.
+ *
+ *  So a lock is broken only when it is old AND its owner is GONE. The owner is asked about
+ *  directly: `process.kill(pid, 0)` sends no signal and answers "does this process exist".
+ *
+ *  Three cases the pid cannot answer, each resolved toward the safe side:
+ *
+ *  - **Another host.** `~/.mulmoterminal` can live on a network share, where a pid means nothing
+ *    — it might match an unrelated local process, or miss a live remote one. The token carries
+ *    the hostname, and a lock from elsewhere is left alone: a foreign writer we cannot ask about
+ *    is treated as alive.
+ *  - **A lock we cannot parse** (an older build, a crash mid-claim). Nothing owns it that we can
+ *    find, and refusing forever would wedge the config, so age decides — as it did before.
+ *  - **A live owner that is genuinely stuck.** Its lock is never broken, so writers time out and
+ *    answer "try again" instead of overlapping. Refusing is the right failure: the wedged process
+ *    is a problem the user can see, while a silent lost update is not.
+ */
+function breakable(lockPath: string): boolean {
+  if (!olderThanStale(lockPath)) return false;
+  const owner = readOwner(lockPath);
+  if (!owner) return true; // unreadable or unparseable: age is all there is to go on
+  if (owner.host !== hostname()) return false; // another machine's pid means nothing here
+  return !processAlive(owner.pid);
+}
+
+function olderThanStale(lockPath: string): boolean {
   try {
     return Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS;
   } catch {
     // Vanished between the failed claim and this check — not stale, just gone.
     return false;
+  }
+}
+
+function readOwner(lockPath: string): { host: string; pid: number } | null {
+  try {
+    const [host, pid] = readFileSync(lockPath, "utf8").split(":");
+    const parsed = Number(pid);
+    return host && Number.isInteger(parsed) && parsed > 0 ? { host, pid: parsed } : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Does this process still exist? Signal 0 performs the permission and existence checks without
+ *  delivering anything. An EPERM means it exists and belongs to someone else — still alive. */
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return hasErrnoCode(err) && err.code === "EPERM";
   }
 }

--- a/server/config/config-lock.ts
+++ b/server/config/config-lock.ts
@@ -1,0 +1,150 @@
+// Serializing a read-modify-write of the config ACROSS PROCESSES.
+//
+// Its own module because it is its own concern: every writer of ~/.mulmoterminal/config.json
+// needs it, while app-config.ts is about the SHAPE of that file rather than about who may touch
+// it when — and that file is already well over its line budget.
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { openSync, closeSync, unlinkSync, statSync, mkdirSync, writeSync, readFileSync } from "node:fs";
+import { isRecord } from "../../common/isRecord.js";
+
+// One machine runs several mulmoterminals (several checkouts, side by side) and they share ONE
+// config.json. `writeFileAtomicSync` makes each write all-or-nothing, which stops a truncated
+// file — it does nothing about two processes that both READ the old list, each add their own
+// directory, and each write: the second rename replaces the first process's addition, and a
+// saved directory is gone with no error anywhere.
+//
+// The window is small, and it is exactly the window a user hits by launching a terminal in two
+// windows at once — which is how the whole list was lost once already (a client-side version of
+// the same race). So the critical section is claimed with a lock file rather than hoped over.
+const LOCK_SUFFIX = ".lock";
+// A critical section here is synchronous file I/O — microseconds. So a lock still held after
+// SECONDS is not a slow writer, it is a crashed one, and it is broken rather than obeyed: a crash
+// must not wedge the config for the rest of the session.
+const LOCK_STALE_MS = 5_000;
+// Deliberately LONGER than the stale window, so a lock left by a crash is always broken inside
+// the wait instead of timing out. A timeout therefore means real contention, never wreckage.
+const LOCK_WAIT_MS = 6_000;
+const LOCK_RETRY_MS = 15;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const hasErrnoCode = (err: unknown): err is { code: string } => isRecord(err) && typeof err.code === "string";
+
+/** Thrown when the lock could not be taken. Its own class so a route can answer "retry" rather
+ *  than reporting a generic failure for something that will very likely work in a moment. */
+export class ConfigLockTimeout extends Error {
+  constructor(file: string) {
+    super(`config is being written by another process (${path.basename(file)}) — try again`);
+    this.name = "ConfigLockTimeout";
+  }
+}
+
+/** Take the config lock, run `critical`, and release it — whatever `critical` does.
+ *
+ *  IT NEVER RUNS `critical` WITHOUT THE LOCK. An earlier version proceeded on timeout, on the
+ *  reasoning that losing the user's action is worse than a narrow race; that was wrong twice
+ *  over. The action is not lost — the caller gets a retryable error, and the one caller that
+ *  matters (recording a launched directory) retries on the next launch. And "a narrow race" is
+ *  precisely the bug this exists to close: this writer would read the old config while the holder
+ *  is still inside its own read-modify-write, and overwrite it. A rare silent deletion of someone
+ *  else's data is worse than a visible "try again". */
+export async function withConfigLock<T>(file: string, critical: () => T): Promise<T> {
+  const lockPath = `${file}${LOCK_SUFFIX}`;
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  // What identifies THIS claim inside the lock file, so the release can tell "still mine" from
+  // "someone reclaimed it". The pid alone is not enough — one process can hold the lock twice in
+  // sequence, and the second claim must not be releasable by the first.
+  const token = `${process.pid}:${randomUUID()}`;
+  let held = false;
+  while (!held && Date.now() < deadline) {
+    held = tryClaim(lockPath, token);
+    if (!held) await sleep(LOCK_RETRY_MS);
+  }
+  if (!held) throw new ConfigLockTimeout(file);
+  try {
+    return critical();
+  } finally {
+    release(lockPath, token);
+  }
+}
+
+/** Release ONLY a lock we still own.
+ *
+ *  Stale-breaking makes this necessary: if our lock was reclaimed while we were inside (a
+ *  critical section delayed past `LOCK_STALE_MS`), the file now belongs to whoever took it, and
+ *  unlinking it would free a lock somebody else is holding — a cascade where each writer frees
+ *  the next one's claim and several read-modify-writes overlap. The claim writes a token and this
+ *  checks it, so the loser of a theft removes nothing and the cascade stops at one.
+ *
+ *  It also SAYS SO. Being reclaimed means a config write took longer than `LOCK_STALE_MS`, which
+ *  is either a machine in trouble or a wrong assumption in this file; silence would leave the
+ *  next person guessing. */
+function release(lockPath: string, token: string): void {
+  try {
+    // The token is NOT a secret: an ownership marker, minted per claim and readable by anyone who
+    // can read the lock file at all. Nothing is authorised by matching it and no attacker gains
+    // from learning it, so a constant-time compare would be ceremony.
+    // eslint-disable-next-line security/detect-possible-timing-attacks
+    if (readFileSync(lockPath, "utf8") !== token) {
+      console.warn(`[config] lock ${path.basename(lockPath)} was reclaimed while held — a config write took over ${LOCK_STALE_MS}ms`);
+      return;
+    }
+    unlinkSync(lockPath);
+  } catch {
+    // Already gone: a stale-breaker removed it and nothing replaced it yet. Nothing to undo.
+  }
+}
+
+/** One attempt at the claim. True when this call now holds the lock.
+ *
+ *  Every failure is classified rather than lumped into "someone else has it":
+ *
+ *  - **EEXIST** is the only real contention. If the holder is older than `LOCK_STALE_MS` it
+ *    crashed, so the lock is broken; otherwise the caller waits.
+ *  - **ENOENT** is a first-ever write — `~/.mulmoterminal` does not exist yet. Reading that as
+ *    contention made a fresh install wait out the whole timeout and then refuse to save anything.
+ *  - **anything else** (a read-only directory, a permissions problem) will not become true by
+ *    waiting, so it is raised immediately instead of costing the caller the full timeout first. */
+function tryClaim(lockPath: string, token: string): boolean {
+  try {
+    // `wx` is the claim: it fails if the file exists, which is what makes this a lock rather than
+    // a note that someone once intended to hold one. The token goes in through the same handle,
+    // so the lock never exists unowned.
+    const handle = openSync(lockPath, "wx");
+    try {
+      writeSync(handle, token);
+    } finally {
+      closeSync(handle);
+    }
+    return true;
+  } catch (err) {
+    const code = hasErrnoCode(err) ? err.code : "";
+    if (code === "ENOENT") {
+      mkdirSync(path.dirname(lockPath), { recursive: true });
+      return tryClaim(lockPath, token);
+    }
+    if (code !== "EEXIST") throw err;
+    // A stale lock is broken here, not waited out; the next attempt claims it. A FAILED unlink
+    // deliberately falls through to the caller's wait rather than retrying at full speed — the
+    // claim would fail the same way and `staleLock` would say the same thing.
+    if (staleLock(lockPath)) {
+      try {
+        unlinkSync(lockPath);
+        return tryClaim(lockPath, token);
+      } catch {
+        // Someone else broke it first, or we may not remove it at all.
+      }
+    }
+    return false;
+  }
+}
+
+function staleLock(lockPath: string): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS;
+  } catch {
+    // Vanished between the failed claim and this check — not stale, just gone.
+    return false;
+  }
+}

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -17,8 +17,6 @@ import {
   mergeConfigUpdate,
   toPublicAppConfig,
   unknownKeysOf,
-  withConfigLock,
-  ConfigLockTimeout,
   type AppConfig,
 } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
@@ -37,6 +35,7 @@ import { readSoundPreset } from "./sound-presets.js";
 import { isNotifyKind } from "../../common/notifyKinds.js";
 import { parsePresetRef, soundPresetById } from "../../common/notifySounds.js";
 import { requestBody } from "../routes/requestBody.js";
+import { withConfigLock, ConfigLockTimeout } from "./config-lock.js";
 import { lastSegment } from "../../common/pathSegments.js";
 
 export const APP_CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -197,7 +197,22 @@ export function getAppendSystemPrompt(): boolean {
 /** Called after a config write that CHANGED the saved directories. Injected rather than imported,
  *  so this module stays config-shaped and does not reach into a backend: the collection watchers
  *  are the caller's concern, not the config route's. */
-export type CwdPresetsChanged = () => void;
+export type CwdPresetsChanged = () => void | Promise<void>;
+
+/** Tell the subscriber, and let nothing it does reach the response.
+ *
+ *  The config is ALREADY PERSISTED by the time this runs, so a subscriber that throws — or hands
+ *  back a promise that rejects — must not turn a save that succeeded into a 500 the client will
+ *  retry. Fire-and-forget is the contract this makes true rather than merely states. */
+function notifyPresetsChanged(onCwdPresetsChanged?: CwdPresetsChanged): void {
+  try {
+    void Promise.resolve(onCwdPresetsChanged?.()).catch((err: unknown) => {
+      console.warn("[config] cwdPresets subscriber failed", err);
+    });
+  } catch (err) {
+    console.warn("[config] cwdPresets subscriber threw", err);
+  }
+}
 
 /** The saved-directory routes, at module scope so `mountConfigRoutes` stays inside its line
  *  budget — and because they are their own subsystem: one-entry mutations of a global list. */
@@ -256,9 +271,14 @@ function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChan
     const base = loaded.status === "ok" ? loaded.config : emptyConfig();
     const next = mergeConfigUpdate(base, { cwdPresets: mutate(base.cwdPresets) });
     if (!saveAppConfig(CONFIG_FILE, next, unknownKeysOf(loaded))) return res.status(500).json({ error: "failed to persist config" });
-    const changed = !samePresets(base.cwdPresets, next.cwdPresets);
+    // Compared against what THIS PROCESS was serving, not against what was on disk. The two
+    // differ exactly when another mulmoterminal wrote the file since we booted: the disk-vs-next
+    // comparison then sees no change, while `config = next` silently ADOPTS that instance's
+    // directories — and the collection watchers, which read the in-memory list
+    // (`getCwdPresets` → `listProjectRoots`), would never hear about the projects they now serve.
+    const changed = !samePresets(config.cwdPresets, next.cwdPresets);
     config = next;
-    if (changed) onCwdPresetsChanged?.();
+    if (changed) notifyPresetsChanged(onCwdPresetsChanged);
     return res.json({ cwdPresets: next.cwdPresets });
   }
 }
@@ -328,13 +348,16 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
     // mulmoterminal sharing the file may have written since we booted, and that is the same
     // reason the merge base above is re-read. A stale comparison would both miss a change and
     // invent one.
-    const presetsChanged = !samePresets(base.cwdPresets, next.cwdPresets);
+    // See mutatePresets: the question is whether the list THIS process serves has moved, not
+    // whether the file did. A change another instance made and we are only now absorbing is a
+    // change from here.
+    const presetsChanged = !samePresets(config.cwdPresets, next.cwdPresets);
     config = next;
     // AFTER the commit, and only when the list actually moved: the saved directories are the
     // projects the collection watchers mount for, and without this a directory added mid-session
     // waits out the poll before its collections can ring. Fire-and-forget by contract — a
     // subscriber's failure is its own, and must not turn a saved config into a 500.
-    if (presetsChanged) onCwdPresetsChanged?.();
+    if (presetsChanged) notifyPresetsChanged(onCwdPresetsChanged);
     res.json(configResponse());
   });
 

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,7 @@
 import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
-import type { Express, Response } from "express";
+import type { Express, Request, Response } from "express";
 import {
   loadAppConfig,
   loadAppConfigResult,
@@ -17,6 +17,7 @@ import {
   mergeConfigUpdate,
   toPublicAppConfig,
   unknownKeysOf,
+  withConfigLock,
   type AppConfig,
 } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
@@ -242,7 +243,7 @@ function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChan
     const path_ = typeof body.path === "string" ? body.path.trim() : "";
     if (!path_) return res.status(400).json({ error: "path is required" });
     const label = typeof body.label === "string" && body.label.trim().length > 0 ? body.label.trim() : path_.split("/").filter(Boolean).at(-1) || path_;
-    return mutatePresets(res, (current) => {
+    return void mutatePresets(res, (current) => {
       // Most-recently-used first, and an existing entry keeps the label the user gave it.
       const existing = current.find((preset) => preset.path === path_);
       return [existing ?? { label, path: path_ }, ...current.filter((preset) => preset.path !== path_)];
@@ -255,13 +256,20 @@ function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChan
     const body = requestBody(req.body);
     const path_ = typeof body.path === "string" ? body.path : "";
     if (!path_) return res.status(400).json({ error: "path is required" });
-    return mutatePresets(res, (current) => current.filter((preset) => preset.path !== path_));
+    return void mutatePresets(res, (current) => current.filter((preset) => preset.path !== path_));
   });
 
   /** Apply a one-entry change to the saved directories, reading and writing the file the same way
    *  `POST /api/config` does — including refusing a config we could not parse, so a stray comma
    *  never costs the user the rest of their settings. Answers the resulting list. */
-  function mutatePresets(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
+  async function mutatePresets(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
+    // The READ and the WRITE are one critical section, held across processes: several
+    // mulmoterminals share this file, and two that each read the old list before either writes
+    // both save a list missing the other's directory. See `withConfigLock`.
+    return withConfigLock(CONFIG_FILE, () => mutatePresetsLocked(res, mutate));
+  }
+
+  function mutatePresetsLocked(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
     const loaded = loadAppConfigResult(CONFIG_FILE);
     if (loaded.status === "corrupt") {
       const bak = backupCorruptConfig(CONFIG_FILE);
@@ -309,6 +317,12 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
   });
 
   app.post("/api/config", (req, res) => {
+    // Held for the same reason as the one-entry routes below: this re-reads the file as its merge
+    // base, so two processes saving different fields at once can each write the other's away.
+    void withConfigLock(CONFIG_FILE, () => saveWholeConfig(req, res));
+  });
+
+  function saveWholeConfig(req: Request, res: Response) {
     const body = requestBody(req.body);
     // Partial update: keep the field the request omits so saving the sound doesn't
     // wipe the presets (and vice-versa). cwdPresets, when present, must be an array.
@@ -359,7 +373,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
     // subscriber's failure is its own, and must not turn a saved config into a 500.
     if (presetsChanged) notifyPresetsChanged(onCwdPresetsChanged);
     res.json(configResponse());
-  });
+  }
 
   mountCwdPresetRoutes(app, onCwdPresetsChanged);
 

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -18,6 +18,7 @@ import {
   toPublicAppConfig,
   unknownKeysOf,
   withConfigLock,
+  ConfigLockTimeout,
   type AppConfig,
 } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
@@ -36,6 +37,7 @@ import { readSoundPreset } from "./sound-presets.js";
 import { isNotifyKind } from "../../common/notifyKinds.js";
 import { parsePresetRef, soundPresetById } from "../../common/notifySounds.js";
 import { requestBody } from "../routes/requestBody.js";
+import { lastSegment } from "../../common/pathSegments.js";
 
 export const APP_CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 const CONFIG_FILE = APP_CONFIG_FILE;
@@ -200,6 +202,29 @@ export function getAppendSystemPrompt(): boolean {
  *  are the caller's concern, not the config route's. */
 export type CwdPresetsChanged = () => void | Promise<void>;
 
+/** Answer a write that never happened.
+ *
+ *  A LOCK TIMEOUT IS NOT A FAILURE OF THE SAVE — it is "someone else is mid-write", so it says
+ *  retry (503) rather than reporting the user's settings as broken. Not taken means not
+ *  attempted: writing anyway is the cross-process race the lock exists to close, and the one
+ *  caller that matters records its directory again on the next launch.
+ *
+ *  Anything else escaping the critical section IS a failure, and must not be dressed as a
+ *  transient one — a 503 there would send the client into a retry loop over something that will
+ *  never succeed. It also must not go unanswered: an unobserved rejection leaves the request
+ *  hanging until the client's own timeout.
+ *
+ *  `headersSent` because the critical section may have answered already before throwing. */
+function answerLockFailure(res: Response, err: unknown): void {
+  if (res.headersSent) return;
+  if (err instanceof ConfigLockTimeout) {
+    res.status(503).json({ error: "config is being written by another process — try again" });
+    return;
+  }
+  console.error("[config] write failed", err);
+  res.status(500).json({ error: "failed to persist config" });
+}
+
 /** Tell the subscriber, and let nothing it does reach the response.
  *
  *  The config is ALREADY PERSISTED by the time this runs, so a subscriber that throws — or hands
@@ -242,7 +267,9 @@ function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChan
     const body = requestBody(req.body);
     const path_ = typeof body.path === "string" ? body.path.trim() : "";
     if (!path_) return res.status(400).json({ error: "path is required" });
-    const label = typeof body.label === "string" && body.label.trim().length > 0 ? body.label.trim() : path_.split("/").filter(Boolean).at(-1) || path_;
+    // `lastSegment` rather than a "/" split: a Windows path would otherwise become its own label,
+    // i.e. the whole absolute path shown as the directory's name.
+    const label = typeof body.label === "string" && body.label.trim().length > 0 ? body.label.trim() : lastSegment(path_);
     return void mutatePresets(res, (current) => {
       // Most-recently-used first, and an existing entry keeps the label the user gave it.
       const existing = current.find((preset) => preset.path === path_);
@@ -266,7 +293,11 @@ function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChan
     // The READ and the WRITE are one critical section, held across processes: several
     // mulmoterminals share this file, and two that each read the old list before either writes
     // both save a list missing the other's directory. See `withConfigLock`.
-    return withConfigLock(CONFIG_FILE, () => mutatePresetsLocked(res, mutate));
+    try {
+      await withConfigLock(CONFIG_FILE, () => mutatePresetsLocked(res, mutate));
+    } catch (err) {
+      answerLockFailure(res, err);
+    }
   }
 
   function mutatePresetsLocked(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
@@ -319,7 +350,9 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
   app.post("/api/config", (req, res) => {
     // Held for the same reason as the one-entry routes below: this re-reads the file as its merge
     // base, so two processes saving different fields at once can each write the other's away.
-    void withConfigLock(CONFIG_FILE, () => saveWholeConfig(req, res));
+    void withConfigLock(CONFIG_FILE, () => saveWholeConfig(req, res)).catch((err: unknown) => {
+      answerLockFailure(res, err);
+    });
   });
 
   function saveWholeConfig(req: Request, res: Response) {

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -62,6 +62,14 @@ setDeclaredGitlabHosts(getGitlabHosts);
 // The saved directories and the recorded clone-per-repo choices, for the repo -> dir reverse
 // lookup (#1172). Read live for the same reason as the repos above: choosing a clone writes the
 // config, and the next lookup has to see it without a restart.
+/** Whether the saved-directory list is the same one. By PATH: a relabelled preset is the same
+ *  directory to everything downstream of this (the collection watchers, the project ids), and
+ *  waking them for a rename would be work with no question behind it. */
+function samePresets(before: readonly CwdPreset[], after: readonly CwdPreset[]): boolean {
+  if (before.length !== after.length) return false;
+  return before.every((preset, index) => preset.path === after[index]?.path);
+}
+
 export function getCwdPresets(): CwdPreset[] {
   return config.cwdPresets;
 }
@@ -186,7 +194,12 @@ export function getAppendSystemPrompt(): boolean {
   return loadAppConfig(CONFIG_FILE).appendSystemPrompt;
 }
 
-export function mountConfigRoutes(app: Express, claudeCwd: string): void {
+/** Called after a config write that CHANGED the saved directories. Injected rather than imported,
+ *  so this module stays config-shaped and does not reach into a backend: the collection watchers
+ *  are the caller's concern, not the config route's. */
+export type CwdPresetsChanged = () => void;
+
+export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsChanged?: CwdPresetsChanged): void {
   // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
   // everything it can write — buttons/chips included — and round-trip it.
   const configResponse = () => ({ cwd: claudeCwd, ...toPublicAppConfig(config) });
@@ -247,7 +260,17 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     // Carry the keys this build doesn't know straight back to disk. Another version's setting
     // must not disappear because this one saved over it (#966).
     if (!saveAppConfig(CONFIG_FILE, next, unknownKeysOf(loaded))) return res.status(500).json({ error: "failed to persist config" });
+    // Compared against the config just read from DISK, not this instance's cached copy: another
+    // mulmoterminal sharing the file may have written since we booted, and that is the same
+    // reason the merge base above is re-read. A stale comparison would both miss a change and
+    // invent one.
+    const presetsChanged = !samePresets(base.cwdPresets, next.cwdPresets);
     config = next;
+    // AFTER the commit, and only when the list actually moved: the saved directories are the
+    // projects the collection watchers mount for, and without this a directory added mid-session
+    // waits out the poll before its collections can ring. Fire-and-forget by contract — a
+    // subscriber's failure is its own, and must not turn a saved config into a 500.
+    if (presetsChanged) onCwdPresetsChanged?.();
     res.json(configResponse());
   });
 

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,7 @@
 import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
-import type { Express } from "express";
+import type { Express, Response } from "express";
 import {
   loadAppConfig,
   loadAppConfigResult,
@@ -199,6 +199,70 @@ export function getAppendSystemPrompt(): boolean {
  *  are the caller's concern, not the config route's. */
 export type CwdPresetsChanged = () => void;
 
+/** The saved-directory routes, at module scope so `mountConfigRoutes` stays inside its line
+ *  budget — and because they are their own subsystem: one-entry mutations of a global list. */
+function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChanged): void {
+  // ── recording ONE saved directory, server-side ─────────────────────────────────────────────
+  //
+  // WHY THIS EXISTS AT ALL, and why the client must not do it with `POST /api/config`:
+  //
+  // `cwdPresets` is a REPLACE-ALL field, and it is global — every mulmoterminal on this machine
+  // shares the file, and the list decides which projects the server serves collections for
+  // (server/infra/project-root.ts). A client that sends the whole list sends ITS OWN VIEW of it,
+  // and any way that view is short, the difference is deleted from disk: the initial GET has not
+  // landed yet, the GET failed, another instance added a directory this tab never saw.
+  //
+  // On 2026-08-09 that cost a user four of five saved directories — a terminal launched while the
+  // first GET was in flight persisted `[the one just launched]`, and the collections of the other
+  // four stopped being served. Nothing said anything; the config was simply smaller.
+  //
+  // So "remember this directory" is expressed as what it IS: a one-entry mutation, applied to the
+  // list ON DISK, read and written here. A caller cannot clobber a list it never has to hold, and
+  // two instances recording different directories at once no longer race each other.
+  //
+  // The client keeps `POST /api/config` for a genuine replace-all (reordering in a settings UI),
+  // where sending the whole list is the user's actual intent.
+  app.post("/api/config/cwd-presets/record", (req, res) => {
+    const body = requestBody(req.body);
+    const path_ = typeof body.path === "string" ? body.path.trim() : "";
+    if (!path_) return res.status(400).json({ error: "path is required" });
+    const label = typeof body.label === "string" && body.label.trim().length > 0 ? body.label.trim() : path_.split("/").filter(Boolean).at(-1) || path_;
+    return mutatePresets(res, (current) => {
+      // Most-recently-used first, and an existing entry keeps the label the user gave it.
+      const existing = current.find((preset) => preset.path === path_);
+      return [existing ?? { label, path: path_ }, ...current.filter((preset) => preset.path !== path_)];
+    });
+  });
+
+  // The chip's close button. Same reasoning: a stale client filtering its own copy would drop
+  // whatever it had not seen.
+  app.post("/api/config/cwd-presets/remove", (req, res) => {
+    const body = requestBody(req.body);
+    const path_ = typeof body.path === "string" ? body.path : "";
+    if (!path_) return res.status(400).json({ error: "path is required" });
+    return mutatePresets(res, (current) => current.filter((preset) => preset.path !== path_));
+  });
+
+  /** Apply a one-entry change to the saved directories, reading and writing the file the same way
+   *  `POST /api/config` does — including refusing a config we could not parse, so a stray comma
+   *  never costs the user the rest of their settings. Answers the resulting list. */
+  function mutatePresets(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
+    const loaded = loadAppConfigResult(CONFIG_FILE);
+    if (loaded.status === "corrupt") {
+      const bak = backupCorruptConfig(CONFIG_FILE);
+      const backupNote = bak ? ` (backed up to ${path.basename(bak)})` : "";
+      return res.status(409).json({ error: `config.json is unreadable and was NOT overwritten${backupNote}. Fix or remove it, then retry.` });
+    }
+    const base = loaded.status === "ok" ? loaded.config : emptyConfig();
+    const next = mergeConfigUpdate(base, { cwdPresets: mutate(base.cwdPresets) });
+    if (!saveAppConfig(CONFIG_FILE, next, unknownKeysOf(loaded))) return res.status(500).json({ error: "failed to persist config" });
+    const changed = !samePresets(base.cwdPresets, next.cwdPresets);
+    config = next;
+    if (changed) onCwdPresetsChanged?.();
+    return res.json({ cwdPresets: next.cwdPresets });
+  }
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsChanged?: CwdPresetsChanged): void {
   // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
   // everything it can write — buttons/chips included — and round-trip it.
@@ -273,6 +337,8 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
     if (presetsChanged) onCwdPresetsChanged?.();
     res.json(configResponse());
   });
+
+  mountCwdPresetRoutes(app, onCwdPresetsChanged);
 
   // What the launch form may offer (#584): the configured backends, whether each can be
   // reached right now, and the models it can run. Never the tokens themselves — only the

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -22,6 +22,10 @@ import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { workspaceScope } from "./project-root.js";
 import { isManagedWorkspace } from "../backends/workspaceSetup.js";
+// A successful `putSchema` carries back whether the collection would survive a clone — the agent
+// is the one that chose the storage kind or dropped the primaryKey, and it is holding the file
+// open at the moment that is cheapest to fix.
+import { withPortabilityNote } from "./collectionToolPortability.js";
 
 const tool = makeManageCollectionTool({
   bundledHelpsDir: helpsAssetDir,
@@ -36,7 +40,7 @@ const tool = makeManageCollectionTool({
  *
  *  This one is the AGENT's data plane and operates on the workspace, which is what the
  *  getter above says. A REQUEST must not use it — see `manageCollectionHandlerFor`. */
-export const manageCollectionHandler = tool.handler;
+export const manageCollectionHandler = withPortabilityNote(tool.handler, () => workspaceScope().workspaceRoot);
 
 // One tool instance per root. `makeManageCollectionTool` takes its root in the FACTORY deps,
 // not per call, so a request-scoped operation needs its own instance; they are cached because
@@ -53,20 +57,23 @@ const byRoot = new Map<string, typeof tool.handler>();
 export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
   const cached = byRoot.get(workspaceRoot);
   if (cached) return cached;
-  const handler = makeManageCollectionTool({
-    bundledHelpsDir: helpsAssetDir,
-    workspaceRoot,
-    // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`, mirrored
-    // by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent writes a
-    // draft nothing mirrors and nothing discovers — it does as instructed and produces a
-    // collection that does not exist, with no error anywhere.
-    //
-    // The engine also derives the variant from `skillsStagingDir` returning null, so this agrees
-    // with the host binding rather than overriding it. Passed anyway: two levers that must agree
-    // are worth stating at both ends, and this one says WHY the root has no staging rather than
-    // leaving it to be inferred from a path that came back empty.
-    stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
-  }).handler;
+  const handler = withPortabilityNote(
+    makeManageCollectionTool({
+      bundledHelpsDir: helpsAssetDir,
+      workspaceRoot,
+      // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`, mirrored
+      // by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent writes a
+      // draft nothing mirrors and nothing discovers — it does as instructed and produces a
+      // collection that does not exist, with no error anywhere.
+      //
+      // The engine also derives the variant from `skillsStagingDir` returning null, so this agrees
+      // with the host binding rather than overriding it. Passed anyway: two levers that must agree
+      // are worth stating at both ends, and this one says WHY the root has no staging rather than
+      // leaving it to be inferred from a path that came back empty.
+      stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
+    }).handler,
+    () => workspaceRoot,
+  );
   byRoot.set(workspaceRoot, handler);
   return handler;
 }

--- a/server/infra/collectionToolPortability.ts
+++ b/server/infra/collectionToolPortability.ts
@@ -1,0 +1,63 @@
+// Tell the AGENT when a schema it just wrote would not survive a clone.
+//
+// The portability check has a route and a button (plans/HANDOFF-collections-projects.md §3.6), and
+// both need a person to think of asking. The agent is the one who chose the storage kind, dropped
+// the `primaryKey` or put the collection in user scope — and it is holding the file open at the
+// moment the answer is cheapest to act on.
+//
+// WHY `putSchema` AND NOTHING ELSE. It is the only action that changes what the check reads:
+// creation is a plain file write the engine never sees (`putSchema` refuses an unknown collection
+// and says to create it by writing SKILL.md + schema.json), and the record actions cannot move a
+// collection in or out of portability. Hooking a read action would spend a git call on every
+// listing to say the same thing repeatedly.
+//
+// It is ADDITIVE and quiet: a clean collection is not mentioned at all, a refusal or a validation
+// error is passed through untouched, and a failure of the check itself changes nothing. The agent
+// never has to handle a new failure mode to keep working.
+import { isRecord } from "../../common/isRecord.js";
+import { checkCollectionSelfContainment } from "../backends/collectionSelfContainment.js";
+
+/** `putSchema`'s success narration, parsed — or null for anything else, INCLUDING its refusals.
+ *  Those are prose, and prose is what the agent is meant to read and act on: appending to it
+ *  would bury the reason the write did not happen. */
+function writtenPayload(narration: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(narration);
+  } catch {
+    return null;
+  }
+  return isRecord(parsed) && parsed.written === true ? parsed : null;
+}
+
+function slugOf(args: Record<string, unknown>): string | null {
+  return typeof args.slug === "string" && args.slug.length > 0 ? args.slug : null;
+}
+
+/** Wrap a manageCollection handler so a successful `putSchema` carries the collection's
+ *  portability findings back with it.
+ *
+ *  `rootOf` is a thunk for the same reason the tool's own `workspaceRoot` is: the workspace
+ *  handler is built at module scope, before boot binds a root. */
+export function withPortabilityNote(handler: (args: Record<string, unknown>) => Promise<string>, rootOf: () => string) {
+  return async (args: Record<string, unknown>): Promise<string> => {
+    const narration = await handler(args);
+    if (args.action !== "putSchema") return narration;
+    const slug = slugOf(args);
+    if (slug === null) return narration;
+    const written = writtenPayload(narration);
+    if (!written) return narration;
+    try {
+      const report = await checkCollectionSelfContainment(slug, { workspaceRoot: rootOf() });
+      // Nothing to say about a collection that already travels — silence is the answer there,
+      // and a `portability: { findings: [] }` on every write would be noise the agent learns to
+      // skip, which is how the one that matters gets skipped too.
+      if (!report || report.findings.length === 0) return narration;
+      return JSON.stringify({ ...written, portability: { portable: report.portable, findings: report.findings } });
+    } catch {
+      // The check is an extra, not a gate: the schema IS written, and reporting the write is the
+      // handler's actual job. A git that would not run must not turn that into an error.
+      return narration;
+    }
+  };
+}

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -102,6 +102,20 @@ export function projectId(root: string): string {
   return createHash("sha256").update(root).digest("hex").slice(0, 16);
 }
 
+/** A directory's NAME, never its location.
+ *
+ *  `lastSegment` answers with the path itself when there is nothing to take — `"/"` for a POSIX
+ *  root, `"C:"` for a Windows drive root — and that value travels: the phone's project listing
+ *  promises a label that is never a path. Derived here, once, rather than checked wherever a
+ *  label is used.
+ *
+ *  `path.basename` is not used for the same reason `lastSegment` exists: this process's `path` is
+ *  its own platform's, and a config written on Windows can be read on a mac. */
+function nameOf(root: string): string {
+  const name = lastSegment(root).trim();
+  return name.length > 0 && !name.includes("/") && !name.includes("\\") && !/^[a-z]:$/i.test(name) ? name : "root";
+}
+
 /** Every project a request may name, workspace first. Deduped by root: a user who has launched
  *  from the workspace has it among the saved directories too. */
 export function listProjectRoots(): ProjectSummary[] {
@@ -110,7 +124,7 @@ export function listProjectRoots(): ProjectSummary[] {
   // written on Windows can be read on a mac (a synced config, a restored backup). A POSIX
   // basename hands `C:\Users\me\proj` back WHOLE — which then travels as a "label" to a phone
   // that is promised it will never receive a path.
-  const rows: Array<{ root: string; label: string }> = [{ root: ws, label: lastSegment(ws) }];
+  const rows: Array<{ root: string; label: string }> = [{ root: ws, label: nameOf(ws) }];
   for (const project of knownProjects()) {
     if (!rows.some((row) => row.root === project.path)) rows.push({ root: project.path, label: project.label });
   }

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -21,6 +21,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import type { Request } from "express";
 import { describeValue } from "../../common/readString.js";
+import { lastSegment } from "../../common/pathSegments.js";
 
 /** A root, in the shape the collection engine's options already take, so it can be passed
  *  straight through as `opts` rather than unpacked at every call site. */
@@ -105,7 +106,11 @@ export function projectId(root: string): string {
  *  from the workspace has it among the saved directories too. */
 export function listProjectRoots(): ProjectSummary[] {
   const ws = requireWorkspace();
-  const rows: Array<{ root: string; label: string }> = [{ root: ws, label: path.basename(ws) || ws }];
+  // `lastSegment`, not `path.basename`: this process's `path` is its own platform's, and a config
+  // written on Windows can be read on a mac (a synced config, a restored backup). A POSIX
+  // basename hands `C:\Users\me\proj` back WHOLE — which then travels as a "label" to a phone
+  // that is promised it will never receive a path.
+  const rows: Array<{ root: string; label: string }> = [{ root: ws, label: lastSegment(ws) }];
   for (const project of knownProjects()) {
     if (!rows.some((row) => row.root === project.path)) rows.push({ root: project.path, label: project.label });
   }

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -39,6 +39,7 @@ import { mountCostRoute } from "../session/cost.js";
 import { mountCollectionRoutes } from "../backends/collections.js";
 // "Would this collection survive a clone?" — mounts itself beside the collection routes.
 import { mountSelfContainmentRoutes } from "../backends/collectionSelfContainment.js";
+import { syncCollectionWatcherRoots } from "../backends/collectionWatchers.js";
 import { mountGoogleRoutes } from "../backends/google.js";
 import { mountWikiRoutes } from "../backends/wiki.js";
 import { mountAccountingRoutes } from "../backends/accounting.js";
@@ -327,7 +328,13 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   // GET/POST /api/config (workspace dir + directory presets) — in its own module.
   // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
   // modal's directory presets. The single view never calls it.
-  mountConfigRoutes(app, CLAUDE_CWD);
+  // A directory saved here is a project the collection watchers should mount for, and the sync
+  // is otherwise a 60s poll — long enough that a new project's first collection looks broken.
+  mountConfigRoutes(app, CLAUDE_CWD, () => {
+    void syncCollectionWatcherRoots().catch((err: unknown) => {
+      console.warn("[collection-watchers] sync after a config write failed", err);
+    });
+  });
 
   // Project-scoped file browsing + editing for the full-screen Files view
   // (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -271,7 +271,22 @@ configureCollectionUi({
   importRegistry: (author, slug, registry) => apiPost<RegistryImportResponse>("/api/collections/registry/import", { author, slug, registry }),
 
   // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
-  reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
+  // ONLY EVER FROM THE WORKSPACE'S OWN LIST. This is data loss when it is wrong, and it was:
+  // the pinned-shortcuts file is ONE workspace-global file (shared with MulmoClaude), while the
+  // list the index just fetched is scoped to the surface's project (`withActiveProject`, applied
+  // by `apiGet` above). Reconciling one against the other says "every collection the workspace
+  // pinned is gone" whenever the pane is open on a project — and `reconcile` prunes and PERSISTS.
+  //
+  // That is not hypothetical. On 2026-08-09 opening the Collections pane on a project with one
+  // collection deleted TWENTY-ONE pinned collections from `<workspace>/config/shortcuts.json`, in
+  // both apps, with no undo and nothing on screen to say it had happened. The feeds survived only
+  // because they are a different `kind`.
+  //
+  // So a project-scoped answer reconciles NOTHING. It is not "reconcile the project's pins
+  // instead": pins are not per project, and pretending otherwise would delete the workspace's on
+  // the way. If pins ever become per project, this is the line that has to learn about it — not
+  // the store, which cannot see a scope from where it sits.
+  reconcileShortcuts: (kind, live) => (activeCollectionProjectId() === null ? useShortcuts().reconcile(kind, live) : Promise.resolve()),
   unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
   // ── chat: spawn a new terminal session seeded with the prompt and surface it
   //    (hidden=false → make it visible). Backs the index "create" button + the

--- a/src/composables/reconcileShortcuts.ts
+++ b/src/composables/reconcileShortcuts.ts
@@ -23,6 +23,12 @@ export interface Reconciled {
 
 // Only entries of `kind` are judged; the authoritative list says nothing about the others,
 // so a collection fetch must never prune a feed shortcut (or vice versa).
+//
+// `live` MUST BE THE WHOLE WORKSPACE'S LIST OF THAT KIND. Everything here treats "absent from
+// `live`" as "no longer exists", so a list that is merely a SUBSET — one project's collections,
+// a filtered view, a page of results — reads as a mass deletion and is written back as one. The
+// caller is what knows the difference; see the `reconcileShortcuts` binding in collectionUi.ts,
+// which refuses to call this at all while a project scope is active, and why.
 export function reconcileShortcuts(current: readonly Shortcut[], kind: ShortcutKind, live: readonly LiveEntry[]): Reconciled {
   const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
   let drifted = false;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -165,10 +165,9 @@ const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typ
 // every mutation reads the freshly-saved list before computing its own.
 function createPresetMutations(
   presets: Ref<CwdPreset[]>,
-  savePresets: (next: CwdPreset[]) => Promise<boolean>,
   hasAuthoritativeList: () => boolean,
-  recordPresetOnServer: (path: string, label: string) => Promise<void>,
-  removePresetOnServer: (path: string) => Promise<void>,
+  recordPresetOnServer: (path: string, label: string) => Promise<boolean>,
+  removePresetOnServer: (path: string) => Promise<boolean>,
 ) {
   let presetWrite: Promise<unknown> = Promise.resolve();
   function serialize(mutate: () => Promise<void>): Promise<void> {
@@ -239,19 +238,30 @@ function createPresetMutations(
   // is cleared on success so a chip the user later deletes can't reappear. Dedup keeps it
   // harmless if it runs twice.
   async function migrateLegacyRecents(): Promise<void> {
-    // Same rule as the two above, and stated rather than relied upon: this only runs after a
-    // successful GET today, so the list IS authoritative — but it prepends to `presets.value`
-    // and saves the whole thing, which is the shape that costs the user their directories the
-    // day a caller moves it.
+    // The list is only consulted to decide what is NEW; the writing below is per entry, so a
+    // stale read costs at most a duplicate the server then dedupes by path.
     if (!hasAuthoritativeList()) return;
     const legacy = readLegacyRecents();
     if (!legacy.length) return;
     const known = new Set(presets.value.map((p) => p.path));
-    const additions = legacy.filter((path) => !known.has(path)).map((path) => ({ label: presetLabel(path), path }));
+    const additions = legacy.filter((path) => !known.has(path));
     let saved = true;
     if (additions.length) {
       await serialize(async () => {
-        saved = await savePresets([...additions, ...presets.value]);
+        // ONE ENTRY AT A TIME, like every other preset write. An authoritative GET describes the
+        // instant it completed: another mulmoterminal can record a directory before this
+        // migration's POST reaches the config lock, and a replace-all built from the list we read
+        // BEFORE that would delete it. This migration is purely add-only, so it has no business
+        // sending a whole list at all.
+        //
+        // REVERSED, because each record goes to the FRONT: replaying most-recent-last leaves the
+        // legacy order intact ahead of what was already saved.
+        for (const path of [...additions].reverse()) {
+          // A failure stops the import and KEEPS the localStorage key, so the whole thing is
+          // retried on the next load rather than half-migrated and forgotten.
+          saved = await recordPresetOnServer(path, presetLabel(path));
+          if (!saved) return;
+        }
       });
     }
     if (!saved) return; // keep the key so the import retries on the next load
@@ -325,7 +335,7 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
    *  A failed call leaves the list exactly as it was: the directory is simply not recorded, and
    *  the next launch tries again. It counts as a local write (`version++`) so a GET already in
    *  flight cannot re-adopt the pre-change list over it (#164). */
-  async function mutateOneOnServer(url: string, body: Record<string, string>): Promise<void> {
+  async function mutateOneOnServer(url: string, body: Record<string, string>): Promise<boolean> {
     version++;
     try {
       const res = await fetchWithTimeout(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -336,8 +346,10 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
         loaded = true;
       }
       error.value = null;
+      return true;
     } catch {
       error.value = "Couldn't save presets. Check the server and try again.";
+      return false;
     }
   }
 
@@ -346,7 +358,7 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
 
   return {
     savePresets,
-    ...createPresetMutations(presets, savePresets, () => loaded, recordPresetOnServer, removePresetOnServer),
+    ...createPresetMutations(presets, () => loaded, recordPresetOnServer, removePresetOnServer),
     snapshotVersion,
     adoptServerPresets,
   };

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -163,7 +163,13 @@ const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typ
 // `next` from the same stale snapshot — the later POST would clobber the earlier one
 // (last-write-wins, dropping a just-launched dir). `serialize` runs the writes in order so
 // every mutation reads the freshly-saved list before computing its own.
-function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: CwdPreset[]) => Promise<boolean>) {
+function createPresetMutations(
+  presets: Ref<CwdPreset[]>,
+  savePresets: (next: CwdPreset[]) => Promise<boolean>,
+  hasAuthoritativeList: () => boolean,
+  recordPresetOnServer: (path: string, label: string) => Promise<void>,
+  removePresetOnServer: (path: string) => Promise<void>,
+) {
   let presetWrite: Promise<unknown> = Promise.resolve();
   function serialize(mutate: () => Promise<void>): Promise<void> {
     const run = presetWrite.then(mutate, mutate);
@@ -200,17 +206,30 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
     if (isManagedWorktreePath(path, worktreesRoot.value)) return;
     return serialize(async () => {
       if (presets.value[0]?.path === path) return; // already most-recent — nothing to reorder
-      const existing = presets.value.find((p) => p.path === path);
-      const entry = existing ?? { label: presetLabel(path), path };
-      await savePresets([entry, ...presets.value.filter((p) => p.path !== path)]);
+      // A ONE-ENTRY MUTATION, applied to the list on disk by the server — never a replace-all
+      // built from `presets.value`.
+      //
+      // This is the fix for a data-loss bug, so it is worth being blunt about: `presets.value` is
+      // this tab's view, and it is EMPTY until the initial GET lands, empty again if that GET
+      // fails, and stale the moment another mulmoterminal (or another tab) saves a directory.
+      // Sending it as the whole list deletes the difference from a file every instance shares —
+      // and that list is what decides which projects the server serves collections for. On
+      // 2026-08-09 a terminal launched during the first GET reduced five saved directories to
+      // one, silently.
+      //
+      // Recording is inherently "add this, keep the rest", so it is expressed that way and the
+      // rest is never in this tab's hands. That also keeps #164's guarantee — a launch during the
+      // initial GET is recorded immediately, with nothing to wait for.
+      await recordPresetOnServer(path, presetLabel(path));
     });
   }
 
   // Drop one preset (the chip's close button). No-op when the path isn't present.
   function removePreset(path: string): Promise<void> {
     return serialize(async () => {
-      if (!presets.value.some((p) => p.path === path)) return;
-      await savePresets(presets.value.filter((p) => p.path !== path));
+      // Server-side for the same reason as recordPreset: filtering this tab's copy and sending it
+      // back would drop every directory this tab had not seen.
+      await removePresetOnServer(path);
     });
   }
 
@@ -220,6 +239,11 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
   // is cleared on success so a chip the user later deletes can't reappear. Dedup keeps it
   // harmless if it runs twice.
   async function migrateLegacyRecents(): Promise<void> {
+    // Same rule as the two above, and stated rather than relied upon: this only runs after a
+    // successful GET today, so the list IS authoritative — but it prepends to `presets.value`
+    // and saves the whole thing, which is the shape that costs the user their directories the
+    // day a caller moves it.
+    if (!hasAuthoritativeList()) return;
     const legacy = readLegacyRecents();
     if (!legacy.length) return;
     const known = new Set(presets.value.map((p) => p.path));
@@ -248,6 +272,18 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
 // resolves would be dropped by the stale GET.
 function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, error: Ref<string | null>) {
   let version = 0;
+  // True only once a GET (or our own successful save) has authoritatively populated `presets`.
+  //
+  // THIS IS THE DIFFERENCE BETWEEN RECORDING A DIRECTORY AND DELETING EVERY OTHER ONE. The save
+  // is a REPLACE-ALL POST built from `presets.value`, so writing before the list is known sends
+  // the empty default plus the one entry — and the user's whole saved-directory list becomes
+  // that single directory, on disk, in a file every mulmoterminal on the machine shares.
+  //
+  // That happened on 2026-08-09: a terminal launched while the initial GET was still in flight
+  // reduced five saved directories to one, and the collections of the other four stopped being
+  // served (they are the project list — server/infra/project-root.ts). The same guard exists in
+  // useShortcuts for the same reason, on the same kind of file.
+  let loaded = false;
 
   // Persist the directory presets. Posts only cwdPresets — the server keeps the other fields,
   // so this never clobbers them. Returns whether the save succeeded.
@@ -263,6 +299,8 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
       if (!res.ok) throw new Error(`save failed (${res.status})`);
       const saved: unknown = await res.json();
       presets.value = isRecord(saved) && isUnknownArray(saved.cwdPresets) ? saved.cwdPresets.filter(isCwdPreset) : [];
+      // The server has now told us what the list IS, so the next write may build on it.
+      loaded = true;
       version++;
       return true;
     } catch {
@@ -275,10 +313,43 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
 
   const snapshotVersion = (): number => version;
   const adoptServerPresets = (list: unknown, capturedVersion: number): void => {
-    if (version === capturedVersion) presets.value = isUnknownArray(list) ? list.filter(isCwdPreset) : [];
+    if (version !== capturedVersion) return;
+    presets.value = isUnknownArray(list) ? list.filter(isCwdPreset) : [];
+    loaded = true;
   };
 
-  return { savePresets, ...createPresetMutations(presets, savePresets), snapshotVersion, adoptServerPresets };
+  /** Apply a one-entry change on the SERVER and adopt the list it answers with. The response is
+   *  the file's real contents after the change, so this tab ends up agreeing with disk even when
+   *  its own copy was empty or stale — which is the point.
+   *
+   *  A failed call leaves the list exactly as it was: the directory is simply not recorded, and
+   *  the next launch tries again. It counts as a local write (`version++`) so a GET already in
+   *  flight cannot re-adopt the pre-change list over it (#164). */
+  async function mutateOneOnServer(url: string, body: Record<string, string>): Promise<void> {
+    version++;
+    try {
+      const res = await fetchWithTimeout(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      const saved: unknown = await res.json();
+      if (isRecord(saved) && isUnknownArray(saved.cwdPresets)) {
+        presets.value = saved.cwdPresets.filter(isCwdPreset);
+        loaded = true;
+      }
+      error.value = null;
+    } catch {
+      error.value = "Couldn't save presets. Check the server and try again.";
+    }
+  }
+
+  const recordPresetOnServer = (path: string, label: string) => mutateOneOnServer("/api/config/cwd-presets/record", { path, label });
+  const removePresetOnServer = (path: string) => mutateOneOnServer("/api/config/cwd-presets/remove", { path });
+
+  return {
+    savePresets,
+    ...createPresetMutations(presets, savePresets, () => loaded, recordPresetOnServer, removePresetOnServer),
+    snapshotVersion,
+    adoptServerPresets,
+  };
 }
 
 // The single-field savers each persist ONE config field and update its SINGLETON ref, so

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -117,7 +117,13 @@ function unpin(kind: ShortcutKind, slug: string): Promise<boolean> {
 
 /** Bulk reconcile one kind against the authoritative {slug,title,icon} list an
  *  index just fetched: prune dead slugs, refresh stale title/icon, self-heal the
- *  file. Other kinds untouched. */
+ *  file. Other kinds untouched.
+ *
+ *  `live` MUST be the whole WORKSPACE's list of that kind — this prunes and persists, to a file
+ *  shared with MulmoClaude, so a subset is written back as a deletion. This store cannot check
+ *  that from here (it has no idea what scope produced the list), which is exactly why the caller
+ *  carries the rule: collectionUi.ts refuses to call this while a project scope is active, after
+ *  a project-scoped list deleted twenty-one of the user's pins on 2026-08-09. */
 function reconcile(kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]): Promise<void> {
   return enqueue(async () => {
     await load();

--- a/test/common/pathSegments.spec.ts
+++ b/test/common/pathSegments.spec.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+//
+// One separator is not enough. These paths come from a config file and from a saved directory
+// list, so a Windows path can be read on a mac and a POSIX one on Windows — and code that splits
+// on "/" alone does not fail loudly on `C:\Users\me\project`, it returns the WHOLE STRING as one
+// segment. That is how a "label" becomes an absolute path, which is exactly what the phone's
+// project listing promises never to send.
+import { describe, it, expect } from "vitest";
+import { pathSegments, lastSegment } from "../../common/pathSegments";
+
+describe("pathSegments", () => {
+  it("splits a POSIX path", () => {
+    expect(pathSegments("/Users/me/git/ai/mag2")).toEqual(["Users", "me", "git", "ai", "mag2"]);
+  });
+
+  it("splits a WINDOWS path — the case a '/' split silently passes through whole", () => {
+    expect(pathSegments("C:\\Users\\me\\project")).toEqual(["C:", "Users", "me", "project"]);
+    expect(pathSegments("\\\\server\\share\\project")).toEqual(["server", "share", "project"]);
+  });
+
+  it("splits a mixed path, which a synced config really does contain", () => {
+    expect(pathSegments("C:/Users\\me/project")).toEqual(["C:", "Users", "me", "project"]);
+  });
+
+  it("drops empty parts rather than emitting them", () => {
+    expect(pathSegments("//a///b//")).toEqual(["a", "b"]);
+    expect(pathSegments("")).toEqual([]);
+  });
+});
+
+describe("lastSegment", () => {
+  it("names the directory, on either platform's spelling", () => {
+    expect(lastSegment("/Users/me/mag2")).toBe("mag2");
+    expect(lastSegment("C:\\src\\mag2")).toBe("mag2");
+    expect(lastSegment("/Users/me/mag2/")).toBe("mag2");
+  });
+
+  it("falls back to the input when there is nothing to take", () => {
+    expect(lastSegment("")).toBe("");
+    expect(lastSegment("/")).toBe("/");
+  });
+});

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -122,6 +122,23 @@ describe("listCollectionProjects", () => {
       }
     });
 
+    // A project at a filesystem ROOT has no directory name to fall back to: `lastSegment("/")` is
+    // `"/"` and a Windows drive root is `"C:"`. Both would walk past the check just made.
+    it("does not fall back to a path for a project at the filesystem root", async () => {
+      initProjectRoots({
+        workspace: "/",
+        knownProjects: () => [{ label: "C:\\", path: "C:\\" }],
+      });
+      const labels = (await listing()).map((project) => project.label);
+      for (const label of labels) {
+        expect(label).not.toContain("/");
+        expect(label).not.toContain("\\");
+        expect(label).not.toContain(":");
+      }
+      // Two nameless roots collide, and the normal disambiguation resolves them.
+      expect(new Set(labels).size).toBe(2);
+    });
+
     // A Windows path split on "/" alone is ONE segment, so the "tail" would be the whole absolute
     // path — the no-path guarantee off on Windows, with nothing in the code that states it
     // changing at all.

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -82,6 +82,46 @@ describe("listCollectionProjects", () => {
       }
     });
 
+    // Saved labels are ARBITRARY STRINGS — hand-edited, written by an older version, or set to the
+    // directory itself. One that IS a path is perfectly unique, so nothing else here would look
+    // at it twice, and it would go out verbatim to a client the protocol promises never receives
+    // one. The rule is this listing's to keep, not something to assume of the config.
+    it("replaces a saved label that is itself a path", async () => {
+      initProjectRoots({
+        workspace: "/srv/ws",
+        knownProjects: () => [
+          { label: "/Users/alice/work/private", path: "/Users/alice/work/private" },
+          { label: "~/secrets/vault", path: "/Users/alice/secrets/vault" },
+          { label: "C:\\Users\\alice\\win", path: "/Users/alice/win" },
+        ],
+      });
+      const labels = (await listing()).map((project) => project.label);
+      expect(labels).toEqual(["ws", "private", "vault", "win"]);
+    });
+
+    it("keeps a hand-written label that is a NAME rather than a location", async () => {
+      initProjectRoots({
+        workspace: "/srv/ws",
+        knownProjects: () => [{ label: "Client work (2026)", path: "/srv/clients" }],
+      });
+      expect((await listing()).map((project) => project.label)).toEqual(["ws", "Client work (2026)"]);
+    });
+
+    it("never lets a path through, whatever the config says", async () => {
+      initProjectRoots({
+        workspace: "/Users/alice/ws",
+        knownProjects: () => [
+          { label: "/Users/alice/a", path: "/Users/alice/a" },
+          { label: "  ", path: "/Users/alice/b" },
+        ],
+      });
+      for (const project of await listing()) {
+        expect(project.label).not.toContain("/");
+        expect(project.label).not.toContain("\\");
+        expect(project.label.trim()).not.toBe("");
+      }
+    });
+
     // A Windows path split on "/" alone is ONE segment, so the "tail" would be the whole absolute
     // path — the no-path guarantee off on Windows, with nothing in the code that states it
     // changing at all.

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+//
+// How the phone LEARNS which projects it may name. The handlers could already resolve a named one
+// (commandScope.ts); without this they could resolve an id the phone had no way to obtain.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { listCollectionProjects } from "../../../../server/backends/remoteHost/handlers/listCollectionProjects.js";
+import { scopeFromCommand } from "../../../../server/backends/remoteHost/commandScope.js";
+import { initProjectRoots, projectId, resetProjectRootsForTesting } from "../../../../server/infra/project-root.js";
+
+const WORKSPACE = "/srv/ws";
+const PROJECT = "/srv/mag2";
+
+interface Listing {
+  projects: { id: string; label: string; cwd?: unknown }[];
+}
+
+beforeEach(() => {
+  initProjectRoots({ workspace: WORKSPACE, knownProjects: () => [{ label: "mag2", path: PROJECT }] });
+});
+
+afterEach(() => {
+  resetProjectRootsForTesting();
+});
+
+describe("listCollectionProjects", () => {
+  it("lists the workspace first, then the saved directories", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    expect(projects.map((project) => project.label)).toEqual(["ws", "mag2"]);
+  });
+
+  // The phone is a genuinely remote client: an absolute root in a command or an artifact
+  // publishes the user's home directory over the wire. The browser's listing carries `cwd`
+  // because it has to match a project to a cell it is already showing; the phone has no such
+  // need, so the path stays on the host.
+  it("carries NO path — only the opaque id and a label", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    for (const project of projects) {
+      expect(Object.keys(project).sort()).toEqual(["id", "label"]);
+    }
+    expect(JSON.stringify(projects)).not.toContain("/srv");
+  });
+
+  // The listing is only useful if what it hands out is what the handlers accept — the two halves
+  // are separately correct and together are the feature.
+  it("hands out ids the command scope resolves", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    for (const project of projects) {
+      expect(scopeFromCommand({ project: project.id })).toEqual({ workspaceRoot: project.label === "ws" ? WORKSPACE : PROJECT });
+    }
+    expect(projects.map((project) => project.id)).toEqual([projectId(WORKSPACE), projectId(PROJECT)]);
+  });
+
+  it("is just the workspace when nothing else is saved", async () => {
+    initProjectRoots({ workspace: WORKSPACE });
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    expect(projects).toEqual([{ id: projectId(WORKSPACE), label: "ws" }]);
+  });
+});

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -137,6 +137,9 @@ describe("listCollectionProjects", () => {
       }
       // Two nameless roots collide, and the normal disambiguation resolves them.
       expect(new Set(labels).size).toBe(2);
+      // A root has NO segments to borrow, so the "distinguishing" tail was a blank string — the
+      // second way a tail can fail, after being a location in its own right.
+      for (const label of labels) expect(label.trim()).not.toBe("");
     });
 
     // A Windows path split on "/" alone is ONE segment, so the "tail" would be the whole absolute

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -82,6 +82,23 @@ describe("listCollectionProjects", () => {
       }
     });
 
+    // A Windows path split on "/" alone is ONE segment, so the "tail" would be the whole absolute
+    // path — the no-path guarantee off on Windows, with nothing in the code that states it
+    // changing at all.
+    it("never returns a Windows path as a label", async () => {
+      initProjectRoots({
+        workspace: "C:\\Users\\me\\dup",
+        knownProjects: () => [{ label: "dup", path: "C:\\work\\dup" }],
+      });
+      const labels = (await listing()).map((project) => project.label);
+      expect(new Set(labels).size).toBe(2);
+      for (const label of labels) {
+        expect(label).not.toContain("\\");
+        expect(label).not.toContain("C:");
+        expect(label).not.toContain("Users");
+      }
+    });
+
     // Two directories whose tails match all the way up: the id breaks the tie rather than the
     // listing walking to the home directory.
     it("falls back to an id fragment rather than sending the whole path", async () => {

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -51,6 +51,68 @@ describe("listCollectionProjects", () => {
     expect(projects.map((project) => project.id)).toEqual([projectId(WORKSPACE), projectId(PROJECT)]);
   });
 
+  // `cwdPresets` dedupes by PATH and an auto-derived label is just the basename, so a repo and
+  // its clone are both "mulmoclaude" — this is the author's own config. The browser tells them
+  // apart by the `cwd` it also receives; the phone deliberately gets none, so two identical rows
+  // would be a coin toss.
+  describe("labels a person can tell apart", () => {
+    const listing = async () => ((await listCollectionProjects({})) as unknown as Listing).projects;
+
+    it("borrows the least it needs from the parent directories", async () => {
+      initProjectRoots({
+        workspace: "/Users/me/mulmoclaude",
+        knownProjects: () => [{ label: "mulmoclaude", path: "/Users/me/git/ai/mulmoclaude" }],
+      });
+      expect((await listing()).map((project) => project.label)).toEqual(["me/mulmoclaude", "ai/mulmoclaude"]);
+    });
+
+    it("leaves a label that is already unique completely alone", async () => {
+      initProjectRoots({ workspace: "/srv/ws", knownProjects: () => [{ label: "mag2", path: "/srv/mag2" }] });
+      expect((await listing()).map((project) => project.label)).toEqual(["ws", "mag2"]);
+    });
+
+    it("still carries no absolute path, however deep it had to borrow", async () => {
+      initProjectRoots({
+        workspace: "/Users/me/a/b/c/dup",
+        knownProjects: () => [{ label: "dup", path: "/Users/me/x/b/c/dup" }],
+      });
+      for (const project of await listing()) {
+        expect(project.label.startsWith("/")).toBe(false);
+        expect(project.label).not.toContain("/Users/me");
+      }
+    });
+
+    // Two directories whose tails match all the way up: the id breaks the tie rather than the
+    // listing walking to the home directory.
+    it("falls back to an id fragment rather than sending the whole path", async () => {
+      initProjectRoots({
+        workspace: "/one/a/b/dup",
+        knownProjects: () => [{ label: "dup", path: "/two/a/b/dup" }],
+      });
+      const labels = (await listing()).map((project) => project.label);
+      expect(new Set(labels).size).toBe(2);
+      for (const label of labels) expect(label.split("/").length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // The handler being correct is half of it; the phone can only call a command the TABLE carries.
+  // That registration is one line in a 20-entry object, which is exactly the kind of line a merge
+  // drops without anything failing.
+  it("is registered in the command table the runner serves", async () => {
+    const { createRemoteHostHandlers } = await import("../../../../server/backends/remoteHost/handlers/index.js");
+    const handlers = createRemoteHostHandlers({
+      workspace: WORKSPACE,
+      spawnChat: () => ({ chatId: "x" }),
+      ingest: async () => ({ attachments: [], cleanup: async () => {} }) as never,
+      listTerminalSessions: async () => ({}) as never,
+      captureTerminalScreen: async () => ({}) as never,
+      writeToSession: () => false,
+    } as never);
+    expect(typeof handlers.listCollectionProjects).toBe("function");
+    const answered = (await handlers.listCollectionProjects({})) as unknown as Listing;
+    expect(answered.projects.map((project) => project.label)).toEqual(["ws", "mag2"]);
+  });
+
   it("is just the workspace when nothing else is saved", async () => {
     initProjectRoots({ workspace: WORKSPACE });
     const { projects } = (await listCollectionProjects({})) as unknown as Listing;

--- a/test/server/config/config-lock.spec.ts
+++ b/test/server/config/config-lock.spec.ts
@@ -10,6 +10,7 @@
 // the lock is real rather than decorative.
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, utimesSync } from "node:fs";
+import { hostname } from "node:os";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -91,14 +92,55 @@ describe("withConfigLock", () => {
     }
   });
 
+  // THE CORRECTION AGE ALONE COULD NOT MAKE. An old lock whose owner is still RUNNING is not
+  // stale — it belongs to a writer that is merely slow, and taking it lets a second writer into
+  // the read-modify-write the first is still inside. That overlap is what this file exists to
+  // prevent, so recovery must not reintroduce it.
+  it("refuses an old lock whose owner is still alive", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      // This very process is the owner, and it is definitely running.
+      writeFileSync(`${file}.lock`, `${hostname()}:${process.pid}:still-here`);
+      const longAgo = new Date(Date.now() - 60_000);
+      utimesSync(`${file}.lock`, longAgo, longAgo);
+
+      await expect(withConfigLock(file, () => "should not run")).rejects.toThrow(/try again/);
+      // Untouched: refusing is the right failure here — a wedged process is something the user
+      // can see, a silent lost update is not.
+      expect(readFileSync(`${file}.lock`, "utf8")).toBe(`${hostname()}:${process.pid}:still-here`);
+    } finally {
+      rmSync(`${file}.lock`, { force: true });
+      cleanup();
+    }
+  }, 10_000);
+
+  // A pid from another machine means nothing to `process.kill` — it might match an unrelated
+  // local process or miss a live remote one — so a foreign lock is treated as alive.
+  it("refuses an old lock written by another host", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      writeFileSync(`${file}.lock`, "some-other-machine:999999:elsewhere");
+      const longAgo = new Date(Date.now() - 60_000);
+      utimesSync(`${file}.lock`, longAgo, longAgo);
+      await expect(withConfigLock(file, () => "should not run")).rejects.toThrow(/try again/);
+    } finally {
+      rmSync(`${file}.lock`, { force: true });
+      cleanup();
+    }
+  }, 10_000);
+
   // A crash leaves the lock file behind. Waiting it out forever would wedge the config for the
   // rest of the session, so an old one is broken rather than obeyed.
   it("breaks a stale lock left by a crashed process", async () => {
     const { file, cleanup } = tmp();
     try {
       writeFileSync(file, "[]");
-      // Mtime in the past: older than LOCK_STALE_MS, i.e. nobody honest is still inside.
-      writeFileSync(`${file}.lock`, "");
+      // Old AND owned by a pid that no longer exists — the two halves together are what makes it
+      // safe to take. A pid this high is not in use; if it somehow were, the test would refuse
+      // rather than pass wrongly.
+      writeFileSync(`${file}.lock`, `${hostname()}:4194303:crashed`);
       const longAgo = new Date(Date.now() - 60_000);
       utimesSync(`${file}.lock`, longAgo, longAgo);
 
@@ -190,10 +232,35 @@ describe("withConfigLock", () => {
       await withConfigLock(file, () => {
         seen = readFileSync(`${file}.lock`, "utf8");
       });
-      // pid + a unique part: one process can hold the lock twice in sequence, and the second
-      // claim must not be releasable by the first.
-      expect(seen.startsWith(`${process.pid}:`)).toBe(true);
-      expect(seen.length).toBeGreaterThan(String(process.pid).length + 1);
+      // host + pid + a unique part. The host is what makes the liveness check honest on a network
+      // share (another machine's pid means nothing here); the unique part is because one process
+      // can hold the lock twice in sequence, and the second claim must not be releasable by the
+      // first.
+      const [host, pid, unique] = seen.split(":");
+      expect(host).toBe(hostname());
+      expect(Number(pid)).toBe(process.pid);
+      expect(unique?.length).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // A critical section that returns a promise must be awaited INSIDE the lock. Releasing when the
+  // promise is merely created would run the section outside the protection it asked for — worse
+  // than not locking, because it looks locked.
+  it("holds the lock until an async critical section finishes", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      let lockedDuring: string | null = null;
+      const result = await withConfigLock(file, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        lockedDuring = existsSync(`${file}.lock`) ? "held" : "released";
+        return "done";
+      });
+      expect(lockedDuring).toBe("held");
+      expect(result).toBe("done");
+      expect(existsSync(`${file}.lock`)).toBe(false);
     } finally {
       cleanup();
     }

--- a/test/server/config/config-lock.spec.ts
+++ b/test/server/config/config-lock.spec.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+//
+// One machine runs several mulmoterminals (several checkouts, side by side) sharing ONE
+// config.json. `writeFileAtomicSync` makes each write all-or-nothing — it says nothing about two
+// processes that both READ the old list, each add their own directory, and each write: the second
+// rename replaces the first's addition, and a saved directory is gone with no error anywhere.
+//
+// A saved directory is not cosmetic here: the list is what decides which projects the server
+// serves collections for. So the read-modify-write is claimed with a lock, and this is what says
+// the lock is real rather than decorative.
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { withConfigLock } from "../../../server/config/app-config";
+
+const tmp = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-config-lock-"));
+  return { dir, file: path.join(dir, "config.json"), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+};
+
+/** A read-modify-write of a JSON list — the shape every config writer has. */
+const appendUnderLock = (file: string, value: string, onEnter?: () => void) =>
+  withConfigLock(file, () => {
+    const current: string[] = JSON.parse(readFileSync(file, "utf8"));
+    onEnter?.();
+    writeFileSync(file, JSON.stringify([...current, value]));
+    return value;
+  });
+
+describe("withConfigLock", () => {
+  // The race is between PROCESSES, so the other party is played by holding the lock file directly
+  // — two calls inside one process cannot interleave (the critical section is synchronous), which
+  // is why a test that merely starts two of them passes with or without the lock and proves
+  // nothing.
+  it("waits for the holder, then reads what the holder wrote", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      // "Another mulmoterminal" claims the lock and has not written yet.
+      writeFileSync(`${file}.lock`, "");
+
+      let entered = false;
+      const ours = appendUnderLock(file, "ours", () => {
+        entered = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      // Still outside: without the lock it would have read `[]` by now and be about to erase the
+      // other process's entry.
+      expect(entered).toBe(false);
+
+      // The holder finishes its own read-modify-write and releases.
+      writeFileSync(file, JSON.stringify(["theirs"]));
+      rmSync(`${file}.lock`);
+
+      await ours;
+      // Ours read AFTER theirs landed, so both survive — which is the whole point.
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(["theirs", "ours"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("releases the lock even when the critical section throws", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      await expect(
+        withConfigLock(file, () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(existsSync(`${file}.lock`)).toBe(false);
+      // …and the next writer is not shut out by the wreckage.
+      await appendUnderLock(file, "after");
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(["after"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("leaves no lock file behind on the happy path", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      await appendUnderLock(file, "a");
+      expect(existsSync(`${file}.lock`)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // A crash leaves the lock file behind. Waiting it out forever would wedge the config for the
+  // rest of the session, so an old one is broken rather than obeyed.
+  it("breaks a stale lock left by a crashed process", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      // Mtime in the past: older than LOCK_STALE_MS, i.e. nobody honest is still inside.
+      writeFileSync(`${file}.lock`, "");
+      const { utimesSync } = await import("node:fs");
+      const longAgo = new Date(Date.now() - 60_000);
+      utimesSync(`${file}.lock`, longAgo, longAgo);
+
+      await appendUnderLock(file, "after-crash");
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(["after-crash"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns what the critical section returned", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      expect(await withConfigLock(file, () => 42)).toBe(42);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/test/server/config/config-lock.spec.ts
+++ b/test/server/config/config-lock.spec.ts
@@ -9,7 +9,7 @@
 // serves collections for. So the read-modify-write is claimed with a lock, and this is what says
 // the lock is real rather than decorative.
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -99,12 +99,60 @@ describe("withConfigLock", () => {
       writeFileSync(file, "[]");
       // Mtime in the past: older than LOCK_STALE_MS, i.e. nobody honest is still inside.
       writeFileSync(`${file}.lock`, "");
-      const { utimesSync } = await import("node:fs");
       const longAgo = new Date(Date.now() - 60_000);
       utimesSync(`${file}.lock`, longAgo, longAgo);
 
       await appendUnderLock(file, "after-crash");
       expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(["after-crash"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // THE ESCAPE HATCH THAT WAS WRONG. An earlier version ran the critical section anyway when the
+  // lock could not be taken, reasoning that losing the user's action beats a narrow race. Both
+  // halves were false: the action is not lost (the caller retries — a launched directory is
+  // recorded again on the next launch), and "a narrow race" is exactly this bug — the writer
+  // would read the old config while the holder is mid-write and overwrite it. A visible "try
+  // again" beats a rare silent deletion of someone else's data.
+  it("REFUSES rather than running without the lock", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      writeFileSync(`${file}.lock`, ""); // a live holder, kept fresh below
+      let entered = false;
+      const keepFresh = setInterval(() => {
+        try {
+          const now = new Date();
+          utimesSync(`${file}.lock`, now, now);
+        } catch {
+          // gone — the test is finishing
+        }
+      }, 200);
+      try {
+        await expect(withConfigLock(file, () => (entered = true))).rejects.toThrow(/try again/);
+      } finally {
+        clearInterval(keepFresh);
+      }
+      expect(entered).toBe(false);
+      // And nothing was written: the file is exactly as the holder left it.
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  }, 10_000);
+
+  // ~/.mulmoterminal does not exist on a first-ever write, and a failed claim there is not
+  // contention. Treating it as such made a fresh install wait out the timeout and then refuse to
+  // save anything at all.
+  it("creates the config directory rather than reading a missing one as contention", async () => {
+    const { dir, cleanup } = tmp();
+    try {
+      const nested = path.join(dir, "never-created", "config.json");
+      const started = Date.now();
+      await withConfigLock(nested, () => writeFileSync(nested, '["made it"]'));
+      expect(JSON.parse(readFileSync(nested, "utf8"))).toEqual(["made it"]);
+      expect(Date.now() - started).toBeLessThan(1_000); // i.e. it did not wait anything out
     } finally {
       cleanup();
     }

--- a/test/server/config/config-lock.spec.ts
+++ b/test/server/config/config-lock.spec.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, utimesSyn
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { withConfigLock } from "../../../server/config/app-config";
+import { withConfigLock } from "../../../server/config/config-lock";
 
 const tmp = () => {
   const dir = mkdtempSync(path.join(tmpdir(), "mt-config-lock-"));
@@ -153,6 +153,47 @@ describe("withConfigLock", () => {
       await withConfigLock(nested, () => writeFileSync(nested, '["made it"]'));
       expect(JSON.parse(readFileSync(nested, "utf8"))).toEqual(["made it"]);
       expect(Date.now() - started).toBeLessThan(1_000); // i.e. it did not wait anything out
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Stale-breaking is what stops a crash from wedging the config, and its cost is that a lock can
+  // be taken from a LIVE holder whose critical section ran long. What must not follow is a
+  // cascade: the original owner reaching `finally` and freeing the NEW holder's lock, so a third
+  // writer walks in while the second is inside. The claim carries a token and the release checks
+  // it, so the loser of a theft removes nothing.
+  it("does not release a lock that was reclaimed while it was held", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      let released: string | null = null;
+      await withConfigLock(file, () => {
+        // Somebody breaks our (apparently stale) lock and claims it.
+        rmSync(`${file}.lock`);
+        writeFileSync(`${file}.lock`, "the-new-owner");
+      });
+      released = existsSync(`${file}.lock`) ? readFileSync(`${file}.lock`, "utf8") : null;
+      // The new owner's lock is still there — we did not free somebody else's claim.
+      expect(released).toBe("the-new-owner");
+    } finally {
+      rmSync(`${file}.lock`, { force: true });
+      cleanup();
+    }
+  });
+
+  it("writes an owner token, not an empty file", async () => {
+    const { file, cleanup } = tmp();
+    try {
+      writeFileSync(file, "[]");
+      let seen = "";
+      await withConfigLock(file, () => {
+        seen = readFileSync(`${file}.lock`, "utf8");
+      });
+      // pid + a unique part: one process can hold the lock twice in sequence, and the second
+      // claim must not be releasable by the first.
+      expect(seen.startsWith(`${process.pid}:`)).toBe(true);
+      expect(seen.length).toBeGreaterThan(String(process.pid).length + 1);
     } finally {
       cleanup();
     }

--- a/test/server/config/cwd-preset-routes.spec.ts
+++ b/test/server/config/cwd-preset-routes.spec.ts
@@ -26,12 +26,17 @@ async function mountAgainstTempHome(initial: Record<string, unknown>) {
   dirs.push(dir);
   vi.stubEnv("HOME", dir);
   vi.stubEnv("USERPROFILE", dir);
+  // WRITTEN BEFORE THE IMPORT, because that is the order production has: the module reads the
+  // file once at load and serves that list until something writes. A fixture that writes it
+  // afterwards leaves the module's view empty while the disk is full — a state the server is
+  // never in, and one that makes the "did the list THIS process serves move?" comparison look
+  // wrong when it is right.
+  mkdirSync(path.join(dir, ".mulmoterminal"), { recursive: true });
+  writeFileSync(path.join(dir, ".mulmoterminal", "config.json"), JSON.stringify(initial, null, 2));
   vi.resetModules();
   const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
-  // Guard before anything writes: a stub that did not take would target the real config.
+  // Guard: a stub that did not take would have targeted the real config.
   expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
-  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
-  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
 
   const onChanged = vi.fn();
   const app = express();

--- a/test/server/config/cwd-preset-routes.spec.ts
+++ b/test/server/config/cwd-preset-routes.spec.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+//
+// Recording a working directory is a ONE-ENTRY mutation applied to the file, not a replace-all.
+//
+// This is a data-loss fix, so what these pin is mostly what must NOT happen: `cwdPresets` is
+// global (every mulmoterminal on the machine shares the file) and it decides which projects the
+// server serves collections for. A client that sent the whole list sent its own view of it, and
+// on 2026-08-09 a terminal launched during the initial GET reduced five saved directories to one.
+// The routes below exist so the caller never holds the list at all.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import express from "express";
+import request from "supertest";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function mountAgainstTempHome(initial: Record<string, unknown>) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-preset-routes-"));
+  dirs.push(dir);
+  vi.stubEnv("HOME", dir);
+  vi.stubEnv("USERPROFILE", dir);
+  vi.resetModules();
+  const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+  // Guard before anything writes: a stub that did not take would target the real config.
+  expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
+  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
+
+  const onChanged = vi.fn();
+  const app = express();
+  app.use(express.json());
+  mountConfigRoutes(app, dir, onChanged);
+  const onDisk = () => JSON.parse(readFileSync(APP_CONFIG_FILE, "utf8"));
+  return { app, onChanged, onDisk };
+}
+
+const TWO = [
+  { label: "mag2", path: "/srv/mag2" },
+  { label: "site", path: "/srv/site" },
+];
+
+describe("POST /api/config/cwd-presets/record", () => {
+  it("adds one entry and KEEPS every other, whatever the caller knows", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new", label: "new" });
+    expect(res.status).toBe(200);
+    // The caller sent ONE path. It could not have deleted the others if it tried.
+    expect(res.body.cwdPresets.map((preset: { path: string }) => preset.path)).toEqual(["/srv/new", "/srv/mag2", "/srv/site"]);
+    expect(onDisk().cwdPresets).toHaveLength(3);
+  });
+
+  it("bumps an existing directory to the front, keeping the label the user gave it", async () => {
+    const { app } = await mountAgainstTempHome({
+      cwdPresets: [
+        { label: "two", path: "/b" },
+        { label: "Custom", path: "/a" },
+      ],
+    });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/a", label: "a" });
+    expect(res.body.cwdPresets).toEqual([
+      { label: "Custom", path: "/a" },
+      { label: "two", path: "/b" },
+    ]);
+  });
+
+  it("falls back to the basename when no label is sent", async () => {
+    const { app } = await mountAgainstTempHome({});
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/home/me/alpha" });
+    expect(res.body.cwdPresets).toEqual([{ label: "alpha", path: "/home/me/alpha" }]);
+  });
+
+  it("keeps every OTHER setting in the file", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO, pushEnabled: true, futureFeature: "on" });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    const saved = onDisk();
+    expect(saved.pushEnabled).toBe(true);
+    // Including a key THIS build does not know — another version's setting must not vanish (#966).
+    expect(saved.futureFeature).toBe("on");
+  });
+
+  it("refuses a request with no path", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    expect((await request(app).post("/api/config/cwd-presets/record").send({})).status).toBe(400);
+    expect((await request(app).post("/api/config/cwd-presets/record").send({ path: "   " })).status).toBe(400);
+    expect(onDisk().cwdPresets).toHaveLength(2);
+  });
+
+  // A single stray comma must not cost the user the rest of their settings — the same refusal
+  // POST /api/config makes.
+  it("refuses to write over a config it could not parse", async () => {
+    const { app } = await mountAgainstTempHome({});
+    const { APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+    writeFileSync(APP_CONFIG_FILE, "{ not json");
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    expect(res.status).toBe(409);
+  });
+
+  it("tells the caller the project list moved, so the collection watchers can follow", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when the directory was already at the front", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/mag2" });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/config/cwd-presets/remove", () => {
+  it("drops one entry and keeps the rest", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/mag2" });
+    expect(res.body.cwdPresets).toEqual([{ label: "site", path: "/srv/site" }]);
+    expect(onDisk().cwdPresets).toHaveLength(1);
+  });
+
+  it("is a no-op for a path that is not saved, and says nothing changed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/never" });
+    expect(res.body.cwdPresets).toHaveLength(2);
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request with no path", async () => {
+    const { app } = await mountAgainstTempHome({ cwdPresets: TWO });
+    expect((await request(app).post("/api/config/cwd-presets/remove").send({})).status).toBe(400);
+  });
+});

--- a/test/server/config/cwd-presets-notify.spec.ts
+++ b/test/server/config/cwd-presets-notify.spec.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+//
+// The saved directories ARE the projects the collection watchers mount for, so a directory added
+// mid-session used to wait out a 60s poll before its collections could ring — long enough that a
+// new project's first collection reads as broken. The config route now says when the list moved.
+//
+// Deliberately a callback rather than an import: the config module stays config-shaped, and the
+// watchers are the caller's concern (server/routes/app-routes.ts wires them).
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import express from "express";
+import request from "supertest";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A config route mounted against a throwaway HOME, with the change callback captured. `HOME` and
+ *  `USERPROFILE` both, because `os.homedir()` reads the latter on Windows — stubbing one left a
+ *  Windows run pointed at the real config. */
+async function mountAgainstTempHome(initial: Record<string, unknown>) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+  dirs.push(dir);
+  vi.stubEnv("HOME", dir);
+  vi.stubEnv("USERPROFILE", dir);
+  vi.resetModules();
+  const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+  // Guard before anything writes: a stub that did not take would target the real config.
+  expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
+  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
+
+  const onChanged = vi.fn();
+  const app = express();
+  app.use(express.json());
+  mountConfigRoutes(app, dir, onChanged);
+  return { app, onChanged };
+}
+
+const PRESETS = [{ label: "mag2", path: "/srv/mag2" }];
+
+describe("POST /api/config tells the caller when the saved directories move", () => {
+  it("fires when a directory is added", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({});
+    const res = await request(app).post("/api/config").send({ cwdPresets: PRESETS });
+    expect(res.status).toBe(200);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires when one is removed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app).post("/api/config").send({ cwdPresets: [] });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // The write that saves a sound, a theme or a keymap is the common one, and waking the watchers
+  // for it would be work with no question behind it.
+  it("stays quiet for a write that leaves the list alone", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app).post("/api/config").send({ pushEnabled: true });
+    await request(app).post("/api/config").send({ cwdPresets: PRESETS });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  // A relabelled preset is the SAME directory to everything downstream — the watchers and the
+  // project ids are keyed by path.
+  it("stays quiet when only a label changed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app)
+      .post("/api/config")
+      .send({ cwdPresets: [{ label: "renamed", path: "/srv/mag2" }] });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("fires when the same count points somewhere else", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app)
+      .post("/api/config")
+      .send({ cwdPresets: [{ label: "mag2", path: "/srv/elsewhere" }] });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // Mounting without one is what every other caller does; the route must not require it.
+  it("does not require a subscriber", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+    dirs.push(dir);
+    vi.stubEnv("HOME", dir);
+    vi.stubEnv("USERPROFILE", dir);
+    vi.resetModules();
+    const { mountConfigRoutes } = await import("../../../server/config/config-routes.js");
+    const app = express();
+    app.use(express.json());
+    mountConfigRoutes(app, dir);
+    expect((await request(app).post("/api/config").send({ cwdPresets: PRESETS })).status).toBe(200);
+  });
+});

--- a/test/server/config/cwd-presets-notify.spec.ts
+++ b/test/server/config/cwd-presets-notify.spec.ts
@@ -7,7 +7,7 @@
 // Deliberately a callback rather than an import: the config module stays config-shaped, and the
 // watchers are the caller's concern (server/routes/app-routes.ts wires them).
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import express from "express";
 import request from "supertest";
 import { tmpdir } from "node:os";
@@ -28,18 +28,23 @@ async function mountAgainstTempHome(initial: Record<string, unknown>) {
   dirs.push(dir);
   vi.stubEnv("HOME", dir);
   vi.stubEnv("USERPROFILE", dir);
+  // WRITTEN BEFORE THE IMPORT, because that is the order production has: the module reads the
+  // file once at load and serves that list until something writes. A fixture that writes it
+  // afterwards leaves the module's view empty while the disk is full — a state the server is
+  // never in, and one that makes the "did the list THIS process serves move?" comparison look
+  // wrong when it is right.
+  mkdirSync(path.join(dir, ".mulmoterminal"), { recursive: true });
+  writeFileSync(path.join(dir, ".mulmoterminal", "config.json"), JSON.stringify(initial, null, 2));
   vi.resetModules();
   const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
-  // Guard before anything writes: a stub that did not take would target the real config.
+  // Guard: a stub that did not take would have targeted the real config.
   expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
-  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
-  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
 
   const onChanged = vi.fn();
   const app = express();
   app.use(express.json());
   mountConfigRoutes(app, dir, onChanged);
-  return { app, onChanged };
+  return { app, onChanged, configFile: APP_CONFIG_FILE };
 }
 
 const PRESETS = [{ label: "mag2", path: "/srv/mag2" }];
@@ -83,6 +88,62 @@ describe("POST /api/config tells the caller when the saved directories move", ()
       .post("/api/config")
       .send({ cwdPresets: [{ label: "mag2", path: "/srv/elsewhere" }] });
     expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // ANOTHER INSTANCE'S CHANGE, absorbed here. Every mulmoterminal on the machine shares the file,
+  // and a POST re-reads it as the merge base — so an unrelated write (a sound, a theme) can move
+  // THIS process from one project list to another. Comparing the disk to itself sees nothing;
+  // comparing what we WERE serving to what we now serve is the question the watchers are asking.
+  it("fires when an unrelated write absorbs a list another instance saved", async () => {
+    const { app, onChanged, configFile } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    // A second instance adds a directory behind our back.
+    writeFileSync(configFile, JSON.stringify({ cwdPresets: [...PRESETS, { label: "site", path: "/srv/site" }] }, null, 2));
+    // …and we save something else entirely.
+    const res = await request(app).post("/api/config").send({ pushEnabled: true });
+    expect(res.status).toBe(200);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // The config is ALREADY on disk when the subscriber runs, so a subscriber that fails must not
+  // turn a save that succeeded into a 500 the client will retry.
+  it("answers 200 even when the subscriber throws", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+    dirs.push(dir);
+    vi.stubEnv("HOME", dir);
+    vi.stubEnv("USERPROFILE", dir);
+    vi.resetModules();
+    const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+    expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
+    mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+    writeFileSync(APP_CONFIG_FILE, "{}");
+    const app = express();
+    app.use(express.json());
+    mountConfigRoutes(app, dir, () => {
+      throw new Error("watchers exploded");
+    });
+
+    const res = await request(app).post("/api/config").send({ cwdPresets: PRESETS });
+    expect(res.status).toBe(200);
+    // …and the save is real, not merely reported.
+    expect(JSON.parse(readFileSync(APP_CONFIG_FILE, "utf8")).cwdPresets).toHaveLength(1);
+  });
+
+  it("answers 200 when the subscriber's promise rejects", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+    dirs.push(dir);
+    vi.stubEnv("HOME", dir);
+    vi.stubEnv("USERPROFILE", dir);
+    vi.resetModules();
+    const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+    mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+    writeFileSync(APP_CONFIG_FILE, "{}");
+    const app = express();
+    app.use(express.json());
+    mountConfigRoutes(app, dir, async () => {
+      await Promise.reject(new Error("sync failed"));
+    });
+
+    expect((await request(app).post("/api/config").send({ cwdPresets: PRESETS })).status).toBe(200);
   });
 
   // Mounting without one is what every other caller does; the route must not require it.

--- a/test/server/infra/collectionToolPortability.spec.ts
+++ b/test/server/infra/collectionToolPortability.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+//
+// The agent's half of the portability check. What matters here is how QUIET it is: the note rides
+// along with a write the agent already made, and everything else — a refusal, a read, a clean
+// collection, a check that could not run — comes back exactly as it did before this existed.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const check = vi.fn();
+vi.mock("../../../server/backends/collectionSelfContainment.js", () => ({
+  checkCollectionSelfContainment: (slug: string, scope: { workspaceRoot: string }) => check(slug, scope),
+}));
+
+import { withPortabilityNote } from "../../../server/infra/collectionToolPortability.js";
+
+const WRITTEN = JSON.stringify({ collection: "notes", written: true });
+const BLOCKED = {
+  slug: "notes",
+  portable: false,
+  findings: [{ code: "sqlite-store", severity: "blocker", message: "Records are one SQLite file; git cannot merge it." }],
+};
+
+/** The wrapped handler, plus the inner handler's call log. */
+function wrap(narration: string | (() => Promise<string>), root = "/srv/proj") {
+  const inner = vi.fn(async () => (typeof narration === "string" ? narration : narration()));
+  return { run: withPortabilityNote(inner, () => root), inner };
+}
+
+beforeEach(() => {
+  check.mockReset().mockResolvedValue(BLOCKED);
+});
+
+describe("withPortabilityNote", () => {
+  it("adds the findings to a successful putSchema, keeping what the tool already said", async () => {
+    const { run } = wrap(WRITTEN);
+    const out = JSON.parse(await run({ action: "putSchema", slug: "notes" }));
+    expect(out).toMatchObject({ collection: "notes", written: true });
+    expect(out.portability).toEqual({ portable: false, findings: BLOCKED.findings });
+    expect(check).toHaveBeenCalledWith("notes", { workspaceRoot: "/srv/proj" });
+  });
+
+  it("says NOTHING about a collection that already travels", async () => {
+    check.mockResolvedValue({ slug: "notes", portable: true, findings: [] });
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  // A refusal is PROSE, and prose is what the agent is meant to read and act on — appending to it
+  // would bury the reason the write did not happen.
+  it("passes a refusal through untouched, and does not ask about it", async () => {
+    const refusal = "manageCollection: unknown collection 'notes' — create it by writing SKILL.md…";
+    const { run } = wrap(refusal);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(refusal);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("leaves a JSON result that is not a write alone", async () => {
+    const body = JSON.stringify({ collection: "notes", written: false });
+    const { run } = wrap(body);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(body);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  // Every other action either cannot change the answer (the record actions) or would spend a git
+  // call per listing to repeat it.
+  it("does not touch the other actions, or spend a check on them", async () => {
+    for (const action of ["getSchema", "getItems", "putItems", "deleteItems", "queryItems", "schemaDocs", "getOntology"]) {
+      const { run } = wrap(WRITTEN);
+      expect(await run({ action, slug: "notes" })).toBe(WRITTEN);
+    }
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("still reports the write when the check itself fails", async () => {
+    check.mockRejectedValue(new Error("git is not on PATH"));
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  it("still reports the write when the collection cannot be loaded back", async () => {
+    check.mockResolvedValue(null);
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  it("needs a slug to ask about", async () => {
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema" })).toBe(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "" })).toBe(WRITTEN);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("reads the root at CALL time, not when the handler was built", async () => {
+    // The workspace handler is built at module scope, before boot binds a root — a value read
+    // then would be the wrong one, or none.
+    let root = "/srv/first";
+    const run = withPortabilityNote(
+      async () => WRITTEN,
+      () => root,
+    );
+    await run({ action: "putSchema", slug: "notes" });
+    root = "/srv/second";
+    await run({ action: "putSchema", slug: "notes" });
+    expect(check.mock.calls.map((call) => call[1])).toEqual([{ workspaceRoot: "/srv/first" }, { workspaceRoot: "/srv/second" }]);
+  });
+});

--- a/test/src/composables/shortcutsProjectScope.spec.ts
+++ b/test/src/composables/shortcutsProjectScope.spec.ts
@@ -1,0 +1,92 @@
+// The pinned-shortcuts file is ONE workspace-global file, shared with MulmoClaude. The collection
+// index that triggers a reconcile fetches a list scoped to the SURFACE'S PROJECT. Those are two
+// different universes, and reconciling one against the other is a mass deletion: every pin the
+// workspace holds looks "gone" from a project's point of view, and `reconcile` prunes and
+// PERSISTS.
+//
+// It happened. On 2026-08-09 opening the Collections pane on a project with one collection deleted
+// twenty-one pinned collections from <workspace>/config/shortcuts.json — in both apps, with no undo
+// and nothing on screen to say so. The feeds survived only because they are a different `kind`.
+//
+// So this spec is not about a nicety. It pins that a project-scoped answer reconciles NOTHING.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const reconcile = vi.fn(async () => {});
+vi.mock("../../../src/composables/useShortcuts", () => ({
+  useShortcuts: () => ({ reconcile, unpin: vi.fn() }),
+}));
+
+// The binding is registered as a module side effect, not exported — so the way to test the REAL
+// one is to catch what it registers.
+interface Bound {
+  reconcileShortcuts?: (kind: string, live: { slug: string; title: string; icon: string }[]) => Promise<void>;
+}
+let bound: Bound = {};
+vi.mock("@mulmoclaude/collection-plugin/vue", () => ({
+  configureCollectionUi: (context: Bound) => {
+    bound = context;
+  },
+  CollectionsIndexView: { name: "CollectionsIndexView", template: "<div />" },
+  CollectionView: { name: "CollectionView", template: "<div />" },
+  FeedsView: { name: "FeedsView", template: "<div />" },
+}));
+
+// Imported at module scope so its module graph is collection's cost, not the first test's
+// (CLAUDE.md). The import itself is what registers the binding above.
+await import("../../../src/composables/collectionUi");
+const { pushCollectionSurface, popCollectionSurface } = await import("../../../src/composables/collectionSurface");
+type CollectionSurface = import("../../../src/composables/collectionSurface").CollectionSurface;
+
+const LIVE = [{ slug: "tasks", title: "Tasks", icon: "check" }];
+const surfaces: CollectionSurface[] = [];
+
+function showSurface(projectId: string | null) {
+  const surface: CollectionSurface = { projectId, layer: "pane" };
+  surfaces.push(surface);
+  pushCollectionSurface(surface);
+}
+
+beforeEach(() => {
+  reconcile.mockClear();
+});
+
+afterEach(() => {
+  for (const surface of surfaces.splice(0)) popCollectionSurface(surface);
+});
+
+describe("reconcileShortcuts is refused for a project-scoped list", () => {
+  it("reconciles when the visible surface is the workspace", async () => {
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledWith("collection", LIVE);
+  });
+
+  it("reconciles when a surface says it IS the workspace", async () => {
+    showSurface(null);
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  // The bug, exactly: a pane open on a project, an index fetch scoped to it, and the workspace's
+  // pins judged against a list that was never about them.
+  it("does NOTHING when the visible surface is a project", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for feeds either — the scope is what matters, not the kind", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("feed", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("resumes once the project surface is gone", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+
+    for (const surface of surfaces.splice(0)) popCollectionSurface(surface);
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -39,10 +39,12 @@ function mockServer(initial: Preset[] = [], opts: { gate?: Promise<void>; get?: 
       await opts.gate;
       return { ok: true, json: async () => ({ cwdPresets: snapshot, worktreesRoot: WORKTREES_ROOT, ...opts.get }) };
     }
-    // POST /api/config — the genuine replace-all: a settings-UI reorder, and the legacy import.
+    // POST /api/config — the genuine replace-all: a settings-UI reorder.
     if (Array.isArray(body.cwdPresets)) list = body.cwdPresets as Preset[];
     return { ok: true, json: async () => ({ cwdPresets: list }) };
   }) as unknown as typeof fetch;
+  // What ANOTHER mulmoterminal doing its own one-entry write looks like from here.
+  return { recordExternally: (preset: Preset) => (list = [preset, ...list.filter((entry) => entry.path !== preset.path)]) };
 }
 
 const mockConfigFetch = () => mockServer();
@@ -158,11 +160,7 @@ describe("useAppConfig — auto preset recording", () => {
 
   it("imports legacy localStorage recents (recent_dirs_v1) to the FRONT of presets on load, then clears the key", async () => {
     localStorage.setItem("recent_dirs_v1", JSON.stringify(["/r/one", "/r/two"]));
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      if (!init?.body) return { ok: true, json: async () => ({ cwd: "/w", home: "/h", cwdPresets: [{ label: "kept", path: "/p/kept" }], soundFile: null }) };
-      const body = init.body ? JSON.parse(init.body) : {};
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    mockServer([{ label: "kept", path: "/p/kept" }], { get: { cwd: "/w", home: "/h", soundFile: null } });
     const { presets, loadConfig } = useAppConfig();
     await loadConfig();
     expect(presets.value).toEqual([
@@ -175,11 +173,7 @@ describe("useAppConfig — auto preset recording", () => {
 
   it("does not duplicate a legacy recent already present, but still clears the key", async () => {
     localStorage.setItem("recent_dirs_v1", JSON.stringify(["/p/kept", "/r/new"]));
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      if (!init?.body) return { ok: true, json: async () => ({ cwd: "/w", home: "/h", cwdPresets: [{ label: "kept", path: "/p/kept" }], soundFile: null }) };
-      const body = init.body ? JSON.parse(init.body) : {};
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    mockServer([{ label: "kept", path: "/p/kept" }], { get: { cwd: "/w", home: "/h", soundFile: null } });
     const { presets, loadConfig } = useAppConfig();
     await loadConfig();
     expect(presets.value.map((p) => p.path)).toEqual(["/r/new", "/p/kept"]);
@@ -224,6 +218,22 @@ describe("useAppConfig — auto preset recording", () => {
     const { presets, removePreset } = useAppConfig();
     await removePreset("/srv/mag2");
     expect(presets.value.map((p) => p.path)).toEqual(["/srv/site"]);
+  });
+
+  // The legacy import is ADD-ONLY, so it has no business sending a whole list: an authoritative
+  // GET describes the instant it completed, and another instance can record a directory before
+  // the import's write lands. A replace-all built from the earlier read would delete it.
+  it("imports legacy recents without erasing a directory saved meanwhile", async () => {
+    localStorage.setItem("recent_dirs_v1", JSON.stringify(["/legacy/one"]));
+    const server = mockServer([{ label: "kept", path: "/p/kept" }], { get: { cwd: "/w" } });
+    const { presets, loadConfig } = useAppConfig();
+    const loading = loadConfig();
+    // Another mulmoterminal saves a directory while the import is in flight.
+    server.recordExternally({ label: "other", path: "/srv/other" });
+    await loading;
+    expect(presets.value.map((p) => p.path)).toContain("/srv/other");
+    expect(presets.value.map((p) => p.path)).toContain("/legacy/one");
+    expect(presets.value.map((p) => p.path)).toContain("/p/kept");
   });
 
   // A save that fails must lose the RECORD, never the list.
@@ -271,14 +281,7 @@ describe("useAppConfig — auto preset recording", () => {
     const getGate = new Promise<void>((r) => {
       releaseGet = r;
     });
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      if (!init?.body) {
-        await getGate;
-        return { ok: true, json: async () => ({ cwd: "/w", worktreesRoot: WORKTREES_ROOT, cwdPresets: [] }) };
-      }
-      const body = JSON.parse(init.body);
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    mockServer([], { gate: getGate, get: { cwd: "/w" } });
     const { presets, loadConfig, recordPreset } = useAppConfig();
     const loading = loadConfig();
     const recording = recordPreset(`${WORKTREES_ROOT}/myrepo-1a2b3c4d/fix-bug`);

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -1,20 +1,51 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { currentGitlabHosts, useAppConfig } from "../../../src/composables/useAppConfig";
 
-// Echo the posted cwdPresets back as the server would, so presets.value reflects
-// each save. useAppConfig's presets ref is per-call (not a singleton), so every
-// useAppConfig() in these tests starts from an empty list.
 // Where the server keeps the worktrees it created. The GET carries it (the real /api/config does,
 // alongside `home`) because that is the only way this side can tell one of ours from a directory
 // that merely looks like one — see isManagedWorktreePath.
 const WORKTREES_ROOT = "/Users/me/.mulmoterminal/worktrees";
 
-function mockConfigFetch() {
-  globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-    const body = init?.body ? JSON.parse(init.body) : {};
-    return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [], worktreesRoot: WORKTREES_ROOT }) };
+interface Preset {
+  label: string;
+  path: string;
+}
+
+// A stand-in for the SERVER'S list, not an echo of what the client posted — because that is the
+// property under test. Recording a directory is a ONE-ENTRY mutation applied on the server
+// (`/api/config/cwd-presets/record`), so a client whose own copy is empty or stale cannot send it
+// back as the whole list and delete the rest. An echoing fake could not tell the difference
+// between the fix and the bug it replaced, which is why it is gone.
+//
+// `gate` stalls the GET; `snapshot` is what that stalled GET will answer with — taken when it
+// STARTS, so a slow response is genuinely stale rather than magically current.
+function mockServer(initial: Preset[] = [], opts: { gate?: Promise<void>; get?: Record<string, unknown>; delayMs?: number } = {}) {
+  let list: Preset[] = [...initial];
+  globalThis.fetch = vi.fn(async (url: string, init?: { body?: string }) => {
+    const target = String(url);
+    const body: Record<string, unknown> = init?.body ? JSON.parse(init.body) : {};
+    if (opts.delayMs && target.startsWith("/api/config/cwd-presets/")) await new Promise((resolve) => setTimeout(resolve, opts.delayMs));
+    if (target === "/api/config/cwd-presets/record") {
+      const existing = list.find((preset) => preset.path === body.path);
+      list = [existing ?? { label: String(body.label), path: String(body.path) }, ...list.filter((preset) => preset.path !== body.path)];
+      return { ok: true, json: async () => ({ cwdPresets: list }) };
+    }
+    if (target === "/api/config/cwd-presets/remove") {
+      list = list.filter((preset) => preset.path !== body.path);
+      return { ok: true, json: async () => ({ cwdPresets: list }) };
+    }
+    if (!init?.body) {
+      const snapshot = [...list];
+      await opts.gate;
+      return { ok: true, json: async () => ({ cwdPresets: snapshot, worktreesRoot: WORKTREES_ROOT, ...opts.get }) };
+    }
+    // POST /api/config — the genuine replace-all: a settings-UI reorder, and the legacy import.
+    if (Array.isArray(body.cwdPresets)) list = body.cwdPresets as Preset[];
+    return { ok: true, json: async () => ({ cwdPresets: list }) };
   }) as unknown as typeof fetch;
 }
+
+const mockConfigFetch = () => mockServer();
 
 beforeEach(() => {
   localStorage.clear();
@@ -37,11 +68,13 @@ describe("useAppConfig — auto preset recording", () => {
   });
 
   it("keeps an existing entry's label when bumping it to the front", async () => {
-    const { presets, recordPreset } = useAppConfig();
-    presets.value = [
+    // Seeded on the SERVER — the label the user gave a directory lives in the file, and it is the
+    // server that decides what a record does to it now.
+    mockServer([
       { label: "two", path: "/b/two" },
       { label: "Custom", path: "/a/one" }, // a manual label from legacy cwdPresets
-    ];
+    ]);
+    const { presets, recordPreset } = useAppConfig();
     await recordPreset("/a/one");
     expect(presets.value).toEqual([
       { label: "Custom", path: "/a/one" },
@@ -103,12 +136,12 @@ describe("useAppConfig — auto preset recording", () => {
   // Saved config is the user's, so an entry an earlier version recorded is left where it is
   // rather than dropped — it just stops being maintained (no bump to the front).
   it("leaves an already-saved worktree entry alone instead of bumping it", async () => {
-    const { presets, recordPreset, loadConfig } = useAppConfig();
-    await loadConfig();
-    presets.value = [
+    mockServer([
       { label: "alpha", path: "/home/me/alpha" },
       { label: "myrepo (fix-bug)", path: WORKTREE },
-    ];
+    ]);
+    const { presets, recordPreset, loadConfig } = useAppConfig();
+    await loadConfig();
     const before = vi.mocked(globalThis.fetch).mock.calls.length;
     await recordPreset(WORKTREE);
     expect(vi.mocked(globalThis.fetch).mock.calls).toHaveLength(before); // no POST
@@ -158,20 +191,49 @@ describe("useAppConfig — auto preset recording", () => {
     const getGate = new Promise<void>((r) => {
       releaseGet = r;
     });
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      if (!init?.body) {
-        await getGate; // the initial GET stalls until we release it
-        return { ok: true, json: async () => ({ cwd: "/w", home: "/h", cwdPresets: [], soundFile: null }) };
-      }
-      const body = init.body ? JSON.parse(init.body) : {};
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    mockServer([], { gate: getGate, get: { cwd: "/w", home: "/h", soundFile: null } });
     const { presets, loadConfig, recordPreset } = useAppConfig();
     const loading = loadConfig(); // GET in flight (stalled)
     await recordPreset("/launched/now"); // user launches before the GET resolves
     releaseGet(); // the stale (empty) GET snapshot now lands
     await loading;
     expect(presets.value.map((p) => p.path)).toEqual(["/launched/now"]);
+  });
+
+  // THE BUG THIS PAIR OF ROUTES EXISTS FOR. A launch during (or after a failed) initial GET used
+  // to persist "[the one just launched]" as the WHOLE list, and every other saved directory was
+  // gone from a file every mulmoterminal on the machine shares — taking the projects whose
+  // collections the server serves with it (2026-08-09).
+  it("records a directory WITHOUT deleting the ones this tab has never seen", async () => {
+    mockServer([
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ]);
+    const { presets, recordPreset } = useAppConfig();
+    // No loadConfig: this tab's own list is empty, exactly as it is during the first GET.
+    expect(presets.value).toEqual([]);
+    await recordPreset("/srv/new");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/new", "/srv/mag2", "/srv/site"]);
+  });
+
+  it("removes one directory WITHOUT deleting the ones this tab has never seen", async () => {
+    mockServer([
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ]);
+    const { presets, removePreset } = useAppConfig();
+    await removePreset("/srv/mag2");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/site"]);
+  });
+
+  // A save that fails must lose the RECORD, never the list.
+  it("leaves the list alone when the server refuses the record", async () => {
+    mockServer([{ label: "mag2", path: "/srv/mag2" }]);
+    const { presets, loadConfig, recordPreset } = useAppConfig();
+    await loadConfig();
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch;
+    await recordPreset("/srv/new");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/mag2"]);
   });
 
   // The other side of the test above: a launch that lands before the initial GET has no worktree
@@ -227,13 +289,11 @@ describe("useAppConfig — auto preset recording", () => {
   });
 
   it("serializes concurrent records so neither write clobbers the other (#163 review)", async () => {
-    // A slow POST means two un-serialized records would both read the empty list and
-    // the second would overwrite the first. Serialization keeps both.
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      const body = init?.body ? JSON.parse(init.body) : {};
-      await new Promise((r) => setTimeout(r, 5));
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    // Two records in flight at once, against a slow server. The clobber this guarded against is
+    // now impossible by construction — the server applies one entry at a time to its own list, so
+    // neither request carries the other's absence. Serialization still decides the ORDER, and the
+    // guarantee the ticket asked for (both survive) is asserted the same way.
+    mockServer([], { delayMs: 5 });
     const { presets, recordPreset } = useAppConfig();
     await Promise.all([recordPreset("/a"), recordPreset("/b")]);
     expect(presets.value.map((p) => p.path).sort()).toEqual(["/a", "/b"]);


### PR DESCRIPTION
Everything left on `plans/HANDOFF-collections-projects.md` that was not waiting on a package release.

## 1. The agent hears the verdict (§3.6's last gap)

The portability check had a route (#1582) and a button (#1584), and both need a person to think of asking. **The agent is the one that chose the storage kind, dropped the `primaryKey` or put the collection in user scope** — and it is holding the file open at the moment that is cheapest to fix.

A successful `putSchema` now carries a `portability` field beside `written: true`.

- **`putSchema` and nothing else**: it is the only action that can change what the check reads. Creation is a plain file write the engine never sees (`putSchema` *refuses* an unknown collection and says to create it by writing SKILL.md + schema.json), and the record actions cannot move a collection in or out of portability. Hooking a read would spend a git call per listing to repeat the same answer.
- **Quiet by construction**, so the agent never has to handle a new failure mode: a clean collection is not mentioned, a refusal is prose the agent is meant to act on and passes through untouched, and a check that cannot run changes nothing about a write that *did* happen.

This also answers §11.4's "at collection-creation time": there is nowhere to put a creation hook, because creation never reaches the host. The schema edit that follows is the first moment it can speak.

## 2. The phone can learn which projects exist (§3.4's other half)

#1584 taught the handlers to **resolve** a project a command names. Nothing could tell a phone which ids exist, so the parameter was unusable from the client that needs it.

`listCollectionProjects` returns `{ id, label }`, workspace first, and **deliberately not the `cwd`** the browser's listing carries — the browser needs the path to match a project to a cell it is already showing; the phone is genuinely remote, and an absolute root in a command or artifact publishes the user's home directory over the wire.

`docs/remote-host-protocol.md` is updated in the same commit (its own header requires it): the listing, `project?` on every command that takes one, and the three rules — opaque id never a path; omitted means the host's workspace; **an unresolvable id is an error, not a fallback**.

Still not in this repo: the phone's own picker.

## 3. A new project's watchers start when it is saved (§3.1's known lag)

The saved directories are the roots the watchers mount for, and only a 60s poll reconciled them — long enough that a new project's first collection reads as broken rather than as pending.

`POST /api/config` now reports when the list actually **moved** and `app-routes` pulls the sync forward; the poll stays as the fallback for anything that changes the file behind our back.

- Compared **by path**, so a relabelled preset (same directory to the watchers and to the project ids) wakes nothing.
- Compared against the config just read from **disk**, not this instance's cached copy: another mulmoterminal sharing the file may have written since we booted — the same reason the merge base is re-read. A stale comparison both misses a change and invents one; the spec fails on the cached form.
- The callback is **injected**, not imported: the config module stays config-shaped.

## Verification

`yarn format / lint / typecheck / build / test` — 9586 passing (+42), 0 lint errors.

Not covered here, and unchanged: §3.3 and §3.5 wait on `@mulmoclaude/core` / `@mulmoclaude/collection-plugin` releases (written up in `../mulmoclaude/plans/feat-collection-multi-root-3.md`), and the Collections **pane** still has no live browser check — that needs a session reporting the `data` MCP group, i.e. a real agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote connections can list available projects with opaque IDs and labels.
  - Collection, feed, skill, and view commands support optional project selection.
  - Successful collection schema saves report portability findings when applicable.
  - Collection watchers synchronize automatically when saved directory settings change.
  - Saved directory presets can be added or removed without overwriting concurrent updates.

- **Bug Fixes**
  - Project-scoped collection views no longer remove workspace-pinned shortcuts.
  - Concurrent configuration changes are handled more safely.

- **Documentation**
  - Added guidance for project discovery, project-scoped commands, workspace defaults, and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->