### PR TITLE
fix: two ways a global list was being deleted by a partial view of it

### DIFF
--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -41,16 +41,40 @@ grouped in `handlers/terminalSession.ts`.
 | `startChat` | `message`, `attachments?` | `{ started: true, chatId }` |
 | `listIssues` | — | `{ repos: RepoIssueRows[] }` |
 | `startIssueWork` | `repo`, `issue`, `run?` | `{ started: true, sessionId, branch, issue, outcome, ran }` |
-| `listFeeds` | — | `{ feeds }` |
-| `getFeed` | `slug`, `offset?`, `limit?` | the feed page |
-| `listCollections` | — | `{ collections }` (feed-backed ones excluded) |
-| `getCollection` | `slug`, `offset?`, `limit?` | one page of the collection's items |
+| `listFeeds` | `project?` | `{ feeds }` |
+| `getFeed` | `slug`, `project?`, `offset?`, `limit?` | the feed page |
+| `listCollectionProjects` | — | `{ projects: { id, label }[] }` — workspace first |
+| `listCollections` | `project?` | `{ collections }` (feed-backed ones excluded) |
+| `getCollection` | `slug`, `project?`, `offset?`, `limit?` | one page of the collection's items |
 | `listShortcuts` | — | `{ shortcuts }` |
-| `listSkills` | — | `{ skills }` (collection slugs excluded) |
+| `listSkills` | `project?` | `{ skills }` (collection slugs excluded) |
 | `listAccountingBooks` | — | `{ books: { id, name }[] }` |
-| `getRemoteView` | `slug`, `viewId`, `locale?` | `{ view, srcdoc, bytes }` |
-| `getRemoteViewItems` | `slug`, `viewId`, `offset?`, `limit?`, `fields?` | `{ page, inlined, omitted }` |
-| `mutateRemoteViewItem` | `slug`, `viewId`, `op`, `id`, `patch?` | `{ op, item }` / `{ op, id }` |
+| `getRemoteView` | `slug`, `viewId`, `project?`, `locale?` | `{ view, srcdoc, bytes }` |
+| `getRemoteViewItems` | `slug`, `viewId`, `project?`, `offset?`, `limit?`, `fields?` | `{ page, inlined, omitted }` |
+| `mutateRemoteViewItem` | `slug`, `viewId`, `project?`, `op`, `id`, `patch?` | `{ op, item }` / `{ op, id }` |
+
+### Which project a command means (`project`)
+
+A collection lives in a **directory**, and the host serves several: its own workspace plus every
+directory the user has saved. Every command above that reads collections, feeds or skills accepts
+an optional **`project`**, and `listCollectionProjects` is how the phone learns the ids to put in
+it.
+
+Three rules, and they are the contract rather than this host's preference:
+
+1. **The value is an OPAQUE ID, never a path.** The phone is a genuinely remote client — an
+   absolute root in a command or an artifact publishes the user's home directory over the wire.
+   Ids come from `listCollectionProjects` and are resolved host-side against the list the host
+   owns; a path is refused even when it names a real project.
+2. **Omitting it means the host's own workspace**, which is what every command meant before this
+   parameter existed. A phone that never sends it behaves exactly as it always did.
+3. **An id the host cannot resolve is an ERROR, not a fallback.** Serving the workspace's records
+   to a request that named a project would be the same slug, the same shape and different records,
+   with nothing saying so. Re-fetch the list and retry rather than treating the answer as the
+   project's.
+
+The ids are derived from the directory, not stored, so they survive a host restart — but they are
+not a name: a project the user removes stops resolving, which is the error in (3).
 
 The three `*RemoteView*` commands serve a collection's **mobile custom views**. The host wraps
 each view into its sandboxed `srcdoc` (CSP + postMessage bootstrap) and the phone renders that

--- a/plans/HANDOFF-collections-projects.md
+++ b/plans/HANDOFF-collections-projects.md
@@ -104,9 +104,10 @@ which is the canonical authoring path.
   generation. `feat-collections-project-root.md` §7b describes the 3.0.0 contract and is now
   historical on that point.
 
-Not done: nothing calls `syncCollectionWatcherRoots` when a directory is recorded, so a project
-launched for the first time waits up to a minute for its watcher. Config writes go through several
-paths (`POST /api/config`, `cli-init`) and the poll covers them all.
+The poll is now the FALLBACK, not the only path: `POST /api/config` reports when the saved-directory
+list actually moved (by path — a relabel is the same directory) and `app-routes.ts` pulls the sync
+forward. `cli-init` writes before the server runs, so it needs nothing. The callback is injected
+rather than imported, so the config module stays config-shaped.
 
 ### 3.2 Notification deep links — DONE
 
@@ -167,8 +168,14 @@ did before.
   per call rather than captured at construction — the one shape a later `project` param could not
   have changed.
 
-Still missing (deliberately, per §8): the phone-side picker, and a command that lets it LEARN the
-`{ id, label }` list.
+`listCollectionProjects` completes the host half: the handlers could already resolve a project a
+command NAMES, and this is how the phone learns which ids exist. It carries id + label and
+deliberately NOT the cwd the browser listing has — the browser needs the path to match a project to
+a cell it is already showing, and the phone, being genuinely remote, must not be handed one.
+`docs/remote-host-protocol.md` documents the parameter, the listing, and the three rules (opaque
+id; omitted means the workspace; an unresolvable id is an error, not a fallback).
+
+Still missing, and it is not in this repo: the phone's own project picker.
 
 ### 3.5 Per-root scheduled feed refresh — BLOCKED UPSTREAM (attempted, reverted)
 
@@ -239,8 +246,19 @@ never heard of, and narrowing would drop a real finding behind a version skew. `
 narrowed — it decides how the row renders. A spec pins that the server only ever produces a
 documented code.
 
-Still missing: an agent-facing form (a tool or a skill step), and a creation-time hook. §11.4 asked
-for "collection-creation time and as a command"; this is the command half.
+**The agent gets it too**, on the one action that can change the answer: a successful `putSchema`
+carries the findings back as a `portability` field beside `written: true`
+(`server/infra/collectionToolPortability.ts`). The agent is the one that chose the storage kind or
+dropped the `primaryKey`, and it is holding the file open at the moment that is cheapest to fix.
+
+Quiet by construction: a clean collection is not mentioned, a refusal (which is PROSE the agent is
+meant to act on) is passed through untouched, every other action is left alone rather than spending
+a git call per listing, and a failure of the check itself changes nothing about the write.
+
+Still missing: a creation-time hook. There is nowhere to put one — creation is a plain file write
+the engine never sees (`putSchema` refuses an unknown collection and tells the agent to create it
+by writing SKILL.md + schema.json), so the first moment the host can speak is the schema edit that
+follows. §11.4's "at collection-creation time" is answered by that, not by a hook.
 
 ### 3.7 A live browser check — DONE for the overlay, still owed for the pane
 

--- a/server/backends/remoteHost/handlers/index.ts
+++ b/server/backends/remoteHost/handlers/index.ts
@@ -19,6 +19,7 @@ import { getRemoteView } from "./getRemoteView.js";
 import { createIssueWorkHandlers } from "./issueWork.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
 import { createListAccountingBooks } from "./listAccountingBooks.js";
+import { listCollectionProjects } from "./listCollectionProjects.js";
 import { listCollections } from "./listCollections.js";
 import { createListFeeds } from "./listFeeds.js";
 import { createListShortcuts } from "./listShortcuts.js";
@@ -35,6 +36,9 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
 
   return {
     listCollections,
+    // How the phone LEARNS which projects it may name — the other half of the scope the
+    // collection handlers already resolve (../commandScope.ts).
+    listCollectionProjects,
     getCollection,
     getRemoteView,
     getRemoteViewItems,

--- a/server/backends/remoteHost/handlers/listCollectionProjects.ts
+++ b/server/backends/remoteHost/handlers/listCollectionProjects.ts
@@ -1,0 +1,20 @@
+// listCollectionProjects command handler.
+//
+// The other half of the project scope (../commandScope.ts): the handlers can already RESOLVE a
+// project a command names, and this is how the phone LEARNS which ones there are. A picker needs
+// `{ id, label }` pairs from the host and can invent neither.
+//
+// Mirrors GET /api/collection-projects, minus the `cwd`. The browser is handed each project's
+// path because it has to MATCH a project to a cell it is already showing, and it knows every
+// cell's cwd anyway. The phone has no such need and is a genuinely remote client, so the path
+// stays here: an absolute root in a command or an artifact publishes the user's home directory
+// over the wire, and the id is what the host resolves against its own list.
+//
+// The workspace is included and leads the list, as it does in the HTTP listing — a phone that
+// wants "the host's own collections" names it like any other project rather than by omitting the
+// parameter and hoping.
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { listProjectRoots } from "../../../infra/project-root.js";
+
+export const listCollectionProjects: CommandHandlers["listCollectionProjects"] = async () =>
+  toJsonObject({ projects: listProjectRoots().map((project) => ({ id: project.id, label: project.label })) });

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -62,6 +62,14 @@ setDeclaredGitlabHosts(getGitlabHosts);
 // The saved directories and the recorded clone-per-repo choices, for the repo -> dir reverse
 // lookup (#1172). Read live for the same reason as the repos above: choosing a clone writes the
 // config, and the next lookup has to see it without a restart.
+/** Whether the saved-directory list is the same one. By PATH: a relabelled preset is the same
+ *  directory to everything downstream of this (the collection watchers, the project ids), and
+ *  waking them for a rename would be work with no question behind it. */
+function samePresets(before: readonly CwdPreset[], after: readonly CwdPreset[]): boolean {
+  if (before.length !== after.length) return false;
+  return before.every((preset, index) => preset.path === after[index]?.path);
+}
+
 export function getCwdPresets(): CwdPreset[] {
   return config.cwdPresets;
 }
@@ -186,7 +194,12 @@ export function getAppendSystemPrompt(): boolean {
   return loadAppConfig(CONFIG_FILE).appendSystemPrompt;
 }
 
-export function mountConfigRoutes(app: Express, claudeCwd: string): void {
+/** Called after a config write that CHANGED the saved directories. Injected rather than imported,
+ *  so this module stays config-shaped and does not reach into a backend: the collection watchers
+ *  are the caller's concern, not the config route's. */
+export type CwdPresetsChanged = () => void;
+
+export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsChanged?: CwdPresetsChanged): void {
   // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
   // everything it can write — buttons/chips included — and round-trip it.
   const configResponse = () => ({ cwd: claudeCwd, ...toPublicAppConfig(config) });
@@ -247,7 +260,17 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     // Carry the keys this build doesn't know straight back to disk. Another version's setting
     // must not disappear because this one saved over it (#966).
     if (!saveAppConfig(CONFIG_FILE, next, unknownKeysOf(loaded))) return res.status(500).json({ error: "failed to persist config" });
+    // Compared against the config just read from DISK, not this instance's cached copy: another
+    // mulmoterminal sharing the file may have written since we booted, and that is the same
+    // reason the merge base above is re-read. A stale comparison would both miss a change and
+    // invent one.
+    const presetsChanged = !samePresets(base.cwdPresets, next.cwdPresets);
     config = next;
+    // AFTER the commit, and only when the list actually moved: the saved directories are the
+    // projects the collection watchers mount for, and without this a directory added mid-session
+    // waits out the poll before its collections can ring. Fire-and-forget by contract — a
+    // subscriber's failure is its own, and must not turn a saved config into a 500.
+    if (presetsChanged) onCwdPresetsChanged?.();
     res.json(configResponse());
   });
 

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,7 @@
 import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
-import type { Express } from "express";
+import type { Express, Response } from "express";
 import {
   loadAppConfig,
   loadAppConfigResult,
@@ -199,6 +199,70 @@ export function getAppendSystemPrompt(): boolean {
  *  are the caller's concern, not the config route's. */
 export type CwdPresetsChanged = () => void;
 
+/** The saved-directory routes, at module scope so `mountConfigRoutes` stays inside its line
+ *  budget — and because they are their own subsystem: one-entry mutations of a global list. */
+function mountCwdPresetRoutes(app: Express, onCwdPresetsChanged?: CwdPresetsChanged): void {
+  // ── recording ONE saved directory, server-side ─────────────────────────────────────────────
+  //
+  // WHY THIS EXISTS AT ALL, and why the client must not do it with `POST /api/config`:
+  //
+  // `cwdPresets` is a REPLACE-ALL field, and it is global — every mulmoterminal on this machine
+  // shares the file, and the list decides which projects the server serves collections for
+  // (server/infra/project-root.ts). A client that sends the whole list sends ITS OWN VIEW of it,
+  // and any way that view is short, the difference is deleted from disk: the initial GET has not
+  // landed yet, the GET failed, another instance added a directory this tab never saw.
+  //
+  // On 2026-08-09 that cost a user four of five saved directories — a terminal launched while the
+  // first GET was in flight persisted `[the one just launched]`, and the collections of the other
+  // four stopped being served. Nothing said anything; the config was simply smaller.
+  //
+  // So "remember this directory" is expressed as what it IS: a one-entry mutation, applied to the
+  // list ON DISK, read and written here. A caller cannot clobber a list it never has to hold, and
+  // two instances recording different directories at once no longer race each other.
+  //
+  // The client keeps `POST /api/config` for a genuine replace-all (reordering in a settings UI),
+  // where sending the whole list is the user's actual intent.
+  app.post("/api/config/cwd-presets/record", (req, res) => {
+    const body = requestBody(req.body);
+    const path_ = typeof body.path === "string" ? body.path.trim() : "";
+    if (!path_) return res.status(400).json({ error: "path is required" });
+    const label = typeof body.label === "string" && body.label.trim().length > 0 ? body.label.trim() : path_.split("/").filter(Boolean).at(-1) || path_;
+    return mutatePresets(res, (current) => {
+      // Most-recently-used first, and an existing entry keeps the label the user gave it.
+      const existing = current.find((preset) => preset.path === path_);
+      return [existing ?? { label, path: path_ }, ...current.filter((preset) => preset.path !== path_)];
+    });
+  });
+
+  // The chip's close button. Same reasoning: a stale client filtering its own copy would drop
+  // whatever it had not seen.
+  app.post("/api/config/cwd-presets/remove", (req, res) => {
+    const body = requestBody(req.body);
+    const path_ = typeof body.path === "string" ? body.path : "";
+    if (!path_) return res.status(400).json({ error: "path is required" });
+    return mutatePresets(res, (current) => current.filter((preset) => preset.path !== path_));
+  });
+
+  /** Apply a one-entry change to the saved directories, reading and writing the file the same way
+   *  `POST /api/config` does — including refusing a config we could not parse, so a stray comma
+   *  never costs the user the rest of their settings. Answers the resulting list. */
+  function mutatePresets(res: Response, mutate: (current: CwdPreset[]) => CwdPreset[]) {
+    const loaded = loadAppConfigResult(CONFIG_FILE);
+    if (loaded.status === "corrupt") {
+      const bak = backupCorruptConfig(CONFIG_FILE);
+      const backupNote = bak ? ` (backed up to ${path.basename(bak)})` : "";
+      return res.status(409).json({ error: `config.json is unreadable and was NOT overwritten${backupNote}. Fix or remove it, then retry.` });
+    }
+    const base = loaded.status === "ok" ? loaded.config : emptyConfig();
+    const next = mergeConfigUpdate(base, { cwdPresets: mutate(base.cwdPresets) });
+    if (!saveAppConfig(CONFIG_FILE, next, unknownKeysOf(loaded))) return res.status(500).json({ error: "failed to persist config" });
+    const changed = !samePresets(base.cwdPresets, next.cwdPresets);
+    config = next;
+    if (changed) onCwdPresetsChanged?.();
+    return res.json({ cwdPresets: next.cwdPresets });
+  }
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsChanged?: CwdPresetsChanged): void {
   // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
   // everything it can write — buttons/chips included — and round-trip it.
@@ -273,6 +337,8 @@ export function mountConfigRoutes(app: Express, claudeCwd: string, onCwdPresetsC
     if (presetsChanged) onCwdPresetsChanged?.();
     res.json(configResponse());
   });
+
+  mountCwdPresetRoutes(app, onCwdPresetsChanged);
 
   // What the launch form may offer (#584): the configured backends, whether each can be
   // reached right now, and the models it can run. Never the tokens themselves — only the

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -22,6 +22,10 @@ import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { workspaceScope } from "./project-root.js";
 import { isManagedWorkspace } from "../backends/workspaceSetup.js";
+// A successful `putSchema` carries back whether the collection would survive a clone — the agent
+// is the one that chose the storage kind or dropped the primaryKey, and it is holding the file
+// open at the moment that is cheapest to fix.
+import { withPortabilityNote } from "./collectionToolPortability.js";
 
 const tool = makeManageCollectionTool({
   bundledHelpsDir: helpsAssetDir,
@@ -36,7 +40,7 @@ const tool = makeManageCollectionTool({
  *
  *  This one is the AGENT's data plane and operates on the workspace, which is what the
  *  getter above says. A REQUEST must not use it — see `manageCollectionHandlerFor`. */
-export const manageCollectionHandler = tool.handler;
+export const manageCollectionHandler = withPortabilityNote(tool.handler, () => workspaceScope().workspaceRoot);
 
 // One tool instance per root. `makeManageCollectionTool` takes its root in the FACTORY deps,
 // not per call, so a request-scoped operation needs its own instance; they are cached because
@@ -53,20 +57,23 @@ const byRoot = new Map<string, typeof tool.handler>();
 export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
   const cached = byRoot.get(workspaceRoot);
   if (cached) return cached;
-  const handler = makeManageCollectionTool({
-    bundledHelpsDir: helpsAssetDir,
-    workspaceRoot,
-    // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`, mirrored
-    // by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent writes a
-    // draft nothing mirrors and nothing discovers — it does as instructed and produces a
-    // collection that does not exist, with no error anywhere.
-    //
-    // The engine also derives the variant from `skillsStagingDir` returning null, so this agrees
-    // with the host binding rather than overriding it. Passed anyway: two levers that must agree
-    // are worth stating at both ends, and this one says WHY the root has no staging rather than
-    // leaving it to be inferred from a path that came back empty.
-    stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
-  }).handler;
+  const handler = withPortabilityNote(
+    makeManageCollectionTool({
+      bundledHelpsDir: helpsAssetDir,
+      workspaceRoot,
+      // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`, mirrored
+      // by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent writes a
+      // draft nothing mirrors and nothing discovers — it does as instructed and produces a
+      // collection that does not exist, with no error anywhere.
+      //
+      // The engine also derives the variant from `skillsStagingDir` returning null, so this agrees
+      // with the host binding rather than overriding it. Passed anyway: two levers that must agree
+      // are worth stating at both ends, and this one says WHY the root has no staging rather than
+      // leaving it to be inferred from a path that came back empty.
+      stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
+    }).handler,
+    () => workspaceRoot,
+  );
   byRoot.set(workspaceRoot, handler);
   return handler;
 }

--- a/server/infra/collectionToolPortability.ts
+++ b/server/infra/collectionToolPortability.ts
@@ -1,0 +1,63 @@
+// Tell the AGENT when a schema it just wrote would not survive a clone.
+//
+// The portability check has a route and a button (plans/HANDOFF-collections-projects.md §3.6), and
+// both need a person to think of asking. The agent is the one who chose the storage kind, dropped
+// the `primaryKey` or put the collection in user scope — and it is holding the file open at the
+// moment the answer is cheapest to act on.
+//
+// WHY `putSchema` AND NOTHING ELSE. It is the only action that changes what the check reads:
+// creation is a plain file write the engine never sees (`putSchema` refuses an unknown collection
+// and says to create it by writing SKILL.md + schema.json), and the record actions cannot move a
+// collection in or out of portability. Hooking a read action would spend a git call on every
+// listing to say the same thing repeatedly.
+//
+// It is ADDITIVE and quiet: a clean collection is not mentioned at all, a refusal or a validation
+// error is passed through untouched, and a failure of the check itself changes nothing. The agent
+// never has to handle a new failure mode to keep working.
+import { isRecord } from "../../common/isRecord.js";
+import { checkCollectionSelfContainment } from "../backends/collectionSelfContainment.js";
+
+/** `putSchema`'s success narration, parsed — or null for anything else, INCLUDING its refusals.
+ *  Those are prose, and prose is what the agent is meant to read and act on: appending to it
+ *  would bury the reason the write did not happen. */
+function writtenPayload(narration: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(narration);
+  } catch {
+    return null;
+  }
+  return isRecord(parsed) && parsed.written === true ? parsed : null;
+}
+
+function slugOf(args: Record<string, unknown>): string | null {
+  return typeof args.slug === "string" && args.slug.length > 0 ? args.slug : null;
+}
+
+/** Wrap a manageCollection handler so a successful `putSchema` carries the collection's
+ *  portability findings back with it.
+ *
+ *  `rootOf` is a thunk for the same reason the tool's own `workspaceRoot` is: the workspace
+ *  handler is built at module scope, before boot binds a root. */
+export function withPortabilityNote(handler: (args: Record<string, unknown>) => Promise<string>, rootOf: () => string) {
+  return async (args: Record<string, unknown>): Promise<string> => {
+    const narration = await handler(args);
+    if (args.action !== "putSchema") return narration;
+    const slug = slugOf(args);
+    if (slug === null) return narration;
+    const written = writtenPayload(narration);
+    if (!written) return narration;
+    try {
+      const report = await checkCollectionSelfContainment(slug, { workspaceRoot: rootOf() });
+      // Nothing to say about a collection that already travels — silence is the answer there,
+      // and a `portability: { findings: [] }` on every write would be noise the agent learns to
+      // skip, which is how the one that matters gets skipped too.
+      if (!report || report.findings.length === 0) return narration;
+      return JSON.stringify({ ...written, portability: { portable: report.portable, findings: report.findings } });
+    } catch {
+      // The check is an extra, not a gate: the schema IS written, and reporting the write is the
+      // handler's actual job. A git that would not run must not turn that into an error.
+      return narration;
+    }
+  };
+}

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -39,6 +39,7 @@ import { mountCostRoute } from "../session/cost.js";
 import { mountCollectionRoutes } from "../backends/collections.js";
 // "Would this collection survive a clone?" — mounts itself beside the collection routes.
 import { mountSelfContainmentRoutes } from "../backends/collectionSelfContainment.js";
+import { syncCollectionWatcherRoots } from "../backends/collectionWatchers.js";
 import { mountGoogleRoutes } from "../backends/google.js";
 import { mountWikiRoutes } from "../backends/wiki.js";
 import { mountAccountingRoutes } from "../backends/accounting.js";
@@ -327,7 +328,13 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   // GET/POST /api/config (workspace dir + directory presets) — in its own module.
   // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
   // modal's directory presets. The single view never calls it.
-  mountConfigRoutes(app, CLAUDE_CWD);
+  // A directory saved here is a project the collection watchers should mount for, and the sync
+  // is otherwise a 60s poll — long enough that a new project's first collection looks broken.
+  mountConfigRoutes(app, CLAUDE_CWD, () => {
+    void syncCollectionWatcherRoots().catch((err: unknown) => {
+      console.warn("[collection-watchers] sync after a config write failed", err);
+    });
+  });
 
   // Project-scoped file browsing + editing for the full-screen Files view
   // (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -271,7 +271,22 @@ configureCollectionUi({
   importRegistry: (author, slug, registry) => apiPost<RegistryImportResponse>("/api/collections/registry/import", { author, slug, registry }),
 
   // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
-  reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
+  // ONLY EVER FROM THE WORKSPACE'S OWN LIST. This is data loss when it is wrong, and it was:
+  // the pinned-shortcuts file is ONE workspace-global file (shared with MulmoClaude), while the
+  // list the index just fetched is scoped to the surface's project (`withActiveProject`, applied
+  // by `apiGet` above). Reconciling one against the other says "every collection the workspace
+  // pinned is gone" whenever the pane is open on a project — and `reconcile` prunes and PERSISTS.
+  //
+  // That is not hypothetical. On 2026-08-09 opening the Collections pane on a project with one
+  // collection deleted TWENTY-ONE pinned collections from `<workspace>/config/shortcuts.json`, in
+  // both apps, with no undo and nothing on screen to say it had happened. The feeds survived only
+  // because they are a different `kind`.
+  //
+  // So a project-scoped answer reconciles NOTHING. It is not "reconcile the project's pins
+  // instead": pins are not per project, and pretending otherwise would delete the workspace's on
+  // the way. If pins ever become per project, this is the line that has to learn about it — not
+  // the store, which cannot see a scope from where it sits.
+  reconcileShortcuts: (kind, live) => (activeCollectionProjectId() === null ? useShortcuts().reconcile(kind, live) : Promise.resolve()),
   unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
   // ── chat: spawn a new terminal session seeded with the prompt and surface it
   //    (hidden=false → make it visible). Backs the index "create" button + the

--- a/src/composables/reconcileShortcuts.ts
+++ b/src/composables/reconcileShortcuts.ts
@@ -23,6 +23,12 @@ export interface Reconciled {
 
 // Only entries of `kind` are judged; the authoritative list says nothing about the others,
 // so a collection fetch must never prune a feed shortcut (or vice versa).
+//
+// `live` MUST BE THE WHOLE WORKSPACE'S LIST OF THAT KIND. Everything here treats "absent from
+// `live`" as "no longer exists", so a list that is merely a SUBSET — one project's collections,
+// a filtered view, a page of results — reads as a mass deletion and is written back as one. The
+// caller is what knows the difference; see the `reconcileShortcuts` binding in collectionUi.ts,
+// which refuses to call this at all while a project scope is active, and why.
 export function reconcileShortcuts(current: readonly Shortcut[], kind: ShortcutKind, live: readonly LiveEntry[]): Reconciled {
   const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
   let drifted = false;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -163,7 +163,13 @@ const isLauncher = (value: unknown): value is Launcher => isRecord(value) && typ
 // `next` from the same stale snapshot — the later POST would clobber the earlier one
 // (last-write-wins, dropping a just-launched dir). `serialize` runs the writes in order so
 // every mutation reads the freshly-saved list before computing its own.
-function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: CwdPreset[]) => Promise<boolean>) {
+function createPresetMutations(
+  presets: Ref<CwdPreset[]>,
+  savePresets: (next: CwdPreset[]) => Promise<boolean>,
+  hasAuthoritativeList: () => boolean,
+  recordPresetOnServer: (path: string, label: string) => Promise<void>,
+  removePresetOnServer: (path: string) => Promise<void>,
+) {
   let presetWrite: Promise<unknown> = Promise.resolve();
   function serialize(mutate: () => Promise<void>): Promise<void> {
     const run = presetWrite.then(mutate, mutate);
@@ -200,17 +206,30 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
     if (isManagedWorktreePath(path, worktreesRoot.value)) return;
     return serialize(async () => {
       if (presets.value[0]?.path === path) return; // already most-recent — nothing to reorder
-      const existing = presets.value.find((p) => p.path === path);
-      const entry = existing ?? { label: presetLabel(path), path };
-      await savePresets([entry, ...presets.value.filter((p) => p.path !== path)]);
+      // A ONE-ENTRY MUTATION, applied to the list on disk by the server — never a replace-all
+      // built from `presets.value`.
+      //
+      // This is the fix for a data-loss bug, so it is worth being blunt about: `presets.value` is
+      // this tab's view, and it is EMPTY until the initial GET lands, empty again if that GET
+      // fails, and stale the moment another mulmoterminal (or another tab) saves a directory.
+      // Sending it as the whole list deletes the difference from a file every instance shares —
+      // and that list is what decides which projects the server serves collections for. On
+      // 2026-08-09 a terminal launched during the first GET reduced five saved directories to
+      // one, silently.
+      //
+      // Recording is inherently "add this, keep the rest", so it is expressed that way and the
+      // rest is never in this tab's hands. That also keeps #164's guarantee — a launch during the
+      // initial GET is recorded immediately, with nothing to wait for.
+      await recordPresetOnServer(path, presetLabel(path));
     });
   }
 
   // Drop one preset (the chip's close button). No-op when the path isn't present.
   function removePreset(path: string): Promise<void> {
     return serialize(async () => {
-      if (!presets.value.some((p) => p.path === path)) return;
-      await savePresets(presets.value.filter((p) => p.path !== path));
+      // Server-side for the same reason as recordPreset: filtering this tab's copy and sending it
+      // back would drop every directory this tab had not seen.
+      await removePresetOnServer(path);
     });
   }
 
@@ -220,6 +239,11 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
   // is cleared on success so a chip the user later deletes can't reappear. Dedup keeps it
   // harmless if it runs twice.
   async function migrateLegacyRecents(): Promise<void> {
+    // Same rule as the two above, and stated rather than relied upon: this only runs after a
+    // successful GET today, so the list IS authoritative — but it prepends to `presets.value`
+    // and saves the whole thing, which is the shape that costs the user their directories the
+    // day a caller moves it.
+    if (!hasAuthoritativeList()) return;
     const legacy = readLegacyRecents();
     if (!legacy.length) return;
     const known = new Set(presets.value.map((p) => p.path));
@@ -248,6 +272,18 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
 // resolves would be dropped by the stale GET.
 function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, error: Ref<string | null>) {
   let version = 0;
+  // True only once a GET (or our own successful save) has authoritatively populated `presets`.
+  //
+  // THIS IS THE DIFFERENCE BETWEEN RECORDING A DIRECTORY AND DELETING EVERY OTHER ONE. The save
+  // is a REPLACE-ALL POST built from `presets.value`, so writing before the list is known sends
+  // the empty default plus the one entry — and the user's whole saved-directory list becomes
+  // that single directory, on disk, in a file every mulmoterminal on the machine shares.
+  //
+  // That happened on 2026-08-09: a terminal launched while the initial GET was still in flight
+  // reduced five saved directories to one, and the collections of the other four stopped being
+  // served (they are the project list — server/infra/project-root.ts). The same guard exists in
+  // useShortcuts for the same reason, on the same kind of file.
+  let loaded = false;
 
   // Persist the directory presets. Posts only cwdPresets — the server keeps the other fields,
   // so this never clobbers them. Returns whether the save succeeded.
@@ -263,6 +299,8 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
       if (!res.ok) throw new Error(`save failed (${res.status})`);
       const saved: unknown = await res.json();
       presets.value = isRecord(saved) && isUnknownArray(saved.cwdPresets) ? saved.cwdPresets.filter(isCwdPreset) : [];
+      // The server has now told us what the list IS, so the next write may build on it.
+      loaded = true;
       version++;
       return true;
     } catch {
@@ -275,10 +313,43 @@ function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, er
 
   const snapshotVersion = (): number => version;
   const adoptServerPresets = (list: unknown, capturedVersion: number): void => {
-    if (version === capturedVersion) presets.value = isUnknownArray(list) ? list.filter(isCwdPreset) : [];
+    if (version !== capturedVersion) return;
+    presets.value = isUnknownArray(list) ? list.filter(isCwdPreset) : [];
+    loaded = true;
   };
 
-  return { savePresets, ...createPresetMutations(presets, savePresets), snapshotVersion, adoptServerPresets };
+  /** Apply a one-entry change on the SERVER and adopt the list it answers with. The response is
+   *  the file's real contents after the change, so this tab ends up agreeing with disk even when
+   *  its own copy was empty or stale — which is the point.
+   *
+   *  A failed call leaves the list exactly as it was: the directory is simply not recorded, and
+   *  the next launch tries again. It counts as a local write (`version++`) so a GET already in
+   *  flight cannot re-adopt the pre-change list over it (#164). */
+  async function mutateOneOnServer(url: string, body: Record<string, string>): Promise<void> {
+    version++;
+    try {
+      const res = await fetchWithTimeout(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      const saved: unknown = await res.json();
+      if (isRecord(saved) && isUnknownArray(saved.cwdPresets)) {
+        presets.value = saved.cwdPresets.filter(isCwdPreset);
+        loaded = true;
+      }
+      error.value = null;
+    } catch {
+      error.value = "Couldn't save presets. Check the server and try again.";
+    }
+  }
+
+  const recordPresetOnServer = (path: string, label: string) => mutateOneOnServer("/api/config/cwd-presets/record", { path, label });
+  const removePresetOnServer = (path: string) => mutateOneOnServer("/api/config/cwd-presets/remove", { path });
+
+  return {
+    savePresets,
+    ...createPresetMutations(presets, savePresets, () => loaded, recordPresetOnServer, removePresetOnServer),
+    snapshotVersion,
+    adoptServerPresets,
+  };
 }
 
 // The single-field savers each persist ONE config field and update its SINGLETON ref, so

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -117,7 +117,13 @@ function unpin(kind: ShortcutKind, slug: string): Promise<boolean> {
 
 /** Bulk reconcile one kind against the authoritative {slug,title,icon} list an
  *  index just fetched: prune dead slugs, refresh stale title/icon, self-heal the
- *  file. Other kinds untouched. */
+ *  file. Other kinds untouched.
+ *
+ *  `live` MUST be the whole WORKSPACE's list of that kind — this prunes and persists, to a file
+ *  shared with MulmoClaude, so a subset is written back as a deletion. This store cannot check
+ *  that from here (it has no idea what scope produced the list), which is exactly why the caller
+ *  carries the rule: collectionUi.ts refuses to call this while a project scope is active, after
+ *  a project-scoped list deleted twenty-one of the user's pins on 2026-08-09. */
 function reconcile(kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]): Promise<void> {
   return enqueue(async () => {
     await load();

--- a/test/server/backends/remoteHost/listCollectionProjects.spec.ts
+++ b/test/server/backends/remoteHost/listCollectionProjects.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+//
+// How the phone LEARNS which projects it may name. The handlers could already resolve a named one
+// (commandScope.ts); without this they could resolve an id the phone had no way to obtain.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { listCollectionProjects } from "../../../../server/backends/remoteHost/handlers/listCollectionProjects.js";
+import { scopeFromCommand } from "../../../../server/backends/remoteHost/commandScope.js";
+import { initProjectRoots, projectId, resetProjectRootsForTesting } from "../../../../server/infra/project-root.js";
+
+const WORKSPACE = "/srv/ws";
+const PROJECT = "/srv/mag2";
+
+interface Listing {
+  projects: { id: string; label: string; cwd?: unknown }[];
+}
+
+beforeEach(() => {
+  initProjectRoots({ workspace: WORKSPACE, knownProjects: () => [{ label: "mag2", path: PROJECT }] });
+});
+
+afterEach(() => {
+  resetProjectRootsForTesting();
+});
+
+describe("listCollectionProjects", () => {
+  it("lists the workspace first, then the saved directories", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    expect(projects.map((project) => project.label)).toEqual(["ws", "mag2"]);
+  });
+
+  // The phone is a genuinely remote client: an absolute root in a command or an artifact
+  // publishes the user's home directory over the wire. The browser's listing carries `cwd`
+  // because it has to match a project to a cell it is already showing; the phone has no such
+  // need, so the path stays on the host.
+  it("carries NO path — only the opaque id and a label", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    for (const project of projects) {
+      expect(Object.keys(project).sort()).toEqual(["id", "label"]);
+    }
+    expect(JSON.stringify(projects)).not.toContain("/srv");
+  });
+
+  // The listing is only useful if what it hands out is what the handlers accept — the two halves
+  // are separately correct and together are the feature.
+  it("hands out ids the command scope resolves", async () => {
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    for (const project of projects) {
+      expect(scopeFromCommand({ project: project.id })).toEqual({ workspaceRoot: project.label === "ws" ? WORKSPACE : PROJECT });
+    }
+    expect(projects.map((project) => project.id)).toEqual([projectId(WORKSPACE), projectId(PROJECT)]);
+  });
+
+  it("is just the workspace when nothing else is saved", async () => {
+    initProjectRoots({ workspace: WORKSPACE });
+    const { projects } = (await listCollectionProjects({})) as unknown as Listing;
+    expect(projects).toEqual([{ id: projectId(WORKSPACE), label: "ws" }]);
+  });
+});

--- a/test/server/config/cwd-preset-routes.spec.ts
+++ b/test/server/config/cwd-preset-routes.spec.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+//
+// Recording a working directory is a ONE-ENTRY mutation applied to the file, not a replace-all.
+//
+// This is a data-loss fix, so what these pin is mostly what must NOT happen: `cwdPresets` is
+// global (every mulmoterminal on the machine shares the file) and it decides which projects the
+// server serves collections for. A client that sent the whole list sent its own view of it, and
+// on 2026-08-09 a terminal launched during the initial GET reduced five saved directories to one.
+// The routes below exist so the caller never holds the list at all.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import express from "express";
+import request from "supertest";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function mountAgainstTempHome(initial: Record<string, unknown>) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-preset-routes-"));
+  dirs.push(dir);
+  vi.stubEnv("HOME", dir);
+  vi.stubEnv("USERPROFILE", dir);
+  vi.resetModules();
+  const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+  // Guard before anything writes: a stub that did not take would target the real config.
+  expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
+  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
+
+  const onChanged = vi.fn();
+  const app = express();
+  app.use(express.json());
+  mountConfigRoutes(app, dir, onChanged);
+  const onDisk = () => JSON.parse(readFileSync(APP_CONFIG_FILE, "utf8"));
+  return { app, onChanged, onDisk };
+}
+
+const TWO = [
+  { label: "mag2", path: "/srv/mag2" },
+  { label: "site", path: "/srv/site" },
+];
+
+describe("POST /api/config/cwd-presets/record", () => {
+  it("adds one entry and KEEPS every other, whatever the caller knows", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new", label: "new" });
+    expect(res.status).toBe(200);
+    // The caller sent ONE path. It could not have deleted the others if it tried.
+    expect(res.body.cwdPresets.map((preset: { path: string }) => preset.path)).toEqual(["/srv/new", "/srv/mag2", "/srv/site"]);
+    expect(onDisk().cwdPresets).toHaveLength(3);
+  });
+
+  it("bumps an existing directory to the front, keeping the label the user gave it", async () => {
+    const { app } = await mountAgainstTempHome({
+      cwdPresets: [
+        { label: "two", path: "/b" },
+        { label: "Custom", path: "/a" },
+      ],
+    });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/a", label: "a" });
+    expect(res.body.cwdPresets).toEqual([
+      { label: "Custom", path: "/a" },
+      { label: "two", path: "/b" },
+    ]);
+  });
+
+  it("falls back to the basename when no label is sent", async () => {
+    const { app } = await mountAgainstTempHome({});
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/home/me/alpha" });
+    expect(res.body.cwdPresets).toEqual([{ label: "alpha", path: "/home/me/alpha" }]);
+  });
+
+  it("keeps every OTHER setting in the file", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO, pushEnabled: true, futureFeature: "on" });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    const saved = onDisk();
+    expect(saved.pushEnabled).toBe(true);
+    // Including a key THIS build does not know — another version's setting must not vanish (#966).
+    expect(saved.futureFeature).toBe("on");
+  });
+
+  it("refuses a request with no path", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    expect((await request(app).post("/api/config/cwd-presets/record").send({})).status).toBe(400);
+    expect((await request(app).post("/api/config/cwd-presets/record").send({ path: "   " })).status).toBe(400);
+    expect(onDisk().cwdPresets).toHaveLength(2);
+  });
+
+  // A single stray comma must not cost the user the rest of their settings — the same refusal
+  // POST /api/config makes.
+  it("refuses to write over a config it could not parse", async () => {
+    const { app } = await mountAgainstTempHome({});
+    const { APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+    writeFileSync(APP_CONFIG_FILE, "{ not json");
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    expect(res.status).toBe(409);
+  });
+
+  it("tells the caller the project list moved, so the collection watchers can follow", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when the directory was already at the front", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/mag2" });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/config/cwd-presets/remove", () => {
+  it("drops one entry and keeps the rest", async () => {
+    const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/mag2" });
+    expect(res.body.cwdPresets).toEqual([{ label: "site", path: "/srv/site" }]);
+    expect(onDisk().cwdPresets).toHaveLength(1);
+  });
+
+  it("is a no-op for a path that is not saved, and says nothing changed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/never" });
+    expect(res.body.cwdPresets).toHaveLength(2);
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request with no path", async () => {
+    const { app } = await mountAgainstTempHome({ cwdPresets: TWO });
+    expect((await request(app).post("/api/config/cwd-presets/remove").send({})).status).toBe(400);
+  });
+});

--- a/test/server/config/cwd-presets-notify.spec.ts
+++ b/test/server/config/cwd-presets-notify.spec.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+//
+// The saved directories ARE the projects the collection watchers mount for, so a directory added
+// mid-session used to wait out a 60s poll before its collections could ring — long enough that a
+// new project's first collection reads as broken. The config route now says when the list moved.
+//
+// Deliberately a callback rather than an import: the config module stays config-shaped, and the
+// watchers are the caller's concern (server/routes/app-routes.ts wires them).
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import express from "express";
+import request from "supertest";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A config route mounted against a throwaway HOME, with the change callback captured. `HOME` and
+ *  `USERPROFILE` both, because `os.homedir()` reads the latter on Windows — stubbing one left a
+ *  Windows run pointed at the real config. */
+async function mountAgainstTempHome(initial: Record<string, unknown>) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+  dirs.push(dir);
+  vi.stubEnv("HOME", dir);
+  vi.stubEnv("USERPROFILE", dir);
+  vi.resetModules();
+  const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
+  // Guard before anything writes: a stub that did not take would target the real config.
+  expect(APP_CONFIG_FILE.startsWith(dir), "config path must be inside the temp HOME").toBe(true);
+  mkdirSync(path.dirname(APP_CONFIG_FILE), { recursive: true });
+  writeFileSync(APP_CONFIG_FILE, JSON.stringify(initial, null, 2));
+
+  const onChanged = vi.fn();
+  const app = express();
+  app.use(express.json());
+  mountConfigRoutes(app, dir, onChanged);
+  return { app, onChanged };
+}
+
+const PRESETS = [{ label: "mag2", path: "/srv/mag2" }];
+
+describe("POST /api/config tells the caller when the saved directories move", () => {
+  it("fires when a directory is added", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({});
+    const res = await request(app).post("/api/config").send({ cwdPresets: PRESETS });
+    expect(res.status).toBe(200);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires when one is removed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app).post("/api/config").send({ cwdPresets: [] });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // The write that saves a sound, a theme or a keymap is the common one, and waking the watchers
+  // for it would be work with no question behind it.
+  it("stays quiet for a write that leaves the list alone", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app).post("/api/config").send({ pushEnabled: true });
+    await request(app).post("/api/config").send({ cwdPresets: PRESETS });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  // A relabelled preset is the SAME directory to everything downstream — the watchers and the
+  // project ids are keyed by path.
+  it("stays quiet when only a label changed", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app)
+      .post("/api/config")
+      .send({ cwdPresets: [{ label: "renamed", path: "/srv/mag2" }] });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("fires when the same count points somewhere else", async () => {
+    const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: PRESETS });
+    await request(app)
+      .post("/api/config")
+      .send({ cwdPresets: [{ label: "mag2", path: "/srv/elsewhere" }] });
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // Mounting without one is what every other caller does; the route must not require it.
+  it("does not require a subscriber", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-presets-notify-"));
+    dirs.push(dir);
+    vi.stubEnv("HOME", dir);
+    vi.stubEnv("USERPROFILE", dir);
+    vi.resetModules();
+    const { mountConfigRoutes } = await import("../../../server/config/config-routes.js");
+    const app = express();
+    app.use(express.json());
+    mountConfigRoutes(app, dir);
+    expect((await request(app).post("/api/config").send({ cwdPresets: PRESETS })).status).toBe(200);
+  });
+});

--- a/test/server/infra/collectionToolPortability.spec.ts
+++ b/test/server/infra/collectionToolPortability.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+//
+// The agent's half of the portability check. What matters here is how QUIET it is: the note rides
+// along with a write the agent already made, and everything else — a refusal, a read, a clean
+// collection, a check that could not run — comes back exactly as it did before this existed.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const check = vi.fn();
+vi.mock("../../../server/backends/collectionSelfContainment.js", () => ({
+  checkCollectionSelfContainment: (slug: string, scope: { workspaceRoot: string }) => check(slug, scope),
+}));
+
+import { withPortabilityNote } from "../../../server/infra/collectionToolPortability.js";
+
+const WRITTEN = JSON.stringify({ collection: "notes", written: true });
+const BLOCKED = {
+  slug: "notes",
+  portable: false,
+  findings: [{ code: "sqlite-store", severity: "blocker", message: "Records are one SQLite file; git cannot merge it." }],
+};
+
+/** The wrapped handler, plus the inner handler's call log. */
+function wrap(narration: string | (() => Promise<string>), root = "/srv/proj") {
+  const inner = vi.fn(async () => (typeof narration === "string" ? narration : narration()));
+  return { run: withPortabilityNote(inner, () => root), inner };
+}
+
+beforeEach(() => {
+  check.mockReset().mockResolvedValue(BLOCKED);
+});
+
+describe("withPortabilityNote", () => {
+  it("adds the findings to a successful putSchema, keeping what the tool already said", async () => {
+    const { run } = wrap(WRITTEN);
+    const out = JSON.parse(await run({ action: "putSchema", slug: "notes" }));
+    expect(out).toMatchObject({ collection: "notes", written: true });
+    expect(out.portability).toEqual({ portable: false, findings: BLOCKED.findings });
+    expect(check).toHaveBeenCalledWith("notes", { workspaceRoot: "/srv/proj" });
+  });
+
+  it("says NOTHING about a collection that already travels", async () => {
+    check.mockResolvedValue({ slug: "notes", portable: true, findings: [] });
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  // A refusal is PROSE, and prose is what the agent is meant to read and act on — appending to it
+  // would bury the reason the write did not happen.
+  it("passes a refusal through untouched, and does not ask about it", async () => {
+    const refusal = "manageCollection: unknown collection 'notes' — create it by writing SKILL.md…";
+    const { run } = wrap(refusal);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(refusal);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("leaves a JSON result that is not a write alone", async () => {
+    const body = JSON.stringify({ collection: "notes", written: false });
+    const { run } = wrap(body);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(body);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  // Every other action either cannot change the answer (the record actions) or would spend a git
+  // call per listing to repeat it.
+  it("does not touch the other actions, or spend a check on them", async () => {
+    for (const action of ["getSchema", "getItems", "putItems", "deleteItems", "queryItems", "schemaDocs", "getOntology"]) {
+      const { run } = wrap(WRITTEN);
+      expect(await run({ action, slug: "notes" })).toBe(WRITTEN);
+    }
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("still reports the write when the check itself fails", async () => {
+    check.mockRejectedValue(new Error("git is not on PATH"));
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  it("still reports the write when the collection cannot be loaded back", async () => {
+    check.mockResolvedValue(null);
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "notes" })).toBe(WRITTEN);
+  });
+
+  it("needs a slug to ask about", async () => {
+    const { run } = wrap(WRITTEN);
+    expect(await run({ action: "putSchema" })).toBe(WRITTEN);
+    expect(await run({ action: "putSchema", slug: "" })).toBe(WRITTEN);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("reads the root at CALL time, not when the handler was built", async () => {
+    // The workspace handler is built at module scope, before boot binds a root — a value read
+    // then would be the wrong one, or none.
+    let root = "/srv/first";
+    const run = withPortabilityNote(
+      async () => WRITTEN,
+      () => root,
+    );
+    await run({ action: "putSchema", slug: "notes" });
+    root = "/srv/second";
+    await run({ action: "putSchema", slug: "notes" });
+    expect(check.mock.calls.map((call) => call[1])).toEqual([{ workspaceRoot: "/srv/first" }, { workspaceRoot: "/srv/second" }]);
+  });
+});

--- a/test/src/composables/shortcutsProjectScope.spec.ts
+++ b/test/src/composables/shortcutsProjectScope.spec.ts
@@ -1,0 +1,92 @@
+// The pinned-shortcuts file is ONE workspace-global file, shared with MulmoClaude. The collection
+// index that triggers a reconcile fetches a list scoped to the SURFACE'S PROJECT. Those are two
+// different universes, and reconciling one against the other is a mass deletion: every pin the
+// workspace holds looks "gone" from a project's point of view, and `reconcile` prunes and
+// PERSISTS.
+//
+// It happened. On 2026-08-09 opening the Collections pane on a project with one collection deleted
+// twenty-one pinned collections from <workspace>/config/shortcuts.json — in both apps, with no undo
+// and nothing on screen to say so. The feeds survived only because they are a different `kind`.
+//
+// So this spec is not about a nicety. It pins that a project-scoped answer reconciles NOTHING.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const reconcile = vi.fn(async () => {});
+vi.mock("../../../src/composables/useShortcuts", () => ({
+  useShortcuts: () => ({ reconcile, unpin: vi.fn() }),
+}));
+
+// The binding is registered as a module side effect, not exported — so the way to test the REAL
+// one is to catch what it registers.
+interface Bound {
+  reconcileShortcuts?: (kind: string, live: { slug: string; title: string; icon: string }[]) => Promise<void>;
+}
+let bound: Bound = {};
+vi.mock("@mulmoclaude/collection-plugin/vue", () => ({
+  configureCollectionUi: (context: Bound) => {
+    bound = context;
+  },
+  CollectionsIndexView: { name: "CollectionsIndexView", template: "<div />" },
+  CollectionView: { name: "CollectionView", template: "<div />" },
+  FeedsView: { name: "FeedsView", template: "<div />" },
+}));
+
+// Imported at module scope so its module graph is collection's cost, not the first test's
+// (CLAUDE.md). The import itself is what registers the binding above.
+await import("../../../src/composables/collectionUi");
+const { pushCollectionSurface, popCollectionSurface } = await import("../../../src/composables/collectionSurface");
+type CollectionSurface = import("../../../src/composables/collectionSurface").CollectionSurface;
+
+const LIVE = [{ slug: "tasks", title: "Tasks", icon: "check" }];
+const surfaces: CollectionSurface[] = [];
+
+function showSurface(projectId: string | null) {
+  const surface: CollectionSurface = { projectId, layer: "pane" };
+  surfaces.push(surface);
+  pushCollectionSurface(surface);
+}
+
+beforeEach(() => {
+  reconcile.mockClear();
+});
+
+afterEach(() => {
+  for (const surface of surfaces.splice(0)) popCollectionSurface(surface);
+});
+
+describe("reconcileShortcuts is refused for a project-scoped list", () => {
+  it("reconciles when the visible surface is the workspace", async () => {
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledWith("collection", LIVE);
+  });
+
+  it("reconciles when a surface says it IS the workspace", async () => {
+    showSurface(null);
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  // The bug, exactly: a pane open on a project, an index fetch scoped to it, and the workspace's
+  // pins judged against a list that was never about them.
+  it("does NOTHING when the visible surface is a project", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for feeds either — the scope is what matters, not the kind", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("feed", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("resumes once the project surface is gone", async () => {
+    showSurface("p1");
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).not.toHaveBeenCalled();
+
+    for (const surface of surfaces.splice(0)) popCollectionSurface(surface);
+    await bound.reconcileShortcuts?.("collection", LIVE);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -1,20 +1,51 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { currentGitlabHosts, useAppConfig } from "../../../src/composables/useAppConfig";
 
-// Echo the posted cwdPresets back as the server would, so presets.value reflects
-// each save. useAppConfig's presets ref is per-call (not a singleton), so every
-// useAppConfig() in these tests starts from an empty list.
 // Where the server keeps the worktrees it created. The GET carries it (the real /api/config does,
 // alongside `home`) because that is the only way this side can tell one of ours from a directory
 // that merely looks like one — see isManagedWorktreePath.
 const WORKTREES_ROOT = "/Users/me/.mulmoterminal/worktrees";
 
-function mockConfigFetch() {
-  globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-    const body = init?.body ? JSON.parse(init.body) : {};
-    return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [], worktreesRoot: WORKTREES_ROOT }) };
+interface Preset {
+  label: string;
+  path: string;
+}
+
+// A stand-in for the SERVER'S list, not an echo of what the client posted — because that is the
+// property under test. Recording a directory is a ONE-ENTRY mutation applied on the server
+// (`/api/config/cwd-presets/record`), so a client whose own copy is empty or stale cannot send it
+// back as the whole list and delete the rest. An echoing fake could not tell the difference
+// between the fix and the bug it replaced, which is why it is gone.
+//
+// `gate` stalls the GET; `snapshot` is what that stalled GET will answer with — taken when it
+// STARTS, so a slow response is genuinely stale rather than magically current.
+function mockServer(initial: Preset[] = [], opts: { gate?: Promise<void>; get?: Record<string, unknown>; delayMs?: number } = {}) {
+  let list: Preset[] = [...initial];
+  globalThis.fetch = vi.fn(async (url: string, init?: { body?: string }) => {
+    const target = String(url);
+    const body: Record<string, unknown> = init?.body ? JSON.parse(init.body) : {};
+    if (opts.delayMs && target.startsWith("/api/config/cwd-presets/")) await new Promise((resolve) => setTimeout(resolve, opts.delayMs));
+    if (target === "/api/config/cwd-presets/record") {
+      const existing = list.find((preset) => preset.path === body.path);
+      list = [existing ?? { label: String(body.label), path: String(body.path) }, ...list.filter((preset) => preset.path !== body.path)];
+      return { ok: true, json: async () => ({ cwdPresets: list }) };
+    }
+    if (target === "/api/config/cwd-presets/remove") {
+      list = list.filter((preset) => preset.path !== body.path);
+      return { ok: true, json: async () => ({ cwdPresets: list }) };
+    }
+    if (!init?.body) {
+      const snapshot = [...list];
+      await opts.gate;
+      return { ok: true, json: async () => ({ cwdPresets: snapshot, worktreesRoot: WORKTREES_ROOT, ...opts.get }) };
+    }
+    // POST /api/config — the genuine replace-all: a settings-UI reorder, and the legacy import.
+    if (Array.isArray(body.cwdPresets)) list = body.cwdPresets as Preset[];
+    return { ok: true, json: async () => ({ cwdPresets: list }) };
   }) as unknown as typeof fetch;
 }
+
+const mockConfigFetch = () => mockServer();
 
 beforeEach(() => {
   localStorage.clear();
@@ -37,11 +68,13 @@ describe("useAppConfig — auto preset recording", () => {
   });
 
   it("keeps an existing entry's label when bumping it to the front", async () => {
-    const { presets, recordPreset } = useAppConfig();
-    presets.value = [
+    // Seeded on the SERVER — the label the user gave a directory lives in the file, and it is the
+    // server that decides what a record does to it now.
+    mockServer([
       { label: "two", path: "/b/two" },
       { label: "Custom", path: "/a/one" }, // a manual label from legacy cwdPresets
-    ];
+    ]);
+    const { presets, recordPreset } = useAppConfig();
     await recordPreset("/a/one");
     expect(presets.value).toEqual([
       { label: "Custom", path: "/a/one" },
@@ -103,12 +136,12 @@ describe("useAppConfig — auto preset recording", () => {
   // Saved config is the user's, so an entry an earlier version recorded is left where it is
   // rather than dropped — it just stops being maintained (no bump to the front).
   it("leaves an already-saved worktree entry alone instead of bumping it", async () => {
-    const { presets, recordPreset, loadConfig } = useAppConfig();
-    await loadConfig();
-    presets.value = [
+    mockServer([
       { label: "alpha", path: "/home/me/alpha" },
       { label: "myrepo (fix-bug)", path: WORKTREE },
-    ];
+    ]);
+    const { presets, recordPreset, loadConfig } = useAppConfig();
+    await loadConfig();
     const before = vi.mocked(globalThis.fetch).mock.calls.length;
     await recordPreset(WORKTREE);
     expect(vi.mocked(globalThis.fetch).mock.calls).toHaveLength(before); // no POST
@@ -158,20 +191,49 @@ describe("useAppConfig — auto preset recording", () => {
     const getGate = new Promise<void>((r) => {
       releaseGet = r;
     });
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      if (!init?.body) {
-        await getGate; // the initial GET stalls until we release it
-        return { ok: true, json: async () => ({ cwd: "/w", home: "/h", cwdPresets: [], soundFile: null }) };
-      }
-      const body = init.body ? JSON.parse(init.body) : {};
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    mockServer([], { gate: getGate, get: { cwd: "/w", home: "/h", soundFile: null } });
     const { presets, loadConfig, recordPreset } = useAppConfig();
     const loading = loadConfig(); // GET in flight (stalled)
     await recordPreset("/launched/now"); // user launches before the GET resolves
     releaseGet(); // the stale (empty) GET snapshot now lands
     await loading;
     expect(presets.value.map((p) => p.path)).toEqual(["/launched/now"]);
+  });
+
+  // THE BUG THIS PAIR OF ROUTES EXISTS FOR. A launch during (or after a failed) initial GET used
+  // to persist "[the one just launched]" as the WHOLE list, and every other saved directory was
+  // gone from a file every mulmoterminal on the machine shares — taking the projects whose
+  // collections the server serves with it (2026-08-09).
+  it("records a directory WITHOUT deleting the ones this tab has never seen", async () => {
+    mockServer([
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ]);
+    const { presets, recordPreset } = useAppConfig();
+    // No loadConfig: this tab's own list is empty, exactly as it is during the first GET.
+    expect(presets.value).toEqual([]);
+    await recordPreset("/srv/new");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/new", "/srv/mag2", "/srv/site"]);
+  });
+
+  it("removes one directory WITHOUT deleting the ones this tab has never seen", async () => {
+    mockServer([
+      { label: "mag2", path: "/srv/mag2" },
+      { label: "site", path: "/srv/site" },
+    ]);
+    const { presets, removePreset } = useAppConfig();
+    await removePreset("/srv/mag2");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/site"]);
+  });
+
+  // A save that fails must lose the RECORD, never the list.
+  it("leaves the list alone when the server refuses the record", async () => {
+    mockServer([{ label: "mag2", path: "/srv/mag2" }]);
+    const { presets, loadConfig, recordPreset } = useAppConfig();
+    await loadConfig();
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch;
+    await recordPreset("/srv/new");
+    expect(presets.value.map((p) => p.path)).toEqual(["/srv/mag2"]);
   });
 
   // The other side of the test above: a launch that lands before the initial GET has no worktree
@@ -227,13 +289,11 @@ describe("useAppConfig — auto preset recording", () => {
   });
 
   it("serializes concurrent records so neither write clobbers the other (#163 review)", async () => {
-    // A slow POST means two un-serialized records would both read the empty list and
-    // the second would overwrite the first. Serialization keeps both.
-    globalThis.fetch = vi.fn(async (_url: string, init?: { body?: string }) => {
-      const body = init?.body ? JSON.parse(init.body) : {};
-      await new Promise((r) => setTimeout(r, 5));
-      return { ok: true, json: async () => ({ cwdPresets: body.cwdPresets ?? [] }) };
-    }) as unknown as typeof fetch;
+    // Two records in flight at once, against a slow server. The clobber this guarded against is
+    // now impossible by construction — the server applies one entry at a time to its own list, so
+    // neither request carries the other's absence. Serialization still decides the ORDER, and the
+    // guarantee the ticket asked for (both survive) is asserted the same way.
+    mockServer([], { delayMs: 5 });
     const { presets, recordPreset } = useAppConfig();
     await Promise.all([recordPreset("/a"), recordPreset("/b")]);
     expect(presets.value.map((p) => p.path).sort()).toEqual(["/a", "/b"]);


### PR DESCRIPTION
Two data-loss bugs, found because the user noticed their pinned favourites and their saved directories had shrunk. Both are the same shape: **a list that lives in one shared file, replaced wholesale from whatever one client happened to hold.**

## 1. Pinned shortcuts, deleted by a project-scoped index — a regression from #1573

`<workspace>/config/shortcuts.json` is workspace-global and shared with MulmoClaude. The collection index that triggers `reconcileShortcuts` fetches a list scoped to the **surface's project** (`withActiveProject`). Reconciling one against the other says "every collection the workspace pinned is gone" — and `reconcile` prunes and **persists**.

Opening the Collections pane on a project with one collection **deleted 21 pinned collections**, in both apps, with no undo and nothing on screen to say so. The feeds survived only because they are a different `kind`.

A project-scoped answer now reconciles **nothing**. Not "reconcile the project's pins instead": pins are not per project, and pretending otherwise deletes the workspace's on the way. The rule is stated at all three layers — the binding that knows the scope, the pure function that does the pruning, and the store that owns the file.

## 2. Saved directories, deleted by a client that had not loaded them yet

`cwdPresets` is a replace-all field in a file every mulmoterminal on the machine shares, and it decides which projects the server serves collections for. `recordPreset` sent `presets.value` plus one entry — and that ref is **empty until the first GET lands**, empty again if it fails, and stale the moment another instance saves.

A terminal launched during that GET persisted `[the one just launched]`: **five saved directories became one**, and four projects' collections stopped being served.

Recording is inherently "add this, keep the rest", so it is now expressed that way — `POST /api/config/cwd-presets/record` and `/remove` apply **one entry** to the list on disk:

- a caller cannot clobber a list it never holds;
- two instances recording different directories no longer race;
- **#164's guarantee survives** — a launch during the initial GET is still recorded immediately, because there is nothing to wait for. (Waiting was tried first; it breaks that ticket's spec, which is what sent me looking for the right fix.)
- the replace-all `POST /api/config` stays for a settings-UI reorder, where the whole list *is* the intent.

## About the tests

The preset spec's fake server now **models** the list instead of echoing what was posted. An echoing fake cannot tell this fix from the bug it replaces — which is part of why the bug was there — and the new tests ("records a directory WITHOUT deleting the ones this tab has never seen") fail against the old implementation.

## Verification

`yarn format / lint / typecheck / build / test` — 9605 passing (+19), 0 lint errors. Each fix was also checked by reverting it and watching the new tests fail.

The user's two files were restored after the fix landed locally (25 shortcuts back; the five directories back), and mag2's collection is served again — confirmed against the running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-scoped remote access for feeds, collections, skills, and remote views.
  * Added project discovery with opaque IDs and readable labels.
  * Added portability guidance after successful collection schema updates.
  * Added saved-directory preset recording and removal.

* **Improvements**
  * Invalid or unresolved project selections now fail clearly instead of falling back.
  * Collection watchers synchronize after saved-directory changes.
  * Workspace shortcuts are protected from project-scoped changes.
  * Preset updates better preserve concurrent and server-side changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->