### PR TITLE
ui(toolbar): the Collections door wears the pane's own icon

### DIFF
--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -153,8 +153,10 @@ function showRooms(): void {
         <!-- The way IN to the workspace's own data, beside the views it is a peer of — the content
              surfaces used to be reachable only from the single view (#886), which left them with
              no door at all once that view goes. One button here rather than four: the rest appear
-             below once you are inside, so the row a terminal user sees does not grow by four. -->
-        <LauncherButton icon="apps" title="Collections" label="Collections" :active="collectionsActive" @click="showCollections" />
+             below once you are inside, so the row a terminal user sees does not grow by four.
+             Same `database` icon as the cell header's collections pane (CellChromeButtons.vue), so
+             the door and the pane read as one thing wherever you meet them. -->
+        <LauncherButton icon="database" title="Collections" label="Collections" :active="collectionsActive" @click="showCollections" />
       </span>
       <!-- The other content surfaces, revealed by being IN the section rather than always present.
            Same reasoning as the fence above: everything here acts within the view you are in. -->


### PR DESCRIPTION
The top toolbar's way in to Collections was `apps`, while the cell header's collections pane toggle is `database`. Same room, two doors, two different marks on them — nothing broke, but the pairing was invisible.

Both are `database` now, and the comment above the toolbar button says the pairing is deliberate, so a later edit to one knows it has to move the other.

- `src/components/AppToolbar.vue:157` — `icon="apps"` -> `icon="database"`, matching `CellChromeButtons.vue`'s collections pane button.

The neighbouring pane toggles are unchanged (canvas `draw`, tools `build`), as is every other toolbar icon.

`yarn format` / `yarn lint` / `yarn typecheck` clean (pre-existing warnings only). Icon-only change, no test covers the glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Collections launcher icon to use a database symbol for clearer visual identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->