### PR TITLE
feat(collections): a project cannot reach a collection under ~ (core 3.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mulmoclaude/accounting-plugin": "^2.1.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
-    "@mulmoclaude/core": "^3.2.0",
+    "@mulmoclaude/core": "^3.3.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/plans/HANDOFF-collections-projects.md
+++ b/plans/HANDOFF-collections-projects.md
@@ -384,35 +384,40 @@ surface someone adds.
    project; a directory that is not in `cwdPresets` has no collections here whatever it contains
    — see §3.4's listing.) If the empty pane ever reads as a fault rather than as a fact, the fix
    is a clearer message naming the repository root — a HINT, not a search.
-2. **A user-scope dependency in a git-tracked collection (§11 L1) — DECIDED (2026-08-09), NOT YET
-   IMPLEMENTED.** The decision is that the answer is neither of the two this question offered: it
-   must be PROHIBITED in the engine. `~` and a project are separate worlds, so standing in a
+2. **A user-scope dependency in a git-tracked collection (§11 L1) — DECIDED (2026-08-09), and
+   IMPLEMENTED (2026-08-09, core 3.3.0).** The decision is that the answer is neither of the two
+   this question offered: it must be PROHIBITED in the engine. `~` and a project are separate worlds, so standing in a
    project a collection under `~/.claude/skills` must not be reachable at all — not listed, and
    not resolvable by slug.
 
-   **Today it still is.** `initCollectionsBackend` hands `configureCollectionHost` one
-   unconditional `userSkillsDir` string for every root, so discovery still merges user scope into
-   a project's list and `loadCollection` still falls back to it. Nothing about this is enforced
-   until both halves below land — do not read the decision as the behaviour.
+   **It no longer is.** `initCollectionsBackend` binds
+   `userSkillsDir: (root) => isManagedWorkspace(root) ? ~/.claude/skills : null`, and core 3.3.0
+   skips the user pass in BOTH `discoverCollections` and `loadCollection` when that is null. The
+   managed workspace keeps user scope, exactly as MulmoClaude has it.
+   `test/server/backends/collectionScopeIsolation.spec.ts` pins all three: merged in the
+   workspace, absent from a project's listing, and a MISS on `loadCollection` by slug.
 
    Warning was the wrong shape because the check runs where someone asks, and the leak lives where
-   resolution happens: `loadCollection` falls back to the user dir for ANY root, so `getSchema`,
-   `getItems`, `putItems`, the detail route, a view token and the watcher all reach it whatever a
-   listing shows. Hiding the entry would have been a label on a door that still opens.
+   resolution happens: `loadCollection` fell back to the user dir for ANY root, so `getSchema`,
+   `getItems`, `putItems`, the detail route, a view token and the watcher all reached it whatever a
+   listing showed. Hiding the entry would have been a label on a door that still opens.
 
-   **Upstream**, because the host cannot express it: `paths.userSkillsDir` is one string for every
-   root. The ask is written as `../mulmoclaude/plans/feat-collection-scope-isolation.md` — make it
-   `(workspaceRoot) => string | null`, exactly the shape `skillsStagingDir` already has, and skip
-   both the discovery pass and the load fallback when it is null. MulmoClaude is one workspace and
-   is unaffected.
+   **Upstream shipped it**: `paths.userSkillsDir` is now
+   `string | ((workspaceRoot) => string | null)` (core 3.3.0 — the string form is kept, deprecated,
+   so a host floating on `^3.2.0` does not crash on install). MulmoClaude is one workspace and is
+   unaffected.
 
-   MulmoTerminal's half, once that ships: bind `isManagedWorkspace(root) ? <~/.claude/skills> :
-   null`, and bring `server/backends/remoteHost/skills.ts` — which scans both dirs for the phone's
-   skill list — into line.
+   **The skill list is deliberately NOT brought into line**, which is the one thing here that
+   changed on review of the original ask. `server/backends/remoteHost/skills.ts` still scans
+   `~/.claude/skills` for every root, because `claude` itself does: a bundled skill mirrored there
+   is runnable from any directory, and hiding it would break the Skill menu in every project. The
+   consequence is that a user-scope dir holding both `SKILL.md` and `schema.json` now appears in a
+   project's `listSkills` where it used to be subtracted — correctly, since the reason to subtract
+   is that `listCollections` serves it, and for that root it no longer does. It is a skill there.
 
-   Nothing leaks TODAY, and that is luck rather than design: `~/.claude/skills` currently holds 12
-   skills and no `schema.json`, so there are no user-scope collections to merge. One would appear
-   in every project the moment someone wrote one.
+   Nothing had leaked before the fix, and that was luck rather than design: `~/.claude/skills` held
+   12 skills and no `schema.json`, so there were no user-scope collections to merge. One would have
+   appeared in every project the moment someone wrote one.
 3. **`generateItemId()` is 4 random bytes.** Two machines creating records offline can collide;
    `primaryKey` avoids it. Widen upstream, or keep the guidance?
 4. **A feed's ignored records — DECIDED (2026-08-09): warning, not blocker.** They are a cache

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -92,8 +92,13 @@ const log = hostLogger;
 
 // Skill roots — the single source of truth for where skills live on disk, shared
 // with the collection engine (below) AND the remote-host listSkills scanner
-// (remoteHost/skills.ts) so both scan the exact same directories and stay
-// consistent about the skill/collection split.
+// (remoteHost/skills.ts) so both scan the exact same directories.
+//
+// The two do NOT apply the same SCOPE to them. The skill scanner reads the user dir for every
+// root, because `claude` itself does — a bundled skill mirrored to `~/.claude/skills` is
+// runnable from any directory. The collection engine reads it only for the managed workspace
+// (see `userSkillsDir` in the host binding below). So in a project a dir holding both SKILL.md
+// and schema.json is a skill and not a collection, which is precisely what it is there.
 /** `~/.claude/skills` — user scope (read-only). */
 export const userSkillsDir = (): string => path.join(os.homedir(), ".claude", "skills");
 /** `<root>/.claude/skills` — project scope. */
@@ -118,8 +123,23 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
     workspaceRoot: null,
     log,
     paths: {
-      // ~/.claude/skills — user scope (read-only).
-      userSkillsDir: userSkillsDir(),
+      // ~/.claude/skills — user scope (read-only), and ONLY for the managed workspace.
+      //
+      // `~` and a project are separate worlds. A collection under `~/.claude/skills` is a
+      // machine-global thing no clone of a repository can have, so standing in a project it must
+      // not be reachable at all — not listed, and not resolvable by slug. Filtering the listing
+      // alone would have been a label on a door that still opens: `loadCollection` is what
+      // getSchema, getItems, putItems, the detail route, the view-token mint and the watcher all
+      // go through, so a slug typed by the agent (or arriving in a URL) would still resolve into
+      // the other world and write to its data dir.
+      //
+      // `null` is what core 3.3.0 added for exactly this — the same shape `skillsStagingDir`
+      // above already had — and it skips the user pass in BOTH discovery and `loadCollection`,
+      // so a user-only slug is a MISS for a project root rather than a quiet hop.
+      //
+      // The managed workspace keeps user scope: it IS the one workspace, exactly as MulmoClaude
+      // binds it, so a project slug there still shadows a user one.
+      userSkillsDir: (root) => (isManagedWorkspace(root) ? userSkillsDir() : null),
       // <root>/.claude/skills — project scope.
       projectSkillsDir,
       // <root>/feeds — feed registry root.

--- a/server/backends/remoteHost/handlers/listSkills.ts
+++ b/server/backends/remoteHost/handlers/listSkills.ts
@@ -3,6 +3,12 @@
 // Discoverable skill ids (~/.claude/skills + <workspace>/.claude/skills), read-only. Collection
 // slugs are subtracted — a skill dir that ships a schema.json is a collection served by
 // listCollections, so it must not double-list here (mirrors MulmoClaude's listSkills).
+//
+// The subtraction is what `discoverCollections` answers FOR THIS ROOT, and since core 3.3.0 that
+// is scope-isolated: outside the managed workspace it excludes `~/.claude/skills` (see
+// backends/collections.ts). So a user-scope collection stays in this list when a project is
+// named — correctly, because the reason to subtract is that listCollections serves it, and for
+// that root it does not. It is a skill there, runnable by `claude` like any other under `~`.
 import { discoverCollections } from "@mulmoclaude/core/collection/server";
 import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
 import { discoverSkillNames } from "../skills.js";

--- a/test/server/backends/collectionScopeIsolation.spec.ts
+++ b/test/server/backends/collectionScopeIsolation.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// `~` and a project are separate worlds. A collection under `~/.claude/skills` is a
+// machine-global thing no clone of a repository can have, so standing in a project directory it
+// must not be reachable AT ALL — and "at all" is the point of this file. Filtering the listing
+// alone would be a label on a door that still opens: `loadCollection` is what getSchema,
+// getItems, putItems, the detail route, the view-token mint and the watcher all go through, so a
+// slug typed by the agent (or arriving in a URL) would still resolve into the other world and
+// write to its data dir.
+//
+// Nothing leaked before core 3.3.0 by luck rather than design — `~/.claude/skills` happened to
+// hold no `schema.json`. One user-scope collection would have appeared in every project.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { discoverCollections, loadCollection } from "@mulmoclaude/core/collection/server";
+
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const schemaFor = (title: string, slug: string) => ({
+  title,
+  icon: "star",
+  dataPath: `data/${slug}/items`,
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+});
+
+/** Write `<skillsRoot>/<slug>/schema.json`, the shape discovery accepts as a collection. */
+function writeCollection(skillsRoot: string, slug: string, title: string): void {
+  mkdirSync(path.join(skillsRoot, slug), { recursive: true });
+  writeFileSync(path.join(skillsRoot, slug, "schema.json"), JSON.stringify(schemaFor(title, slug)));
+}
+
+const slugs = (collections: Array<{ slug: string }>): string[] => collections.map((collection) => collection.slug).sort();
+
+describe("user scope reaches the managed workspace only", () => {
+  const savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  const savedHome = process.env.HOME;
+  let workspace = "";
+  let project = "";
+
+  // ONE binding for the file — `configureCollectionHost` refuses a second call with a different
+  // host on purpose. HOME is redirected because the binding derives `~/.claude/skills` from
+  // `os.homedir()`, which reads HOME on every call; the real one must never be scanned here.
+  beforeAll(() => {
+    const home = makeTempDir("mt-scope-home-");
+    process.env.HOME = home;
+    writeCollection(path.join(home, ".claude", "skills"), "user-only", "User Only");
+
+    workspace = makeTempDir("mt-scope-ws-");
+    project = makeTempDir("mt-scope-proj-");
+    for (const root of [workspace, project]) {
+      writeCollection(path.join(root, ".claude", "skills"), "tasks", "Tasks");
+      mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
+      mkdirSync(path.join(root, "data", "user-only", "items"), { recursive: true });
+    }
+    // `isManagedWorkspace` compares against this, so a temp dir can stand in for ~/mulmoclaude.
+    process.env.MULMOCLAUDE_WORKSPACE_PATH = workspace;
+    initCollectionsBackend({ workspace, knownProjects: () => [{ label: "project", path: project }] });
+  });
+
+  afterAll(() => {
+    if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+    else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  it("merges user scope into the managed workspace", async () => {
+    expect(slugs(await discoverCollections({ workspaceRoot: workspace }))).toEqual(["tasks", "user-only"]);
+    expect(await loadCollection("user-only", { workspaceRoot: workspace })).not.toBeNull();
+  });
+
+  it("hides user scope from a project, in the listing", async () => {
+    expect(slugs(await discoverCollections({ workspaceRoot: project }))).toEqual(["tasks"]);
+  });
+
+  // The half that matters: a slug is a MISS, not a quiet hop into ~/.claude/skills.
+  it("hides user scope from a project, in resolution by slug", async () => {
+    expect(await loadCollection("user-only", { workspaceRoot: project })).toBeNull();
+  });
+});

--- a/test/server/backends/collectionScopeIsolation.spec.ts
+++ b/test/server/backends/collectionScopeIsolation.spec.ts
@@ -17,6 +17,7 @@ import { discoverCollections, loadCollection } from "@mulmoclaude/core/collectio
 
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
 import { makeTempDir } from "../../support/tempDir";
+import { takeScratchHome, type ScratchHome } from "../../support/scratchHome";
 
 const schemaFor = (title: string, slug: string) => ({
   title,
@@ -36,17 +37,19 @@ const slugs = (collections: Array<{ slug: string }>): string[] => collections.ma
 
 describe("user scope reaches the managed workspace only", () => {
   const savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
-  const savedHome = process.env.HOME;
+  let home: ScratchHome | null = null;
   let workspace = "";
   let project = "";
 
   // ONE binding for the file — `configureCollectionHost` refuses a second call with a different
-  // host on purpose. HOME is redirected because the binding derives `~/.claude/skills` from
-  // `os.homedir()`, which reads HOME on every call; the real one must never be scanned here.
+  // host on purpose. Home is redirected because the binding derives `~/.claude/skills` from
+  // `os.homedir()`, called afresh on every discovery; the real one must never be scanned here.
+  // Through `takeScratchHome`, which moves HOME *and* USERPROFILE and then verifies os.homedir()
+  // followed — on Windows only the latter counts, and stubbing HOME alone would leave this test
+  // reading the runner's own `~/.claude/skills`.
   beforeAll(() => {
-    const home = makeTempDir("mt-scope-home-");
-    process.env.HOME = home;
-    writeCollection(path.join(home, ".claude", "skills"), "user-only", "User Only");
+    home = takeScratchHome("mt-scope-home-");
+    writeCollection(path.join(home.path, ".claude", "skills"), "user-only", "User Only");
 
     workspace = makeTempDir("mt-scope-ws-");
     project = makeTempDir("mt-scope-proj-");
@@ -63,8 +66,7 @@ describe("user scope reaches the managed workspace only", () => {
   afterAll(() => {
     if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
     else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
-    if (savedHome === undefined) delete process.env.HOME;
-    else process.env.HOME = savedHome;
+    home?.release();
   });
 
   it("merges user scope into the managed workspace", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,10 +1912,10 @@
     js-yaml "^5.2.3"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.2.0.tgz#daed54c5fa936485adc14e348ce8e54875c06f36"
-  integrity sha512-8rxcd9DV9IwkoIL1/RAS8eBb4JeyP4L6T2xfHUwlWJzi5gPDgcaQQkqX/dDp197+wZjuYUySZwAddazvMls02g==
+"@mulmoclaude/core@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.3.0.tgz#e45795e9f38a995113d5707659420af9cb9d39b2"
+  integrity sha512-YNBWp9Ju7PHss+44sTWSgyR1iHAep95gTG0e+XUSOlSZU2XwgzW+6ClJh4sq0QUunZmMeEq8547xPegDSBs3WA==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"


### PR DESCRIPTION
## What

Bumps `@mulmoclaude/core` to **3.3.0** and takes MulmoTerminal's half of the collection scope-isolation change decided in `plans/HANDOFF-collections-projects.md` §4.2.

`~` and a project are separate worlds. A collection under `~/.claude/skills` is machine-global — no clone of a repository can have it — so standing in a project directory it must not be reachable **at all**: not listed, and not resolvable by slug. The host could not express that before; `paths.userSkillsDir` was one string applied to every root.

core 3.3.0 makes it `(root) => string | null` (the shape `skillsStagingDir` already had) and skips the user pass in **both** `discoverCollections` and `loadCollection`. The second half is the one that matters: `loadCollection` is what `getSchema`, `getItems`, `putItems`, the detail route, the view-token mint and the watcher all go through, so filtering only the listing would have been a label on a door that still opens.

MulmoTerminal now binds `isManagedWorkspace(root) ? ~/.claude/skills : null`. The managed workspace keeps user scope, exactly as MulmoClaude has it.

## The skill list is deliberately NOT brought into line

The original ask said to bring `server/backends/remoteHost/skills.ts` along. It should not be: it scans `~/.claude/skills` for every root because **`claude` itself does**, and a bundled skill mirrored there is runnable from any directory — hiding it would empty the Skill menu in every project.

The consequence, accepted and commented at both sites: a user-scope dir holding both `SKILL.md` and `schema.json` now stays in a project's `listSkills`, where it used to be subtracted. That is correct — the reason to subtract is that `listCollections` serves it, and for that root it no longer does. It is a skill there.

## Nothing leaked before this

By luck rather than design: `~/.claude/skills` holds 12 skills and no `schema.json`, so there were no user-scope collections to merge. One would have appeared in every project the moment someone wrote it.

## Test plan

- `test/server/backends/collectionScopeIsolation.spec.ts` (new) pins all three: merged in the managed workspace, absent from a project's listing, and a **MISS** on `loadCollection` by slug. Verified it fails against the old string binding.
- `yarn typecheck`, `yarn lint`, `yarn format` clean; `yarn test` — 9675 passed, 45 skipped, 0 failed.

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved collection scope isolation across managed workspaces and projects.
  * Project collections no longer display or resolve collections from unrelated user scopes.
  * Managed workspaces continue to access user-level collections.
  * User-level skills remain available to run, even when excluded from project collection listings.

* **Bug Fixes**
  * Prevented cross-project collection access and unintended collection visibility.

* **Chores**
  * Updated the core platform dependency to version 3.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->