### PR TITLE
docs(plans): 初稿ルールの delete 行に、実際のルールと違うことを注記する

### DIFF
--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -429,6 +429,10 @@ service cloud.firestore {
       allow update: if roleIn(aid, '*') == "owner"
                     && request.resource.data.owner == resource.data.owner
                     && membersConsistent();
+      // 【初稿。実際のルールは違う】 owner に削除を許すと、Firestore は
+      // カスケードしないので子が孤児になり、空いた aid を拾った他人が
+      // owner になれる（下記「アプリの削除（再帰削除）」）。
+      // 実際のルールは `allow delete: if false;` で、削除は再帰削除に属する。
       allow delete: if roleIn(aid, '*') == "owner";
 
       // participant / 匿名が読む公開設定（名簿を含まない）。owner が publish 時に書く


### PR DESCRIPTION
**#1615 の取りこぼしの回収。** #1615 に対する codex の P1 指摘への修正を push したのが
マージの後だったため、この 1 コミットだけが main に載っていない。内容は #1615 と同じ話。

## 指摘（codex, P1）

#1615 は「アプリ本体（`apps/{aid}`）はクライアントから削除できない」を方針として足したが、
本文のルール記録には

```js
allow delete: if roleIn(aid, '*') == "owner";
```

が残っている（現在の 432 行）。**読むと、足したばかりの方針が実現不可能に見える。**
ロール表を「レコードの削除」に狭めても、その行は変わらない。

## なぜブロック全体の断り書きでは足りないか

ルールのコードブロックには既に「これは動かない初稿である」と断ってある。しかしそれは
**1 リクエスト 1000 式の評価上限**と **`match /session` が何にもマッチしない**という、
*実行できるかどうか*の話。この行は**方針そのものが違う**ので、同じ断り書きでは区別がつかない。

行単位で注記した。実際のルール（`allow delete: if false;`）は
`../mulmoserver/firestore.rules` が正で、削除は再帰削除に属する（同じ文書の
「アプリの削除（再帰削除）— 手順」を参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented app deletion as an unsafe operation due to potential orphaned data and ownership conflicts.
  * Clarified that deletion is denied by access rules and handled through an operational cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->