### PR TITLE
ci: cache yarn in dead-code-scan (refs #1618)

### DIFF
--- a/.github/workflows/dead-code-scan.yaml
+++ b/.github/workflows/dead-code-scan.yaml
@@ -57,9 +57,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # `cache: yarn` costs this step ~18s (the yarn download folder is a 1.6 GB tarball) and
+      # takes ~38s off the install below — net ~20s. It shares ci.yml's entry rather than adding
+      # one: setup-node keys on platform-arch-manager-lockfilehash with no workflow or node
+      # version in it, so this hits what ci.yml already saves on main.
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: yarn
 
       # knip resolves imports through the real dependency graph, so node_modules has
       # to be installed. `--frozen-lockfile` keeps CI honest against yarn.lock.

--- a/plans/ci-1618-cache-yarn.md
+++ b/plans/ci-1618-cache-yarn.md
@@ -1,0 +1,85 @@
+# #1618 — yarn caching across the workflows
+
+## What the issue asked
+
+Add `cache: yarn` to the `setup-node` steps in `codex_review.yaml`, `dead-code-scan.yaml` and
+`windows-daily.yaml`, on the grounds that `ci.yml` caches and they do not.
+
+## What is actually true
+
+Measured from the jobs API over 27 runs (see numbers below), only **one** of the three is a real
+gap. The other two are correct as they stand.
+
+| workflow | runs `yarn install`? | verdict |
+|---|---|---|
+| `ci.yml` | yes, 2 jobs | already cached |
+| `dead-code-scan.yaml` | yes | **the gap — fixed here** |
+| `codex_review.yaml` | **no** | leave alone |
+| `windows-daily.yaml` | yes | leave alone |
+| `duplication-scan.yaml` | no (downloads a jscpd binary) | n/a |
+| `pages.yml`, `pr_triage.yaml` | no node | n/a |
+
+### `codex_review.yaml` — never installs the project
+
+There is no `yarn` anywhere in the file. It `npm install -g`s the Codex CLI and nothing else, and
+its review prompt states the arrangement outright: *"This checkout has NO project dependencies
+installed — only the codex CLI itself."* Caching yarn's download folder there restores a 1.6 GB
+tarball that no step reads. That is a ~18s loss per run for zero gain. Its existing `~/.npm` cache
+is the one that matches what it does.
+
+### `windows-daily.yaml` — already decided, with a reason
+
+The file carries the decision in a comment: *"Deliberately no `cache: yarn`: restoring the yarn
+cache tar onto NTFS is slower than a fresh install. node_modules is cached directly instead."*
+It caches `node_modules` keyed on `matrix.node-version` + `hashFiles('yarn.lock')`, plus
+`~/.cache/puppeteer`. The issue's worry about a `node_modules` cache restoring a foreign tree does
+not apply: the runner is windows-only and the node version is in the key.
+
+Overturning a documented decision needs a Windows measurement, and `windows-daily` is red on all
+five of its recent runs (the `Test` step), so there is no clean baseline to measure against. Out
+of scope here.
+
+## The measurement
+
+`setup-node` performs the cache **restore inside its own step**, so the comparison has to be
+`setup-node + yarn install`, not `yarn install` alone. The issue's table quotes only the install
+column and therefore overstates the gain by roughly 1.8x.
+
+Medians, ubuntu, from `actions/runs/<id>/jobs`:
+
+| | n | `setup-node` | `yarn install` | **sum** |
+|---|---:|---:|---:|---:|
+| `ci.yml` `lint-and-build (ubuntu-latest)` — cached | 12 | 20s | 20s | **38s** |
+| `dead-code-scan` — uncached | 15 | 2s | 58s | **59s** |
+
+Expected saving: **~20s per run**, about a third of that step pair — not the ~38s a
+58s-vs-20s reading of the install column alone suggests.
+
+## Why the first run is not a cache miss
+
+The issue warns that the first run after the change pays the save cost and shows no saving. That
+warning does not apply here. The restore key logged by `ci.yml` is:
+
+```
+node-cache-Linux-x64-yarn-3aa92fc03863d9b5c690db69623c75d198b7dac5560ca7f7e68671611ba15374
+```
+
+Platform, arch, package manager, lockfile hash — **no workflow name and no node version**.
+`dead-code-scan` runs node 22 on ubuntu against the same single root `yarn.lock`, so it computes
+that exact key and hits the entry `ci.yml` already maintains on main. Nothing extra is stored
+(the entry is shared, not duplicated), and it is warm from the first run.
+
+`cache-dependency-path` is left unset on purpose: the repo has exactly one lockfile, `yarn.lock`
+at the root, which is already `setup-node`'s default. Naming it would change nothing.
+
+## Verifying after merge
+
+Compare the same two step names across several runs, not one pair:
+
+```sh
+gh api "repos/receptron/mulmoterminal/actions/runs/<RUN_ID>/jobs?per_page=50" \
+  --jq '.jobs[] | "\(.name)", (.steps[] | "  \(.name)  \(.started_at) \(.completed_at)")'
+```
+
+Success is the **sum** of `setup-node` + `yarn install` landing near 40s, against the 59s median
+above. A run where `setup-node` alone grew to ~20s is the cache working, not a regression.


### PR DESCRIPTION
## Summary

`refs #1618`. The issue asked for `cache: yarn` on three workflows. Measurement says **one** of
them is a real gap; the other two are correct as they stand, and this PR leaves them alone.

- **`dead-code-scan.yaml`** — runs `yarn install` with no caching of any kind. Fixed here.
- **`codex_review.yaml`** — never runs `yarn install`. Untouched.
- **`windows-daily.yaml`** — already carries the opposite decision, in a comment, with a reason.
  Untouched.

Expected saving: **~20s per `dead-code-scan` run**, warm from the first run.

## Items to Confirm / Review

1. **The scope call is the main thing to check.** I am declining two thirds of what the issue
   asks for. The reasoning is in `plans/ci-1618-cache-yarn.md`; the short version is below. If
   you disagree on either, say so and I will add them.
2. **`refs #1618`, not `Closes`** — deliberately. Since this PR overrides the issue's stated
   request for two of its three targets, closing it should be your call, not the merge's.
3. **The saving is smaller than the issue projects** (~20s, not ~38s). If ~20s on a job that runs
   on most PRs is not worth a config line, this PR is fine to drop — the measurement is the
   durable part and it is recorded in the plan file either way.
4. **`cache-dependency-path` is left unset**, against the issue's advice to list every lockfile.
   The repo has exactly one, `yarn.lock` at the root, which is already setup-node's default.
5. Unrelated, found while measuring: **`windows-daily` has failed 12 runs in a row** (since
   ~Aug 9, the `Test` step). Not touched here, but it is why item 3 below could not be measured.

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1618

Follow-ups: asked for the findings in Japanese, then — on seeing that only `dead-code-scan` was a
genuine gap — confirmed the narrowed scope with "じゃぁそこだけ" (just that part).

## Why only one workflow

### 1. `dead-code-scan.yaml` — the gap

`yarn install --frozen-lockfile`, no `cache:` on `setup-node`, no `actions/cache`. Fixed.

### 2. `codex_review.yaml` — never installs the project

There is no `yarn` anywhere in the file. It `npm install -g`s the Codex CLI and nothing else, and
its own review prompt states the arrangement outright:

> This checkout has NO project dependencies installed — only the codex CLI itself.

Caching yarn's download folder there restores a 1.6 GB tarball no step reads — roughly **-18s per
run for zero gain**. Its existing `~/.npm` cache is the one that matches what it does.

### 3. `windows-daily.yaml` — already decided, with a reason

The file records the decision in a comment:

> Deliberately no `cache: yarn`: restoring the yarn cache tar onto NTFS is slower than a fresh
> install. node_modules is cached directly instead.

It caches `node_modules` keyed on `matrix.node-version` + `hashFiles('yarn.lock')`, plus
`~/.cache/puppeteer`. The issue's concern that a `node_modules` cache could restore a tree built
for another platform or Node version does not apply — the runner is windows-only and the node
version is in the key.

Overturning a documented decision needs a Windows measurement, and the workflow is red on all of
its recent runs, so there is no clean baseline to measure against.

## The measurement

`setup-node` performs the cache **restore inside its own step**, so the honest comparison is
`setup-node + yarn install`, not `yarn install` alone. The issue's table quotes only the install
column, which overstates the gain by roughly 1.8x.

Medians, ubuntu, from `actions/runs/<id>/jobs`:

| | n | `setup-node` | `yarn install` | **sum** |
|---|---:|---:|---:|---:|
| `ci.yml` `lint-and-build (ubuntu-latest)` — cached | 12 | 20s | 20s | **38s** |
| `dead-code-scan` — uncached | 15 | 2s | 58s | **59s** |

Reading the install column alone suggests 58s -> 20s. The real figure is 59s -> ~40s, because
`setup-node` grows from 2s to ~20s pulling a 1.6 GB tarball.

## No cold first run

The issue warns that the first run after the change is a cache miss by definition. It is not,
here. The restore key `ci.yml` logs is:

```
node-cache-Linux-x64-yarn-3aa92fc03863d9b5c690db69623c75d198b7dac5560ca7f7e68671611ba15374
```

Platform, arch, package manager, lockfile hash — **no workflow name, no node version**.
`dead-code-scan` is node 22 on ubuntu against the same single root `yarn.lock`, so it computes
that exact key and hits what `ci.yml` already maintains on main. Nothing extra is stored; the
entry is shared, not duplicated.

## Verifying after merge

Compare the same two step names across several runs, not one pair:

```sh
gh api "repos/receptron/mulmoterminal/actions/runs/<RUN_ID>/jobs?per_page=50" \
  --jq '.jobs[] | "\(.name)", (.steps[] | "  \(.name)  \(.started_at) \(.completed_at)")'
```

Success is the **sum** landing near 40s against the 59s median. A run where `setup-node` alone
grew to ~20s is the cache working, not a regression.

## Verification done here

- `npx prettier --check .github/workflows/dead-code-scan.yaml` — clean.
- Parsed the workflow with the `yaml` package and asserted the `setup-node` step resolves to
  `{node-version: 22, cache: yarn}` and the install step is unchanged.
- Timings collected from the jobs API over 27 runs (15 `dead-code-scan`, 12 `ci.yml` ubuntu),
  not from the Actions UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
