### PR TITLE
fix(markdown): 新規ドキュメントの ID を 64 ビットにし、上書きを禁じる (#1623)

### DIFF
--- a/plans/fix-1623-doc-filename-collision.md
+++ b/plans/fix-1623-doc-filename-collision.md
@@ -1,0 +1,56 @@
+# fix #1623 — a new document's filename is 32 bits, and a collision overwrites
+
+## The report
+
+[#1623](https://github.com/receptron/mulmoterminal/issues/1623): `saveNewDoc`
+composed `artifacts/documents/YYYY/MM/<prefix>-<8 hex>.md` and wrote it with a
+plain `fs.promises.writeFile`. Two things compound:
+
+- **32 bits**, shared by every document with the same prefix in the same month.
+  `prefix` comes from the LLM's title and falls back to `document`, so a
+  month's worth of untitled documents share one namespace.
+- **No overwrite guard.** Unlike the collections store (`refuseOverwrite: true`,
+  which turns a collision into a 409), this write replaces whatever is there and
+  reports success. The older document is gone with no error anywhere.
+
+Found while surveying both repos for the same class of bug as
+receptron/mulmoclaude#2851; not observed in the wild.
+
+## Root cause
+
+The id width and the write mode were each chosen in isolation: an 8-char slice
+"looks like enough" for a filename, and `writeFile` is the obvious call for
+"write a new file". Neither is wrong alone; together they make silent data loss
+the failure mode of a name collision.
+
+MulmoClaude — the reference host for this backend — already answers both:
+`buildArtifactPathRandom` (`server/utils/files/naming.ts`) uses `shortId()`,
+16 hex = 64 bits. So this was also a divergence from the counterpart.
+
+## The change
+
+1. `server/backends/docPath.ts` — `newDocId()`, 16 hex from a UUID, matching
+   MulmoClaude's `shortId()` width. The generator lives next to `buildDocPath`
+   because they are the two halves of one filename.
+2. `server/backends/markdown.ts` — `createDoc()` writes with `flag: "wx"`, which
+   refuses an existing file, and re-rolls the id on `EEXIST` (5 attempts, then
+   throws). `saveNewDoc` is now three lines over it.
+
+64 bits alone would have made the collision unreachable in practice, but the
+guard is what removes *overwriting* as a possible outcome — a filename can also
+be taken by something this code did not generate (a hand-written document, a
+restored backup), and no width protects against that.
+
+`createDoc` takes the id generator as a parameter so the collision is testable;
+`saveNewDoc` passes nothing.
+
+## Tests
+
+- `test/server/backends/createDoc.spec.ts` (new) — writes under the dated
+  directory; a taken name re-rolls and **the older document keeps its content**;
+  exhausting the attempts throws and still leaves the existing document intact;
+  50 concurrent creates with one title get 50 distinct paths.
+- `test/server/backends/docPath.spec.ts` — `newDocId` is 16 lowercase hex, 1000
+  rolls are distinct, and the composed path passes `isDocPath`.
+- `test/server/backends/openPath.spec.ts` — the shape assertion for
+  `saveNewDoc` moves from `{8}` to `{16}`.

--- a/plans/fix-1623-doc-filename-collision.md
+++ b/plans/fix-1623-doc-filename-collision.md
@@ -29,9 +29,16 @@ MulmoClaude — the reference host for this backend — already answers both:
 
 ## The change
 
-1. `server/backends/docPath.ts` — `newDocId()`, 16 hex from a UUID, matching
-   MulmoClaude's `shortId()` width. The generator lives next to `buildDocPath`
-   because they are the two halves of one filename.
+1. `server/backends/docPath.ts` — `newDocId()`, 16 hex characters (8 random
+   bytes), the same shape MulmoClaude's `shortId()` gives a filename. The
+   generator lives next to `buildDocPath` because they are the two halves of one
+   filename.
+
+   Straight `randomBytes(8)` rather than a slice of a UUID: the 13th character
+   of a v4 is the version nibble, always `4`, so 16 characters taken from a
+   UUID carry 60 random bits while reading as 64 (codex review on the PR). A
+   test pins that no position is constant, so a future "just slice a UUID"
+   rewrite has to notice.
 2. `server/backends/markdown.ts` — `createDoc()` writes with `flag: "wx"`, which
    refuses an existing file, and re-rolls the id on `EEXIST` (5 attempts, then
    throws). `saveNewDoc` is now three lines over it.
@@ -51,6 +58,7 @@ restored backup), and no width protects against that.
   exhausting the attempts throws and still leaves the existing document intact;
   50 concurrent creates with one title get 50 distinct paths.
 - `test/server/backends/docPath.spec.ts` — `newDocId` is 16 lowercase hex, 1000
-  rolls are distinct, and the composed path passes `isDocPath`.
+  rolls are distinct, no position is a constant nibble, and the composed path
+  passes `isDocPath`.
 - `test/server/backends/openPath.spec.ts` — the shape assertion for
   `saveNewDoc` moves from `{8}` to `{16}`.

--- a/server/backends/docPath.ts
+++ b/server/backends/docPath.ts
@@ -9,6 +9,7 @@
 // that never updates on screen.
 
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 export const DOCS_DIR = "artifacts/documents";
 
@@ -42,6 +43,16 @@ export function sanitizeDocPrefix(prefix: string): string {
     .replace(/^-|-$/g, "")
     .slice(0, PREFIX_MAX_LENGTH);
   return cleaned || "document";
+}
+
+// 16 hex chars = 64 bits, the same width as MulmoClaude's `shortId()` — a document created
+// through either host gets a name of the same shape. It was 8 chars, and since documents
+// sharing a prefix and a month share one namespace, 32 bits put a birthday collision within
+// reach of an ordinary month's writing (#1623).
+const DOC_ID_HEX_LEN = 16;
+
+export function newDocId(): string {
+  return randomUUID().replace(/-/g, "").slice(0, DOC_ID_HEX_LEN);
 }
 
 // The workspace-relative path a new document is written to: artifacts/documents/YYYY/MM/<prefix>-<rand>.md.

--- a/server/backends/docPath.ts
+++ b/server/backends/docPath.ts
@@ -9,7 +9,7 @@
 // that never updates on screen.
 
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 
 export const DOCS_DIR = "artifacts/documents";
 
@@ -45,14 +45,18 @@ export function sanitizeDocPrefix(prefix: string): string {
   return cleaned || "document";
 }
 
-// 16 hex chars = 64 bits, the same width as MulmoClaude's `shortId()` — a document created
-// through either host gets a name of the same shape. It was 8 chars, and since documents
-// sharing a prefix and a month share one namespace, 32 bits put a birthday collision within
-// reach of an ordinary month's writing (#1623).
-const DOC_ID_HEX_LEN = 16;
+// 16 hex chars, the same shape as MulmoClaude's `shortId()` — a document created through
+// either host gets a name of the same form. It was 8 chars, and since documents sharing a
+// prefix and a month share one namespace, 32 bits put a birthday collision within reach of
+// an ordinary month's writing (#1623).
+//
+// Straight random bytes rather than a slice of a UUID: the 13th character of a v4 is the
+// version nibble, always "4", so the same 16 characters taken from a UUID would carry 60
+// random bits while reading as 64.
+const DOC_ID_BYTES = 8;
 
 export function newDocId(): string {
-  return randomUUID().replace(/-/g, "").slice(0, DOC_ID_HEX_LEN);
+  return randomBytes(DOC_ID_BYTES).toString("hex");
 }
 
 // The workspace-relative path a new document is written to: artifacts/documents/YYYY/MM/<prefix>-<rand>.md.

--- a/server/backends/markdown.ts
+++ b/server/backends/markdown.ts
@@ -15,13 +15,13 @@
 //     and PDF export needs no image-resolution step.
 import fs from "fs";
 import path from "path";
-import { randomUUID } from "node:crypto";
 import { marked } from "marked";
 import { renderMarpDeck, fillImagePlaceholders } from "@mulmoclaude/markdown-plugin";
 import type { MarkdownHostApp, ExportPdfOptions } from "@mulmoclaude/markdown-plugin";
 import { publishFileChange } from "./fileChange.js";
 import { generateImage } from "./image-gen.js";
-import { buildDocPath } from "./docPath.js";
+import { buildDocPath, newDocId, DOCS_DIR } from "./docPath.js";
+import { hasErrnoCode } from "../errors.js";
 import { markdownByPath } from "./openPath.js";
 
 // Set once at boot (server/index.ts) — workspace = CLAUDE_CWD. File-change
@@ -43,6 +43,27 @@ const MARKDOWN_PDF_CSS = `
   pre { background: #f3f4f6; padding: .75rem; border-radius: .375rem; overflow-x: auto; } code { background: #f3f4f6; padding: .1rem .3rem; border-radius: .25rem; }
   table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid #e5e7eb; padding: .5rem .75rem; } a { color: #2563eb; } img { max-width: 100%; height: auto; }
 `;
+
+const DOC_CREATE_ATTEMPTS = 5;
+
+/** Write `markdown` to a document path nothing else holds, and return that path.
+ *  `wx` refuses an existing file, so a taken name re-rolls instead of replacing a
+ *  document nobody was told about — the create path used to overwrite silently and
+ *  report success (#1623). `nextId` is a parameter so a test can force the collision. */
+export async function createDoc(prefix: string, markdown: string, nextId: () => string = newDocId): Promise<string> {
+  for (let attempt = 0; attempt < DOC_CREATE_ATTEMPTS; attempt++) {
+    const rel = buildDocPath(prefix, new Date(), nextId());
+    const abs = absFor(rel);
+    await fs.promises.mkdir(path.dirname(abs), { recursive: true });
+    try {
+      await fs.promises.writeFile(abs, markdown, { flag: "wx" });
+      return rel;
+    } catch (err) {
+      if (!hasErrnoCode(err) || err.code !== "EEXIST") throw err;
+    }
+  }
+  throw new Error(`could not create a document under ${DOCS_DIR}: ${DOC_CREATE_ATTEMPTS} generated names were all taken`);
+}
 
 export const markdownHostApp: MarkdownHostApp = {
   // Any `.md` the tool was pointed at — a repo's README, `docs/design.md`, an
@@ -68,10 +89,7 @@ export const markdownHostApp: MarkdownHostApp = {
   },
 
   async saveNewDoc(prefix, markdown) {
-    const rel = buildDocPath(prefix, new Date(), randomUUID().slice(0, 8));
-    const abs = absFor(rel);
-    await fs.promises.mkdir(path.dirname(abs), { recursive: true });
-    await fs.promises.writeFile(abs, markdown);
+    const rel = await createDoc(prefix, markdown);
     // Publish the create too (previously an unpublished gap) so a View already
     // open on this path live-refreshes instead of going stale.
     await publishFileChange(rel);

--- a/test/server/backends/createDoc.spec.ts
+++ b/test/server/backends/createDoc.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+// The create path for a NEW presentDocument document. What matters here is that a
+// filename already on disk is never written through: the write used to be a plain
+// writeFile, so a generated name that collided replaced the older document and still
+// reported success (#1623).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createDoc, initMarkdownBackend } from "../../../server/backends/markdown.js";
+import { DOCS_DIR } from "../../../server/backends/docPath.js";
+
+let ws: string;
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  ws = mkdtempSync(path.join(tmpdir(), "mt-createdoc-"));
+  tempDirs.push(ws);
+  initMarkdownBackend({ workspace: ws });
+});
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const read = (rel: string): string => readFileSync(path.join(ws, rel), "utf8");
+
+/** Returns each id in turn, then repeats the last one forever. */
+function sequence(...ids: string[]): () => string {
+  let index = 0;
+  return () => ids[Math.min(index++, ids.length - 1)] ?? "";
+}
+
+describe("createDoc", () => {
+  it("writes the document under the dated documents directory", async () => {
+    const rel = await createDoc("Design Review", "# hello");
+    expect(rel).toMatch(new RegExp(`^${DOCS_DIR}/\\d{4}/\\d{2}/design-review-[0-9a-f]{16}\\.md$`));
+    expect(read(rel)).toBe("# hello");
+  });
+
+  it("re-rolls past a taken name instead of overwriting the document that holds it", async () => {
+    const first = await createDoc("notes", "original", sequence("aaaaaaaaaaaaaaaa"));
+    const second = await createDoc("notes", "newcomer", sequence("aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"));
+
+    expect(second).not.toBe(first);
+    expect(read(first)).toBe("original");
+    expect(read(second)).toBe("newcomer");
+  });
+
+  it("fails loudly when every generated name is taken, leaving the existing document alone", async () => {
+    const only = sequence("cccccccccccccccc");
+    const first = await createDoc("notes", "original", only);
+
+    await expect(createDoc("notes", "newcomer", sequence("cccccccccccccccc"))).rejects.toThrow(/names were all taken/);
+    expect(read(first)).toBe("original");
+  });
+
+  it("generates a distinct id per document", async () => {
+    const paths = await Promise.all(Array.from({ length: 50 }, () => createDoc("same-title", "body")));
+    expect(new Set(paths).size).toBe(50);
+  });
+});

--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -164,7 +164,8 @@ describe("buildDocPath", () => {
 });
 
 describe("newDocId", () => {
-  // 64 bits, the same width MulmoClaude's shortId() gives a document filename.
+  // 8 random bytes: 16 hex characters, the shape MulmoClaude's shortId() gives a document
+  // filename, and 64 bits rather than the 60 a same-length slice of a v4 UUID would carry.
   it("is 16 lowercase hex characters", () => {
     expect(newDocId()).toMatch(/^[0-9a-f]{16}$/);
   });
@@ -172,6 +173,13 @@ describe("newDocId", () => {
   it("does not repeat itself", () => {
     const ids = new Set(Array.from({ length: 1000 }, () => newDocId()));
     expect(ids.size).toBe(1000);
+  });
+
+  // The character a v4 UUID pins to "4". Asserted so a future "just slice a UUID" rewrite
+  // has to notice it is spending 4 of the 64 bits on a constant.
+  it("carries no fixed nibble", () => {
+    const thirteenth = new Set(Array.from({ length: 200 }, () => newDocId()[12]));
+    expect(thirteenth.size).toBeGreaterThan(1);
   });
 
   it("composes a path isDocPath accepts", () => {

--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { buildDocPath, DOCS_DIR, isDocPath, sanitizeDocPrefix } from "../../../server/backends/docPath.js";
+import { buildDocPath, DOCS_DIR, isDocPath, newDocId, sanitizeDocPrefix } from "../../../server/backends/docPath.js";
 
 describe("isDocPath", () => {
   it("accepts a document under the documents directory", () => {
@@ -9,7 +9,7 @@ describe("isDocPath", () => {
   });
 
   it("accepts the dated path saveNewDoc composes", () => {
-    expect(isDocPath(`${DOCS_DIR}/2026/07/design-review-ab12cd34.md`)).toBe(true);
+    expect(isDocPath(`${DOCS_DIR}/2026/07/design-review-ab12cd34ef56ab78.md`)).toBe(true);
   });
 
   // This is the only thing keeping an LLM-authored path inside the workspace: the write
@@ -160,5 +160,21 @@ describe("buildDocPath", () => {
       expect(underTz("America/Los_Angeles", () => buildDocPath("x", midnightUtcMar1, rand))).toContain("/2026/02/");
       expect(underTz("Asia/Tokyo", () => buildDocPath("x", midnightUtcMar1, rand))).toContain("/2026/03/");
     });
+  });
+});
+
+describe("newDocId", () => {
+  // 64 bits, the same width MulmoClaude's shortId() gives a document filename.
+  it("is 16 lowercase hex characters", () => {
+    expect(newDocId()).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does not repeat itself", () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => newDocId()));
+    expect(ids.size).toBe(1000);
+  });
+
+  it("composes a path isDocPath accepts", () => {
+    expect(isDocPath(buildDocPath("notes", new Date(), newDocId()))).toBe(true);
   });
 });

--- a/test/server/backends/openPath.spec.ts
+++ b/test/server/backends/openPath.spec.ts
@@ -100,7 +100,7 @@ describe("markdownHostApp over by-path files", () => {
 
   it("still writes NEW documents under artifacts/documents", async () => {
     const { path: rel } = await markdownHostApp.saveNewDoc("Design Review", "# New");
-    expect(rel).toMatch(/^artifacts\/documents\/\d{4}\/\d{2}\/design-review-[a-f0-9]{8}\.md$/);
+    expect(rel).toMatch(/^artifacts\/documents\/\d{4}\/\d{2}\/design-review-[a-f0-9]{16}\.md$/);
     expect(readFileSync(path.join(ws, rel), "utf8")).toBe("# New");
   });
 });


### PR DESCRIPTION
## Summary

`saveNewDoc` が作るファイル名の乱数を **8 hex (32 ビット) → 16 hex (64 ビット)** に広げ、書き込みを **`flag: "wx"`（既存ファイルがあれば失敗）** にして、衝突したら ID を引き直すようにしました。

問題は 2 つが重なっていた点です。パスは `artifacts/documents/YYYY/MM/<prefix>-<rand>.md` で、`prefix` は LLM のタイトル由来（空なら `document`）なので、**同じ月・同じ prefix のドキュメント群が 32 ビットの名前空間を共有**していました。そのうえ書き込みが素の `writeFile` だったため、**衝突すると既存ドキュメントを黙って上書きして成功を返します**。collections 側（receptron/mulmoclaude#2851）は `refuseOverwrite: true` で 409 になりデータは無事でしたが、こちらは静かなデータ損失でした。

16 hex は MulmoClaude の対応物 `buildArtifactPathRandom`（`server/utils/files/naming.ts` → `shortId()`）と同じ形です。CLAUDE.md の「MulmoClaude is the reference host」に合わせました。

## Items to Confirm / Review

1. **64 ビットだけでなく `wx` も入れた理由**: 幅を広げれば衝突は実質起きませんが、`wx` は「上書きという結果自体」を消します。ファイル名は自分が生成したもの以外（手書きのドキュメント、バックアップからの復元）にも取られ得るので、幅では守れない範囲が残るためです。
2. **`randomBytes(8)` を使っています（初版から変更、codex の指摘で修正）**: `randomUUID()` の 16 文字スライスは 13 文字目が版数の `4` で固定なので、実際には 60 ビットしかありませんでした。形は同じ 16 hex のまま、乱数はちょうど 64 ビットになります。どの位置も固定でないことをテストで pin しています。
3. **`createDoc` の再試行は 5 回**で、使い切ったら throw します（黙って諦めない）。この回数と、エラーメッセージの文言をご確認ください。
4. **`createDoc` を export し、ID 生成器を引数に取れるようにしています**（既定は `newDocId`）。衝突をテストで再現するためだけの引数で、`saveNewDoc` は何も渡しません。
5. **既存ドキュメントは影響を受けません。** 変わるのは今後作られるファイル名の長さだけです。
6. **このチェックアウトの `node_modules` が古い**ため（`@mulmoclaude/core@3.0.1` / package.json は `^3.3.0`）、ローカルの `yarn typecheck` と `yarn test` には既存の失敗があります。**origin/main を detach して同じコマンドを流し、失敗が完全に同一（typecheck 27 件・test 43 件、同じファイル群）であることを確認済み**です。増えたのは本 PR が追加した pass だけです。CI（クリーン install）が ground truth で、こちらは全て green です。

## User Prompt

- receptron/mulmoclaude#2851 について「uuid に置き換えるのでよいかな」
- 「ここだけじゃなく、ほかでもないかみてね」— 同種の ID 生成が他に無いか調査
- 調査結果を報告したうえで「推奨で」— 推奨した範囲（mulmoclaude 側の #2851 修正 + 本 PR）を実施

## 変更点

| ファイル | 変更 |
|---|---|
| `server/backends/docPath.ts` | `newDocId()` 追加（`randomBytes(8)` の 16 hex）。`buildDocPath` の隣に置いたのは、この 2 つで 1 つのファイル名だから |
| `server/backends/markdown.ts` | `createDoc()` 追加（`wx` で書き、EEXIST なら引き直し）。`saveNewDoc` はその上の 3 行に |
| `test/server/backends/createDoc.spec.ts` | 新規。上書きしないこと・使い切ったら throw すること・50 件同時作成が全て別パスになること |
| `test/server/backends/docPath.spec.ts` | `newDocId` のテスト（16 hex / 1000 個ユニーク / 固定 nibble が無い / `isDocPath` を通る） |
| `test/server/backends/openPath.spec.ts` | 形の assert を `{8}` → `{16}` |
| `plans/fix-1623-doc-filename-collision.md` | 設計メモ |

## 検証

`yarn format` / `yarn lint`（変更ファイルは 0 エラー。リポジトリ全体の 10 エラーは未変更ファイルの既存分）/ `yarn test`（上記のとおり origin/main と同一の既存失敗のみ、追加分は全 pass）/ CI green。

refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented newly created documents from overwriting existing files when filename collisions occur.
  - Added automatic retries for collisions and clear failure handling when unique filenames cannot be created.
  - Improved concurrent document creation reliability.

- **Tests**
  - Added coverage for unique identifiers, collision handling, concurrent creation, valid paths, and preserved file contents.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->