### PR TITLE
fix(terminal): 端末クエリ応答による誤割り込みを防ぐ (#1625)

### DIFF
--- a/server/session/output-relay.ts
+++ b/server/session/output-relay.ts
@@ -5,7 +5,7 @@
 // speed makes each read SMALLER, so the same output arrives as far more chunks — six cells went
 // from 118k to 655k in one measurement (#1506). One frame each would move the cost we just
 // removed from appendBoundedOutput onto JSON.stringify and the socket.
-import { growOutputTail } from "./terminal-replay.js";
+import { containsTerminalQuery, growOutputTail, terminalQueryPrefixTail } from "./terminal-replay.js";
 import { sendFrame } from "./ws-frames.js";
 import type { PtyEntry } from "./types.js";
 
@@ -17,6 +17,12 @@ const FLUSH_INTERVAL_MS = 8;
 // loop is busy enough that the timer cannot fire — so without a ceiling one burst decides how long
 // a single stringify-and-send blocks. Measured batches run ~30 KB; this is the pathological case.
 const MAX_BATCH_CHARS = 256 * 1024;
+
+// Long enough to bridge any terminal query we recognise when node-pty splits it across reads.
+// Kept independently of the pending output: the first half may already have been sent in an
+// immediate frame, while xterm's parser is still waiting for the terminator in the next one.
+const QUERY_SCAN_TAIL_CHARS = 64;
+const ESC = String.fromCharCode(0x1b);
 
 export interface OutputRelay {
   /** Keep a chunk for replay, and queue it for the browser. */
@@ -32,8 +38,9 @@ export function createOutputRelay(entry: PtyEntry, limit: number): OutputRelay {
   let pendingChars = 0;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let lastSentMs = 0;
+  let queryScanTail = "";
 
-  const discard = () => {
+  const clearPending = () => {
     pending.length = 0;
     pendingChars = 0;
     if (timer) {
@@ -42,10 +49,15 @@ export function createOutputRelay(entry: PtyEntry, limit: number): OutputRelay {
     }
   };
 
+  const discard = () => {
+    clearPending();
+    queryScanTail = "";
+  };
+
   const flush = () => {
-    if (pending.length === 0) return discard();
+    if (pending.length === 0) return clearPending();
     const data = pending.join("");
-    discard();
+    clearPending();
     lastSentMs = Date.now();
     // Read the socket now, not at push time: a reattach swaps it while a batch is queued.
     sendFrame(entry.ws, { type: "output", data });
@@ -56,9 +68,25 @@ export function createOutputRelay(entry: PtyEntry, limit: number): OutputRelay {
     // Nobody to send to — a session whose browser has closed, still working in the background.
     // Queueing would only build batches to throw away, and the buffer above is already the
     // record: a reattach replays it (and discards the queue for exactly that reason).
-    if (!entry.ws) return;
+    if (!entry.ws) {
+      queryScanTail = "";
+      return;
+    }
     pending.push(data);
     pendingChars += data.length;
+    let hasQuery = false;
+    // Plain output is the hot path under a flood. Avoid concatenating and scanning it unless an
+    // ESC starts a possible query, or the preceding chunk ended after one.
+    if (queryScanTail || data.includes(ESC)) {
+      const queryScan = queryScanTail + data;
+      hasQuery = containsTerminalQuery(queryScan);
+      queryScanTail = terminalQueryPrefixTail(queryScan, QUERY_SCAN_TAIL_CHARS);
+    }
+    // A terminal query is invisible output whose answer comes back through xterm's onData as
+    // PTY input. Do not add the normal output-batching delay to that round trip: Claude can move
+    // from rendering its final frame into Stop hooks during the 8 ms window, at which point the
+    // late ESC-prefixed terminal reply is liable to be read as a user interrupt (#1625).
+    if (hasQuery) return flush();
     if (pendingChars >= MAX_BATCH_CHARS) return flush();
     if (timer) return;
     // Nothing went out recently, so this is a keystroke echo or a fresh prompt rather than a

--- a/server/session/terminal-replay.ts
+++ b/server/session/terminal-replay.ts
@@ -4,20 +4,55 @@
 // output, xterm re-answers the queries baked into it and the stale replies are sent back as
 // INPUT, surfacing as junk like "0;276;0c" in the app's prompt (codex writes several at startup).
 // Strip them from the replay only: they render nothing, so the visual restore is unchanged, and
-// the app re-queries live if it still needs to.
+// the app re-queries live if it still needs to. The same definitions also identify queries in the
+// live output path, where they bypass frame batching so the emulator can answer promptly.
 //
 // Built via new RegExp so the ESC/BEL control chars stay out of the regex source (satisfies
 // no-control-regex without a disable).
 const ESC = String.fromCharCode(0x1b);
 const BEL = String.fromCharCode(0x07);
+const OSC_QUERY_CODES = ["10", "11", "12"] as const;
+const OSC_QUERY_TERMINATORS = [BEL, `${ESC}\\`] as const;
+const OSC_QUERY_SEQUENCES = OSC_QUERY_CODES.flatMap((code) => OSC_QUERY_TERMINATORS.map((terminator) => `${ESC}]${code};?${terminator}`));
 
-const QUERY_PATTERNS: RegExp[] = [
-  new RegExp(ESC + "\\[[>=]?\\d*c", "g"), // Device Attributes (DA1/DA2/DA3) — the "…c" symptom
-  new RegExp(ESC + "\\[\\??\\d*n", "g"), // device / cursor status report (DSR / CPR)
-  new RegExp(ESC + "\\[\\?u", "g"), // kitty keyboard flags query
-  new RegExp(ESC + "\\[>\\d*q", "g"), // XTVERSION
-  new RegExp(ESC + "\\]1[012];\\?(?:" + BEL + "|" + ESC + "\\\\)", "g"), // OSC 10/11/12 fg/bg/cursor color query
+const QUERY_SOURCES: string[] = [
+  ESC + "\\[[>=]?\\d*c", // Device Attributes (DA1/DA2/DA3) — the "…c" symptom
+  ESC + "\\[(?:[56]|\\?\\d+)n", // standard or DEC-private device / cursor status query
+  ESC + "\\[\\?u", // kitty keyboard flags query
+  ESC + "\\[>\\d*q", // XTVERSION
+  ESC + "\\](?:" + OSC_QUERY_CODES.join("|") + ");\\?(?:" + BEL + "|" + ESC + "\\\\)", // OSC fg/bg/cursor color query
 ];
+const QUERY_PATTERNS = QUERY_SOURCES.map((source) => new RegExp(source, "g"));
+const ANY_QUERY_PATTERN = new RegExp(QUERY_SOURCES.map((source) => `(?:${source})`).join("|"));
+
+/** Whether a live output fragment contains a terminal query that the browser will answer through
+ *  the PTY input channel. A caller may include a short tail from the preceding fragment so a
+ *  sequence split across node-pty reads is still recognised. */
+export function containsTerminalQuery(data: string): boolean {
+  return ANY_QUERY_PATTERN.test(data);
+}
+
+/** Return a trailing fragment that can still become a recognised terminal query. Completed or
+ *  unrelated escape sequences return an empty string, keeping ordinary live output off the scan
+ *  path after its next chunk. */
+export function terminalQueryPrefixTail(data: string, limit: number): string {
+  let candidate = "";
+  for (let escapeAt = data.lastIndexOf(ESC); escapeAt >= 0;) {
+    const suffix = data.slice(escapeAt);
+    if (suffix.length > limit) break;
+    if (suffix === ESC || OSC_QUERY_SEQUENCES.some((query) => query.length > suffix.length && query.startsWith(suffix))) {
+      candidate = suffix;
+    } else if (suffix.startsWith(`${ESC}[`)) {
+      const parameters = suffix.slice(2);
+      // DA and XTVERSION accept an optional marker followed by digits; private DSR and kitty share
+      // the '?' prefix. A final c/n/q/u makes the sequence complete and therefore fails these tests.
+      if (/^[>=]?\d*$/.test(parameters) || /^\?\d*$/.test(parameters)) candidate = suffix;
+    }
+    if (escapeAt === 0) break;
+    escapeAt = data.lastIndexOf(ESC, escapeAt - 1);
+  }
+  return candidate;
+}
 
 export function stripTerminalQueries(data: string): string {
   return QUERY_PATTERNS.reduce((out, re) => out.replace(re, ""), data);

--- a/test/server/session/output-relay.spec.ts
+++ b/test/server/session/output-relay.spec.ts
@@ -141,6 +141,48 @@ describe("createOutputRelay", () => {
     for (let i = 0; i < 100; i++) relay.push("0123456789");
     expect(entry.buffer.length).toBeLessThanOrEqual(12); // 10 * TAIL_SLACK
   });
+
+  it("sends a terminal query immediately instead of delaying its reply round trip", () => {
+    const s = fakeSocket();
+    const relay = createOutputRelay(fakeEntry(s.socket), LIMIT);
+    relay.push("first");
+    vi.advanceTimersByTime(1);
+    relay.push(`${String.fromCharCode(0x1b)}[c`);
+    expect(outputs(s.sent)).toEqual(["first", `${String.fromCharCode(0x1b)}[c`]);
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    expect(outputs(s.sent)).toHaveLength(2);
+  });
+
+  it("recognises a terminal query split after its first half was already sent", () => {
+    const s = fakeSocket();
+    const relay = createOutputRelay(fakeEntry(s.socket), LIMIT);
+    relay.push(String.fromCharCode(0x1b) + "[");
+    vi.advanceTimersByTime(1);
+    relay.push("c");
+    expect(outputs(s.sent)).toEqual([String.fromCharCode(0x1b) + "[", "c"]);
+  });
+
+  it("forgets a partial query when a reattach discards the old relay state", () => {
+    const s = fakeSocket();
+    const relay = createOutputRelay(fakeEntry(s.socket), LIMIT);
+    relay.push(String.fromCharCode(0x1b) + "[");
+    relay.discard();
+    vi.advanceTimersByTime(1);
+    relay.push("c");
+    expect(outputs(s.sent)).toEqual([String.fromCharCode(0x1b) + "["]);
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    expect(outputs(s.sent)).toEqual([String.fromCharCode(0x1b) + "[", "c"]);
+  });
+
+  it("keeps a second partial query after immediately sending a completed one", () => {
+    const s = fakeSocket();
+    const relay = createOutputRelay(fakeEntry(s.socket), LIMIT);
+    const escape = String.fromCharCode(0x1b);
+    relay.push(`first${escape}[6n${escape}[`);
+    vi.advanceTimersByTime(1);
+    relay.push("c");
+    expect(outputs(s.sent)).toEqual([`first${escape}[6n${escape}[`, "c"]);
+  });
 });
 
 describe("wireBufferedOutput", () => {

--- a/test/server/session/terminal-replay.spec.ts
+++ b/test/server/session/terminal-replay.spec.ts
@@ -1,9 +1,33 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { appendBoundedOutput, boundedTail, growOutputTail, stripTerminalQueries, terminalModePrefix } from "../../../server/session/terminal-replay.js";
+import {
+  appendBoundedOutput,
+  boundedTail,
+  containsTerminalQuery,
+  growOutputTail,
+  stripTerminalQueries,
+  terminalQueryPrefixTail,
+  terminalModePrefix,
+} from "../../../server/session/terminal-replay.js";
 
 const ESC = String.fromCharCode(0x1b);
 const BEL = String.fromCharCode(0x07);
+const TERMINAL_QUERIES = [
+  `${ESC}[c`,
+  `${ESC}[>0c`,
+  `${ESC}[6n`,
+  `${ESC}[?6n`,
+  `${ESC}[?25n`,
+  `${ESC}[?996n`,
+  `${ESC}[?u`,
+  `${ESC}[>0q`,
+  `${ESC}]10;?${BEL}`,
+  `${ESC}]10;?${ESC}\\`,
+  `${ESC}]11;?${BEL}`,
+  `${ESC}]11;?${ESC}\\`,
+  `${ESC}]12;?${BEL}`,
+  `${ESC}]12;?${ESC}\\`,
+];
 
 describe("stripTerminalQueries", () => {
   it("removes a Device Attributes query embedded in output (the 0;276;0c symptom source)", () => {
@@ -16,6 +40,8 @@ describe("stripTerminalQueries", () => {
     expect(stripTerminalQueries(`${ESC}[6n`)).toBe("");
     expect(stripTerminalQueries(`x${ESC}[5ny`)).toBe("xy");
     expect(stripTerminalQueries(`${ESC}[?6n`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[?25n`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[?996n`)).toBe("");
   });
 
   it("removes kitty-keyboard and XTVERSION queries", () => {
@@ -34,10 +60,52 @@ describe("stripTerminalQueries", () => {
     expect(stripTerminalQueries(response)).toBe(response);
   });
 
+  it("does NOT strip terminal status or cursor-position responses", () => {
+    expect(stripTerminalQueries(`${ESC}[0n`)).toBe(`${ESC}[0n`);
+    expect(stripTerminalQueries(`${ESC}[12;34R`)).toBe(`${ESC}[12;34R`);
+  });
+
   it("leaves visible text and SGR colour sequences untouched", () => {
     const styled = `${ESC}[31mhello${ESC}[0m world`;
     expect(stripTerminalQueries(styled)).toBe(styled);
     expect(stripTerminalQueries("plain text")).toBe("plain text");
+  });
+});
+
+describe("containsTerminalQuery", () => {
+  it("recognises the terminal queries that xterm answers through onData", () => {
+    for (const query of TERMINAL_QUERIES) {
+      expect(containsTerminalQuery(`before${query}after`)).toBe(true);
+    }
+  });
+
+  it("does not mistake terminal replies, styling or ordinary text for queries", () => {
+    for (const output of [`${ESC}[?1;2c`, `${ESC}[0n`, `${ESC}[12;34R`, `${ESC}[31mred${ESC}[0m`, "plain text"])
+      expect(containsTerminalQuery(output)).toBe(false);
+  });
+});
+
+describe("terminalQueryPrefixTail", () => {
+  it("keeps only a trailing fragment that can become a query", () => {
+    expect(terminalQueryPrefixTail(`text${ESC}[`, 64)).toBe(`${ESC}[`);
+    expect(terminalQueryPrefixTail(`text${ESC}[?99`, 64)).toBe(`${ESC}[?99`);
+    expect(terminalQueryPrefixTail(`text${ESC}]10;?${ESC}`, 64)).toBe(`${ESC}]10;?${ESC}`);
+  });
+
+  it("drops completed and unrelated escape sequences", () => {
+    expect(terminalQueryPrefixTail(`${ESC}[31m`, 64)).toBe("");
+    expect(terminalQueryPrefixTail(`${ESC}[6n`, 64)).toBe("");
+    expect(terminalQueryPrefixTail(`${ESC}[6n${ESC}[`, 64)).toBe(`${ESC}[`);
+  });
+
+  it("retains every possible split of every recognised query", () => {
+    for (const query of TERMINAL_QUERIES) {
+      for (let splitAt = 1; splitAt < query.length; splitAt++) {
+        const prefix = query.slice(0, splitAt);
+        expect(terminalQueryPrefixTail(prefix, 64), `${JSON.stringify(query)} at ${splitAt}`).toBe(prefix);
+        expect(containsTerminalQuery(prefix + query.slice(splitAt))).toBe(true);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- PTY出力中の端末クエリを検出し、通常の8msバッチを待たずブラウザへ即時転送する
- node-ptyのチャンク境界で分割されたクエリを追跡し、再接続時には古い追跡状態を破棄する
- DSR応答をクエリとして扱わず、既存のreplay除去対象との互換性を維持する

MulmoTerminalではPTY出力をWebSocketフレームへまとめていますが、xtermがPTY入力として応答する端末クエリまで遅延していました。Claude Codeが最終描画からStop hookへ移るタイミングで遅れたESC応答が届くと、ユーザー割り込みとして解釈される場合があります。端末クエリだけを即時転送し、通常出力のバッチングは維持します。

## Tests

- `corepack yarn@1.22.22 vitest run test/server/session/output-relay.spec.ts test/server/session/terminal-replay.spec.ts` (55 passed)
- `env -u PORT corepack yarn@1.22.22 test` (9729 passed, 45 skipped)
- `corepack yarn@1.22.22 typecheck`
- `corepack yarn@1.22.22 build`
- `corepack yarn@1.22.22 lint` (0 errors; 14 existing warnings)

Fixes #1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal responses are now forwarded immediately, improving compatibility with terminal features that require prompt replies.
  * Terminal queries split across output chunks are detected and handled correctly.
  * Terminal replay continues to preserve valid responses while filtering query sequences appropriately.

* **Tests**
  * Expanded coverage for cursor, status, keyboard, version, and color queries, including fragmented output and discard scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->