### PR TITLE
feat(collections): MulmoTerminal を共有コレクションのホストにする（実装順 7b）

### DIFF
--- a/common/collectionPortability.ts
+++ b/common/collectionPortability.ts
@@ -22,7 +22,10 @@ export type SelfContainmentCode =
   /** No `primaryKey`, so ids are 4 random bytes and two machines can mint the same one. */
   | "no-primary-key"
   /** The project is not a git repo, so there is nothing to clone and most checks do not apply. */
-  | "not-a-repo";
+  | "not-a-repo"
+  /** Records live in the app's Firestore, not in the repository — by design for a SHARED
+   *  collection, and the reason it clones differently from every other kind. */
+  | "shared-store";
 
 /** `blocker` stops the clone working; `warning` costs something on the other machine; `info` is
  *  context. Only a blocker makes `portable` false. */

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mulmoclaude/accounting-plugin": "^2.1.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
-    "@mulmoclaude/core": "^3.3.0",
+    "@mulmoclaude/core": "^3.10.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -2992,18 +2992,16 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
 6. **onSnapshot watcher** — `CollectionStore.watch` に載せる。
    `hostRunner.ts:154-184` の実装から `docChanges()` の扱いを持ち込む
 7. **worktreeEnv による aid の分岐** — D6
-   - **7a. MulmoClaude を触る変更（2 本で打ち止め）** — **7b 以降はこの 2 本の
-     マージと publish を待つ**:
+   - **7a. MulmoClaude を触る変更（2 本で打ち止め）— 完了**（2026-08-12、
+     `@mulmoclaude/core` **3.10.0** が npm に公開済み）:
      - **mulmoclaude #2870**（マージ済み）— 能力の宣言と受け入れゲート、MC の
        Firestore バインド解除
-     - **mulmoclaude #2871**（レビュー中）— ホストが deploy / publish を自前で回すのに
+     - **mulmoclaude #2871**（マージ済み）— ホストが deploy / publish を自前で回すのに
        要る投影（`projectDeploy` / `projectPublish` / `promoteSchema`）、`staging` と
        `appSlugs` の置き場所、そして **`manageCollection.publishApp` の削除**。
        削除は必須で、任意ではない（下記）。ホストが依存する export は
        `test_sharedHostSurface.ts` で固定した
-     以下は当初の 7a の記述（#2870 のみを指していた）— **PR 済み・未マージ**
-     （mulmoclaude #2870、`@mulmoclaude/core` 3.9.0 はそのブランチにしか無く、npm にも
-     出ていない）。**7b 以降はこれのマージと publish を待つ**:
+     以下は当初の 7a の記述（#2870 のみを指していた）:
      1. `setSharedCollectionsSupport()` と `acceptStorageSchema` のゲート
      2. MC の Firestore バインド解除（`initFirestoreCollectionBinding` を落とす）
 
@@ -3012,15 +3010,14 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
      `server/backends/collections.ts` が現に import している
    - **7b. MT の Firestore 接続** — `setFirestoreAccessor` を MT で呼び、
      **`setSharedCollectionsSupport(true)` を別に呼ぶ**（`configureCollectionHost` の
-     フィールドではない。理由は D5)
+     フィールドではない。理由は D5)。**PR 済み・未マージ**（mulmoterminal #1632）
    - **7c. MT 独自ツール `manageSharedApp`** — `deploy` / `publish` / `unpublish` の 3 つ。
-     **#2871 のマージと npm 公開を待ってから着手する** — それまで core の `publishApp` は
-     生きており、MT は `manageCollection` をホストツールとして登録しているので、
-     書き込み経路が 2 本ある状態が続く（「残すが呼ばない」では MT で普通に動いてしまう。
-     D5 の移行）。1 本になるのは #2871 が入ってから。
+     書き込み経路が 2 本ある状態（core の `publishApp`）は #2871 のマージで解消済み。
      門番と射影は core の純粋関数を呼び、**順序（fail closed）と書き分けは MT が持つ**（D10）。
-     `appSlugs` のルール（`published` フラグ）と **`match /staging/{cid}`** を
-     mulmoserver に足すのはここ（1 回のデプロイにまとめる）
+     ルール側は先行して済んでいる — `appSlugs`（`published` フラグ）と
+     **`match /staging/{cid}`** は **mulmoserver #157 でマージし、2026-08-12 に本番へ
+     deploy 済み**（mulmoserver に CI は無く、デプロイ状態はどのリポジトリにも記録されない
+     ので、ここが唯一の記録）
    - **7d. `aid` の UUID 自動生成**（決定 2）— `app.json` を書くのは MT なので MT 側
 
 **共有**

--- a/server/backends/collectionSelfContainment.ts
+++ b/server/backends/collectionSelfContainment.ts
@@ -16,7 +16,7 @@
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { storageKindFor } from "@mulmoclaude/core/collection";
+import { storageKindFor, type CollectionStorageKind } from "@mulmoclaude/core/collection";
 import { loadCollection } from "@mulmoclaude/core/collection/server";
 import type { Express, Request, Response } from "express";
 import { errorStatus, resolveProjectRoot, type ProjectScope } from "../infra/project-root.js";
@@ -31,7 +31,10 @@ const run = promisify(execFile);
  *  exercised without a git repo and a workspace on disk, and so each rule reads as one line. */
 export interface SelfContainmentFacts {
   source: "user" | "project" | "feed";
-  storageKind: "file" | "csv" | "sqlite";
+  /** Widened from core rather than re-listed: core 3.10.0 added `firestore`, and a local
+   *  copy of the union is how this file would stop compiling on the NEXT kind instead of
+   *  reporting it. */
+  storageKind: CollectionStorageKind;
   hasPrimaryKey: boolean;
   inGitRepo: boolean;
   /** Whether git ignores anything the RECORDS need in order to travel — the external
@@ -81,6 +84,19 @@ export function selfContainmentFindings(facts: SelfContainmentFacts): SelfContai
       severity: "blocker",
       message:
         "Records are stored in one SQLite file. Git cannot merge a binary file, so two machines editing this collection offline produce a conflict nobody can resolve — where the default one-file-per-record storage merges cleanly.",
+    });
+  }
+
+  if (facts.storageKind === "firestore") {
+    // Not a defect: a shared collection's records are SUPPOSED to live in the app's
+    // Firestore, which is exactly what lets two people work on the same data. But it
+    // answers the question this report asks — "what does a clone get?" — differently
+    // from every other kind, and silence would read as "the records travel".
+    findings.push({
+      code: "shared-store",
+      severity: "info",
+      message:
+        "This is a shared collection: the schema is committed and the records live in the app's Firestore. A clone brings the definition and reaches the same records once its user is on the app's roster — nobody gets a private copy, which is the point.",
     });
   }
 

--- a/server/backends/collectionSelfContainment.ts
+++ b/server/backends/collectionSelfContainment.ts
@@ -59,7 +59,12 @@ export function selfContainmentFindings(facts: SelfContainmentFacts): SelfContai
     });
   }
 
-  if (facts.dataDirIgnored === true) {
+  // A SHARED collection has no records on disk to be ignored: they live in the app's Firestore,
+  // and `dataDir` is then only the conventional per-slug directory nothing was ever written to.
+  // Asking git about it answers about the wrong place, so a workspace that ignores `data/` would
+  // call every shared collection unclonable and every record lost — the one verdict this file
+  // exists to keep trustworthy, spent on a collection whose records are exactly what DOES travel.
+  if (facts.dataDirIgnored === true && facts.storageKind !== "firestore") {
     // A FEED's records are a CACHE, and that changes the verdict rather than the fact. They are
     // re-fetched from the source the clone can reach too, so "the records do not travel" costs a
     // refresh, not the data — while for a collection the records ARE the data and nothing brings

--- a/server/backends/remoteHost/session.spec.ts
+++ b/server/backends/remoteHost/session.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { RemoteHostSessionExpiredError, reconnectErrorStatus } from "./session.js";
+import { RemoteHostSessionExpiredError, reconnectErrorStatus, verifiedEmailOf } from "./session.js";
 
 describe("reconnectErrorStatus", () => {
   it("maps an expired/invalid session to 401 (client drops the blob)", () => {
@@ -11,5 +11,23 @@ describe("reconnectErrorStatus", () => {
     expect(reconnectErrorStatus(new Error("firestore unavailable"))).toBe(500);
     expect(reconnectErrorStatus("network down")).toBe(500);
     expect(reconnectErrorStatus(undefined)).toBe(500);
+  });
+});
+
+describe("verifiedEmailOf", () => {
+  it("hands back the address of a verified user", () => {
+    expect(verifiedEmailOf({ email: "owner@example.com", emailVerified: true })).toBe("owner@example.com");
+  });
+
+  it("answers null for an unverified address — the rules deny it every document anyway", () => {
+    // `listedIn()` in firestore.rules is guarded by `verified()`, so an unverified
+    // address matches no roster entry. Reporting it as a principal would open the
+    // pane and fail every row instead of saying there is nothing to act on.
+    expect(verifiedEmailOf({ email: "owner@example.com", emailVerified: false })).toBeNull();
+  });
+
+  it("answers null with no session and with no address", () => {
+    expect(verifiedEmailOf(null)).toBeNull();
+    expect(verifiedEmailOf({ email: null, emailVerified: true })).toBeNull();
   });
 });

--- a/server/backends/remoteHost/session.ts
+++ b/server/backends/remoteHost/session.ts
@@ -81,11 +81,24 @@ const requireHandles = (): RemoteHostSessionHandles => {
 };
 
 export const currentUid = (): string | null => handles?.auth.currentUser?.uid ?? null;
-// The signed-in address. Shared collections are keyed by EMAIL — the roster in
-// `app.json` lists addresses and the Firestore rules match
-// `request.auth.token.email` against it — so a session without one cannot act
-// on them at all (null, not a guess).
-export const currentEmail = (): string | null => handles?.auth.currentUser?.email ?? null;
+
+/** The address a shared collection may be authorized on, or null.
+ *
+ *  Shared collections are keyed by EMAIL — the roster in `app.json` lists addresses — and the
+ *  deployed rules match it as `request.auth.token.email` through `listedIn()`, which is guarded
+ *  by `verified()`: `email_verified == true`. So an UNVERIFIED address is not a weaker identity
+ *  there, it is no identity at all; every read and write it attempts is denied.
+ *
+ *  Answering null for one is therefore not an extra restriction, it is agreeing with the rules.
+ *  The alternative reads worse rather than allowing more: the collection lists, the pane opens,
+ *  and every row fails permission-denied with nothing naming the reason.
+ *
+ *  Pure and exported so this is pinned without standing up a Firebase session — the module's
+ *  handles are private and only replaced by a real connect. */
+export const verifiedEmailOf = (user: { email: string | null; emailVerified: boolean } | null | undefined): string | null =>
+  user?.emailVerified === true && user.email ? user.email : null;
+
+export const currentEmail = (): string | null => verifiedEmailOf(handles?.auth.currentUser);
 export const currentFirestore = (): Firestore => requireHandles().firestore;
 export const currentStorage = (): FirebaseStorage => requireHandles().storage;
 

--- a/server/backends/remoteHost/session.ts
+++ b/server/backends/remoteHost/session.ts
@@ -81,6 +81,11 @@ const requireHandles = (): RemoteHostSessionHandles => {
 };
 
 export const currentUid = (): string | null => handles?.auth.currentUser?.uid ?? null;
+// The signed-in address. Shared collections are keyed by EMAIL — the roster in
+// `app.json` lists addresses and the Firestore rules match
+// `request.auth.token.email` against it — so a session without one cannot act
+// on them at all (null, not a guess).
+export const currentEmail = (): string | null => handles?.auth.currentUser?.email ?? null;
 export const currentFirestore = (): Firestore => requireHandles().firestore;
 export const currentStorage = (): FirebaseStorage => requireHandles().storage;
 

--- a/server/backends/sharedCollections.ts
+++ b/server/backends/sharedCollections.ts
@@ -1,0 +1,46 @@
+// Shared (firestore-backed) collections — MulmoTerminal is their host.
+//
+// WHY HERE AND NOT IN MulmoClaude. A shared collection's roster lives in one
+// `app.json` per repository, so the unit of sharing is a project directory.
+// MulmoClaude is a single managed workspace holding unrelated collections side
+// by side, where one `app.json` would put a client list and a set of blood-test
+// results under the same roster; it therefore declares no support and unbound
+// its accessor (mulmoclaude#2870). MulmoTerminal's roots ARE repositories, so
+// the capability is declared here.
+//
+// TWO SEAMS, NOT ONE. `setSharedCollectionsSupport` answers "does this host
+// serve shared collections AT ALL" and is fixed for the process;
+// `setFirestoreAccessor` answers "is there a session RIGHT NOW" and comes and
+// goes with the remote-host connection. Deriving the first from the second
+// would make a schema INVALID whenever nobody is signed in — the acceptance
+// gate would refuse it, and the author would be told their collection is
+// misconfigured because they happened to be disconnected.
+import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs } from "@mulmoclaude/core/collection/server";
+// The adapter is the one collection module that pulls the firebase SDK in at
+// runtime; it ships from its own subpath so the optional peer stays optional.
+import { createFirestoreDocs } from "@mulmoclaude/core/collection/firestore";
+import type { Firestore } from "firebase/firestore";
+import { currentEmail, currentFirestore, currentUid } from "./remoteHost/session.js";
+
+// One adapter per Firestore instance. The accessor runs on every store call and
+// the session's Firestore changes on each (re)connect, so cache on identity
+// rather than allocating a closure set per read.
+let cached: { firestore: Firestore; docs: FirestoreDocs } | null = null;
+
+function docsFor(firestore: Firestore): FirestoreDocs {
+  if (cached?.firestore !== firestore) cached = { firestore, docs: createFirestoreDocs(firestore) };
+  return cached.docs;
+}
+
+export function initSharedCollections(): void {
+  setSharedCollectionsSupport(true);
+  setFirestoreAccessor(() => {
+    const uid = currentUid();
+    const email = currentEmail();
+    // No session, or a session with no verified address to match the roster
+    // against: null, which the store turns into "connect remote-host first"
+    // rather than an empty collection.
+    if (uid === null || email === null) return null;
+    return { docs: docsFor(currentFirestore()), email, uid };
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -111,6 +111,7 @@ import { repoForDir } from "./git/forge-support.js";
 import { resolveGithubUrl } from "./git/gitRemote.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { initCollectionsBackend } from "./backends/collections.js";
+import { initSharedCollections } from "./backends/sharedCollections.js";
 import { initGoogleBackend } from "./backends/google.js";
 import { initPluginRuntime } from "./infra/pluginRuntime.js";
 import { initAccountingBackend } from "./backends/accounting.js";
@@ -555,6 +556,14 @@ initMulmoScriptBackend({ workspace: CLAUDE_CWD, pubsub });
 // Configure the collection engine against the shared workspace (CLAUDE_CWD). The
 // path layout matches MulmoClaude's so discovery sees the same collection skills.
 initCollectionsBackend({ workspace: CLAUDE_CWD });
+
+// Shared (firestore-backed) collections. MulmoTerminal is their host — its roots
+// are project repositories, which is what one `app.json` per roster requires —
+// and MulmoClaude unbound its own accessor for that reason (mulmoclaude#2870).
+// Wired HERE rather than inside initCollectionsBackend because that file is at
+// its line budget, and because the Firebase session this reads is a boot-level
+// concern of this file's, not of the collection engine's configuration.
+initSharedCollections();
 
 // Give factory-style gui-chat-protocol plugins their scoped runtime (per-package
 // data/config under <workspace>, namespaced pub/sub, prefixed log) — see

--- a/test/server/backends/collectionSelfContainment.spec.ts
+++ b/test/server/backends/collectionSelfContainment.spec.ts
@@ -29,7 +29,15 @@ const codes = (facts: Partial<SelfContainmentFacts>): string[] => selfContainmen
 // The wire type widens `code` to a plain string so a newer server's finding is not dropped by an
 // older client. That widening must not become licence for THIS server to invent one: every code
 // it can produce is pinned to the documented union here.
-const KNOWN_CODES: readonly SelfContainmentCode[] = ["user-scope", "sqlite-store", "csv-runtime", "data-ignored", "no-primary-key", "not-a-repo"];
+const KNOWN_CODES: readonly SelfContainmentCode[] = [
+  "user-scope",
+  "sqlite-store",
+  "csv-runtime",
+  "data-ignored",
+  "no-primary-key",
+  "not-a-repo",
+  "shared-store",
+];
 
 const verdict = (facts: Partial<SelfContainmentFacts>): boolean => isPortable(selfContainmentFindings({ ...PORTABLE, ...facts }));
 
@@ -98,6 +106,17 @@ describe("selfContainmentFindings", () => {
     expect(verdict({ storageKind: "csv" })).toBe(true);
   });
 
+  it("discloses a shared collection without calling it a defect", () => {
+    // Records living in the app's Firestore is what lets two people work on the
+    // same data — the opposite of a portability problem. But this report answers
+    // "what does a clone get?", and for this kind the answer differs from every
+    // other, so silence would read as "the records travel".
+    expect(codes({ storageKind: "firestore" })).toEqual(["shared-store"]);
+    expect(verdict({ storageKind: "firestore" })).toBe(true);
+    const [finding] = selfContainmentFindings({ ...PORTABLE, storageKind: "firestore" });
+    expect(finding?.severity).toBe("info");
+  });
+
   it("warns about a missing primaryKey in a repo — two machines can mint one id", () => {
     expect(codes({ hasPrimaryKey: false })).toContain("no-primary-key");
     expect(verdict({ hasPrimaryKey: false })).toBe(true);
@@ -127,6 +146,7 @@ describe("selfContainmentFindings", () => {
     const everyFinding = [
       ...selfContainmentFindings({ source: "user", storageKind: "sqlite", hasPrimaryKey: false, inGitRepo: true, dataDirIgnored: true }),
       ...selfContainmentFindings({ source: "project", storageKind: "csv", hasPrimaryKey: true, inGitRepo: false, dataDirIgnored: null }),
+      ...selfContainmentFindings({ source: "project", storageKind: "firestore", hasPrimaryKey: true, inGitRepo: true, dataDirIgnored: false }),
     ];
     expect(everyFinding.length).toBeGreaterThan(4);
     for (const finding of everyFinding) expect(KNOWN_CODES).toContain(finding.code);

--- a/test/server/backends/collectionSelfContainment.spec.ts
+++ b/test/server/backends/collectionSelfContainment.spec.ts
@@ -117,6 +117,18 @@ describe("selfContainmentFindings", () => {
     expect(finding?.severity).toBe("info");
   });
 
+  it("does not call a shared collection unclonable for an ignored local data directory", () => {
+    // The one case where the two rules meet: a shared collection's records are in
+    // Firestore, so the conventional per-slug directory holds nothing and whether git
+    // ignores it says nothing about what a clone gets. The managed workspace really
+    // does ignore `data/`, so this is the ordinary case, not a corner — and a blocker
+    // here would report the records as lost when they are precisely what travels.
+    expect(codes({ storageKind: "firestore", dataDirIgnored: true })).toEqual(["shared-store"]);
+    expect(verdict({ storageKind: "firestore", dataDirIgnored: true })).toBe(true);
+    // Still a blocker for every kind whose records ARE on disk.
+    expect(codes({ dataDirIgnored: true })).toContain("data-ignored");
+  });
+
   it("warns about a missing primaryKey in a repo — two machines can mint one id", () => {
     expect(codes({ hasPrimaryKey: false })).toContain("no-primary-key");
     expect(verdict({ hasPrimaryKey: false })).toBe(true);

--- a/test/server/backends/sharedCollections.spec.ts
+++ b/test/server/backends/sharedCollections.spec.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+//
+// MulmoTerminal is the host for shared (firestore-backed) collections, and the
+// binding is two separate seams: a capability that is fixed for the process,
+// and a session that comes and goes. Getting those two confused is what this
+// pins — deriving the capability from the session would make a schema INVALID
+// while nobody is signed in, so the author would be told their collection is
+// misconfigured because they happened to be disconnected.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const session = { uid: null as string | null, email: null as string | null };
+// One STABLE instance: the real session hands back the same Firestore until it
+// reconnects, and the adapter cache is keyed on that identity.
+const firestore = { __fake: "firestore" };
+
+vi.mock("../../../server/backends/remoteHost/session.js", () => ({
+  currentUid: () => session.uid,
+  currentEmail: () => session.email,
+  currentFirestore: () => firestore,
+}));
+// The adapter is the one module that pulls the firebase SDK in at runtime.
+vi.mock("@mulmoclaude/core/collection/firestore", () => ({
+  createFirestoreDocs: (firestore: unknown) => ({ __docsFor: firestore }),
+}));
+
+const { initSharedCollections } = await import("../../../server/backends/sharedCollections.js");
+const { hostSupportsSharedCollections, firestoreHandle, setSharedCollectionsSupport, setFirestoreAccessor } =
+  await import("@mulmoclaude/core/collection/server");
+
+describe("shared collections host binding", () => {
+  beforeEach(() => {
+    session.uid = null;
+    session.email = null;
+    setSharedCollectionsSupport(false);
+    setFirestoreAccessor(null);
+  });
+
+  it("declares the capability, so a firestore schema is acceptable at all", () => {
+    expect(hostSupportsSharedCollections()).toBe(false);
+    initSharedCollections();
+    expect(hostSupportsSharedCollections()).toBe(true);
+  });
+
+  it("keeps the capability while there is no session", () => {
+    // The distinction the two seams exist for: signed out is "connect first",
+    // not "this schema is invalid".
+    initSharedCollections();
+    expect(firestoreHandle()).toBeNull();
+    expect(hostSupportsSharedCollections()).toBe(true);
+  });
+
+  it("hands back the signed-in principal once a session is open", () => {
+    initSharedCollections();
+    session.uid = "uid_owner";
+    session.email = "owner@example.com";
+    const handle = firestoreHandle();
+    expect(handle?.uid).toBe("uid_owner");
+    expect(handle?.email).toBe("owner@example.com");
+  });
+
+  it("answers null for a session with no address — the roster is keyed by email", () => {
+    // A uid alone cannot be matched against `members`, and guessing an address
+    // would be a permission decision made on a fabricated identity.
+    initSharedCollections();
+    session.uid = "uid_owner";
+    session.email = null;
+    expect(firestoreHandle()).toBeNull();
+  });
+
+  it("reuses one adapter per Firestore instance", () => {
+    initSharedCollections();
+    session.uid = "uid_owner";
+    session.email = "owner@example.com";
+    expect(firestoreHandle()?.docs).toBe(firestoreHandle()?.docs);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,10 +1912,10 @@
     js-yaml "^5.2.3"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.3.0.tgz#e45795e9f38a995113d5707659420af9cb9d39b2"
-  integrity sha512-YNBWp9Ju7PHss+44sTWSgyR1iHAep95gTG0e+XUSOlSZU2XwgzW+6ClJh4sq0QUunZmMeEq8547xPegDSBs3WA==
+"@mulmoclaude/core@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.10.0.tgz#ade5538458dbd822461cc8785a5b4f7ef55f6209"
+  integrity sha512-S6uNeD323ExbqZm7S7kl1p1epREzWvLm4Y6aNv8bqH4UJKU4JWT4+VR0ZoDAz8g6+4vpCHU1/pk4wmQ87xUbNw==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"


### PR DESCRIPTION
`@mulmoclaude/core` 3.10.0 で入った seam を MulmoTerminal 側で受けます。実装順 7b です。

共有コレクションの名簿は 1 リポジトリに 1 つの `app.json` なので、共有の単位は**プロジェクトフォルダ**です。MulmoTerminal の root はまさにそれで、MulmoClaude は単一の管理ワークスペース（無関係なコレクションが並ぶ）ゆえに自分の accessor を外しました（receptron/mulmoclaude#2870）。

## 何を入れたか

**`server/backends/sharedCollections.ts`** — `setSharedCollectionsSupport(true)` と `setFirestoreAccessor` を wire します。

**seam は 2 つのまま扱います。** 能力はプロセスで固定、セッションは remote-host の接続とともに現れて消えます。前者を後者から導くと、**サインインしていないだけでスキーマが「無効」になり**、受け入れゲートに拒否されます（「接続してください」であるべきものが「このコレクションは壊れています」になる）。

**名簿は email で引く**ので、uid はあるが address が無いセッションには `null` を返します。住所を推測するのは、でっち上げた identity で権限判断をすることです。

**配線は `server/index.ts` の boot 側**です。`collections.ts` は行数上限ちょうど（ファイル自身のコメントにもそう書かれています）で、読む Firebase セッションはそちらの関心でもあります。

## 巻き添えの 1 件

core 3.10.0 が `CollectionStorageKind` に `firestore` を足したので、self-containment 検査のローカル型が壊れました。core の型に広げ、**`shared-store` の所見を追加**しています。

records がリポジトリに入らないのは設計どおり（それが 2 人で同じデータを扱えるということ）ですが、この検査が答える問い —「clone は何を得るか」— に対しては他の種別と違う答えになります。黙っていると「records も travel する」と読まれるので、`info` として出します。

## 依存とテスト

`@mulmoclaude/core` を `^3.3.0` → `^3.10.0` に。

`yarn test` 9724 pass / 0 fail（新規スペック 5 本）、`yarn typecheck` 0、`yarn lint` 0 error。

## 前提

- receptron/mulmoclaude#2870 / #2871 — **マージ済み・3.10.0 公開済み**
- receptron/mulmoserver#157（`staging` と `appSlugs` のルール）— 7c で必要になります。この PR 自体はルールに依存しません

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for shared Firestore-backed collections.
  * Shared collections now reflect the signed-in account and provide access to shared records.
  * Added collection status information for data stored in the shared store.
* **Bug Fixes**
  * Improved handling when no authenticated account or email is available.
  * Improved efficiency when accessing shared collections.
* **Tests**
  * Added coverage for shared collection setup, authentication states, account details, and connection reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->