### PR TITLE
feat(collections): 共有アプリの deploy / publish / unpublish（実装順 7c）

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -90,6 +90,12 @@ const GROUP_BY_TOOL = new Map<string, ToolGroup>([
   ["presentCollection", "data"],
   ["manageCollection", "data"],
   ["manageAccounting", "data"],
+  // manageSharedApp deploys and publishes the SHARED collections of the directory the cell is
+  // open in, so it belongs where their store does: a cell without the data group has no
+  // collection tools, and a deploy tool beside no collections is a tool with nothing to deploy.
+  // It is not in AUTO_ALLOWED_TOOLS — publish is the one operation here that changes what people
+  // outside the roster can see, and Claude Code's permission prompt is wanted in front of it.
+  ["manageSharedApp", "data"],
 
   ["generateImage", "media"],
   ["presentMulmoScript", "media"],

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -3012,12 +3012,27 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
      **`setSharedCollectionsSupport(true)` を別に呼ぶ**（`configureCollectionHost` の
      フィールドではない。理由は D5)。**PR 済み・未マージ**（mulmoterminal #1632）
    - **7c. MT 独自ツール `manageSharedApp`** — `deploy` / `publish` / `unpublish` の 3 つ。
+     **slug の予約を除いて PR 済み・未マージ**（mulmoterminal #1633）。
      書き込み経路が 2 本ある状態（core の `publishApp`）は #2871 のマージで解消済み。
      門番と射影は core の純粋関数を呼び、**順序（fail closed）と書き分けは MT が持つ**（D10）。
      ルール側は先行して済んでいる — `appSlugs`（`published` フラグ）と
      **`match /staging/{cid}`** は **mulmoserver #157 でマージし、2026-08-12 に本番へ
      deploy 済み**（mulmoserver に CI は無く、デプロイ状態はどのリポジトリにも記録されない
      ので、ここが唯一の記録）
+
+     実装で分かったことを 2 つ。どちらも設計の穴で、コードを書くまで見えていなかった:
+
+     - **`app.json` に希望の slug を書けない。** `AuthoredAppZ` は strict なので、
+       `slug` を足した `app.json` は core の `parseAuthoredApp` が
+       `Unrecognized key: "slug"` で**丸ごと拒否する**。足すのは core の変更＝
+       「MC を二度と触らない」に反するので、**slug の置き場所は決め直しが要る**
+       （下の「未解決」参照）。7c はそこだけ落として先に入れた — `/staging/{aid}` は
+       slug を経由しないので、招待とテストは slug 無しで最後まで回る
+     - **staging は「積み上げ」ではなく「置換」でなければならない。** コレクションを
+       リポジトリから消しても `staging/{cid}` は残り、publish は
+       「昇格させる版をライブレコードで検証する」ため**リポジトリに無い cid を検証できず
+       止まる**。deploy が消えた cid の staging を**撤回する**ことで解いた
+       （撤回は最後に書く — 何も grant しないので）
    - **7d. `aid` の UUID 自動生成**（決定 2）— `app.json` を書くのは MT なので MT 側
 
 **共有**
@@ -3067,6 +3082,18 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
   補助関数の連鎖が深いと非自明な経路が全部そこに達し、症状は「権限エラー」ではなく
   `Unable to evaluate the expression…`。**次にルールへ条件を足すときは、正しさと同じだけ
   式数を見ること。** 目安は、app ドキュメントを 1 回だけ取得して引数で下へ渡す形を崩さないこと
+- **希望の slug をどこに書くか（未決。7c で判明）** — D10 は「`app.json` に希望の slug を
+  書き、deploy が予約する」としているが、**それは書けない**。`AuthoredAppZ` は strict で、
+  `slug` を含む `app.json` は `parseAuthoredApp` が `Unrecognized key: "slug"` として
+  丸ごと拒否する。core にキーを足すのは「MC を二度と触らない」に反する。残る案は 3 つ:
+  - **(a) MT 所有の別ファイル**（例: リポジトリ直下に slug の予約控えを 1 本）。
+    **git に入って clone に付いていく**のが条件 — 予約は `published: false` の間は
+    ルール上**オーナー自身も読み返せない**ので、Firestore からは復元できない
+  - **(b) `name` から導出**（`slugify(name)`、衝突時は連番）。控えを持たないので、
+    連番が付いた瞬間に再現できなくなる。予約の再利用も検証できない
+  - **(c) slug をやめる** — 公開ページも `/{aid}` にする。URL は人が配るものという
+    D2b の前提を落とすことになる
+  実装済みの `deploy` / `publish` は slug に触っていないので、どれを採っても後から足せる
 - **Storage ルールから `firestore.get()`** でメンバー判定できるか — 仕様上可能のはずだが実機未確認
 - **repo 権限と members のずれ**をどう見せるか（当面は members をヘッダーに常時出すだけ）
 - **email の同一性**（変更・再利用）— 当面受容

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -1,0 +1,161 @@
+// What every shared-app operation needs before it can decide anything: a signed-in session, the
+// declaration in `app.json`, and this repository's shared collections.
+//
+// It lives in MulmoTerminal rather than in `@mulmoclaude/core` because the OPERATIONS are
+// MulmoTerminal's (design D5). What core keeps is the pure half — parsing the declaration,
+// deciding what is wrong with it, projecting documents — and every one of those is a function
+// that answers "what is correct?" without knowing which operation asked. What is here is the
+// other half: which order to write in, and what a half-finished write leaves behind.
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  APP_MANIFEST_FILE,
+  discoverCollections,
+  firestoreHandle,
+  parseAuthoredApp,
+  publishProblems,
+  type AuthoredApp,
+  type LoadedCollection,
+} from "@mulmoclaude/core/collection/server";
+import type { CollectionSchema } from "@mulmoclaude/core/collection";
+
+const execFileAsync = promisify(execFile);
+
+/** The live session, as the operations use it. Named rather than inlined because both halves —
+ *  the uid the app document's `owner` is pinned to, and the email the roster is keyed by — are
+ *  required, and a session holding one is not a usable one. */
+export type SharedAppHandle = NonNullable<ReturnType<typeof firestoreHandle>>;
+
+/** Who and when, resolved once per operation. `dirty` is carried because a commit that does not
+ *  describe what was written is worse than no commit — it looks auditable. */
+export interface GitStamp {
+  commit?: string | undefined;
+  dirty?: boolean | undefined;
+}
+
+export interface SharedAppOptions {
+  /** Proceed although live records fail the schema being written. Never a default, and never
+   *  inherited: deploy's confirm says "let me stage this anyway", which is not the same sentence
+   *  as "let the public have it" (design D10). */
+  confirm?: boolean | undefined;
+  /** Wall clock, injectable so a test can assert an exact document. */
+  now?: (() => number) | undefined;
+  /** Resolve the commit being written from. Injectable for the same reason, and because a
+   *  repository without git is a normal state rather than a failure. */
+  resolveCommit?: ((root: string) => Promise<GitStamp>) | undefined;
+}
+
+/** Every refusal is a list of lines the author can act on, and `partial` answers the one question
+ *  prose cannot be trusted with: did anything reach Firestore before this failed?
+ *
+ *  Almost every refusal happens before the first write, so a caller that has to infer it will
+ *  infer "nothing was written" — which is exactly wrong in the one case that matters. */
+export interface SharedAppFailure {
+  ok: false;
+  problems: string[];
+  partial: boolean;
+}
+
+/** `git rev-parse HEAD` plus a dirty check, or nothing. A missing git, a repository with no
+ *  commits and a non-repository are the same answer here: the stamp is attribution, not a
+ *  requirement. */
+export async function gitStamp(root: string): Promise<GitStamp> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", root, "rev-parse", "HEAD"]);
+    const commit = stdout.trim();
+    const { stdout: status } = await execFileAsync("git", ["-C", root, "status", "--porcelain"]);
+    return { commit: commit.length > 0 ? commit : undefined, dirty: status.trim().length > 0 };
+  } catch {
+    return {};
+  }
+}
+
+/** The shared collections of THIS REPOSITORY, by cid.
+ *
+ *  `userSkillsDir: null` is a boundary, not a test convenience. A globally installed skill under
+ *  `~/.claude/skills` carrying `storage.type: "firestore"` would otherwise pick up whichever
+ *  repository's `aid` it happened to be discovered from — and, because a view is HTML, deploying
+ *  one is the machine's own skills reaching every member's browser. An app is a REPOSITORY (D1):
+ *  its collections are the ones committed beside its `app.json`.
+ *
+ *  MulmoTerminal binds the engine in explicit-root mode, so the root is passed rather than
+ *  defaulted — a forgotten root here would not be a crash but the wrong project. */
+export async function sharedCollections(root: string): Promise<LoadedCollection[]> {
+  const all = await discoverCollections({ workspaceRoot: root, userSkillsDir: null });
+  return all.filter((collection) => collection.appId !== undefined);
+}
+
+/** The schemas as the projections want them: sorted, so two runs over the same repository produce
+ *  the same documents and a diff of them means something. */
+export function schemasOf(collections: readonly LoadedCollection[]): { cid: string; schema: CollectionSchema }[] {
+  return collections.map((collection) => ({ cid: collection.slug, schema: collection.schema })).sort(byCid);
+}
+
+/** Code-unit order, not `localeCompare`: this is the order Firestore lists document ids in, and
+ *  a projection sorted one way against a listing sorted another is a diff that reads as a change. */
+function byCid(left: { cid: string }, right: { cid: string }): number {
+  if (left.cid === right.cid) return 0;
+  return left.cid < right.cid ? -1 : 1;
+}
+
+async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp } | { ok: false; problems: string[] }> {
+  let raw: string;
+  try {
+    raw = await readFile(path.join(root, APP_MANIFEST_FILE), "utf-8");
+  } catch (err) {
+    return { ok: false, problems: [`cannot read ${path.join(root, APP_MANIFEST_FILE)}: ${String(err)}`] };
+  }
+  return parseAuthoredApp(raw);
+}
+
+/** Everything wrong with the declaration itself, publisher included. */
+function declarationProblems(app: AuthoredApp, collections: readonly LoadedCollection[], handle: SharedAppHandle): string[] {
+  const problems = publishProblems(
+    app,
+    collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
+    handle.email,
+  );
+  if (app.owner !== undefined && app.owner !== handle.uid) {
+    // Not fatal on its own — the rules pin `owner` to the EXISTING document on update — but a
+    // declaration naming somebody else's uid is either the sample's `<uid>` placeholder or a
+    // misunderstanding of what the key is.
+    problems.push(
+      `app.json declares owner "${app.owner}", which is not your uid (${handle.uid}). ` +
+        "`owner` is stamped by deploy and carried forward unchanged afterwards — remove it from app.json rather than maintaining it by hand.",
+    );
+  }
+  return problems;
+}
+
+export interface SharedAppContext {
+  ok: true;
+  authored: AuthoredApp;
+  collections: LoadedCollection[];
+  handle: SharedAppHandle;
+}
+
+/** Load and vet everything the three operations share, in one place so they cannot disagree about
+ *  what a valid declaration is — the gate that runs before deploy has to be the same one that runs
+ *  before publish, or `confirm` on the cheap operation becomes a way past the expensive one. */
+export async function sharedAppContext(root: string): Promise<SharedAppContext | SharedAppFailure> {
+  const handle = firestoreHandle();
+  if (!handle) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        "this needs a signed-in Firestore session: connect remote-host first. Shared-app writes go out as the app's owner, which is an authenticated write, " +
+          "and the roster is keyed by your VERIFIED address — an unverified one is not a weaker identity to the rules, it is no identity at all.",
+      ],
+    };
+  }
+  const authored = await readAuthored(root);
+  if (!authored.ok) return { ...authored, partial: false };
+
+  const collections = await sharedCollections(root);
+  const problems = declarationProblems(authored.app, collections, handle);
+  if (problems.length > 0) return { ok: false, partial: false, problems };
+  return { ok: true, authored: authored.app, collections, handle };
+}

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -1,0 +1,159 @@
+// deploy — put the declaration where the ROSTER can see it, and nowhere else.
+//
+// It is the safe half of the split (design D10): everything it writes is readable only by people
+// already on the roster, so it can be run as often as anyone likes. Two things are deliberately
+// absent, and both are what make that true:
+//
+//   - the `public` block on `apps/{aid}`. That block is what the rules read to authorize
+//     anonymous access — `publicOn` and `subOpen` read the APP document, never the world-readable
+//     `config/public` projection — so writing it here would open the app the moment someone
+//     deployed to test.
+//   - the published schemas. They go to `staging/{cid}`, which only the roster can read, so a
+//     deploy against a LIVE app does not swap the view its visitors are looking at.
+//
+// The write order is "app document first": `appSlugs`' create rule and the staging rules both
+// resolve the owner through `get(apps/{aid})`, so on a first deploy nothing else is authorized
+// until that document exists.
+import { isRecord } from "../../../common/isRecord.js";
+import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
+import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { recordRefusal, scanRecords } from "./records.js";
+import { runWrites } from "./writes.js";
+
+export interface DeploySuccess {
+  ok: true;
+  aid: string;
+  cids: string[];
+  created: boolean;
+  commit?: string | undefined;
+  dirty: boolean;
+  /** How many live records the pre-check found that the staged schemas reject — and whether that
+   *  number is a FLOOR (the scan stops at its cap per collection). The two travel together
+   *  because they are read together: reporting the number without the flag understates how much
+   *  repair is owed, on the one path (a confirmed deploy) where it is already staged. */
+  recordIssues: number;
+  recordIssuesCapped: boolean;
+  /** cids that were staged before and are not in the repository any more — dropped by this
+   *  deploy. Reported because a withdrawal is not what the operator asked for; it is what
+   *  deleting a collection's directory MEANT, and the two are easy to confuse. */
+  withdrawn: string[];
+}
+
+/** The app document as it stands, or the refusal.
+ *
+ *  The preflight read decides two things the rules care about: whether `owner` is stamped or
+ *  carried forward, and which of publish's fields are carried through the replacement. A rejection
+ *  here — permission, network, quota — must become the documented result rather than escape as a
+ *  raw exception; it happens before any write, which is what the caller most needs told.
+ *
+ *  It also normalizes "was there an app document?" ONCE, for the projection and the report both.
+ *  Two spellings of that question disagree the moment `get` resolves to something that is neither
+ *  a record nor null: the projection stamps a fresh `owner` while the reply says "Updated". */
+async function readCurrentApp(handle: SharedAppHandle, aid: string): Promise<{ ok: true; app: Record<string, unknown> | null } | SharedAppFailure> {
+  try {
+    const existing = await handle.docs.get(APPS_COLLECTION, aid);
+    return { ok: true, app: isRecord(existing) ? existing : null };
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `deploy failed while reading the current app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Nothing was written. Deploying again is safe — this read only decides whether the app is created or updated.",
+      ],
+    };
+  }
+}
+
+/** Staged documents whose collection this repository no longer has.
+ *
+ *  Dropping them is what makes staging a REPLACEMENT of the repository's shared collections rather
+ *  than an accumulation of everything ever deployed. Without it, deleting a collection leaves its
+ *  schema staged forever, and publish — which promotes what is staged and refuses to promote a
+ *  version it cannot check against the repository — has no way forward at all.
+ *
+ *  Only asked when the app document already exists: the staging rules resolve the roster through
+ *  `get(apps/{aid})`, so on a FIRST deploy the listing is denied rather than empty, and treating
+ *  that denial as a real one would make an app impossible to create. */
+async function staleStaged(
+  handle: SharedAppHandle,
+  aid: string,
+  existingApp: Record<string, unknown> | null,
+  keep: ReadonlySet<string>,
+): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
+  if (existingApp === null) return { ok: true, cids: [] };
+  try {
+    const staged = await handle.docs.list(appStagingPath(aid));
+    return { ok: true, cids: staged.map((doc) => doc.id).filter((cid) => !keep.has(cid)) };
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `deploy failed while reading what is already staged (apps/${aid}/staging): ${err instanceof Error ? err.message : String(err)}`,
+        "Nothing was written. This read is what lets a deleted collection be withdrawn from staging, so deploying without it would leave a stale schema behind for publish to trip over.",
+      ],
+    };
+  }
+}
+
+export type DeployResult = DeploySuccess | SharedAppFailure;
+
+export async function deploySharedApp(root: string, opts: SharedAppOptions = {}): Promise<DeployResult> {
+  const context = await sharedAppContext(root);
+  if (!context.ok) return context;
+  const { authored, collections, handle } = context;
+
+  const scan = await scanRecords(collections, root);
+  const refusal = recordRefusal(scan, "deploy", opts.confirm);
+  if (refusal) return { ok: false, partial: false, problems: refusal };
+
+  const { aid } = authored;
+  const current = await readCurrentApp(handle, aid);
+  if (!current.ok) return current;
+  const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
+  const stamp: PublishStamp = {
+    uid: handle.uid,
+    email: handle.email,
+    publishedAt: (opts.now ?? Date.now)(),
+    commit: stampSource.commit,
+    dirty: stampSource.dirty,
+  };
+  const existingApp = current.app;
+  const deployed = projectDeploy(authored, schemasOf(collections), stamp, existingApp);
+
+  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
+  if (!stale.ok) return stale;
+
+  const failure = await runWrites(
+    [
+      { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, deployed.app) },
+      ...deployed.staging.map(({ cid, doc }) => ({
+        what: `the staged schema for '${cid}' (apps/${aid}/staging/${cid})`,
+        run: () => handle.docs.set(appStagingPath(aid), cid, doc),
+      })),
+      // Withdrawals last: they grant nothing, and doing them after the writes keeps a failure
+      // part-way through from leaving the roster with fewer collections than it had.
+      ...stale.cids.map((cid) => ({
+        what: `the withdrawal of the staged schema for '${cid}' (apps/${aid}/staging/${cid})`,
+        run: async (): Promise<void> => {
+          await handle.docs.delete(appStagingPath(aid), cid);
+        },
+      })),
+    ],
+    "deploy",
+  );
+  if (failure) return failure;
+
+  return {
+    ok: true,
+    aid,
+    cids: deployed.staging.map((entry) => entry.cid),
+    withdrawn: stale.cids,
+    created: existingApp === null,
+    commit: stamp.commit,
+    dirty: stampSource.dirty === true,
+    recordIssues: scan.records,
+    recordIssuesCapped: scan.capped,
+  };
+}

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -1,0 +1,172 @@
+// publish — promote what the roster tested, and open it LAST.
+//
+// The one dangerous operation in a shared app (design D10). Merging a pull request changes
+// nobody's screen; publishing changes everyone's, immediately, and in two ways at once: a breaking
+// schema change leaves live records inconsistent with the schema that is now supposed to describe
+// them, and — because a view is HTML — the right to publish is in practice the right to run
+// JavaScript in every member's browser.
+//
+// Two properties are load-bearing and neither is obvious from the call site:
+//
+//   - it PROMOTES `staging/{cid}` rather than re-projecting the working tree, so what shipped is
+//     what the roster reviewed;
+//   - it writes `apps/{aid}.public` LAST, as its own write, because that block — not the
+//     world-readable `config/public` projection — is what the rules read to authorize anonymous
+//     access. A run that stops part-way therefore leaves the app private.
+//
+// A re-publish passes through a moment with no `public` block. That is a brief denial for
+// visitors, not a brief exposure, and it is the trade the ordering is chosen for.
+import { isRecord } from "../../../common/isRecord.js";
+import {
+  APPS_COLLECTION,
+  PUBLIC_CONFIG_DOC,
+  appConfigPath,
+  appSchemasPath,
+  promoteSchema,
+  projectPublish,
+  type LoadedCollection,
+  type PublishStamp,
+} from "@mulmoclaude/core/collection/server";
+import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { recordRefusal, scanRecords } from "./records.js";
+import { readStaged, type StagedEntry } from "./staged.js";
+import { runWrites, type WriteStep } from "./writes.js";
+
+export interface PublishSuccess {
+  ok: true;
+  aid: string;
+  cids: string[];
+  /** Whether this publish left the app open to anonymous visitors. False is a normal outcome — a
+   *  declaration with no `public` block publishes the schemas to the roster's URL and grants the
+   *  world nothing — and it is the one thing an operator is most likely to assume wrongly. */
+  publicOpen: boolean;
+  commit?: string | undefined;
+  dirty: boolean;
+  recordIssues: number;
+  recordIssuesCapped: boolean;
+}
+
+export type PublishResult = PublishSuccess | SharedAppFailure;
+
+/** The staged version as something the record scan can run against: this repository's collection,
+ *  with the STAGED schema in place of the one on disk.
+ *
+ *  Validating the working tree's schema would answer the wrong question — the tree may have moved
+ *  on since the deploy, and the version being promoted is the staged one. */
+function stagedForValidation(
+  staged: readonly StagedEntry[],
+  collections: readonly LoadedCollection[],
+): { ok: true; collections: LoadedCollection[] } | { ok: false; problems: string[] } {
+  const byCid = new Map(collections.map((collection) => [collection.slug, collection]));
+  const scanned: LoadedCollection[] = [];
+  const problems: string[] = [];
+  for (const entry of staged) {
+    const collection = byCid.get(entry.cid);
+    if (!collection) {
+      // Fail closed rather than promote it unchecked: the records live in the app and would be
+      // read under this schema by everyone, and nothing here can tell whether they still fit.
+      problems.push(
+        `'${entry.cid}' is staged but is not a collection in this repository any more, so its live records cannot be checked against the version about to be published. ` +
+          "Run deploy again — it re-stages what the repository actually has and drops what it does not.",
+      );
+      continue;
+    }
+    scanned.push({ ...collection, schema: entry.doc.publishedSchema });
+  }
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, collections: scanned };
+}
+
+/** The writes, in the order the design fixes: promote, project, then open. */
+function publishSteps(
+  handle: SharedAppHandle,
+  aid: string,
+  staged: readonly StagedEntry[],
+  stamp: PublishStamp,
+  face: ReturnType<typeof projectPublish>,
+): WriteStep[] {
+  return [
+    ...staged.map(({ cid, doc }) => ({
+      what: `the published schema for '${cid}' (apps/${aid}/collections/${cid})`,
+      run: () => handle.docs.set(appSchemasPath(aid), cid, promoteSchema(doc, stamp)),
+    })),
+    {
+      what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
+      run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, face.config),
+    },
+    // The app document WITHOUT `public`: the promoted rule configuration lands with the schemas it
+    // was staged beside, so the public write path is never judged by one version's constraints
+    // against another's schema.
+    { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, face.app) },
+    // LAST, and only when the declaration asks for it. This is the authorization itself.
+    ...(face.public === undefined
+      ? []
+      : [
+          {
+            what: `the public block on apps/${aid} — the authorization itself`,
+            run: () => handle.docs.set(APPS_COLLECTION, aid, { ...face.app, public: face.public }),
+          },
+        ]),
+  ];
+}
+
+export async function publishSharedApp(root: string, opts: SharedAppOptions = {}): Promise<PublishResult> {
+  const context = await sharedAppContext(root);
+  if (!context.ok) return context;
+  const { authored, collections, handle } = context;
+  const { aid } = authored;
+
+  const staged = await readStaged(handle, aid);
+  if (!staged.ok) return { ...staged, partial: false };
+  if (staged.staged.length === 0) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `nothing is staged for apps/${aid}, so there is nothing to promote. Run deploy first — publish promotes what the roster reviewed at /staging/${aid} rather than reading the working tree.`,
+      ],
+    };
+  }
+
+  const toScan = stagedForValidation(staged.staged, collections);
+  if (!toScan.ok) return { ...toScan, partial: false };
+  const scan = await scanRecords(toScan.collections, root);
+  const refusal = recordRefusal(scan, "publish", opts.confirm);
+  if (refusal) return { ok: false, partial: false, problems: refusal };
+
+  let existing: unknown;
+  try {
+    existing = await handle.docs.get(APPS_COLLECTION, aid);
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `publish failed while reading the current app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Nothing was written. Publishing again is safe — this read carries `owner` forward and decides what a rollback would restore.",
+      ],
+    };
+  }
+  const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
+  const stamp: PublishStamp = {
+    uid: handle.uid,
+    email: handle.email,
+    publishedAt: (opts.now ?? Date.now)(),
+    commit: stampSource.commit,
+    dirty: stampSource.dirty,
+  };
+  const face = projectPublish(authored, staged.staged, stamp, isRecord(existing) ? existing : null);
+
+  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face), "publish");
+  if (failure) return failure;
+
+  return {
+    ok: true,
+    aid,
+    cids: staged.staged.map((entry) => entry.cid),
+    publicOpen: face.public !== undefined,
+    commit: stamp.commit,
+    dirty: stampSource.dirty === true,
+    recordIssues: scan.records,
+    recordIssuesCapped: scan.capped,
+  };
+}

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -1,0 +1,80 @@
+// The migration gate: existing records that would not satisfy the schema about to be written.
+//
+// Read from FIRESTORE, not from disk — a shared collection's records live in the app, and the
+// question is what the LIVE data looks like under the new schema. Reported as a refusal the
+// operator can override, because a breaking change is sometimes exactly what is intended; the
+// point is that it is a decision rather than a discovery.
+//
+// It runs at BOTH boundaries (design D10). Deploy's `confirm` lets a draft into staging on
+// purpose — mid-migration, that is the useful thing — so publish re-runs the scan against the
+// version it is about to promote rather than trusting that deploy was clean. A confirm spent on
+// staging must not buy the public.
+import { MAX_RECORD_ISSUES, STORE_UNREADABLE, validateCollectionRecords, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+
+/** How many broken records to name before summarising. A write that would break a thousand rows
+ *  is answered by the count and a sample; dumping all of them buries the number, which is the
+ *  part the decision turns on. */
+const MAX_LISTED_ISSUES = 10;
+
+export interface RecordScan {
+  lines: string[];
+  records: number;
+  capped: boolean;
+  /** Collections whose records could not be READ at all. Kept apart from `lines` because
+   *  `confirm` may not override them. */
+  unreadable: string[];
+}
+
+export async function scanRecords(collections: readonly LoadedCollection[], workspaceRoot: string): Promise<RecordScan> {
+  const lines: string[] = [];
+  const unreadable: string[] = [];
+  let records = 0;
+  let cappedAnywhere = false;
+  for (const collection of collections) {
+    const issues = await validateCollectionRecords(collection, { workspaceRoot });
+    if (issues.length === 0) continue;
+    // "the backend could not be read" is not a broken record, and must not be overridable the way
+    // a broken record is: `confirm` means "I know these rows will not fit the new schema", and
+    // here nobody knows anything — the gate did not run. Overriding it would write blind.
+    const unread = issues.filter((issue) => issue.file === STORE_UNREADABLE);
+    if (unread.length > 0) {
+      unreadable.push(`${collection.slug}: ${unread.map((issue) => issue.problem).join("; ")}`);
+      continue;
+    }
+    records += issues.length;
+    // `validateCollectionRecords` stops at its own cap (25 per collection), so a full batch means
+    // "at least this many" and saying otherwise would read as a complete count of the damage.
+    const capped = issues.length >= MAX_RECORD_ISSUES;
+    cappedAnywhere = cappedAnywhere || capped;
+    const count = capped ? `at least ${issues.length}` : String(issues.length);
+    const plural = issues.length === 1 ? "" : "s";
+    const note = capped ? " (the scan stops there)" : "";
+    lines.push(`${collection.slug}: ${count} existing record${plural} would not satisfy the schema about to be written${note}`);
+    for (const issue of issues.slice(0, MAX_LISTED_ISSUES)) lines.push(`  - ${issue.file}: ${issue.problem}`);
+    if (issues.length > MAX_LISTED_ISSUES) lines.push(`  - … and ${issues.length - MAX_LISTED_ISSUES} more`);
+  }
+  return { lines, records, capped: cappedAnywhere, unreadable };
+}
+
+/** The scan as a refusal, or null when the operation may proceed.
+ *
+ *  `what` names the boundary in both messages, because the two differ in what confirming COSTS:
+ *  a confirmed deploy is visible to the roster, a confirmed publish to everyone. */
+export function recordRefusal(scan: RecordScan, what: "deploy" | "publish", confirm: boolean | undefined): string[] | null {
+  if (scan.unreadable.length > 0) {
+    return [
+      ...scan.unreadable,
+      `${what} stopped: the live records could not be read, so nothing checked whether the schemas about to be written still fit them. ` +
+        "This is not something `confirm` overrides — confirming means accepting a known breakage, and here there is no reading at all. " +
+        "Fix the access (or the connection) and try again.",
+    ];
+  }
+  if (scan.records === 0 || confirm === true) return null;
+  return [
+    ...scan.lines,
+    what === "deploy"
+      ? "deploy stopped: these records are live and the roster is reading them. Migrate them first, or re-run with confirm to stage the schema anyway and repair the records afterwards."
+      : "publish stopped: this is the version about to become public, and these records do not fit it. " +
+        "A confirm given to deploy is deliberately not inherited here — re-run publish with confirm to accept the breakage for everyone, or migrate the records first.",
+  ];
+}

--- a/server/backends/sharedApp/staged.ts
+++ b/server/backends/sharedApp/staged.ts
@@ -1,0 +1,55 @@
+// Reading back what deploy staged.
+//
+// The staged documents are the thing publish promotes — NOT the working tree. That is the whole
+// point of the split: what the roster tested through `/staging/{aid}` is exactly what ships, where
+// re-projecting from disk would publish whatever the tree says at publish time, which nobody has
+// looked at.
+//
+// They come back from Firestore as `unknown`, and they are documents a previous version of this
+// code (or a hand edit) could have written, so they are checked rather than asserted.
+import { isRecord } from "../../../common/isRecord.js";
+import { appStagingPath, type StagedSchemaDoc } from "@mulmoclaude/core/collection/server";
+import type { SharedAppHandle } from "./context.js";
+
+/** A checked narrowing rather than an assertion: these documents come back from Firestore as
+ *  `unknown`, and a hand edit or an older version of this code could have written anything.
+ *
+ *  The provenance keys are part of the check, not decoration. A staged document always carries
+ *  them (deploy writes them in the same projection as the schema), so one that does not is not a
+ *  document this code wrote — and promoting it would publish a schema nobody can attribute. */
+function isStagedDoc(value: unknown): value is StagedSchemaDoc {
+  return isRecord(value) && isRecord(value.publishedSchema) && typeof value.deployedAt === "number" && typeof value.deployedBy === "string";
+}
+
+export interface StagedEntry {
+  cid: string;
+  doc: StagedSchemaDoc;
+}
+
+/** Everything under `apps/{aid}/staging`, in document-id order, or the reason it could not be
+ *  read. A document missing `publishedSchema` is reported rather than skipped: silently dropping
+ *  it would publish an app with one collection fewer than the roster reviewed. */
+export async function readStaged(handle: SharedAppHandle, aid: string): Promise<{ ok: true; staged: StagedEntry[] } | { ok: false; problems: string[] }> {
+  let docs;
+  try {
+    docs = await handle.docs.list(appStagingPath(aid));
+  } catch (err) {
+    return {
+      ok: false,
+      problems: [`cannot read the staged schemas (apps/${aid}/staging): ${err instanceof Error ? err.message : String(err)}`, "Nothing was written."],
+    };
+  }
+  const staged: StagedEntry[] = [];
+  const problems: string[] = [];
+  for (const doc of docs) {
+    if (isStagedDoc(doc.data)) {
+      staged.push({ cid: doc.id, doc: doc.data });
+      continue;
+    }
+    problems.push(
+      `apps/${aid}/staging/${doc.id} is not a staged schema — it carries no publishedSchema, or no record of the deploy that wrote it — ` +
+        `so there is nothing to promote for '${doc.id}'. Run deploy again.`,
+    );
+  }
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, staged };
+}

--- a/server/backends/sharedApp/unpublish.ts
+++ b/server/backends/sharedApp/unpublish.ts
@@ -1,0 +1,77 @@
+// unpublish — close the app to anonymous visitors, first thing and on its own.
+//
+// The exact reverse of publish's order (design D10): `apps/{aid}.public` is the authorization, so
+// removing it goes FIRST. A run that stops after that leaves the app closed with a stale public
+// projection behind it, which is a tidiness problem; the other order would leave it open with the
+// projection gone, which is the failure this ordering exists to make impossible.
+//
+// The promoted schemas under `collections/{cid}` are deliberately LEFT: nobody can read them
+// while the app is closed, so they cost nothing, and re-publishing is then a promotion rather
+// than a rebuild.
+//
+// It deliberately does NOT run the declaration gate that deploy and publish share. Those gates
+// decide whether something may go OUT; taking it down has to work when the declaration is broken,
+// which is one of the times an operator most wants it. Only the `aid` is read from `app.json`.
+import { isRecord } from "../../../common/isRecord.js";
+import { APPS_COLLECTION, PUBLIC_CONFIG_DOC, appConfigPath, appManifestReason, firestoreHandle, loadAppManifest } from "@mulmoclaude/core/collection/server";
+import type { SharedAppFailure } from "./context.js";
+import { runWrites } from "./writes.js";
+
+export interface UnpublishSuccess {
+  ok: true;
+  aid: string;
+  /** Was it open in the first place? An unpublish of an already-closed app is a no-op worth
+   *  saying out loud — the operator asked for a state, and hearing "done" when nothing changed
+   *  reads as confirmation that it HAD been open. */
+  wasOpen: boolean;
+}
+
+export type UnpublishResult = UnpublishSuccess | SharedAppFailure;
+
+export async function unpublishSharedApp(root: string): Promise<UnpublishResult> {
+  const handle = firestoreHandle();
+  if (!handle) {
+    return { ok: false, partial: false, problems: ["unpublish needs a signed-in Firestore session: connect remote-host first."] };
+  }
+  const manifest = loadAppManifest(root);
+  if (!manifest.ok) return { ok: false, partial: false, problems: [appManifestReason(manifest, root)] };
+  const { aid } = manifest.manifest;
+
+  let existing: unknown;
+  try {
+    existing = await handle.docs.get(APPS_COLLECTION, aid);
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [`unpublish failed while reading the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`, "Nothing was written."],
+    };
+  }
+  if (!isRecord(existing)) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [`there is no app document at apps/${aid}, so there is nothing to close. Nothing was written.`],
+    };
+  }
+  // Replacement without the key, because a merge cannot DELETE — and here the deletion IS the
+  // operation. Everything else is carried through from the document as it stands rather than
+  // re-projected, so closing the app cannot also apply an unrelated edit nobody asked to publish.
+  const closed = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== "public"));
+  const wasOpen = "public" in existing;
+
+  const failure = await runWrites(
+    [
+      { what: `the public block on apps/${aid} — the authorization itself`, run: () => handle.docs.set(APPS_COLLECTION, aid, closed) },
+      {
+        what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
+        run: async () => {
+          await handle.docs.delete(appConfigPath(aid), PUBLIC_CONFIG_DOC);
+        },
+      },
+    ],
+    "unpublish",
+  );
+  if (failure) return failure;
+  return { ok: true, aid, wasOpen };
+}

--- a/server/backends/sharedApp/writes.ts
+++ b/server/backends/sharedApp/writes.ts
@@ -1,0 +1,57 @@
+// Ordered writes, and what a half-finished one leaves behind.
+//
+// The ORDER is the design (D10), and it is different for each operation because the thing being
+// protected is the same in all three: `apps/{aid}.public` is what the rules read to authorize
+// anonymous access, so it goes LAST when opening and FIRST when closing. A run that stops
+// part-way then leaves the app private, which is the direction to fail in.
+//
+// `FirestoreDocs` has no batch — it is a document seam, deliberately — so the order is kept by
+// running the steps in sequence and reporting exactly where it stopped. A summary written for one
+// failure point is wrong at the others, so the report ENUMERATES what landed.
+import type { SharedAppFailure } from "./context.js";
+
+export interface WriteStep {
+  /** Named as the operator would name it, because it is printed both as the failure and as part
+   *  of the list of what is live. */
+  what: string;
+  run: () => Promise<void>;
+}
+
+/** Run the steps in order. Returns null when every one landed, a failure otherwise. */
+export async function runWrites(steps: readonly WriteStep[], what: string): Promise<SharedAppFailure | null> {
+  const landed: string[] = [];
+  for (const [index, step] of steps.entries()) {
+    try {
+      await step.run();
+      landed.push(step.what);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        // The whole reason the flag exists: this is the one failure where documents ARE live.
+        partial: index > 0,
+        problems: [
+          `${what} failed while writing ${step.what}: ${reason}`,
+          // The failed step belongs to "not written" — it is the first thing that did not land.
+          ...partialState(landed, [step.what, ...steps.slice(index + 1).map((rest) => rest.what)], what),
+        ],
+      };
+    }
+  }
+  return null;
+}
+
+/** What is live and what is not, listed rather than summarised.
+ *
+ *  Two facts, and both matter for the repair: a document this run wrote is live NOW, and a
+ *  document it did not write still holds what the LAST run left — which is not the same as being
+ *  absent, and not the same as matching the declaration that was just half-applied. */
+function partialState(landed: readonly string[], notWritten: readonly string[], what: string): string[] {
+  const repair = `Running ${what} again is the repair: the write is idempotent, and it re-does every step, including the ones that did land.`;
+  if (landed.length === 0) return [`Nothing was written. ${repair}`];
+  return [
+    `Written by this ${what}, and live now: ${landed.join("; ")}.`,
+    `NOT written: ${notWritten.join("; ")} — ${notWritten.length === 1 ? "it still holds" : "they still hold"} whatever the previous ${what} left.`,
+    repair,
+  ];
+}

--- a/server/infra/host-tools.ts
+++ b/server/infra/host-tools.ts
@@ -7,6 +7,7 @@
 import type { ToolDefinition } from "gui-chat-protocol";
 import { MANAGE_ACCOUNTING } from "./accounting-tool.js";
 import { MANAGE_COLLECTION } from "./collection-tool.js";
+import { MANAGE_SHARED_APP } from "./shared-app-tool.js";
 
 // Mirrors MulmoClaude's spawnBackgroundChat signature (message/role/hidden) so the
 // tool is a drop-in from the model's point of view — but the implementation is
@@ -52,4 +53,6 @@ export const SPAWN_BACKGROUND_CHAT: ToolDefinition = {
 // manageCollection is the shared collection data plane from
 // @mulmoclaude/core/collection/server, bound in collection-tool.ts; its dispatch
 // route calls the engine handler in-process.
-export const HOST_TOOL_DEFINITIONS: ToolDefinition[] = [SPAWN_BACKGROUND_CHAT, MANAGE_ACCOUNTING, MANAGE_COLLECTION];
+// manageSharedApp is MulmoTerminal's OWN — the deploy/publish/unpublish operations on a shared
+// app, which core deliberately does not have (see shared-app-tool.ts).
+export const HOST_TOOL_DEFINITIONS: ToolDefinition[] = [SPAWN_BACKGROUND_CHAT, MANAGE_ACCOUNTING, MANAGE_COLLECTION, MANAGE_SHARED_APP];

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -1,0 +1,119 @@
+// manageSharedApp — MulmoTerminal's own tool for the three shared-app operations.
+//
+// It is NOT an action on `manageCollection`. That tool's definition and dispatch both live in
+// `@mulmoclaude/core`, so adding to it would be a change to MulmoClaude for a feature only
+// MulmoTerminal has — the boundary this design fixed (D5). Core keeps the pure half: parsing the
+// declaration, deciding what is wrong with it, projecting documents. What is here, and in
+// `server/backends/sharedApp/`, is the operation: the order the documents are written in, and
+// what a half-finished write leaves behind.
+//
+// There is exactly ONE write path to a shared app, and this is it. Core's whole-app `publishApp`
+// was deleted rather than left unused (mulmoclaude #2871) because MulmoTerminal declares the
+// shared-collections capability and binds the Firestore accessor — an action left in core would
+// simply work here, and it wrote `public` without ever passing through staging.
+import type { ToolDefinition } from "gui-chat-protocol";
+import { deploySharedApp } from "../backends/sharedApp/deploy.js";
+import { publishSharedApp } from "../backends/sharedApp/publish.js";
+import { unpublishSharedApp } from "../backends/sharedApp/unpublish.js";
+import { isRecord } from "../../common/isRecord.js";
+
+export const SHARED_APP_ACTIONS = ["deploy", "publish", "unpublish"] as const;
+export type SharedAppAction = (typeof SHARED_APP_ACTIONS)[number];
+
+export const MANAGE_SHARED_APP: ToolDefinition = {
+  type: "function",
+  name: "manageSharedApp",
+  description:
+    "Deploy, publish or unpublish this repository's shared app (the one declared by its app.json). " +
+    "deploy stages the declaration and the collection schemas where only the app's roster can see them; publish promotes what was staged and opens the app to the public; unpublish closes it again.",
+  prompt:
+    "`manageSharedApp` operates on the repository the session is open in — the one holding `app.json` — and it is the only way to write a shared app.\n" +
+    "**deploy** is the safe one and is meant to be run often. It writes the roster and internal settings to `apps/{aid}` and each collection's schema to `apps/{aid}/staging/{cid}`, which only people on the roster can read. " +
+    "An invitation added to `members` takes effect at deploy, so the roster can try the real app at `/staging/{aid}` before anybody outside sees it. Deploy never opens the app to the public, and never changes what a published app's visitors are looking at.\n" +
+    "**publish** is the dangerous one. It promotes the STAGED schemas — not the working tree, so what ships is what the roster reviewed — and then opens the app. Publish it only when the user asks for it in those terms.\n" +
+    "**unpublish** closes the app to the public and leaves the promoted schemas in place, so publishing again is a promotion rather than a rebuild.\n" +
+    "Both deploy and publish refuse when live records would not satisfy the schema being written, and list the records. `confirm: true` overrides that refusal — ask the user first, and note that confirming a deploy does NOT carry over to publish: the second refusal is about the same records reaching everyone.",
+  parameters: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: [...SHARED_APP_ACTIONS],
+        description: "deploy = stage for the roster; publish = promote the staged version and open it; unpublish = close it again.",
+      },
+      confirm: {
+        type: "boolean",
+        description:
+          "Write the schema although live records do not satisfy it. Applies to deploy and publish separately — a confirmed deploy still meets publish's own refusal.",
+      },
+    },
+    required: ["action"],
+  },
+};
+
+function parseAction(raw: unknown): SharedAppAction | null {
+  if (typeof raw !== "string") return null;
+  return SHARED_APP_ACTIONS.find((action) => action === raw) ?? null;
+}
+
+/** A stamp line both successes end with, because "which commit is this?" is the first question
+ *  asked of a shared app that behaves unexpectedly — and `dirty` is the answer that matters, a
+ *  commit that does not describe what was written being worse than no commit at all. */
+function provenance(commit: string | undefined, dirty: boolean): string {
+  if (commit === undefined) return "No commit was recorded (no git, or no commits yet).";
+  return dirty ? `Recorded commit ${commit}, but the working tree was MODIFIED — the commit does not describe what was written.` : `Recorded commit ${commit}.`;
+}
+
+function recordNote(issues: number, capped: boolean): string[] {
+  if (issues === 0) return [];
+  const count = capped ? `at least ${issues}` : String(issues);
+  return [`${count} live record${issues === 1 ? "" : "s"} do not satisfy the schema that was just written (you confirmed this) — they need repairing.`];
+}
+
+async function narrateDeploy(root: string, confirm: boolean): Promise<string> {
+  const result = await deploySharedApp(root, { confirm });
+  if (!result.ok) return result.problems.join("\n");
+  const plural = result.cids.length === 1 ? "" : "s";
+  return [
+    `${result.created ? "Created" : "Updated"} apps/${result.aid} and staged ${result.cids.length} collection${plural}: ${result.cids.join(", ") || "(none)"}.`,
+    `The roster can try it at /staging/${result.aid}. Nothing is public until you publish.`,
+    ...(result.withdrawn.length > 0 ? [`Withdrawn from staging (no longer in this repository): ${result.withdrawn.join(", ")}.`] : []),
+    ...recordNote(result.recordIssues, result.recordIssuesCapped),
+    provenance(result.commit, result.dirty),
+  ].join("\n");
+}
+
+async function narratePublish(root: string, confirm: boolean): Promise<string> {
+  const result = await publishSharedApp(root, { confirm });
+  if (!result.ok) return result.problems.join("\n");
+  const plural = result.cids.length === 1 ? "" : "s";
+  return [
+    `Published apps/${result.aid}: promoted ${result.cids.length} staged collection${plural} (${result.cids.join(", ")}).`,
+    result.publicOpen
+      ? "The app is now OPEN to anonymous visitors."
+      : "The app is NOT open to anonymous visitors — app.json declares no `public` block, so the promoted schemas are readable only by the roster.",
+    ...recordNote(result.recordIssues, result.recordIssuesCapped),
+    provenance(result.commit, result.dirty),
+  ].join("\n");
+}
+
+async function narrateUnpublish(root: string): Promise<string> {
+  const result = await unpublishSharedApp(root);
+  if (!result.ok) return result.problems.join("\n");
+  return result.wasOpen
+    ? `Unpublished apps/${result.aid}: the public block is gone, so anonymous access is closed, and the public config document was deleted. ` +
+        "The promoted schemas were left in place, so publishing again is a promotion."
+    : `apps/${result.aid} was already closed to the public — nothing was open to take down. The public config document was deleted if it was still there.`;
+}
+
+/** Run one action against `root` and narrate the result. The agent's whole contract with this
+ *  tool is actionable prose, so a refusal is text and never a throw. */
+export async function manageSharedApp(root: string, args: unknown): Promise<string> {
+  const body = isRecord(args) ? args : {};
+  const action = parseAction(body.action);
+  if (action === null) return `manageSharedApp: action must be one of ${SHARED_APP_ACTIONS.join(", ")}.`;
+  const confirm = body.confirm === true;
+  if (action === "deploy") return narrateDeploy(root, confirm);
+  if (action === "publish") return narratePublish(root, confirm);
+  return narrateUnpublish(root);
+}

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -23,6 +23,7 @@ import { SESSION_ID_RE } from "../config/env.js";
 import { cwdForSession } from "../session/session-cwd.js";
 import { projectScopeForCwd, rootForProjectId } from "../infra/project-root.js";
 import { manageCollectionHandlerFor } from "../infra/collection-tool.js";
+import { manageSharedApp } from "../infra/shared-app-tool.js";
 import { upstreamFailureMessage } from "./plugin-narration.js";
 import type { SpawnClaudePty, SpawnCodexPty, SpawnAntigravityPty, SpawnGrokPty, SpawnMusePty } from "../session/spawners.js";
 
@@ -195,6 +196,13 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     }
   });
 
+  mountCollectionRoute(app);
+  mountSharedAppRoute(app);
+}
+
+/** Split out of `mountPluginRoutes` for its line budget. Both of these are host-tool dispatch
+ *  routes and belong beside each other; only the enclosing function's size moved them out. */
+function mountCollectionRoute(app: Express): void {
   // Host tool: manageCollection — the shared collection data plane
   // (@mulmoclaude/core/collection/server, bound in server/infra/collection-tool.ts).
   // The engine runs in-process against the configured workspace, so the route calls the
@@ -219,6 +227,28 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     } catch (err) {
       console.error(`[manageCollection] dispatch failed: ${messageOf(err)}`);
       return res.json({ message: `manageCollection failed: ${messageOf(err)}` });
+    }
+  });
+}
+
+function mountSharedAppRoute(app: Express): void {
+  // Host tool: manageSharedApp — deploy / publish / unpublish for the shared app declared by the
+  // repository's app.json (server/infra/shared-app-tool.ts). MulmoTerminal's own; there is no
+  // counterpart in MulmoClaude to match, which is the point of the tool existing here.
+  //
+  // Scoped to the SESSION's directory for the same reason manageCollection is: an app is a
+  // REPOSITORY, and "deploy this app" means the one the cell is open in. Resolving it to the
+  // workspace would deploy a different app than the agent is looking at — and unlike a misplaced
+  // collection, that one is visible to other people the moment it lands.
+  app.post("/api/plugin/manageSharedApp", async (req, res) => {
+    try {
+      const header = req.get(SESSION_HEADER);
+      const sessionId = header && SESSION_ID_RE.test(header) ? header : null;
+      const root = projectScopeForCwd(cwdForSession(sessionId)).workspaceRoot;
+      return res.json({ message: await manageSharedApp(root, req.body) });
+    } catch (err) {
+      console.error(`[manageSharedApp] dispatch failed: ${messageOf(err)}`);
+      return res.json({ message: `manageSharedApp failed: ${messageOf(err)}` });
     }
   });
 }

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -232,6 +232,7 @@ const TOOL_HINTS = new Map<string, string>([
   ["presentCollection", "a collection from this workspace, laid out to browse"],
   ["manageCollection", "reads and writes those collections and their schemas"],
   ["manageAccounting", "reads and writes the workspace's books"],
+  ["manageSharedApp", "deploys this repository's shared app to its roster, and publishes it"],
 
   ["generateImage", "an image generated from a prompt"],
   ["presentMulmoScript", "a MulmoScript presentation, built and played here"],

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -1,0 +1,266 @@
+// @vitest-environment node
+//
+// The three shared-app operations, exercised end to end against an in-memory Firestore.
+//
+// What is pinned here is ORDER and OWNERSHIP, because those are what MulmoTerminal added and what
+// nothing else checks. The projections are core's and are tested there; the failure this file
+// exists to catch is a write landing in the wrong sequence — `apps/{aid}.public` is what the
+// deployed rules read to authorize anonymous access, so a deploy that wrote it would open an app
+// somebody was only testing, and a publish that wrote it FIRST would leave anonymous access live
+// against a half-published surface if the next write failed.
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs, type FirestoreDoc } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { deploySharedApp } from "../../../server/backends/sharedApp/deploy.js";
+import { publishSharedApp } from "../../../server/backends/sharedApp/publish.js";
+import { unpublishSharedApp } from "../../../server/backends/sharedApp/unpublish.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const AID = "app-under-test";
+const OWNER = { uid: "uid-owner", email: "owner@example.com" };
+
+/** An in-memory `FirestoreDocs` that REMEMBERS THE ORDER of writes. The order is the assertion in
+ *  half this file, and a store that only kept final state would pass every one of these tests
+ *  while the app opened before it had anything to show. */
+class FakeDocs implements FirestoreDocs {
+  readonly store = new Map<string, Map<string, Record<string, unknown>>>();
+  readonly writes: string[] = [];
+  /** Path/id whose next write throws — how a half-finished run is produced. */
+  failAt: string | null = null;
+
+  private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
+    const existing = this.store.get(collectionPath);
+    if (existing) return existing;
+    const created = new Map<string, Record<string, unknown>>();
+    this.store.set(collectionPath, created);
+    return created;
+  }
+
+  list = (collectionPath: string): Promise<FirestoreDoc[]> =>
+    Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+
+  get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
+
+  set = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<void> => {
+    const key = `${collectionPath}/${docId}`;
+    if (this.failAt === key) return Promise.reject(new Error("permission-denied (test)"));
+    this.writes.push(`set ${key}`);
+    this.bucket(collectionPath).set(docId, structuredClone(data));
+    return Promise.resolve();
+  };
+
+  create = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<boolean> => {
+    if (this.bucket(collectionPath).has(docId)) return Promise.resolve(false);
+    this.writes.push(`create ${collectionPath}/${docId}`);
+    this.bucket(collectionPath).set(docId, structuredClone(data));
+    return Promise.resolve(true);
+  };
+
+  delete = (collectionPath: string, docId: string): Promise<boolean> => {
+    this.writes.push(`delete ${collectionPath}/${docId}`);
+    return Promise.resolve(this.bucket(collectionPath).delete(docId));
+  };
+
+  watch = (): (() => void) => () => {};
+
+  app = (): Record<string, unknown> | undefined => this.store.get("apps")?.get(AID);
+  doc = (collectionPath: string, docId: string): Record<string, unknown> | undefined => this.store.get(collectionPath)?.get(docId);
+}
+
+let docs = new FakeDocs();
+
+const schemaFor = (slug: string) => ({
+  title: slug,
+  icon: "star",
+  primaryKey: "id",
+  // Exactly one of dataPath / dataSource / storage — a shared collection's records are in the
+  // app, so it declares the backend and no local path at all.
+  storage: { type: "firestore" },
+  fields: { id: { type: "string", label: "ID", primary: true, required: true }, note: { type: "string", label: "Note" } },
+});
+
+function writeCollection(root: string, slug: string): void {
+  mkdirSync(path.join(root, ".claude", "skills", slug), { recursive: true });
+  writeFileSync(path.join(root, ".claude", "skills", slug, "schema.json"), JSON.stringify(schemaFor(slug)));
+}
+
+function writeApp(root: string, app: Record<string, unknown>): void {
+  writeFileSync(path.join(root, "app.json"), JSON.stringify(app));
+}
+
+/** A declaration with the roster the rules require: the publisher as owner of everything. */
+const declaration = (extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  aid: AID,
+  name: "App Under Test",
+  members: { [OWNER.email]: { "*": "owner" } },
+  ...extra,
+});
+
+const stamp = { now: () => 1_700_000_000_000, resolveCommit: () => Promise.resolve({ commit: "c0ffee", dirty: false }) };
+
+let root = "";
+
+describe("shared app deploy / publish / unpublish", () => {
+  beforeAll(() => {
+    // ONE binding per file — `configureCollectionHost` refuses a second call with a different host.
+    initCollectionsBackend({ workspace: makeTempDir("mt-shared-app-ws-") });
+    setSharedCollectionsSupport(true);
+    setFirestoreAccessor(() => ({ docs, email: OWNER.email, uid: OWNER.uid }));
+  });
+
+  beforeEach(() => {
+    docs = new FakeDocs();
+    root = makeTempDir("mt-shared-app-");
+    writeApp(root, declaration());
+    writeCollection(root, "bookings");
+  });
+
+  it("deploys to the roster only — no public block, no published schema, no public config", async () => {
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(true);
+    // The one that matters: `publicOn` reads THIS field, not the world-readable projection, so a
+    // deploy that wrote it would open the app for anyone testing.
+    expect(docs.app()).not.toHaveProperty("public");
+    expect(docs.app()?.memberEmails).toEqual([OWNER.email]);
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toMatchObject({ deployedBy: OWNER.email, deployedCommit: "c0ffee" });
+    // The two documents the public page reads. Deploy must leave a LIVE app looking exactly as it did.
+    expect(docs.store.get(`apps/${AID}/collections`)).toBeUndefined();
+    expect(docs.store.get(`apps/${AID}/config`)).toBeUndefined();
+  });
+
+  it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
+    await deploySharedApp(root, stamp);
+    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+  });
+
+  it("does not silently unpublish a live app when it is deployed again", async () => {
+    writeApp(root, declaration({ public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    await publishSharedApp(root, stamp);
+    expect(docs.app()?.public).toMatchObject({ enabled: true });
+
+    // The declaration is replaced, not merged — carrying `public` forward is what keeps a
+    // replacement from revoking the publish.
+    await deploySharedApp(root, stamp);
+    expect(docs.app()?.public).toMatchObject({ enabled: true });
+  });
+
+  it("refuses to publish what was never staged", async () => {
+    const result = await publishSharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("nothing is staged");
+    expect(result.ok === false && result.partial).toBe(false);
+  });
+
+  it("promotes the staged version and opens the app LAST", async () => {
+    writeApp(root, declaration({ public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    docs.writes.length = 0;
+
+    const result = await publishSharedApp(root, stamp);
+    expect(result.ok).toBe(true);
+    expect(result.ok === true && result.publicOpen).toBe(true);
+    // Promotion first, the projection next, and the authorization at the very end.
+    expect(docs.writes).toEqual([`set apps/${AID}/collections/bookings`, `set apps/${AID}/config/public`, `set apps/${AID}`, `set apps/${AID}`]);
+    expect(docs.doc(`apps/${AID}/collections`, "bookings")).toMatchObject({ publishedBy: OWNER.email });
+    expect(docs.app()?.public).toMatchObject({ enabled: true });
+  });
+
+  it("leaves the app PRIVATE when a publish fails part-way", async () => {
+    writeApp(root, declaration({ public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    docs.failAt = `apps/${AID}/config/public`;
+
+    const result = await publishSharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    // The whole point of the ordering: documents ARE live, and none of them grants anything.
+    expect(result.ok === false && result.partial).toBe(true);
+    expect(docs.app()).not.toHaveProperty("public");
+    expect(result.ok === false && result.problems.join("\n")).toContain("Written by this publish, and live now");
+  });
+
+  it("publishes the STAGED version, not the working tree", async () => {
+    await deploySharedApp(root, stamp);
+    // The tree moves on after the deploy. Nobody has looked at this through /staging/{aid}.
+    writeFileSync(
+      path.join(root, ".claude", "skills", "bookings", "schema.json"),
+      JSON.stringify({ ...schemaFor("bookings"), title: "Edited after the deploy" }),
+    );
+    await publishSharedApp(root, stamp);
+    const published = docs.doc(`apps/${AID}/collections`, "bookings");
+    expect((published?.publishedSchema as { title: string }).title).toBe("bookings");
+  });
+
+  it("withdraws a staged collection the repository no longer has", async () => {
+    writeCollection(root, "waitlist");
+    await deploySharedApp(root, stamp);
+    expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeDefined();
+
+    // The directory is gone from the next deploy's point of view (discovery reads the tree).
+    writeFileSync(path.join(root, ".claude", "skills", "waitlist", "schema.json"), "not json at all");
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok === true && result.withdrawn).toEqual(["waitlist"]);
+    expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
+    // A withdrawal grants nothing, so it happens after the writes rather than before them.
+    expect(docs.writes.at(-1)).toBe(`delete apps/${AID}/staging/waitlist`);
+  });
+
+  it("closes the app by removing the authorization first, and keeps the promoted schemas", async () => {
+    writeApp(root, declaration({ public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    await publishSharedApp(root, stamp);
+    docs.writes.length = 0;
+
+    const result = await unpublishSharedApp(root);
+    expect(result.ok === true && result.wasOpen).toBe(true);
+    expect(docs.writes).toEqual([`set apps/${AID}`, `delete apps/${AID}/config/public`]);
+    expect(docs.app()).not.toHaveProperty("public");
+    // Nobody can read them while the app is closed, so they cost nothing — and re-publishing is
+    // then a promotion rather than a rebuild.
+    expect(docs.doc(`apps/${AID}/collections`, "bookings")).toBeDefined();
+  });
+
+  it("stops at live records that would not fit the new schema, and confirming stages it anyway", async () => {
+    docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
+    writeFileSync(
+      path.join(root, ".claude", "skills", "bookings", "schema.json"),
+      JSON.stringify({ ...schemaFor("bookings"), fields: { ...schemaFor("bookings").fields, note: { type: "string", label: "Note", required: true } } }),
+    );
+
+    const refused = await deploySharedApp(root, stamp);
+    expect(refused.ok).toBe(false);
+    expect(refused.ok === false && refused.problems.join("\n")).toContain("would not satisfy the schema");
+    expect(docs.app()).toBeUndefined();
+
+    const confirmed = await deploySharedApp(root, { ...stamp, confirm: true });
+    expect(confirmed.ok === true && confirmed.recordIssues).toBe(1);
+  });
+
+  it("does not let a confirmed deploy buy the publish", async () => {
+    // The reason the scan runs at BOTH boundaries: deploy's confirm says "let me stage this
+    // anyway", which mid-migration is the useful thing. It is not the same sentence as "let
+    // everyone have it", so publish asks again and needs its own confirm.
+    docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
+    writeFileSync(
+      path.join(root, ".claude", "skills", "bookings", "schema.json"),
+      JSON.stringify({ ...schemaFor("bookings"), fields: { ...schemaFor("bookings").fields, note: { type: "string", label: "Note", required: true } } }),
+    );
+    await deploySharedApp(root, { ...stamp, confirm: true });
+
+    const refused = await publishSharedApp(root, stamp);
+    expect(refused.ok).toBe(false);
+    expect(refused.ok === false && refused.problems.join("\n")).toContain("not inherited");
+    expect(docs.store.get(`apps/${AID}/collections`)?.get("bookings")).toBeUndefined();
+
+    const confirmed = await publishSharedApp(root, { ...stamp, confirm: true });
+    expect(confirmed.ok).toBe(true);
+  });
+
+  it("says so rather than reporting success when there was nothing open to close", async () => {
+    await deploySharedApp(root, stamp);
+    const result = await unpublishSharedApp(root);
+    expect(result.ok === true && result.wasOpen).toBe(false);
+  });
+});

--- a/test/server/infra/sharedAppTool.spec.ts
+++ b/test/server/infra/sharedAppTool.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+//
+// The tool's contract with the agent is ACTIONABLE PROSE, and that is the part a refusal is most
+// likely to break: an operation that throws reaches the agent as a tool crash, which it will
+// retry rather than report. So every path out of here is a string.
+import { describe, it, expect, beforeAll } from "vitest";
+import { MANAGE_SHARED_APP, SHARED_APP_ACTIONS, manageSharedApp } from "../../../server/infra/shared-app-tool.js";
+import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
+import { groupOfTool } from "../../../common/toolGroups.js";
+import { setFirestoreAccessor, setSharedCollectionsSupport } from "@mulmoclaude/core/collection/server";
+import { makeTempDir } from "../../support/tempDir";
+
+describe("manageSharedApp, the tool", () => {
+  beforeAll(() => {
+    // Signed out on purpose: the operations then refuse, which is the path being pinned.
+    setSharedCollectionsSupport(true);
+    setFirestoreAccessor(null);
+  });
+
+  it("is registered as a host tool and reaches the group the collections live in", () => {
+    expect(HOST_TOOL_DEFINITIONS.map((d) => d.name)).toContain("manageSharedApp");
+    // Ungrouped would mean it is offered only through the all-tools URL — a cell with the
+    // Collections pane would have the store and no way to deploy it.
+    expect(groupOfTool("manageSharedApp")).toBe("data");
+  });
+
+  it("names the three operations in the schema the agent is given", () => {
+    expect(SHARED_APP_ACTIONS).toEqual(["deploy", "publish", "unpublish"]);
+    expect(MANAGE_SHARED_APP.parameters?.properties?.action).toMatchObject({ enum: ["deploy", "publish", "unpublish"] });
+  });
+
+  it("answers an unknown action with the ones that exist", async () => {
+    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), { action: "ship" })).toContain("deploy, publish, unpublish");
+    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), {})).toContain("deploy, publish, unpublish");
+  });
+
+  it("returns every refusal as text rather than throwing", async () => {
+    const root = makeTempDir("mt-shared-tool-");
+    for (const action of SHARED_APP_ACTIONS) {
+      const message = await manageSharedApp(root, { action });
+      expect(typeof message).toBe("string");
+      expect(message).toContain("signed-in Firestore session");
+    }
+  });
+});


### PR DESCRIPTION
実装順 7c。MulmoTerminal 独自のホストツール **`manageSharedApp`** で、共有アプリの
`deploy` / `publish` / `unpublish` を回せるようにする。`@mulmoclaude/core` の変更は **ゼロ**
（3.10.0 の純粋関数をそのまま呼ぶ）。

> この変更は一度 main に直接入っていたため revert し、レビューを通すために PR として
> 出し直しました（内容は同一）。

## なぜ MT のツールなのか

`manageCollection` に action を足すと core の変更になる。共有コレクションは MT だけの機能なので、
**core は「何が正しいか」を判定する純粋な部品**（`parseAuthoredApp` / `publishProblems` /
`projectDeploy` / `projectPublish` / `promoteSchema` / `validateCollectionRecords`）、
**MT は操作と書き込み順**、という分け方にした（設計の D5）。書き込み経路は 1 本だけで、
core の whole-app `publishApp` は mulmoclaude#2871 で削除済み。

## 何を保証しているか

- **deploy は安全**。書くのは名簿の人しか読めないもの（`apps/{aid}` と `staging/{cid}`）だけで、
  `apps/{aid}.public` は**書かない**。ルールが匿名アクセスを判定するのに読むのはこのブロックで、
  世界に読める `config/public` ではないので、ここを deploy が書くと「テストのために反映した」が
  そのまま公開になる
- **publish は昇格**。ワーキングツリーではなく **staging を昇格させる**ので、公開されるのは
  名簿の人が `/staging/{aid}` で見た版そのもの。書き込み順は
  `collections/{cid}` → `config/public` → app 本体 → **`public` は最後**。途中で失敗しても
  公開は開かない（config の書き込みを失敗させると app に `public` が付かないことをテストで固定）
- **unpublish はちょうど逆順**で、`public` を外すのが最初。昇格済みスキーマは残す
- **ライブレコードの検証は両方の境界で走る**。deploy の `confirm` は publish に引き継がれない
- **staging は置換であって積み上げではない**。リポジトリから消えたコレクションの staging を
  deploy が撤回する（撤回は何も grant しないので最後に書く）。これが無いと publish は
  「昇格させる版を検証できない cid」で永久に止まる

## 積み残し

`app.json` に希望の slug を書く前提が成立しなかった（`AuthoredAppZ` は strict で、
`slug` を含む `app.json` は `parseAuthoredApp` が丸ごと拒否する。キーを足すのは core の変更）。
slug の予約はこの PR に入れておらず、選択肢を plans の「未解決の論点」に起こした。
`/staging/{aid}` は slug を経由しないので、招待とテストは slug 無しで最後まで回る。

## テスト

`test/server/backends/sharedApp.spec.ts`（12 件、順序と所有権をインメモリ Firestore で固定）と
`test/server/infra/sharedAppTool.spec.ts`（4 件、拒否が例外でなく文字列で返ること）。
specs 全件 pass / lint 0 errors / typecheck 0。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to deploy, publish, and unpublish shared apps.
  * Added staging and promotion of collection schemas, with stale collection withdrawal.
  * Added optional anonymous access when publishing.
  * Added safeguards that detect schema-incompatible records and require confirmation before risky changes.
  * Added clear status reporting for publication state, collection changes, record issues, and partial failures.
* **Bug Fixes**
  * Improved safe handling of failed operations and retries.
* **Tests**
  * Added comprehensive coverage for shared-app lifecycle operations and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->