### PR TITLE
feat(collections): URL slug を deploy が予約し、publish が公開する（実装順 7e）

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mulmoclaude/accounting-plugin": "^2.1.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
-    "@mulmoclaude/core": "^3.10.0",
+    "@mulmoclaude/core": "3.11.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -3022,18 +3022,24 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
 
      実装で分かったことを 2 つ。どちらも設計の穴で、コードを書くまで見えていなかった:
 
-     - **`app.json` に希望の slug を書けない。** `AuthoredAppZ` は strict なので、
-       `slug` を足した `app.json` は core の `parseAuthoredApp` が
-       `Unrecognized key: "slug"` で**丸ごと拒否する**。足すのは core の変更＝
-       「MC を二度と触らない」に反するので、**slug の置き場所は決め直しが要る**
-       （下の「未解決」参照）。7c はそこだけ落として先に入れた — `/staging/{aid}` は
-       slug を経由しないので、招待とテストは slug 無しで最後まで回る
+     - **`app.json` に希望の slug を書けなかった。** `AuthoredAppZ` が strict で、
+       `slug` を足した `app.json` は `parseAuthoredApp` が `Unrecognized key: "slug"` で
+       丸ごと拒否していた。7c はそこだけ落として先に入れ、**MC への最後の 1 回**
+       （mulmoclaude #2872、core 3.11.0）でキーを足してから 7e として実装した
      - **staging は「積み上げ」ではなく「置換」でなければならない。** コレクションを
        リポジトリから消しても `staging/{cid}` は残り、publish は
        「昇格させる版をライブレコードで検証する」ため**リポジトリに無い cid を検証できず
        止まる**。deploy が消えた cid の staging を**撤回する**ことで解いた
        （撤回は最後に書く — 何も grant しないので）
-   - **7d. `aid` の UUID 自動生成**（決定 2）— `app.json` を書くのは MT なので MT 側
+   - **7d. `aid` の UUID 自動生成**（決定 2）— `app.json` を書くのは MT なので MT 側。
+     **完了**（mulmoterminal #1636 でレビュー対応まで込み）。`app.json` は著者のファイルで
+     あってこちらの出力物ではないので、書き込みは**原子的・モード保持・シンボリックリンクの
+     実体を更新・1 度に 1 つ**（`manifestWrite.ts`）
+   - **7e. URL slug の予約**（D2b / D10）— deploy が `appSlugs/{slug}` を
+     `published: false` で押さえ、取られていたら `-2`, `-3`… と番号を付ける。取れた名前は
+     `app.json` に書き戻し、**`apps/{aid}.slug` にも記録**して次の deploy が二重に取らない
+     ようにする。publish が `published` を反転（**公開の直前、`public` の直前**）、
+     unpublish がその逆順で戻す
 
 **共有**
 
@@ -3082,18 +3088,18 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
   補助関数の連鎖が深いと非自明な経路が全部そこに達し、症状は「権限エラー」ではなく
   `Unable to evaluate the expression…`。**次にルールへ条件を足すときは、正しさと同じだけ
   式数を見ること。** 目安は、app ドキュメントを 1 回だけ取得して引数で下へ渡す形を崩さないこと
-- **希望の slug をどこに書くか（未決。7c で判明）** — D10 は「`app.json` に希望の slug を
-  書き、deploy が予約する」としているが、**それは書けない**。`AuthoredAppZ` は strict で、
-  `slug` を含む `app.json` は `parseAuthoredApp` が `Unrecognized key: "slug"` として
-  丸ごと拒否する。core にキーを足すのは「MC を二度と触らない」に反する。残る案は 3 つ:
-  - **(a) MT 所有の別ファイル**（例: リポジトリ直下に slug の予約控えを 1 本）。
-    **git に入って clone に付いていく**のが条件 — 予約は `published: false` の間は
-    ルール上**オーナー自身も読み返せない**ので、Firestore からは復元できない
-  - **(b) `name` から導出**（`slugify(name)`、衝突時は連番）。控えを持たないので、
-    連番が付いた瞬間に再現できなくなる。予約の再利用も検証できない
-  - **(c) slug をやめる** — 公開ページも `/{aid}` にする。URL は人が配るものという
-    D2b の前提を落とすことになる
-  実装済みの `deploy` / `publish` は slug に触っていないので、どれを採っても後から足せる
+- ~~**希望の slug をどこに書くか**~~ — **決定・実装済み。`app.json` の `slug`**。
+  当初 `AuthoredAppZ` が strict でこのキーを拒否していたため保留していたが、
+  **MC への最後の 1 回**（mulmoclaude #2872、core **3.11.0**）で任意キーとして受け入れた。
+  別ファイル案（clone に付いていく必要がある）と `name` からの導出案（連番が付いた瞬間に
+  再現できない）は採らない。予約は `published: false` の間**オーナー自身も読み返せない**ので、
+  記録が要るのはそのため。MT 側の実装で分かった 1 点:
+  **「もう持っているか」は `apps/{aid}.slug` に置く。** `app.json` は clone に付いていく
+  記録だが、deploy の入口では「著者が今書いた希望」と区別がつかない — 区別できないまま
+  再予約すると、deploy のたびに URL が変わる。`projectDeploy` はこのキーを射影に含めない
+  （予約はホストの領分）ので、**MT が毎回現在値から載せ直す**。`projectPublish` の方は
+  未知キーを持ち越すので publish では消えない — この非対称は core の仕様であって、
+  片方だけ見て「持ち越されるはず」と考えると消える
 - **Storage ルールから `firestore.get()`** でメンバー判定できるか — 仕様上可能のはずだが実機未確認
 - **repo 権限と members のずれ**をどう見せるか（当面は members をヘッダーに常時出すだけ）
 - **email の同一性**（変更・再利用）— 当面受容

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -19,7 +19,7 @@ import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords } from "./records.js";
-import { reserveSlug, type SlugResult } from "./slug.js";
+import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
 export interface DeploySuccess {
@@ -92,6 +92,24 @@ async function reserveHeldSlug(
   // flag mirrors that, and a reclaim must not change the answer.
   const reservation = await reserveSlug(handle, aid, root, wanted, held === wanted, appDoc.public !== undefined);
   if (!reservation.ok || !reservation.reserved) return reservation;
+  // A rename leaves the previous name pointing here, and a published one goes on RESOLVING —
+  // while every later unpublish acts on the new name, so the URL the owner believes they took
+  // down still opens the app. Retire it before the record moves, so a failure here leaves the
+  // record on the old name and the next deploy repeats exactly this step.
+  if (held !== undefined && held !== reservation.slug) {
+    try {
+      await retireSlug(handle, aid, held);
+    } catch (err) {
+      return {
+        ok: false,
+        partial: true,
+        problems: [
+          `the URL name '${reservation.slug}' was reserved, but the previous name '${held}' could not be retired: ${err instanceof Error ? err.message : String(err)}`,
+          `Deploy again — until '${held}' is closed it still resolves to this app, and later unpublishes would not touch it.`,
+        ],
+      };
+    }
+  }
   try {
     await handle.docs.set(APPS_COLLECTION, aid, { ...appDoc, slug: reservation.slug });
   } catch (err) {

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -88,7 +88,9 @@ async function reserveHeldSlug(
   appDoc: Record<string, unknown>,
 ): Promise<SlugResult | undefined> {
   if (wanted === undefined) return undefined;
-  const reservation = await reserveSlug(handle, aid, root, wanted, held === wanted);
+  // Whether the app is OPEN, from the document that decides it. The reservation's `published`
+  // flag mirrors that, and a reclaim must not change the answer.
+  const reservation = await reserveSlug(handle, aid, root, wanted, held === wanted, appDoc.public !== undefined);
   if (!reservation.ok || !reservation.reserved) return reservation;
   try {
     await handle.docs.set(APPS_COLLECTION, aid, { ...appDoc, slug: reservation.slug });
@@ -98,7 +100,7 @@ async function reserveHeldSlug(
       partial: true,
       problems: [
         `the URL name '${reservation.slug}' was reserved and written to app.json, but recording it on apps/${aid} failed: ${err instanceof Error ? err.message : String(err)}`,
-        "Deploy again — it reads the name back from app.json and only records it.",
+        "Deploy again — the reservation is this app's, and the next deploy recognises that rather than taking a numbered name.",
       ],
     };
   }

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -19,6 +19,7 @@ import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords } from "./records.js";
+import { reserveSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
 export interface DeploySuccess {
@@ -34,6 +35,9 @@ export interface DeploySuccess {
    *  repair is owed, on the one path (a confirmed deploy) where it is already staged. */
   recordIssues: number;
   recordIssuesCapped: boolean;
+  /** The URL name this app holds, once one has been reserved. Absent when `app.json` declares no
+   *  `slug` — an app reachable only at `/staging/{aid}` never needs one. */
+  slug?: string | undefined;
   /** cids that were staged before and are not in the repository any more — dropped by this
    *  deploy. Reported because a withdrawal is not what the operator asked for; it is what
    *  deleting a collection's directory MEANT, and the two are easy to confuse. */
@@ -64,6 +68,41 @@ async function readCurrentApp(handle: SharedAppHandle, aid: string): Promise<{ o
       ],
     };
   }
+}
+
+/** Reserve the declared URL name if this app does not already hold it, and record the result on
+ *  the app document so the next deploy does not reserve a SECOND one.
+ *
+ *  Undefined when the declaration names no slug: an app reachable only at `/staging/{aid}` never
+ *  needs one, and reserving a name nobody asked for would take it from someone who did.
+ *
+ *  The extra app-document write is the price of the ordering: the reservation cannot be made
+ *  before `apps/{aid}` exists, and what was reserved cannot be recorded before it is reserved. It
+ *  happens only on the deploy that actually takes a name. */
+async function reserveHeldSlug(
+  handle: SharedAppHandle,
+  aid: string,
+  root: string,
+  wanted: string | undefined,
+  held: string | undefined,
+  appDoc: Record<string, unknown>,
+): Promise<SlugResult | undefined> {
+  if (wanted === undefined) return undefined;
+  const reservation = await reserveSlug(handle, aid, root, wanted, held === wanted);
+  if (!reservation.ok || !reservation.reserved) return reservation;
+  try {
+    await handle.docs.set(APPS_COLLECTION, aid, { ...appDoc, slug: reservation.slug });
+  } catch (err) {
+    return {
+      ok: false,
+      partial: true,
+      problems: [
+        `the URL name '${reservation.slug}' was reserved and written to app.json, but recording it on apps/${aid} failed: ${err instanceof Error ? err.message : String(err)}`,
+        "Deploy again — it reads the name back from app.json and only records it.",
+      ],
+    };
+  }
+  return reservation;
 }
 
 /** Staged documents whose collection this repository no longer has.
@@ -131,9 +170,17 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
   if (!stale.ok) return stale;
 
+  // The slug this app already holds, carried on the app document because NOTHING ELSE CAN BE
+  // ASKED: `appSlugs/{slug}` is unreadable until the app is published, so "do we already have
+  // one?" has no other answer. `projectDeploy` does not carry it — the reservation is the host's
+  // business and core has no opinion about it — so it is re-attached here, from the document as
+  // it stands, on every deploy.
+  const held = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
+  const appDoc = held === undefined ? deployed.app : { ...deployed.app, slug: held };
+
   const failure = await runWrites(
     [
-      { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, deployed.app) },
+      { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) },
       ...deployed.staging.map(({ cid, doc }) => ({
         what: `the staged schema for '${cid}' (apps/${aid}/staging/${cid})`,
         run: () => handle.docs.set(appStagingPath(aid), cid, doc),
@@ -151,9 +198,15 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   );
   if (failure) return failure;
 
+  // AFTER the app document, because `appSlugs`' create rule resolves the owner through
+  // `get(apps/{aid})` — on a first deploy there is nothing to resolve until it exists.
+  const slug = await reserveHeldSlug(handle, aid, root, authored.slug, held, appDoc);
+  if (slug !== undefined && !slug.ok) return slug;
+
   return {
     ok: true,
     aid,
+    slug: slug?.slug,
     cids: deployed.staging.map((entry) => entry.cid),
     withdrawn: stale.cids,
     created: existingApp === null,

--- a/server/backends/sharedApp/ensureAid.ts
+++ b/server/backends/sharedApp/ensureAid.ts
@@ -10,11 +10,12 @@
 // a firestore schema whose root declares no aid, so waiting until publish would make the author's
 // first collection unopenable until they had published — the wrong end of the process to discover
 // it from.
+//
+// The writing itself — atomic, mode-preserving, symlink-following, one at a time — is
+// `updateManifest`'s, shared with the slug write-back for the reason both are here: `app.json`
+// belongs to the author, and each of these changes exactly one key of it.
 import { randomUUID } from "node:crypto";
-import { chmod, readFile, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
-import path from "node:path";
-import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
-import { isRecord } from "../../../common/isRecord.js";
+import { updateManifest } from "./manifestWrite.js";
 
 export interface EnsureAidSuccess {
   ok: true;
@@ -26,130 +27,23 @@ export interface EnsureAidSuccess {
 
 export type EnsureAidResult = EnsureAidSuccess | { ok: false; problems: string[] };
 
-/** Read `<root>/app.json`, and give it an `aid` if it has none.
- *
- *  Everything else in the file is carried through untouched — this rewrites the declaration the
- *  author is editing, so anything it dropped would be silently deleted work.
- *
- *  It does NOT create `app.json`. A missing one means this directory is not a shared app at all,
- *  and writing a bare `{ aid }` would turn a typo'd path into an app declaration. */
-/** One write at a time per `app.json`, in this process.
- *
- *  Read-mint-write is three steps, and two callers interleaving them both see "no aid", mint
- *  different UUIDs, and each rename its own file. The loser's uuid is the one it goes on to create
- *  an app document for — leaving a live `apps/{uuid}` that the declaration no longer names, and
- *  nothing afterwards would notice.
- *
- *  A Map keyed by the manifest PATH, not the root: two roots are two files and must not wait on
- *  each other, while two spellings of one root are one file. The chain is what serializes — each
- *  caller appends to the previous promise — and entries are dropped when the last one settles so
- *  the map does not grow with every project ever deployed.
- *
- *  In-process is the honest scope, and it is the scope of the problem: MulmoTerminal is ONE server,
- *  every cell's tool call runs in it, and "two cells deployed at once" is the way this happens. Two
- *  separate servers over one checkout would still race, and a lock file is what that would need —
- *  not written, because nothing here can produce that arrangement. */
-const inFlight = new Map<string, Promise<EnsureAidResult>>();
-
-function serialize(key: string, run: () => Promise<EnsureAidResult>): Promise<EnsureAidResult> {
-  const previous = inFlight.get(key) ?? Promise.resolve<EnsureAidResult>({ ok: true, aid: "", created: false });
-  // `catch` before `then`: a rejected predecessor must not reject its successor, and a settled
-  // chain is the only thing this needs from it.
-  const next = previous.catch(() => {}).then(run);
-  inFlight.set(key, next);
-  void next.finally(() => {
-    if (inFlight.get(key) === next) inFlight.delete(key);
-  });
-  return next;
-}
-
+/** Read `<root>/app.json`, and give it an `aid` if it has none. */
 export async function ensureAid(root: string): Promise<EnsureAidResult> {
-  return serialize(await manifestKey(root), () => ensureAidOnce(root));
-}
+  let minted: string | null = null;
+  const updated = await updateManifest(root, (manifest) => {
+    const current = manifest.aid;
+    if (typeof current === "string" && current.length > 0) return null;
+    minted = randomUUID();
+    return { ...manifest, aid: minted };
+  });
+  if (!updated.ok) return updated;
+  if (minted !== null) return { ok: true, aid: minted, created: true };
 
-/** The key two callers must AGREE on to be serialized against each other: one file, one key.
- *
- *  The caller's spelling will not do. A root arrives as the session's cwd, which is taken
- *  verbatim — so one cell opened at a symlink and another at the path it points to name the same
- *  `app.json` in two ways, and two spellings are two chains: exactly the interleaving the
- *  serializer exists to prevent, with the lock quietly not held.
- *
- *  `realpath` resolves both the links and the relative spelling. When it fails — the root does not
- *  exist — `resolve` is enough: the read is about to fail anyway, and a key that cannot be
- *  canonicalised must still not collide with another root's. */
-async function manifestKey(root: string): Promise<string> {
-  try {
-    return path.join(await realpath(root), APP_MANIFEST_FILE);
-  } catch {
-    return path.join(path.resolve(root), APP_MANIFEST_FILE);
+  const current = updated.manifest.aid;
+  // Unreachable by construction — the mutation returns null only when it read a usable string —
+  // but stated rather than asserted: this is the value every later step keys on.
+  if (typeof current !== "string" || current.length === 0) {
+    return { ok: false, problems: ["app.json has no usable aid, and one could not be generated."] };
   }
-}
-
-async function ensureAidOnce(root: string): Promise<EnsureAidResult> {
-  const manifestPath = path.join(root, APP_MANIFEST_FILE);
-  let raw: string;
-  try {
-    raw = await readFile(manifestPath, "utf-8");
-  } catch (err) {
-    return {
-      ok: false,
-      problems: [
-        `cannot read ${manifestPath}: ${String(err)}`,
-        "A shared app is a repository with an app.json at its root. Write one first — this step only fills in the aid.",
-      ],
-    };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    return { ok: false, problems: [`${manifestPath} is not valid JSON: ${String(err)}`] };
-  }
-  if (!isRecord(parsed)) {
-    return { ok: false, problems: [`${manifestPath} must contain a JSON object.`] };
-  }
-
-  const current = parsed.aid;
-  if (typeof current === "string" && current.length > 0) return { ok: true, aid: current, created: false };
-
-  const aid = randomUUID();
-  // Two spaces and a trailing newline: this file is committed and edited by hand, so it is
-  // written the way the author would have.
-  const body = `${JSON.stringify({ ...parsed, aid }, null, 2)}\n`;
-  // Write beside it and RENAME, rather than writing over it.
-  //
-  // `writeFile` truncates first, so a failure between the truncate and the last byte leaves a
-  // half-written `app.json` — and the file it would destroy is the author's declaration, holding
-  // the roster and the public settings, which nothing here could put back. Rename is atomic
-  // within a directory: a reader sees the old file or the new one. That is also what makes
-  // "nothing else was changed" a promise rather than a hope.
-  //
-  // Same directory on purpose — a rename across filesystems is a copy, and the temp directory is
-  // routinely on another one.
-  //
-  // And beside the RESOLVED file, not beside the name we were given. `readFile` follows a
-  // symlink; `rename` replaces one. A manifest linked to a shared declaration would therefore be
-  // read through the link and then have the link overwritten by a detached copy — the target
-  // never gets the aid, and the next reader of the target is looking at a different app.
-  // Resolving means the link stays a link and the file it points at is what gets updated.
-  const target = await realpath(manifestPath).catch(() => manifestPath);
-  const scratch = path.join(path.dirname(target), `.${path.basename(target)}.${aid}.tmp`);
-  try {
-    await writeFile(scratch, body, "utf-8");
-    // The replacement is a NEW file, so it carries this process's umask rather than the mode the
-    // author gave `app.json`. Carrying the declaration through unchanged has to include that: a
-    // manifest someone deliberately kept at 0600 would come back 0644 and nothing would say so.
-    await chmod(scratch, (await stat(target)).mode);
-    await rename(scratch, target);
-  } catch (err) {
-    // Best effort: the scratch file is only litter, and the failure being reported is the one
-    // worth reporting.
-    await unlink(scratch).catch(() => {});
-    return {
-      ok: false,
-      problems: [`cannot write ${manifestPath}: ${String(err)}`, "Nothing else was changed — the declaration is as it was."],
-    };
-  }
-  return { ok: true, aid, created: true };
+  return { ok: true, aid: current, created: false };
 }

--- a/server/backends/sharedApp/manifestWrite.ts
+++ b/server/backends/sharedApp/manifestWrite.ts
@@ -21,6 +21,7 @@ import { chmod, readFile, realpath, rename, stat, unlink, writeFile } from "node
 import path from "node:path";
 import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { isRecord } from "../../../common/isRecord.js";
+import { serializeBy } from "./serialize.js";
 
 export type ManifestFailure = { ok: false; problems: string[] };
 
@@ -30,32 +31,11 @@ export type ManifestMutation = (manifest: Record<string, unknown>) => Record<str
 
 export type ManifestUpdate = { ok: true; manifest: Record<string, unknown>; written: boolean } | ManifestFailure;
 
-/** One write at a time per `app.json`, in this process.
- *
- *  In-process is the honest scope, and it is the scope of the problem: MulmoTerminal is ONE
- *  server, every cell's tool call runs in it, and "two cells deployed at once" is how this
- *  happens. Two separate servers over one checkout would still race, and a lock file is what that
- *  would need — not written, because nothing here can produce that arrangement.
- *
- *  Keyed by the manifest PATH so two roots do not wait on each other, and entries are dropped
- *  when the last one settles so the map does not grow with every project ever deployed. */
-const inFlight = new Map<string, Promise<unknown>>();
-
-function serialize<T>(key: string, run: () => Promise<T>): Promise<T> {
-  const previous = inFlight.get(key) ?? Promise.resolve();
-  // `catch` before `then`: a rejected predecessor must not reject its successor, and a settled
-  // chain is the only thing this needs from it.
-  const next = previous.catch(() => {}).then(run);
-  inFlight.set(key, next);
-  void next
-    .catch(() => {})
-    .finally(() => {
-      if (inFlight.get(key) === next) inFlight.delete(key);
-    });
-  return next;
-}
-
 /** The key two callers must AGREE on to be serialized against each other: one file, one key.
+ *
+ *  Exported because a whole shared-app OPERATION serializes on the same repository — one deploy
+ *  landing inside a publish is the same class of interleaving as two writes to `app.json`, and
+ *  keying them differently would leave each holding a lock the other does not.
  *
  *  The caller's spelling will not do. A root arrives as the session's cwd, which is taken
  *  verbatim — so one cell opened at a symlink and another at the path it points to name the same
@@ -65,7 +45,7 @@ function serialize<T>(key: string, run: () => Promise<T>): Promise<T> {
  *  When `realpath` fails — the root does not exist — `resolve` is enough: the read is about to
  *  fail anyway, and a key that cannot be canonicalised must still not collide with another
  *  root's. */
-async function manifestKey(root: string): Promise<string> {
+export async function manifestKey(root: string): Promise<string> {
   try {
     return path.join(await realpath(root), APP_MANIFEST_FILE);
   } catch {
@@ -78,7 +58,7 @@ async function manifestKey(root: string): Promise<string> {
  *  It does NOT create `app.json`. A missing one means this directory is not a shared app at all,
  *  and writing a bare object would turn a mistyped path into an app declaration. */
 export function updateManifest(root: string, mutate: ManifestMutation): Promise<ManifestUpdate> {
-  return manifestKey(root).then((key) => serialize(key, () => updateOnce(root, mutate)));
+  return manifestKey(root).then((key) => serializeBy(`manifest:${key}`, () => updateOnce(root, mutate)));
 }
 
 async function updateOnce(root: string, mutate: ManifestMutation): Promise<ManifestUpdate> {

--- a/server/backends/sharedApp/manifestWrite.ts
+++ b/server/backends/sharedApp/manifestWrite.ts
@@ -1,0 +1,146 @@
+// Editing `app.json` — the one file in a shared app that both a person and this server write.
+//
+// Everything here exists because of that shared ownership. The file holds the roster and the
+// public settings; the author edits it by hand and commits it; and two of MulmoTerminal's own
+// steps have to change one key in it (the generated `aid`, and the URL slug that was actually
+// reserved). So a write here is never "produce the file" — it is "change one key of the file
+// somebody else is keeping", which is why it reads, mutates, and replaces rather than rendering.
+//
+// Three properties are load-bearing, and each was a review finding before it was a rule:
+//
+//   - **atomic.** `writeFile` truncates first, so a failure part-way leaves a half-written
+//     declaration — and nothing here could put back the roster it destroyed. Write beside it and
+//     rename; a reader sees the old file or the new one.
+//   - **the author's file, not ours.** The mode is preserved (a manifest kept at 0600 must not
+//     come back 0644), a symlink is followed to the file it points at rather than replaced, and
+//     every key the author wrote is carried through untouched.
+//   - **one writer at a time.** Read-mutate-write is three steps; two callers interleaving them
+//     both see the old file and one write is lost. Serialized on the RESOLVED path, because two
+//     spellings of one root are one file.
+import { chmod, readFile, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
+import { isRecord } from "../../../common/isRecord.js";
+
+export type ManifestFailure = { ok: false; problems: string[] };
+
+/** What a caller does with the declaration it was handed: a replacement object, or `null` for
+ *  "nothing to change" — which writes nothing at all rather than rewriting identical bytes. */
+export type ManifestMutation = (manifest: Record<string, unknown>) => Record<string, unknown> | null;
+
+export type ManifestUpdate = { ok: true; manifest: Record<string, unknown>; written: boolean } | ManifestFailure;
+
+/** One write at a time per `app.json`, in this process.
+ *
+ *  In-process is the honest scope, and it is the scope of the problem: MulmoTerminal is ONE
+ *  server, every cell's tool call runs in it, and "two cells deployed at once" is how this
+ *  happens. Two separate servers over one checkout would still race, and a lock file is what that
+ *  would need — not written, because nothing here can produce that arrangement.
+ *
+ *  Keyed by the manifest PATH so two roots do not wait on each other, and entries are dropped
+ *  when the last one settles so the map does not grow with every project ever deployed. */
+const inFlight = new Map<string, Promise<unknown>>();
+
+function serialize<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const previous = inFlight.get(key) ?? Promise.resolve();
+  // `catch` before `then`: a rejected predecessor must not reject its successor, and a settled
+  // chain is the only thing this needs from it.
+  const next = previous.catch(() => {}).then(run);
+  inFlight.set(key, next);
+  void next
+    .catch(() => {})
+    .finally(() => {
+      if (inFlight.get(key) === next) inFlight.delete(key);
+    });
+  return next;
+}
+
+/** The key two callers must AGREE on to be serialized against each other: one file, one key.
+ *
+ *  The caller's spelling will not do. A root arrives as the session's cwd, which is taken
+ *  verbatim — so one cell opened at a symlink and another at the path it points to name the same
+ *  `app.json` in two ways, and two spellings are two chains: exactly the interleaving the
+ *  serializer exists to prevent, with the lock quietly not held.
+ *
+ *  When `realpath` fails — the root does not exist — `resolve` is enough: the read is about to
+ *  fail anyway, and a key that cannot be canonicalised must still not collide with another
+ *  root's. */
+async function manifestKey(root: string): Promise<string> {
+  try {
+    return path.join(await realpath(root), APP_MANIFEST_FILE);
+  } catch {
+    return path.join(path.resolve(root), APP_MANIFEST_FILE);
+  }
+}
+
+/** Read `<root>/app.json`, hand it to `mutate`, and replace it with the result.
+ *
+ *  It does NOT create `app.json`. A missing one means this directory is not a shared app at all,
+ *  and writing a bare object would turn a mistyped path into an app declaration. */
+export function updateManifest(root: string, mutate: ManifestMutation): Promise<ManifestUpdate> {
+  return manifestKey(root).then((key) => serialize(key, () => updateOnce(root, mutate)));
+}
+
+async function updateOnce(root: string, mutate: ManifestMutation): Promise<ManifestUpdate> {
+  const manifestPath = path.join(root, APP_MANIFEST_FILE);
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, "utf-8");
+  } catch (err) {
+    return {
+      ok: false,
+      problems: [
+        `cannot read ${manifestPath}: ${String(err)}`,
+        "A shared app is a repository with an app.json at its root. Write one first — this step only fills in what it can.",
+      ],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, problems: [`${manifestPath} is not valid JSON: ${String(err)}`] };
+  }
+  if (!isRecord(parsed)) {
+    return { ok: false, problems: [`${manifestPath} must contain a JSON object.`] };
+  }
+
+  const updated = mutate(parsed);
+  if (updated === null) return { ok: true, manifest: parsed, written: false };
+
+  const failure = await replaceManifest(manifestPath, updated);
+  return failure ?? { ok: true, manifest: updated, written: true };
+}
+
+/** Replace the file, or say why not. Returns null when it landed. */
+async function replaceManifest(manifestPath: string, manifest: Record<string, unknown>): Promise<ManifestFailure | null> {
+  // Two spaces and a trailing newline: this file is committed and edited by hand, so it is
+  // written the way the author would have.
+  const body = `${JSON.stringify(manifest, null, 2)}\n`;
+  // Beside the RESOLVED file, not beside the name we were given. `readFile` follows a symlink;
+  // `rename` replaces one. A manifest linked to a shared declaration would otherwise be read
+  // through the link and then have the link overwritten by a detached copy — the target never
+  // gets the change, and the next reader of the target is looking at a different app.
+  //
+  // Same directory on purpose: a rename across filesystems is a copy, and the temp directory is
+  // routinely on another one.
+  const target = await realpath(manifestPath).catch(() => manifestPath);
+  const scratch = path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.tmp`);
+  try {
+    await writeFile(scratch, body, "utf-8");
+    // The replacement is a NEW file, so it carries this process's umask rather than the mode the
+    // author gave `app.json`. Carrying the declaration through unchanged has to include that.
+    await chmod(scratch, (await stat(target)).mode);
+    await rename(scratch, target);
+    return null;
+  } catch (err) {
+    // Best effort: the scratch file is only litter, and the failure being reported is the one
+    // worth reporting.
+    await unlink(scratch).catch(() => {});
+    return {
+      ok: false,
+      problems: [`cannot write ${manifestPath}: ${String(err)}`, "Nothing else was changed — the declaration is as it was."],
+    };
+  }
+}

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -129,10 +129,22 @@ function publishSteps(
     // was staged beside, so the public write path is never judged by one version's constraints
     // against another's schema.
     { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, face.app) },
-    // The URL name starts resolving here: before the authorization, after everything it points
-    // at. A slug that resolved first would be a link that 404s inside; a slug that resolves late
-    // is only a link that is not ready yet.
-    ...(slug === undefined ? [] : [{ what: `the URL name '${slug}' (appSlugs/${slug})`, run: () => setSlugPublished(handle, aid, slug, true) }]),
+    // The URL name follows the app's own openness — `face.public` — and NOT the fact that a
+    // publish happened.
+    //
+    // A published reservation is world-readable, and what it reveals is the aid, which is the
+    // `/staging/{aid}` entrance this whole feature keeps unguessable. So publishing a declaration
+    // with no `public` block — a roster-only app, which is a normal thing to publish — must not
+    // make its name resolvable: that would hand out the private entrance while the operation
+    // itself reports the app is closed to anonymous visitors.
+    //
+    // Placed here, before the authorization and after everything the name points at: a slug that
+    // resolved first would be a link that 404s inside, and one that resolves late is only a link
+    // that is not ready yet. When the publish CLOSES the app instead, the same position is the
+    // reverse and equally right — the app document above has already dropped `public`.
+    ...(slug === undefined
+      ? []
+      : [{ what: `the URL name '${slug}' (appSlugs/${slug})`, run: () => setSlugPublished(handle, aid, slug, face.public !== undefined) }]),
     // LAST, and only when the declaration asks for it. This is the authorization itself.
     ...(face.public === undefined
       ? []

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -38,14 +38,17 @@ import {
 } from "@mulmoclaude/core/collection/server";
 import { ensureAid } from "./ensureAid.js";
 import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
-import { recordRefusal, scanRecords } from "./records.js";
+import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
+import { setSlugPublished } from "./slug.js";
 import { runWrites, type WriteStep } from "./writes.js";
 
 export interface PublishSuccess {
   ok: true;
   aid: string;
   cids: string[];
+  /** The URL name that now resolves to this app, when it has one. */
+  slug?: string | undefined;
   /** Whether this publish left the app open to anonymous visitors. False is a normal outcome — a
    *  declaration with no `public` block publishes the schemas to the roster's URL and grants the
    *  world nothing — and it is the one thing an operator is most likely to assume wrongly. */
@@ -111,6 +114,7 @@ function publishSteps(
   staged: readonly StagedEntry[],
   stamp: PublishStamp,
   face: ReturnType<typeof projectPublish>,
+  slug: string | undefined,
 ): WriteStep[] {
   return [
     ...staged.map(({ cid, doc }) => ({
@@ -125,6 +129,10 @@ function publishSteps(
     // was staged beside, so the public write path is never judged by one version's constraints
     // against another's schema.
     { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, face.app) },
+    // The URL name starts resolving here: before the authorization, after everything it points
+    // at. A slug that resolved first would be a link that 404s inside; a slug that resolves late
+    // is only a link that is not ready yet.
+    ...(slug === undefined ? [] : [{ what: `the URL name '${slug}' (appSlugs/${slug})`, run: () => setSlugPublished(handle, aid, slug, true) }]),
     // LAST, and only when the declaration asks for it. This is the authorization itself.
     ...(face.public === undefined
       ? []
@@ -135,6 +143,32 @@ function publishSteps(
           },
         ]),
   ];
+}
+
+/** Everything that must hold before a promotion: something IS staged, the staged set matches the
+ *  repository, and the live records fit the version about to become public. Split out for the
+ *  line budget, and it reads as the one thing it is — the gate. */
+async function stagedGate(
+  staged: readonly StagedEntry[],
+  collections: readonly LoadedCollection[],
+  aid: string,
+  root: string,
+  confirm: boolean | undefined,
+): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
+  if (staged.length === 0) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `nothing is staged for apps/${aid}, so there is nothing to promote. Run deploy first — publish promotes what the roster reviewed at /staging/${aid} rather than reading the working tree.`,
+      ],
+    };
+  }
+  const toScan = stagedForValidation(staged, collections);
+  if (!toScan.ok) return { ...toScan, partial: false };
+  const scan = await scanRecords(toScan.collections, root);
+  const refusal = recordRefusal(scan, "publish", confirm);
+  return refusal ? { ok: false, partial: false, problems: refusal } : { ok: true, scan };
 }
 
 export async function publishSharedApp(root: string, opts: SharedAppOptions = {}): Promise<PublishResult> {
@@ -150,21 +184,9 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
 
   const staged = await readStaged(handle, aid);
   if (!staged.ok) return { ...staged, partial: false };
-  if (staged.staged.length === 0) {
-    return {
-      ok: false,
-      partial: false,
-      problems: [
-        `nothing is staged for apps/${aid}, so there is nothing to promote. Run deploy first — publish promotes what the roster reviewed at /staging/${aid} rather than reading the working tree.`,
-      ],
-    };
-  }
-
-  const toScan = stagedForValidation(staged.staged, collections);
-  if (!toScan.ok) return { ...toScan, partial: false };
-  const scan = await scanRecords(toScan.collections, root);
-  const refusal = recordRefusal(scan, "publish", opts.confirm);
-  if (refusal) return { ok: false, partial: false, problems: refusal };
+  const gate = await stagedGate(staged.staged, collections, aid, root, opts.confirm);
+  if (!gate.ok) return gate;
+  const scan = gate.scan;
 
   let existing: unknown;
   try {
@@ -187,9 +209,16 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
     commit: stampSource.commit,
     dirty: stampSource.dirty,
   };
-  const face = projectPublish(authored, staged.staged, stamp, isRecord(existing) ? existing : null);
+  const existingApp = isRecord(existing) ? existing : null;
+  const face = projectPublish(authored, staged.staged, stamp, existingApp);
 
-  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face), "publish");
+  // The name this app HOLDS, which is the app document's — not necessarily the one `app.json`
+  // wants right now. An author who edits `slug` between deploy and publish has changed what the
+  // next deploy will reserve, not what this publish may flip: flipping a name this app never
+  // reserved is a write the rules refuse, and that refusal is the point of them.
+  const slug = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
+
+  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug), "publish");
   if (failure) return failure;
 
   return {
@@ -197,6 +226,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
     aid,
     cids: staged.staged.map((entry) => entry.cid),
     publicOpen: face.public !== undefined,
+    slug,
     commit: stamp.commit,
     dirty: stampSource.dirty === true,
     recordIssues: scan.records,

--- a/server/backends/sharedApp/serialize.ts
+++ b/server/backends/sharedApp/serialize.ts
@@ -1,0 +1,33 @@
+// One at a time, per thing.
+//
+// Two chains are kept with this: `app.json` writes (so a read-modify-write cannot lose the other
+// half) and whole shared-app OPERATIONS (so a deploy cannot land in the middle of a publish).
+// They are the same mechanism because they are the same problem — a sequence of reads and writes
+// that is only correct if nothing interleaves with it — and having one implementation is what
+// keeps a second one from being written with the subtle parts left out.
+//
+// In-process is the honest scope, and it is the scope of the problem: MulmoTerminal is ONE server
+// and every cell's tool call runs in it, so "two cells at once" is how this happens. Two separate
+// servers over one checkout would still race, and a lock file is what that would need — not
+// written, because nothing here can produce that arrangement.
+//
+// Keys are PREFIXED by what they name (`manifest:` / `operation:`), because the two namespaces
+// overlap in the obvious spelling and an operation waiting on its own manifest write would be a
+// deadlock rather than a bug you can see.
+const chains = new Map<string, Promise<unknown>>();
+
+export function serializeBy<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const previous = chains.get(key) ?? Promise.resolve();
+  // `catch` before `then`: a rejected predecessor must not reject its successor, and a settled
+  // chain is the only thing this needs from it.
+  const next = previous.catch(() => {}).then(run);
+  chains.set(key, next);
+  // Dropped when the last waiter settles, so the map does not grow with every project ever
+  // deployed.
+  void next
+    .catch(() => {})
+    .finally(() => {
+      if (chains.get(key) === next) chains.delete(key);
+    });
+  return next;
+}

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -1,0 +1,118 @@
+// The URL name — reserving it at deploy, and flipping it public at publish.
+//
+// An app is handed out as `https://<host>/{slug}`, and `appSlugs/{slug}` is what resolves that
+// name to an aid. Two things about that document shape the whole of this file:
+//
+//   - it is a TOP-LEVEL collection, because the public page has to resolve a slug BEFORE it can
+//     read anything under `apps/{aid}`;
+//   - it is UNREADABLE until the app is published (`allow read: if resource.data.published ==
+//     true`), so that a human-readable name cannot be guessed to discover the aid — which is the
+//     `/staging/{aid}` entrance.
+//
+// The second one is why this is more than a write. Nobody — the owner included — can ask which
+// slug an app already holds, so `app.json` is the record: the reserved name is written back
+// there, and a slug already recorded is never re-reserved. "Once you have it, you keep it" is
+// the point (D2b) — a URL is a thing people have already sent to each other.
+import { APP_SLUGS_COLLECTION, appSlugDoc } from "@mulmoclaude/core/collection/server";
+import type { SharedAppFailure, SharedAppHandle } from "./context.js";
+import { updateManifest } from "./manifestWrite.js";
+
+/** How many numbered alternatives to try before giving up. The number is small on purpose: past
+ *  `sakura-hair-8`, the author wanted a different name, not another digit. */
+const MAX_CANDIDATES = 8;
+
+export interface SlugReservation {
+  ok: true;
+  /** The slug this app holds now — the wanted one, or the numbered alternative that was free. */
+  slug: string;
+  /** Whether this call took it. False means it was already recorded in `app.json`. */
+  reserved: boolean;
+}
+
+export type SlugResult = SlugReservation | SharedAppFailure;
+
+/** `sakura-hair`, `sakura-hair-2`, `sakura-hair-3`, … — the collision rule from D2b.
+ *
+ *  Numbering starts at 2 because the unnumbered one IS the first: `sakura-hair-1` beside a
+ *  `sakura-hair` owned by someone else reads as two apps of one company rather than a name that
+ *  was taken. */
+function candidates(wanted: string): string[] {
+  return [wanted, ...Array.from({ length: MAX_CANDIDATES - 1 }, (_, index) => `${wanted}-${index + 2}`)];
+}
+
+/** Reserve the declared slug (or the first free numbering of it) and record it in `app.json`.
+ *
+ *  `recorded` is what the declaration said BEFORE this deploy — when it names a slug this app
+ *  already reserved, nothing is done at all. That is the whole reason the write-back exists: a
+ *  reservation cannot be read back, so re-reserving on every deploy would hand the app a new URL
+ *  each time somebody deployed.
+ *
+ *  Ordering: this runs AFTER `apps/{aid}` is written, because the reservation's `allow create`
+ *  resolves the owner through `get(apps/{aid})` — on a first deploy there is nothing to resolve
+ *  until that document exists. */
+export async function reserveSlug(handle: SharedAppHandle, aid: string, root: string, wanted: string, alreadyHeld: boolean): Promise<SlugResult> {
+  if (alreadyHeld) return { ok: true, slug: wanted, reserved: false };
+
+  const taken: string[] = [];
+  for (const candidate of candidates(wanted)) {
+    let claimed: boolean;
+    try {
+      // `create`, not `set`: create-if-absent is atomic, so two apps racing for one name cannot
+      // both observe it missing. `set` would take a name somebody else already holds — or, worse,
+      // rewrite `published` on it.
+      claimed = await handle.docs.create(APP_SLUGS_COLLECTION, candidate, appSlugDoc(aid, false));
+    } catch (err) {
+      return {
+        ok: false,
+        partial: true,
+        problems: [
+          `deploy reached the app and its schemas, but could not reserve the URL name '${candidate}': ${err instanceof Error ? err.message : String(err)}`,
+          "The app is deployed and the roster can use /staging/{aid}; only the public URL is unreserved. Deploying again retries just this step.",
+        ],
+      };
+    }
+    if (!claimed) {
+      taken.push(candidate);
+      continue;
+    }
+    const recorded = await recordSlug(root, candidate);
+    return recorded ?? { ok: true, slug: candidate, reserved: true };
+  }
+  return {
+    ok: false,
+    partial: true,
+    problems: [
+      `every candidate for the URL name is taken: ${taken.join(", ")}.`,
+      "The app itself is deployed — this is only the public name. Choose a different `slug` in app.json and deploy again.",
+    ],
+  };
+}
+
+/** Write the reserved name back, so the next deploy does not reserve a second one.
+ *
+ *  Returns a failure only when the write failed, and that failure is REAL rather than cosmetic:
+ *  the reservation is live and unreadable, so a lost write-back means the next deploy takes
+ *  another name and the first one is held forever by an app that no longer claims it. */
+async function recordSlug(root: string, slug: string): Promise<SharedAppFailure | null> {
+  const updated = await updateManifest(root, (manifest) => (manifest.slug === slug ? null : { ...manifest, slug }));
+  if (updated.ok) return null;
+  return {
+    ok: false,
+    partial: true,
+    problems: [
+      `the URL name '${slug}' was reserved, but writing it back to app.json failed:`,
+      ...updated.problems,
+      `Put \`"slug": "${slug}"\` in app.json by hand before deploying again — a reservation cannot be read back, so a deploy that does not find it there will reserve ANOTHER name and leave this one held by nobody.`,
+    ],
+  };
+}
+
+/** Flip the reservation's visibility. `true` is publish (the name starts resolving), `false` is
+ *  unpublish (it stops).
+ *
+ *  A full replacement rather than a field update: `appSlugDoc` is two fields, both of which this
+ *  operation knows, and the `FirestoreDocs` seam has no field-level write. The rules pin `aid`
+ *  across an update, so a replacement naming a different app is refused rather than accepted. */
+export function setSlugPublished(handle: SharedAppHandle, aid: string, slug: string, published: boolean): Promise<void> {
+  return handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, published));
+}

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -179,6 +179,17 @@ async function recordSlug(root: string, slug: string): Promise<SharedAppFailure 
   };
 }
 
+/** Stop a name this app no longer uses from resolving.
+ *
+ *  An author who renames the app's URL leaves the old reservation behind, and it keeps pointing at
+ *  this aid. If it was published it goes on RESOLVING — and every later unpublish acts on the new
+ *  name, so the URL the owner believes they took down still opens the app. Retiring means flipping
+ *  the old one closed, not deleting it: the rules refuse deletes on purpose, because a freed name
+ *  is one somebody else can claim and then serve from a URL that is already in circulation. */
+export function retireSlug(handle: SharedAppHandle, aid: string, slug: string): Promise<void> {
+  return handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, false));
+}
+
 /** Flip the reservation's visibility. `true` is publish (the name starts resolving), `false` is
  *  unpublish (it stops).
  *

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -50,7 +50,14 @@ function candidates(wanted: string): string[] {
  *  Ordering: this runs AFTER `apps/{aid}` is written, because the reservation's `allow create`
  *  resolves the owner through `get(apps/{aid})` — on a first deploy there is nothing to resolve
  *  until that document exists. */
-export async function reserveSlug(handle: SharedAppHandle, aid: string, root: string, wanted: string, alreadyHeld: boolean): Promise<SlugResult> {
+export async function reserveSlug(
+  handle: SharedAppHandle,
+  aid: string,
+  root: string,
+  wanted: string,
+  alreadyHeld: boolean,
+  appIsPublic: boolean,
+): Promise<SlugResult> {
   if (alreadyHeld) return { ok: true, slug: wanted, reserved: false };
 
   const taken: string[] = [];
@@ -58,20 +65,12 @@ export async function reserveSlug(handle: SharedAppHandle, aid: string, root: st
     let claimed: boolean;
     try {
       // `create`, not `set`: create-if-absent is atomic, so two apps racing for one name cannot
-      // both observe it missing. `set` would take a name somebody else already holds — or, worse,
-      // rewrite `published` on it.
+      // both observe it missing.
       claimed = await handle.docs.create(APP_SLUGS_COLLECTION, candidate, appSlugDoc(aid, false));
     } catch (err) {
-      return {
-        ok: false,
-        partial: true,
-        problems: [
-          `deploy reached the app and its schemas, but could not reserve the URL name '${candidate}': ${err instanceof Error ? err.message : String(err)}`,
-          "The app is deployed and the roster can use /staging/{aid}; only the public URL is unreserved. Deploying again retries just this step.",
-        ],
-      };
+      return reservationFailed(candidate, err);
     }
-    if (!claimed) {
+    if (!claimed && !(await isOurs(handle, aid, candidate, appIsPublic))) {
       taken.push(candidate);
       continue;
     }
@@ -88,6 +87,49 @@ export async function reserveSlug(handle: SharedAppHandle, aid: string, root: st
   };
 }
 
+function reservationFailed(candidate: string, err: unknown): SharedAppFailure {
+  return {
+    ok: false,
+    partial: true,
+    problems: [
+      `deploy reached the app and its schemas, but could not reserve the URL name '${candidate}': ${err instanceof Error ? err.message : String(err)}`,
+      "The app is deployed and the roster can use /staging/{aid}; only the public URL is unreserved. Deploying again retries just this step.",
+    ],
+  };
+}
+
+/** Does an EXISTING reservation belong to this app? Asked by WRITING to it, because it cannot be
+ *  read.
+ *
+ *  This is why a failed `create` is not the end. The rules allow an update only when the caller
+ *  owns the app the document ALREADY names and the `aid` is unchanged — so a write that succeeds
+ *  proves ownership, and one that is refused proves somebody else holds the name. There is no
+ *  other way to ask: `allow read` needs `published == true`, which is exactly the state a
+ *  reservation is not in.
+ *
+ *  Without it, three ordinary situations end with a stranded name: a deploy that reserved and then
+ *  failed to record it, two deploys of one repository at once, and a repository whose app document
+ *  lost the record. Each would see `create` fail, decide the name belonged to somebody else, and
+ *  take `-2` — while the first reservation stayed live, held by an app that no longer claims it,
+ *  and unreadable by anyone who might have noticed.
+ *
+ *  `published` is written from the APP's state rather than guessed: the app document holds the
+ *  `public` block, so it is the authority on whether this app is open, and the reservation should
+ *  say the same. When they agree this is a no-op; when they have drifted it repairs the drift
+ *  toward the app.
+ *
+ *  A refusal is the ANSWER here, not an error, which is why nothing is reported. A real fault
+ *  (network, quota) lands here too and reads as "not ours" — costing a numbered name rather than
+ *  taking a wrong one. */
+async function isOurs(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<boolean> {
+  try {
+    await handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, appIsPublic));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Write the reserved name back, so the next deploy does not reserve a second one.
  *
  *  Returns a failure only when the write failed, and that failure is REAL rather than cosmetic:
@@ -102,7 +144,7 @@ async function recordSlug(root: string, slug: string): Promise<SharedAppFailure 
     problems: [
       `the URL name '${slug}' was reserved, but writing it back to app.json failed:`,
       ...updated.problems,
-      `Put \`"slug": "${slug}"\` in app.json by hand before deploying again — a reservation cannot be read back, so a deploy that does not find it there will reserve ANOTHER name and leave this one held by nobody.`,
+      "Deploying again is the repair: a deploy that finds the name taken now asks whether it is THIS app's before moving on, so the reservation is not stranded.",
     ],
   };
 }

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -14,6 +14,7 @@
 // there, and a slug already recorded is never re-reserved. "Once you have it, you keep it" is
 // the point (D2b) — a URL is a thing people have already sent to each other.
 import { APP_SLUGS_COLLECTION, appSlugDoc } from "@mulmoclaude/core/collection/server";
+import { isRecord } from "../../../common/isRecord.js";
 import type { SharedAppFailure, SharedAppHandle } from "./context.js";
 import { updateManifest } from "./manifestWrite.js";
 
@@ -70,9 +71,13 @@ export async function reserveSlug(
     } catch (err) {
       return reservationFailed(candidate, err);
     }
-    if (!claimed && !(await isOurs(handle, aid, candidate, appIsPublic))) {
-      taken.push(candidate);
-      continue;
+    if (!claimed) {
+      const ownership = await probeOwnership(handle, aid, candidate, appIsPublic);
+      if (ownership === "unknown") return probeFailed(candidate);
+      if (ownership === "theirs") {
+        taken.push(candidate);
+        continue;
+      }
     }
     const recorded = await recordSlug(root, candidate);
     return recorded ?? { ok: true, slug: candidate, reserved: true };
@@ -98,36 +103,61 @@ function reservationFailed(candidate: string, err: unknown): SharedAppFailure {
   };
 }
 
-/** Does an EXISTING reservation belong to this app? Asked by WRITING to it, because it cannot be
- *  read.
+/** Whose is an EXISTING reservation? Asked by WRITING to it, because it cannot be read.
  *
  *  This is why a failed `create` is not the end. The rules allow an update only when the caller
  *  owns the app the document ALREADY names and the `aid` is unchanged — so a write that succeeds
- *  proves ownership, and one that is refused proves somebody else holds the name. There is no
- *  other way to ask: `allow read` needs `published == true`, which is exactly the state a
+ *  proves ownership, and one REFUSED FOR THAT REASON proves somebody else holds the name. There is
+ *  no other way to ask: `allow read` needs `published == true`, which is exactly the state a
  *  reservation is not in.
  *
  *  Without it, three ordinary situations end with a stranded name: a deploy that reserved and then
- *  failed to record it, two deploys of one repository at once, and a repository whose app document
- *  lost the record. Each would see `create` fail, decide the name belonged to somebody else, and
- *  take `-2` — while the first reservation stayed live, held by an app that no longer claims it,
- *  and unreadable by anyone who might have noticed.
+ *  failed to record it, two deploys of one repository at once, and an app document that lost the
+ *  record. Each would see `create` fail, decide the name belonged to somebody else, and take `-2`
+ *  — while the first reservation stayed live, held by an app that no longer claims it, and
+ *  unreadable by anyone who might have noticed.
+ *
+ *  The third answer is the one that took a review to get right. A timeout or a quota error is NOT
+ *  "somebody else's": reading it that way turns an outage into a second reservation, and if the
+ *  name being reclaimed was a PUBLIC one, the app records the numbered name while the original
+ *  keeps resolving — and can no longer be taken down, because unpublish works from the record.
+ *  Only a refusal decides; anything else stops the deploy with the name unresolved, which a retry
+ *  fixes and nothing else has to.
  *
  *  `published` is written from the APP's state rather than guessed: the app document holds the
  *  `public` block, so it is the authority on whether this app is open, and the reservation should
  *  say the same. When they agree this is a no-op; when they have drifted it repairs the drift
- *  toward the app.
- *
- *  A refusal is the ANSWER here, not an error, which is why nothing is reported. A real fault
- *  (network, quota) lands here too and reads as "not ours" — costing a numbered name rather than
- *  taking a wrong one. */
-async function isOurs(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<boolean> {
+ *  toward the app. */
+type Ownership = "ours" | "theirs" | "unknown";
+
+async function probeOwnership(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<Ownership> {
   try {
     await handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, appIsPublic));
-    return true;
-  } catch {
-    return false;
+    return "ours";
+  } catch (err) {
+    return isRefusal(err) ? "theirs" : "unknown";
   }
+}
+
+/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
+ *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
+ *  `failed-precondition` is the document not being what the rules required. Everything else —
+ *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
+ *  never having been answered. */
+function isRefusal(err: unknown): boolean {
+  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
+}
+
+function probeFailed(candidate: string): SharedAppFailure {
+  return {
+    ok: false,
+    partial: true,
+    problems: [
+      `the URL name '${candidate}' is taken, and this deploy could not establish whether it is this app's own reservation.`,
+      "Stopping rather than guessing: taking the next numbered name would strand the original, which stays live and — if the app is public — keeps resolving to it.",
+      "The app and its schemas are deployed and the roster can use /staging/{aid}. Deploying again retries just this step.",
+    ],
+  };
 }
 
 /** Write the reserved name back, so the next deploy does not reserve a second one.

--- a/server/backends/sharedApp/unpublish.ts
+++ b/server/backends/sharedApp/unpublish.ts
@@ -19,6 +19,7 @@ import { isRecord } from "../../../common/isRecord.js";
 import { APPS_COLLECTION, PUBLIC_CONFIG_DOC, appConfigPath, appManifestReason, firestoreHandle, loadAppManifest } from "@mulmoclaude/core/collection/server";
 import type { SharedAppFailure } from "./context.js";
 import { runWrites } from "./writes.js";
+import { setSlugPublished } from "./slug.js";
 
 export interface UnpublishSuccess {
   ok: true;
@@ -27,6 +28,8 @@ export interface UnpublishSuccess {
    *  saying out loud — the operator asked for a state, and hearing "done" when nothing changed
    *  reads as confirmation that it HAD been open. */
   wasOpen: boolean;
+  /** The URL name that stopped resolving, when there was one. */
+  slug?: string | undefined;
 }
 
 export type UnpublishResult = UnpublishSuccess | SharedAppFailure;
@@ -63,9 +66,15 @@ export async function unpublishSharedApp(root: string): Promise<UnpublishResult>
   const closed = Object.fromEntries(Object.entries(existing).filter(([key]) => key !== "public"));
   const wasOpen = "public" in existing;
 
+  // The name stops resolving on the way down, after the authorization is gone and before the
+  // rendering data. Exactly the reverse of publish, for the reverse reason: what is taken away
+  // first is what grants.
+  const slug = typeof existing.slug === "string" ? existing.slug : undefined;
+
   const failure = await runWrites(
     [
       { what: `the public block on apps/${aid} — the authorization itself`, run: () => handle.docs.set(APPS_COLLECTION, aid, closed) },
+      ...(slug === undefined ? [] : [{ what: `the URL name '${slug}' (appSlugs/${slug})`, run: () => setSlugPublished(handle, aid, slug, false) }]),
       {
         what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
         run: async () => {
@@ -76,5 +85,5 @@ export async function unpublishSharedApp(root: string): Promise<UnpublishResult>
     "unpublish",
   );
   if (failure) return failure;
-  return { ok: true, aid, wasOpen };
+  return { ok: true, aid, wasOpen, slug };
 }

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -64,6 +64,13 @@ function provenance(commit: string | undefined, dirty: boolean): string {
   return dirty ? `Recorded commit ${commit}, but the working tree was MODIFIED — the commit does not describe what was written.` : `Recorded commit ${commit}.`;
 }
 
+/** " at /sakura-hair", or nothing. Two of these rather than an inline conditional inside a
+ *  template, because a sentence that reads well with and without the clause is the only thing
+ *  worth optimising here. */
+const at = (slug: string | undefined): string => (slug === undefined ? "" : ` at /${slug}`);
+
+const noLonger = (slug: string | undefined): string => (slug === undefined ? "" : `, /${slug} no longer resolves`);
+
 function recordNote(issues: number, capped: boolean): string[] {
   if (issues === 0) return [];
   const count = capped ? `at least ${issues}` : String(issues);
@@ -77,6 +84,11 @@ async function narrateDeploy(root: string, confirm: boolean): Promise<string> {
   return [
     `${result.created ? "Created" : "Updated"} apps/${result.aid} and staged ${result.cids.length} collection${plural}: ${result.cids.join(", ") || "(none)"}.`,
     `The roster can try it at /staging/${result.aid}. Nothing is public until you publish.`,
+    ...(result.slug === undefined
+      ? []
+      : [
+          `URL name held: '${result.slug}'. It starts resolving at /${result.slug} when you publish — until then nobody can look it up, which is what keeps /staging/{aid} unguessable.`,
+        ]),
     ...(result.withdrawn.length > 0 ? [`Withdrawn from staging (no longer in this repository): ${result.withdrawn.join(", ")}.`] : []),
     ...recordNote(result.recordIssues, result.recordIssuesCapped),
     provenance(result.commit, result.dirty),
@@ -90,7 +102,7 @@ async function narratePublish(root: string, confirm: boolean): Promise<string> {
   return [
     `Published apps/${result.aid}: promoted ${result.cids.length} staged collection${plural} (${result.cids.join(", ")}).`,
     result.publicOpen
-      ? "The app is now OPEN to anonymous visitors."
+      ? `The app is now OPEN to anonymous visitors${at(result.slug)}.`
       : "The app is NOT open to anonymous visitors — app.json declares no `public` block, so the promoted schemas are readable only by the roster.",
     ...recordNote(result.recordIssues, result.recordIssuesCapped),
     provenance(result.commit, result.dirty),
@@ -101,7 +113,7 @@ async function narrateUnpublish(root: string): Promise<string> {
   const result = await unpublishSharedApp(root);
   if (!result.ok) return result.problems.join("\n");
   return result.wasOpen
-    ? `Unpublished apps/${result.aid}: the public block is gone, so anonymous access is closed, and the public config document was deleted. ` +
+    ? `Unpublished apps/${result.aid}: the public block is gone, so anonymous access is closed${noLonger(result.slug)}, and the public config document was deleted. ` +
         "The promoted schemas were left in place, so publishing again is a promotion."
     : `apps/${result.aid} was already closed to the public — nothing was open to take down. The public config document was deleted if it was still there.`;
 }

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -16,6 +16,8 @@ import { deploySharedApp } from "../backends/sharedApp/deploy.js";
 import { publishSharedApp } from "../backends/sharedApp/publish.js";
 import { unpublishSharedApp } from "../backends/sharedApp/unpublish.js";
 import { isRecord } from "../../common/isRecord.js";
+import { manifestKey } from "../backends/sharedApp/manifestWrite.js";
+import { serializeBy } from "../backends/sharedApp/serialize.js";
 
 export const SHARED_APP_ACTIONS = ["deploy", "publish", "unpublish"] as const;
 export type SharedAppAction = (typeof SHARED_APP_ACTIONS)[number];
@@ -125,7 +127,16 @@ export async function manageSharedApp(root: string, args: unknown): Promise<stri
   const action = parseAction(body.action);
   if (action === null) return `manageSharedApp: action must be one of ${SHARED_APP_ACTIONS.join(", ")}.`;
   const confirm = body.confirm === true;
-  if (action === "deploy") return narrateDeploy(root, confirm);
-  if (action === "publish") return narratePublish(root, confirm);
-  return narrateUnpublish(root);
+  // ONE operation at a time per repository. Each of these is a read-then-write sequence over the
+  // same documents, and interleaved they undo each other: a publish that read the app document
+  // before a deploy renamed the URL would go on to open the OLD name, which the deploy had just
+  // retired — leaving a resolving name that no later unpublish touches, because unpublish works
+  // from the record the deploy moved.
+  //
+  // At the entry point rather than inside each operation, because what must not interleave is the
+  // whole sequence, and this is the only place all three pass through.
+  const key = `operation:${await manifestKey(root)}`;
+  if (action === "deploy") return serializeBy(key, () => narrateDeploy(root, confirm));
+  if (action === "publish") return serializeBy(key, () => narratePublish(root, confirm));
+  return serializeBy(key, () => narrateUnpublish(root));
 }

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -51,7 +51,9 @@ class FakeDocs implements FirestoreDocs {
     // the reservation code asks "is this name ours?" about a document it may not read.
     const existing = this.bucket(collectionPath).get(docId);
     if (collectionPath === "appSlugs" && existing && existing.aid !== data.aid) {
-      return Promise.reject(new Error("permission-denied: appSlugs.aid is immutable (test)"));
+      // Rejected the way the SDK rejects: the `code` is what separates "the rules said no" from
+      // "the question never got an answer", and the caller reads exactly that difference.
+      return Promise.reject(Object.assign(new Error("appSlugs.aid is immutable (test)"), { code: "permission-denied" }));
     }
     this.writes.push(`set ${key}`);
     this.bucket(collectionPath).set(docId, structuredClone(data));
@@ -369,6 +371,22 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(again.ok === true && again.slug).toBe("sakura-hair");
     expect(docs.doc("appSlugs", "sakura-hair-2")).toBeUndefined();
     expect(docs.app()?.slug).toBe("sakura-hair");
+  });
+
+  it("stops rather than taking a numbered name when the ownership probe cannot be answered", async () => {
+    // An outage is not "somebody else's". Reading it that way turns a timeout into a second
+    // reservation — and if the name being reclaimed was public, the app records the numbered one
+    // while the original keeps resolving, beyond the reach of unpublish.
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+    await deploySharedApp(root, stamp);
+    const app = docs.app();
+    if (app) delete app.slug;
+    docs.failAt = "appSlugs/sakura-hair";
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("could not establish");
+    expect(docs.doc("appSlugs", "sakura-hair-2")).toBeUndefined();
   });
 
   it("says so rather than reporting success when there was nothing open to close", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -389,6 +389,25 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc("appSlugs", "sakura-hair-2")).toBeUndefined();
   });
 
+  it("stops the previous name from resolving when the app is renamed", async () => {
+    writeApp(root, declaration({ slug: "sakura-hair", public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    await publishSharedApp(root, stamp);
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: true });
+
+    // The author renames the app's URL.
+    writeApp(root, declaration({ slug: "sakura-salon", public: { enabled: true, read: ["bookings"] } }));
+    const renamed = await deploySharedApp(root, stamp);
+    expect(renamed.ok === true && renamed.slug).toBe("sakura-salon");
+
+    // The old one keeps pointing here — it is never deleted, because a freed name is one somebody
+    // else can claim and then serve from a URL already in circulation — but it stops resolving.
+    // Otherwise every later unpublish would act on the new name while the old URL still opened
+    // the app.
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
+    expect(docs.app()?.slug).toBe("sakura-salon");
+  });
+
   it("says so rather than reporting success when there was nothing open to close", async () => {
     await deploySharedApp(root, stamp);
     const result = await unpublishSharedApp(root);

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -9,7 +9,7 @@
 // somebody was only testing, and a publish that wrote it FIRST would leave anonymous access live
 // against a half-published surface if the next write failed.
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs, type FirestoreDoc } from "@mulmoclaude/core/collection/server";
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
@@ -274,6 +274,67 @@ describe("shared app deploy / publish / unpublish", () => {
 
     const confirmed = await publishSharedApp(root, { ...stamp, confirm: true });
     expect(confirmed.ok).toBe(true);
+  });
+
+  it("reserves the declared URL name at deploy, and records it where it can be read back", async () => {
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok === true && result.slug).toBe("sakura-hair");
+    // `published: false` — the reservation exists and nobody can resolve it yet, which is what
+    // keeps /staging/{aid} unguessable while the roster tests the app.
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
+    // On the app document, because appSlugs is unreadable until publish: this is the only place
+    // "which name do we hold?" can be asked from.
+    expect(docs.app()?.slug).toBe("sakura-hair");
+  });
+
+  it("does not reserve a SECOND name when the same app is deployed again", async () => {
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+    await deploySharedApp(root, stamp);
+    docs.writes.length = 0;
+
+    const again = await deploySharedApp(root, stamp);
+    expect(again.ok === true && again.slug).toBe("sakura-hair");
+    // A URL is a thing people have already sent to each other (D2b). Re-reserving would hand the
+    // app `sakura-hair-2` on every deploy, and the reservation cannot be read back to notice.
+    expect(docs.writes.filter((write) => write.includes("appSlugs"))).toEqual([]);
+  });
+
+  it("takes the next numbering when the wanted name is held by someone else", async () => {
+    docs.store.set("appSlugs", new Map([["sakura-hair", { aid: "someone-else", published: true }]]));
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok === true && result.slug).toBe("sakura-hair-2");
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: "someone-else", published: true });
+    // Written BACK to app.json — the reservation cannot be read back, so a deploy that did not
+    // find it there would reserve yet another name and leave this one held by nobody.
+    expect(JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")).slug).toBe("sakura-hair-2");
+  });
+
+  it("makes the name resolve at publish and stop at unpublish, in that order", async () => {
+    writeApp(root, declaration({ slug: "sakura-hair", public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    docs.writes.length = 0;
+
+    const published = await publishSharedApp(root, stamp);
+    expect(published.ok === true && published.slug).toBe("sakura-hair");
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: true });
+    // After everything the name points at, before the authorization: a slug that resolved first
+    // would be a link that 404s inside.
+    expect(docs.writes).toEqual([
+      `set apps/${AID}/collections/bookings`,
+      `set apps/${AID}/config/public`,
+      `set apps/${AID}`,
+      "set appSlugs/sakura-hair",
+      `set apps/${AID}`,
+    ]);
+
+    docs.writes.length = 0;
+    await unpublishSharedApp(root);
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
+    // Reversed: what grants is taken away first.
+    expect(docs.writes).toEqual([`set apps/${AID}`, "set appSlugs/sakura-hair", `delete apps/${AID}/config/public`]);
   });
 
   it("says so rather than reporting success when there was nothing open to close", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -46,6 +46,13 @@ class FakeDocs implements FirestoreDocs {
   set = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<void> => {
     const key = `${collectionPath}/${docId}`;
     if (this.failAt === key) return Promise.reject(new Error("permission-denied (test)"));
+    // The one rule this fake models, because a caller DEPENDS on being refused: `appSlugs`'
+    // update rule pins `aid`, so a write naming a different app is rejected. That refusal is how
+    // the reservation code asks "is this name ours?" about a document it may not read.
+    const existing = this.bucket(collectionPath).get(docId);
+    if (collectionPath === "appSlugs" && existing && existing.aid !== data.aid) {
+      return Promise.reject(new Error("permission-denied: appSlugs.aid is immutable (test)"));
+    }
     this.writes.push(`set ${key}`);
     this.bucket(collectionPath).set(docId, structuredClone(data));
     return Promise.resolve();
@@ -335,6 +342,33 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
     // Reversed: what grants is taken away first.
     expect(docs.writes).toEqual([`set apps/${AID}`, "set appSlugs/sakura-hair", `delete apps/${AID}/config/public`]);
+  });
+
+  it("does not make the name resolve when the app is not open to anonymous visitors", async () => {
+    // A published reservation is world-readable, and what it reveals is the aid — the
+    // /staging/{aid} entrance. Publishing a roster-only declaration is a normal thing to do, and
+    // it must not hand that out while the same operation reports the app is closed.
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+    await deploySharedApp(root, stamp);
+    const result = await publishSharedApp(root, stamp);
+    expect(result.ok === true && result.publicOpen).toBe(false);
+    expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
+  });
+
+  it("reclaims its own reservation rather than taking a numbered one", async () => {
+    // The record on the app document can be lost — a deploy that reserved and then failed to
+    // record it, a document restored from before. `create` then fails for a name this app already
+    // holds, and taking `-2` would strand the first reservation: live, held by an app that no
+    // longer claims it, and unreadable by anyone who might notice.
+    writeApp(root, declaration({ slug: "sakura-hair" }));
+    await deploySharedApp(root, stamp);
+    const app = docs.app();
+    if (app) delete app.slug;
+
+    const again = await deploySharedApp(root, stamp);
+    expect(again.ok === true && again.slug).toBe("sakura-hair");
+    expect(docs.doc("appSlugs", "sakura-hair-2")).toBeUndefined();
+    expect(docs.app()?.slug).toBe("sakura-hair");
   });
 
   it("says so rather than reporting success when there was nothing open to close", async () => {

--- a/test/server/backends/sharedAppSerialize.spec.ts
+++ b/test/server/backends/sharedAppSerialize.spec.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+//
+// The primitive both `app.json` writes and whole shared-app operations are kept in line by.
+//
+// It is tested here rather than through the operations because the property is about ORDER, and
+// order is exactly what an integration test of two refusals cannot show: they finish too fast to
+// have overlapped, whatever the lock does.
+import { describe, it, expect } from "vitest";
+import { serializeBy } from "../../../server/backends/sharedApp/serialize.js";
+
+/** A task that reports when it starts and finishes, so overlap is visible rather than inferred. */
+const tracked = (log: string[], name: string, ms: number) => async (): Promise<void> => {
+  log.push(`${name}:start`);
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  log.push(`${name}:end`);
+};
+
+describe("serializeBy", () => {
+  it("runs same-key work one at a time, in the order it was asked for", async () => {
+    const log: string[] = [];
+    // The slow one FIRST: without a lock it would finish last and the interleaving would show.
+    await Promise.all([serializeBy("k", tracked(log, "a", 20)), serializeBy("k", tracked(log, "b", 0)), serializeBy("k", tracked(log, "c", 0))]);
+    expect(log).toEqual(["a:start", "a:end", "b:start", "b:end", "c:start", "c:end"]);
+  });
+
+  it("lets different keys run at once — two repositories must not wait on each other", async () => {
+    const log: string[] = [];
+    await Promise.all([serializeBy("one", tracked(log, "one", 20)), serializeBy("two", tracked(log, "two", 0))]);
+    expect(log).toEqual(["one:start", "two:start", "two:end", "one:end"]);
+  });
+
+  it("does not let a failure stop the next one", async () => {
+    // A rejected predecessor must not reject its successor: the chain is a lock, not a pipeline,
+    // and one operation refusing is the ordinary case here.
+    const failing = serializeBy("k", () => Promise.reject(new Error("nope")));
+    await expect(failing).rejects.toThrow("nope");
+    await expect(serializeBy("k", () => Promise.resolve("after"))).resolves.toBe("after");
+  });
+
+  it("forgets a key once its work is done", async () => {
+    // Otherwise the map grows with every project ever deployed. Observable only through behaviour:
+    // a later call must not be waiting on a settled chain.
+    await serializeBy("k", () => Promise.resolve());
+    const log: string[] = [];
+    await Promise.all([serializeBy("k", tracked(log, "a", 0)), serializeBy("other", tracked(log, "b", 0))]);
+    expect(log).toContain("a:end");
+    expect(log).toContain("b:end");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,10 +1897,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/common/-/common-1.2.0.tgz#ad2d696a6a06ea47c078e45d8d7f6f41b53d4aeb"
   integrity sha512-Y459jz/3fGY+QPSOtRUpq+JA1v839qlhaKmuz6LohoJp0nneP9Eot+gsn7Yl8RKhEGqxhfmJaCDa28bWK7RhCA==
 
-"@mulmoclaude/core@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.0.0.tgz#4cdc36c2fd190568cba78c6cf10772c24e9a353b"
-  integrity sha512-CCX9K2xDXoCiMhGep+S2fcom2SI3ioTvddqtwwuYiWfgTT2N7mKleQcqyEi82g5QXXW6WHwRv/3USQXO5MhXrw==
+"@mulmoclaude/core@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.11.0.tgz#66605dab3e90c233f49c50c01ec88b8aba91bc8c"
+  integrity sha512-vxR6xaJdHCdNPGXE1036EYQBl6pVFyIr3Eo/qcvzHHjNA8OZbUPvqR4XTNjGtyt0XWkcxE79rpHGr6SiQzkYFg==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"
@@ -1912,10 +1912,10 @@
     js-yaml "^5.2.3"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.10.0.tgz#ade5538458dbd822461cc8785a5b4f7ef55f6209"
-  integrity sha512-S6uNeD323ExbqZm7S7kl1p1epREzWvLm4Y6aNv8bqH4UJKU4JWT4+VR0ZoDAz8g6+4vpCHU1/pk4wmQ87xUbNw==
+"@mulmoclaude/core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.0.0.tgz#4cdc36c2fd190568cba78c6cf10772c24e9a353b"
+  integrity sha512-CCX9K2xDXoCiMhGep+S2fcom2SI3ioTvddqtwwuYiWfgTT2N7mKleQcqyEi82g5QXXW6WHwRv/3USQXO5MhXrw==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"


### PR DESCRIPTION
`@mulmoclaude/core` **3.11.0**（mulmoclaude#2872）で `app.json` が `slug` を持てるように
なったので、その予約と公開を MulmoTerminal 側に入れます。**core の変更はもう要りません。**

## やること

- **deploy** が `appSlugs/{slug}` を **`published: false`** で押さえる。取られていたら
  `sakura-hair-2`, `-3`… と番号を付ける（D2b）。取れた名前は `app.json` に書き戻す
- **publish** が `published` を反転させる。**名前が指す先を全部書いたあと、`public`
  （＝認可）の直前** — 先に解決する名前は、開くと中で 404 するリンクになる
- **unpublish** はその逆順（認可を外す → 名前が解決しなくなる → 描画データを消す）

## 急所: 「もう持っているか」をどこで判定するか

予約は `published: false` の間、**ルール上オーナー自身も読み返せません**
（`allow read: if resource.data.published == true`）。人間可読な名前を総当たりされて
aid が漏れないための設計で、その aid は `/staging/{aid}` の入口です。つまり
**Firestore には聞けません**。

`app.json` の値は clone に付いていく記録ですが、deploy の入口では**「著者が今書いた希望」と
区別がつきません**。区別しないまま再予約すると、deploy のたびに URL が変わります —
URL は人がもう送ってしまっているものです。

なので **`apps/{aid}.slug`** に記録します。`projectDeploy` はこのキーを射影に含めない
（予約はホストの領分で、core は意見を持たない）ので、**MT が毎回現在値から載せ直します**。
`projectPublish` の方は未知キーを持ち越すので publish では消えません — この非対称は
core の仕様で、片方だけ見て「持ち越されるはず」と考えると消えます。

## ついでに

`ensureAid` の書き込み（原子的 / モード保持 / シンボリックリンクの実体を更新 / 1 度に 1 つ）を
`manifestWrite.ts` に出し、slug の書き戻しと共有しました。#1636 のレビューで 4 回に分けて
学んだ性質で、理由は両方に等しく効きます — **`app.json` は著者のファイルであって、
こちらの出力物ではない**。

## テスト

`sharedApp.spec.ts` に 4 件（予約して記録する / 2 回目の deploy は再予約しない /
取られていたら番号を付けて app.json に書き戻す / publish と unpublish の書き込み順）。
`test/server` 全体 5145 pass / lint 0 errors / `yarn build` 通過。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shareable app URL slugs with automatic reservation, conflict handling, reuse, and persistence.
  * Deploy and publish results now include the app’s slug when available.
  * Publishing and unpublishing update URL visibility and report affected URLs in status messages.
* **Bug Fixes**
  * Improved app identifier generation and manifest updates while preserving existing valid data.
* **Tests**
  * Added coverage for slug reservation, reuse, conflicts, persistence, publishing, and unpublishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->