### PR TITLE
feat(skills): 「みんなで使うもの」を作る道筋をエージェントに教える

### DIFF
--- a/common/bundledSkills.ts
+++ b/common/bundledSkills.ts
@@ -22,6 +22,7 @@ export const BUNDLED_SKILL_NAMES = [
   "mulmoterminal-notify",
   "mulmoterminal-bug-report",
   "mulmoterminal-decisions",
+  "mulmoterminal-shared-app",
 ] as const;
 
 export type BundledSkillName = (typeof BUNDLED_SKILL_NAMES)[number];

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -3035,11 +3035,28 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
      **完了**（mulmoterminal #1636 でレビュー対応まで込み）。`app.json` は著者のファイルで
      あってこちらの出力物ではないので、書き込みは**原子的・モード保持・シンボリックリンクの
      実体を更新・1 度に 1 つ**（`manifestWrite.ts`）
-   - **7e. URL slug の予約**（D2b / D10）— deploy が `appSlugs/{slug}` を
+   - **7e. URL slug の予約**（D2b / D10）— **完了**（mulmoterminal #1638）。
+     deploy が `appSlugs/{slug}` を
      `published: false` で押さえ、取られていたら `-2`, `-3`… と番号を付ける。取れた名前は
      `app.json` に書き戻し、**`apps/{aid}.slug` にも記録**して次の deploy が二重に取らない
      ようにする。publish が `published` を反転（**公開の直前、`public` の直前**）、
-     unpublish がその逆順で戻す
+     unpublish がその逆順で戻す。
+
+     レビューで出て設計に足りていなかったもの（いずれも「予約は読めない」の帰結）:
+
+     - **公開の反転は `public` ブロックの有無に従う。** publish したから公開する、では
+       ない — 名簿だけのアプリを publish したときに slug が解決すると、**世界から読める
+       予約が aid を配る**ことになり、それは `/staging/{aid}` の入口
+     - **`create` が false でも、自分の予約かどうかを書いて確かめる**（ルールは「既存文書が
+       名指すアプリのオーナーで aid 不変」の更新だけ許すので、通れば自分のもの）。
+       これが無いと、記録が失われた・同時に走った・記録に失敗した deploy がどれも `-2` を
+       取り、元の名前は**もう名乗らないアプリに握られたまま誰にも読めない**状態で残る。
+       **失敗を一律に「他人のもの」と読んではいけない** — 一時的な失敗まで番号に流すと、
+       公開中の名前が解決したまま unpublish の射程から外れる
+     - **`slug` を変えたら前の名前を閉じる**（削除はしない）。以降の unpublish は新しい
+       名前しか見ないので、**下ろしたつもりの URL でアプリが開き続ける**
+     - **操作はリポジトリごとに 1 つずつ**。deploy と publish が交差すると、publish が
+       deploy の閉じた旧名を開き直す
 
 **共有**
 

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -29,6 +29,7 @@ export const MANAGE_SHARED_APP: ToolDefinition = {
     "Deploy, publish or unpublish this repository's shared app (the one declared by its app.json). " +
     "deploy stages the declaration and the collection schemas where only the app's roster can see them; publish promotes what was staged and opens the app to the public; unpublish closes it again.",
   prompt:
+    "A request for something OTHER PEOPLE fill in or read — a survey, a sign-up sheet, a booking form, a form behind a link — is a shared app, and the `mulmoterminal-shared-app` skill is the path from that sentence to this tool. Read it before offering a printable page or a third-party form.\n" +
     "`manageSharedApp` operates on the repository the session is open in — the one holding `app.json` — and it is the only way to write a shared app.\n" +
     "**deploy** is the safe one and is meant to be run often. It writes the roster and internal settings to `apps/{aid}` and each collection's schema to `apps/{aid}/staging/{cid}`, which only people on the roster can read. " +
     "An invitation added to `members` takes effect at deploy, so the roster can try the real app at `/staging/{aid}` before anybody outside sees it. Deploy never opens the app to the public, and never changes what a published app's visitors are looking at.\n" +

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: mulmoterminal-shared-app
+description: Build something several people use together — a survey, a sign-up sheet, a booking form, a shared list, a form on a link — where the answers are kept in one place rather than on this machine. Use when the user asks for anything other people will fill in or read, and when they later say show it to someone, invite an address, publish it, or take it down. Turns the request into a shared app in this repository and drives deploy / publish / unpublish. Works in whatever language the user writes in.
+---
+
+# Something other people use
+
+A request like "make a survey for my talk", "I need a sign-up sheet", "let people book a slot",
+"a form I can send a link to" is asking for a SHARED APP — a thing that lives on the web, keeps
+its answers in one place, and can be handed to people who do not have this repository or this
+machine.
+
+**Do not offer a printable page, a Google Form, or a stand-alone HTML form as the answer.** They
+are what this looked like before there was anywhere to keep the answers, and each of them leaves
+the user to solve the actual problem — where the responses go — by themselves. Offer them only if
+the user turns this down.
+
+## What a shared app is
+
+- **One repository is one app.** The folder this session is open in becomes the app; its
+  declaration is `app.json` at the root.
+- **The definition is committed; the answers are not.** Schemas and views are files in the
+  repository. Records live in the app's cloud store, so everyone sees the same rows.
+- **Who may do what is a list of email addresses** in `app.json`. Inviting somebody is adding a
+  line and deploying — they need no account here and no repository.
+
+## The path
+
+Say what you are doing in the user's words ("作っています", "みんなが見えるようにしました"). The
+words below are for you, not for them: an author does not need to know what a `cid` is.
+
+### 1. Write the declaration
+
+`app.json` at the repository root:
+
+```json
+{
+  "name": "Talk feedback",
+  "slug": "aug-talk-survey",
+  "members": { "owner@example.com": { "*": "owner" } }
+}
+```
+
+- `members` is keyed by **email**, and the user's own address goes in as `owner`. Ask for it if
+  you do not know it — it is the one thing you cannot infer.
+- `slug` is the name in the URL people will be given. Take it from what the thing IS
+  (`aug-talk-survey`), lowercase with hyphens. It is a wish: if it is taken, a number is appended
+  and written back here.
+- **Never invent an `aid`.** It is generated for you the moment you write the first collection,
+  and it is a UUID on purpose — a memorable one would be first-come-first-served across every user
+  of the deployment.
+
+### 2. Write the collection
+
+One collection per kind of record — a survey has one (`responses`), a booking app might have two
+(`bookings`, `services`). It is an ordinary collection skill (`.claude/skills/<slug>/schema.json`
+plus its SKILL.md) with ONE difference:
+
+```json
+{ "storage": { "type": "firestore" } }
+```
+
+That is what makes the records shared. Declare no `dataPath` beside it — exactly one of the two.
+
+**Everything in the folder is shared or nothing is.** Do not mix a shared collection and a local
+one in an app's repository.
+
+### 3. Deploy
+
+`manageSharedApp` with `action: "deploy"`. Run it after every change to the declaration or a
+schema. It is safe and meant to be run often: it writes only what the roster can see, and it can
+never open the app to the public.
+
+Tell the user they can look at it now, and give them the address the tool reports.
+
+### 4. Invite
+
+Add the address to `members` and deploy again. Roles:
+
+| role | what they get |
+|---|---|
+| `owner` | everything, including publishing |
+| `editor` | reads and writes the records |
+| `viewer` | reads the records |
+| `participant` | named on the roster, sees only their OWN rows |
+
+`{ "tanaka@example.com": { "*": "viewer" } }` is the whole app; `{ "bookings": "editor" }` is one
+collection.
+
+### 5. Publish, when the user asks to open it
+
+Publishing is the one dangerous step: it changes what everybody outside sees, immediately. Do it
+when the user asks for it in those terms ("公開して", "リンクを配りたい"), not as the last step of
+building.
+
+What being public MEANS is declared in `app.json`, and it is worth reading back to the user before
+you publish:
+
+```json
+"public": {
+  "enabled": true,
+  "read": ["summary"],
+  "submit": {
+    "responses": {
+      "auth": "anonymous",
+      "createFields": ["name", "affiliation", "score", "comment"],
+      "initialStatus": "submitted"
+    }
+  }
+}
+```
+
+- `read` — which collections a visitor may READ. A survey usually lists none: people answer, they
+  do not browse the answers.
+- `submit` — which collections a visitor may WRITE, and **`createFields` is the whole list of
+  fields they may set**. Anything you leave out cannot be written by them. Leave `status` out, or
+  a respondent can mark their own submission approved.
+- `auth`: `none` (nothing at all), `anonymous` (a device identity, so a person can come back to
+  their own row), `verifiedEmail` (a signed-in address, which is what lets a row be tied to a
+  person).
+
+Then `manageSharedApp` with `action: "publish"`.
+
+`action: "unpublish"` closes it again and keeps everything, so re-opening it later is one step.
+
+## What the tool refuses, and why it is right
+
+- **Live records that do not fit the schema you are about to write.** It lists them. Migrate them,
+  or pass `confirm: true` — after telling the user what breaks, not before.
+- **A confirm on `deploy` does not carry to `publish`.** They are different sentences: one says
+  "stage it anyway", the other says "let everyone have it".
+- **`publish` promotes what was deployed**, not what is in the working tree. If the user edited
+  something after the last deploy, deploy again first — otherwise you publish a version nobody
+  looked at.
+
+## Before you ask the user a question
+
+Two things are worth asking and the rest are not:
+
+- **their email address**, if you do not have it — nothing works without it in `members`;
+- **who should be able to answer** — anyone with the link, or only invited people. It decides the
+  whole `public` block.
+
+Do not ask which storage to use, whether to make it "an app", or what to call the collection.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -50,17 +50,26 @@ words below are for you, not for them: an author does not need to know what a `c
   and it is a UUID on purpose — a memorable one would be first-come-first-served across every user
   of the deployment.
 
-### 2. Write the collection
+### 2. Write the collection THROUGH `manageCollection`
 
 One collection per kind of record — a survey has one (`responses`), a booking app might have two
-(`bookings`, `services`). It is an ordinary collection skill (`.claude/skills/<slug>/schema.json`
-plus its SKILL.md) with ONE difference:
+(`bookings`, `services`).
+
+**Do not hand-write `schema.json`.** Call `manageCollection` with `action: "schemaDocs"` for the
+shape, then `action: "putSchema"` to write it. The shape is not what a reasonable person guesses:
+`fields` is an OBJECT keyed by field name (not a list), `primaryKey` and `icon` are required, and
+the key for a field's human name is `label`. A hand-written file in the shape you would design
+does not parse, and nothing tells you until a deploy finds no collections at all.
+
+The one thing that differs from an ordinary collection:
 
 ```json
 { "storage": { "type": "firestore" } }
 ```
 
 That is what makes the records shared. Declare no `dataPath` beside it — exactly one of the two.
+Writing this schema is also what generates the app's `aid`, which is why the declaration comes
+first.
 
 **Everything in the folder is shared or nothing is.** Do not mix a shared collection and a local
 one in an app's repository.
@@ -90,34 +99,49 @@ collection.
 ### 5. Publish, when the user asks to open it
 
 Publishing is the one dangerous step: it changes what everybody outside sees, immediately. Do it
-when the user asks for it in those terms ("公開して", "リンクを配りたい"), not as the last step of
-building.
+when the user asks for it in those terms, not as the last step of building.
 
 What being public MEANS is declared in `app.json`, and it is worth reading back to the user before
-you publish:
+you publish. This is a survey anyone may answer once they sign in:
 
 ```json
-"public": {
-  "enabled": true,
-  "read": ["summary"],
-  "submit": {
-    "responses": {
-      "auth": "anonymous",
-      "createFields": ["name", "affiliation", "score", "comment"],
-      "initialStatus": "submitted"
+{
+  "collections": {
+    "responses": { "submitOnly": true, "statusField": "status" }
+  },
+  "public": {
+    "enabled": true,
+    "read": [],
+    "submit": {
+      "responses": {
+        "auth": "verifiedEmail",
+        "emailField": "email",
+        "createFields": ["name", "affiliation", "score", "comment", "email", "status"],
+        "initialStatus": "submitted"
+      }
     }
   }
 }
 ```
 
-- `read` — which collections a visitor may READ. A survey usually lists none: people answer, they
-  do not browse the answers.
-- `submit` — which collections a visitor may WRITE, and **`createFields` is the whole list of
-  fields they may set**. Anything you leave out cannot be written by them. Leave `status` out, or
-  a respondent can mark their own submission approved.
-- `auth`: `none` (nothing at all), `anonymous` (a device identity, so a person can come back to
-  their own row), `verifiedEmail` (a signed-in address, which is what lets a row be tied to a
-  person).
+Every line of that is load-bearing, and deploy refuses the declaration without them:
+
+- **`auth` must be `verifiedEmail`.** `none` and `anonymous` exist in the rules and are REFUSED
+  here — a product decision, not an oversight. So "anyone with the link, no sign-in" is not
+  something you can offer today: a respondent signs in with an email address. Say that to the user
+  rather than promising anonymity and discovering it at deploy.
+- **`emailField` names the field their address lands in**, and it must be in `createFields`.
+- **`submitOnly: true` is required** whenever the submission binds a record to its submitter. The
+  record means "this person said this", and without it an owner or editor could write rows that
+  carry that meaning without having earned it.
+- **`initialStatus` needs `collections.<cid>.statusField`** and that field must be in
+  `createFields`. It is NOT a hole: the rules pin the value to `initialStatus` on create, so a
+  respondent can only write `submitted` — listing it is what lets the rules check it. What
+  `createFields` must NOT contain is anything else you do not want them setting.
+- **`read: []`** — a survey lists nothing publicly. People answer; they do not browse the answers.
+
+The simplest correct survey omits status entirely (`submitOnly` + `verifiedEmail` + `emailField`).
+Add a status only when somebody is going to work through the responses.
 
 Then `manageSharedApp` with `action: "publish"`.
 
@@ -138,7 +162,28 @@ Then `manageSharedApp` with `action: "publish"`.
 Two things are worth asking and the rest are not:
 
 - **their email address**, if you do not have it — nothing works without it in `members`;
-- **who should be able to answer** — anyone with the link, or only invited people. It decides the
-  whole `public` block.
+- **whether people outside the roster should be able to answer** — it decides whether there is a
+  `public` block at all. Ask it in those words: everyone who answers signs in with an email
+  address either way, so "public" here means "anyone who signs in", not "anonymous".
 
 Do not ask which storage to use, whether to make it "an app", or what to call the collection.
+
+## Where people actually look — say what is true today
+
+- **The roster's entrance exists.** After a deploy, `manageSharedApp` reports the address; hand
+  that to the people you invited.
+- **The public page does not exist yet.** Publishing writes everything a public page needs and
+  turns the URL name on, but the page that renders it is not built. So do not promise the user a
+  link to hand out at an event. What works end to end today is an app used by the people on its
+  roster.
+
+Say this at the START, when the user's request implies handing out a link — not after they have
+watched you build it.
+
+## If the tools are not here
+
+`manageSharedApp` and `manageCollection` are only offered in a cell whose directory has the
+workspace-data tool group. If they are not in your tool list, **stop and say so**: a shared app
+cannot be deployed from here, and writing `app.json` and a schema by hand produces files nothing
+can act on. Point the user at the launcher's tool-group switch for this folder rather than
+carrying on.

--- a/test/server/infra/install-bundled-skills.spec.ts
+++ b/test/server/infra/install-bundled-skills.spec.ts
@@ -200,9 +200,13 @@ describe("mulmoterminal-config routes to skills that exist", () => {
   // reader who turns it on needs to be told where the result is consumed. Naming a skill that does
   // not ship is still caught, by the test above.
   it("routes to every skill that writes settings", () => {
-    const writers = BUNDLED_SKILL_NAMES.filter(
-      (name) => name !== "mulmoterminal-config" && name !== "mulmoterminal-bug-report" && name !== "mulmoterminal-decisions",
-    );
+    // The three that are not settings at all, and one that is not MulmoTerminal's settings:
+    // `mulmoterminal-shared-app` builds the user's own app — it writes that repository's `app.json`
+    // and its collections, never anything the router is a table of contents for. Routing to it
+    // would put "make a survey" in a list of places to change fonts and keybindings, and the agent
+    // finds it the way it finds any skill: by what the user asked for.
+    const notSettings = ["mulmoterminal-config", "mulmoterminal-bug-report", "mulmoterminal-decisions", "mulmoterminal-shared-app"];
+    const writers = BUNDLED_SKILL_NAMES.filter((name) => !notSettings.some((excluded) => excluded === name));
     expect(writers.filter((name) => !routed().includes(name))).toEqual([]);
   });
 });

--- a/test/server/skills/sharedAppSkill.spec.ts
+++ b/test/server/skills/sharedAppSkill.spec.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+//
+// The declaration in the skill is COPIED by the agent, verbatim, into a user's repository. The one
+// this shipped with could not be deployed at all — `auth: "anonymous"` is refused, `initialStatus`
+// needs a `statusField` beside it, and an identity-binding submit needs `submitOnly` — and nothing
+// caught it, because prose is not run.
+//
+// So it is run here: the sample is lifted out of the file and put through the same gate a deploy
+// puts it through. Documentation that stops matching the engine fails as a test rather than as a
+// user's first attempt.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { CollectionSchemaZ, parseAuthoredApp, publishProblems } from "@mulmoclaude/core/collection/server";
+
+const SKILL = path.join(process.cwd(), "server/skills/mulmoterminal-shared-app/SKILL.md");
+const body = readFileSync(SKILL, "utf-8");
+
+/** Every ```json block in the skill, in order. */
+const jsonBlocks = (): unknown[] => [...body.matchAll(/```json\n([\s\S]*?)```/g)].map((match) => JSON.parse(match[1] ?? "null") as unknown);
+
+/** The blocks that are whole declarations (as opposed to the one-key fragments the prose uses to
+ *  point at a single line). */
+const declarations = (): Record<string, unknown>[] =>
+  jsonBlocks().filter((block): block is Record<string, unknown> => typeof block === "object" && block !== null && ("members" in block || "public" in block));
+
+describe("the shared-app skill's sample declarations", () => {
+  it("has some to check", () => {
+    expect(declarations().length).toBeGreaterThan(0);
+  });
+
+  it("parse, and pass the gate a deploy puts them through", () => {
+    for (const declaration of declarations()) {
+      // The samples are fragments of one app: the roster is in the first, the public block in the
+      // second. Merged with an aid and an owner, each must be a declaration that would deploy.
+      const whole = { aid: "app-under-test", members: { "owner@example.com": { "*": "owner" } }, ...declaration };
+      const parsed = parseAuthoredApp(JSON.stringify(whole));
+      expect(parsed.ok ? [] : parsed.problems).toEqual([]);
+      if (!parsed.ok) continue;
+      const collections = Object.keys(parsed.app.public?.submit ?? {}).map((cid) => ({ cid, primaryKey: "id" }));
+      expect(publishProblems(parsed.app, collections, "owner@example.com")).toEqual([]);
+    }
+  });
+});
+
+describe("the shared-app skill's schema advice", () => {
+  // The agent that followed this wrote `fields` as a LIST of `{ name, title }`, with no
+  // `primaryKey` and no `icon` — a shape nothing in the engine accepts. The skill now sends it to
+  // `schemaDocs` instead of describing the shape, and this pins the two facts that made the
+  // guess wrong.
+  it("names the tool that owns the shape rather than describing it", () => {
+    expect(body).toContain("schemaDocs");
+    expect(body).toContain("putSchema");
+  });
+
+  it("says what a guessed schema gets wrong", () => {
+    for (const fact of ["`fields` is an OBJECT", "`primaryKey` and `icon` are required", "`label`"]) {
+      expect(body).toContain(fact);
+    }
+  });
+
+  it("agrees with the engine about the shape it warns of", () => {
+    const guessed = { title: "Responses", storage: { type: "firestore" }, fields: [{ name: "name", type: "string", title: "Name" }] };
+    const engine = {
+      title: "Responses",
+      icon: "assignment",
+      primaryKey: "id",
+      storage: { type: "firestore" },
+      fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+    };
+    expect(CollectionSchemaZ.safeParse(guessed).success).toBe(false);
+    expect(CollectionSchemaZ.safeParse(engine).success).toBe(true);
+  });
+});


### PR DESCRIPTION
実機で確かめたら、こうなりました。

```
❯ 講演のアンケートを作って。名前・所属・満足度（1〜5）・感想を書いてもらう。

  1. 印刷用の紙アンケート（推奨）
  2. Webフォーム（回答画面のみ）  ← 「回答の保存先は別途必要です」
  3. Googleフォーム用の設問テキスト
  4. Markdown / テキストの素案
```

**共有アプリという選択肢がありません。** エージェントはそれを知らないので当然で、しかも
提案のどれもが、ユーザーが本当に困っていること — **回答をどこに置くか** — を本人に押し返して
います。ツールは揃っているのに、その入口に立つ言葉が無い状態でした。

## 追加するもの

`server/skills/mulmoterminal-shared-app`。何が「みんなで使うもの」の合図で、`app.json` に何を
書き、いつ deploy し、**公開が実際に何を意味するか**を書いています。

書いた中で効くと思う点:

- **`aid` を発明しない。** 最初のコレクションを書いた時点で生成されます（#1641）
- **`createFields` が回答者の書ける欄の全部。** `status` を入れると、回答者が自分の回答を
  承認済みにできてしまいます
- **publish は「公開して」と言われたときにやる。** 作業の最後にやることではありません
- **ユーザーに聞く価値があるのは 2 つだけ** — 本人のアドレス（`members` に要る）と、
  誰が答えられるか（`public` ブロック全体がこれで決まる）。ストレージの種類やコレクション名は
  聞きません

`manageSharedApp` の prompt にも 1 行入れました（この skill を読んでから紙や外部フォームを
提案すること）。

## ルーターには載せていません

`mulmoterminal-config` は MulmoTerminal の設定の目次で、この skill は**ユーザーのアプリ**を
書きます。「アンケートを作る」がフォントやキーバインドを変える場所の一覧に並ぶのは違うので、
テストの除外リストに理由つきで足しました（載せない skill を黙って増やせないよう、
除外は明示されます）。

`test/server` 5156 pass / lint 0 / `yarn build` 通過。

work in mulmoterminal