### PR TITLE
fix(collections): 初回 deploy ができなかったのを直す

### DIFF
--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -188,6 +188,13 @@ export async function readCurrentApp(
     const existing = await handle.docs.get(APPS_COLLECTION, aid);
     return { ok: true, app: isRecord(existing) ? existing : null };
   } catch (err) {
+    // A REFUSAL is not an answer about the document — it is the absence of one.
+    //
+    // The read rule resolves the roster out of the document itself, so a document that does not
+    // exist makes the expression fail and the read is DENIED: the same answer as somebody else's
+    // app. Reported as "no document" so the caller can go on to the only thing that distinguishes
+    // them, which is trying to CREATE it; everything else (network, quota) is still a failure.
+    if (isRefusal(err)) return { ok: true, app: null };
     return {
       ok: false,
       partial: false,
@@ -197,6 +204,15 @@ export async function readCurrentApp(
       ],
     };
   }
+}
+
+/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
+ *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
+ *  `failed-precondition` is the document not being what the rules required. Everything else —
+ *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
+ *  never having been answered. */
+export function isRefusal(err: unknown): boolean {
+  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
 }
 
 /** Who, when, and from which commit — resolved the same way by both operations.

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -14,10 +14,9 @@
 // The write order is "app document first": `appSlugs`' create rule and the staging rules both
 // resolve the owner through `get(apps/{aid})`, so on a first deploy nothing else is authorized
 // until that document exists.
-import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type LoadedCollection, type PublishStamp } from "@mulmoclaude/core/collection/server";
-import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { gitStamp, readCurrentApp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
@@ -42,32 +41,6 @@ export interface DeploySuccess {
    *  deploy. Reported because a withdrawal is not what the operator asked for; it is what
    *  deleting a collection's directory MEANT, and the two are easy to confuse. */
   withdrawn: string[];
-}
-
-/** The app document as it stands, or the refusal.
- *
- *  The preflight read decides two things the rules care about: whether `owner` is stamped or
- *  carried forward, and which of publish's fields are carried through the replacement. A rejection
- *  here — permission, network, quota — must become the documented result rather than escape as a
- *  raw exception; it happens before any write, which is what the caller most needs told.
- *
- *  It also normalizes "was there an app document?" ONCE, for the projection and the report both.
- *  Two spellings of that question disagree the moment `get` resolves to something that is neither
- *  a record nor null: the projection stamps a fresh `owner` while the reply says "Updated". */
-async function readCurrentApp(handle: SharedAppHandle, aid: string): Promise<{ ok: true; app: Record<string, unknown> | null } | SharedAppFailure> {
-  try {
-    const existing = await handle.docs.get(APPS_COLLECTION, aid);
-    return { ok: true, app: isRecord(existing) ? existing : null };
-  } catch (err) {
-    return {
-      ok: false,
-      partial: false,
-      problems: [
-        `deploy failed while reading the current app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
-        "Nothing was written. Deploying again is safe — this read only decides whether the app is created or updated.",
-      ],
-    };
-  }
 }
 
 /** Reserve the declared URL name if this app does not already hold it, and record the result on
@@ -141,8 +114,8 @@ async function establishAndScan(
   confirm: boolean | undefined,
 ): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
   if (established) {
-    const failed = await runWrites([{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }], "deploy");
-    if (failed) return failed;
+    const claimed = await claimApp(handle, aid, appDoc);
+    if (claimed) return claimed;
   }
   const scan = await scanRecords(collections, root);
   const refusal = recordRefusal(scan, "deploy", confirm);
@@ -150,6 +123,42 @@ async function establishAndScan(
   // The app document is live when this call created it just above — the roster, and nothing else.
   // Saying so is the difference between "nothing happened" and "the app exists now".
   return { ok: false, partial: established, problems: refusal };
+}
+
+/** Create the app document, which is also what SETTLES what a refused read left open.
+ *
+ *  `create` is create-if-absent and atomic, and the rules let only the declared owner do it. So:
+ *  it succeeds and the app is ours; it reports the id taken, which means the document exists and
+ *  the earlier read was refused because this address is not on ITS roster; or it is refused, which
+ *  means the declaration does not name this address as owner.
+ *
+ *  Each of those is a different thing to tell the operator, and none of them is "Missing or
+ *  insufficient permissions" — the message a first deploy used to end on. */
+async function claimApp(handle: SharedAppHandle, aid: string, appDoc: Record<string, unknown>): Promise<SharedAppFailure | null> {
+  let created: boolean;
+  try {
+    created = await handle.docs.create(APPS_COLLECTION, aid, appDoc);
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `cannot create the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Creating an app requires the signed-in address to be its OWNER in app.json's `members` — check that the address you are signed in with is the one listed there.",
+        "Nothing was written.",
+      ],
+    };
+  }
+  if (created) return null;
+  return {
+    ok: false,
+    partial: false,
+    problems: [
+      `apps/${aid} already exists and this session cannot read it.`,
+      "That combination means the app belongs to somebody else's roster: the aid in app.json was not created here, or the address you are signed in with was removed from it. Ask its owner to add you, or start a new app by removing `aid` from app.json.",
+      "Nothing was written.",
+    ],
+  };
 }
 
 /** Staged documents whose collection this repository no longer has.
@@ -211,7 +220,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   //
   // So a denial is not conclusive here, and the CREATE is what settles it (below): create-if-absent
   // is atomic, and only the declared owner may do it.
-  const current = await readCurrentApp(handle, aid);
+  const current = await readCurrentApp(handle, aid, "deploy", "Deploying again is safe — this read only decides whether the app is created or updated.");
   if (!current.ok) return current;
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -159,16 +159,12 @@ async function establishAndScan(
  *  schema staged forever, and publish — which promotes what is staged and refuses to promote a
  *  version it cannot check against the repository — has no way forward at all.
  *
- *  Only asked when the app document already exists: the staging rules resolve the roster through
- *  `get(apps/{aid})`, so on a FIRST deploy the listing is denied rather than empty, and treating
- *  that denial as a real one would make an app impossible to create. */
-async function staleStaged(
-  handle: SharedAppHandle,
-  aid: string,
-  existingApp: Record<string, unknown> | null,
-  keep: ReadonlySet<string>,
-): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
-  if (existingApp === null) return { ok: true, cids: [] };
+ *  Always asked, because by the time it runs the app document EXISTS: either it already did, or
+ *  this deploy has just written it. That matters for a resurrected aid — Firestore leaves
+ *  `staging/*` behind exactly as it leaves the records — where skipping the listing would carry an
+ *  orphaned staged collection through a successful deploy and into a publish that then fails
+ *  closed. For a genuinely new aid the listing is simply empty. */
+async function staleStaged(handle: SharedAppHandle, aid: string, keep: ReadonlySet<string>): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
   try {
     const staged = await handle.docs.list(appStagingPath(aid));
     return { ok: true, cids: staged.map((doc) => doc.id).filter((cid) => !keep.has(cid)) };
@@ -244,7 +240,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!gate.ok) return gate;
   const { scan } = gate;
 
-  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
+  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)));
   if (!stale.ok) return stale;
 
   const failure = await runWrites(

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -16,9 +16,9 @@
 // until that document exists.
 import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
-import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
+import { APPS_COLLECTION, appStagingPath, projectDeploy, type LoadedCollection, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
-import { EMPTY_SCAN, recordRefusal, scanRecords } from "./records.js";
+import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
@@ -125,6 +125,33 @@ async function reserveHeldSlug(
   return reservation;
 }
 
+/** Write the roster when it is missing, then run the migration gate over the records — or the
+ *  refusal that stops the deploy. Null when it may go on.
+ *
+ *  Split out for the line budget, but the two steps belong together anyway: the write is what
+ *  makes the read possible, and doing them apart is what let a missing parent be mistaken for an
+ *  empty store. */
+async function establishAndScan(
+  handle: SharedAppHandle,
+  aid: string,
+  appDoc: Record<string, unknown>,
+  established: boolean,
+  collections: readonly LoadedCollection[],
+  root: string,
+  confirm: boolean | undefined,
+): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
+  if (established) {
+    const failed = await runWrites([{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }], "deploy");
+    if (failed) return failed;
+  }
+  const scan = await scanRecords(collections, root);
+  const refusal = recordRefusal(scan, "deploy", confirm);
+  if (!refusal) return { ok: true, scan };
+  // The app document is live when this call created it just above — the roster, and nothing else.
+  // Saying so is the difference between "nothing happened" and "the app exists now".
+  return { ok: false, partial: established, problems: refusal };
+}
+
 /** Staged documents whose collection this repository no longer has.
  *
  *  Dropping them is what makes staging a REPLACEMENT of the repository's shared collections rather
@@ -181,12 +208,6 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const current = await readCurrentApp(handle, aid);
   if (!current.ok) return current;
 
-  // There is nothing live to break before the app exists, so the gate has nothing to say. It
-  // returns in force on the next deploy, when there IS an app and there may be records in it.
-  const scan = current.app === null ? EMPTY_SCAN : await scanRecords(collections, root);
-  const refusal = recordRefusal(scan, "deploy", opts.confirm);
-  if (refusal) return { ok: false, partial: false, problems: refusal };
-
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,
@@ -198,9 +219,6 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const existingApp = current.app;
   const deployed = projectDeploy(authored, schemasOf(collections), stamp, existingApp);
 
-  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
-  if (!stale.ok) return stale;
-
   // The slug this app already holds, carried on the app document because NOTHING ELSE CAN BE
   // ASKED: `appSlugs/{slug}` is unreadable until the app is published, so "do we already have
   // one?" has no other answer. `projectDeploy` does not carry it — the reservation is the host's
@@ -209,9 +227,31 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const held = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
   const appDoc = held === undefined ? deployed.app : { ...deployed.app, slug: held };
 
+  // ESTABLISH THE PARENT, THEN SCAN — rather than deciding that a missing app document means there
+  // are no records.
+  //
+  // It does not. Firestore deletes do not cascade, and this design documents the orphan state that
+  // leaves: `apps/{aid}` can be gone while `collections/*/items` beneath it survives. Reading the
+  // missing parent as an empty store would let a deploy that re-creates it make those records
+  // readable under a schema nothing ever checked them against.
+  //
+  // Writing the roster first is what makes the question ANSWERABLE. It grants nothing outside the
+  // roster — no `public` block is written here, ever — it is the same document this deploy is
+  // about to write anyway, and afterwards the records can be read. So the gate runs for real: on a
+  // new app it finds nothing, and on a resurrected aid it finds whatever survived.
+  const established = existingApp === null;
+  const gate = await establishAndScan(handle, aid, appDoc, established, collections, root, opts.confirm);
+  if (!gate.ok) return gate;
+  const { scan } = gate;
+
+  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
+  if (!stale.ok) return stale;
+
   const failure = await runWrites(
     [
-      { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) },
+      // Not written again when the step above just wrote it, byte for byte: the roster is already
+      // live, and the staging writes below need exactly that and nothing more.
+      ...(established ? [] : [{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }]),
       ...deployed.staging.map(({ cid, doc }) => ({
         what: `the staged schema for '${cid}' (apps/${aid}/staging/${cid})`,
         run: () => handle.docs.set(appStagingPath(aid), cid, doc),

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -18,7 +18,7 @@ import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
-import { recordRefusal, scanRecords } from "./records.js";
+import { EMPTY_SCAN, recordRefusal, scanRecords } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
@@ -169,13 +169,24 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!context.ok) return context;
   const { authored, collections, handle } = context;
 
-  const scan = await scanRecords(collections, root);
+  const { aid } = authored;
+  // The app document FIRST, because the migration gate below depends on it — not merely for the
+  // projection.
+  //
+  // A shared collection's records are authorized through `apps/{aid}`: the rules resolve the
+  // roster from that document. On a FIRST deploy it does not exist, so reading the records is
+  // denied — and the gate reads that as "the live records could not be read", which is the one
+  // refusal `confirm` may not override. The app could then never be created at all: every deploy
+  // of a new app died on a check about records that do not exist yet.
+  const current = await readCurrentApp(handle, aid);
+  if (!current.ok) return current;
+
+  // There is nothing live to break before the app exists, so the gate has nothing to say. It
+  // returns in force on the next deploy, when there IS an app and there may be records in it.
+  const scan = current.app === null ? EMPTY_SCAN : await scanRecords(collections, root);
   const refusal = recordRefusal(scan, "deploy", opts.confirm);
   if (refusal) return { ok: false, partial: false, problems: refusal };
 
-  const { aid } = authored;
-  const current = await readCurrentApp(handle, aid);
-  if (!current.ok) return current;
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -125,40 +125,35 @@ async function establishAndScan(
   return { ok: false, partial: established, problems: refusal };
 }
 
-/** Create the app document, which is also what SETTLES what a refused read left open.
+/** Write the app document when it is not there — which is also the only way to LEARN whether it
+ *  was ours to write.
  *
- *  `create` is create-if-absent and atomic, and the rules let only the declared owner do it. So:
- *  it succeeds and the app is ours; it reports the id taken, which means the document exists and
- *  the earlier read was refused because this address is not on ITS roster; or it is refused, which
- *  means the declaration does not name this address as owner.
+ *  `set` and not `create`. The create-if-absent primitive is a transaction that begins by READING
+ *  the document, and that read is refused for exactly the document it is meant to create: the read
+ *  rule resolves the roster out of the document itself, so for a missing one the expression fails
+ *  and the answer is denied. The transaction dies there, every time, on a brand-new aid.
  *
- *  Each of those is a different thing to tell the operator, and none of them is "Missing or
- *  insufficient permissions" — the message a first deploy used to end on. */
+ *  A `set` is subject to `allow create` when the document is absent and `allow update` when it is
+ *  not — and both require this session to be the owner. So it succeeds exactly when the app is
+ *  ours to write, and a refusal covers the two cases we cannot tell apart from here. The message
+ *  names both, because both are things the operator can check. */
 async function claimApp(handle: SharedAppHandle, aid: string, appDoc: Record<string, unknown>): Promise<SharedAppFailure | null> {
-  let created: boolean;
   try {
-    created = await handle.docs.create(APPS_COLLECTION, aid, appDoc);
+    await handle.docs.set(APPS_COLLECTION, aid, appDoc);
+    return null;
   } catch (err) {
     return {
       ok: false,
       partial: false,
       problems: [
-        `cannot create the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
-        "Creating an app requires the signed-in address to be its OWNER in app.json's `members` — check that the address you are signed in with is the one listed there.",
+        `cannot write the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Two things are refused the same way here, and both are worth checking:",
+        `  - the address this session is signed in with is not the one app.json names as owner (it must be a key of \`members\` with \`"*": "owner"\`);`,
+        `  - apps/${aid} already exists and belongs to somebody else's roster — the aid was not created here, or this address was removed from it. Removing \`aid\` from app.json starts a new app.`,
         "Nothing was written.",
       ],
     };
   }
-  if (created) return null;
-  return {
-    ok: false,
-    partial: false,
-    problems: [
-      `apps/${aid} already exists and this session cannot read it.`,
-      "That combination means the app belongs to somebody else's roster: the aid in app.json was not created here, or the address you are signed in with was removed from it. Ask its owner to add you, or start a new app by removing `aid` from app.json.",
-      "Nothing was written.",
-    ],
-  };
 }
 
 /** Staged documents whose collection this repository no longer has.

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -164,17 +164,25 @@ async function establishAndScan(
  *  `staging/*` behind exactly as it leaves the records — where skipping the listing would carry an
  *  orphaned staged collection through a successful deploy and into a publish that then fails
  *  closed. For a genuinely new aid the listing is simply empty. */
-async function staleStaged(handle: SharedAppHandle, aid: string, keep: ReadonlySet<string>): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
+async function staleStaged(
+  handle: SharedAppHandle,
+  aid: string,
+  keep: ReadonlySet<string>,
+  established: boolean,
+): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
   try {
     const staged = await handle.docs.list(appStagingPath(aid));
     return { ok: true, cids: staged.map((doc) => doc.id).filter((cid) => !keep.has(cid)) };
   } catch (err) {
     return {
       ok: false,
-      partial: false,
+      // The roster is LIVE when this deploy created it a moment ago, and a failure report that
+      // says "nothing was written" about an app that now exists is worse than no report.
+      partial: established,
       problems: [
         `deploy failed while reading what is already staged (apps/${aid}/staging): ${err instanceof Error ? err.message : String(err)}`,
-        "Nothing was written. This read is what lets a deleted collection be withdrawn from staging, so deploying without it would leave a stale schema behind for publish to trip over.",
+        established ? "The app document was written and the roster is live; nothing was staged. Deploying again continues from here." : "Nothing was written.",
+        "This read is what lets a deleted collection be withdrawn from staging, so deploying without it would leave a stale schema behind for publish to trip over.",
       ],
     };
   }
@@ -193,17 +201,18 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const { authored, collections, handle } = context;
 
   const { aid } = authored;
-  // The app document FIRST, because the migration gate below depends on it — not merely for the
-  // projection.
+  // WHAT THE APP DOCUMENT IS, asked in the only way the rules allow.
   //
-  // A shared collection's records are authorized through `apps/{aid}`: the rules resolve the
-  // roster from that document. On a FIRST deploy it does not exist, so reading the records is
-  // denied — and the gate reads that as "the live records could not be read", which is the one
-  // refusal `confirm` may not override. The app could then never be created at all: every deploy
-  // of a new app died on a check about records that do not exist yet.
+  // Reading `apps/{aid}` cannot tell you it is missing. The read rule resolves the roster out of
+  // the document itself (`readerOf(app(aid), '*')`), so for a document that does not exist the
+  // expression fails and the answer is DENIED — the same answer as somebody else's app. A first
+  // deploy therefore cannot start by reading, and did not: it reported
+  // "Missing or insufficient permissions" and stopped, with nothing else to try.
+  //
+  // So a denial is not conclusive here, and the CREATE is what settles it (below): create-if-absent
+  // is atomic, and only the declared owner may do it.
   const current = await readCurrentApp(handle, aid);
   if (!current.ok) return current;
-
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,
@@ -240,7 +249,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!gate.ok) return gate;
   const { scan } = gate;
 
-  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)));
+  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)), established);
   if (!stale.ok) return stale;
 
   const failure = await runWrites(

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -25,11 +25,6 @@ export interface RecordScan {
   unreadable: string[];
 }
 
-/** The answer for an app that does not exist yet: nothing is live, so nothing can break. Named
- *  rather than inlined so the reason travels with it — an empty scan is a STATEMENT here, not a
- *  scan that happened to find nothing. */
-export const EMPTY_SCAN: RecordScan = { lines: [], records: 0, capped: false, unreadable: [] };
-
 export async function scanRecords(collections: readonly LoadedCollection[], workspaceRoot: string): Promise<RecordScan> {
   const lines: string[] = [];
   const unreadable: string[] = [];

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -25,6 +25,11 @@ export interface RecordScan {
   unreadable: string[];
 }
 
+/** The answer for an app that does not exist yet: nothing is live, so nothing can break. Named
+ *  rather than inlined so the reason travels with it — an empty scan is a STATEMENT here, not a
+ *  scan that happened to find nothing. */
+export const EMPTY_SCAN: RecordScan = { lines: [], records: 0, capped: false, unreadable: [] };
+
 export async function scanRecords(collections: readonly LoadedCollection[], workspaceRoot: string): Promise<RecordScan> {
   const lines: string[] = [];
   const unreadable: string[] = [];

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -14,8 +14,7 @@
 // there, and a slug already recorded is never re-reserved. "Once you have it, you keep it" is
 // the point (D2b) — a URL is a thing people have already sent to each other.
 import { APP_SLUGS_COLLECTION, appSlugDoc } from "@mulmoclaude/core/collection/server";
-import { isRecord } from "../../../common/isRecord.js";
-import type { SharedAppFailure, SharedAppHandle } from "./context.js";
+import { isRefusal, type SharedAppFailure, type SharedAppHandle } from "./context.js";
 import { updateManifest } from "./manifestWrite.js";
 
 /** How many numbered alternatives to try before giving up. The number is small on purpose: past
@@ -137,15 +136,6 @@ async function probeOwnership(handle: SharedAppHandle, aid: string, slug: string
   } catch (err) {
     return isRefusal(err) ? "theirs" : "unknown";
   }
-}
-
-/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
- *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
- *  `failed-precondition` is the document not being what the rules required. Everything else —
- *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
- *  never having been answered. */
-function isRefusal(err: unknown): boolean {
-  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
 }
 
 function probeFailed(candidate: string): SharedAppFailure {

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -62,21 +62,19 @@ export async function reserveSlug(
 
   const taken: string[] = [];
   for (const candidate of candidates(wanted)) {
-    let claimed: boolean;
-    try {
-      // `create`, not `set`: create-if-absent is atomic, so two apps racing for one name cannot
-      // both observe it missing.
-      claimed = await handle.docs.create(APP_SLUGS_COLLECTION, candidate, appSlugDoc(aid, false));
-    } catch (err) {
-      return reservationFailed(candidate, err);
-    }
-    if (!claimed) {
-      const ownership = await probeOwnership(handle, aid, candidate, appIsPublic);
-      if (ownership === "unknown") return probeFailed(candidate);
-      if (ownership === "theirs") {
-        taken.push(candidate);
-        continue;
-      }
+    // `set`, not `create`. The create-if-absent primitive is a transaction that READS first, and
+    // that read is refused for a reservation that does not exist yet (`allow read` tests
+    // `resource.data.published`, which is not there) — so it can never claim a free name.
+    //
+    // A `set` is judged by `allow create` when the document is absent and by `allow update` when
+    // it is not, and both require this app's owner: it succeeds exactly when the name is free or
+    // already ours, and is refused when somebody else holds it. That refusal IS the answer, which
+    // is why nothing is reported for it.
+    const claimed = await claimSlug(handle, aid, candidate, appIsPublic);
+    if (claimed === "unknown") return probeFailed(candidate);
+    if (claimed === "theirs") {
+      taken.push(candidate);
+      continue;
     }
     const recorded = await recordSlug(root, candidate);
     return recorded ?? { ok: true, slug: candidate, reserved: true };
@@ -91,45 +89,21 @@ export async function reserveSlug(
   };
 }
 
-function reservationFailed(candidate: string, err: unknown): SharedAppFailure {
-  return {
-    ok: false,
-    partial: true,
-    problems: [
-      `deploy reached the app and its schemas, but could not reserve the URL name '${candidate}': ${err instanceof Error ? err.message : String(err)}`,
-      "The app is deployed and the roster can use /staging/{aid}; only the public URL is unreserved. Deploying again retries just this step.",
-    ],
-  };
-}
-
-/** Whose is an EXISTING reservation? Asked by WRITING to it, because it cannot be read.
- *
- *  This is why a failed `create` is not the end. The rules allow an update only when the caller
- *  owns the app the document ALREADY names and the `aid` is unchanged — so a write that succeeds
- *  proves ownership, and one REFUSED FOR THAT REASON proves somebody else holds the name. There is
- *  no other way to ask: `allow read` needs `published == true`, which is exactly the state a
- *  reservation is not in.
- *
- *  Without it, three ordinary situations end with a stranded name: a deploy that reserved and then
- *  failed to record it, two deploys of one repository at once, and an app document that lost the
- *  record. Each would see `create` fail, decide the name belonged to somebody else, and take `-2`
- *  — while the first reservation stayed live, held by an app that no longer claims it, and
- *  unreadable by anyone who might have noticed.
- *
- *  The third answer is the one that took a review to get right. A timeout or a quota error is NOT
- *  "somebody else's": reading it that way turns an outage into a second reservation, and if the
- *  name being reclaimed was a PUBLIC one, the app records the numbered name while the original
- *  keeps resolving — and can no longer be taken down, because unpublish works from the record.
- *  Only a refusal decides; anything else stops the deploy with the name unresolved, which a retry
- *  fixes and nothing else has to.
+/** Take the name, or find out that somebody else has it. One write, three answers.
  *
  *  `published` is written from the APP's state rather than guessed: the app document holds the
  *  `public` block, so it is the authority on whether this app is open, and the reservation should
  *  say the same. When they agree this is a no-op; when they have drifted it repairs the drift
- *  toward the app. */
+ *  toward the app.
+ *
+ *  A rules refusal means the name is somebody else's — the reservation cannot be read, so this is
+ *  the only way to ask. Anything else (a timeout, a quota) is the question never having been
+ *  answered, and must NOT be read as a collision: doing so turns an outage into a second
+ *  reservation, and if the name being reclaimed was public, the app records the numbered one while
+ *  the original keeps resolving, beyond the reach of unpublish. */
 type Ownership = "ours" | "theirs" | "unknown";
 
-async function probeOwnership(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<Ownership> {
+async function claimSlug(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<Ownership> {
   try {
     await handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, appIsPublic));
     return "ours";

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -50,16 +50,22 @@ words below are for you, not for them: an author does not need to know what a `c
   and it is a UUID on purpose — a memorable one would be first-come-first-served across every user
   of the deployment.
 
-### 2. Write the collection THROUGH `manageCollection`
+### 2. Write the collection
 
 One collection per kind of record — a survey has one (`responses`), a booking app might have two
 (`bookings`, `services`).
 
-**Do not hand-write `schema.json`.** Call `manageCollection` with `action: "schemaDocs"` for the
-shape, then `action: "putSchema"` to write it. The shape is not what a reasonable person guesses:
-`fields` is an OBJECT keyed by field name (not a list), `primaryKey` and `icon` are required, and
-the key for a field's human name is `label`. A hand-written file in the shape you would design
-does not parse, and nothing tells you until a deploy finds no collections at all.
+**A NEW collection is created by writing the files**: `SKILL.md` and `schema.json` under
+`.claude/skills/<slug>/`. `putSchema` is EDIT-ONLY and refuses a collection that does not exist
+yet ("unknown collection … create it by writing SKILL.md + schema.json"), so do not try to create
+one with it. Use it afterwards, to CHANGE a schema.
+
+**Read the shape first**: `manageCollection` with `action: "schemaDocs"`, and
+`topic: "Shared storage (firestore)"` for this part specifically. The shape is not what a
+reasonable person guesses — `fields` is an OBJECT keyed by field name (not a list), `primaryKey`
+and `icon` are required, and the key for a field's human name is `label`. A schema in the shape
+you would design does not parse, and a collection whose schema fails validation is **skipped
+silently**: nothing errors, it simply never appears.
 
 The one thing that differs from an ordinary collection:
 
@@ -68,8 +74,11 @@ The one thing that differs from an ordinary collection:
 ```
 
 That is what makes the records shared. Declare no `dataPath` beside it — exactly one of the two.
-Writing this schema is also what generates the app's `aid`, which is why the declaration comes
-first.
+
+**A shared collection is invisible until the app has an `aid`**, which is generated for you — by
+the first deploy, or by `putSchema` when you edit one later. So between writing the files and
+deploying, `getSchema` reporting "unknown collection" is expected, not a mistake to chase. Deploy,
+then look.
 
 **Everything in the folder is shared or nothing is.** Do not mix a shared collection and a local
 one in an app's repository.
@@ -187,3 +196,16 @@ workspace-data tool group. If they are not in your tool list, **stop and say so*
 cannot be deployed from here, and writing `app.json` and a schema by hand produces files nothing
 can act on. Point the user at the launcher's tool-group switch for this folder rather than
 carrying on.
+
+## Two refusals that are NOT your cue to start editing
+
+The run this skill was written from lost several minutes to each of these, and both times the
+repair made things worse — an `aid` was deleted and a second app was created by accident.
+
+- **`getSchema` / `putSchema` says "unknown collection".** For a collection you just wrote, that
+  means its schema has not been accepted yet — most often because the app has no `aid` until the
+  first deploy. Deploy; do not rewrite the schema, and do not move the directory.
+- **Anything about permissions on `apps/{aid}`.** The `aid` in `app.json` is the app's identity.
+  Removing it does not reset anything: the next deploy mints a NEW one and the old app stays where
+  it is, owned by nobody who can reach it. If a deploy is refused, read what it says and fix that;
+  never edit the `aid` by hand.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -202,9 +202,12 @@ carrying on.
 The run this skill was written from lost several minutes to each of these, and both times the
 repair made things worse — an `aid` was deleted and a second app was created by accident.
 
-- **`getSchema` / `putSchema` says "unknown collection".** For a collection you just wrote, that
-  means its schema has not been accepted yet — most often because the app has no `aid` until the
-  first deploy. Deploy; do not rewrite the schema, and do not move the directory.
+- **`getSchema` / `putSchema` says "unknown collection".** It means the schema was not ACCEPTED,
+  and there are two reasons: the app has no `aid` yet (nothing is wrong — the first deploy mints
+  it), or the schema failed validation (something is wrong, and it is skipped silently).
+  Tell them apart before acting: re-read the schema against `schemaDocs` — `primaryKey` naming a
+  field flagged `primary: true`, `icon` present, exactly one of `dataPath` / `dataSource` /
+  `storage`. If the schema is sound, deploy; do not rewrite it, and do not move the directory.
 - **Anything about permissions on `apps/{aid}`.** The `aid` in `app.json` is the app's identity.
   Removing it does not reset anything: the next deploy mints a NEW one and the old app stays where
   it is, owned by nobody who can reach it. If a deploy is refused, read what it says and fix that;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -88,6 +88,14 @@ class FakeDocs implements FirestoreDocs {
   };
 
   create = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<boolean> => {
+    // create-if-absent is a TRANSACTION, and it begins by reading the document. For the two
+    // collections whose read rule resolves out of a document that does not exist yet
+    // (`apps/{aid}`, `appSlugs/{slug}`), that read is refused — so `create` can never claim a
+    // fresh id there, however atomic it looks. Modelled here because the code got it wrong once
+    // and nothing in a fake that answered `false` would have said so.
+    if (!this.bucket(collectionPath).has(docId) && (collectionPath === "apps" || collectionPath === "appSlugs")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
     if (this.bucket(collectionPath).has(docId)) return Promise.resolve(false);
     this.writes.push(`create ${collectionPath}/${docId}`);
     this.bucket(collectionPath).set(docId, structuredClone(data));
@@ -219,6 +227,9 @@ describe("shared app deploy / publish / unpublish", () => {
     // it, and the message has to name the situation rather than repeat "insufficient permissions".
     docs.store.set("apps", new Map([[AID, { aid: AID, owner: "somebody-else" }]]));
     docs.readsDeniedForApp = true;
+    // The rules refuse the WRITE too — an update needs this session to be the app's owner — and
+    // that refusal is the only signal available, because the document cannot be read.
+    docs.failAt = `apps/${AID}`;
 
     const result = await deploySharedApp(root, stamp);
     expect(result.ok).toBe(false);
@@ -240,11 +251,11 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
-    // CREATE, then the staging document. On a first deploy the app write is what makes the records
-    // readable, so it happens before the migration gate rather than beside the staging writes —
-    // and it is a create because that is the only operation that can tell "this app does not
-    // exist" from "this app is somebody else's", which a refused read cannot.
-    expect(docs.writes).toEqual([`create apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+    // The app write, then the staging document. On a first deploy the app write is what makes the
+    // records readable, so it happens before the migration gate rather than beside the staging
+    // writes — and it is a `set`, because create-if-absent is a transaction that reads first and
+    // that read is refused for the very document it would create.
+    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
 
     // And on a redeploy, where the app already exists, the same order without the extra write.
     docs.writes.length = 0;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -32,6 +32,8 @@ class FakeDocs implements FirestoreDocs {
   /** Model the rules' actual shape: a shared collection's records are authorized through
    *  `apps/{aid}`, so while that document is missing, reading them is denied rather than empty. */
   readsDeniedUntilApp = false;
+  /** Collection path whose listing throws — a transient failure, as opposed to a refusal. */
+  failListing: string | null = null;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -42,9 +44,11 @@ class FakeDocs implements FirestoreDocs {
   }
 
   list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
-      ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
-      : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+    this.failListing === collectionPath
+      ? Promise.reject(new Error("unavailable (test)"))
+      : this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
+        ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
+        : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
 
   get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
 
@@ -189,6 +193,18 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
     // And the deploy still did its own job.
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
+  it("says the roster is live when it cannot read staging after creating the app", async () => {
+    // "Nothing was written" about an app that now exists is worse than no report at all: the next
+    // decision — deploy again, or go looking for what half-happened — turns on it.
+    docs.failListing = `apps/${AID}/staging`;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.partial).toBe(true);
+    expect(result.ok === false && result.problems.join("\n")).toContain("the roster is live");
+    expect(docs.app()).toBeDefined();
   });
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -29,6 +29,9 @@ class FakeDocs implements FirestoreDocs {
   readonly writes: string[] = [];
   /** Path/id whose next write throws — how a half-finished run is produced. */
   failAt: string | null = null;
+  /** Model the rules' actual shape: a shared collection's records are authorized through
+   *  `apps/{aid}`, so while that document is missing, reading them is denied rather than empty. */
+  readsDeniedUntilApp = false;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -39,7 +42,9 @@ class FakeDocs implements FirestoreDocs {
   }
 
   list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+    this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
+      ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
+      : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
 
   get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
 
@@ -139,6 +144,19 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.store.get(`apps/${AID}/config`)).toBeUndefined();
   });
 
+  it("creates an app whose records cannot be read yet — the first deploy of all", async () => {
+    // The deadlock this pins: a shared collection's records are authorized THROUGH `apps/{aid}`,
+    // so before that document exists the records cannot be read at all. The migration gate read
+    // that as "the live records could not be read", which is the one refusal `confirm` may not
+    // override — and a new app could never be created.
+    docs.readsDeniedUntilApp = true;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(true);
+    expect(docs.app()).toBeDefined();
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
     expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
@@ -232,6 +250,9 @@ describe("shared app deploy / publish / unpublish", () => {
   });
 
   it("stops at live records that would not fit the new schema, and confirming stages it anyway", async () => {
+    // The app has to EXIST for this gate to run: before it does there are no live records, and the
+    // records cannot even be read — the rules resolve their roster from the app document.
+    await deploySharedApp(root, stamp);
     docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
     writeFileSync(
       path.join(root, ".claude", "skills", "bookings", "schema.json"),
@@ -241,7 +262,6 @@ describe("shared app deploy / publish / unpublish", () => {
     const refused = await deploySharedApp(root, stamp);
     expect(refused.ok).toBe(false);
     expect(refused.ok === false && refused.problems.join("\n")).toContain("would not satisfy the schema");
-    expect(docs.app()).toBeUndefined();
 
     const confirmed = await deploySharedApp(root, { ...stamp, confirm: true });
     expect(confirmed.ok === true && confirmed.recordIssues).toBe(1);
@@ -266,6 +286,8 @@ describe("shared app deploy / publish / unpublish", () => {
   });
 
   it("does not let a confirmed deploy buy the publish", async () => {
+    // Same reason as above: the gate needs an app to exist before there is anything live in it.
+    await deploySharedApp(root, stamp);
     // The reason the scan runs at BOTH boundaries: deploy's confirm says "let me stage this
     // anyway", which mid-migration is the useful thing. It is not the same sentence as "let
     // everyone have it", so publish asks again and needs its own confirm.

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -157,7 +157,36 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
   });
 
+  it("runs the migration gate on records that survived their app document", async () => {
+    // Firestore deletes do not cascade: `apps/{aid}` can be gone while the records under it
+    // survive. A missing app document therefore proves only that the records cannot be READ right
+    // now — not that they do not exist — and a deploy that re-creates the app must still check
+    // them, or it hands them to the roster under a schema nothing compared them against.
+    docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
+    writeFileSync(
+      path.join(root, ".claude", "skills", "bookings", "schema.json"),
+      JSON.stringify({ ...schemaFor("bookings"), fields: { ...schemaFor("bookings").fields, note: { type: "string", label: "Note", required: true } } }),
+    );
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join("\n")).toContain("would not satisfy the schema");
+    // The app document IS live — that is what made the records readable — and the result says so.
+    expect(docs.app()).toBeDefined();
+    expect(result.ok === false && result.partial).toBe(true);
+    // Nothing was staged: the gate stopped before that.
+    expect(docs.store.get(`apps/${AID}/staging`)).toBeUndefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
+    await deploySharedApp(root, stamp);
+    // One app write, then the staging document — on a first deploy the app write is the one that
+    // makes the records readable, which is why it happens before the migration gate rather than
+    // beside the staging writes.
+    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+
+    // And on a redeploy, where the app already exists, the same order without the extra write.
+    docs.writes.length = 0;
     await deploySharedApp(root, stamp);
     expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
   });

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -34,6 +34,8 @@ class FakeDocs implements FirestoreDocs {
   readsDeniedUntilApp = false;
   /** Collection path whose listing throws — a transient failure, as opposed to a refusal. */
   failListing: string | null = null;
+  /** Refuse the app-document read even though it exists — somebody else's app. */
+  readsDeniedForApp = false;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -43,14 +45,30 @@ class FakeDocs implements FirestoreDocs {
     return created;
   }
 
-  list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    this.failListing === collectionPath
-      ? Promise.reject(new Error("unavailable (test)"))
-      : this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
-        ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
-        : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+  list = (collectionPath: string): Promise<FirestoreDoc[]> => {
+    if (this.failListing === collectionPath) {
+      return Promise.reject(new Error("unavailable (test)"));
+    }
+    // The rules again: a record listing is authorized through the app document, so while that is
+    // missing the listing is REFUSED rather than empty.
+    if (this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    const docs = [...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1));
+    return Promise.resolve(docs.map(([id, data]) => ({ id, data })));
+  };
 
-  get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
+  get = (collectionPath: string, docId: string): Promise<unknown | null> => {
+    // The rules' actual shape: `apps/{aid}`'s read resolves the roster out of the document, so a
+    // document that does not exist makes the expression fail and the read is REFUSED — the same
+    // answer as somebody else's app. A fake that answered `null` would let a first deploy pass a
+    // test the real thing cannot pass.
+    const existing = this.bucket(collectionPath).get(docId);
+    if (collectionPath === "apps" && (!existing || this.readsDeniedForApp)) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    return Promise.resolve(existing ?? null);
+  };
 
   set = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<void> => {
     const key = `${collectionPath}/${docId}`;
@@ -137,6 +155,7 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("deploys to the roster only — no public block, no published schema, no public config", async () => {
     const result = await deploySharedApp(root, stamp);
+    expect(result.ok === false ? result.problems : []).toEqual([]);
     expect(result.ok).toBe(true);
     // The one that matters: `publicOn` reads THIS field, not the world-readable projection, so a
     // deploy that wrote it would open the app for anyone testing.
@@ -195,6 +214,18 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
   });
 
+  it("says whose app it is when the id is taken and unreadable", async () => {
+    // The two are indistinguishable by reading — both are refusals — so the create is what settles
+    // it, and the message has to name the situation rather than repeat "insufficient permissions".
+    docs.store.set("apps", new Map([[AID, { aid: AID, owner: "somebody-else" }]]));
+    docs.readsDeniedForApp = true;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join("\n")).toContain("belongs to somebody else's roster");
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeUndefined();
+  });
+
   it("says the roster is live when it cannot read staging after creating the app", async () => {
     // "Nothing was written" about an app that now exists is worse than no report at all: the next
     // decision — deploy again, or go looking for what half-happened — turns on it.
@@ -209,10 +240,11 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
-    // One app write, then the staging document — on a first deploy the app write is the one that
-    // makes the records readable, which is why it happens before the migration gate rather than
-    // beside the staging writes.
-    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+    // CREATE, then the staging document. On a first deploy the app write is what makes the records
+    // readable, so it happens before the migration gate rather than beside the staging writes —
+    // and it is a create because that is the only operation that can tell "this app does not
+    // exist" from "this app is somebody else's", which a refused read cannot.
+    expect(docs.writes).toEqual([`create apps/${AID}`, `set apps/${AID}/staging/bookings`]);
 
     // And on a redeploy, where the app already exists, the same order without the extra write.
     docs.writes.length = 0;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -178,6 +178,19 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.store.get(`apps/${AID}/staging`)).toBeUndefined();
   });
 
+  it("withdraws staging that outlived its app document", async () => {
+    // Firestore leaves `staging/*` behind exactly as it leaves the records. Carried through a
+    // resurrecting deploy, an orphaned staged collection then makes publish fail closed — it
+    // promotes what is staged and refuses a cid the repository does not have.
+    docs.store.set(`apps/${AID}/staging`, new Map([["waitlist", { publishedSchema: { title: "Waitlist" }, deployedAt: 1, deployedBy: OWNER.email }]]));
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok === true && result.withdrawn).toEqual(["waitlist"]);
+    expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
+    // And the deploy still did its own job.
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
     // One app write, then the staging document — on a first deploy the app write is the one that

--- a/test/server/skills/sharedAppSkill.spec.ts
+++ b/test/server/skills/sharedAppSkill.spec.ts
@@ -53,8 +53,15 @@ describe("the shared-app skill's schema advice", () => {
     expect(body).toContain("putSchema");
   });
 
+  // The run this was written from tried to CREATE a collection with `putSchema` and was refused:
+  // it is edit-only. Getting that backwards costs the agent its whole first attempt.
+  it("says that a new collection is created by writing the files", () => {
+    expect(body).toContain("EDIT-ONLY");
+    expect(body).toContain("SKILL.md");
+  });
+
   it("says what a guessed schema gets wrong", () => {
-    for (const fact of ["`fields` is an OBJECT", "`primaryKey` and `icon` are required", "`label`"]) {
+    for (const fact of ["`fields` is an OBJECT", "`primaryKey`", "`icon` are required", "`label`"]) {
       expect(body).toContain(fact);
     }
   });


### PR DESCRIPTION
実機で新しい共有アプリを作ろうとして**詰みました**。ログ全文はセッションにありますが、要点は
これです。

```
responses: records could not be read from the storage backend: permission denied on
shared collection 'responses' of app '1a3b…' — signed in as satoshi.nakajima@gmail.com.
deploy stopped: the live records could not be read … This is not something `confirm` overrides.
```

## 何が起きていたか

deploy の順序が **レコードを検証 → app ドキュメントを読む → 書く** でした。ところが共有
コレクションのレコードは **`apps/{aid}` 経由で認可されます** — ルールは名簿をその文書から
引くので、**初回はまだ存在せず、読み取りが denied**。門番はそれを「ライブレコードが読めなかった」
と読み、それは `confirm` で越えられない唯一の拒否です。つまり **新しいアプリは永久に作れません**。

しかも詰んだあとが悪い。エージェントはコレクションを退避し、**`aid` を消して deploy し直し**、
結果として**孤児の app id を 2 つ**作りました（`1a3b7143…` と `1842c77c…`）。`aid` は削除
できない文書の identity なので、これは戻せません。

## 直し方

app ドキュメントの読み取りを**先**にして、まだ無ければ検証を飛ばします。**アプリが存在する前に
壊れるライブレコードは存在しない**ので、門番には言うことがありません。2 回目以降は元どおり
働きます（既存アプリにコレクションを足すときは、名簿があるので読めます）。

テストは初回 deploy を再現します — app ドキュメントが無い間、レコードの読み取りが
`permission-denied` になるフェイクで、これは実機のルールの形そのものです。

## skill 側も 2 つ

実機ではどちらも「直そうとして悪化」しました。

- **新しいコレクションは `putSchema` では作れない**（edit 専用で、存在しないコレクションを
  断る）。ファイルを書いて作ります。エージェントは `putSchema` で作ろうとして最初の試行を
  丸ごと失いました
- **`aid` が無い間、共有コレクションは discovery に載らない。** `getSchema` の
  「unknown collection」は**想定内**で、追いかけるものではありません。実機ではここで schema を
  書き直し、ディレクトリを移動し、最後に aid を消しました

`test/server` 5178 pass / lint 0 / build 通過。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared app deployment when app records are new, recreated, or temporarily unavailable due to permissions.
  * Ensured surviving records are validated against the schema after app recreation.
  * Prevented unnecessary rewrites during deployment.

* **Documentation**
  * Clarified how to create and edit shared collections, define schemas, and resolve validation or permission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->