### PR TITLE
feat(collections): app.json を作る・検算する・招待する操作を足す

### DIFF
--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -206,13 +206,24 @@ export async function readCurrentApp(
   }
 }
 
-/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
- *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
- *  `failed-precondition` is the document not being what the rules required. Everything else —
- *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
- *  never having been answered. */
+/** A rules REFUSAL, as opposed to a failure to ask.
+ *
+ *  ONLY `permission-denied`. The SDK reports both refusals and faults as thrown errors and the
+ *  `code` is what separates them — but `failed-precondition` is not the rules saying no: it is a
+ *  missing index, a stale transaction, a client the backend wants restarted. Reading it as a
+ *  refusal is dangerous in both places this predicate is used, and in the same direction:
+ *
+ *  - the app document would look ABSENT, so a deploy would rebuild it from the declaration alone
+ *    and drop the `public` block and the held slug — silently unpublishing a live app and
+ *    stranding its URL name;
+ *  - a slug would look like SOMEBODY ELSE'S, so a numbered alternative would be taken while the
+ *    app's own name went on resolving.
+ *
+ *  An unanswered question must stay unanswered: everything else — `unavailable`,
+ *  `deadline-exceeded`, `resource-exhausted`, `failed-precondition`, an offline client — stops the
+ *  operation instead. */
 export function isRefusal(err: unknown): boolean {
-  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
+  return isRecord(err) && err.code === "permission-denied";
 }
 
 /** Who, when, and from which commit — resolved the same way by both operations.

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -188,6 +188,13 @@ export async function readCurrentApp(
     const existing = await handle.docs.get(APPS_COLLECTION, aid);
     return { ok: true, app: isRecord(existing) ? existing : null };
   } catch (err) {
+    // A REFUSAL is not an answer about the document — it is the absence of one.
+    //
+    // The read rule resolves the roster out of the document itself, so a document that does not
+    // exist makes the expression fail and the read is DENIED: the same answer as somebody else's
+    // app. Reported as "no document" so the caller can go on to the only thing that distinguishes
+    // them, which is trying to CREATE it; everything else (network, quota) is still a failure.
+    if (isRefusal(err)) return { ok: true, app: null };
     return {
       ok: false,
       partial: false,
@@ -197,6 +204,15 @@ export async function readCurrentApp(
       ],
     };
   }
+}
+
+/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
+ *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
+ *  `failed-precondition` is the document not being what the rules required. Everything else —
+ *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
+ *  never having been answered. */
+export function isRefusal(err: unknown): boolean {
+  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
 }
 
 /** Who, when, and from which commit — resolved the same way by both operations.

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -113,14 +113,27 @@ async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp 
   return parseAuthoredApp(raw);
 }
 
-/** Everything wrong with the declaration itself, publisher included. */
-function declarationProblems(app: AuthoredApp, collections: readonly LoadedCollection[], handle: SharedAppHandle): string[] {
+/** The first address the declaration makes an app-wide owner, or undefined when it names none. */
+function ownerFromRoster(app: AuthoredApp): string | undefined {
+  return Object.entries(app.members).find(([, roles]) => roles["*"] === "owner")?.[0];
+}
+
+/** Everything wrong with the declaration itself, publisher included.
+ *
+ *  Shared by the gate that runs before a deploy and by `check`, which exists to answer "would a
+ *  deploy be refused?" — two implementations of that question is two answers, and the one `check`
+ *  gave was the optimistic one (it missed the `owner` uid mismatch, and said deployable about a
+ *  declaration the next deploy refused). */
+export function declarationProblems(app: AuthoredApp, collections: readonly LoadedCollection[], handle: { email: string; uid: string } | null): string[] {
   const problems = publishProblems(
     app,
     collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
-    handle.email,
+    // Signed out, the caller asks as the owner the declaration NAMES — see `checkSharedApp`. An
+    // empty address is not neutral here: `publishProblems` asks whether the publisher is an
+    // app-wide owner, so it would report a missing owner for every sound declaration.
+    handle?.email ?? ownerFromRoster(app) ?? "",
   );
-  if (app.owner !== undefined && app.owner !== handle.uid) {
+  if (handle !== null && app.owner !== undefined && app.owner !== handle.uid) {
     // Not fatal on its own — the rules pin `owner` to the EXISTING document on update — but a
     // declaration naming somebody else's uid is either the sample's `<uid>` placeholder or a
     // misunderstanding of what the key is.

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -1,0 +1,160 @@
+// Writing the declaration, instead of asking the agent to compose it.
+//
+// `app.json` is a small file, and every one of its failures found in testing came from the same
+// place: the agent had to write it from memory, before anything could check it. It guessed the
+// owner's address (the tool knows it), it wrote a `public` block that deploy refused for three
+// separate reasons, and when a deploy failed it edited the file by hand — deleting the `aid` and
+// creating a second, orphaned app.
+//
+// So the three things a person actually asks for become operations: start an app, check it, invite
+// somebody. What stays out is anything that would make the file OURS — it is a committed
+// declaration that people read and edit in a pull request, and it must survive being written by
+// hand. These only ever change the key they are about.
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { APP_MANIFEST_FILE, firestoreHandle, parseAuthoredApp, publishProblems } from "@mulmoclaude/core/collection/server";
+import { isRecord } from "../../../common/isRecord.js";
+import { sharedCollections, type SharedAppFailure } from "./context.js";
+import { createManifest, newAid, updateManifest } from "./manifestWrite.js";
+
+/** The roles the rules understand, in the order a person picks from. */
+export const APP_ROLE_NAMES = ["owner", "editor", "viewer", "participant"] as const;
+export type AppRoleName = (typeof APP_ROLE_NAMES)[number];
+
+export interface DeclareSuccess {
+  ok: true;
+  aid: string;
+  /** The signed-in address the declaration now names as owner. */
+  owner: string;
+  slug?: string | undefined;
+}
+
+export type DeclareResult = DeclareSuccess | SharedAppFailure;
+
+/** Start an app in this repository: `app.json` with the SIGNED-IN address as its owner.
+ *
+ *  The address is the whole reason this is an operation rather than a paragraph of instructions.
+ *  It has to match what the rules see (`request.auth.token.email`), the agent cannot read it, and
+ *  asking the user invites the one answer that fails at deploy — the address they think they are
+ *  using. */
+export async function initSharedApp(root: string, name: string | undefined, slug: string | undefined): Promise<DeclareResult> {
+  // The file first, because "you already have one" is the more useful answer and it does not
+  // depend on being connected. The write below is still `wx`, so the guarantee does not rest on
+  // this check — two sessions racing still get one app.
+  const existing = await readManifest(root);
+  if (existing.ok) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `${path.join(root, APP_MANIFEST_FILE)} already exists — this repository already declares an app.`,
+        "Overwriting it would replace the roster, which is the app's permission list. Edit the file, or use `invite` for one address.",
+      ],
+    };
+  }
+  const handle = firestoreHandle();
+  if (!handle) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        "starting an app needs a signed-in session: connect remote-host first.",
+        "The declaration names its owner by EMAIL, and it has to be the address this machine is signed in with — guessing it produces an app nobody can deploy.",
+      ],
+    };
+  }
+  const aid = newAid();
+  const manifest: Record<string, unknown> = {
+    ...(name === undefined ? {} : { name }),
+    ...(slug === undefined ? {} : { slug }),
+    aid,
+    members: { [handle.email]: { "*": "owner" } },
+  };
+  const written = await createManifest(root, manifest);
+  if (!written.ok) return { ok: false, partial: false, problems: written.problems };
+  return { ok: true, aid, owner: handle.email, slug };
+}
+
+export interface CheckReport {
+  ok: true;
+  aid: string | undefined;
+  collections: string[];
+  problems: string[];
+}
+
+/** Everything wrong with the declaration and this repository's collections, WITHOUT writing
+ *  anything or touching the app.
+ *
+ *  The gate that used to run only at deploy. An agent that has just written a declaration cannot
+ *  otherwise find out whether it is deployable — and in testing it did not: the invalid `public`
+ *  block travelled all the way to a live refusal, and by then the agent was editing files to
+ *  recover. */
+export async function checkSharedApp(root: string): Promise<CheckReport | SharedAppFailure> {
+  const raw = await readManifest(root);
+  if (!raw.ok) return raw;
+  const parsed = parseAuthoredApp(raw.text);
+  if (!parsed.ok) return { ok: true, aid: undefined, collections: [], problems: parsed.problems };
+
+  const collections = await sharedCollections(root);
+  const handle = firestoreHandle();
+  const problems = publishProblems(
+    parsed.app,
+    collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
+    // Without a session there is no address to check the roster against, so that half is skipped
+    // rather than guessed — and the report says so.
+    handle?.email ?? "",
+  );
+  return {
+    ok: true,
+    aid: parsed.app.aid,
+    collections: collections.map((collection) => collection.slug),
+    problems: handle ? problems : [...problems, "(not signed in: the check could not compare the roster against your address)"],
+  };
+}
+
+export interface InviteSuccess {
+  ok: true;
+  email: string;
+  role: AppRoleName | null;
+  cid: string;
+}
+
+/** Add, change or remove one address on the roster.
+ *
+ *  One key, left where it was — the file belongs to the author, and an operation that rewrote it
+ *  would be a worse version of editing it by hand. `role: null` removes. */
+export async function inviteToSharedApp(root: string, email: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
+  const updated = await updateManifest(root, (manifest) => nextMembers(manifest, email, role, cid));
+  if (!updated.ok) return { ok: false, partial: false, problems: updated.problems };
+  return { ok: true, email, role, cid };
+}
+
+/** The declaration with one roster entry changed, or null when it already says that.
+ *
+ *  Built by filtering rather than by deleting keys: the roster is the permission list, and an
+ *  entry that half-survives a removal is the failure mode the rules cannot save us from —
+ *  `membersConsistent()` would reject the deploy, which is the good case, but only after the
+ *  operator believed somebody had been removed. */
+function nextMembers(manifest: Record<string, unknown>, email: string, role: AppRoleName | null, cid: string): Record<string, unknown> | null {
+  const members = isRecord(manifest.members) ? manifest.members : {};
+  const current = isRecord(members[email]) ? members[email] : {};
+  const kept = Object.entries(current).filter(([key]) => key !== cid);
+  const roles = Object.fromEntries(role === null ? kept : [...kept, [cid, role]]);
+  const others = Object.entries(members).filter(([key]) => key !== email);
+  const nextRoster = Object.fromEntries(Object.keys(roles).length === 0 ? others : [...others, [email, roles]]);
+  if (JSON.stringify(nextRoster) === JSON.stringify(members)) return null;
+  return { ...manifest, members: nextRoster };
+}
+
+async function readManifest(root: string): Promise<{ ok: true; text: string } | SharedAppFailure> {
+  const manifestPath = path.join(root, APP_MANIFEST_FILE);
+  try {
+    return { ok: true, text: await readFile(manifestPath, "utf-8") };
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [`cannot read ${manifestPath}: ${String(err)}`, "This repository does not declare an app yet — start one with `init`."],
+    };
+  }
+}

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -12,9 +12,9 @@
 // hand. These only ever change the key they are about.
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { APP_MANIFEST_FILE, firestoreHandle, parseAuthoredApp, publishProblems } from "@mulmoclaude/core/collection/server";
+import { APP_MANIFEST_FILE, firestoreHandle, parseAuthoredApp } from "@mulmoclaude/core/collection/server";
 import { isRecord } from "../../../common/isRecord.js";
-import { sharedCollections, type SharedAppFailure } from "./context.js";
+import { declarationProblems, sharedCollections, type SharedAppFailure } from "./context.js";
 import { createManifest, newAid, updateManifest } from "./manifestWrite.js";
 
 /** The roles the rules understand, in the order a person picks from. */
@@ -101,28 +101,17 @@ export async function checkSharedApp(root: string): Promise<CheckReport | Shared
 
   const collections = await sharedCollections(root);
   const handle = firestoreHandle();
-  // WHOSE deploy is being checked.
-  //
-  // `publishProblems` asks, among other things, whether the publisher is an app-wide owner — so an
-  // empty address is not a neutral value: it reports `members must give you app-wide owner: add
-  // "": {"*": "owner"}` for every declaration, and a signed-out check could never come back clean.
-  //
-  // Signed out, the honest question is "would this deploy for the owner it names?", so the check
-  // runs as that owner and the report says which. Signed in, it is you — which is the stricter and
-  // more useful answer, because being signed in as somebody else is one of the things this catches.
-  const declaredOwner = ownerFromRoster(parsed.app);
-  const publisher = handle?.email ?? declaredOwner ?? "";
-  const problems = publishProblems(
-    parsed.app,
-    collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
-    publisher,
-  );
+  // The SAME gate a deploy runs, not a second opinion. `check` exists to answer "would a deploy be
+  // refused?", and a separate implementation of that question answers it differently — this one
+  // used to miss the `owner` uid mismatch and call a declaration deployable that deploy then
+  // refused.
+  const problems = declarationProblems(parsed.app, collections, handle);
   return {
     ok: true,
     aid: parsed.app.aid,
     collections: collections.map((collection) => collection.slug),
     checkedAs: handle?.email ?? null,
-    declaredOwner,
+    declaredOwner: ownerFromRoster(parsed.app),
     problems,
   };
 }

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -79,6 +79,10 @@ export interface CheckReport {
   ok: true;
   aid: string | undefined;
   collections: string[];
+  /** The signed-in address the check ran as, or null when there is no session. */
+  checkedAs: string | null;
+  /** The address the declaration names as app-wide owner, when it names one. */
+  declaredOwner: string | undefined;
   problems: string[];
 }
 
@@ -93,23 +97,42 @@ export async function checkSharedApp(root: string): Promise<CheckReport | Shared
   const raw = await readManifest(root);
   if (!raw.ok) return raw;
   const parsed = parseAuthoredApp(raw.text);
-  if (!parsed.ok) return { ok: true, aid: undefined, collections: [], problems: parsed.problems };
+  if (!parsed.ok) return { ok: true, aid: undefined, collections: [], checkedAs: null, declaredOwner: undefined, problems: parsed.problems };
 
   const collections = await sharedCollections(root);
   const handle = firestoreHandle();
+  // WHOSE deploy is being checked.
+  //
+  // `publishProblems` asks, among other things, whether the publisher is an app-wide owner — so an
+  // empty address is not a neutral value: it reports `members must give you app-wide owner: add
+  // "": {"*": "owner"}` for every declaration, and a signed-out check could never come back clean.
+  //
+  // Signed out, the honest question is "would this deploy for the owner it names?", so the check
+  // runs as that owner and the report says which. Signed in, it is you — which is the stricter and
+  // more useful answer, because being signed in as somebody else is one of the things this catches.
+  const declaredOwner = ownerFromRoster(parsed.app);
+  const publisher = handle?.email ?? declaredOwner ?? "";
   const problems = publishProblems(
     parsed.app,
     collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
-    // Without a session there is no address to check the roster against, so that half is skipped
-    // rather than guessed — and the report says so.
-    handle?.email ?? "",
+    publisher,
   );
   return {
     ok: true,
     aid: parsed.app.aid,
     collections: collections.map((collection) => collection.slug),
-    problems: handle ? problems : [...problems, "(not signed in: the check could not compare the roster against your address)"],
+    checkedAs: handle?.email ?? null,
+    declaredOwner,
+    problems,
   };
+}
+
+/** The first address the declaration makes an app-wide owner, or undefined when it names none.
+ *
+ *  Used only to ask the offline question as somebody. A declaration with no app-wide owner is a
+ *  real problem, and passing an empty address is how `publishProblems` is asked to say so. */
+function ownerFromRoster(app: { members: Record<string, Record<string, string>> }): string | undefined {
+  return Object.entries(app.members).find(([, roles]) => roles["*"] === "owner")?.[0];
 }
 
 export interface InviteSuccess {

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -147,7 +147,30 @@ export interface InviteSuccess {
  *  One key, left where it was — the file belongs to the author, and an operation that rewrote it
  *  would be a worse version of editing it by hand. `role: null` removes. */
 export async function inviteToSharedApp(root: string, email: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
-  const updated = await updateManifest(root, (manifest) => nextMembers(manifest, email, role, cid));
+  let orphaned = false;
+  const updated = await updateManifest(root, (manifest) => {
+    const next = nextMembers(manifest, email, role, cid);
+    if (next === null) return null;
+    // An app with no app-wide owner has no publisher: every deploy is refused, INCLUDING the one
+    // that would put an owner back. The file can still be edited by hand, but this tool must not
+    // be the way somebody locks themselves out — removing or demoting an owner is fine once
+    // another one exists.
+    if (!hasOwner(next)) {
+      orphaned = true;
+      return null;
+    }
+    return next;
+  });
+  if (orphaned) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `that would leave the app with no owner: ${email} is the only address holding \`"*": "owner"\`.`,
+        "An app with no owner cannot be deployed at all — not even to put an owner back. Add another owner first, then remove this one.",
+      ],
+    };
+  }
   if (!updated.ok) return { ok: false, partial: false, problems: updated.problems };
   return { ok: true, email, role, cid };
 }
@@ -167,6 +190,12 @@ function nextMembers(manifest: Record<string, unknown>, email: string, role: App
   const nextRoster = Object.fromEntries(Object.keys(roles).length === 0 ? others : [...others, [email, roles]]);
   if (JSON.stringify(nextRoster) === JSON.stringify(members)) return null;
   return { ...manifest, members: nextRoster };
+}
+
+/** Does this declaration still name somebody who may publish it? */
+function hasOwner(manifest: Record<string, unknown>): boolean {
+  const members = isRecord(manifest.members) ? manifest.members : {};
+  return Object.values(members).some((roles) => isRecord(roles) && roles["*"] === "owner");
 }
 
 async function readManifest(root: string): Promise<{ ok: true; text: string } | SharedAppFailure> {

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -14,10 +14,9 @@
 // The write order is "app document first": `appSlugs`' create rule and the staging rules both
 // resolve the owner through `get(apps/{aid})`, so on a first deploy nothing else is authorized
 // until that document exists.
-import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type LoadedCollection, type PublishStamp } from "@mulmoclaude/core/collection/server";
-import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { gitStamp, readCurrentApp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
@@ -42,32 +41,6 @@ export interface DeploySuccess {
    *  deploy. Reported because a withdrawal is not what the operator asked for; it is what
    *  deleting a collection's directory MEANT, and the two are easy to confuse. */
   withdrawn: string[];
-}
-
-/** The app document as it stands, or the refusal.
- *
- *  The preflight read decides two things the rules care about: whether `owner` is stamped or
- *  carried forward, and which of publish's fields are carried through the replacement. A rejection
- *  here — permission, network, quota — must become the documented result rather than escape as a
- *  raw exception; it happens before any write, which is what the caller most needs told.
- *
- *  It also normalizes "was there an app document?" ONCE, for the projection and the report both.
- *  Two spellings of that question disagree the moment `get` resolves to something that is neither
- *  a record nor null: the projection stamps a fresh `owner` while the reply says "Updated". */
-async function readCurrentApp(handle: SharedAppHandle, aid: string): Promise<{ ok: true; app: Record<string, unknown> | null } | SharedAppFailure> {
-  try {
-    const existing = await handle.docs.get(APPS_COLLECTION, aid);
-    return { ok: true, app: isRecord(existing) ? existing : null };
-  } catch (err) {
-    return {
-      ok: false,
-      partial: false,
-      problems: [
-        `deploy failed while reading the current app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
-        "Nothing was written. Deploying again is safe — this read only decides whether the app is created or updated.",
-      ],
-    };
-  }
 }
 
 /** Reserve the declared URL name if this app does not already hold it, and record the result on
@@ -141,8 +114,8 @@ async function establishAndScan(
   confirm: boolean | undefined,
 ): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
   if (established) {
-    const failed = await runWrites([{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }], "deploy");
-    if (failed) return failed;
+    const claimed = await claimApp(handle, aid, appDoc);
+    if (claimed) return claimed;
   }
   const scan = await scanRecords(collections, root);
   const refusal = recordRefusal(scan, "deploy", confirm);
@@ -150,6 +123,42 @@ async function establishAndScan(
   // The app document is live when this call created it just above — the roster, and nothing else.
   // Saying so is the difference between "nothing happened" and "the app exists now".
   return { ok: false, partial: established, problems: refusal };
+}
+
+/** Create the app document, which is also what SETTLES what a refused read left open.
+ *
+ *  `create` is create-if-absent and atomic, and the rules let only the declared owner do it. So:
+ *  it succeeds and the app is ours; it reports the id taken, which means the document exists and
+ *  the earlier read was refused because this address is not on ITS roster; or it is refused, which
+ *  means the declaration does not name this address as owner.
+ *
+ *  Each of those is a different thing to tell the operator, and none of them is "Missing or
+ *  insufficient permissions" — the message a first deploy used to end on. */
+async function claimApp(handle: SharedAppHandle, aid: string, appDoc: Record<string, unknown>): Promise<SharedAppFailure | null> {
+  let created: boolean;
+  try {
+    created = await handle.docs.create(APPS_COLLECTION, aid, appDoc);
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `cannot create the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Creating an app requires the signed-in address to be its OWNER in app.json's `members` — check that the address you are signed in with is the one listed there.",
+        "Nothing was written.",
+      ],
+    };
+  }
+  if (created) return null;
+  return {
+    ok: false,
+    partial: false,
+    problems: [
+      `apps/${aid} already exists and this session cannot read it.`,
+      "That combination means the app belongs to somebody else's roster: the aid in app.json was not created here, or the address you are signed in with was removed from it. Ask its owner to add you, or start a new app by removing `aid` from app.json.",
+      "Nothing was written.",
+    ],
+  };
 }
 
 /** Staged documents whose collection this repository no longer has.
@@ -211,7 +220,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   //
   // So a denial is not conclusive here, and the CREATE is what settles it (below): create-if-absent
   // is atomic, and only the declared owner may do it.
-  const current = await readCurrentApp(handle, aid);
+  const current = await readCurrentApp(handle, aid, "deploy", "Deploying again is safe — this read only decides whether the app is created or updated.");
   if (!current.ok) return current;
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -159,16 +159,12 @@ async function establishAndScan(
  *  schema staged forever, and publish — which promotes what is staged and refuses to promote a
  *  version it cannot check against the repository — has no way forward at all.
  *
- *  Only asked when the app document already exists: the staging rules resolve the roster through
- *  `get(apps/{aid})`, so on a FIRST deploy the listing is denied rather than empty, and treating
- *  that denial as a real one would make an app impossible to create. */
-async function staleStaged(
-  handle: SharedAppHandle,
-  aid: string,
-  existingApp: Record<string, unknown> | null,
-  keep: ReadonlySet<string>,
-): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
-  if (existingApp === null) return { ok: true, cids: [] };
+ *  Always asked, because by the time it runs the app document EXISTS: either it already did, or
+ *  this deploy has just written it. That matters for a resurrected aid — Firestore leaves
+ *  `staging/*` behind exactly as it leaves the records — where skipping the listing would carry an
+ *  orphaned staged collection through a successful deploy and into a publish that then fails
+ *  closed. For a genuinely new aid the listing is simply empty. */
+async function staleStaged(handle: SharedAppHandle, aid: string, keep: ReadonlySet<string>): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
   try {
     const staged = await handle.docs.list(appStagingPath(aid));
     return { ok: true, cids: staged.map((doc) => doc.id).filter((cid) => !keep.has(cid)) };
@@ -244,7 +240,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!gate.ok) return gate;
   const { scan } = gate;
 
-  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
+  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)));
   if (!stale.ok) return stale;
 
   const failure = await runWrites(

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -16,9 +16,9 @@
 // until that document exists.
 import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
-import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
+import { APPS_COLLECTION, appStagingPath, projectDeploy, type LoadedCollection, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
-import { EMPTY_SCAN, recordRefusal, scanRecords } from "./records.js";
+import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
@@ -125,6 +125,33 @@ async function reserveHeldSlug(
   return reservation;
 }
 
+/** Write the roster when it is missing, then run the migration gate over the records — or the
+ *  refusal that stops the deploy. Null when it may go on.
+ *
+ *  Split out for the line budget, but the two steps belong together anyway: the write is what
+ *  makes the read possible, and doing them apart is what let a missing parent be mistaken for an
+ *  empty store. */
+async function establishAndScan(
+  handle: SharedAppHandle,
+  aid: string,
+  appDoc: Record<string, unknown>,
+  established: boolean,
+  collections: readonly LoadedCollection[],
+  root: string,
+  confirm: boolean | undefined,
+): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
+  if (established) {
+    const failed = await runWrites([{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }], "deploy");
+    if (failed) return failed;
+  }
+  const scan = await scanRecords(collections, root);
+  const refusal = recordRefusal(scan, "deploy", confirm);
+  if (!refusal) return { ok: true, scan };
+  // The app document is live when this call created it just above — the roster, and nothing else.
+  // Saying so is the difference between "nothing happened" and "the app exists now".
+  return { ok: false, partial: established, problems: refusal };
+}
+
 /** Staged documents whose collection this repository no longer has.
  *
  *  Dropping them is what makes staging a REPLACEMENT of the repository's shared collections rather
@@ -181,12 +208,6 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const current = await readCurrentApp(handle, aid);
   if (!current.ok) return current;
 
-  // There is nothing live to break before the app exists, so the gate has nothing to say. It
-  // returns in force on the next deploy, when there IS an app and there may be records in it.
-  const scan = current.app === null ? EMPTY_SCAN : await scanRecords(collections, root);
-  const refusal = recordRefusal(scan, "deploy", opts.confirm);
-  if (refusal) return { ok: false, partial: false, problems: refusal };
-
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,
@@ -198,9 +219,6 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const existingApp = current.app;
   const deployed = projectDeploy(authored, schemasOf(collections), stamp, existingApp);
 
-  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
-  if (!stale.ok) return stale;
-
   // The slug this app already holds, carried on the app document because NOTHING ELSE CAN BE
   // ASKED: `appSlugs/{slug}` is unreadable until the app is published, so "do we already have
   // one?" has no other answer. `projectDeploy` does not carry it — the reservation is the host's
@@ -209,9 +227,31 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const held = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
   const appDoc = held === undefined ? deployed.app : { ...deployed.app, slug: held };
 
+  // ESTABLISH THE PARENT, THEN SCAN — rather than deciding that a missing app document means there
+  // are no records.
+  //
+  // It does not. Firestore deletes do not cascade, and this design documents the orphan state that
+  // leaves: `apps/{aid}` can be gone while `collections/*/items` beneath it survives. Reading the
+  // missing parent as an empty store would let a deploy that re-creates it make those records
+  // readable under a schema nothing ever checked them against.
+  //
+  // Writing the roster first is what makes the question ANSWERABLE. It grants nothing outside the
+  // roster — no `public` block is written here, ever — it is the same document this deploy is
+  // about to write anyway, and afterwards the records can be read. So the gate runs for real: on a
+  // new app it finds nothing, and on a resurrected aid it finds whatever survived.
+  const established = existingApp === null;
+  const gate = await establishAndScan(handle, aid, appDoc, established, collections, root, opts.confirm);
+  if (!gate.ok) return gate;
+  const { scan } = gate;
+
+  const stale = await staleStaged(handle, aid, existingApp, new Set(deployed.staging.map((entry) => entry.cid)));
+  if (!stale.ok) return stale;
+
   const failure = await runWrites(
     [
-      { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) },
+      // Not written again when the step above just wrote it, byte for byte: the roster is already
+      // live, and the staging writes below need exactly that and nothing more.
+      ...(established ? [] : [{ what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, appDoc) }]),
       ...deployed.staging.map(({ cid, doc }) => ({
         what: `the staged schema for '${cid}' (apps/${aid}/staging/${cid})`,
         run: () => handle.docs.set(appStagingPath(aid), cid, doc),

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -149,7 +149,8 @@ async function claimApp(handle: SharedAppHandle, aid: string, appDoc: Record<str
         `cannot write the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
         "Two things are refused the same way here, and both are worth checking:",
         `  - the address this session is signed in with is not the one app.json names as owner (it must be a key of \`members\` with \`"*": "owner"\`);`,
-        `  - apps/${aid} already exists and belongs to somebody else's roster — the aid was not created here, or this address was removed from it. Removing \`aid\` from app.json starts a new app.`,
+        `  - apps/${aid} already exists and belongs to somebody else's roster — this address was removed from it, or the aid came from a repository you are not on.`,
+        "**Do not edit or remove `aid`.** It is the app's identity: a new one does not repair anything, it creates a SECOND app while the first — and everybody's records in it — stays where it is, reachable only by whoever is still on its roster. Recover access from an owner, or confirm this declaration is the app you meant.",
         "Nothing was written.",
       ],
     };

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -18,7 +18,7 @@ import { isRecord } from "../../../common/isRecord.js";
 import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type PublishStamp } from "@mulmoclaude/core/collection/server";
 import { gitStamp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
-import { recordRefusal, scanRecords } from "./records.js";
+import { EMPTY_SCAN, recordRefusal, scanRecords } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
 import { runWrites } from "./writes.js";
 
@@ -169,13 +169,24 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!context.ok) return context;
   const { authored, collections, handle } = context;
 
-  const scan = await scanRecords(collections, root);
+  const { aid } = authored;
+  // The app document FIRST, because the migration gate below depends on it — not merely for the
+  // projection.
+  //
+  // A shared collection's records are authorized through `apps/{aid}`: the rules resolve the
+  // roster from that document. On a FIRST deploy it does not exist, so reading the records is
+  // denied — and the gate reads that as "the live records could not be read", which is the one
+  // refusal `confirm` may not override. The app could then never be created at all: every deploy
+  // of a new app died on a check about records that do not exist yet.
+  const current = await readCurrentApp(handle, aid);
+  if (!current.ok) return current;
+
+  // There is nothing live to break before the app exists, so the gate has nothing to say. It
+  // returns in force on the next deploy, when there IS an app and there may be records in it.
+  const scan = current.app === null ? EMPTY_SCAN : await scanRecords(collections, root);
   const refusal = recordRefusal(scan, "deploy", opts.confirm);
   if (refusal) return { ok: false, partial: false, problems: refusal };
 
-  const { aid } = authored;
-  const current = await readCurrentApp(handle, aid);
-  if (!current.ok) return current;
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -125,40 +125,35 @@ async function establishAndScan(
   return { ok: false, partial: established, problems: refusal };
 }
 
-/** Create the app document, which is also what SETTLES what a refused read left open.
+/** Write the app document when it is not there — which is also the only way to LEARN whether it
+ *  was ours to write.
  *
- *  `create` is create-if-absent and atomic, and the rules let only the declared owner do it. So:
- *  it succeeds and the app is ours; it reports the id taken, which means the document exists and
- *  the earlier read was refused because this address is not on ITS roster; or it is refused, which
- *  means the declaration does not name this address as owner.
+ *  `set` and not `create`. The create-if-absent primitive is a transaction that begins by READING
+ *  the document, and that read is refused for exactly the document it is meant to create: the read
+ *  rule resolves the roster out of the document itself, so for a missing one the expression fails
+ *  and the answer is denied. The transaction dies there, every time, on a brand-new aid.
  *
- *  Each of those is a different thing to tell the operator, and none of them is "Missing or
- *  insufficient permissions" — the message a first deploy used to end on. */
+ *  A `set` is subject to `allow create` when the document is absent and `allow update` when it is
+ *  not — and both require this session to be the owner. So it succeeds exactly when the app is
+ *  ours to write, and a refusal covers the two cases we cannot tell apart from here. The message
+ *  names both, because both are things the operator can check. */
 async function claimApp(handle: SharedAppHandle, aid: string, appDoc: Record<string, unknown>): Promise<SharedAppFailure | null> {
-  let created: boolean;
   try {
-    created = await handle.docs.create(APPS_COLLECTION, aid, appDoc);
+    await handle.docs.set(APPS_COLLECTION, aid, appDoc);
+    return null;
   } catch (err) {
     return {
       ok: false,
       partial: false,
       problems: [
-        `cannot create the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
-        "Creating an app requires the signed-in address to be its OWNER in app.json's `members` — check that the address you are signed in with is the one listed there.",
+        `cannot write the app document (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Two things are refused the same way here, and both are worth checking:",
+        `  - the address this session is signed in with is not the one app.json names as owner (it must be a key of \`members\` with \`"*": "owner"\`);`,
+        `  - apps/${aid} already exists and belongs to somebody else's roster — the aid was not created here, or this address was removed from it. Removing \`aid\` from app.json starts a new app.`,
         "Nothing was written.",
       ],
     };
   }
-  if (created) return null;
-  return {
-    ok: false,
-    partial: false,
-    problems: [
-      `apps/${aid} already exists and this session cannot read it.`,
-      "That combination means the app belongs to somebody else's roster: the aid in app.json was not created here, or the address you are signed in with was removed from it. Ask its owner to add you, or start a new app by removing `aid` from app.json.",
-      "Nothing was written.",
-    ],
-  };
 }
 
 /** Staged documents whose collection this repository no longer has.

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -164,17 +164,25 @@ async function establishAndScan(
  *  `staging/*` behind exactly as it leaves the records — where skipping the listing would carry an
  *  orphaned staged collection through a successful deploy and into a publish that then fails
  *  closed. For a genuinely new aid the listing is simply empty. */
-async function staleStaged(handle: SharedAppHandle, aid: string, keep: ReadonlySet<string>): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
+async function staleStaged(
+  handle: SharedAppHandle,
+  aid: string,
+  keep: ReadonlySet<string>,
+  established: boolean,
+): Promise<{ ok: true; cids: string[] } | SharedAppFailure> {
   try {
     const staged = await handle.docs.list(appStagingPath(aid));
     return { ok: true, cids: staged.map((doc) => doc.id).filter((cid) => !keep.has(cid)) };
   } catch (err) {
     return {
       ok: false,
-      partial: false,
+      // The roster is LIVE when this deploy created it a moment ago, and a failure report that
+      // says "nothing was written" about an app that now exists is worse than no report.
+      partial: established,
       problems: [
         `deploy failed while reading what is already staged (apps/${aid}/staging): ${err instanceof Error ? err.message : String(err)}`,
-        "Nothing was written. This read is what lets a deleted collection be withdrawn from staging, so deploying without it would leave a stale schema behind for publish to trip over.",
+        established ? "The app document was written and the roster is live; nothing was staged. Deploying again continues from here." : "Nothing was written.",
+        "This read is what lets a deleted collection be withdrawn from staging, so deploying without it would leave a stale schema behind for publish to trip over.",
       ],
     };
   }
@@ -193,17 +201,18 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   const { authored, collections, handle } = context;
 
   const { aid } = authored;
-  // The app document FIRST, because the migration gate below depends on it — not merely for the
-  // projection.
+  // WHAT THE APP DOCUMENT IS, asked in the only way the rules allow.
   //
-  // A shared collection's records are authorized through `apps/{aid}`: the rules resolve the
-  // roster from that document. On a FIRST deploy it does not exist, so reading the records is
-  // denied — and the gate reads that as "the live records could not be read", which is the one
-  // refusal `confirm` may not override. The app could then never be created at all: every deploy
-  // of a new app died on a check about records that do not exist yet.
+  // Reading `apps/{aid}` cannot tell you it is missing. The read rule resolves the roster out of
+  // the document itself (`readerOf(app(aid), '*')`), so for a document that does not exist the
+  // expression fails and the answer is DENIED — the same answer as somebody else's app. A first
+  // deploy therefore cannot start by reading, and did not: it reported
+  // "Missing or insufficient permissions" and stopped, with nothing else to try.
+  //
+  // So a denial is not conclusive here, and the CREATE is what settles it (below): create-if-absent
+  // is atomic, and only the declared owner may do it.
   const current = await readCurrentApp(handle, aid);
   if (!current.ok) return current;
-
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,
@@ -240,7 +249,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   if (!gate.ok) return gate;
   const { scan } = gate;
 
-  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)));
+  const stale = await staleStaged(handle, aid, new Set(deployed.staging.map((entry) => entry.cid)), established);
   if (!stale.ok) return stale;
 
   const failure = await runWrites(

--- a/server/backends/sharedApp/manifestWrite.ts
+++ b/server/backends/sharedApp/manifestWrite.ts
@@ -18,6 +18,7 @@
 //     both see the old file and one write is lost. Serialized on the RESOLVED path, because two
 //     spellings of one root are one file.
 import { chmod, readFile, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { isRecord } from "../../../common/isRecord.js";
@@ -124,3 +125,33 @@ async function replaceManifest(manifestPath: string, manifest: Record<string, un
     };
   }
 }
+
+/** Write `app.json` for a repository that does not have one.
+ *
+ *  Separate from `updateManifest` because the two must not be one call: updating REFUSES to create
+ *  (a mistyped path would become an app declaration), and creating must refuse to overwrite (an
+ *  existing declaration holds the roster, and re-writing it would revoke everybody silently).
+ *
+ *  `wx` is what makes the refusal atomic rather than a check followed by a write — two sessions
+ *  asked to start the same app cannot both see it missing. It is written directly rather than
+ *  through the rename dance for the same reason: there is no file to protect, and `wx` on the real
+ *  path IS the protection. */
+export async function createManifest(root: string, manifest: Record<string, unknown>): Promise<ManifestUpdate> {
+  const manifestPath = path.join(root, APP_MANIFEST_FILE);
+  return serializeBy(`manifest:${await manifestKey(root)}`, async () => {
+    try {
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: "utf-8", flag: "wx" });
+      return { ok: true, manifest, written: true };
+    } catch (err) {
+      if (isRecord(err) && err.code === "EEXIST") {
+        return { ok: false, problems: [`${manifestPath} already exists — this repository already declares an app.`] };
+      }
+      return { ok: false, problems: [`cannot write ${manifestPath}: ${String(err)}`] };
+    }
+  });
+}
+
+/** The `aid` a new declaration gets. Generated here, by code, for the reason D2b gives: `apps/{aid}`
+ *  is a shelf every user of the deployment shares, a memorable id there is first-come-first-served,
+ *  and a model asked to invent an identifier writes a memorable one. */
+export const newAid = (): string => randomUUID();

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -25,11 +25,6 @@ export interface RecordScan {
   unreadable: string[];
 }
 
-/** The answer for an app that does not exist yet: nothing is live, so nothing can break. Named
- *  rather than inlined so the reason travels with it — an empty scan is a STATEMENT here, not a
- *  scan that happened to find nothing. */
-export const EMPTY_SCAN: RecordScan = { lines: [], records: 0, capped: false, unreadable: [] };
-
 export async function scanRecords(collections: readonly LoadedCollection[], workspaceRoot: string): Promise<RecordScan> {
   const lines: string[] = [];
   const unreadable: string[] = [];

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -25,6 +25,11 @@ export interface RecordScan {
   unreadable: string[];
 }
 
+/** The answer for an app that does not exist yet: nothing is live, so nothing can break. Named
+ *  rather than inlined so the reason travels with it — an empty scan is a STATEMENT here, not a
+ *  scan that happened to find nothing. */
+export const EMPTY_SCAN: RecordScan = { lines: [], records: 0, capped: false, unreadable: [] };
+
 export async function scanRecords(collections: readonly LoadedCollection[], workspaceRoot: string): Promise<RecordScan> {
   const lines: string[] = [];
   const unreadable: string[] = [];

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -14,8 +14,7 @@
 // there, and a slug already recorded is never re-reserved. "Once you have it, you keep it" is
 // the point (D2b) — a URL is a thing people have already sent to each other.
 import { APP_SLUGS_COLLECTION, appSlugDoc } from "@mulmoclaude/core/collection/server";
-import { isRecord } from "../../../common/isRecord.js";
-import type { SharedAppFailure, SharedAppHandle } from "./context.js";
+import { isRefusal, type SharedAppFailure, type SharedAppHandle } from "./context.js";
 import { updateManifest } from "./manifestWrite.js";
 
 /** How many numbered alternatives to try before giving up. The number is small on purpose: past
@@ -137,15 +136,6 @@ async function probeOwnership(handle: SharedAppHandle, aid: string, slug: string
   } catch (err) {
     return isRefusal(err) ? "theirs" : "unknown";
   }
-}
-
-/** A rules REFUSAL, as opposed to a failure to ask. The Firestore SDK reports both as a thrown
- *  error and only the `code` separates them: `permission-denied` is the rules saying no, and
- *  `failed-precondition` is the document not being what the rules required. Everything else —
- *  `unavailable`, `deadline-exceeded`, `resource-exhausted`, an offline client — is the question
- *  never having been answered. */
-function isRefusal(err: unknown): boolean {
-  return isRecord(err) && (err.code === "permission-denied" || err.code === "failed-precondition");
 }
 
 function probeFailed(candidate: string): SharedAppFailure {

--- a/server/backends/sharedApp/slug.ts
+++ b/server/backends/sharedApp/slug.ts
@@ -62,21 +62,19 @@ export async function reserveSlug(
 
   const taken: string[] = [];
   for (const candidate of candidates(wanted)) {
-    let claimed: boolean;
-    try {
-      // `create`, not `set`: create-if-absent is atomic, so two apps racing for one name cannot
-      // both observe it missing.
-      claimed = await handle.docs.create(APP_SLUGS_COLLECTION, candidate, appSlugDoc(aid, false));
-    } catch (err) {
-      return reservationFailed(candidate, err);
-    }
-    if (!claimed) {
-      const ownership = await probeOwnership(handle, aid, candidate, appIsPublic);
-      if (ownership === "unknown") return probeFailed(candidate);
-      if (ownership === "theirs") {
-        taken.push(candidate);
-        continue;
-      }
+    // `set`, not `create`. The create-if-absent primitive is a transaction that READS first, and
+    // that read is refused for a reservation that does not exist yet (`allow read` tests
+    // `resource.data.published`, which is not there) — so it can never claim a free name.
+    //
+    // A `set` is judged by `allow create` when the document is absent and by `allow update` when
+    // it is not, and both require this app's owner: it succeeds exactly when the name is free or
+    // already ours, and is refused when somebody else holds it. That refusal IS the answer, which
+    // is why nothing is reported for it.
+    const claimed = await claimSlug(handle, aid, candidate, appIsPublic);
+    if (claimed === "unknown") return probeFailed(candidate);
+    if (claimed === "theirs") {
+      taken.push(candidate);
+      continue;
     }
     const recorded = await recordSlug(root, candidate);
     return recorded ?? { ok: true, slug: candidate, reserved: true };
@@ -91,45 +89,21 @@ export async function reserveSlug(
   };
 }
 
-function reservationFailed(candidate: string, err: unknown): SharedAppFailure {
-  return {
-    ok: false,
-    partial: true,
-    problems: [
-      `deploy reached the app and its schemas, but could not reserve the URL name '${candidate}': ${err instanceof Error ? err.message : String(err)}`,
-      "The app is deployed and the roster can use /staging/{aid}; only the public URL is unreserved. Deploying again retries just this step.",
-    ],
-  };
-}
-
-/** Whose is an EXISTING reservation? Asked by WRITING to it, because it cannot be read.
- *
- *  This is why a failed `create` is not the end. The rules allow an update only when the caller
- *  owns the app the document ALREADY names and the `aid` is unchanged — so a write that succeeds
- *  proves ownership, and one REFUSED FOR THAT REASON proves somebody else holds the name. There is
- *  no other way to ask: `allow read` needs `published == true`, which is exactly the state a
- *  reservation is not in.
- *
- *  Without it, three ordinary situations end with a stranded name: a deploy that reserved and then
- *  failed to record it, two deploys of one repository at once, and an app document that lost the
- *  record. Each would see `create` fail, decide the name belonged to somebody else, and take `-2`
- *  — while the first reservation stayed live, held by an app that no longer claims it, and
- *  unreadable by anyone who might have noticed.
- *
- *  The third answer is the one that took a review to get right. A timeout or a quota error is NOT
- *  "somebody else's": reading it that way turns an outage into a second reservation, and if the
- *  name being reclaimed was a PUBLIC one, the app records the numbered name while the original
- *  keeps resolving — and can no longer be taken down, because unpublish works from the record.
- *  Only a refusal decides; anything else stops the deploy with the name unresolved, which a retry
- *  fixes and nothing else has to.
+/** Take the name, or find out that somebody else has it. One write, three answers.
  *
  *  `published` is written from the APP's state rather than guessed: the app document holds the
  *  `public` block, so it is the authority on whether this app is open, and the reservation should
  *  say the same. When they agree this is a no-op; when they have drifted it repairs the drift
- *  toward the app. */
+ *  toward the app.
+ *
+ *  A rules refusal means the name is somebody else's — the reservation cannot be read, so this is
+ *  the only way to ask. Anything else (a timeout, a quota) is the question never having been
+ *  answered, and must NOT be read as a collision: doing so turns an outage into a second
+ *  reservation, and if the name being reclaimed was public, the app records the numbered one while
+ *  the original keeps resolving, beyond the reach of unpublish. */
 type Ownership = "ours" | "theirs" | "unknown";
 
-async function probeOwnership(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<Ownership> {
+async function claimSlug(handle: SharedAppHandle, aid: string, slug: string, appIsPublic: boolean): Promise<Ownership> {
   try {
     await handle.docs.set(APP_SLUGS_COLLECTION, slug, appSlugDoc(aid, appIsPublic));
     return "ours";

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -15,22 +15,26 @@ import type { ToolDefinition } from "gui-chat-protocol";
 import { deploySharedApp } from "../backends/sharedApp/deploy.js";
 import { publishSharedApp } from "../backends/sharedApp/publish.js";
 import { unpublishSharedApp } from "../backends/sharedApp/unpublish.js";
+import { APP_ROLE_NAMES, checkSharedApp, initSharedApp, inviteToSharedApp, type AppRoleName } from "../backends/sharedApp/declare.js";
 import { isRecord } from "../../common/isRecord.js";
 import { manifestKey } from "../backends/sharedApp/manifestWrite.js";
 import { serializeBy } from "../backends/sharedApp/serialize.js";
 
-export const SHARED_APP_ACTIONS = ["deploy", "publish", "unpublish"] as const;
+export const SHARED_APP_ACTIONS = ["init", "check", "invite", "deploy", "publish", "unpublish"] as const;
 export type SharedAppAction = (typeof SHARED_APP_ACTIONS)[number];
 
 export const MANAGE_SHARED_APP: ToolDefinition = {
   type: "function",
   name: "manageSharedApp",
   description:
-    "Deploy, publish or unpublish this repository's shared app (the one declared by its app.json). " +
+    "Start, check, invite to, deploy, publish or unpublish this repository's shared app (the one declared by its app.json). " +
     "deploy stages the declaration and the collection schemas where only the app's roster can see them; publish promotes what was staged and opens the app to the public; unpublish closes it again.",
   prompt:
     "A request for something OTHER PEOPLE fill in or read — a survey, a sign-up sheet, a booking form, a form behind a link — is a shared app, and the `mulmoterminal-shared-app` skill is the path from that sentence to this tool. Read it before offering a printable page or a third-party form.\n" +
     "`manageSharedApp` operates on the repository the session is open in — the one holding `app.json` — and it is the only way to write a shared app.\n" +
+    "**init** writes `app.json` for a repository that has none, with the SIGNED-IN address as its owner — use it instead of composing the file yourself, because the owner has to be the address this machine is signed in with and you cannot read that.\n" +
+    "**check** reports everything wrong with the declaration and this repository's shared collections WITHOUT writing or deploying anything. Run it after any edit to `app.json`; it is the only way to find out whether a declaration is deployable before it is deployed.\n" +
+    "**invite** adds, changes or removes ONE address on the roster (`email`, `role`, optional `cid`; omit `role` to remove). It takes effect at the next deploy.\n" +
     "**deploy** is the safe one and is meant to be run often. It writes the roster and internal settings to `apps/{aid}` and each collection's schema to `apps/{aid}/staging/{cid}`, which only people on the roster can read. " +
     "An invitation added to `members` takes effect at deploy, so the roster can try the real app at `/staging/{aid}` before anybody outside sees it. Deploy never opens the app to the public, and never changes what a published app's visitors are looking at.\n" +
     "**publish** is the dangerous one. It promotes the STAGED schemas — not the working tree, so what ships is what the roster reviewed — and then opens the app. Publish it only when the user asks for it in those terms.\n" +
@@ -42,8 +46,19 @@ export const MANAGE_SHARED_APP: ToolDefinition = {
       action: {
         type: "string",
         enum: [...SHARED_APP_ACTIONS],
-        description: "deploy = stage for the roster; publish = promote the staged version and open it; unpublish = close it again.",
+        description:
+          "init = write app.json for a new app; check = report what is wrong without writing; invite = one roster entry; deploy = stage for the roster; publish = promote the staged version and open it; unpublish = close it again.",
       },
+      name: { type: "string", description: "init: the app's human name." },
+      slug: { type: "string", description: "init: the wanted URL name (lowercase, hyphens). It is a wish — a taken one gets a number appended." },
+      email: { type: "string", description: "invite: the address to add, change or remove." },
+      role: {
+        type: "string",
+        enum: [...APP_ROLE_NAMES],
+        description:
+          "invite: what they may do. Omit to REMOVE the address. owner publishes; editor writes records; viewer reads them; participant sees only its own rows.",
+      },
+      cid: { type: "string", description: "invite: one collection instead of the whole app. Defaults to the whole app." },
       confirm: {
         type: "boolean",
         description:
@@ -121,6 +136,49 @@ async function narrateUnpublish(root: string): Promise<string> {
     : `apps/${result.aid} was already closed to the public — nothing was open to take down. The public config document was deleted if it was still there.`;
 }
 
+async function narrateInit(root: string, body: Record<string, unknown>): Promise<string> {
+  const result = await initSharedApp(root, str(body.name), str(body.slug));
+  if (!result.ok) return result.problems.join("\n");
+  return [
+    `Started an app in this repository: app.json now declares it, with ${result.owner} as owner.`,
+    "The `aid` was generated — it is the app's identity and is never chosen or edited by hand.",
+    ...(result.slug === undefined ? [] : [`The wanted URL name is '${result.slug}'; deploy reserves it, and a taken one gets a number appended.`]),
+    "Next: write the collections, then deploy.",
+  ].join("\n");
+}
+
+async function narrateCheck(root: string): Promise<string> {
+  const report = await checkSharedApp(root);
+  if (!report.ok) return report.problems.join("\n");
+  const found = report.collections.length === 0 ? "no shared collections in this repository yet" : `shared collections: ${report.collections.join(", ")}`;
+  if (report.problems.length === 0) {
+    return [`The declaration is deployable. ${found}.`, "Nothing was written or deployed — this only reads."].join("\n");
+  }
+  return [`The declaration would be refused (${found}):`, ...report.problems.map((problem) => `  - ${problem}`), "Nothing was written."].join("\n");
+}
+
+async function narrateInvite(root: string, body: Record<string, unknown>): Promise<string> {
+  const email = str(body.email);
+  if (email === undefined) return "manageSharedApp invite: `email` is required — it is what the roster is keyed by.";
+  const role = parseRole(body.role);
+  if (role === undefined) return `manageSharedApp invite: role must be one of ${APP_ROLE_NAMES.join(", ")}, or omitted to remove the address.`;
+  const cid = str(body.cid) ?? "*";
+  const result = await inviteToSharedApp(root, email, role, cid);
+  if (!result.ok) return result.problems.join("\n");
+  const where = cid === "*" ? "the whole app" : `'${cid}'`;
+  const what = role === null ? `Removed ${email} from ${where}.` : `${email} is now ${role} of ${where}.`;
+  return [what, "It takes effect at the next deploy — nothing has changed in the app yet."].join("\n");
+}
+
+const str = (value: unknown): string | undefined => (typeof value === "string" && value.length > 0 ? value : undefined);
+
+/** `undefined` means the argument was not one of the roles — which is different from being ABSENT,
+ *  and absent is how a removal is spelled. */
+function parseRole(value: unknown): AppRoleName | null | undefined {
+  if (value === undefined || value === null || value === "") return null;
+  return APP_ROLE_NAMES.find((role) => role === value);
+}
+
 /** Run one action against `root` and narrate the result. The agent's whole contract with this
  *  tool is actionable prose, so a refusal is text and never a throw. */
 export async function manageSharedApp(root: string, args: unknown): Promise<string> {
@@ -137,6 +195,9 @@ export async function manageSharedApp(root: string, args: unknown): Promise<stri
   // At the entry point rather than inside each operation, because what must not interleave is the
   // whole sequence, and this is the only place all three pass through.
   const key = `operation:${await manifestKey(root)}`;
+  if (action === "init") return serializeBy(key, () => narrateInit(root, body));
+  if (action === "check") return serializeBy(key, () => narrateCheck(root));
+  if (action === "invite") return serializeBy(key, () => narrateInvite(root, body));
   if (action === "deploy") return serializeBy(key, () => narrateDeploy(root, confirm));
   if (action === "publish") return serializeBy(key, () => narratePublish(root, confirm));
   return serializeBy(key, () => narrateUnpublish(root));

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -151,10 +151,16 @@ async function narrateCheck(root: string): Promise<string> {
   const report = await checkSharedApp(root);
   if (!report.ok) return report.problems.join("\n");
   const found = report.collections.length === 0 ? "no shared collections in this repository yet" : `shared collections: ${report.collections.join(", ")}`;
+  // WHOSE deploy was checked, always said out loud: signed in it is you, signed out it is the
+  // owner the declaration names, and "it would deploy for somebody else" is not the same answer.
+  const as =
+    report.checkedAs === null
+      ? `Checked as the declared owner (${report.declaredOwner ?? "none named"}) — not signed in, so it could not be checked against your address.`
+      : `Checked as ${report.checkedAs}.`;
   if (report.problems.length === 0) {
-    return [`The declaration is deployable. ${found}.`, "Nothing was written or deployed — this only reads."].join("\n");
+    return [`The declaration is deployable. ${found}.`, as, "Nothing was written or deployed — this only reads."].join("\n");
   }
-  return [`The declaration would be refused (${found}):`, ...report.problems.map((problem) => `  - ${problem}`), "Nothing was written."].join("\n");
+  return [`The declaration would be refused (${found}):`, ...report.problems.map((problem) => `  - ${problem}`), as, "Nothing was written."].join("\n");
 }
 
 async function narrateInvite(root: string, body: Record<string, unknown>): Promise<string> {

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -50,16 +50,22 @@ words below are for you, not for them: an author does not need to know what a `c
   and it is a UUID on purpose — a memorable one would be first-come-first-served across every user
   of the deployment.
 
-### 2. Write the collection THROUGH `manageCollection`
+### 2. Write the collection
 
 One collection per kind of record — a survey has one (`responses`), a booking app might have two
 (`bookings`, `services`).
 
-**Do not hand-write `schema.json`.** Call `manageCollection` with `action: "schemaDocs"` for the
-shape, then `action: "putSchema"` to write it. The shape is not what a reasonable person guesses:
-`fields` is an OBJECT keyed by field name (not a list), `primaryKey` and `icon` are required, and
-the key for a field's human name is `label`. A hand-written file in the shape you would design
-does not parse, and nothing tells you until a deploy finds no collections at all.
+**A NEW collection is created by writing the files**: `SKILL.md` and `schema.json` under
+`.claude/skills/<slug>/`. `putSchema` is EDIT-ONLY and refuses a collection that does not exist
+yet ("unknown collection … create it by writing SKILL.md + schema.json"), so do not try to create
+one with it. Use it afterwards, to CHANGE a schema.
+
+**Read the shape first**: `manageCollection` with `action: "schemaDocs"`, and
+`topic: "Shared storage (firestore)"` for this part specifically. The shape is not what a
+reasonable person guesses — `fields` is an OBJECT keyed by field name (not a list), `primaryKey`
+and `icon` are required, and the key for a field's human name is `label`. A schema in the shape
+you would design does not parse, and a collection whose schema fails validation is **skipped
+silently**: nothing errors, it simply never appears.
 
 The one thing that differs from an ordinary collection:
 
@@ -68,8 +74,11 @@ The one thing that differs from an ordinary collection:
 ```
 
 That is what makes the records shared. Declare no `dataPath` beside it — exactly one of the two.
-Writing this schema is also what generates the app's `aid`, which is why the declaration comes
-first.
+
+**A shared collection is invisible until the app has an `aid`**, which is generated for you — by
+the first deploy, or by `putSchema` when you edit one later. So between writing the files and
+deploying, `getSchema` reporting "unknown collection" is expected, not a mistake to chase. Deploy,
+then look.
 
 **Everything in the folder is shared or nothing is.** Do not mix a shared collection and a local
 one in an app's repository.
@@ -187,3 +196,16 @@ workspace-data tool group. If they are not in your tool list, **stop and say so*
 cannot be deployed from here, and writing `app.json` and a schema by hand produces files nothing
 can act on. Point the user at the launcher's tool-group switch for this folder rather than
 carrying on.
+
+## Two refusals that are NOT your cue to start editing
+
+The run this skill was written from lost several minutes to each of these, and both times the
+repair made things worse — an `aid` was deleted and a second app was created by accident.
+
+- **`getSchema` / `putSchema` says "unknown collection".** For a collection you just wrote, that
+  means its schema has not been accepted yet — most often because the app has no `aid` until the
+  first deploy. Deploy; do not rewrite the schema, and do not move the directory.
+- **Anything about permissions on `apps/{aid}`.** The `aid` in `app.json` is the app's identity.
+  Removing it does not reset anything: the next deploy mints a NEW one and the old app stays where
+  it is, owned by nobody who can reach it. If a deploy is refused, read what it says and fix that;
+  never edit the `aid` by hand.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -29,26 +29,22 @@ the user turns this down.
 Say what you are doing in the user's words ("作っています", "みんなが見えるようにしました"). The
 words below are for you, not for them: an author does not need to know what a `cid` is.
 
-### 1. Write the declaration
+### 1. Start the app
 
-`app.json` at the repository root:
+`manageSharedApp` with `action: "init"`, and `name` (and `slug`, if you have one worth wanting).
 
-```json
-{
-  "name": "Talk feedback",
-  "slug": "aug-talk-survey",
-  "members": { "owner@example.com": { "*": "owner" } }
-}
-```
+**Do not compose `app.json` yourself.** The declaration names its owner by EMAIL and it has to be
+the address this machine is SIGNED IN with — you cannot read that, and the address the user tells
+you is the one that fails at deploy. `init` writes it, generates the `aid`, and refuses if the
+repository already declares an app.
 
-- `members` is keyed by **email**, and the user's own address goes in as `owner`. Ask for it if
-  you do not know it — it is the one thing you cannot infer.
-- `slug` is the name in the URL people will be given. Take it from what the thing IS
-  (`aug-talk-survey`), lowercase with hyphens. It is a wish: if it is taken, a number is appended
-  and written back here.
-- **Never invent an `aid`.** It is generated for you the moment you write the first collection,
-  and it is a UUID on purpose — a memorable one would be first-come-first-served across every user
-  of the deployment.
+`slug` is the name in the URL people will be given. Take it from what the thing IS
+(`aug-talk-survey`), lowercase with hyphens. It is a wish: if it is taken, a number is appended and
+written back.
+
+The file is an ordinary committed declaration afterwards — you may read it, and the user may edit
+it in a pull request. What you should not do is REWRITE it: `invite` changes one roster entry, and
+`check` tells you whether what is there would deploy.
 
 ### 2. Write the collection
 
@@ -93,7 +89,8 @@ Tell the user they can look at it now, and give them the address the tool report
 
 ### 4. Invite
 
-Add the address to `members` and deploy again. Roles:
+`manageSharedApp` with `action: "invite"`, `email`, and `role` (omit `role` to remove them). It
+edits the roster and nothing else; deploy is what makes it real.
 
 | role | what they get |
 |---|---|
@@ -102,8 +99,16 @@ Add the address to `members` and deploy again. Roles:
 | `viewer` | reads the records |
 | `participant` | named on the roster, sees only their OWN rows |
 
-`{ "tanaka@example.com": { "*": "viewer" } }` is the whole app; `{ "bookings": "editor" }` is one
-collection.
+`cid` narrows it to one collection instead of the whole app.
+
+### 4b. Check, whenever you have edited `app.json`
+
+`manageSharedApp` with `action: "check"` runs the gate a deploy runs — the declaration, the
+collections it names — and writes nothing. It needs no connection.
+
+Use it after any hand edit, and before telling the user something is ready. The alternative is
+finding out at deploy, and a deploy that refuses in the middle is where an agent starts editing
+files to recover.
 
 ### 5. Publish, when the user asks to open it
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -202,9 +202,12 @@ carrying on.
 The run this skill was written from lost several minutes to each of these, and both times the
 repair made things worse — an `aid` was deleted and a second app was created by accident.
 
-- **`getSchema` / `putSchema` says "unknown collection".** For a collection you just wrote, that
-  means its schema has not been accepted yet — most often because the app has no `aid` until the
-  first deploy. Deploy; do not rewrite the schema, and do not move the directory.
+- **`getSchema` / `putSchema` says "unknown collection".** It means the schema was not ACCEPTED,
+  and there are two reasons: the app has no `aid` yet (nothing is wrong — the first deploy mints
+  it), or the schema failed validation (something is wrong, and it is skipped silently).
+  Tell them apart before acting: re-read the schema against `schemaDocs` — `primaryKey` naming a
+  field flagged `primary: true`, `icon` present, exactly one of `dataPath` / `dataSource` /
+  `storage`. If the schema is sound, deploy; do not rewrite it, and do not move the directory.
 - **Anything about permissions on `apps/{aid}`.** The `aid` in `app.json` is the app's identity.
   Removing it does not reset anything: the next deploy mints a NEW one and the old app stays where
   it is, owned by nobody who can reach it. If a deploy is refused, read what it says and fix that;

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -71,10 +71,12 @@ The one thing that differs from an ordinary collection:
 
 That is what makes the records shared. Declare no `dataPath` beside it — exactly one of the two.
 
-**A shared collection is invisible until the app has an `aid`**, which is generated for you — by
-the first deploy, or by `putSchema` when you edit one later. So between writing the files and
-deploying, `getSchema` reporting "unknown collection" is expected, not a mistake to chase. Deploy,
-then look.
+**The app already has its `aid`** — `init` wrote it in step 1 — so a shared collection you write
+correctly is discovered straight away. If `getSchema` says "unknown collection" after you have
+written the files, that is the schema FAILING VALIDATION, not something a deploy will fix: read it
+back against `schemaDocs` (`primaryKey` naming a field flagged `primary: true`, `icon` present,
+exactly one of `dataPath` / `dataSource` / `storage`). Deploying past it produces an app with the
+collection missing and no error anywhere.
 
 **Everything in the folder is shared or nothing is.** Do not mix a shared collection and a local
 one in an app's repository.
@@ -207,12 +209,10 @@ carrying on.
 The run this skill was written from lost several minutes to each of these, and both times the
 repair made things worse — an `aid` was deleted and a second app was created by accident.
 
-- **`getSchema` / `putSchema` says "unknown collection".** It means the schema was not ACCEPTED,
-  and there are two reasons: the app has no `aid` yet (nothing is wrong — the first deploy mints
-  it), or the schema failed validation (something is wrong, and it is skipped silently).
-  Tell them apart before acting: re-read the schema against `schemaDocs` — `primaryKey` naming a
-  field flagged `primary: true`, `icon` present, exactly one of `dataPath` / `dataSource` /
-  `storage`. If the schema is sound, deploy; do not rewrite it, and do not move the directory.
+- **`getSchema` / `putSchema` says "unknown collection".** The schema was not ACCEPTED. With
+  `init` having written the `aid`, that means it failed validation — read it back against
+  `schemaDocs` rather than deploying past it. (Before `init` existed this could also mean "no aid
+  yet"; it no longer does, and treating it that way deploys an app with the collection missing.)
 - **Anything about permissions on `apps/{aid}`.** The `aid` in `app.json` is the app's identity.
   Removing it does not reset anything: the next deploy mints a NEW one and the old app stays where
   it is, owned by nobody who can reach it. If a deploy is refused, read what it says and fix that;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -88,6 +88,14 @@ class FakeDocs implements FirestoreDocs {
   };
 
   create = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<boolean> => {
+    // create-if-absent is a TRANSACTION, and it begins by reading the document. For the two
+    // collections whose read rule resolves out of a document that does not exist yet
+    // (`apps/{aid}`, `appSlugs/{slug}`), that read is refused — so `create` can never claim a
+    // fresh id there, however atomic it looks. Modelled here because the code got it wrong once
+    // and nothing in a fake that answered `false` would have said so.
+    if (!this.bucket(collectionPath).has(docId) && (collectionPath === "apps" || collectionPath === "appSlugs")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
     if (this.bucket(collectionPath).has(docId)) return Promise.resolve(false);
     this.writes.push(`create ${collectionPath}/${docId}`);
     this.bucket(collectionPath).set(docId, structuredClone(data));
@@ -219,6 +227,9 @@ describe("shared app deploy / publish / unpublish", () => {
     // it, and the message has to name the situation rather than repeat "insufficient permissions".
     docs.store.set("apps", new Map([[AID, { aid: AID, owner: "somebody-else" }]]));
     docs.readsDeniedForApp = true;
+    // The rules refuse the WRITE too — an update needs this session to be the app's owner — and
+    // that refusal is the only signal available, because the document cannot be read.
+    docs.failAt = `apps/${AID}`;
 
     const result = await deploySharedApp(root, stamp);
     expect(result.ok).toBe(false);
@@ -240,11 +251,11 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
-    // CREATE, then the staging document. On a first deploy the app write is what makes the records
-    // readable, so it happens before the migration gate rather than beside the staging writes —
-    // and it is a create because that is the only operation that can tell "this app does not
-    // exist" from "this app is somebody else's", which a refused read cannot.
-    expect(docs.writes).toEqual([`create apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+    // The app write, then the staging document. On a first deploy the app write is what makes the
+    // records readable, so it happens before the migration gate rather than beside the staging
+    // writes — and it is a `set`, because create-if-absent is a transaction that reads first and
+    // that read is refused for the very document it would create.
+    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
 
     // And on a redeploy, where the app already exists, the same order without the extra write.
     docs.writes.length = 0;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -32,6 +32,8 @@ class FakeDocs implements FirestoreDocs {
   /** Model the rules' actual shape: a shared collection's records are authorized through
    *  `apps/{aid}`, so while that document is missing, reading them is denied rather than empty. */
   readsDeniedUntilApp = false;
+  /** Collection path whose listing throws — a transient failure, as opposed to a refusal. */
+  failListing: string | null = null;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -42,9 +44,11 @@ class FakeDocs implements FirestoreDocs {
   }
 
   list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
-      ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
-      : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+    this.failListing === collectionPath
+      ? Promise.reject(new Error("unavailable (test)"))
+      : this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
+        ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
+        : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
 
   get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
 
@@ -189,6 +193,18 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
     // And the deploy still did its own job.
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
+  it("says the roster is live when it cannot read staging after creating the app", async () => {
+    // "Nothing was written" about an app that now exists is worse than no report at all: the next
+    // decision — deploy again, or go looking for what half-happened — turns on it.
+    docs.failListing = `apps/${AID}/staging`;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.partial).toBe(true);
+    expect(result.ok === false && result.problems.join("\n")).toContain("the roster is live");
+    expect(docs.app()).toBeDefined();
   });
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -29,6 +29,9 @@ class FakeDocs implements FirestoreDocs {
   readonly writes: string[] = [];
   /** Path/id whose next write throws — how a half-finished run is produced. */
   failAt: string | null = null;
+  /** Model the rules' actual shape: a shared collection's records are authorized through
+   *  `apps/{aid}`, so while that document is missing, reading them is denied rather than empty. */
+  readsDeniedUntilApp = false;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -39,7 +42,9 @@ class FakeDocs implements FirestoreDocs {
   }
 
   list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+    this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
+      ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
+      : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
 
   get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
 
@@ -139,6 +144,19 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.store.get(`apps/${AID}/config`)).toBeUndefined();
   });
 
+  it("creates an app whose records cannot be read yet — the first deploy of all", async () => {
+    // The deadlock this pins: a shared collection's records are authorized THROUGH `apps/{aid}`,
+    // so before that document exists the records cannot be read at all. The migration gate read
+    // that as "the live records could not be read", which is the one refusal `confirm` may not
+    // override — and a new app could never be created.
+    docs.readsDeniedUntilApp = true;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(true);
+    expect(docs.app()).toBeDefined();
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
     expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
@@ -232,6 +250,9 @@ describe("shared app deploy / publish / unpublish", () => {
   });
 
   it("stops at live records that would not fit the new schema, and confirming stages it anyway", async () => {
+    // The app has to EXIST for this gate to run: before it does there are no live records, and the
+    // records cannot even be read — the rules resolve their roster from the app document.
+    await deploySharedApp(root, stamp);
     docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
     writeFileSync(
       path.join(root, ".claude", "skills", "bookings", "schema.json"),
@@ -241,7 +262,6 @@ describe("shared app deploy / publish / unpublish", () => {
     const refused = await deploySharedApp(root, stamp);
     expect(refused.ok).toBe(false);
     expect(refused.ok === false && refused.problems.join("\n")).toContain("would not satisfy the schema");
-    expect(docs.app()).toBeUndefined();
 
     const confirmed = await deploySharedApp(root, { ...stamp, confirm: true });
     expect(confirmed.ok === true && confirmed.recordIssues).toBe(1);
@@ -266,6 +286,8 @@ describe("shared app deploy / publish / unpublish", () => {
   });
 
   it("does not let a confirmed deploy buy the publish", async () => {
+    // Same reason as above: the gate needs an app to exist before there is anything live in it.
+    await deploySharedApp(root, stamp);
     // The reason the scan runs at BOTH boundaries: deploy's confirm says "let me stage this
     // anyway", which mid-migration is the useful thing. It is not the same sentence as "let
     // everyone have it", so publish asks again and needs its own confirm.

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -36,6 +36,9 @@ class FakeDocs implements FirestoreDocs {
   failListing: string | null = null;
   /** Refuse the app-document read even though it exists — somebody else's app. */
   readsDeniedForApp = false;
+  /** The `code` a refused read carries. `failed-precondition` is a FAULT, not a refusal, and the
+   *  caller has to tell them apart. */
+  readErrorCode = "permission-denied";
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -64,8 +67,8 @@ class FakeDocs implements FirestoreDocs {
     // answer as somebody else's app. A fake that answered `null` would let a first deploy pass a
     // test the real thing cannot pass.
     const existing = this.bucket(collectionPath).get(docId);
-    if (collectionPath === "apps" && (!existing || this.readsDeniedForApp)) {
-      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    if (collectionPath === "apps" && (!existing || this.readsDeniedForApp || this.readErrorCode !== "permission-denied")) {
+      return Promise.reject(Object.assign(new Error("read refused (test)"), { code: this.readErrorCode }));
     }
     return Promise.resolve(existing ?? null);
   };
@@ -220,6 +223,23 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
     // And the deploy still did its own job.
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
+  it("does not mistake a fault for an absent app and rebuild it", async () => {
+    // `failed-precondition` is not the rules saying no — it is a missing index, a stale
+    // transaction, a client the backend wants restarted. Read as a refusal, the app document looks
+    // ABSENT: the deploy would rebuild it from the declaration alone, dropping the `public` block
+    // and the held slug — silently unpublishing a live app and stranding its URL name.
+    writeApp(root, declaration({ slug: "sakura-hair", public: { enabled: true, read: ["bookings"] } }));
+    await deploySharedApp(root, stamp);
+    await publishSharedApp(root, stamp);
+    docs.readErrorCode = "failed-precondition";
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    // The app is untouched: still public, still holding its name.
+    expect(docs.app()?.public).toMatchObject({ enabled: true });
+    expect(docs.app()?.slug).toBe("sakura-hair");
   });
 
   it("says whose app it is when the id is taken and unreadable", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -157,7 +157,36 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
   });
 
+  it("runs the migration gate on records that survived their app document", async () => {
+    // Firestore deletes do not cascade: `apps/{aid}` can be gone while the records under it
+    // survive. A missing app document therefore proves only that the records cannot be READ right
+    // now — not that they do not exist — and a deploy that re-creates the app must still check
+    // them, or it hands them to the roster under a schema nothing compared them against.
+    docs.store.set(`apps/${AID}/collections/bookings/items`, new Map([["1", { id: "1" }]]));
+    writeFileSync(
+      path.join(root, ".claude", "skills", "bookings", "schema.json"),
+      JSON.stringify({ ...schemaFor("bookings"), fields: { ...schemaFor("bookings").fields, note: { type: "string", label: "Note", required: true } } }),
+    );
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join("\n")).toContain("would not satisfy the schema");
+    // The app document IS live — that is what made the records readable — and the result says so.
+    expect(docs.app()).toBeDefined();
+    expect(result.ok === false && result.partial).toBe(true);
+    // Nothing was staged: the gate stopped before that.
+    expect(docs.store.get(`apps/${AID}/staging`)).toBeUndefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
+    await deploySharedApp(root, stamp);
+    // One app write, then the staging document — on a first deploy the app write is the one that
+    // makes the records readable, which is why it happens before the migration gate rather than
+    // beside the staging writes.
+    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+
+    // And on a redeploy, where the app already exists, the same order without the extra write.
+    docs.writes.length = 0;
     await deploySharedApp(root, stamp);
     expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
   });

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -34,6 +34,8 @@ class FakeDocs implements FirestoreDocs {
   readsDeniedUntilApp = false;
   /** Collection path whose listing throws — a transient failure, as opposed to a refusal. */
   failListing: string | null = null;
+  /** Refuse the app-document read even though it exists — somebody else's app. */
+  readsDeniedForApp = false;
 
   private bucket(collectionPath: string): Map<string, Record<string, unknown>> {
     const existing = this.store.get(collectionPath);
@@ -43,14 +45,30 @@ class FakeDocs implements FirestoreDocs {
     return created;
   }
 
-  list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    this.failListing === collectionPath
-      ? Promise.reject(new Error("unavailable (test)"))
-      : this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")
-        ? Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }))
-        : Promise.resolve([...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1)).map(([id, data]) => ({ id, data })));
+  list = (collectionPath: string): Promise<FirestoreDoc[]> => {
+    if (this.failListing === collectionPath) {
+      return Promise.reject(new Error("unavailable (test)"));
+    }
+    // The rules again: a record listing is authorized through the app document, so while that is
+    // missing the listing is REFUSED rather than empty.
+    if (this.readsDeniedUntilApp && !this.app() && collectionPath.includes("/collections/")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    const docs = [...this.bucket(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1));
+    return Promise.resolve(docs.map(([id, data]) => ({ id, data })));
+  };
 
-  get = (collectionPath: string, docId: string): Promise<unknown | null> => Promise.resolve(this.bucket(collectionPath).get(docId) ?? null);
+  get = (collectionPath: string, docId: string): Promise<unknown | null> => {
+    // The rules' actual shape: `apps/{aid}`'s read resolves the roster out of the document, so a
+    // document that does not exist makes the expression fail and the read is REFUSED — the same
+    // answer as somebody else's app. A fake that answered `null` would let a first deploy pass a
+    // test the real thing cannot pass.
+    const existing = this.bucket(collectionPath).get(docId);
+    if (collectionPath === "apps" && (!existing || this.readsDeniedForApp)) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    return Promise.resolve(existing ?? null);
+  };
 
   set = (collectionPath: string, docId: string, data: Record<string, unknown>): Promise<void> => {
     const key = `${collectionPath}/${docId}`;
@@ -137,6 +155,7 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("deploys to the roster only — no public block, no published schema, no public config", async () => {
     const result = await deploySharedApp(root, stamp);
+    expect(result.ok === false ? result.problems : []).toEqual([]);
     expect(result.ok).toBe(true);
     // The one that matters: `publicOn` reads THIS field, not the world-readable projection, so a
     // deploy that wrote it would open the app for anyone testing.
@@ -195,6 +214,18 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
   });
 
+  it("says whose app it is when the id is taken and unreadable", async () => {
+    // The two are indistinguishable by reading — both are refusals — so the create is what settles
+    // it, and the message has to name the situation rather than repeat "insufficient permissions".
+    docs.store.set("apps", new Map([[AID, { aid: AID, owner: "somebody-else" }]]));
+    docs.readsDeniedForApp = true;
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join("\n")).toContain("belongs to somebody else's roster");
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeUndefined();
+  });
+
   it("says the roster is live when it cannot read staging after creating the app", async () => {
     // "Nothing was written" about an app that now exists is worse than no report at all: the next
     // decision — deploy again, or go looking for what half-happened — turns on it.
@@ -209,10 +240,11 @@ describe("shared app deploy / publish / unpublish", () => {
 
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
-    // One app write, then the staging document — on a first deploy the app write is the one that
-    // makes the records readable, which is why it happens before the migration gate rather than
-    // beside the staging writes.
-    expect(docs.writes).toEqual([`set apps/${AID}`, `set apps/${AID}/staging/bookings`]);
+    // CREATE, then the staging document. On a first deploy the app write is what makes the records
+    // readable, so it happens before the migration gate rather than beside the staging writes —
+    // and it is a create because that is the only operation that can tell "this app does not
+    // exist" from "this app is somebody else's", which a refused read cannot.
+    expect(docs.writes).toEqual([`create apps/${AID}`, `set apps/${AID}/staging/bookings`]);
 
     // And on a redeploy, where the app already exists, the same order without the extra write.
     docs.writes.length = 0;

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -178,6 +178,19 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.store.get(`apps/${AID}/staging`)).toBeUndefined();
   });
 
+  it("withdraws staging that outlived its app document", async () => {
+    // Firestore leaves `staging/*` behind exactly as it leaves the records. Carried through a
+    // resurrecting deploy, an orphaned staged collection then makes publish fail closed — it
+    // promotes what is staged and refuses a cid the repository does not have.
+    docs.store.set(`apps/${AID}/staging`, new Map([["waitlist", { publishedSchema: { title: "Waitlist" }, deployedAt: 1, deployedBy: OWNER.email }]]));
+
+    const result = await deploySharedApp(root, stamp);
+    expect(result.ok === true && result.withdrawn).toEqual(["waitlist"]);
+    expect(docs.doc(`apps/${AID}/staging`, "waitlist")).toBeUndefined();
+    // And the deploy still did its own job.
+    expect(docs.doc(`apps/${AID}/staging`, "bookings")).toBeDefined();
+  });
+
   it("writes the app document before the staged schemas — the staging rules resolve the owner through it", async () => {
     await deploySharedApp(root, stamp);
     // One app write, then the staging document — on a first deploy the app write is the one that

--- a/test/server/infra/sharedAppTool.spec.ts
+++ b/test/server/infra/sharedAppTool.spec.ts
@@ -4,7 +4,7 @@
 // likely to break: an operation that throws reaches the agent as a tool crash, which it will
 // retry rather than report. So every path out of here is a string.
 import { describe, it, expect, beforeAll } from "vitest";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { MANAGE_SHARED_APP, SHARED_APP_ACTIONS, manageSharedApp } from "../../../server/infra/shared-app-tool.js";
 import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
 import { groupOfTool } from "../../../common/toolGroups.js";
@@ -27,20 +27,54 @@ describe("manageSharedApp, the tool", () => {
   });
 
   it("names the three operations in the schema the agent is given", () => {
-    expect(SHARED_APP_ACTIONS).toEqual(["deploy", "publish", "unpublish"]);
-    expect(MANAGE_SHARED_APP.parameters?.properties?.action).toMatchObject({ enum: ["deploy", "publish", "unpublish"] });
+    expect(SHARED_APP_ACTIONS).toEqual(["init", "check", "invite", "deploy", "publish", "unpublish"]);
+    expect(MANAGE_SHARED_APP.parameters?.properties?.action).toMatchObject({ enum: [...SHARED_APP_ACTIONS] });
   });
 
   it("answers an unknown action with the ones that exist", async () => {
-    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), { action: "ship" })).toContain("deploy, publish, unpublish");
-    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), {})).toContain("deploy, publish, unpublish");
+    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), { action: "ship" })).toContain("init, check, invite, deploy, publish, unpublish");
+    expect(await manageSharedApp(makeTempDir("mt-shared-tool-"), {})).toContain("init, check, invite, deploy, publish, unpublish");
+  });
+
+  it("refuses to start an app in a repository that already declares one", async () => {
+    const root = makeTempDir("mt-shared-tool-");
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: {} }));
+    // Overwriting would revoke the whole roster without saying so.
+    expect(await manageSharedApp(root, { action: "init", name: "Second" })).toContain("already");
+  });
+
+  it("checks the declaration without a session, and without writing", async () => {
+    const root = makeTempDir("mt-shared-tool-");
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: { "o@e.com": { "*": "owner" } }, slug: "Not A Slug" }));
+
+    const message = await manageSharedApp(root, { action: "check" });
+    // The strict declaration refuses that slug's shape, and `check` is where an author is meant to
+    // learn it — not at a deploy, and not from a live refusal.
+    expect(message).toContain("slug");
+    expect(JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")).slug).toBe("Not A Slug");
+  });
+
+  it("adds and removes one roster entry, leaving the rest of the file alone", async () => {
+    const root = makeTempDir("mt-shared-tool-");
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", name: "Survey", members: { "o@e.com": { "*": "owner" } } }));
+
+    expect(await manageSharedApp(root, { action: "invite", email: "t@e.com", role: "viewer" })).toContain("viewer");
+    const after = JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8"));
+    expect(after.members).toEqual({ "o@e.com": { "*": "owner" }, "t@e.com": { "*": "viewer" } });
+    expect(after.name).toBe("Survey");
+
+    expect(await manageSharedApp(root, { action: "invite", email: "t@e.com" })).toContain("Removed");
+    // Removed ENTIRELY rather than left as an empty object: the rules require the roster and its
+    // email list to agree, and a half-removed entry is a permission somebody still holds.
+    expect(JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")).members).toEqual({ "o@e.com": { "*": "owner" } });
   });
 
   it("returns every refusal as text rather than throwing", async () => {
     const root = makeTempDir("mt-shared-tool-");
-    // Create a minimal app.json so ensureAid doesn't fail first
-    writeFileSync(path.join(root, "app.json"), JSON.stringify({ name: "test", collections: [] }));
-    for (const action of SHARED_APP_ACTIONS) {
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: {} }));
+    // The three that reach the APP need a session and say so. `check` and `invite` are about the
+    // file and need none; `init` refuses here because the declaration already exists.
+    for (const action of ["deploy", "publish", "unpublish"]) {
       const message = await manageSharedApp(root, { action });
       expect(typeof message).toBe("string");
       expect(message).toContain("signed-in Firestore session");

--- a/test/server/infra/sharedAppTool.spec.ts
+++ b/test/server/infra/sharedAppTool.spec.ts
@@ -131,6 +131,23 @@ describe("manageSharedApp, the tool", () => {
     expect(await manageSharedApp(root, { action: "invite", email: "o@e.com" })).toContain("Removed");
   });
 
+  it("catches, while signed in, what a deploy would refuse about `owner`", async () => {
+    // `check` answers "would a deploy be refused?", so it has to run the SAME gate. A second
+    // implementation answers differently, and this one answered optimistically: a declaration
+    // naming somebody else's uid checked clean and was refused a moment later.
+    const root = makeTempDir("mt-shared-tool-");
+    writeFileSync(
+      path.join(root, "app.json"),
+      JSON.stringify({ aid: "a1", members: { "signed-in@example.com": { "*": "owner" } }, owner: "somebody-elses-uid" }),
+    );
+    setFirestoreAccessor(() => ({ docs: FAKE_DOCS, email: "signed-in@example.com", uid: "uid-1" }));
+    try {
+      expect(await manageSharedApp(root, { action: "check" })).toContain("somebody-elses-uid");
+    } finally {
+      setFirestoreAccessor(null);
+    }
+  });
+
   it("returns every refusal as text rather than throwing", async () => {
     const root = makeTempDir("mt-shared-tool-");
     writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: {} }));

--- a/test/server/infra/sharedAppTool.spec.ts
+++ b/test/server/infra/sharedAppTool.spec.ts
@@ -9,12 +9,17 @@ import { MANAGE_SHARED_APP, SHARED_APP_ACTIONS, manageSharedApp } from "../../..
 import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
 import { groupOfTool } from "../../../common/toolGroups.js";
 import { setFirestoreAccessor, setSharedCollectionsSupport } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
 import { makeTempDir } from "../../support/tempDir";
 import path from "node:path";
 
 describe("manageSharedApp, the tool", () => {
   beforeAll(() => {
-    // Signed out on purpose: the operations then refuse, which is the path being pinned.
+    // Discovery needs a bound host: `check` reads this repository's collections, and without the
+    // binding it throws rather than reporting. ONE call per file — the binding refuses a second.
+    initCollectionsBackend({ workspace: makeTempDir("mt-shared-tool-ws-") });
+    // Signed out on purpose: it is the state `check` has to work in, and the state the other
+    // operations have to refuse in.
     setSharedCollectionsSupport(true);
     setFirestoreAccessor(null);
   });
@@ -41,6 +46,19 @@ describe("manageSharedApp, the tool", () => {
     writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: {} }));
     // Overwriting would revoke the whole roster without saying so.
     expect(await manageSharedApp(root, { action: "init", name: "Second" })).toContain("already");
+  });
+
+  it("calls a sound declaration deployable while signed out", async () => {
+    // The publisher check asks whether the caller is an app-wide owner, so an empty address is not
+    // neutral — it reported a missing owner for every signed-out call, and `check` could never
+    // come back clean. Signed out, the honest question is "would this deploy for the owner it
+    // names?", and the answer has to be able to be yes.
+    const root = makeTempDir("mt-shared-tool-");
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", name: "Survey", members: { "o@e.com": { "*": "owner" } } }));
+
+    const message = await manageSharedApp(root, { action: "check" });
+    expect(message).toContain("deployable");
+    expect(message).toContain("o@e.com");
   });
 
   it("checks the declaration without a session, and without writing", async () => {

--- a/test/server/infra/sharedAppTool.spec.ts
+++ b/test/server/infra/sharedAppTool.spec.ts
@@ -13,6 +13,16 @@ import { initCollectionsBackend } from "../../../server/backends/collections.js"
 import { makeTempDir } from "../../support/tempDir";
 import path from "node:path";
 
+/** The accessor hands back a Firestore adapter; `init` never uses it, but the shape is required. */
+const FAKE_DOCS = {
+  list: () => Promise.resolve([]),
+  get: () => Promise.resolve(null),
+  set: () => Promise.resolve(),
+  create: () => Promise.resolve(true),
+  delete: () => Promise.resolve(true),
+  watch: () => () => {},
+};
+
 describe("manageSharedApp, the tool", () => {
   beforeAll(() => {
     // Discovery needs a bound host: `check` reads this repository's collections, and without the
@@ -85,6 +95,40 @@ describe("manageSharedApp, the tool", () => {
     // Removed ENTIRELY rather than left as an empty object: the rules require the roster and its
     // email list to agree, and a half-removed entry is a permission somebody still holds.
     expect(JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")).members).toEqual({ "o@e.com": { "*": "owner" } });
+  });
+
+  it("writes the SIGNED-IN address as owner, and generates the aid", async () => {
+    // The whole reason `init` is an operation: the owner has to be the address the rules will see,
+    // the agent cannot read it, and the address a user offers is the one that fails at deploy.
+    const root = makeTempDir("mt-shared-tool-");
+    setFirestoreAccessor(() => ({ docs: FAKE_DOCS, email: "signed-in@example.com", uid: "uid-1" }));
+    try {
+      const message = await manageSharedApp(root, { action: "init", name: "Talk feedback", slug: "aug-talk-survey" });
+      expect(message).toContain("signed-in@example.com");
+      const written = JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8"));
+      expect(written.members).toEqual({ "signed-in@example.com": { "*": "owner" } });
+      expect(written.aid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+      expect(written.name).toBe("Talk feedback");
+      expect(written.slug).toBe("aug-talk-survey");
+    } finally {
+      setFirestoreAccessor(null);
+    }
+  });
+
+  it("refuses to leave the app without an owner", async () => {
+    // An app with no app-wide owner has no publisher: every deploy is refused, including the one
+    // that would put an owner back.
+    const root = makeTempDir("mt-shared-tool-");
+    const roster = { "o@e.com": { "*": "owner" }, "t@e.com": { "*": "viewer" } };
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: roster }));
+
+    expect(await manageSharedApp(root, { action: "invite", email: "o@e.com" })).toContain("no owner");
+    expect(await manageSharedApp(root, { action: "invite", email: "o@e.com", role: "viewer" })).toContain("no owner");
+    expect(JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")).members).toEqual(roster);
+
+    // With a second owner in place, the first may go.
+    await manageSharedApp(root, { action: "invite", email: "t@e.com", role: "owner" });
+    expect(await manageSharedApp(root, { action: "invite", email: "o@e.com" })).toContain("Removed");
   });
 
   it("returns every refusal as text rather than throwing", async () => {

--- a/test/server/skills/sharedAppSkill.spec.ts
+++ b/test/server/skills/sharedAppSkill.spec.ts
@@ -43,6 +43,21 @@ describe("the shared-app skill's sample declarations", () => {
   });
 });
 
+describe("the shared-app skill's operations", () => {
+  // Every one of these was learned by watching the agent do it the other way: compose the
+  // declaration from memory (and guess the owner), rewrite the file to recover from a refusal, and
+  // find out only at deploy that it would not deploy.
+  it("sends the declaration through the tool rather than describing the file", () => {
+    for (const fact of ['action: "init"', 'action: "check"', 'action: "invite"']) {
+      expect(body).toContain(fact);
+    }
+  });
+
+  it("says why the owner cannot be composed by hand", () => {
+    expect(body).toContain("SIGNED IN");
+  });
+});
+
 describe("the shared-app skill's schema advice", () => {
   // The agent that followed this wrote `fields` as a LIST of `{ name, title }`, with no
   // `primaryKey` and no `icon` — a shape nothing in the engine accepts. The skill now sends it to

--- a/test/server/skills/sharedAppSkill.spec.ts
+++ b/test/server/skills/sharedAppSkill.spec.ts
@@ -53,8 +53,15 @@ describe("the shared-app skill's schema advice", () => {
     expect(body).toContain("putSchema");
   });
 
+  // The run this was written from tried to CREATE a collection with `putSchema` and was refused:
+  // it is edit-only. Getting that backwards costs the agent its whole first attempt.
+  it("says that a new collection is created by writing the files", () => {
+    expect(body).toContain("EDIT-ONLY");
+    expect(body).toContain("SKILL.md");
+  });
+
   it("says what a guessed schema gets wrong", () => {
-    for (const fact of ["`fields` is an OBJECT", "`primaryKey` and `icon` are required", "`label`"]) {
+    for (const fact of ["`fields` is an OBJECT", "`primaryKey`", "`icon` are required", "`label`"]) {
       expect(body).toContain(fact);
     }
   });


### PR DESCRIPTION
`manageSharedApp` に **`init` / `check` / `invite`** を足します。

> **#1643 の上に積んでいます**（`fix/first-deploy`）。マージ順は **#1643 → これ**。

## なぜ

実機で 4 回試して、失敗の出どころが毎回同じでした — **宣言をエージェントが記憶から書く**しか
なく、書いた直後に確かめる手段が無い。

- **オーナーのアドレスをエージェントが知らない。** ツールは `handle.email` を持っているのに、
  エージェントはユーザーに聞くか推測します。返ってくるのは「本人がそう思っているアドレス」で、
  それが deploy で落ちる方の答えでした
- **`public` ブロックの誤りが deploy まで分からない。** 実機では 3 つ同時に間違えた宣言が
  そのまま最後まで進みました
- **失敗のあと、エージェントがファイルを手で直す。** `aid` を消して deploy し直し、
  **孤児のアプリを 2 つ**作りました

## 何を足すか

| action | すること |
|---|---|
| `init` | `app.json` を書く。オーナーは**サインイン中のアドレス**、`aid` は生成。既に宣言があれば断る（上書きは名簿ごと差し替えること） |
| `check` | deploy と同じ門番を、**何も書かず・接続も要らずに**回す |
| `invite` | 名簿の 1 エントリを足す・変える・外す。効くのは次の deploy |

**`app.json` をツールのものにはしません。** git に入ってレビューされる宣言なので、手で書ける
ままにしておきます — これらは対象のキーしか触りません。

実装で 2 点:

- `init` は `wx` で書きます。既存チェックしてから書くのではなく、**作成そのものが原子的**に
  失敗します（二重に走っても片方しかアプリを作れない）。存在チェックは**文面のため**だけに
  先に行います
- `invite` の削除はキーごと消します。ルールが `members` と `memberEmails` の一致を要求するので、
  半端に残ったエントリは「消したつもりの権限」になります

skill も書き換えました（宣言を自分で組み立てない、編集したら `check` する）。

`test/server` 5187 pass / lint 0 / build 通過。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared-app initialization, declaration checks, and invitation management.
  * Invite collaborators by email, assign collection roles, or remove access.
  * Added validation for app declarations, collections, and ownership.
* **Improvements**
  * Deployments now establish app ownership and validate records before writing.
  * Improved handling of permission-related responses and app creation conflicts.
  * Manifest creation is protected against accidental overwrites.
* **Documentation**
  * Updated shared-app guidance with setup, roster management, validation, and troubleshooting instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->