### PR TITLE
feat(collections): 公開ページが描けるよう、publish がフォームの形も載せる

### DIFF
--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -3124,8 +3124,24 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
 
 **シナリオを揃える**
 
-12. **公開ページ（`/{slug}`）+ App Check** — `auth` の 3 段階を同時に。
-    9 の `/staging/{aid}` とは**別の顔**で、`config/public` だけを読んで未サインインでも描ける（D10）
+12. **公開ページ（`/a/{slug}`）+ App Check** — `auth` の 3 段階を同時に。
+    9 の `/staging/{aid}` とは**別の顔**で、`config/public` だけを読んで未サインインでも描ける（D10）。
+
+    **URL は `/a/{slug}`**（2026-08-12 決定）。トップレベルの `/{slug}` は、mulmoserver が
+    すでに持っているページ名（`/account` `/collections` `/staging` …）と**同じ名前空間**に
+    なる。予約語リストで避ける手はあるが、それは**後から破れる約束**で、破れたときに
+    壊れるのは**すでに配られた URL** — しかも `appSlugs` は削除できない設計なので回収も
+    効かない。前置き 1 文字で原理的に消える。
+
+    **`config/public` だけでは足りなかった**（実装時に判明）。公開ページはスキーマを
+    読めない — `schemaRead = readerOf || publicRead || partRead` で、回答者はどれでもない
+    （submit 専用のコレクションは `public.read` に入れない。入れたら回答が全部読める）。
+    つまり**フィールド名しか手元に無く、入力欄が描けない**。訪問者が読める文書は
+    `apps/{aid}/config/*`（`allow read: if true`）だけなので、**publish がそこに
+    フォームの形も載せる**: `createFields` に載っているフィールドだけの
+    `{ label, type, values? }`。core の射影ではなく **MT が書く**（その文書を書いているのは
+    MT なので、MulmoClaude の変更は要らない）。`createFields` の外を載せないのは、
+    書けない欄のラベルを世界に配る理由が無いから
 13. **`then.email` + Trigger Email 拡張**
 14. **`schedule` ビュー** → **美容室シナリオが揃う**
 15. **`idFrom` / `finalize` / `window` / `aggregate`**（UI と集計側）→ **アンケートシナリオが揃う**

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -3139,9 +3139,24 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
     つまり**フィールド名しか手元に無く、入力欄が描けない**。訪問者が読める文書は
     `apps/{aid}/config/*`（`allow read: if true`）だけなので、**publish がそこに
     フォームの形も載せる**: `createFields` に載っているフィールドだけの
-    `{ label, type, values? }`。core の射影ではなく **MT が書く**（その文書を書いているのは
-    MT なので、MulmoClaude の変更は要らない）。`createFields` の外を載せないのは、
-    書けない欄のラベルを世界に配る理由が無いから
+    `{ label, type, values?, required? }` と、コレクション単位の `statusField`。core の射影では
+    なく **MT が書く**（その文書を書いているのは MT なので、MulmoClaude の変更は要らない）。
+    `createFields` の外を載せないのは、書けない欄のラベルを世界に配る理由が無いから。
+
+    `required` は**スキーマの `required` と `public.submit.<cid>.validate.required` の和**。
+    どちらもルールが公開 create で見るので、片方だけだとページは欄に印を付けられず、訪問者は
+    **どの欄が足りないのか名前の出ない権限エラー**として知ることになる。`statusField` を載せる
+    のは、既定が `status` ではなく**推測できない**から — create ルールは
+    `collections[cid].statusField` の欄が `initialStatus` と等しいことを要求し、core の設定射影は
+    それを運ばない。
+
+    載せる**型も絞る**（実装時に決定）: `string` `text` `markdown` `number` `boolean` `date`
+    `datetime` `email` `enum`。`ref` `table` `money` は、公開ページがこの射影しか読めない以上
+    `to` も行スキーマも通貨設定も届かず**正しく埋められない入力**になる。host が計算する型
+    （`derived` `embed` `backlinks` `rollup` `toggle` `flag` = core の `COMPUTED_TYPES`）は
+    そもそも誰も submit してはいけない。どちらも**宣言の時点で断る** — `createFields` は
+    ページが描く元であるだけでなく、公開 create をルールが判定するホワイトリストそのものなので、
+    射影から落とすだけでは「外部からの値を受け入れ続ける」状態が残るから
 13. **`then.email` + Trigger Email 拡張**
 14. **`schedule` ビュー** → **美容室シナリオが揃う**
 15. **`idFrom` / `finalize` / `window` / `aggregate`**（UI と集計側）→ **アンケートシナリオが揃う**

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -23,7 +23,7 @@ import {
 import type { PublishStamp } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
 import { isRecord } from "../../../common/isRecord.js";
-import { publicInputProblems } from "./publicForm.js";
+import { publicInputProblems, schemasOfCollections } from "./publicForm.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -134,7 +134,7 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
     // app-wide owner, so it would report a missing owner for every sound declaration.
     handle?.email ?? ownerFromRoster(app) ?? "",
   );
-  problems.push(...publicInputProblems(app, collections));
+  problems.push(...publicInputProblems(app, schemasOfCollections(collections)));
   if (handle !== null && app.owner !== undefined && app.owner !== handle.uid) {
     // Not fatal on its own — the rules pin `owner` to the EXISTING document on update — but a
     // declaration naming somebody else's uid is either the sample's `<uid>` placeholder or a

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -23,6 +23,7 @@ import {
 import type { PublishStamp } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
 import { isRecord } from "../../../common/isRecord.js";
+import { publicInputProblems } from "./publicForm.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -133,6 +134,7 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
     // app-wide owner, so it would report a missing owner for every sound declaration.
     handle?.email ?? ownerFromRoster(app) ?? "",
   );
+  problems.push(...publicInputProblems(app, collections));
   if (handle !== null && app.owner !== undefined && app.owner !== handle.uid) {
     // Not fatal on its own — the rules pin `owner` to the EXISTING document on update — but a
     // declaration naming somebody else's uid is either the sample's `<uid>` placeholder or a

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -79,16 +79,24 @@ export type PublicForm = Record<string, PublicCollectionForm>;
  *  now. */
 export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry[]): PublicForm {
   const submit = authored.public?.submit ?? {};
-  const byCid = new Map(staged.map((entry) => [entry.cid, entry.doc.publishedSchema]));
+  const byCid = new Map(staged.map((entry) => [entry.cid, entry.doc]));
   const entries = Object.entries(submit).flatMap(([cid, spec]) => {
-    const schema = byCid.get(cid);
-    if (schema === undefined) return [];
+    const doc = byCid.get(cid);
+    if (doc === undefined) return [];
+    const schema = doc.publishedSchema;
     const fields = fieldsOf(schema, spec.createFields, spec.validate?.required ?? []);
     // A collection whose `createFields` name nothing the schema declares publishes no entry at
     // all: an empty object would read as a form that failed to load, where absence is a fact the
     // page can state.
     if (Object.keys(fields).length === 0) return [];
-    const statusField = authored.collections?.[cid]?.statusField;
+    // From the STAGED rule configuration, not from `app.json`. What the rules will check is
+    // `apps/{aid}.collections[cid].statusField`, and publish promotes that from `staging/{cid}` —
+    // deliberately, so a manifest edit between deploy and publish cannot change the rule behaviour
+    // being published. Reading the manifest here would re-open exactly that gap from the other
+    // side: deploy with `statusField: "state"`, edit it to `status`, publish, and the page writes
+    // a key the promoted rule does not accept, so every submission is denied with nothing on the
+    // page to say why.
+    const statusField = doc.config?.statusField;
     return [[cid, { fields, ...(statusField === undefined ? {} : { statusField }) }] as const];
   });
   return Object.fromEntries(entries);

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -1,0 +1,66 @@
+// What a stranger needs in order to fill in the form.
+//
+// The public page cannot read the schema. `schemaRead` is `readerOf || publicRead || partRead`,
+// and the person answering a survey is none of those: they are not on the roster, and a
+// submit-only collection is not in `public.read` — deliberately, because listing the answers is
+// exactly what a survey must not do. So the labels, the types and the choices are unreachable, and
+// the page would have field NAMES and nothing else to draw with.
+//
+// The one document a visitor may read is `apps/{aid}/config/*` (`allow read: if true`), which
+// publish already writes. So the form's shape is published beside the settings — by MulmoTerminal,
+// which writes that document, rather than by a change to the projection in `@mulmoclaude/core`.
+//
+// ONLY the fields the visitor may write. `createFields` is the rules' whitelist for a public
+// create, so a field outside it cannot be submitted; publishing its label would put the app's
+// internal vocabulary (`status`, a reviewer's note) on a world-readable document for nobody's
+// benefit.
+import type { CollectionSchema } from "@mulmoclaude/core/collection";
+import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
+import type { StagedEntry } from "./staged.js";
+
+/** One input, as the page will draw it. */
+export interface PublicField {
+  label: string;
+  type: string;
+  /** An `enum`'s choices, so the page renders a select rather than a text box. */
+  values?: readonly string[];
+}
+
+export type PublicForm = Record<string, Record<string, PublicField>>;
+
+/** The form spec for every collection the declaration opens for public submission.
+ *
+ *  Read from the STAGED schemas — the version publish is promoting — for the same reason the
+ *  promotion itself is: what ships is what the roster reviewed, not what the working tree says
+ *  now. */
+export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry[]): PublicForm {
+  const submit = authored.public?.submit ?? {};
+  const byCid = new Map(staged.map((entry) => [entry.cid, entry.doc.publishedSchema]));
+  const entries = Object.entries(submit).flatMap(([cid, spec]) => {
+    const schema = byCid.get(cid);
+    if (schema === undefined) return [];
+    const fields = fieldsOf(schema, spec.createFields);
+    // A collection whose `createFields` name nothing the schema declares publishes no entry at
+    // all: an empty object would read as a form that failed to load, where absence is a fact the
+    // page can state.
+    return Object.keys(fields).length === 0 ? [] : [[cid, fields] as const];
+  });
+  return Object.fromEntries(entries);
+}
+
+function fieldsOf(schema: CollectionSchema, createFields: readonly string[]): Record<string, PublicField> {
+  const declared = schema.fields;
+  const pairs = createFields.flatMap((name) => {
+    // Own-property guarded: a `createFields` entry of `toString` or `constructor` must miss here
+    // rather than read an Object.prototype member and publish a "field" nobody declared.
+    if (!Object.hasOwn(declared, name)) return [];
+    const spec = declared[name];
+    if (spec === undefined) return [];
+    // `values` belongs to the `enum` variant alone — read through a narrowing rather than off the
+    // union, so a field type that gains choices later has to be added here on purpose.
+    const values = "values" in spec ? spec.values : undefined;
+    const field: PublicField = { label: spec.label, type: spec.type, ...(values === undefined ? {} : { values }) };
+    return [[name, field] as const];
+  });
+  return Object.fromEntries(pairs);
+}

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -14,9 +14,33 @@
 // create, so a field outside it cannot be submitted; publishing its label would put the app's
 // internal vocabulary (`status`, a reviewer's note) on a world-readable document for nobody's
 // benefit.
-import type { CollectionSchema } from "@mulmoclaude/core/collection";
+import { COMPUTED_TYPES, type CollectionFieldType, type CollectionSchema } from "@mulmoclaude/core/collection";
 import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
+import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
 import type { StagedEntry } from "./staged.js";
+
+/** The field types a STRANGER may be asked to fill in.
+ *
+ *  Deliberately a short list rather than "everything that is not computed". A public input has to
+ *  survive two things a roster member's editor does not: it is drawn by a page that can read
+ *  nothing but this projection, and whatever it produces is judged by the deployed rules with no
+ *  host in between. `ref` needs the target collection (unreadable to a visitor), `table` needs a
+ *  row sub-schema, `money` needs its currency configuration — publishing any of them as a bare
+ *  `{label, type}` would draw an input that cannot be filled in correctly.
+ *
+ *  `enum` is here because its choices travel WITH it (`values`), which is exactly what makes it
+ *  renderable. */
+const PUBLIC_INPUT_TYPES: ReadonlySet<CollectionFieldType> = new Set<CollectionFieldType>([
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "text",
+  "email",
+  "markdown",
+  "enum",
+]);
 
 /** One input, as the page will draw it. */
 export interface PublicField {
@@ -70,6 +94,39 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
   return Object.fromEntries(entries);
 }
 
+/** What is wrong with the fields a declaration opens for public submission, in the author's terms.
+ *
+ *  This is a REFUSAL rather than a projection that quietly drops the field, because `createFields`
+ *  is not only what the page draws from — it is the whitelist the deployed rules judge a public
+ *  create by (`request.resource.data.keys().hasOnly(s.createFields)`). Dropping a computed field
+ *  from the form would still leave the app accepting a written value for a field the host computes,
+ *  from anybody on the internet, with nothing on the page to show for it.
+ *
+ *  Read against the WORKING TREE's schemas, which is what `declarationProblems` holds and what
+ *  deploy is about to stage — so the answer arrives before the first write rather than at publish. */
+export function publicInputProblems(app: AuthoredApp, collections: readonly LoadedCollection[]): string[] {
+  const submit = app.public?.submit ?? {};
+  const byCid = new Map(collections.map((collection) => [collection.slug, collection.schema]));
+  return Object.entries(submit).flatMap(([cid, spec]) => {
+    const schema = byCid.get(cid);
+    if (schema === undefined) return [];
+    return spec.createFields.flatMap((name) => problemWith(cid, name, schema));
+  });
+}
+
+function problemWith(cid: string, name: string, schema: CollectionSchema): string[] {
+  if (!Object.hasOwn(schema.fields, name)) return [];
+  const spec = schema.fields[name];
+  if (spec === undefined || PUBLIC_INPUT_TYPES.has(spec.type)) return [];
+  const why = COMPUTED_TYPES.has(spec.type)
+    ? `'${spec.type}' fields are computed by the host from the rest of the record, so a submitted value for one is never read and must never be accepted`
+    : `'${spec.type}' fields need more than a label to fill in — the public page can read only the published form, not the schema, so it cannot draw one`;
+  return [
+    `public.submit.${cid}.createFields names '${name}', and ${why}. ` +
+      `Remove '${name}' from createFields — it stays in the collection, it is just not something a stranger fills in.`,
+  ];
+}
+
 function fieldsOf(schema: CollectionSchema, createFields: readonly string[], requiredBySubmit: readonly string[]): Record<string, PublicField> {
   const declared = schema.fields;
   const pairs = createFields.flatMap((name) => {
@@ -78,6 +135,9 @@ function fieldsOf(schema: CollectionSchema, createFields: readonly string[], req
     if (!Object.hasOwn(declared, name)) return [];
     const spec = declared[name];
     if (spec === undefined) return [];
+    // The same list the declaration is refused by, applied again where the drawing happens: a
+    // projection that published an input it cannot describe would be a broken form either way.
+    if (!PUBLIC_INPUT_TYPES.has(spec.type)) return [];
     // `values` belongs to the `enum` variant alone — read through a narrowing rather than off the
     // union, so a field type that gains choices later has to be added here on purpose.
     const values = "values" in spec ? spec.values : undefined;
@@ -91,4 +151,22 @@ function fieldsOf(schema: CollectionSchema, createFields: readonly string[], req
     return [[name, field] as const];
   });
   return Object.fromEntries(pairs);
+}
+
+/** How much of the world-readable config document the projection may take up.
+ *
+ *  Firestore refuses a document over 1 MiB, and `config/public` carries core's settings projection
+ *  as well as this form. A refusal from the database arrives mid-publish — after schemas have
+ *  already been promoted — and says only that a document was too large; this says which app is too
+ *  big to draw and stops before the first write. The margin is for the settings beside it. */
+const PUBLIC_CONFIG_BUDGET = 700_000;
+
+/** The refusal when the public config document would not fit, or null. */
+export function oversizeProblem(config: unknown): string | null {
+  const size = Buffer.byteLength(JSON.stringify(config) ?? "", "utf8");
+  if (size <= PUBLIC_CONFIG_BUDGET) return null;
+  return (
+    `the public form comes to ${Math.round(size / 1000)} kB, and everything a visitor reads has to fit in one Firestore document (1 MB, shared with the app's settings). ` +
+    "Publish fewer collections for public submission, or shorten the longest field labels and choice lists — the limit is on the form, not on the records."
+  );
 }

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -102,6 +102,10 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
   return Object.fromEntries(entries);
 }
 
+/** Which version of the schemas a check is reading, because the answer differs and the author has
+ *  to be told which one disagreed with the declaration. */
+export type SchemaSource = "tree" | "staged";
+
 /** What is wrong with the fields a declaration opens for public submission, in the author's terms.
  *
  *  This is a REFUSAL rather than a projection that quietly drops the field, because `createFields`
@@ -110,20 +114,32 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
  *  from the form would still leave the app accepting a written value for a field the host computes,
  *  from anybody on the internet, with nothing on the page to show for it.
  *
- *  Read against the WORKING TREE's schemas, which is what `declarationProblems` holds and what
- *  deploy is about to stage — so the answer arrives before the first write rather than at publish. */
-export function publicInputProblems(app: AuthoredApp, collections: readonly LoadedCollection[]): string[] {
+ *  Run TWICE, against both versions, and that is the point rather than duplication: deploy checks
+ *  the working tree it is about to stage, so the answer arrives before the first write; publish
+ *  checks the STAGED schemas, because those are what it promotes and the two can have drifted
+ *  since. A field added to the tree and to `createFields` but never deployed passes the first
+ *  check and would otherwise ship as a rule that demands a field the form cannot draw. */
+export function publicInputProblems(app: AuthoredApp, schemas: readonly { cid: string; schema: CollectionSchema }[], source: SchemaSource = "tree"): string[] {
   const submit = app.public?.submit ?? {};
-  const byCid = new Map(collections.map((collection) => [collection.slug, collection.schema]));
+  const byCid = new Map(schemas.map((entry) => [entry.cid, entry.schema]));
   return Object.entries(submit).flatMap(([cid, spec]) => {
     const schema = byCid.get(cid);
+    // A cid with no schema here is not this check's to report: at deploy the declaration names a
+    // collection the repository does not have (`publishProblems` says so), and at publish the
+    // staged set is matched against the repository by the gate above.
     if (schema === undefined) return [];
-    return spec.createFields.flatMap((name) => problemWith(cid, name, schema));
+    return spec.createFields.flatMap((name) => problemWith(cid, name, schema, source));
   });
 }
 
-function problemWith(cid: string, name: string, schema: CollectionSchema): string[] {
-  if (!Object.hasOwn(schema.fields, name)) return [];
+/** The schemas as this check reads them — a `LoadedCollection` keys its schema by `slug`. */
+export function schemasOfCollections(collections: readonly LoadedCollection[]): { cid: string; schema: CollectionSchema }[] {
+  return collections.map((collection) => ({ cid: collection.slug, schema: collection.schema }));
+}
+
+function problemWith(cid: string, name: string, schema: CollectionSchema, source: SchemaSource): string[] {
+  // Own-property guarded: `toString` must miss here rather than match an Object.prototype member.
+  if (!Object.hasOwn(schema.fields, name)) return [unknownField(cid, name, source)];
   const spec = schema.fields[name];
   if (spec === undefined || PUBLIC_INPUT_TYPES.has(spec.type)) return [];
   const why = COMPUTED_TYPES.has(spec.type)
@@ -133,6 +149,25 @@ function problemWith(cid: string, name: string, schema: CollectionSchema): strin
     `public.submit.${cid}.createFields names '${name}', and ${why}. ` +
       `Remove '${name}' from createFields — it stays in the collection, it is just not something a stranger fills in.`,
   ];
+}
+
+/** A name in `createFields` that the schema does not declare.
+ *
+ *  Refused rather than ignored, and for a different reason at each version. Against the tree it is
+ *  a typo that would still reach the rules, which would then accept that key from anybody on the
+ *  internet — a field nothing declares and nothing validates. Against the staged schemas it is the
+ *  drift: the rules about to be published would REQUIRE a field the published form cannot draw,
+ *  so a visitor filling the form in correctly is refused with nothing to fix. */
+function unknownField(cid: string, name: string, source: SchemaSource): string {
+  const version =
+    source === "tree"
+      ? `'${cid}' does not declare a field called '${name}'`
+      : `the staged version of '${cid}' — the one publish promotes — has no field called '${name}', even if this repository's schema does now`;
+  const fix =
+    source === "tree"
+      ? "Fix the name, or add the field to the schema."
+      : "Run deploy again, so the version being published is the one the declaration describes.";
+  return `public.submit.${cid}.createFields names '${name}', but ${version}. ${fix}`;
 }
 
 function fieldsOf(schema: CollectionSchema, createFields: readonly string[], requiredBySubmit: readonly string[]): Record<string, PublicField> {

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -24,6 +24,13 @@ export interface PublicField {
   type: string;
   /** An `enum`'s choices, so the page renders a select rather than a text box. */
   values?: readonly string[];
+  /** Whether a submission without it is refused.
+   *
+   *  The UNION of two declarations, because the rules and the app can each insist: the schema's
+   *  own `required`, and `public.submit[cid].validate.required` — which is what the deployed rules
+   *  actually check on a public create. Left out, the page cannot mark the field or stop the
+   *  submit, and the visitor learns of it as a permission error with nothing naming the field. */
+  required?: true;
 }
 
 export type PublicForm = Record<string, Record<string, PublicField>>;
@@ -39,7 +46,7 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
   const entries = Object.entries(submit).flatMap(([cid, spec]) => {
     const schema = byCid.get(cid);
     if (schema === undefined) return [];
-    const fields = fieldsOf(schema, spec.createFields);
+    const fields = fieldsOf(schema, spec.createFields, spec.validate?.required ?? []);
     // A collection whose `createFields` name nothing the schema declares publishes no entry at
     // all: an empty object would read as a form that failed to load, where absence is a fact the
     // page can state.
@@ -48,7 +55,7 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
   return Object.fromEntries(entries);
 }
 
-function fieldsOf(schema: CollectionSchema, createFields: readonly string[]): Record<string, PublicField> {
+function fieldsOf(schema: CollectionSchema, createFields: readonly string[], requiredBySubmit: readonly string[]): Record<string, PublicField> {
   const declared = schema.fields;
   const pairs = createFields.flatMap((name) => {
     // Own-property guarded: a `createFields` entry of `toString` or `constructor` must miss here
@@ -59,7 +66,13 @@ function fieldsOf(schema: CollectionSchema, createFields: readonly string[]): Re
     // `values` belongs to the `enum` variant alone — read through a narrowing rather than off the
     // union, so a field type that gains choices later has to be added here on purpose.
     const values = "values" in spec ? spec.values : undefined;
-    const field: PublicField = { label: spec.label, type: spec.type, ...(values === undefined ? {} : { values }) };
+    const required = spec.required === true || requiredBySubmit.includes(name);
+    const field: PublicField = {
+      label: spec.label,
+      type: spec.type,
+      ...(values === undefined ? {} : { values }),
+      ...(required ? { required: true as const } : {}),
+    };
     return [[name, field] as const];
   });
   return Object.fromEntries(pairs);

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -33,7 +33,20 @@ export interface PublicField {
   required?: true;
 }
 
-export type PublicForm = Record<string, Record<string, PublicField>>;
+/** One collection's public form: the inputs, and the field the rules will insist the initial
+ *  status lands in.
+ *
+ *  `statusField` is here because it is NOT `status` by default and NOT guessable: the create rule
+ *  checks `collections[cid].statusField` and requires that field to equal `initialStatus`. A page
+ *  that assumed the name would write the wrong key and be refused — and core's config projection
+ *  carries the submit declaration but not the collection's rule configuration, so this is the only
+ *  place a visitor can learn it. */
+export interface PublicCollectionForm {
+  fields: Record<string, PublicField>;
+  statusField?: string;
+}
+
+export type PublicForm = Record<string, PublicCollectionForm>;
 
 /** The form spec for every collection the declaration opens for public submission.
  *
@@ -50,7 +63,9 @@ export function publicFormOf(authored: AuthoredApp, staged: readonly StagedEntry
     // A collection whose `createFields` name nothing the schema declares publishes no entry at
     // all: an empty object would read as a form that failed to load, where absence is a fact the
     // page can state.
-    return Object.keys(fields).length === 0 ? [] : [[cid, fields] as const];
+    if (Object.keys(fields).length === 0) return [];
+    const statusField = authored.collections?.[cid]?.statusField;
+    return [[cid, { fields, ...(statusField === undefined ? {} : { statusField }) }] as const];
   });
   return Object.fromEntries(entries);
 }

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -40,6 +40,7 @@ import { ensureAid } from "./ensureAid.js";
 import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
+import { publicFormOf, type PublicForm } from "./publicForm.js";
 import { setSlugPublished } from "./slug.js";
 import { runWrites, type WriteStep } from "./writes.js";
 
@@ -115,6 +116,7 @@ function publishSteps(
   stamp: PublishStamp,
   face: ReturnType<typeof projectPublish>,
   slug: string | undefined,
+  form: PublicForm,
 ): WriteStep[] {
   return [
     ...staged.map(({ cid, doc }) => ({
@@ -123,7 +125,11 @@ function publishSteps(
     })),
     {
       what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
-      run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, face.config),
+      // `form` is MulmoTerminal's addition to core's projection, and it has to be here rather
+      // than anywhere else: this is the ONLY document a visitor may read, and without the labels
+      // and the choices the public page cannot draw the form at all (the schema is unreadable to
+      // somebody who is neither on the roster nor granted a public read).
+      run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, { ...face.config, form }),
     },
     // The app document WITHOUT `public`: the promoted rule configuration lands with the schemas it
     // was staged beside, so the public write path is never judged by one version's constraints
@@ -230,7 +236,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
   // reserved is a write the rules refuse, and that refusal is the point of them.
   const slug = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
 
-  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug), "publish");
+  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, publicFormOf(authored, staged.staged)), "publish");
   if (failure) return failure;
 
   return {

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -33,6 +33,7 @@ import {
   appSchemasPath,
   promoteSchema,
   projectPublish,
+  type AuthoredApp,
   type LoadedCollection,
   type PublishStamp,
 } from "@mulmoclaude/core/collection/server";
@@ -40,7 +41,7 @@ import { ensureAid } from "./ensureAid.js";
 import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
-import { oversizeProblem, publicFormOf, type PublicForm } from "./publicForm.js";
+import { oversizeProblem, publicFormOf, publicInputProblems, type PublicForm } from "./publicForm.js";
 import { setSlugPublished } from "./slug.js";
 import { runWrites, type WriteStep } from "./writes.js";
 
@@ -167,6 +168,7 @@ function publishSteps(
  *  repository, and the live records fit the version about to become public. Split out for the
  *  line budget, and it reads as the one thing it is — the gate. */
 async function stagedGate(
+  authored: AuthoredApp,
   staged: readonly StagedEntry[],
   collections: readonly LoadedCollection[],
   aid: string,
@@ -184,6 +186,15 @@ async function stagedGate(
   }
   const toScan = stagedForValidation(staged, collections);
   if (!toScan.ok) return { ...toScan, partial: false };
+  // Against the STAGED schemas, not the tree the deploy gate already checked: the declaration can
+  // have gained a field since, and publishing it would make the rules demand a field the form
+  // cannot draw.
+  const drifted = publicInputProblems(
+    authored,
+    staged.map((entry) => ({ cid: entry.cid, schema: entry.doc.publishedSchema })),
+    "staged",
+  );
+  if (drifted.length > 0) return { ok: false, partial: false, problems: drifted };
   const scan = await scanRecords(toScan.collections, root);
   const refusal = recordRefusal(scan, "publish", confirm);
   return refusal ? { ok: false, partial: false, problems: refusal } : { ok: true, scan };
@@ -202,7 +213,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
 
   const staged = await readStaged(handle, aid);
   if (!staged.ok) return { ...staged, partial: false };
-  const gate = await stagedGate(staged.staged, collections, aid, root, opts.confirm);
+  const gate = await stagedGate(authored, staged.staged, collections, aid, root, opts.confirm);
   if (!gate.ok) return gate;
   const scan = gate.scan;
 

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -40,7 +40,7 @@ import { ensureAid } from "./ensureAid.js";
 import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
-import { publicFormOf, type PublicForm } from "./publicForm.js";
+import { oversizeProblem, publicFormOf, type PublicForm } from "./publicForm.js";
 import { setSlugPublished } from "./slug.js";
 import { runWrites, type WriteStep } from "./writes.js";
 
@@ -236,7 +236,13 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
   // reserved is a write the rules refuse, and that refusal is the point of them.
   const slug = typeof existingApp?.slug === "string" ? existingApp.slug : undefined;
 
-  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, publicFormOf(authored, staged.staged)), "publish");
+  const form = publicFormOf(authored, staged.staged);
+  // Before the first write: the config document is written in the middle of the run, so a database
+  // refusal there would land with the schemas already promoted.
+  const oversize = oversizeProblem({ ...face.config, form });
+  if (oversize !== null) return { ok: false, partial: false, problems: [oversize] };
+
+  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, form), "publish");
   if (failure) return failure;
 
   return {

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -154,6 +154,12 @@ Every line of that is load-bearing, and deploy refuses the declaration without t
   `createFields`. It is NOT a hole: the rules pin the value to `initialStatus` on create, so a
   respondent can only write `submitted` — listing it is what lets the rules check it. What
   `createFields` must NOT contain is anything else you do not want them setting.
+- **Only simple fields go in `createFields`**: `string`, `text`, `markdown`, `number`, `boolean`,
+  `date`, `datetime`, `email`, and `enum` (whose choices travel with it). A `ref`, `table` or
+  `money` field is refused — the public page reads the published form and nothing else, so it has
+  no way to draw one — and so is anything the host computes (`derived`, `embed`, `backlinks`,
+  `rollup`, `toggle`, `flag`), which is a value nobody may submit. Such fields stay in the
+  collection; they are just not what a stranger fills in. `check` names any that slipped in.
 - **`read: []`** — a survey lists nothing publicly. People answer; they do not browse the answers.
 
 The simplest correct survey omits status entirely (`submitOnly` + `verifiedEmail` + `emailField`).

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -5,7 +5,7 @@
 // the form, and this is the projection that makes it so.
 import { describe, it, expect } from "vitest";
 import { parseAuthoredApp } from "@mulmoclaude/core/collection/server";
-import { publicFormOf } from "../../../server/backends/sharedApp/publicForm.js";
+import { oversizeProblem, publicFormOf, publicInputProblems } from "../../../server/backends/sharedApp/publicForm.js";
 
 const schema = {
   title: "Responses",
@@ -118,5 +118,67 @@ describe("publicFormOf", () => {
     // being published as a field nobody wrote.
     const form = publicFormOf(authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "toString", "nope"] } }), staged);
     expect(form.responses?.fields).toEqual({ name: { label: "お名前", type: "string" } });
+  });
+});
+
+describe("fields a stranger cannot be asked for", () => {
+  // `createFields` is not only what the page draws from — it is the whitelist the deployed rules
+  // judge a public create by. So a computed field left in it is a value from the internet landing
+  // in a field the host is supposed to compute; dropping it from the form alone would not stop it.
+  const withField = (name: string, spec: Record<string, unknown>) => [
+    { cid: "responses", doc: { publishedSchema: { ...schema, fields: { ...schema.fields, [name]: spec } }, deployedAt: 1, deployedBy: "o@e.com" } },
+  ];
+
+  it("does not draw a computed field", () => {
+    const app = authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "flagged"] } });
+    const form = publicFormOf(app, withField("flagged", { type: "flag", label: "要対応", where: { field: "score", in: ["1"] } }));
+    expect(Object.keys(form.responses?.fields ?? {})).toEqual(["name"]);
+  });
+
+  it("does not draw a field it cannot describe", () => {
+    const app = authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "owner"] } });
+    const form = publicFormOf(app, withField("owner", { type: "ref", label: "担当", to: "people" }));
+    expect(Object.keys(form.responses?.fields ?? {})).toEqual(["name"]);
+  });
+});
+
+describe("oversizeProblem", () => {
+  it("says nothing about a form that fits", () => {
+    expect(oversizeProblem({ form: publicFormOf(authored(surveySubmit), staged) })).toBeNull();
+  });
+
+  it("stops a form too big for the one document a visitor may read", () => {
+    const values = Array.from({ length: 80000 }, (_, index) => `choice-${index}`);
+    const problem = oversizeProblem({ form: { responses: { fields: { score: { label: "満足度", type: "enum", values } } } } });
+    expect(problem).toContain("one Firestore document");
+  });
+});
+
+describe("publicInputProblems", () => {
+  // The gate that runs before any write — `declarationProblems`, shared by deploy, publish and
+  // check — so the author is told while it is still a declaration.
+  const collection = (fields: Record<string, unknown>) => [{ slug: "responses", schema: { ...schema, fields: { ...schema.fields, ...fields } } } as never];
+
+  it("says nothing about a form of plain fields", () => {
+    expect(publicInputProblems(authored(surveySubmit), collection({}))).toEqual([]);
+  });
+
+  it("refuses a computed field, naming it and saying what to do", () => {
+    const app = authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "flagged"] } });
+    const problems = publicInputProblems(app, collection({ flagged: { type: "flag", label: "要対応", where: { field: "score", in: ["1"] } } }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("'flagged'");
+    expect(problems[0]).toContain("computed by the host");
+  });
+
+  it("refuses a field the public page cannot draw", () => {
+    const app = authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["owner"] } });
+    const problems = publicInputProblems(app, collection({ owner: { type: "ref", label: "担当", to: "people" } }));
+    expect(problems[0]).toContain("cannot draw one");
+  });
+
+  it("leaves a collection it has no schema for to the checks that own that", () => {
+    const app = authored({ ghost: { auth: "verifiedEmail", emailField: "email", createFields: ["name"] } });
+    expect(publicInputProblems(app, collection({}))).toEqual([]);
   });
 });

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -60,6 +60,24 @@ describe("publicFormOf", () => {
     expect(Object.keys(form.responses ?? {})).not.toContain("id");
   });
 
+  it("marks a field the rules will insist on — from either declaration", async () => {
+    // Two places can insist and the page has to honour both: the schema's own `required`, and
+    // `public.submit[cid].validate.required`, which is what the deployed rules check on a public
+    // create. Dropped, the visitor meets it as a permission error naming no field.
+    const withRequired = {
+      ...schema,
+      fields: { ...schema.fields, name: { type: "string" as const, label: "お名前", required: true } },
+    };
+    const form = publicFormOf(
+      authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "score", "comment"], validate: { required: ["score"] } } }),
+      [{ cid: "responses", doc: { publishedSchema: withRequired, deployedAt: 1, deployedBy: "o@e.com" } }],
+    );
+    expect(form.responses?.name).toMatchObject({ required: true });
+    expect(form.responses?.score).toMatchObject({ required: true });
+    // And nothing is marked that neither declaration asked for.
+    expect(form.responses?.comment).not.toHaveProperty("required");
+  });
+
   it("says nothing about a collection the app does not open", () => {
     expect(publicFormOf(authored({}), staged)).toEqual({});
   });

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+//
+// The public page cannot read the schema — `schemaRead` is `readerOf || publicRead || partRead`,
+// and the person answering a survey is none of those. So what it CAN read has to be enough to draw
+// the form, and this is the projection that makes it so.
+import { describe, it, expect } from "vitest";
+import { parseAuthoredApp } from "@mulmoclaude/core/collection/server";
+import { publicFormOf } from "../../../server/backends/sharedApp/publicForm.js";
+
+const schema = {
+  title: "Responses",
+  icon: "reviews",
+  primaryKey: "id",
+  storage: { type: "firestore" as const },
+  fields: {
+    id: { type: "string" as const, label: "ID", primary: true, required: true },
+    name: { type: "string" as const, label: "お名前" },
+    score: { type: "enum" as const, label: "満足度", values: ["1", "2", "3", "4", "5"] },
+    comment: { type: "text" as const, label: "ご感想" },
+    status: { type: "string" as const, label: "状態" },
+  },
+};
+
+const staged = [{ cid: "responses", doc: { publishedSchema: schema, deployedAt: 1, deployedBy: "o@e.com" } }];
+
+const authored = (submit: Record<string, unknown>) => {
+  const parsed = parseAuthoredApp(
+    JSON.stringify({
+      aid: "a1",
+      members: { "o@e.com": { "*": "owner" } },
+      collections: { responses: { submitOnly: true, statusField: "status" } },
+      public: { enabled: true, read: [], submit },
+    }),
+  );
+  if (!parsed.ok) throw new Error(parsed.problems.join("; "));
+  return parsed.app;
+};
+
+const surveySubmit = {
+  responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "score", "comment"] },
+};
+
+describe("publicFormOf", () => {
+  it("gives the page a label, a type and an enum's choices", () => {
+    expect(publicFormOf(authored(surveySubmit), staged)).toEqual({
+      responses: {
+        name: { label: "お名前", type: "string" },
+        score: { label: "満足度", type: "enum", values: ["1", "2", "3", "4", "5"] },
+        comment: { label: "ご感想", type: "text" },
+      },
+    });
+  });
+
+  it("publishes only what the visitor may write", () => {
+    // `createFields` is the rules' whitelist for a public create, so a field outside it cannot be
+    // submitted — and publishing its label would put the app's internal vocabulary on a
+    // world-readable document for nobody's benefit.
+    const form = publicFormOf(authored(surveySubmit), staged);
+    expect(Object.keys(form.responses ?? {})).not.toContain("status");
+    expect(Object.keys(form.responses ?? {})).not.toContain("id");
+  });
+
+  it("says nothing about a collection the app does not open", () => {
+    expect(publicFormOf(authored({}), staged)).toEqual({});
+  });
+
+  it("skips a submit whose collection is not staged, rather than publishing an empty form", () => {
+    // An empty entry reads as a form that failed to load; absence is a fact the page can state.
+    expect(publicFormOf(authored({ waitlist: { auth: "verifiedEmail", emailField: "email", createFields: ["name"] } }), staged)).toEqual({});
+  });
+
+  it("ignores a createFields entry the schema does not declare", () => {
+    // Including `toString`: an own-property guard is what keeps an Object.prototype member from
+    // being published as a field nobody wrote.
+    const form = publicFormOf(authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "toString", "nope"] } }), staged);
+    expect(form.responses).toEqual({ name: { label: "お名前", type: "string" } });
+  });
+});

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -44,9 +44,15 @@ describe("publicFormOf", () => {
   it("gives the page a label, a type and an enum's choices", () => {
     expect(publicFormOf(authored(surveySubmit), staged)).toEqual({
       responses: {
-        name: { label: "お名前", type: "string" },
-        score: { label: "満足度", type: "enum", values: ["1", "2", "3", "4", "5"] },
-        comment: { label: "ご感想", type: "text" },
+        fields: {
+          name: { label: "お名前", type: "string" },
+          score: { label: "満足度", type: "enum", values: ["1", "2", "3", "4", "5"] },
+          comment: { label: "ご感想", type: "text" },
+        },
+        // Not `status`, and not guessable: the create rule requires the initial value to land in
+        // the field `collections[cid].statusField` names, and core's config projection does not
+        // carry it. A page that assumed the name would be refused.
+        statusField: "status",
       },
     });
   });
@@ -56,8 +62,8 @@ describe("publicFormOf", () => {
     // submitted — and publishing its label would put the app's internal vocabulary on a
     // world-readable document for nobody's benefit.
     const form = publicFormOf(authored(surveySubmit), staged);
-    expect(Object.keys(form.responses ?? {})).not.toContain("status");
-    expect(Object.keys(form.responses ?? {})).not.toContain("id");
+    expect(Object.keys(form.responses?.fields ?? {})).not.toContain("status");
+    expect(Object.keys(form.responses?.fields ?? {})).not.toContain("id");
   });
 
   it("marks a field the rules will insist on — from either declaration", async () => {
@@ -72,10 +78,30 @@ describe("publicFormOf", () => {
       authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "score", "comment"], validate: { required: ["score"] } } }),
       [{ cid: "responses", doc: { publishedSchema: withRequired, deployedAt: 1, deployedBy: "o@e.com" } }],
     );
-    expect(form.responses?.name).toMatchObject({ required: true });
-    expect(form.responses?.score).toMatchObject({ required: true });
+    expect(form.responses?.fields.name).toMatchObject({ required: true });
+    expect(form.responses?.fields.score).toMatchObject({ required: true });
     // And nothing is marked that neither declaration asked for.
-    expect(form.responses?.comment).not.toHaveProperty("required");
+    expect(form.responses?.fields.comment).not.toHaveProperty("required");
+  });
+
+  it("names the status field the rules will check, whatever it is called", async () => {
+    // `status` is a convention, not a rule. The create rule reads `collections[cid].statusField`,
+    // so a collection that calls it `state` refuses a submission that writes `status` — and the
+    // visitor cannot learn the name from anywhere else.
+    const parsed = parseAuthoredApp(
+      JSON.stringify({
+        aid: "a1",
+        members: { "o@e.com": { "*": "owner" } },
+        collections: { responses: { submitOnly: true, statusField: "state" } },
+        public: {
+          enabled: true,
+          read: [],
+          submit: { responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name"], initialStatus: "submitted" } },
+        },
+      }),
+    );
+    if (!parsed.ok) throw new Error(parsed.problems.join("; "));
+    expect(publicFormOf(parsed.app, staged).responses?.statusField).toBe("state");
   });
 
   it("says nothing about a collection the app does not open", () => {
@@ -91,6 +117,6 @@ describe("publicFormOf", () => {
     // Including `toString`: an own-property guard is what keeps an Object.prototype member from
     // being published as a field nobody wrote.
     const form = publicFormOf(authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "toString", "nope"] } }), staged);
-    expect(form.responses).toEqual({ name: { label: "お名前", type: "string" } });
+    expect(form.responses?.fields).toEqual({ name: { label: "お名前", type: "string" } });
   });
 });

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -21,7 +21,13 @@ const schema = {
   },
 };
 
-const staged = [{ cid: "responses", doc: { publishedSchema: schema, deployedAt: 1, deployedBy: "o@e.com" } }];
+// `config` is the STAGED rule configuration — what publish promotes onto the app document and
+// what the rules then check a public create against. The form's `statusField` has to come from
+// here rather than from `app.json`, or an edit between deploy and publish moves one and not the
+// other.
+const staged = [
+  { cid: "responses", doc: { publishedSchema: schema, config: { submitOnly: true, statusField: "status" }, deployedAt: 1, deployedBy: "o@e.com" } },
+];
 
 const authored = (submit: Record<string, unknown>) => {
   const parsed = parseAuthoredApp(
@@ -88,6 +94,9 @@ describe("publicFormOf", () => {
     // `status` is a convention, not a rule. The create rule reads `collections[cid].statusField`,
     // so a collection that calls it `state` refuses a submission that writes `status` — and the
     // visitor cannot learn the name from anywhere else.
+    //
+    // Staged and manifest deliberately DISAGREE here: publish promotes the staged copy, so that
+    // is the one the page must be told about.
     const parsed = parseAuthoredApp(
       JSON.stringify({
         aid: "a1",
@@ -101,7 +110,7 @@ describe("publicFormOf", () => {
       }),
     );
     if (!parsed.ok) throw new Error(parsed.problems.join("; "));
-    expect(publicFormOf(parsed.app, staged).responses?.statusField).toBe("state");
+    expect(publicFormOf(parsed.app, staged).responses?.statusField).toBe("status");
   });
 
   it("says nothing about a collection the app does not open", () => {
@@ -126,7 +135,7 @@ describe("fields a stranger cannot be asked for", () => {
   // judge a public create by. So a computed field left in it is a value from the internet landing
   // in a field the host is supposed to compute; dropping it from the form alone would not stop it.
   const withField = (name: string, spec: Record<string, unknown>) => [
-    { cid: "responses", doc: { publishedSchema: { ...schema, fields: { ...schema.fields, [name]: spec } }, deployedAt: 1, deployedBy: "o@e.com" } },
+    { ...staged[0]!, doc: { ...staged[0]!.doc, publishedSchema: { ...schema, fields: { ...schema.fields, [name]: spec } } } },
   ];
 
   it("does not draw a computed field", () => {
@@ -180,5 +189,22 @@ describe("publicInputProblems", () => {
   it("leaves a collection it has no schema for to the checks that own that", () => {
     const app = authored({ ghost: { auth: "verifiedEmail", emailField: "email", createFields: ["name"] } });
     expect(publicInputProblems(app, collection({}))).toEqual([]);
+  });
+});
+
+describe("the status field the page writes", () => {
+  // publish promotes `collections[cid]` from `staging/{cid}` so a manifest edit after deploy
+  // cannot change the rule behaviour being published. The form has to read the same staged copy:
+  // otherwise deploy with `state`, edit `app.json` to `status`, publish — and the page writes a
+  // key the promoted rule refuses, with nothing on the page to say why.
+  it("comes from what was staged, not from app.json", () => {
+    const app = authored(surveySubmit);
+    const restaged = [{ ...staged[0]!, doc: { ...staged[0]!.doc, config: { submitOnly: true, statusField: "state" } } }];
+    expect(publicFormOf(app, restaged).responses?.statusField).toBe("state");
+  });
+
+  it("is absent when the staged configuration names none", () => {
+    const restaged = [{ ...staged[0]!, doc: { ...staged[0]!.doc, config: { submitOnly: true } } }];
+    expect(publicFormOf(authored(surveySubmit), restaged).responses?.statusField).toBeUndefined();
   });
 });

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -5,7 +5,7 @@
 // the form, and this is the projection that makes it so.
 import { describe, it, expect } from "vitest";
 import { parseAuthoredApp } from "@mulmoclaude/core/collection/server";
-import { oversizeProblem, publicFormOf, publicInputProblems } from "../../../server/backends/sharedApp/publicForm.js";
+import { oversizeProblem, publicFormOf, publicInputProblems, schemasOfCollections } from "../../../server/backends/sharedApp/publicForm.js";
 
 const schema = {
   title: "Responses",
@@ -25,9 +25,12 @@ const schema = {
 // what the rules then check a public create against. The form's `statusField` has to come from
 // here rather than from `app.json`, or an edit between deploy and publish moves one and not the
 // other.
-const staged = [
-  { cid: "responses", doc: { publishedSchema: schema, config: { submitOnly: true, statusField: "status" }, deployedAt: 1, deployedBy: "o@e.com" } },
-];
+const stagedResponses = {
+  cid: "responses",
+  doc: { publishedSchema: schema, config: { submitOnly: true, statusField: "status" }, deployedAt: 1, deployedBy: "o@e.com" },
+};
+
+const staged = [stagedResponses];
 
 const authored = (submit: Record<string, unknown>) => {
   const parsed = parseAuthoredApp(
@@ -135,7 +138,7 @@ describe("fields a stranger cannot be asked for", () => {
   // judge a public create by. So a computed field left in it is a value from the internet landing
   // in a field the host is supposed to compute; dropping it from the form alone would not stop it.
   const withField = (name: string, spec: Record<string, unknown>) => [
-    { ...staged[0]!, doc: { ...staged[0]!.doc, publishedSchema: { ...schema, fields: { ...schema.fields, [name]: spec } } } },
+    { ...stagedResponses, doc: { ...stagedResponses.doc, publishedSchema: { ...schema, fields: { ...schema.fields, [name]: spec } } } },
   ];
 
   it("does not draw a computed field", () => {
@@ -166,7 +169,8 @@ describe("oversizeProblem", () => {
 describe("publicInputProblems", () => {
   // The gate that runs before any write — `declarationProblems`, shared by deploy, publish and
   // check — so the author is told while it is still a declaration.
-  const collection = (fields: Record<string, unknown>) => [{ slug: "responses", schema: { ...schema, fields: { ...schema.fields, ...fields } } } as never];
+  const collection = (fields: Record<string, unknown>) =>
+    schemasOfCollections([{ slug: "responses", schema: { ...schema, fields: { ...schema.fields, ...fields } } } as never]);
 
   it("says nothing about a form of plain fields", () => {
     expect(publicInputProblems(authored(surveySubmit), collection({}))).toEqual([]);
@@ -199,12 +203,37 @@ describe("the status field the page writes", () => {
   // key the promoted rule refuses, with nothing on the page to say why.
   it("comes from what was staged, not from app.json", () => {
     const app = authored(surveySubmit);
-    const restaged = [{ ...staged[0]!, doc: { ...staged[0]!.doc, config: { submitOnly: true, statusField: "state" } } }];
+    const restaged = [{ ...stagedResponses, doc: { ...stagedResponses.doc, config: { submitOnly: true, statusField: "state" } } }];
     expect(publicFormOf(app, restaged).responses?.statusField).toBe("state");
   });
 
   it("is absent when the staged configuration names none", () => {
-    const restaged = [{ ...staged[0]!, doc: { ...staged[0]!.doc, config: { submitOnly: true } } }];
+    const restaged = [{ ...stagedResponses, doc: { ...stagedResponses.doc, config: { submitOnly: true } } }];
     expect(publicFormOf(authored(surveySubmit), restaged).responses?.statusField).toBeUndefined();
+  });
+});
+
+describe("a declaration that has moved on since the deploy", () => {
+  // The deploy gate reads the working tree; publish promotes the STAGED schemas. Add a field to
+  // both the schema and `createFields` without deploying again, and the rules being published
+  // would demand a field the published form cannot draw — a visitor filling the form in correctly
+  // is refused, with nothing to fix.
+  const app = authored({ responses: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "referrer"] } });
+
+  it("passes against the tree that has the field", () => {
+    const withNew = { ...schema, fields: { ...schema.fields, referrer: { type: "string" as const, label: "きっかけ" } } };
+    expect(publicInputProblems(app, [{ cid: "responses", schema: withNew }])).toEqual([]);
+  });
+
+  it("is refused against the staged version that does not, and says to deploy again", () => {
+    const problems = publicInputProblems(app, [{ cid: "responses", schema }], "staged");
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("'referrer'");
+    expect(problems[0]).toContain("Run deploy again");
+  });
+
+  it("calls an undeclared name a name, against the tree", () => {
+    const problems = publicInputProblems(app, [{ cid: "responses", schema }]);
+    expect(problems[0]).toContain("does not declare a field called 'referrer'");
   });
 });

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -502,7 +502,7 @@ describe("shared app deploy / publish / unpublish", () => {
     await deploySharedApp(root, stamp);
     await publishSharedApp(root, stamp);
 
-    expect(docs.doc(`apps/${AID}/config`, "public")?.form).toEqual({ bookings: { note: { label: "Note", type: "string" } } });
+    expect(docs.doc(`apps/${AID}/config`, "public")?.form).toEqual({ bookings: { fields: { note: { label: "Note", type: "string" } } } });
   });
 
   it("does not make the name resolve when the app is not open to anonymous visitors", async () => {

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -489,6 +489,22 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.writes).toEqual([`set apps/${AID}`, "set appSlugs/sakura-hair", `delete apps/${AID}/config/public`]);
   });
 
+  it("publishes the form the public page draws from", async () => {
+    // The page cannot read the schema, so the config document — the only one a visitor may read —
+    // carries the labels and the choices. Without it the form is a row of unlabelled boxes.
+    writeApp(
+      root,
+      declaration({
+        collections: { bookings: { submitOnly: true } },
+        public: { enabled: true, read: [], submit: { bookings: { auth: "verifiedEmail", emailField: "note", createFields: ["note"] } } },
+      }),
+    );
+    await deploySharedApp(root, stamp);
+    await publishSharedApp(root, stamp);
+
+    expect(docs.doc(`apps/${AID}/config`, "public")?.form).toEqual({ bookings: { note: { label: "Note", type: "string" } } });
+  });
+
   it("does not make the name resolve when the app is not open to anonymous visitors", async () => {
     // A published reservation is world-readable, and what it reveals is the aid — the
     // /staging/{aid} entrance. Publishing a roster-only declaration is a normal thing to do, and


### PR DESCRIPTION
実装順 12（公開ページ）の**前提**が足りていなかったので、先に埋めます。

## 何が足りなかったか

公開ページは**スキーマを読めません**:

```
match /collections/{cid} { allow read: if schemaRead(app(aid), cid); }
schemaRead(a, cid) = readerOf(a, cid) || publicRead(a, cid) || partRead(a, cid)
```

アンケートの回答者はどれでもありません — 名簿にいないし、submit 専用のコレクションは
`public.read` に**入れません**（入れたら回答が全部読めてしまう）。

設計 D10 は「公開ページは `config/public` を読んで描ける」と書いていますが、**その中身で
フォームが描けるかは確かめられていませんでした**。実際に入っているのは `createFields` などの
**フィールド名だけ**で、ラベルも型も選択肢もありません。

## 直し方

訪問者が読める文書は `apps/{aid}/config/*`（`allow read: if true`）だけなので、**publish が
そこにフォームの形も載せます**:

```json
"form": {
  "responses": {
    "name":  { "label": "お名前", "type": "string" },
    "score": { "label": "満足度", "type": "enum", "values": ["1","2","3","4","5"] }
  }
}
```

**`@mulmoclaude/core` は変えません。** その文書を書いているのは MulmoTerminal なので、core の
射影に足す必要がありません。

**`createFields` の外は載せません。** ルールがその外の書き込みを弾く以上、書けない欄のラベルを
世界に配る理由が無く、アプリの内部語彙（`status`、レビュー用のメモ）を晒すだけになります。

## あわせて

公開 URL を **`/a/{slug}`** に決めました（plans に理由）。トップレベルの `/{slug}` は
mulmoserver の既存ページ名と同じ名前空間になり、予約語リストは「後から破れる約束」で、
破れたときに壊れるのは**すでに配られた URL** です（`appSlugs` は削除できないので回収も効かない）。

## テスト

`publicForm.spec.ts`（5 件: ラベル・型・選択肢、`createFields` の外を出さない、staged で
ないコレクションを飛ばす、`toString` のような名前を拾わない）と、`sharedApp.spec.ts` に
publish 経由の 1 件。`test/server` 5198 pass / lint 0 / build 通過。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public collection pages now use `/a/{slug}` links.
  * Published forms show supported, writable fields with labels, types, choices, required settings, and status fields.
* **Bug Fixes**
  * Invalid public form configurations are detected before publishing.
  * Unsupported field types are excluded from public forms.
  * Oversized public configurations are rejected without partial changes.
  * Public-page validation errors now appear in shared-app checks.
* **Documentation**
  * Added guidance on supported fields for public submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->