### PR TITLE
fix(shared-app): ロスターのアドレスを小文字に揃える

### DIFF
--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -135,6 +135,7 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
     handle?.email ?? ownerFromRoster(app) ?? "",
   );
   problems.push(...publicInputProblems(app, schemasOfCollections(collections)));
+  problems.push(...rosterCaseProblems(app, handle?.email));
   if (handle !== null && app.owner !== undefined && app.owner !== handle.uid) {
     // Not fatal on its own — the rules pin `owner` to the EXISTING document on update — but a
     // declaration naming somebody else's uid is either the sample's `<uid>` placeholder or a
@@ -145,6 +146,26 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
     );
   }
   return problems;
+}
+
+/** Roster keys the rules will never match, because of their case.
+ *
+ *  `email() in a.members` is an exact string comparison and rules have no `lower()`. Firebase puts
+ *  a lower-cased address in the token, so `Foo@Example.com` on the roster grants nothing — and the
+ *  deploy succeeds, the file reads correctly to a human, and the person invited is refused
+ *  everything with no error anywhere that names them. Said here rather than repaired, because the
+ *  roster is a committed file people edit by hand and rewriting somebody's key is not ours to do.
+ *
+ *  The signed-in address is exempt whatever its case: it IS what the rules compare against, so a
+ *  provider that hands over capitals is right and this check would be wrong. */
+function rosterCaseProblems(app: AuthoredApp, signedInAs: string | undefined): string[] {
+  return Object.keys(app.members)
+    .filter((address) => address !== address.toLowerCase() && address !== signedInAs)
+    .map(
+      (address) =>
+        `app.json puts "${address}" on the roster, and the rules compare an address exactly — they match a signed-in ` +
+        `"${address.toLowerCase()}" against nothing. Write it in lower case.`,
+    );
 }
 
 export interface SharedAppContext {

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -135,7 +135,13 @@ export interface InviteSuccess {
  *
  *  One key, left where it was — the file belongs to the author, and an operation that rewrote it
  *  would be a worse version of editing it by hand. `role: null` removes. */
-export async function inviteToSharedApp(root: string, email: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
+export async function inviteToSharedApp(root: string, rawEmail: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
+  // Lower-cased, because the roster key is compared to `request.auth.token.email` by a rule that
+  // has no `lower()`. Firebase hands the token a lower-cased address, so an entry typed
+  // `Foo@Example.com` matches nothing — and the failure is silent in the worst way: the deploy
+  // succeeds, the roster reads correctly to a human, and the person invited is simply refused
+  // everything with no error naming them.
+  const email = rawEmail.toLowerCase();
   let orphaned = false;
   const updated = await updateManifest(root, (manifest) => {
     const next = nextMembers(manifest, email, role, cid);

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -178,7 +178,7 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
       ok: false,
       partial: false,
       problems: [
-        `app.json has more than one roster entry for that address, differing only in case: ${ambiguous.map((key) => `"${key}"`).join(", ")}.`,
+        `app.json has more than one roster entry for that address, differing only in case: ${quoted(ambiguous)}.`,
         "Which one carries this person's permissions is not something this tool may guess — changing one and leaving the other is how somebody keeps access they were told they had lost. " +
           "Merge them by hand into the lower-cased key (the one the rules compare against), then run this again.",
       ],
@@ -211,6 +211,11 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
  *  over that address, which is exactly the case `rosterCaseProblems` exempts. Silently lower-casing
  *  it while changing somebody's role would revoke everything that person has. The deploy-time check
  *  is where a wrong spelling is reported, and a hand edit is how it gets fixed. */
+/** The keys as they will be shown back to the author: quoted, in the order the file has them. */
+function quoted(keys: readonly string[]): string {
+  return keys.map((key) => JSON.stringify(key)).join(", ");
+}
+
 function rosterMatches(manifest: Record<string, unknown>, email: string): string[] {
   const members = isRecord(manifest.members) ? manifest.members : {};
   return Object.keys(members).filter((key) => key.toLowerCase() === email);

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -142,9 +142,16 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
   // succeeds, the roster reads correctly to a human, and the person invited is simply refused
   // everything with no error naming them.
   const email = rawEmail.toLowerCase();
+  let written = email;
   let orphaned = false;
   const updated = await updateManifest(root, (manifest) => {
-    const next = nextMembers(manifest, email, role, cid);
+    // Which key this operation is ABOUT is decided case-insensitively, before the normalization
+    // above can matter. Lower-casing and then looking the key up would make `invite` act on a
+    // different entry than the one on the roster: removing `Foo@Example.com` would find nothing,
+    // leave it in place, and still report success, and changing its role would add a SECOND entry
+    // beside it — two keys for one person, one of which still holds the old permissions.
+    written = rosterKey(manifest, email);
+    const next = nextMembers(manifest, written, role, cid);
     if (next === null) return null;
     // An app with no app-wide owner has no publisher: every deploy is refused, INCLUDING the one
     // that would put an owner back. The file can still be edited by hand, but this tool must not
@@ -161,13 +168,28 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
       ok: false,
       partial: false,
       problems: [
-        `that would leave the app with no owner: ${email} is the only address holding \`"*": "owner"\`.`,
+        `that would leave the app with no owner: ${written} is the only address holding \`"*": "owner"\`.`,
         "An app with no owner cannot be deployed at all — not even to put an owner back. Add another owner first, then remove this one.",
       ],
     };
   }
   if (!updated.ok) return { ok: false, partial: false, problems: updated.problems };
-  return { ok: true, email, role, cid };
+  return { ok: true, email: written, role, cid };
+}
+
+/** The key this operation changes: the roster's own spelling of the address when it already has
+ *  one, and the lower-cased address otherwise.
+ *
+ *  An existing entry keeps its spelling rather than being migrated, even a spelling
+ *  `rosterCaseProblems` complains about. Two reasons, and the second is the one that bites: the
+ *  file belongs to the author and this tool only ever changes the key it is asked about, and an
+ *  upper-case key can be CORRECT — it is what the rules compare against when the provider hands
+ *  over that address, which is exactly the case `rosterCaseProblems` exempts. Silently lower-casing
+ *  it while changing somebody's role would revoke everything that person has. The deploy-time check
+ *  is where a wrong spelling is reported, and a hand edit is how it gets fixed. */
+function rosterKey(manifest: Record<string, unknown>, email: string): string {
+  const members = isRecord(manifest.members) ? manifest.members : {};
+  return Object.keys(members).find((key) => key.toLowerCase() === email) ?? email;
 }
 
 /** The declaration with one roster entry changed, or null when it already says that.

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -138,19 +138,29 @@ export interface InviteSuccess {
 export async function inviteToSharedApp(root: string, rawEmail: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
   // Lower-cased, because the roster key is compared to `request.auth.token.email` by a rule that
   // has no `lower()`. Firebase hands the token a lower-cased address, so an entry typed
-  // `Foo@Example.com` matches nothing — and the failure is silent in the worst way: the deploy
-  // succeeds, the roster reads correctly to a human, and the person invited is simply refused
-  // everything with no error naming them.
+  // `Foo@Example.com` matches nobody — and once deployed the failure is silent in the worst way:
+  // the roster reads correctly to a human, and the person invited is refused everything with no
+  // error naming them. Written correctly here; a hand-edited one is stopped by
+  // `rosterCaseProblems` before a deploy can carry it.
   const email = rawEmail.toLowerCase();
   let written = email;
+  let ambiguous: string[] = [];
   let orphaned = false;
   const updated = await updateManifest(root, (manifest) => {
+    // A hand edit can leave TWO keys for one person, differing only in case. Whichever this
+    // operation picked would be a guess, and the guess is invisible: the other entry keeps its
+    // permissions while the tool reports the change as done. So it is refused and named.
+    const matches = rosterMatches(manifest, email);
+    if (matches.length > 1) {
+      ambiguous = matches;
+      return null;
+    }
     // Which key this operation is ABOUT is decided case-insensitively, before the normalization
     // above can matter. Lower-casing and then looking the key up would make `invite` act on a
     // different entry than the one on the roster: removing `Foo@Example.com` would find nothing,
     // leave it in place, and still report success, and changing its role would add a SECOND entry
     // beside it — two keys for one person, one of which still holds the old permissions.
-    written = rosterKey(manifest, email);
+    written = matches[0] ?? email;
     const next = nextMembers(manifest, written, role, cid);
     if (next === null) return null;
     // An app with no app-wide owner has no publisher: every deploy is refused, INCLUDING the one
@@ -163,6 +173,17 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
     }
     return next;
   });
+  if (ambiguous.length > 1) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `app.json has more than one roster entry for that address, differing only in case: ${ambiguous.map((key) => `"${key}"`).join(", ")}.`,
+        "Which one carries this person's permissions is not something this tool may guess — changing one and leaving the other is how somebody keeps access they were told they had lost. " +
+          "Merge them by hand into the lower-cased key (the one the rules compare against), then run this again.",
+      ],
+    };
+  }
   if (orphaned) {
     return {
       ok: false,
@@ -177,8 +198,11 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
   return { ok: true, email: written, role, cid };
 }
 
-/** The key this operation changes: the roster's own spelling of the address when it already has
- *  one, and the lower-cased address otherwise.
+/** Every roster key that is this address, differing at most in case — none, one, or (from a hand
+ *  edit) more than one.
+ *
+ *  The one that exists keeps its spelling rather than being migrated, even a spelling
+ *  `rosterCaseProblems` complains about.
  *
  *  An existing entry keeps its spelling rather than being migrated, even a spelling
  *  `rosterCaseProblems` complains about. Two reasons, and the second is the one that bites: the
@@ -187,9 +211,9 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
  *  over that address, which is exactly the case `rosterCaseProblems` exempts. Silently lower-casing
  *  it while changing somebody's role would revoke everything that person has. The deploy-time check
  *  is where a wrong spelling is reported, and a hand edit is how it gets fixed. */
-function rosterKey(manifest: Record<string, unknown>, email: string): string {
+function rosterMatches(manifest: Record<string, unknown>, email: string): string[] {
   const members = isRecord(manifest.members) ? manifest.members : {};
-  return Object.keys(members).find((key) => key.toLowerCase() === email) ?? email;
+  return Object.keys(members).filter((key) => key.toLowerCase() === email);
 }
 
 /** The declaration with one roster entry changed, or null when it already says that.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -103,6 +103,11 @@ edits the roster and nothing else; deploy is what makes it real.
 
 `cid` narrows it to one collection instead of the whole app.
 
+Addresses are written in lower case, because the rules compare one exactly and the sign-in token
+carries a lower-cased address. An entry with capitals matches nobody, and nothing reports it — the
+deploy succeeds and the person is simply refused everything. `invite` lower-cases what you pass;
+a roster edited by hand is checked at deploy.
+
 ### 4b. Check, whenever you have edited `app.json`
 
 `manageSharedApp` with `action: "check"` runs the gate a deploy runs — the declaration, the

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -104,11 +104,15 @@ edits the roster and nothing else; deploy is what makes it real.
 `cid` narrows it to one collection instead of the whole app.
 
 Addresses are written in lower case, because the rules compare one exactly and the sign-in token
-carries a lower-cased address. An entry with capitals matches nobody, and nothing reports it — the
-deploy succeeds and the person is simply refused everything. `invite` lower-cases a NEW address; an address the roster
-already has keeps the spelling it has there — that entry is changed in place, and whether its
-spelling is wrong is the deploy check's business, not this operation's. A roster edited by hand is
-checked at deploy.
+carries a lower-cased address. An entry with capitals matches nobody, and once deployed nothing
+says so — the person is simply refused everything. So `invite` lower-cases a NEW address, and a
+roster edited by hand is checked before a deploy: a key with capitals is reported as a problem and
+the deploy is refused until it is fixed (the exception is the address you are signed in with, which
+is what the rules compare against whatever its case).
+
+An address the roster already has keeps the spelling it has there, and that entry is changed in
+place — `invite` never migrates a key or writes a second one beside it. If a hand edit has left two
+entries for one person differing only in case, `invite` refuses and names them: merge them by hand.
 
 ### 4b. Check, whenever you have edited `app.json`
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -105,8 +105,10 @@ edits the roster and nothing else; deploy is what makes it real.
 
 Addresses are written in lower case, because the rules compare one exactly and the sign-in token
 carries a lower-cased address. An entry with capitals matches nobody, and nothing reports it — the
-deploy succeeds and the person is simply refused everything. `invite` lower-cases what you pass;
-a roster edited by hand is checked at deploy.
+deploy succeeds and the person is simply refused everything. `invite` lower-cases a NEW address; an address the roster
+already has keeps the spelling it has there — that entry is changed in place, and whether its
+spelling is wrong is the deploy check's business, not this operation's. A roster edited by hand is
+checked at deploy.
 
 ### 4b. Check, whenever you have edited `app.json`
 

--- a/test/server/backends/rosterEmailCase.spec.ts
+++ b/test/server/backends/rosterEmailCase.spec.ts
@@ -85,4 +85,18 @@ describe("inviteToSharedApp", () => {
     // And it reports the key it actually wrote, not the address that was typed.
     expect(result.ok && result.email).toBe("Foo@Example.com");
   });
+
+  // Two keys for one person is a hand edit, and picking one would be an invisible guess: the
+  // other entry keeps its permissions while the tool reports the change as done.
+  it("refuses when the roster spells one address two ways, and names both", async () => {
+    const members = { "o@e.com": { "*": "owner" }, "foo@example.com": { survey: "participant" }, "Foo@Example.com": { survey: "editor" } };
+    const root = await repoWith(members);
+
+    const result = await inviteToSharedApp(root, "foo@example.com", null, "survey");
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.problems.join(" ")).toContain('"foo@example.com", "Foo@Example.com"');
+    // Refused means the file is untouched — neither entry half-removed.
+    expect((await manifestAt(root)).members).toEqual(members);
+  });
 });

--- a/test/server/backends/rosterEmailCase.spec.ts
+++ b/test/server/backends/rosterEmailCase.spec.ts
@@ -42,15 +42,47 @@ describe("declarationProblems: roster address case", () => {
   });
 });
 
+const manifestAt = async (root: string) => JSON.parse(await readFile(path.join(root, "app.json"), "utf-8")) as { members: Record<string, unknown> };
+
+const repoWith = async (members: Record<string, unknown>) => {
+  const root = await mkdtemp(path.join(tmpdir(), "roster-case-"));
+  await writeFile(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members }, null, 2));
+  return root;
+};
+
 describe("inviteToSharedApp", () => {
-  it("writes the address in lower case, so the rules can match it", async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "roster-case-"));
-    await writeFile(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: { "o@e.com": { "*": "owner" } } }, null, 2));
+  it("writes a new address in lower case, so the rules can match it", async () => {
+    const root = await repoWith({ "o@e.com": { "*": "owner" } });
 
     const result = await inviteToSharedApp(root, "Foo@Example.com", "participant", "survey");
 
     expect(result.ok).toBe(true);
-    const written = JSON.parse(await readFile(path.join(root, "app.json"), "utf-8")) as { members: Record<string, unknown> };
-    expect(Object.keys(written.members)).toEqual(["o@e.com", "foo@example.com"]);
+    expect(Object.keys((await manifestAt(root)).members)).toEqual(["o@e.com", "foo@example.com"]);
+  });
+
+  // Which entry the operation is ABOUT is decided before the normalization can matter. Otherwise
+  // a removal looks up a key nobody has, changes nothing, and still reports success.
+  it("removes the entry a roster spells with capitals", async () => {
+    const root = await repoWith({ "o@e.com": { "*": "owner" }, "Foo@Example.com": { survey: "participant" } });
+
+    const result = await inviteToSharedApp(root, "foo@example.com", null, "survey");
+
+    expect(result.ok).toBe(true);
+    expect(Object.keys((await manifestAt(root)).members)).toEqual(["o@e.com"]);
+  });
+
+  // The other half of the same bug: a second key beside the first, one of which still holds the
+  // permissions the operator believed they had just changed.
+  it("changes that entry in place rather than adding a lower-cased twin", async () => {
+    const root = await repoWith({ "o@e.com": { "*": "owner" }, "Foo@Example.com": { survey: "participant" } });
+
+    const result = await inviteToSharedApp(root, "Foo@Example.com", "viewer", "survey");
+
+    expect(result.ok).toBe(true);
+    const members = (await manifestAt(root)).members;
+    expect(Object.keys(members)).toEqual(["o@e.com", "Foo@Example.com"]);
+    expect(members["Foo@Example.com"]).toEqual({ survey: "viewer" });
+    // And it reports the key it actually wrote, not the address that was typed.
+    expect(result.ok && result.email).toBe("Foo@Example.com");
   });
 });

--- a/test/server/backends/rosterEmailCase.spec.ts
+++ b/test/server/backends/rosterEmailCase.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+//
+// The roster is keyed by an address the rules compare EXACTLY (`email() in a.members`, and rules
+// have no `lower()`). Firebase puts a lower-cased address in the token, so a key with capitals
+// grants nothing — and nothing fails: the deploy succeeds, the file reads correctly to a human,
+// and the person invited is refused everything with no error naming them.
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseAuthoredApp } from "@mulmoclaude/core/collection/server";
+import { declarationProblems } from "../../../server/backends/sharedApp/context.js";
+import { inviteToSharedApp } from "../../../server/backends/sharedApp/declare.js";
+
+const appWith = (members: Record<string, Record<string, string>>) => {
+  const parsed = parseAuthoredApp(JSON.stringify({ aid: "a1", members }));
+  if (!parsed.ok) throw new Error(parsed.problems.join("; "));
+  return parsed.app;
+};
+
+const owner = { email: "o@e.com", uid: "u1" };
+
+const caseProblems = (members: Record<string, Record<string, string>>, handle: { email: string; uid: string } | null = owner) =>
+  declarationProblems(appWith(members), [], handle).filter((problem) => problem.includes("lower case"));
+
+describe("declarationProblems: roster address case", () => {
+  it("says so when an invited address the rules will never match is on the roster", () => {
+    const problems = caseProblems({ "o@e.com": { "*": "owner" }, "Foo@Example.com": { survey: "participant" } });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("Foo@Example.com");
+    expect(problems[0]).toContain("foo@example.com");
+  });
+
+  it("is quiet about a roster written in lower case", () => {
+    expect(caseProblems({ "o@e.com": { "*": "owner" }, "foo@example.com": { survey: "participant" } })).toEqual([]);
+  });
+
+  // The signed-in address IS what the rules compare against, so a provider that hands over
+  // capitals is right and the check would be wrong.
+  it("exempts the address this session is signed in with, whatever its case", () => {
+    expect(caseProblems({ "Owner@Example.com": { "*": "owner" } }, { email: "Owner@Example.com", uid: "u1" })).toEqual([]);
+  });
+});
+
+describe("inviteToSharedApp", () => {
+  it("writes the address in lower case, so the rules can match it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "roster-case-"));
+    await writeFile(path.join(root, "app.json"), JSON.stringify({ aid: "a1", members: { "o@e.com": { "*": "owner" } } }, null, 2));
+
+    const result = await inviteToSharedApp(root, "Foo@Example.com", "participant", "survey");
+
+    expect(result.ok).toBe(true);
+    const written = JSON.parse(await readFile(path.join(root, "app.json"), "utf-8")) as { members: Record<string, unknown> };
+    expect(Object.keys(written.members)).toEqual(["o@e.com", "foo@example.com"]);
+  });
+});


### PR DESCRIPTION
セキュリティレビュー（Gemini）の SEC-02 に対する修正。

ルールの `email() in a.members` は厳密比較で、rules に `lower()` は無い。Firebase がトークンに入れるのは小文字のアドレスなので、`Foo@Example.com` というロスターのキーは**誰にも一致しない**。しかも失敗の仕方が悪い — deploy は成功し、`app.json` は人間には正しく読め、招待された本人だけが理由の分からない拒否を受ける（どこにもエラーが出ない）。

- `inviteToSharedApp` は書き込む前に小文字化する。
- `declarationProblems` は手で編集されたロスターの大文字キーを deploy 前に指摘する。書き換えはしない（`app.json` は PR で読まれる、人の持ち物のファイル）。サインイン中のアドレスだけは除外する — それ自体がルールの比較対象なので、大文字を返すプロバイダがあればそちらが正しい。

`test/server/backends/rosterEmailCase.spec.ts` に 4 本。

なお同じレビューの他の指摘については、この PR では触っていない（XSS の指摘は該当なし: mulmoserver に `v-html` は一つも無い。App Check は既知の未着手項目）。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invitations now normalize new email addresses to lowercase.
  * Existing roster entries are matched case-insensitively and updated without creating duplicates.
  * Deployment checks identify uppercase roster addresses and provide correction guidance.
  * The currently signed-in address is exempt from uppercase warnings.

* **Documentation**
  * Added guidance on lowercase roster addresses and validation behavior.

* **Bug Fixes**
  * Improved reporting to reference the actual affected roster entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->