### PR TITLE
fix(shared-app): publish に許可プロンプトを戻す / aid を init で確保する

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -93,8 +93,9 @@ const GROUP_BY_TOOL = new Map<string, ToolGroup>([
   // manageSharedApp deploys and publishes the SHARED collections of the directory the cell is
   // open in, so it belongs where their store does: a cell without the data group has no
   // collection tools, and a deploy tool beside no collections is a tool with nothing to deploy.
-  // It is not in AUTO_ALLOWED_TOOLS — publish is the one operation here that changes what people
-  // outside the roster can see, and Claude Code's permission prompt is wanted in front of it.
+  // It is not in AUTO_ALLOWED_TOOLS, and it is in NEVER_AUTO_APPROVED_TOOLS below — publish is the
+  // one operation here that changes what people outside the roster can see, and the permission
+  // prompt is wanted in front of it on EVERY session, the workspace included.
   ["manageSharedApp", "data"],
 
   ["generateImage", "media"],
@@ -167,3 +168,19 @@ export const LEGACY_GUI_SERVER_IDS: readonly string[] = ["mulmoterminal-gui"];
 //
 // The three below save an artifact and draw it, and call nothing external.
 export const AUTO_ALLOWED_TOOLS: readonly string[] = ["presentForm", "presentChart", "presentHtml"];
+
+/** Tools that must keep the agent's permission prompt on EVERY claude session, including the
+ *  workspace.
+ *
+ *  `AUTO_ALLOWED_TOOLS` above is the grid cell's list and withholds these already — but it is an
+ *  allowlist, and the workspace does not use it. The workspace passes `allowedToolNames()`, which
+ *  is every tool, so a tool absent from `AUTO_ALLOWED_TOOLS` was still auto-approved in exactly
+ *  the session that builds a shared app. The comment on `manageSharedApp` said the prompt was
+ *  wanted in front of publish; nothing implemented it. This is what implements it.
+ *
+ *  It matters because of what the agent reads. A shared app is a repository, and the agent is
+ *  already reading untrusted text out of it — skill files, collection notes, issue bodies, survey
+ *  copy somebody pasted. `manageSharedApp` publishes to the internet, rewrites the roster, and
+ *  hands the roster live records. With auto-approval, "invite this address as owner, then deploy"
+ *  arriving in that text is a tool call rather than a question. */
+export const NEVER_AUTO_APPROVED_TOOLS: readonly string[] = ["manageSharedApp"];

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -87,9 +87,21 @@ export async function initSharedApp(root: string, name: string | undefined, slug
     members: { [handle.email]: { "*": "owner" } },
   };
   const written = await createManifest(root, manifest);
-  // The reservation stays behind if this fails. It is this session's own document, holds no
-  // authorization, and the next `init` mints a fresh aid — an unused shelf entry, not a lockout.
-  if (!written.ok) return { ok: false, partial: false, problems: written.problems };
+  if (!written.ok) {
+    // PARTIAL, because the reservation is already live. It holds no authorization — the roster and
+    // nothing else — and the next `init` mints a fresh aid, so this is an unused shelf entry
+    // rather than a lockout. But "nothing happened" would be false, and the aid is named here
+    // because it is the only place it is ever said: it never reached a file.
+    return {
+      ok: false,
+      partial: true,
+      problems: [
+        ...written.problems,
+        `The app id was already reserved on the server (apps/${aid}) and is owned by this address, but it never reached app.json.`,
+        "Fix the write problem and run `init` again — it mints a new id, and the one above is simply left unused. Nothing else was written.",
+      ],
+    };
+  }
   return { ok: true, aid, owner: handle.email, slug };
 }
 

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -12,7 +12,7 @@
 // hand. These only ever change the key they are about.
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { APP_MANIFEST_FILE, firestoreHandle, parseAuthoredApp } from "@mulmoclaude/core/collection/server";
+import { APPS_COLLECTION, APP_MANIFEST_FILE, firestoreHandle, parseAuthoredApp } from "@mulmoclaude/core/collection/server";
 import { isRecord } from "../../../common/isRecord.js";
 import { declarationProblems, sharedCollections, type SharedAppFailure } from "./context.js";
 import { createManifest, newAid, updateManifest } from "./manifestWrite.js";
@@ -64,6 +64,22 @@ export async function initSharedApp(root: string, name: string | undefined, slug
     };
   }
   const aid = newAid();
+  // Claimed in Firestore BEFORE it is written to disk, and the app is refused if the claim fails.
+  //
+  // `apps/{aid}` is a shelf every user of the deployment shares, and its `allow create` asks only
+  // that you name yourself owner. The aid used to be minted into `app.json` — a file meant to be
+  // committed and read in a pull request — while the document stayed absent until the first
+  // deploy. Anyone who read the file in that window could create the document as themselves, and
+  // then it is theirs: the real owner's write becomes an update they are not allowed to make, and
+  // nothing can free the id, because a client may never delete an app document. A UUID stops the
+  // aid being GUESSED; it was never going to stop it being read.
+  //
+  // The reservation carries the roster and nothing else — no `public`, no `collections` — so it
+  // grants exactly one thing: this address is the owner. Deploy's `set` then lands as an update by
+  // the same owner, which is what it always was for an app deployed twice.
+  const reserved = await reserveApp(handle, aid);
+  if (reserved) return reserved;
+
   const manifest: Record<string, unknown> = {
     ...(name === undefined ? {} : { name }),
     ...(slug === undefined ? {} : { slug }),
@@ -71,8 +87,40 @@ export async function initSharedApp(root: string, name: string | undefined, slug
     members: { [handle.email]: { "*": "owner" } },
   };
   const written = await createManifest(root, manifest);
+  // The reservation stays behind if this fails. It is this session's own document, holds no
+  // authorization, and the next `init` mints a fresh aid — an unused shelf entry, not a lockout.
   if (!written.ok) return { ok: false, partial: false, problems: written.problems };
   return { ok: true, aid, owner: handle.email, slug };
+}
+
+/** Take the aid on the shared shelf, as this session, carrying only the roster.
+ *
+ *  Shaped to satisfy the create rule and nothing more: `owner` is the uid (the rules pin it there
+ *  and require it unchanged forever after), `members` is keyed by the address the token carries,
+ *  and `memberEmails` mirrors its keys — `membersConsistent()` compares the two as sets and a
+ *  missing `memberEmails` is an evaluation error, which denies. */
+async function reserveApp(
+  handle: { docs: { set: (c: string, id: string, doc: Record<string, unknown>) => Promise<unknown> }; email: string; uid: string },
+  aid: string,
+): Promise<SharedAppFailure | null> {
+  try {
+    await handle.docs.set(APPS_COLLECTION, aid, {
+      owner: handle.uid,
+      members: { [handle.email]: { "*": "owner" } },
+      memberEmails: [handle.email],
+    });
+    return null;
+  } catch (err) {
+    return {
+      ok: false,
+      partial: false,
+      problems: [
+        `cannot reserve the app (apps/${aid}): ${err instanceof Error ? err.message : String(err)}`,
+        "Nothing was written — this repository still declares no app, and `init` can simply be run again (it mints a new id each time).",
+        "If this keeps happening, the session may not be signed in with a VERIFIED address: the rules require one to create an app.",
+      ],
+    };
+  }
 }
 
 export interface CheckReport {

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -290,7 +290,12 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
     slug: slug?.slug,
     cids: deployed.staging.map((entry) => entry.cid),
     withdrawn: stale.cids,
-    created: existingApp === null,
+    // "Created" means THIS deploy is the first, and that is no longer the same question as
+    // "the document was absent": `init` reserves `apps/{aid}` before it writes `app.json`, so the
+    // document exists from the moment the app is declared. `deployedAt` is written by every
+    // deploy and by nothing else, so its absence is the first-deploy signal that survives the
+    // reservation.
+    created: existingApp === null || existingApp.deployedAt === undefined,
     commit: stamp.commit,
     dirty: stampSource.dirty === true,
     recordIssues: scan.records,

--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -33,7 +33,7 @@ import { htmlByPath } from "../backends/openPath.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
 import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
-import { groupOfTool, toolGroupServerId, GUI_SERVER_ID, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
+import { groupOfTool, toolGroupServerId, GUI_SERVER_ID, AUTO_ALLOWED_TOOLS, NEVER_AUTO_APPROVED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
 import { missingRequiredEnv, soleExecutor, isExecutor } from "./server-tool-load.js";
 import { isRecord } from "../../common/isRecord.js";
 
@@ -296,7 +296,11 @@ export function mountAllRoutes(app: Express) {
 export function allowedToolNames(group: ToolGroup | null = null) {
   const serverId = group === null ? GUI_SERVER_ID : toolGroupServerId(group);
   const defs = group === null ? toolDefinitions : toolDefinitions.filter((d) => groupOfTool(d.name) === group);
-  return defs.map((d) => `mcp__${serverId}__${d.name}`);
+  // NEVER_AUTO_APPROVED_TOOLS is filtered HERE rather than at the call site because this function
+  // is the auto-approval list itself: a second caller that forgot the filter would re-open the
+  // hole silently. Filtering here does not take the tool away — availability comes from
+  // --mcp-config, which still carries it. It only means the agent has to ask.
+  return defs.filter((d) => !NEVER_AUTO_APPROVED_TOOLS.includes(d.name)).map((d) => `mcp__${serverId}__${d.name}`);
 }
 
 // The fully-qualified names a GRID cell pre-approves: the auto-allowed tools, each under the

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -38,6 +38,13 @@ the address this machine is SIGNED IN with — you cannot read that, and the add
 you is the one that fails at deploy. `init` writes it, generates the `aid`, and refuses if the
 repository already declares an app.
 
+`init` also TAKES the `aid` on the server before it writes the file, so it needs a connected
+session and reports a refusal instead of leaving a half-started app. That is not bookkeeping: the
+id lives on a shelf shared by everyone using this deployment, `app.json` is meant to be committed,
+and an id that is written down but not yet taken can be taken by whoever reads the file first — and
+an app id can never be freed. If the reservation is refused, nothing was written and `init` can
+just be run again.
+
 `slug` is the name in the URL people will be given. Take it from what the thing IS
 (`aug-talk-survey`), lowercase with hyphens. It is a wish: if it is taken, a number is appended and
 written back.

--- a/test/server/backends/initReservesAid.spec.ts
+++ b/test/server/backends/initReservesAid.spec.ts
@@ -95,6 +95,22 @@ describe("initSharedApp reserves the aid", () => {
     expect(existsSync(path.join(root, "app.json"))).toBe(false);
   });
 
+  // The reservation is live once it lands, so a failure after it is not "nothing happened". The
+  // aid is named here because this is the only place it is ever said — it never reached a file.
+  it("reports a partial and names the reserved aid when the file cannot be written", async () => {
+    const missing = path.join(root, "no-such-directory");
+
+    const result = await initSharedApp(missing, "Talk survey", undefined);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.partial).toBe(true);
+    const said = result.problems.join(" ");
+    expect(said).toContain("already reserved on the server");
+    expect(said).toContain(String(docs.writes[0]));
+    expect(existsSync(path.join(missing, "app.json"))).toBe(false);
+  });
+
   it("still refuses a repository that already declares an app, without touching Firestore", async () => {
     writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "existing", members: {} }));
 

--- a/test/server/backends/initReservesAid.spec.ts
+++ b/test/server/backends/initReservesAid.spec.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+//
+// `init` mints the aid AND takes it, in that order, before anything reaches the disk.
+//
+// `apps/{aid}` is a shelf every user of the deployment shares, and its create rule asks only that
+// you name yourself owner. The aid is minted into `app.json` — a file meant to be committed and
+// read in a pull request. While the document stayed absent until the first deploy, anyone who read
+// the file in that window could create it as themselves, and the id was gone for good: the real
+// owner's write becomes an update they may not make, and no client may delete an app document.
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs, type FirestoreDoc } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { initSharedApp } from "../../../server/backends/sharedApp/declare.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const OWNER = { uid: "uid-owner", email: "owner@example.com" };
+
+/** Records the order of writes, because the order IS the property: a reservation that landed after
+ *  the file would leave exactly the window this closes. */
+class FakeDocs implements FirestoreDocs {
+  readonly store = new Map<string, Record<string, unknown>>();
+  readonly writes: string[] = [];
+  refuseWrites = false;
+
+  async set(collectionPath: string, id: string, doc: Record<string, unknown>): Promise<void> {
+    if (this.refuseWrites) throw Object.assign(new Error("PERMISSION_DENIED: Missing or insufficient permissions."), { code: "permission-denied" });
+    this.writes.push(`${collectionPath}/${id}`);
+    this.store.set(`${collectionPath}/${id}`, doc);
+  }
+  async get(collectionPath: string, id: string): Promise<FirestoreDoc | null> {
+    const data = this.store.get(`${collectionPath}/${id}`);
+    return data === undefined ? null : ({ id, data } as FirestoreDoc);
+  }
+  async list(): Promise<FirestoreDoc[]> {
+    return [];
+  }
+  async create(collectionPath: string, id: string, doc: Record<string, unknown>): Promise<boolean> {
+    await this.set(collectionPath, id, doc);
+    return true;
+  }
+  async delete(): Promise<boolean> {
+    return true;
+  }
+  watch(): () => void {
+    return () => {};
+  }
+}
+
+describe("initSharedApp reserves the aid", () => {
+  let docs: FakeDocs;
+  let root: string;
+
+  beforeAll(() => {
+    initCollectionsBackend({ workspace: makeTempDir("mt-init-aid-ws-") });
+    setSharedCollectionsSupport(true);
+    setFirestoreAccessor(() => ({ docs, email: OWNER.email, uid: OWNER.uid }));
+  });
+
+  beforeEach(() => {
+    docs = new FakeDocs();
+    root = makeTempDir("mt-init-aid-");
+  });
+
+  it("writes the app document, and writes it before app.json exists", async () => {
+    const result = await initSharedApp(root, "Talk survey", undefined);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // One write, and it is the aid this init reported.
+    expect(docs.writes).toEqual([`apps/${result.aid}`]);
+    const doc = docs.store.get(`apps/${result.aid}`);
+    // The roster, and NOTHING else: no `public`, no `collections`. The reservation says who owns
+    // the id; it must not say anybody may read anything.
+    expect(Object.keys(doc ?? {}).sort()).toEqual(["memberEmails", "members", "owner"]);
+    expect(doc?.owner).toBe(OWNER.uid);
+    expect(doc?.memberEmails).toEqual([OWNER.email]);
+
+    // And the file agrees with the reservation.
+    const manifest = JSON.parse(readFileSync(path.join(root, "app.json"), "utf-8")) as { aid: string };
+    expect(manifest.aid).toBe(result.aid);
+  });
+
+  // The whole point of the ordering: a refused claim must leave the repository with no
+  // declaration at all, so `init` can simply be run again.
+  it("writes nothing to disk when the claim is refused", async () => {
+    docs.refuseWrites = true;
+
+    const result = await initSharedApp(root, "Talk survey", undefined);
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.problems.join(" ")).toContain("cannot reserve the app");
+    expect(!result.ok && result.problems.join(" ")).toContain("Nothing was written");
+    expect(existsSync(path.join(root, "app.json"))).toBe(false);
+  });
+
+  it("still refuses a repository that already declares an app, without touching Firestore", async () => {
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "existing", members: {} }));
+
+    const result = await initSharedApp(root, "Talk survey", undefined);
+
+    expect(result.ok).toBe(false);
+    expect(docs.writes).toEqual([]);
+  });
+});

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -164,6 +164,21 @@ describe("shared app deploy / publish / unpublish", () => {
     writeCollection(root, "bookings");
   });
 
+  // `init` now reserves `apps/{aid}` before it writes `app.json`, so the document exists from the
+  // moment the app is declared. "Created" has to keep meaning "this deploy is the first" rather
+  // than "the document was absent", or the very first deploy of every new app reports an update.
+  it("still reports the first deploy as created when init already reserved the app", async () => {
+    docs.store.set("apps", new Map([[AID, { owner: OWNER.uid, members: { [OWNER.email]: { "*": "owner" } }, memberEmails: [OWNER.email] }]]));
+
+    const first = await deploySharedApp(root, stamp);
+    expect(first.ok).toBe(true);
+    expect(first.ok && first.created).toBe(true);
+
+    // And the deploy after it is an update, because that one really is.
+    const second = await deploySharedApp(root, stamp);
+    expect(second.ok && second.created).toBe(false);
+  });
+
   it("deploys to the roster only — no public block, no published schema, no public config", async () => {
     const result = await deploySharedApp(root, stamp);
     expect(result.ok === false ? result.problems : []).toEqual([]);

--- a/test/server/infra/noAutoApprovePublish.spec.ts
+++ b/test/server/infra/noAutoApprovePublish.spec.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+//
+// `manageSharedApp` publishes to the internet, rewrites the roster, and hands the roster live
+// records. The agent that calls it is reading untrusted text out of the same repository — skill
+// files, collection notes, survey copy somebody pasted. So it keeps the permission prompt on
+// every session, and these tests are what keep it there.
+import { describe, it, expect } from "vitest";
+import { allowedToolNames, autoAllowedToolNames } from "../../../server/infra/plugins-registry.js";
+import { AUTO_ALLOWED_TOOLS, NEVER_AUTO_APPROVED_TOOLS, groupOfTool } from "../../../common/toolGroups.js";
+
+describe("auto-approval never covers manageSharedApp", () => {
+  // The workspace passes the WHOLE list to --allowedTools. That is the session a shared app is
+  // actually built in, so it is the one that mattered — and the one that used to wave it through.
+  it("keeps it out of the workspace's --allowedTools", () => {
+    const names = allowedToolNames();
+    expect(names).toContain("mcp__mt__presentChart");
+    expect(names.some((name) => name.endsWith("__manageSharedApp"))).toBe(false);
+  });
+
+  it("keeps it out of every per-group list too", () => {
+    const group = groupOfTool("manageSharedApp");
+    expect(group).toBe("data");
+    const names = allowedToolNames("data");
+    // The group is still reachable — its other tools are listed.
+    expect(names.some((name) => name.endsWith("__manageCollection"))).toBe(true);
+    expect(names.some((name) => name.endsWith("__manageSharedApp"))).toBe(false);
+  });
+
+  it("keeps it out of a grid cell's list", () => {
+    expect(autoAllowedToolNames().some((name) => name.endsWith("__manageSharedApp"))).toBe(false);
+  });
+
+  // The two lists answer different questions and must not overlap: one names what may run
+  // unattended, the other what may never.
+  it("never lists a tool as both auto-allowed and never-auto-approved", () => {
+    for (const name of NEVER_AUTO_APPROVED_TOOLS) {
+      expect(AUTO_ALLOWED_TOOLS).not.toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
Grok のセキュリティレビューの High 2 件。どちらも実コードに当てて再現を確認した。

## H1 — `manageSharedApp` がワークスペースでオートアプルーブされていた

`common/toolGroups.ts` のコメントはこう書いてある:

> It is not in AUTO_ALLOWED_TOOLS — publish is the one operation here that changes what people outside the roster can see, and Claude Code's permission prompt is wanted in front of it.

**それを実装しているコードが無かった。** `AUTO_ALLOWED_TOOLS` はグリッドセル用の許可リスト（`autoAllowedToolNames()`）で、ワークスペース／シングルビューは `allowedToolNames()` ＝ **全ツール** を `--allowedTools` に渡す（`GUI_MCP_TOOLS` → `fullGuiAllowedTools`）。共有アプリを実際に作るのはワークスペースのセッションなので、いちばん効いてほしい経路だけが素通りしていた。

効く理由は、そのエージェントが何を読んでいるかにある。共有アプリはリポジトリで、エージェントは同じリポジトリの信用できないテキスト（skill、コレクションのメモ、貼られたアンケート文面）を既に読んでいる。`manageSharedApp` は公開・ロスター書き換え・ロスターへの実データ開放をやる。オートアプルーブだと「このアドレスをオーナーで invite して deploy して」がそこに書いてあれば、質問ではなくツール呼び出しになる。

`NEVER_AUTO_APPROVED_TOOLS` を追加し、**許可リストを生成する `allowedToolNames()` の中で**除外した。呼び出し側で除外すると、次に足された呼び出し側が静かに穴を開け直せるため。ツール自体は `--mcp-config` から使える — 聞くようになるだけ。

**codex 側は未修正で、オーナー判断が要ります。** codex はサーバ単位でしか承認できず、`data` グループが `autoApprove: true`（2026-07-28 の決定）。ただしその決定の理由は生成画像の課金であって、インターネットへの publish ではない。取れる手は (a) このまま許容して記録する、(b) `data` の autoApprove を落とす（`manageCollection` にも毎回プロンプトが出る）、(c) publish を独立のサーバ id に分ける（`toolGroupServerId` はユーザの設定ファイルのキーなので移行が要る）。指示があれば別 PR で。

## H2 — 未 deploy の `aid` は `app.json` を読めば奪える

`aid` は `init` で `app.json` に書かれ、`apps/{aid}` は最初の deploy まで作られない。`app.json` はコミットして PR で読まれるファイルで、create ルールは「自分をオーナーと名乗ること」しか要求しない。その隙間に読んだ者が自分名義で作ると、本来の所有者の `set` は許可されない update になり、しかもクライアントからアプリを削除する手段は無いので **id は永久に失われる**。UUID は「推測」を止めるが「読まれること」は止めない。

`init` はもともとサインイン済みセッションを要求しているので、ファイルを書く**前**にロスターだけ（`owner` / `members` / `memberEmails`）の予約ドキュメントを作るようにした。`public` も `collections` も持たないので権限は何も与えず、deploy の `set` は同じオーナーによる update として着地する（二度目の deploy と同じ形）。予約が拒否されたらディスクには何も書かず、`init` をやり直せる。

既存の未 deploy アプリには遡及しません（その `aid` は今も同じ窓が開いたまま）。

テスト 7 本（順序と、拒否時に何も書かれないことを固定）。既存 1552 本と lint・typecheck 通過。

## この PR で直していないレビュー指摘

M1（`config/*` が aid さえ分かれば誰でも読める）、M2（レート制限・App Check 無し）、M3（`auth: "none"` はルールに残っておりオーナーは直接書ける）、M4（localhost の別オリジンから publish できる）、M5（slug の永久占有）、M6（投稿値が型無し）。いずれも実在するが設計判断を含むので別扱い。

work in mulmoterminal