### PR TITLE
fix(test): green the Windows daily job — 5 specs, 3 causes (refs #1653)

### DIFF
--- a/plans/fix-1653-windows-daily-red.md
+++ b/plans/fix-1653-windows-daily-red.md
@@ -1,0 +1,79 @@
+# #1653 — green the Windows daily job
+
+## What was wrong
+
+`windows-daily` failed every run from 2026-08-09T15:07Z. Five specs, three causes, no product bug
+among them. The interesting part is the **accumulation**: it started as one spec and grew to five,
+because a job that is already red cannot report the next breakage.
+
+| when | failing specs |
+|---|---|
+| 08-09 15:07 | `backends/system-tasks` |
+| 08-09 17:48 | + `backends/collectionWatchers` |
+| 08-10 00:13 | + `config/cwd-preset-routes` |
+| later | + `backends/ensureAid`, + `session/pty-spawn-win` |
+
+## Cause 1 — POSIX literals as expectations (3 specs)
+
+The class `docs/windows-gotchas.md` already documents under "Tests that handle paths". The code
+canonicalises with the platform's own `path`, which drive-qualifies on Windows, so `"/srv/mag2"`
+as an expectation matches on a developer's machine and nowhere else:
+
+```
+expected [ 'D:\srv\mag2', 'D:\srv\site', 'D:\srv\ws' ] to deeply equal [ '/srv/mag2', … ]
+```
+
+Fixed by putting **both** the inputs and the expectations through `path.resolve`, per the doc's
+own shape. The "two spellings of one directory" cases keep their intent — they are now a trailing
+`path.sep` and a `.` segment appended to the resolved path, rather than POSIX text.
+
+## Cause 2 — `ensureAid` asserts a POSIX permission bit
+
+`chmodSync(appJson(), 0o600)` then `expect(mode & 0o777).toBe(0o600)`. NTFS has no POSIX bits, so
+chmod moves the read-only attribute and nothing else; the mode reads back `0o666`.
+
+The point worth recording: **the setup cannot establish the precondition there**, so this was not
+a test that failed on Windows — it was a test that could not run on Windows while looking as
+though it did. Skipped with `it.skipIf(process.platform === "win32")`, the way
+`session-settings.spec.ts` already skips its owner-only check.
+
+## Cause 3 — `pty-spawn-win` reads `pid` synchronously
+
+Not a broken spawn, and worth being explicit because the failure reads like one. node-pty fills
+`pid` in asynchronously on Windows, from the conout worker's ready callback. Its own source says
+so (`node_modules/node-pty/lib/windowsTerminal.js`):
+
+```js
+// Not available until `ready` event emitted.
+this._pid = this._agent.innerPid;
+...
+this._socket.on('ready_datapipe', function () {
+  // Update pid now that the agent has connected
+  this._pid = this._agent.innerPid;
+```
+
+So `term.pid` is 0 the moment `spawnPty` returns, however well the spawn went. It read `>0` until
+node-pty `1.2.0-beta.15` (which arrived with #1595's fd-leak fix) and `0` after.
+
+Two things say the spawn itself is fine: all **18** `.cmd` spawns in the same file pass, and this
+test's own remaining assertions — the child's exit code and the `mt-probe ok` it writes — prove a
+real process far better than a number does. The `pid` assertion is dropped rather than made
+asynchronous; it was the weakest of the three.
+
+## How this was verified
+
+Local `yarn test` **cannot** see any of this — the whole class only appears where the separator
+and the drive letter differ. So the branch was pushed and `windows-daily` dispatched against it:
+
+```sh
+gh workflow run windows-daily.yaml --ref fix/windows-daily-red
+```
+
+That run is the evidence, not the local suite. Local checks (9852 tests, typecheck) only confirm
+nothing was broken for the other platforms.
+
+## Not fixed here
+
+A red job hiding the next breakage is the reason one spec became five. Whether `windows-daily`
+should announce its red→green transitions somewhere a human reads is a separate question, left in
+the issue rather than answered here.

--- a/plans/fix-1653-windows-daily-red.md
+++ b/plans/fix-1653-windows-daily-red.md
@@ -15,9 +15,9 @@ because a job that is already red cannot report the next breakage.
 
 ## Cause 1 — POSIX literals as expectations (3 specs)
 
-The class `docs/windows-gotchas.md` already documents under "Tests that handle paths". The code
-canonicalises with the platform's own `path`, which drive-qualifies on Windows, so `"/srv/mag2"`
-as an expectation matches on a developer's machine and nowhere else:
+This is the failure class `docs/windows-gotchas.md` already describes under "Tests that handle
+paths". The code canonicalises with the platform's own `path`, which drive-qualifies on Windows,
+so `"/srv/mag2"` as an expectation matches on a developer's machine and nowhere else:
 
 ```
 expected [ 'D:\srv\mag2', 'D:\srv\site', 'D:\srv\ws' ] to deeply equal [ '/srv/mag2', … ]

--- a/test/server/backends/collectionWatchers.spec.ts
+++ b/test/server/backends/collectionWatchers.spec.ts
@@ -17,9 +17,17 @@ import {
   syncCollectionWatcherRoots,
   watchedCollectionRootsForTesting,
 } from "../../../server/backends/collectionWatchers.js";
+import path from "node:path";
 import { initProjectRoots, resetProjectRootsForTesting } from "../../../server/infra/project-root.js";
 
-const WORKSPACE = "/srv/ws";
+// Through `path.resolve`, never as POSIX literals: the code under test canonicalises roots
+// with the platform's own path, which drive-qualifies on Windows (`D:\srv\ws`), so a literal
+// expectation matches only off Windows. See docs/windows-gotchas.md, "Tests that handle paths".
+const at = (posixPath: string) => path.resolve(posixPath);
+const WORKSPACE = at("/srv/ws");
+const MAG2 = at("/srv/mag2");
+const SITE = at("/srv/site");
+const GONE = at("/srv/gone");
 let projects: Array<{ label: string; path: string }> = [];
 
 const startedRoots = (): string[] => vi.mocked(startCollectionWatchers).mock.calls.map((call) => String(call[0]?.discoveryOpts?.workspaceRoot ?? ""));
@@ -40,12 +48,12 @@ afterEach(async () => {
 describe("startCollectionCompletionWatchers", () => {
   it("mounts one generation per known project, workspace included, each with its root", async () => {
     projects = [
-      { label: "mag2", path: "/srv/mag2" },
-      { label: "site", path: "/srv/site" },
+      { label: "mag2", path: MAG2 },
+      { label: "site", path: SITE },
     ];
     await startCollectionCompletionWatchers();
     expect(configureCollectionWatchers).toHaveBeenCalledTimes(1);
-    expect(startedRoots().sort()).toEqual(["/srv/mag2", "/srv/site", WORKSPACE]);
+    expect(startedRoots().sort()).toEqual([MAG2, SITE, WORKSPACE]);
   });
 
   it("passes an EXPLICIT root on every start — the engine host would otherwise throw", async () => {
@@ -61,45 +69,45 @@ describe("syncCollectionWatcherRoots", () => {
     await startCollectionCompletionWatchers();
     expect(startedRoots()).toEqual([WORKSPACE]);
 
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     await syncCollectionWatcherRoots();
-    expect(startedRoots()).toEqual([WORKSPACE, "/srv/mag2"]);
+    expect(startedRoots()).toEqual([WORKSPACE, MAG2]);
   });
 
   it("releases exactly the root that left the list, by name", async () => {
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     await startCollectionCompletionWatchers();
 
     projects = [];
     await syncCollectionWatcherRoots();
     // Scoped, not the bare form: a bare stop would take the workspace's generation down too.
-    expect(stopCollectionWatchers).toHaveBeenCalledWith({ workspaceRoot: "/srv/mag2" });
+    expect(stopCollectionWatchers).toHaveBeenCalledWith({ workspaceRoot: MAG2 });
     expect(watchedCollectionRootsForTesting()).toEqual([WORKSPACE]);
   });
 
   it("treats two spellings of one directory as one root", async () => {
-    projects = [{ label: "mag2", path: "/srv/mag2/" }];
+    projects = [{ label: "mag2", path: `${MAG2}${path.sep}` }];
     await startCollectionCompletionWatchers();
-    projects = [{ label: "mag2", path: "/srv/mag2/./" }];
+    projects = [{ label: "mag2", path: `${MAG2}${path.sep}.${path.sep}` }];
     await syncCollectionWatcherRoots();
-    expect(startedRoots()).toEqual([WORKSPACE, "/srv/mag2"]);
+    expect(startedRoots()).toEqual([WORKSPACE, MAG2]);
   });
 
   it("keeps the other roots when one fails, and retries it on the next pass", async () => {
     projects = [
-      { label: "gone", path: "/srv/gone" },
-      { label: "mag2", path: "/srv/mag2" },
+      { label: "gone", path: GONE },
+      { label: "mag2", path: MAG2 },
     ];
     vi.mocked(startCollectionWatchers).mockImplementation(async (opts) => {
-      if (opts?.discoveryOpts?.workspaceRoot === "/srv/gone") throw new Error("ENOENT");
+      if (opts?.discoveryOpts?.workspaceRoot === GONE) throw new Error("ENOENT");
     });
     await startCollectionCompletionWatchers();
     // The failure did not stop the loop: the roots after it are watched.
-    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", WORKSPACE]);
+    expect(watchedCollectionRootsForTesting().sort()).toEqual([MAG2, WORKSPACE]);
 
     vi.mocked(startCollectionWatchers).mockResolvedValue(undefined);
     await syncCollectionWatcherRoots();
-    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/gone", "/srv/mag2", WORKSPACE]);
+    expect(watchedCollectionRootsForTesting().sort()).toEqual([GONE, MAG2, WORKSPACE]);
   });
 
   it("does not re-mount a root that is already running", async () => {
@@ -123,31 +131,31 @@ describe("syncCollectionWatcherRoots", () => {
       await gate;
     });
 
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     const first = syncCollectionWatcherRoots();
     await inFlight;
 
     projects = [
-      { label: "mag2", path: "/srv/mag2" },
-      { label: "site", path: "/srv/site" },
+      { label: "mag2", path: MAG2 },
+      { label: "site", path: SITE },
     ];
     const second = syncCollectionWatcherRoots();
     release();
     await Promise.all([first, second]);
-    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", "/srv/site", WORKSPACE]);
+    expect(watchedCollectionRootsForTesting().sort()).toEqual([MAG2, SITE, WORKSPACE]);
   });
 
   // The package deletes its generation on the LAST line of its stop, so a throw can leave one
   // alive. Forgetting the root here would forget the only handle a later pass could retry with,
   // and the project would keep watching files and publishing bells forever.
   it("keeps a root tracked when its stop fails, and retries the stop next pass", async () => {
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     await startCollectionCompletionWatchers();
 
     vi.mocked(stopCollectionWatchers).mockRejectedValueOnce(new Error("EBUSY"));
     projects = [];
     await syncCollectionWatcherRoots();
-    expect(watchedCollectionRootsForTesting().sort()).toEqual(["/srv/mag2", WORKSPACE]);
+    expect(watchedCollectionRootsForTesting().sort()).toEqual([MAG2, WORKSPACE]);
 
     await syncCollectionWatcherRoots();
     expect(vi.mocked(stopCollectionWatchers)).toHaveBeenCalledTimes(2);
@@ -155,7 +163,7 @@ describe("syncCollectionWatcherRoots", () => {
   });
 
   it("does not re-mount a root whose stop failed — it is still watching", async () => {
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     await startCollectionCompletionWatchers();
     const startsAfterBoot = vi.mocked(startCollectionWatchers).mock.calls.length;
 
@@ -164,7 +172,7 @@ describe("syncCollectionWatcherRoots", () => {
     await syncCollectionWatcherRoots();
     // Back on the list before the stop ever succeeded: the generation never went away, so
     // starting it again would be mounting a second one over a live tree.
-    projects = [{ label: "mag2", path: "/srv/mag2" }];
+    projects = [{ label: "mag2", path: MAG2 }];
     await syncCollectionWatcherRoots();
     expect(vi.mocked(startCollectionWatchers).mock.calls).toHaveLength(startsAfterBoot);
     // The teardown stops everything through the same mock, so leave it able to succeed.

--- a/test/server/backends/ensureAid.spec.ts
+++ b/test/server/backends/ensureAid.spec.ts
@@ -68,7 +68,11 @@ describe("ensureAid", () => {
     expect(readdirSync(root)).toEqual(["app.json"]);
   });
 
-  it("keeps the mode the author gave app.json", async () => {
+  // Skipped on Windows, the way session-settings.spec.ts skips its owner-only check: NTFS has no
+  // POSIX permission bits, so `chmodSync(file, 0o600)` moves the read-only attribute and nothing
+  // else, and the mode reads back 0o666. The setup cannot establish the precondition there, so
+  // the assertion tests nothing — it just goes red (0o666 vs 0o600).
+  it.skipIf(process.platform === "win32")("keeps the mode the author gave app.json", async () => {
     // The replacement is a new file, so it carries this process's umask unless something says
     // otherwise. A manifest deliberately kept at 0600 coming back 0644 is a permission change
     // nobody asked for and nothing reports.

--- a/test/server/backends/system-tasks.spec.ts
+++ b/test/server/backends/system-tasks.spec.ts
@@ -4,13 +4,22 @@
 // Pinned by id, not by count: the calendar sync was absent for months with nothing to notice
 // (#1191), because index.ts built the list inline and no spec could read it.
 import { describe, it, expect } from "vitest";
+import path from "node:path";
 
 import { buildSystemTasks } from "../../../server/backends/system-tasks.js";
 
+// Through `path.resolve`, never as POSIX literals: the id carries the CANONICAL root, and
+// canonicalising with the platform's own path drive-qualifies on Windows (`D:\ws`). A literal
+// `/ws` expectation therefore passes everywhere except the daily Windows job — which is where
+// this spec first went red. See docs/windows-gotchas.md, "Tests that handle paths".
+const WS = path.resolve("/ws");
+const MAG2 = path.resolve("/srv/mag2");
+const feedId = (root: string) => `system:feed-refresh:${root}`;
+
 const WORKLOG_OFF = { enabled: false, intervalHours: 6 };
-const buildWithRoots = (feedRoots: string[]) => buildSystemTasks({ workspaceRoot: "/ws", feedRoots, worklog: WORKLOG_OFF, spawnChat: () => "" });
+const buildWithRoots = (feedRoots: string[]) => buildSystemTasks({ workspaceRoot: WS, feedRoots, worklog: WORKLOG_OFF, spawnChat: () => "" });
 const feedIds = (tasks: ReturnType<typeof buildSystemTasks>) => tasks.map((task) => task.id).filter((id) => id.startsWith("system:feed-refresh"));
-const build = (worklog = WORKLOG_OFF) => buildSystemTasks({ workspaceRoot: "/ws", worklog, spawnChat: () => "11111111-1111-1111-1111-111111111111" });
+const build = (worklog = WORKLOG_OFF) => buildSystemTasks({ workspaceRoot: WS, worklog, spawnChat: () => "11111111-1111-1111-1111-111111111111" });
 
 describe("buildSystemTasks", () => {
   // The feed-refresh id carries its ROOT since core 3.1.0 — the task def is per root, so two
@@ -19,7 +28,7 @@ describe("buildSystemTasks", () => {
   // ever written under the OLD id, so there is no stale row to clean up.
   it("registers both shared engines, the feed refresh keyed by its root", () => {
     const ids = build().map((task) => task.id);
-    expect(ids).toContain("system:feed-refresh:/ws");
+    expect(ids).toContain(feedId(WS));
     expect(ids).toContain("system:google-calendar-sync");
   });
 
@@ -37,28 +46,28 @@ describe("buildSystemTasks", () => {
   // addresses records ROOT-RELATIVELY, and until the runner was handed the root, a project's
   // refresh wrote into the WORKSPACE's same-named collection (shipped and reverted, #1582).
   it("registers one feed refresh per root, so a project's feeds refresh too", () => {
-    expect(feedIds(buildWithRoots(["/ws", "/srv/mag2"]))).toEqual(["system:feed-refresh:/ws", "system:feed-refresh:/srv/mag2"]);
+    expect(feedIds(buildWithRoots([WS, MAG2]))).toEqual([feedId(WS), feedId(MAG2)]);
   });
 
   it("keeps the workspace even when it is not among the roots passed in", () => {
-    expect(feedIds(buildWithRoots(["/srv/mag2"]))).toEqual(["system:feed-refresh:/ws", "system:feed-refresh:/srv/mag2"]);
+    expect(feedIds(buildWithRoots([MAG2]))).toEqual([feedId(WS), feedId(MAG2)]);
   });
 
   // A task id is the scheduler's primary key, and core builds it from the CANONICAL root — so two
   // spellings make one id, and the second registration replaces the first rather than adding to
   // it. The dedup has to happen on the resolved path, before that.
   it("registers a directory once however it is spelled", () => {
-    expect(feedIds(buildWithRoots(["/ws/", "/srv/mag2", "/srv/mag2/./"]))).toEqual(["system:feed-refresh:/ws", "system:feed-refresh:/srv/mag2"]);
+    expect(feedIds(buildWithRoots([`${WS}${path.sep}`, MAG2, `${MAG2}${path.sep}.${path.sep}`]))).toEqual([feedId(WS), feedId(MAG2)]);
   });
 
   it("refreshes only the workspace when no roots are given — the pre-projects behaviour", () => {
-    expect(feedIds(build())).toEqual(["system:feed-refresh:/ws"]);
+    expect(feedIds(build())).toEqual([feedId(WS)]);
   });
 
   // Workspace-only, deliberately: a Google grant is user-scope and its sync marker is workspace
   // state, so there is no per-project answer to "which account".
   it("does not multiply the calendar sync per root", () => {
-    const ids = buildWithRoots(["/ws", "/srv/mag2"]).map((task) => task.id);
+    const ids = buildWithRoots([WS, MAG2]).map((task) => task.id);
     expect(ids.filter((id) => id.startsWith("system:google-calendar-sync"))).toEqual(["system:google-calendar-sync"]);
   });
 

--- a/test/server/config/cwd-preset-routes.spec.ts
+++ b/test/server/config/cwd-preset-routes.spec.ts
@@ -46,44 +46,56 @@ async function mountAgainstTempHome(initial: Record<string, unknown>) {
   return { app, onChanged, onDisk };
 }
 
+// Through `path.resolve`, never as POSIX literals: the route canonicalises the path it records,
+// and that drive-qualifies on Windows (`D:\\srv\\mag2`), so a literal expectation matches only off
+// Windows. See docs/windows-gotchas.md, "Tests that handle paths".
+const at = (posixPath: string) => path.resolve(posixPath);
+const MAG2 = at("/srv/mag2");
+const SITE = at("/srv/site");
+const NEW = at("/srv/new");
+const NEVER = at("/srv/never");
+const A = at("/a");
+const B = at("/b");
+const ALPHA = at("/home/me/alpha");
+
 const TWO = [
-  { label: "mag2", path: "/srv/mag2" },
-  { label: "site", path: "/srv/site" },
+  { label: "mag2", path: MAG2 },
+  { label: "site", path: SITE },
 ];
 
 describe("POST /api/config/cwd-presets/record", () => {
   it("adds one entry and KEEPS every other, whatever the caller knows", async () => {
     const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
-    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new", label: "new" });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: NEW, label: "new" });
     expect(res.status).toBe(200);
     // The caller sent ONE path. It could not have deleted the others if it tried.
-    expect(res.body.cwdPresets.map((preset: { path: string }) => preset.path)).toEqual(["/srv/new", "/srv/mag2", "/srv/site"]);
+    expect(res.body.cwdPresets.map((preset: { path: string }) => preset.path)).toEqual([NEW, MAG2, SITE]);
     expect(onDisk().cwdPresets).toHaveLength(3);
   });
 
   it("bumps an existing directory to the front, keeping the label the user gave it", async () => {
     const { app } = await mountAgainstTempHome({
       cwdPresets: [
-        { label: "two", path: "/b" },
-        { label: "Custom", path: "/a" },
+        { label: "two", path: B },
+        { label: "Custom", path: A },
       ],
     });
-    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/a", label: "a" });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: A, label: "a" });
     expect(res.body.cwdPresets).toEqual([
-      { label: "Custom", path: "/a" },
-      { label: "two", path: "/b" },
+      { label: "Custom", path: A },
+      { label: "two", path: B },
     ]);
   });
 
   it("falls back to the basename when no label is sent", async () => {
     const { app } = await mountAgainstTempHome({});
-    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/home/me/alpha" });
-    expect(res.body.cwdPresets).toEqual([{ label: "alpha", path: "/home/me/alpha" }]);
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: ALPHA });
+    expect(res.body.cwdPresets).toEqual([{ label: "alpha", path: ALPHA }]);
   });
 
   it("keeps every OTHER setting in the file", async () => {
     const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO, pushEnabled: true, futureFeature: "on" });
-    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: NEW });
     const saved = onDisk();
     expect(saved.pushEnabled).toBe(true);
     // Including a key THIS build does not know — another version's setting must not vanish (#966).
@@ -103,19 +115,19 @@ describe("POST /api/config/cwd-presets/record", () => {
     const { app } = await mountAgainstTempHome({});
     const { APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
     writeFileSync(APP_CONFIG_FILE, "{ not json");
-    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    const res = await request(app).post("/api/config/cwd-presets/record").send({ path: NEW });
     expect(res.status).toBe(409);
   });
 
   it("tells the caller the project list moved, so the collection watchers can follow", async () => {
     const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
-    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/new" });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: NEW });
     expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
   it("stays quiet when the directory was already at the front", async () => {
     const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
-    await request(app).post("/api/config/cwd-presets/record").send({ path: "/srv/mag2" });
+    await request(app).post("/api/config/cwd-presets/record").send({ path: MAG2 });
     expect(onChanged).not.toHaveBeenCalled();
   });
 });
@@ -123,14 +135,14 @@ describe("POST /api/config/cwd-presets/record", () => {
 describe("POST /api/config/cwd-presets/remove", () => {
   it("drops one entry and keeps the rest", async () => {
     const { app, onDisk } = await mountAgainstTempHome({ cwdPresets: TWO });
-    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/mag2" });
-    expect(res.body.cwdPresets).toEqual([{ label: "site", path: "/srv/site" }]);
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: MAG2 });
+    expect(res.body.cwdPresets).toEqual([{ label: "site", path: SITE }]);
     expect(onDisk().cwdPresets).toHaveLength(1);
   });
 
   it("is a no-op for a path that is not saved, and says nothing changed", async () => {
     const { app, onChanged } = await mountAgainstTempHome({ cwdPresets: TWO });
-    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: "/srv/never" });
+    const res = await request(app).post("/api/config/cwd-presets/remove").send({ path: NEVER });
     expect(res.body.cwdPresets).toHaveLength(2);
     expect(onChanged).not.toHaveBeenCalled();
   });

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -70,12 +70,6 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     expect(resolvePtyLaunchForEnv(PROBE, [], process.env)).toEqual({ file: probeExe, args: [] });
   });
 
-  // No `pid` assertion: on Windows node-pty fills it in asynchronously, from the conout
-  // worker's ready callback ("Not available until `ready` event emitted" — its own comment in
-  // windowsTerminal.js), so reading it the moment spawnPty returns is 0 however well the spawn
-  // went. It read >0 until node-pty 1.2.0-beta.15 and 0 after, which failed this test while
-  // every .cmd spawn beside it still passed. The output and exit code below prove a real
-  // process far better than a number does.
   it("spawns a PTY for a bare name whose only match is an .exe", async () => {
     const term = spawnPty(PROBE, ["-e", "process.stdout.write('mt-probe ok')"], dir);
     let output = "";
@@ -84,6 +78,16 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     });
     expect(await exitCodeOf(term)).toBe(0);
     expect(output).toContain("mt-probe ok");
+    // `pid` is asserted HERE, not the moment spawnPty returned. node-pty fills it in from the
+    // conout worker's ready callback on Windows ("Not available until `ready` event emitted" —
+    // its own comment in windowsTerminal.js), so at spawn it reads 0 however well the spawn went;
+    // that is what broke this test at node-pty 1.2.0-beta.15 while all 18 .cmd spawns passed.
+    //
+    // Still asserted, rather than dropped, because a permanently-zero pid IS a regression worth
+    // catching: liveMuseSessions() hands these pids to the bridge's process-tree walk
+    // (server/session/bridge-session.ts), which is how a muse session is identified at all.
+    // Safe after the exit above — node-pty only ever assigns `_pid`, never clears it.
+    expect(term.pid).toBeGreaterThan(0);
   });
 
   // The reason resolve-bin.ts exists. When this starts failing, node-pty has learned to

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -70,9 +70,14 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     expect(resolvePtyLaunchForEnv(PROBE, [], process.env)).toEqual({ file: probeExe, args: [] });
   });
 
+  // No `pid` assertion: on Windows node-pty fills it in asynchronously, from the conout
+  // worker's ready callback ("Not available until `ready` event emitted" — its own comment in
+  // windowsTerminal.js), so reading it the moment spawnPty returns is 0 however well the spawn
+  // went. It read >0 until node-pty 1.2.0-beta.15 and 0 after, which failed this test while
+  // every .cmd spawn beside it still passed. The output and exit code below prove a real
+  // process far better than a number does.
   it("spawns a PTY for a bare name whose only match is an .exe", async () => {
     const term = spawnPty(PROBE, ["-e", "process.stdout.write('mt-probe ok')"], dir);
-    expect(term.pid).toBeGreaterThan(0);
     let output = "";
     term.onData((data) => {
       output += data;


### PR DESCRIPTION
## Summary

`refs #1653`. `windows-daily` has failed every run since **2026-08-09**. Five specs, three causes,
**no product bug among them**. The shape that matters is the accumulation: it started as one spec
and grew to five, because a job that is already red cannot report the next breakage.

## Items to Confirm / Review

1. **The `pid` assertion is dropped, not made asynchronous.** That is the one judgement call here
   — I read node-pty's source rather than inferring from the failure, but a second opinion is
   worth having. Reasoning below.
2. **`ensureAid`'s mode check is skipped on Windows, not adapted.** The setup cannot establish the
   precondition on NTFS, so there is nothing to assert there — but "skip" always deserves a look.
3. **Local `yarn test` cannot verify any of this.** The evidence is a `windows-daily` dispatch
   against this branch; result reported in a comment below.
4. `refs`, not `Closes` — the question of a red job announcing itself is left open in the issue.

## User Prompt

> fix fix https://github.com/receptron/mulmoterminal/actions/runs/31622121002

## What was failing

| when | failing specs |
|---|---|
| 08-09 15:07 | `backends/system-tasks` |
| 08-09 17:48 | + `backends/collectionWatchers` |
| 08-10 00:13 | + `config/cwd-preset-routes` |
| later | + `backends/ensureAid`, + `session/pty-spawn-win` |

## Cause 1 — POSIX literals as expectations (3 specs)

The class `docs/windows-gotchas.md` already documents. The code canonicalises with the platform's
own `path`, which drive-qualifies on Windows:

```
expected [ 'D:\srv\mag2', 'D:\srv\site', 'D:\srv\ws' ] to deeply equal [ '/srv/mag2', … ]
```

Both inputs and expectations now go through `path.resolve`. The "two spellings of one directory"
cases keep their intent — a trailing `path.sep` and a `.` segment on the resolved path.

## Cause 2 — `ensureAid` asserts a POSIX permission bit

`chmodSync(appJson(), 0o600)` then `expect(mode & 0o777).toBe(0o600)`. NTFS has no POSIX bits, so
chmod moves the read-only attribute and nothing else; the mode reads back `0o666`.

Worth stating precisely: **the setup cannot establish the precondition**, so this was not a test
failing on Windows — it was a test that could not run there while looking as though it did.
Skipped with `it.skipIf`, the way `session-settings.spec.ts` already skips its owner-only check.

## Cause 3 — `pty-spawn-win` reads `pid` synchronously

**Not a broken spawn**, though the failure reads like one. From node-pty's own source
(`lib/windowsTerminal.js`):

```js
// Not available until `ready` event emitted.
this._pid = this._agent.innerPid;
...
this._socket.on('ready_datapipe', function () {
  // Update pid now that the agent has connected
  this._pid = this._agent.innerPid;
```

`pid` is filled in asynchronously from the conout worker's ready callback, so it is 0 the moment
`spawnPty` returns however well the spawn went. It read `>0` until node-pty `1.2.0-beta.15` (which
arrived with #1595's fd-leak fix) and `0` after.

Two things say the spawn is fine: all **18** `.cmd` spawns in the same file pass, and this test's
remaining assertions — the child's exit code and the `mt-probe ok` it writes — prove a real
process better than a number. So the `pid` line is dropped rather than awaited.

## Verification

Local `yarn test` **cannot** see this class at all; it only appears where the separator and drive
letter differ. So:

- `windows-daily` dispatched against this branch — the actual evidence, reported below.
- Local, to confirm nothing broke elsewhere: `yarn format`, `yarn lint`, `yarn typecheck`,
  `yarn test` (685 files, **9852 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows compatibility for filesystem path handling and collection watcher behavior.
  - Updated Windows PTY validation to account for asynchronous process identifiers.
  - Adjusted permission-related checks for Windows behavior.

- **Tests**
  - Expanded coverage for path normalization, deduplication, workspace retention, feed registration, and recovery scenarios.
  - Preserved route, synchronization, and task-processing coverage across platforms.

- **Documentation**
  - Added guidance for diagnosing and verifying Windows daily job failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->