### PR TITLE
feat(shared-app): 公開ビューを publish し、排他のキーを凍らせる

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@mulmoclaude/accounting-plugin": "^2.2.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
-    "@mulmoclaude/core": "3.12.0",
+    "@mulmoclaude/core": "3.13.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -121,6 +121,14 @@ const holdsRecords = async (handle: SharedAppHandle, aid: string, cid: string): 
  *  empty one. */
 const child = (value: unknown, key: string): unknown => (isRecord(value) ? value[key] : undefined);
 
+/** Every collection the LIVE app document configures. Its own reader because
+ *  the gate has to look at collections the new declaration no longer mentions:
+ *  those are exactly the ones whose halves are being dropped. */
+const liveCollectionCids = (live: Record<string, unknown> | null): string[] => {
+  const collections = child(live, "collections");
+  return isRecord(collections) ? Object.keys(collections) : [];
+};
+
 /** The live declaration, as the app document has it now. */
 const liveSubmit = (live: Record<string, unknown> | null, cid: string): Record<string, unknown> | undefined => {
   const entry = child(child(child(live, "public"), "submit"), cid);
@@ -157,9 +165,15 @@ export async function frozenKeyProblems(
   // From what DEPLOY staged, because that is what publish promotes. Reading
   // `app.json` here would let an author deploy a changed mirror, revert the
   // key locally, and publish a promotion this gate never saw.
-  for (const [cid, config] of Object.entries(promoted)) {
+  //
+  // The UNION with what is live, not just what is promoted: deploy withdraws
+  // the staging document of a collection the repository no longer has, so a
+  // mirror REMOVED that way is absent from `promoted` entirely — and a loop
+  // over `promoted` alone would never compare it against the live half it is
+  // about to drop.
+  for (const cid of new Set([...Object.keys(promoted), ...liveCollectionCids(live)])) {
     const was = liveMirrorOf(live, cid);
-    const now = text(config.mirrorOf);
+    const now = text(promoted[cid]?.mirrorOf);
     if (was === now) continue;
     problems.push(
       ...(await movedUnderRecords(handle, authored.aid, cid, [{ key: "mirrorOf", was, now }], "the projection those records are the public face of")),

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -66,7 +66,24 @@ const declaredPins = (submit: AuthoredSubmit): Record<string, string> => ({
 const text = (value: unknown): string => {
   if (value === undefined || value === null) return "";
   if (typeof value === "string") return value;
-  return JSON.stringify(value);
+  return JSON.stringify(canonical(value));
+};
+
+/** The same value with every map's keys in a fixed order.
+ *
+ *  `idIn` is compared as text, and `JSON.stringify` preserves INSERTION order —
+ *  so re-ordering the keys in `app.json`, which changes nothing about what the
+ *  rules do, would otherwise read as a moved identity key and refuse a
+ *  re-publish. The gate is meant to catch a changed CONSTRAINT, not a changed
+ *  spelling of the same one. */
+const canonical = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonical(value[key])]),
+  );
 };
 
 /** What differs between the live declaration and the one about to be written. */

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -1,0 +1,142 @@
+// The keys that decide WHICH DOCUMENT a submission claims, frozen once anything
+// has claimed one.
+//
+// `idFrom: "field"` puts the contested thing's id into the record's id, so two
+// people wanting one slot write one document and Firestore refuses the second.
+// Everything about that rests on one equality — and on both halves of the
+// mirror agreeing about where the public projection lives.
+//
+// Change any of it after records exist and the rules go on enforcing the new
+// version perfectly, against an id space the old rows are not in:
+//
+//   `idField` from `slot` to `slotId`, or `idIn` to another collection, and
+//   every existing booking stops holding the slot it was written for. The
+//   slot is bookable again, by somebody else, while the original booking sits
+//   there looking valid.
+//
+//   `mirror` or `mirrorOf` moved, and a staff delete consults the NEW
+//   destination: the old slot's `state` is never returned to `open`, so it is
+//   unsellable for good.
+//
+// The rules cannot see this. They judge one write at a time and cannot scan the
+// rows that came before, so the refusal has to live at the gate — beside the
+// migration scan, which asks the neighbouring question about the same records.
+//
+// `confirm` does NOT override it. The other gate's confirm means "I know these
+// records will not fit the new schema": a stated, visible breakage. Here what
+// breaks is an exclusivity guarantee, silently, in an app that goes on working.
+// The way forward is to empty the collection or to build the new arrangement
+// under a new cid.
+import { isRecord } from "../../../common/isRecord.js";
+import { appSchemasPath, type AuthoredApp, type AuthoredSubmit } from "@mulmoclaude/core/collection/server";
+import type { SharedAppHandle } from "./context.js";
+
+/** Where a shared collection's records live. Built from core's schemas path so
+ *  the two cannot drift: `apps/{aid}/collections/{cid}/items`. */
+const itemsPath = (aid: string, cid: string): string => `${appSchemasPath(aid)}/${cid}/items`;
+
+/** One frozen value, named as the author wrote it. */
+interface Pinned {
+  key: string;
+  was: string;
+  now: string;
+}
+
+/** The submission-side keys, rendered so that a change reads as a change.
+ *
+ *  `idIn` is compared as JSON because it is a small object and every part of
+ *  it — the collection, and the state a record must be in — decides which
+ *  documents may be claimed. */
+const submitPins = (submit: Record<string, unknown> | undefined): Record<string, string> => ({
+  idFrom: text(submit?.idFrom),
+  idField: text(submit?.idField),
+  idIn: text(submit?.idIn),
+  mirror: text(submit?.mirror),
+});
+
+/** The same four, from the PARSED declaration — where they are typed and no
+ *  narrowing is needed. */
+const declaredPins = (submit: AuthoredSubmit): Record<string, string> => ({
+  idFrom: text(submit.idFrom),
+  idField: text(submit.idField),
+  idIn: text(submit.idIn),
+  mirror: text(submit.mirror),
+});
+
+const text = (value: unknown): string => {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+};
+
+/** What differs between the live declaration and the one about to be written. */
+const changed = (was: Record<string, string>, now: Record<string, string>): Pinned[] =>
+  Object.keys(now)
+    .filter((key) => (was[key] ?? "") !== (now[key] ?? ""))
+    .map((key) => ({ key, was: was[key] ?? "", now: now[key] ?? "" }));
+
+const describe = (pins: Pinned[]): string =>
+  pins.map((pin) => `${pin.key}: ${pin.was === "" ? "(absent)" : pin.was} → ${pin.now === "" ? "(absent)" : pin.now}`).join(", ");
+
+/** Does this collection hold anything?
+ *
+ *  One document is enough to answer, but the handle lists rather than counts —
+ *  and a collection nobody may read yet (a fresh app) is EMPTY for this
+ *  purpose: there is nothing whose claim could be stranded. A read failure is
+ *  deliberately not a refusal here; the gate beside this one already stops a
+ *  publish whose records could not be read at all. */
+const holdsRecords = async (handle: SharedAppHandle, aid: string, cid: string): Promise<boolean> => {
+  try {
+    const docs = await handle.docs.list(itemsPath(aid, cid));
+    return docs.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/** One step into a document nobody validated. The app document is read back
+ *  from Firestore, so every level of it is `unknown` until proven otherwise —
+ *  and a missing level means "not declared", which is the same answer as an
+ *  empty one. */
+const child = (value: unknown, key: string): unknown => (isRecord(value) ? value[key] : undefined);
+
+/** The live declaration, as the app document has it now. */
+const liveSubmit = (live: Record<string, unknown> | null, cid: string): Record<string, unknown> | undefined => {
+  const entry = child(child(child(live, "public"), "submit"), cid);
+  return isRecord(entry) ? entry : undefined;
+};
+
+const liveMirrorOf = (live: Record<string, unknown> | null, cid: string): string => text(child(child(child(live, "collections"), cid), "mirrorOf"));
+
+/** Every exclusivity key that moved under live records.
+ *
+ *  Empty for the ordinary case — a first publish, a collection with nothing in
+ *  it, or a declaration whose identity keys did not move — which is why the
+ *  reads only happen for collections that changed. */
+export async function frozenKeyProblems(authored: AuthoredApp, live: Record<string, unknown> | null, handle: SharedAppHandle): Promise<string[]> {
+  const problems: string[] = [];
+  for (const [cid, submit] of Object.entries(authored.public?.submit ?? {})) {
+    const moved = changed(submitPins(liveSubmit(live, cid)), declaredPins(submit));
+    if (moved.length > 0 && (await holdsRecords(handle, authored.aid, cid))) {
+      problems.push(refusal(cid, moved, "the ids those records were written under"));
+    }
+  }
+  for (const [cid, config] of Object.entries(authored.collections ?? {})) {
+    const was = liveMirrorOf(live, cid);
+    const now = text(config.mirrorOf);
+    if (was !== now && (await holdsRecords(handle, authored.aid, cid))) {
+      problems.push(refusal(cid, [{ key: "mirrorOf", was, now }], "the projection those records are the public face of"));
+    }
+  }
+  return problems;
+}
+
+const refusal = (cid: string, moved: Pinned[], what: string): string =>
+  `'${cid}' holds records, and this changes ${what}: ${describe(moved)}. ` +
+  "Those keys decide WHICH DOCUMENT a submission claims, and the rules cannot see the rows that came before — so the old records would stop holding what they hold, " +
+  "silently, in an app that goes on working. This is not something `confirm` overrides. Empty the collection, or build the new arrangement under a new cid.";
+
+/** Only the identity keys, for the message above and for tests. */
+export const EXCLUSIVITY_KEYS = ["idFrom", "idField", "idIn", "mirror", "mirrorOf"] as const;
+
+export type { AuthoredSubmit };

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -81,7 +81,9 @@ const canonical = (value: unknown): unknown => {
   if (!isRecord(value)) return value;
   return Object.fromEntries(
     Object.keys(value)
-      .sort()
+      // A stable order is all this needs — the strings are never shown, only
+      // compared with another canonicalisation of the same shape.
+      .sort((left, right) => left.localeCompare(right))
       .map((key) => [key, canonical(value[key])]),
   );
 };

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -97,19 +97,21 @@ const changed = (was: Record<string, string>, now: Record<string, string>): Pinn
 const describe = (pins: Pinned[]): string =>
   pins.map((pin) => `${pin.key}: ${pin.was === "" ? "(absent)" : pin.was} → ${pin.now === "" ? "(absent)" : pin.now}`).join(", ");
 
-/** Does this collection hold anything?
+/** Does this collection hold anything — or could we not tell?
  *
- *  One document is enough to answer, but the handle lists rather than counts —
- *  and a collection nobody may read yet (a fresh app) is EMPTY for this
- *  purpose: there is nothing whose claim could be stranded. A read failure is
- *  deliberately not a refusal here; the gate beside this one already stops a
- *  publish whose records could not be read at all. */
-const holdsRecords = async (handle: SharedAppHandle, aid: string, cid: string): Promise<boolean> => {
+ *  Three answers rather than two, because the third one is the dangerous one.
+ *  Treating a failed listing as "empty" lets a changed identity key through on
+ *  a transient error, stranding every existing claim; and the migration scan
+ *  next door cannot cover for it, since that is a SEPARATE read which may well
+ *  have succeeded a moment earlier. */
+type Held = "some" | "none" | "unknown";
+
+const holdsRecords = async (handle: SharedAppHandle, aid: string, cid: string): Promise<Held> => {
   try {
     const docs = await handle.docs.list(itemsPath(aid, cid));
-    return docs.length > 0;
+    return docs.length > 0 ? "some" : "none";
   } catch {
-    return false;
+    return "unknown";
   }
 };
 
@@ -132,23 +134,54 @@ const liveMirrorOf = (live: Record<string, unknown> | null, cid: string): string
  *  Empty for the ordinary case — a first publish, a collection with nothing in
  *  it, or a declaration whose identity keys did not move — which is why the
  *  reads only happen for collections that changed. */
-export async function frozenKeyProblems(authored: AuthoredApp, live: Record<string, unknown> | null, handle: SharedAppHandle): Promise<string[]> {
+export async function frozenKeyProblems(
+  authored: AuthoredApp,
+  promoted: Record<string, { mirrorOf?: string | undefined }>,
+  live: Record<string, unknown> | null,
+  handle: SharedAppHandle,
+): Promise<string[]> {
   const problems: string[] = [];
+  // The submission side is published from the MANIFEST, so that is what this
+  // compares. The collection side below is not.
   for (const [cid, submit] of Object.entries(authored.public?.submit ?? {})) {
-    const moved = changed(submitPins(liveSubmit(live, cid)), declaredPins(submit));
-    if (moved.length > 0 && (await holdsRecords(handle, authored.aid, cid))) {
-      problems.push(refusal(cid, moved, "the ids those records were written under"));
-    }
+    problems.push(
+      ...(await movedUnderRecords(
+        handle,
+        authored.aid,
+        cid,
+        changed(submitPins(liveSubmit(live, cid)), declaredPins(submit)),
+        "the ids those records were written under",
+      )),
+    );
   }
-  for (const [cid, config] of Object.entries(authored.collections ?? {})) {
+  // From what DEPLOY staged, because that is what publish promotes. Reading
+  // `app.json` here would let an author deploy a changed mirror, revert the
+  // key locally, and publish a promotion this gate never saw.
+  for (const [cid, config] of Object.entries(promoted)) {
     const was = liveMirrorOf(live, cid);
     const now = text(config.mirrorOf);
-    if (was !== now && (await holdsRecords(handle, authored.aid, cid))) {
-      problems.push(refusal(cid, [{ key: "mirrorOf", was, now }], "the projection those records are the public face of"));
-    }
+    if (was === now) continue;
+    problems.push(
+      ...(await movedUnderRecords(handle, authored.aid, cid, [{ key: "mirrorOf", was, now }], "the projection those records are the public face of")),
+    );
   }
   return problems;
 }
+
+/** The refusal for one collection whose keys moved — including the one for a
+ *  collection we could not read. */
+async function movedUnderRecords(handle: SharedAppHandle, aid: string, cid: string, moved: Pinned[], what: string): Promise<string[]> {
+  if (moved.length === 0) return [];
+  const held = await holdsRecords(handle, aid, cid);
+  if (held === "none") return [];
+  if (held === "unknown") return [unreadable(cid, moved)];
+  return [refusal(cid, moved, what)];
+}
+
+const unreadable = (cid: string, moved: Pinned[]): string =>
+  `this changes what a submission to '${cid}' claims (${describe(moved)}), and its live records could not be read — so nothing knows whether anything is holding a claim under the old keys. ` +
+  "Publishing anyway would strand those claims silently if there are any. This is not something `confirm` overrides: confirming means accepting a KNOWN breakage, and here there is no reading at all. " +
+  "Fix the access (or the connection) and try again.";
 
 const refusal = (cid: string, moved: Pinned[], what: string): string =>
   `'${cid}' holds records, and this changes ${what}: ${describe(moved)}. ` +

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -84,7 +84,21 @@ export async function readPublicViewFile(root: string, view: { path: string }, p
   const problems = await missingFileProblems(full, view.path);
   if (problems.length > 0) return { ok: false, problems };
 
-  const html = await readFile(full, "utf8");
+  // Between the stat above and this read the file can go: deleted, or its
+  // permissions changed. The gate's whole contract is that it answers with
+  // problems and writes nothing, so a rejection escaping here would come out of
+  // publish as an exception instead — the one shape every caller is written not
+  // to expect.
+  const html = await readFile(full, "utf8").catch(() => null);
+  if (html === null) {
+    return {
+      ok: false,
+      problems: [
+        `public.view.path names '${view.path}', which could not be read. ` +
+          "It was there a moment ago, so it has just been removed or its permissions have changed. Nothing was written.",
+      ],
+    };
+  }
   const bytes = viewDocumentBytes({ html, publishedAt });
   return contentProblems(html, bytes, view.path) ?? { ok: true, view: { html, bytes } };
 }

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -20,7 +20,7 @@
 //   IT MUST BE DELETED, not merely stopped being written. `config/{docId}` is
 //   `allow read: if true` forever: withdraw `public.view` from the declaration
 //   and the old page stays fetchable by anyone until something removes it.
-import { readFile, stat } from "node:fs/promises";
+import { readFile, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
 import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
@@ -78,13 +78,42 @@ const HOST_VIEW_GLOBAL = "__MC_VIEW";
  *  page: a path to nothing, a page too large to publish, or a view written
  *  against the host's bridge. */
 export async function readPublicViewFile(root: string, view: { path: string }, publishedAt: number): Promise<ViewFileResult> {
-  const full = path.join(root, view.path);
+  const inside = await containedPath(root, view.path);
+  if (!inside.ok) return inside;
+  const full = inside.full;
   const problems = await missingFileProblems(full, view.path);
   if (problems.length > 0) return { ok: false, problems };
 
   const html = await readFile(full, "utf8");
   const bytes = viewDocumentBytes({ html, publishedAt });
   return contentProblems(html, bytes, view.path) ?? { ok: true, view: { html, bytes } };
+}
+
+/** The file this path REALLY names, and only if it is still in the repository.
+ *
+ *  Not a second opinion about the declaration's shape — publish already refuses
+ *  a path that is not one name under `views/`. This is about what the file
+ *  system does with it: `..` normalises away silently, and a symlink no regex
+ *  can see points wherever it likes. What is published lands on a document
+ *  whose rule is `allow read: if true`, so a mistake here is not a broken page
+ *  but somebody's `.env` handed to the world.
+ *
+ *  Both ends are resolved (`realpath`) before comparing, because a repository
+ *  reached through a symlinked parent would otherwise fail this test while
+ *  being entirely legitimate. */
+async function containedPath(root: string, declared: string): Promise<{ ok: true; full: string } | { ok: false; problems: string[] }> {
+  const real = await realpath(root).catch(() => path.resolve(root));
+  const full = await realpath(path.resolve(real, declared)).catch(() => path.resolve(real, declared));
+  if (full === real || full.startsWith(real + path.sep)) {
+    return { ok: true, full };
+  }
+  return {
+    ok: false,
+    problems: [
+      `public.view.path names '${declared}', which resolves outside this repository. ` +
+        "A published view is one file inside it — what gets published is world-readable, so a path that leaves (through `..`, or through a symlink) would hand out whatever it landed on.",
+    ],
+  };
 }
 
 async function missingFileProblems(full: string, declared: string): Promise<string[]> {

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -20,7 +20,7 @@
 //   IT MUST BE DELETED, not merely stopped being written. `config/{docId}` is
 //   `allow read: if true` forever: withdraw `public.view` from the declaration
 //   and the old page stays fetchable by anyone until something removes it.
-import { readFile, realpath, stat } from "node:fs/promises";
+import { constants, open, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
@@ -80,67 +80,84 @@ const HOST_VIEW_GLOBAL = "__MC_VIEW";
 export async function readPublicViewFile(root: string, view: { path: string }, publishedAt: number): Promise<ViewFileResult> {
   const inside = await containedPath(root, view.path);
   if (!inside.ok) return inside;
-  const full = inside.full;
-  const problems = await missingFileProblems(full, view.path);
-  if (problems.length > 0) return { ok: false, problems };
 
-  // Between the stat above and this read the file can go: deleted, or its
-  // permissions changed. The gate's whole contract is that it answers with
-  // problems and writes nothing, so a rejection escaping here would come out of
-  // publish as an exception instead — the one shape every caller is written not
-  // to expect.
-  const html = await readFile(full, "utf8").catch(() => null);
-  if (html === null) {
+  const opened = await openContained(inside.full, view.path);
+  if (!opened.ok) return opened;
+  const bytes = viewDocumentBytes({ html: opened.html, publishedAt });
+  return contentProblems(opened.html, bytes, view.path) ?? { ok: true, view: { html: opened.html, bytes } };
+}
+
+/** Read the file, through a handle that cannot be talked into reading another
+ *  one.
+ *
+ *  Checking the path and then reading the path resolves it TWICE, and the
+ *  second one is what gets published: a process that swaps the validated file
+ *  for a symlink in between wins, and what lands on the world-readable document
+ *  is whatever the link points at. So the containment check and the bytes have
+ *  to be about the same object.
+ *
+ *  `O_NOFOLLOW` refuses at open time if the last component is a link, and
+ *  everything after that — the type check and the read — goes through the
+ *  descriptor rather than the name. The remaining theoretical window is an
+ *  ANCESTOR directory replaced between `realpath` and this open; Node exposes
+ *  no `openat`, so that one is named rather than closed.
+ *
+ *  Errors are values here for the same reason as everywhere else in this gate:
+ *  publish answers with problems and writes nothing. */
+async function openContained(full: string, declared: string): Promise<{ ok: true; html: string } | { ok: false; problems: string[] }> {
+  let handle;
+  try {
+    handle = await open(full, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch {
     return {
       ok: false,
       problems: [
-        `public.view.path names '${view.path}', which could not be read. ` +
-          "It was there a moment ago, so it has just been removed or its permissions have changed. Nothing was written.",
+        `public.view.path names '${declared}', which could not be opened as a plain file in this repository. ` +
+          "A published view is read without following links — what gets published is world-readable, so the file checked and the file read have to be the same one. " +
+          "If it was there a moment ago, it has just been removed, replaced, or had its permissions changed. Nothing was written.",
       ],
     };
   }
-  const bytes = viewDocumentBytes({ html, publishedAt });
-  return contentProblems(html, bytes, view.path) ?? { ok: true, view: { html, bytes } };
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) {
+      return { ok: false, problems: [`public.view.path names '${declared}', which is not a file.`] };
+    }
+    return { ok: true, html: await handle.readFile("utf8") };
+  } catch {
+    return {
+      ok: false,
+      problems: [`public.view.path names '${declared}', which could not be read. Nothing was written.`],
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
 }
 
-/** The file this path REALLY names, and only if it is still in the repository.
+/** Where the file must be, resolved ONCE, and the name it must have there.
  *
- *  Not a second opinion about the declaration's shape — publish already refuses
- *  a path that is not one name under `views/`. This is about what the file
- *  system does with it: `..` normalises away silently, and a symlink no regex
- *  can see points wherever it likes. What is published lands on a document
- *  whose rule is `allow read: if true`, so a mistake here is not a broken page
- *  but somebody's `.env` handed to the world.
+ *  The directory is resolved with `realpath` (so a repository reached through a
+ *  symlinked parent is still judged fairly) and must be inside the repository.
+ *  The BASENAME is deliberately left unresolved: resolving it would follow a
+ *  link and hand back its target, so the check would be about one file and the
+ *  read about another. Following it is refused outright at the open below.
  *
- *  Both ends are resolved (`realpath`) before comparing, because a repository
- *  reached through a symlinked parent would otherwise fail this test while
- *  being entirely legitimate. */
+ *  What is published lands on a document whose rule is `allow read: if true`,
+ *  so a mistake here is not a broken page but somebody's `.env` handed out. */
 async function containedPath(root: string, declared: string): Promise<{ ok: true; full: string } | { ok: false; problems: string[] }> {
   const real = await realpath(root).catch(() => path.resolve(root));
-  const full = await realpath(path.resolve(real, declared)).catch(() => path.resolve(real, declared));
-  if (full === real || full.startsWith(real + path.sep)) {
-    return { ok: true, full };
+  const wanted = path.resolve(real, declared);
+  const dir = await realpath(path.dirname(wanted)).catch(() => path.dirname(wanted));
+  if (dir === real || dir.startsWith(real + path.sep)) {
+    return { ok: true, full: path.join(dir, path.basename(wanted)) };
   }
   return {
     ok: false,
     problems: [
       `public.view.path names '${declared}', which resolves outside this repository. ` +
-        "A published view is one file inside it — what gets published is world-readable, so a path that leaves (through `..`, or through a symlink) would hand out whatever it landed on.",
+        "A published view is one file inside it — what gets published is world-readable, so a path that leaves (through `..`, or through a symlinked directory) would hand out whatever it landed on.",
     ],
   };
-}
-
-async function missingFileProblems(full: string, declared: string): Promise<string[]> {
-  try {
-    const info = await stat(full);
-    if (info.isFile()) return [];
-    return [`public.view.path names '${declared}', which is not a file.`];
-  } catch {
-    return [
-      `public.view.path names '${declared}', which does not exist in this repository. ` +
-        "The public page has nothing to draw and would tell a visitor there is nothing here.",
-    ];
-  }
 }
 
 function contentProblems(html: string, bytes: number, declared: string): { ok: false; problems: string[] } | null {

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -20,7 +20,7 @@
 //   IT MUST BE DELETED, not merely stopped being written. `config/{docId}` is
 //   `allow read: if true` forever: withdraw `public.view` from the declaration
 //   and the old page stays fetchable by anyone until something removes it.
-import { constants, open, realpath } from "node:fs/promises";
+import { constants, lstat, open, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
@@ -104,6 +104,35 @@ export async function readPublicViewFile(root: string, view: { path: string }, p
  *
  *  Errors are values here for the same reason as everywhere else in this gate:
  *  publish answers with problems and writes nothing. */
+/** The first directory between the repository and the view that is a symlink,
+ *  or null when none is.
+ *
+ *  `O_NOFOLLOW` covers the last component only, so without this a `views/`
+ *  replaced by a link would be followed. Checked with `lstat`, which does not
+ *  follow, one component at a time.
+ *
+ *  This closes the MISTAKE — a stray link somebody made — completely. It does
+ *  not close a race against a process that swaps a directory between this walk
+ *  and the open below, and no pure-Node implementation can: that needs
+ *  descriptor-relative opens (`openat`), which the runtime does not expose.
+ *
+ *  Which is worth stating precisely, because it bounds what this check is for.
+ *  Publish reads the AUTHOR's own repository as the author. A process able to
+ *  win that race is a process with write access to the repository being
+ *  published — and it does not need a symlink at all: it can put the secret
+ *  into `views/booking.html`, or rewrite `app.json`. The boundary this file
+ *  guards is between a declaration and the world, not between two processes on
+ *  one machine. */
+async function symlinkedAncestor(root: string, dir: string): Promise<string | null> {
+  let at = dir;
+  while (at !== root && at.startsWith(root + path.sep)) {
+    const info = await lstat(at).catch(() => null);
+    if (info?.isSymbolicLink() === true) return at;
+    at = path.dirname(at);
+  }
+  return null;
+}
+
 async function openContained(full: string, declared: string): Promise<{ ok: true; html: string } | { ok: false; problems: string[] }> {
   let handle;
   try {
@@ -147,6 +176,19 @@ async function openContained(full: string, declared: string): Promise<{ ok: true
 async function containedPath(root: string, declared: string): Promise<{ ok: true; full: string } | { ok: false; problems: string[] }> {
   const real = await realpath(root).catch(() => path.resolve(root));
   const wanted = path.resolve(real, declared);
+  // The DECLARED components, before anything is resolved: resolving first
+  // would replace a linked directory with its target, and there would be
+  // nothing left to object to.
+  const linked = await symlinkedAncestor(real, path.dirname(wanted));
+  if (linked !== null) {
+    return {
+      ok: false,
+      problems: [
+        `public.view.path names '${declared}', and '${path.relative(real, linked) || linked}' on the way to it is a symbolic link. ` +
+          "A published view is read without following links, directories included — what gets published is world-readable, so every step has to be inside the repository as written.",
+      ],
+    };
+  }
   const dir = await realpath(path.dirname(wanted)).catch(() => path.dirname(wanted));
   if (dir === real || dir.startsWith(real + path.sep)) {
     return { ok: true, full: path.join(dir, path.basename(wanted)) };

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -1,0 +1,129 @@
+// The HTML a published app shows instead of the generated form.
+//
+// A form is enough to ANSWER something and not enough to CHOOSE from what is
+// available, so an app may name one HTML file and the public page renders it in
+// a sandboxed iframe (mulmoserver `PublicViewFrame`). What the page holds is
+// Firebase; what the view holds is the drawing.
+//
+// Three things about this file are decisions rather than plumbing:
+//
+//   WHERE IT LIVES. `public.view.path` is resolved against the REPOSITORY
+//   ROOT — `app.json` is there, and a path written in a file is naturally
+//   relative to that file. The alternative, resolving it inside one
+//   collection's skill folder, asks which collection owns a page that belongs
+//   to the whole app, and has no answer for an app with three of them.
+//
+//   IT IS A SEPARATE DOCUMENT. Firestore's 1 MiB limit is per document and
+//   HTML is the part that grows, so the page's `config/public` (which every
+//   visitor reads to draw anything at all) is not made hostage to it.
+//
+//   IT MUST BE DELETED, not merely stopped being written. `config/{docId}` is
+//   `allow read: if true` forever: withdraw `public.view` from the declaration
+//   and the old page stays fetchable by anyone until something removes it.
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { AuthoredApp } from "@mulmoclaude/core/collection/server";
+
+/** The document the public page reads the HTML from. Beside core's
+ *  `PUBLIC_CONFIG_DOC` ("public") under `apps/{aid}/config`. */
+export const PUBLIC_VIEW_DOC = "view";
+
+/** What publish writes there.
+ *
+ *  `publishedAt` is the same stamp `config/public` carries, and the runtime
+ *  refuses to draw a pair that disagrees: the two are separate writes and a
+ *  publish can stop between them, leaving a new declaration beside the previous
+ *  page — a view handed fields it has never seen. */
+export interface PublicViewDoc extends Record<string, unknown> {
+  html: string;
+  publishedAt: number;
+}
+
+/** How much of a Firestore document a published view may take.
+ *
+ *  The limit is 1 MiB and it applies to the DOCUMENT: field names, the UTF-8
+ *  length of every string, and the document's own overhead. Measuring the file
+ *  on disk would therefore be measuring the wrong thing — and being wrong here
+ *  is not a smaller page but a refused write at publish time, or a page that
+ *  cannot be updated.
+ *
+ *  The margin is deliberate. What is left of the megabyte is not ours to spend
+ *  on being exact. */
+const MAX_VIEW_BYTES = 900_000;
+
+/** The bytes this document will occupy, near enough to refuse on.
+ *
+ *  Counted as the serialised document rather than as the HTML: the numbers a
+ *  reader cares about — "how much have I got left" — must include everything
+ *  the write carries, not just the part they wrote. */
+export const viewDocumentBytes = (doc: PublicViewDoc): number => Buffer.byteLength(JSON.stringify(doc), "utf8");
+
+export interface ViewFile {
+  html: string;
+  bytes: number;
+}
+
+export type ViewFileResult = { ok: true; view: ViewFile } | { ok: false; problems: string[] };
+
+/** The host-side contract's name. A view written for the collection pane reads
+ *  a capability token and a `dataUrl` off it, neither of which exists on the
+ *  public page — so pointing `public.view` at one produces a blank page and no
+ *  error anywhere. */
+const HOST_VIEW_GLOBAL = "__MC_VIEW";
+
+/** Read and judge the file `public.view.path` names.
+ *
+ *  Every refusal here is a thing the visitor would otherwise meet as an empty
+ *  page: a path to nothing, a page too large to publish, or a view written
+ *  against the host's bridge. */
+export async function readPublicViewFile(root: string, view: { path: string }, publishedAt: number): Promise<ViewFileResult> {
+  const full = path.join(root, view.path);
+  const problems = await missingFileProblems(full, view.path);
+  if (problems.length > 0) return { ok: false, problems };
+
+  const html = await readFile(full, "utf8");
+  const bytes = viewDocumentBytes({ html, publishedAt });
+  return contentProblems(html, bytes, view.path) ?? { ok: true, view: { html, bytes } };
+}
+
+async function missingFileProblems(full: string, declared: string): Promise<string[]> {
+  try {
+    const info = await stat(full);
+    if (info.isFile()) return [];
+    return [`public.view.path names '${declared}', which is not a file.`];
+  } catch {
+    return [
+      `public.view.path names '${declared}', which does not exist in this repository. ` +
+        "The public page has nothing to draw and would tell a visitor there is nothing here.",
+    ];
+  }
+}
+
+function contentProblems(html: string, bytes: number, declared: string): { ok: false; problems: string[] } | null {
+  if (bytes > MAX_VIEW_BYTES) {
+    return {
+      ok: false,
+      problems: [
+        `public.view.path names '${declared}', which comes to ${bytes.toLocaleString()} bytes as a Firestore document — over the ${MAX_VIEW_BYTES.toLocaleString()} this publishes. ` +
+          "The hard limit is 1 MiB per document and it counts field names and string lengths, not the file on disk, so the margin is not spare room. " +
+          "Move what is big out of the page: the datasets arrive from the app, not from the HTML.",
+      ],
+    };
+  }
+  if (html.includes(HOST_VIEW_GLOBAL)) {
+    return {
+      ok: false,
+      problems: [
+        `public.view.path names '${declared}', which reads \`${HOST_VIEW_GLOBAL}\` — that is the HOST's custom-view contract, where a view is handed a capability token and fetches its own data. ` +
+          "The public page has neither: it reads Firestore itself and hands the view its data, and the view asks for writes through `window.__MC_PUBLIC_VIEW`. " +
+          "Published as it stands, this page would render blank with nothing anywhere to say why. Write the public view against the public bridge.",
+      ],
+    };
+  }
+  return null;
+}
+
+/** The view the declaration asks to publish, if any. Null for an app with no
+ *  `public.view` — which is most of them, and is not a problem. */
+export const declaredView = (authored: AuthoredApp): { path: string } | null => authored.public?.view ?? null;

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -42,6 +42,8 @@ import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
 import { oversizeProblem, publicFormOf, publicInputProblems, type PublicForm } from "./publicForm.js";
+import { PUBLIC_VIEW_DOC, declaredView, readPublicViewFile, type ViewFile } from "./publicView.js";
+import { frozenKeyProblems } from "./exclusivity.js";
 import { stagedScopeProblems } from "./scopedFields.js";
 import { setSlugPublished } from "./slug.js";
 import { runWrites, type WriteStep } from "./writes.js";
@@ -119,6 +121,7 @@ function publishSteps(
   face: ReturnType<typeof projectPublish>,
   slug: string | undefined,
   form: PublicForm,
+  view: ViewFile | null,
 ): WriteStep[] {
   return [
     ...staged.map(({ cid, doc }) => ({
@@ -132,6 +135,25 @@ function publishSteps(
       // and the choices the public page cannot draw the form at all (the schema is unreadable to
       // somebody who is neither on the roster nor granted a public read).
       run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, { ...face.config, form }),
+    },
+    // The page itself, carrying the SAME stamp as the config above. The
+    // runtime refuses to draw a pair that disagrees, and these are two writes:
+    // a run that stops between them leaves a new declaration beside the
+    // previous page, which is a view handed fields it has never seen.
+    //
+    // The DELETE is not tidiness. `config/{docId}` is `allow read: if true`
+    // forever, so a view withdrawn from the declaration and merely not
+    // rewritten stays fetchable by anybody who asks for it.
+    {
+      what:
+        view === null ? `removing the published view (apps/${aid}/config/${PUBLIC_VIEW_DOC})` : `the published view (apps/${aid}/config/${PUBLIC_VIEW_DOC})`,
+      run: async () => {
+        if (view === null) {
+          await handle.docs.delete(appConfigPath(aid), PUBLIC_VIEW_DOC);
+          return;
+        }
+        await handle.docs.set(appConfigPath(aid), PUBLIC_VIEW_DOC, { html: view.html, publishedAt: stamp.publishedAt });
+      },
     },
     // The app document WITHOUT `public`: the promoted rule configuration lands with the schemas it
     // was staged beside, so the public write path is never judged by one version's constraints
@@ -207,6 +229,34 @@ async function stagedGate(
   return refusal ? { ok: false, partial: false, problems: refusal } : { ok: true, scan };
 }
 
+/** The two questions that are asked of the PAGE and of the live records before
+ *  anything is written — both of them things a run cannot take back once the
+ *  schemas have been promoted.
+ *
+ *  Together because they share that timing, not because they are alike: one
+ *  reads a file off disk, the other reads what the app already holds. */
+async function pageGate(
+  root: string,
+  authored: AuthoredApp,
+  live: Record<string, unknown> | null,
+  handle: SharedAppHandle,
+  publishedAt: number,
+): Promise<{ ok: true; view: ViewFile | null } | { ok: false; problems: string[] }> {
+  const declared = declaredView(authored);
+  if (declared !== null) {
+    const view = await readPublicViewFile(root, declared, publishedAt);
+    if (!view.ok) return view;
+    const frozen = await frozenKeyProblems(authored, live, handle);
+    return frozen.length > 0 ? { ok: false, problems: frozen } : { ok: true, view: view.view };
+  }
+  // The other question about the same live records, and the one the migration
+  // scan cannot ask: not "do these rows still fit the schema" but "does this
+  // change move the id space they were written into". See ./exclusivity.ts —
+  // `confirm` deliberately does not reach it.
+  const frozen = await frozenKeyProblems(authored, live, handle);
+  return frozen.length > 0 ? { ok: false, problems: frozen } : { ok: true, view: null };
+}
+
 export async function publishSharedApp(root: string, opts: SharedAppOptions = {}): Promise<PublishResult> {
   // Before anything reads the declaration: a repository that has never been deployed has no
   // `aid` yet, and it is generated here rather than invented by the agent (D2b).
@@ -260,7 +310,14 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
   const oversize = oversizeProblem({ ...face.config, form });
   if (oversize !== null) return { ok: false, partial: false, problems: [oversize] };
 
-  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, form), "publish");
+  // Also before the first write, and for the same reason: the page is read
+  // from disk and judged here, so a missing file or one written against the
+  // host's bridge stops the run rather than landing after the schemas have
+  // been promoted.
+  const page = await pageGate(root, authored, existingApp, handle, stamp.publishedAt);
+  if (!page.ok) return { ok: false, partial: false, problems: page.problems };
+
+  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, form, page.view), "publish");
   if (failure) return failure;
 
   return {

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -33,6 +33,7 @@ import {
   appSchemasPath,
   promoteSchema,
   projectPublish,
+  stagedRuleConfig,
   type AuthoredApp,
   type LoadedCollection,
   type PublishStamp,
@@ -238,23 +239,25 @@ async function stagedGate(
 async function pageGate(
   root: string,
   authored: AuthoredApp,
+  staged: readonly StagedEntry[],
   live: Record<string, unknown> | null,
   handle: SharedAppHandle,
   publishedAt: number,
 ): Promise<{ ok: true; view: ViewFile | null } | { ok: false; problems: string[] }> {
   const declared = declaredView(authored);
-  if (declared !== null) {
-    const view = await readPublicViewFile(root, declared, publishedAt);
-    if (!view.ok) return view;
-    const frozen = await frozenKeyProblems(authored, live, handle);
-    return frozen.length > 0 ? { ok: false, problems: frozen } : { ok: true, view: view.view };
-  }
+  const view = declared === null ? null : await readPublicViewFile(root, declared, publishedAt);
+  if (view !== null && !view.ok) return view;
   // The other question about the same live records, and the one the migration
   // scan cannot ask: not "do these rows still fit the schema" but "does this
   // change move the id space they were written into". See ./exclusivity.ts —
   // `confirm` deliberately does not reach it.
-  const frozen = await frozenKeyProblems(authored, live, handle);
-  return frozen.length > 0 ? { ok: false, problems: frozen } : { ok: true, view: null };
+  //
+  // The collection half is read from what DEPLOY staged, because that is what
+  // this publish promotes: `stagedRuleConfig` is the same function the
+  // projection uses, so the value judged is the value written.
+  const frozen = await frozenKeyProblems(authored, stagedRuleConfig(staged).collections ?? {}, live, handle);
+  if (frozen.length > 0) return { ok: false, problems: frozen };
+  return { ok: true, view: view === null ? null : view.view };
 }
 
 export async function publishSharedApp(root: string, opts: SharedAppOptions = {}): Promise<PublishResult> {
@@ -314,7 +317,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
   // from disk and judged here, so a missing file or one written against the
   // host's bridge stops the run rather than landing after the schemas have
   // been promoted.
-  const page = await pageGate(root, authored, existingApp, handle, stamp.publishedAt);
+  const page = await pageGate(root, authored, staged.staged, existingApp, handle, stamp.publishedAt);
   if (!page.ok) return { ok: false, partial: false, problems: page.problems };
 
   const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, form, page.view), "publish");

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -255,7 +255,9 @@ async function pageGate(
   // The collection half is read from what DEPLOY staged, because that is what
   // this publish promotes: `stagedRuleConfig` is the same function the
   // projection uses, so the value judged is the value written.
-  const frozen = await frozenKeyProblems(authored, stagedRuleConfig(staged).collections ?? {}, live, handle);
+  // Copied because `stagedRuleConfig` takes a mutable array; the entries
+  // themselves are not touched.
+  const frozen = await frozenKeyProblems(authored, stagedRuleConfig([...staged]).collections ?? {}, live, handle);
   if (frozen.length > 0) return { ok: false, problems: frozen };
   return { ok: true, view: view === null ? null : view.view };
 }

--- a/server/backends/sharedApp/unpublish.ts
+++ b/server/backends/sharedApp/unpublish.ts
@@ -17,6 +17,7 @@
 // app nobody ever had, in place of the real reason. Only the `aid` is read.
 import { isRecord } from "../../../common/isRecord.js";
 import { APPS_COLLECTION, PUBLIC_CONFIG_DOC, appConfigPath, appManifestReason, firestoreHandle, loadAppManifest } from "@mulmoclaude/core/collection/server";
+import { PUBLIC_VIEW_DOC } from "./publicView.js";
 import type { SharedAppFailure } from "./context.js";
 import { runWrites } from "./writes.js";
 import { setSlugPublished } from "./slug.js";
@@ -79,6 +80,17 @@ export async function unpublishSharedApp(root: string): Promise<UnpublishResult>
         what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
         run: async () => {
           await handle.docs.delete(appConfigPath(aid), PUBLIC_CONFIG_DOC);
+        },
+      },
+      // The page comes down with the settings. `config/{docId}` is
+      // `allow read: if true` whatever else is closed, so a view left behind
+      // is a page anybody can still fetch from an app that has been taken
+      // down — the same shape of leak as the config document above, and the
+      // reason both deletions are here rather than left to the next publish.
+      {
+        what: `the published view (apps/${aid}/config/${PUBLIC_VIEW_DOC})`,
+        run: async () => {
+          await handle.docs.delete(appConfigPath(aid), PUBLIC_VIEW_DOC);
         },
       },
     ],

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -249,6 +249,52 @@ Two more keys, and one thing the rules cannot do. Read
   second. That means the members are on the roster (with `peerVisibility: "public"`), and everyone
   can see who else signed up. Ask before building it.
 
+### If people are racing for ONE thing rather than for a place in a queue
+
+A class has a capacity and the rules cannot count it, so the queue above is drawn rather than
+enforced. **A slot is different: it is one thing, so nothing needs counting.** Put its id into the
+booking's id and the second person to want it is writing a document that already exists — which is
+an update, which the public submission path never allows. Firestore decides that atomically. Read
+[templates/salon.md](./templates/salon.md) before building one.
+
+- **`idFrom: "field"` + `idField`** make the record's id the value of one of its fields. That
+  field cannot be changed afterwards, and the id it produced is what holds the slot.
+- **`idIn`** is REQUIRED with it, and says which collection that id must be found in — with the
+  state it must be in — `"idIn": { "collection": "slots", "where": { "field": "state", "equals": "open" } }`.
+  Without it the id is any string a submitter likes, and the app quietly accepts bookings for
+  things that do not exist. Publish refuses the declaration.
+- **`window.untilField`** is `fromField`'s twin: a per-slot deadline, epoch millis on the same
+  record. A desk that opens per slot and never closes is not a booking desk.
+- **`mirror` (on the submission) and `mirrorOf` (on the collection)** are the two halves of the
+  PUBLIC face. A booking carries a name and a phone number and Firestore cannot hide a field, so
+  the public page must never read bookings — it reads the slot rows, whose `state` is a copy of
+  "does a booking with this id exist". The rules accept the two writes only as one batch, in both
+  directions. **Declare both halves or neither**; publish refuses one on its own.
+- **These five keys freeze once records exist.** `confirm` does not override that, because what
+  breaks is not a visible schema mismatch — it is the exclusivity itself, silently, in an app that
+  goes on working. Say so before an author starts renaming things.
+
+### If a form is not enough to choose from
+
+A form ANSWERS something. Choosing from what is available — a stylist-by-hour grid — is not the
+far end of a table, so an app may publish one HTML page instead:
+
+```json
+{ "view": { "path": "views/booking.html", "collections": ["stylists", "slots"] } }
+```
+
+- The path is **relative to the repository root** (`views/<name>.html`, one file, no
+  sub-directories) — `app.json` is there.
+- **It is not the host's custom view.** A page written against the collection pane reads
+  `__MC_VIEW.token` and fetches its own data; the public page has neither and hands the view its
+  data instead. Publish refuses a file that mentions `__MC_VIEW`, because otherwise it would render
+  blank with nothing to say why.
+- **`collections` is declared, not inferred from `public.read`.** A view fed the wrong data renders
+  perfectly and draws an empty page, which is the one failure nothing reports. Publish refuses a
+  dataset that is not in `public.read`.
+- The view asks for writes through `window.__MC_PUBLIC_VIEW.submit(cid, values)` and **the page
+  confirms with the visitor before writing anything** — the HTML is not trusted to have been asked.
+
 The simplest correct survey omits status entirely (`submitOnly` + `verifiedEmail` + `emailField`).
 Add a status only when somebody is going to work through the responses.
 

--- a/server/skills/mulmoterminal-shared-app/templates/salon.md
+++ b/server/skills/mulmoterminal-shared-app/templates/salon.md
@@ -3,9 +3,17 @@
 **いつ使うか** — 申込みを受けて、**担当者が自分の分だけ承認する**アプリ。美容室の予約、
 面談の申込み、修理の受付、査読の割り当て。「誰が担当か」で権限が変わるものはこの形。
 
-このテンプレートの要点は `assignee` ロールです。担当者は**全予約を見て、自分の担当だけ
-書き換えられる**。受付は全予約を書き換えられる。この 2 つを同時に表現できるのは、絞りが
-コレクションではなく**名簿の側**にあるからです。
+要点は 2 つあります。
+
+**`assignee` ロール。** 担当者は**全予約を見て、自分の担当だけ書き換えられる**。受付は
+全予約を書き換えられる。この 2 つを同時に表現できるのは、絞りがコレクションではなく
+**名簿の側**にあるからです。
+
+**枠（`slots`）を実在させ、予約の id を枠の id にする。** これで「同じ枠を 2 人が取る」が
+起きなくなります。2 人目の書き込みは**既に在るドキュメントへの書き込み**になり、公開の
+申込み経路は create しか許していないので拒否される。ジム（[gym.md](./gym.md)）の
+先着順とは違う仕組みで、あちらは「数えられないので順位で見せる」、こちらは
+**数える必要がない**（枠は 1 行）。
 
 ---
 
@@ -18,9 +26,9 @@
   "slug": "sakura-hair",
   "members": {
     "owner@salon.jp": { "*": "owner" },
-    "reception@salon.jp": { "bookings": "editor", "shifts": "viewer", "services": "viewer" },
-    "anna@salon.jp": { "bookings": "assignee", "shifts": "viewer", "services": "viewer" },
-    "ben@salon.jp": { "bookings": "assignee", "shifts": "viewer", "services": "viewer" }
+    "reception@salon.jp": { "bookings": "editor", "slots": "editor", "services": "viewer" },
+    "anna@salon.jp": { "bookings": "assignee", "slots": "viewer", "services": "viewer" },
+    "ben@salon.jp": { "bookings": "assignee", "slots": "viewer", "services": "viewer" }
   },
   "collections": {
     "bookings": {
@@ -36,24 +44,38 @@
         "toField": "customerEmail",
         "on": { "booking-approved": { "from": ["pending"], "to": "approved" } }
       }
-    }
+    },
+    "slots": { "mirrorOf": "bookings" }
   },
   "public": {
     "enabled": true,
-    "read": ["services", "shifts", "stylists"],
+    "read": ["services", "stylists", "slots"],
+    "view": { "path": "views/booking.html", "collections": ["stylists", "services", "slots"] },
     "submit": {
       "bookings": {
         "auth": "verifiedEmail",
         "emailField": "customerEmail",
-        "createFields": ["customerName", "customerEmail", "service", "startAt", "status"],
+        "createFields": ["customerName", "customerEmail", "service", "slot", "status"],
         "initialStatus": "pending",
-        "selfUpdate": { "pending": ["startAt", "service"] },
+        "idFrom": "field",
+        "idField": "slot",
+        "idIn": { "collection": "slots", "where": { "field": "state", "equals": "open" } },
+        "mirror": "slots",
+        "window": {
+          "fromField": { "ref": "slot", "collection": "slots", "field": "opensAt" },
+          "untilField": { "ref": "slot", "collection": "slots", "field": "closesAt" }
+        },
+        "selfUpdate": { "pending": ["service"] },
         "selfTransitions": { "pending": ["cancelled"] }
       }
     }
   }
 }
 ```
+
+**申込みの宣言は丸ごと書いてください。** `idFrom` と `idField` だけを書いた短い版は
+**publish が拒否します**（`idIn` が無ければ、実在しない枠の予約が黙って通るので）。
+省略が効くところではありません。
 
 ## .claude/skills/bookings/schema.json
 
@@ -68,7 +90,7 @@
     "customerName": { "type": "string", "label": "お名前", "required": true },
     "customerEmail": { "type": "email", "label": "メール", "required": true },
     "service": { "type": "enum", "label": "メニュー", "values": ["カット", "カラー", "パーマ"], "required": true },
-    "startAt": { "type": "datetime", "label": "希望日時", "required": true },
+    "slot": { "type": "string", "label": "枠", "required": true },
     "stylistEmail": { "type": "email", "label": "担当（アドレス）" },
     "stylist": { "type": "ref", "label": "担当", "to": "stylists" },
     "status": { "type": "enum", "label": "状態", "values": ["pending", "approved", "rejected", "cancelled"] }
@@ -76,12 +98,90 @@
 }
 ```
 
-`stylists` / `services` / `shifts` は普通のコレクション（`storage: {"type":"firestore"}` だけ
-足す）。担当者一覧、メニューと所要時間、シフト表です。
+## .claude/skills/slots/schema.json
+
+```json
+{
+  "title": "枠",
+  "icon": "schedule",
+  "primaryKey": "id",
+  "storage": { "type": "firestore" },
+  "fields": {
+    "id": { "type": "string", "label": "ID", "primary": true, "required": true },
+    "stylist": { "type": "ref", "label": "担当", "to": "stylists" },
+    "startAt": { "type": "datetime", "label": "開始", "required": true },
+    "opensAt": { "type": "number", "label": "受付開始（epoch millis）", "required": true },
+    "closesAt": { "type": "number", "label": "受付締切（epoch millis）", "required": true },
+    "state": { "type": "enum", "label": "状態", "values": ["open", "taken"], "required": true }
+  }
+}
+```
+
+**主キーは合成スラッグ**にします（`anna-2026-09-01-1000` のような）。予約の id が
+この id になるので、読める形にしておくと運用が楽です。
+
+`opensAt` / `closesAt` は **epoch millis の数値**で、枠を作るときに計算して入れます。
+ルールに日付の計算はできず `request.time` は UTC なので、「3 日前の朝 7 時」のような
+決め方をするのは枠を作る側の仕事です。ルールは**比べるだけ**。
+
+`state` は予約と**同じ書き込みで**動きます（下記）。手で書き換えるものではありません。
+
+`stylists` / `services` は普通のコレクション（`storage: {"type":"firestore"}` だけ足す）。
+担当者一覧、メニューと所要時間です。
+
+## views/booking.html
+
+**リポジトリの root から見た `views/` に置きます**（`app.json` と同じ場所を起点に、
+`views/<name>.html` の 1 枚だけ）。ホスト側のカスタムビューとは**別の契約**です —
+`__MC_VIEW` を読むビューをここに指すと publish が拒否します。
+
+```html
+<div id="grid"></div>
+<script>
+  const view = window.__MC_PUBLIC_VIEW;
+  view.onState(({ stylists = [], slots = [] }) => {
+    const open = slots.filter((slot) => slot.state === "open");
+    document.getElementById("grid").innerHTML = open
+      .map((slot) => `<button data-slot="${slot.id}">${slot.startAt} ${slot.stylist ?? ""}</button>`)
+      .join("");
+  });
+  document.addEventListener("click", async (event) => {
+    const slot = event.target.dataset?.slot;
+    if (!slot) return;
+    const result = await view.submit("bookings", { slot, customerName: prompt("お名前") ?? "", status: "pending" });
+    if (!result.ok) alert("その枠は取られました");
+  });
+  view.ready();
+</script>
+```
+
+3 つだけ守れば形は自由です。
+
+- **`ready()` を最後に呼ぶ。** これが「listener を張り終えた」の合図で、親はこれを
+  待ってからデータを送ります。呼ばないとデータは永久に来ません
+- **`submit()` の結果を見る。** 「その枠は取られました」を出せるのはここだけです。
+  親が書き込みを行い、ルールが判断し、答えが返ってきます
+- **`customerEmail` は送らない。** サインインした訪問者のアドレスを親が入れます
+  （ルールがトークンと突き合わせるので、入力欄にすると間違えられるだけの欄になります）
+
+**押した瞬間には書き込まれません。** 親が送られてきた値を iframe の外に描いて確認を
+取り、訪問者が押してから書きます。これはビューの HTML が信頼されていないためで、
+読み込んだ瞬間に `submit()` を呼ぶページがあっても、勝手に予約が入ることはありません。
 
 ---
 
-## なぜこの形か — 迷いやすい 5 点
+## 利用者に先に言っておくこと
+
+- **公開されるのは `slots` だけ**で、予約そのもの（氏名・メール）は公開されません。
+  Firestore の読み取りはドキュメント単位でフィールドを隠せないので、これは運用の
+  注意ではなく**構造**で守っています。`bookings` を `public.read` に足すと、その瞬間に
+  客の連絡先が匿名の訪問者から全部読めます
+- **枠は先着で本当に排他されます。** ジムの順位方式と違い、繰り上げは起きません
+- **顧客がキャンセルしても枠はすぐには空きません。** 受付が戻す操作が要ります（下記）
+
+---
+
+## なぜこの形か — 迷いやすい 7 点
 
 ### 1. 担当は `stylistEmail`（アドレス）で、`stylist`（ref）ではない
 
@@ -123,6 +223,36 @@
 再導出されるので、担当者が選べるのは**どのレコードか**だけで、そこにも同じ絞りが
 かかっています。
 
+### 6. 枠は予約と**同じ書き込みで**取られる
+
+予約が作られるとき、`slots` のその行の `state` も同じ batch で `taken` になります。
+ルールが**両側から**要求するので、片方だけの書き込みは通りません:
+
+- 鏡を連れない予約の create は拒否される（＝予約は成立しているのに公開ページが
+  「空き」と言い続ける、が起きない）
+- `state` に書ける値は**真実だけ**です。予約が在れば `taken`、無ければ `open`。
+  嘘は書けないので、この 1 フィールドは**誰でも**書けます
+
+最後の点が効くのは、**先を越された 2 人目**です。その人は「取られていた」と知った
+唯一の人なので、拒否のあと自分で `taken` に直せます。格子はそこで正しくなります。
+
+公開ページの表示は**遅れることがあります**（鏡は写しなので）。ただし遅れる方向は常に
+「空きと言っているが実は埋まっている」で、その先には id の衝突による拒否が必ず待って
+います。**見た目が遅れるだけで、二重予約は起きません。**
+
+### 7. キャンセルは 2 段階 — 客の操作では枠は空かない
+
+| 誰が | どうやって | 枠は |
+|---|---|---|
+| 顧客 | `selfTransitions` で `status: "cancelled"` | **空かない**（ドキュメントが残り id を占有し続ける） |
+| 受付・担当 | 予約を delete（`slots` を `open` に戻す書き込みと対で） | 空く |
+
+顧客に delete はできません（`itemDelete` は writer と自分の担当行を持つ `assignee` だけ）。
+**これは制約であると同時に、たぶん正しい運用でもあります** — 枠が客の操作で即座に他人に
+開く必要はなく、受付が確認してから戻す方が店の実態に合う。ただし**そう決めたことを
+利用者に言ってください**。「キャンセルしたのに枠が空かない」は、書いていなければバグに
+見えます。
+
 ---
 
 ## 担当者に何ができて、何ができないか
@@ -134,7 +264,7 @@
 | 他人の担当を承認 | できる | できる | **できない** |
 | 担当を付け替える | できる | できる | **できない**（自分に付け替えて奪うのも、他人に投げるのも） |
 | 予約を消す | できる | できる | 自分の担当だけ |
-| シフト・メニューを編集 | できる | 読むだけ | 読むだけ |
+| 枠・メニューを編集 | できる | **枠は編集できる**（受付が枠を作り、戻す） | 読むだけ |
 | publish | **できる** | できない | できない |
 
 `assignee` は**コレクションを名指しして**与えます。`{"*": "assignee"}` は拒否されます —
@@ -145,11 +275,21 @@
 ## 作る順番
 
 1. `init`（`slug` に店の名前）
-2. `stylists` / `services` / `shifts` / `bookings` のスキル + スキーマを書く
-3. `check` — ここで `assigneeField` の型やロールの過不足が出ます
-4. `deploy` → 名簿の人に URL を渡す
-5. スタッフを `invite`（担当者は `role: "assignee"` と `cid: "bookings"`）
-6. 客に開くときだけ `publish`
+2. `stylists` / `services` / `slots` / `bookings` のスキル + スキーマを書く
+3. `views/booking.html` を書く（**リポジトリの root から** `views/`。スタイリスト × 時間の
+   格子。埋まっている枠は選べない）
+4. `check` — ここで `assigneeField` の型、ロールの過不足、鏡の片側落ち、ビューが読むと
+   宣言したコレクションが `public.read` に無いこと、が出ます
+5. `deploy` → 名簿の人に URL を渡す
+6. スタッフを `invite`（担当者は `role: "assignee"` と `cid: "bookings"`）
+7. 枠を作る（`opensAt` / `closesAt` / `state: "open"` を入れて `slots` に流し込む）
+8. 客に開くときだけ `publish`
+
+**排他に関わるキーは、レコードが 1 行でもあると変えられません**（`idFrom` / `idField` /
+`idIn` / `mirror` / `mirrorOf`）。publish が拒否し、`confirm` でも通りません — 変えると
+過去の予約が「押さえていたはずの枠」を押さえなくなり、しかも**誰にも見えない**ためです。
+やり直すなら、コレクションを空にするか新しい cid で作ります。7 の前に 3〜4 を済ませる
+順番はそのためです。
 
 参照: [SKILL.md](../SKILL.md) の「公開するとき」、先着順の申込みは
 [gym.md](./gym.md)。

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -127,6 +127,18 @@ describe("the file a published view names", () => {
     expect(result.ok === false && result.problems.join(" ")).toContain("Nothing was written");
   });
 
+  it("refuses a view reached through a symlinked DIRECTORY", async () => {
+    // `O_NOFOLLOW` covers the last component only, so the directories on the
+    // way have to be checked separately — otherwise a `views/` that is a link
+    // to somewhere else is followed silently.
+    const elsewhere = makeTempDir("mt-public-view-elsewhere-");
+    writeFileSync(path.join(elsewhere, "booking.html"), "<p>not ours</p>");
+    symlinkSync(elsewhere, path.join(root, "views"));
+    const result = await readPublicViewFile(root, { path: "views/booking.html" }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("is a symbolic link");
+  });
+
   it("takes a page that only mentions the PUBLIC bridge", async () => {
     // The neighbouring declaration that must still publish — otherwise the
     // check above is satisfied by refusing everything.
@@ -318,6 +330,15 @@ describe("the keys that decide which document a submission claims", () => {
     const problems = await frozenKeyProblems(moved, PROMOTED, live, { docs: new UnreadableDocs(), email: "me@example.com", uid: "uid-me" });
     expect(problems.join(" ")).toContain("could not be read");
     expect(problems.join(" ")).toContain("not something `confirm` overrides");
+  });
+
+  it("refuses a mirror WITHDRAWN with its collection", async () => {
+    // Deploy drops the staging document of a collection the repository no
+    // longer has, so the promoted map omits it entirely — and a gate that
+    // walked only the promoted keys would never notice the live half it is
+    // about to drop, which is the invariant it exists to hold.
+    const problems = await frozenKeyProblems(salon(), {}, live, handleWith({ [slotsPath]: 4 }));
+    expect(problems.join(" ")).toContain("mirrorOf: bookings → (absent)");
   });
 
   it("says nothing about a FIRST publish", async () => {

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -47,7 +47,21 @@ describe("the file a published view names", () => {
     // and the visitor is told there is nothing here.
     const result = await readPublicViewFile(root, { path: "views/missing.html" }, STAMP);
     expect(result.ok).toBe(false);
-    expect(result.ok === false && result.problems.join(" ")).toContain("does not exist in this repository");
+    expect(result.ok === false && result.problems.join(" ")).toContain("could not be opened as a plain file");
+  });
+
+  it("refuses to READ through a symlink, even one that stays inside", async () => {
+    // The second layer, and the one that survives a race: checking the path
+    // and then reading the path resolves it twice, so a process that swaps the
+    // validated file for a link in between wins. This link points at a file in
+    // the repository — containment has nothing to object to — and the read
+    // still refuses, because it goes through a handle opened with O_NOFOLLOW.
+    writeFileSync(path.join(root, "inside.html"), "<p>inside</p>");
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    symlinkSync(path.join(root, "inside.html"), path.join(root, "views", "booking.html"));
+    const result = await readPublicViewFile(root, { path: "views/booking.html" }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("without following links");
   });
 
   it("refuses a page written against the HOST's bridge", async () => {
@@ -88,13 +102,17 @@ describe("the file a published view names", () => {
   it("refuses a view that is a symlink out of the repository", async () => {
     // No regex over the declaration can see this one: the path is a perfectly
     // ordinary `views/<name>.html`, and the file system does the leaving.
+    //
+    // It is refused for being a LINK rather than for where it points, which is
+    // the stronger of the two: the check and the read are then about the same
+    // object, so swapping the file for a link after validation wins nothing.
     const secret = path.join(root, "..", "secret.html");
     writeFileSync(secret, "<p>secret</p>");
     mkdirSync(path.join(root, "views"), { recursive: true });
     symlinkSync(secret, path.join(root, "views", "leak.html"));
     const result = await readPublicViewFile(root, { path: "views/leak.html" }, STAMP);
     expect(result.ok).toBe(false);
-    expect(result.ok === false && result.problems.join(" ")).toContain("resolves outside this repository");
+    expect(result.ok === false && result.problems.join(" ")).toContain("without following links");
   });
 
   it("refuses, rather than throwing, when the file goes between stat and read", async () => {
@@ -106,7 +124,7 @@ describe("the file a published view names", () => {
     const result = await readPublicViewFile(root, { path: declared }, STAMP);
     chmodSync(path.join(root, "views", "booking.html"), 0o644);
     expect(result.ok).toBe(false);
-    expect(result.ok === false && result.problems.join(" ")).toContain("could not be read");
+    expect(result.ok === false && result.problems.join(" ")).toContain("Nothing was written");
   });
 
   it("takes a page that only mentions the PUBLIC bridge", async () => {

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -8,7 +8,7 @@
 // visitor "there is nothing here"; an id space that moved leaves old records
 // holding nothing, in an app that goes on working.
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { AuthoredApp, FirestoreDoc, FirestoreDocs } from "@mulmoclaude/core/collection/server";
 import { readPublicViewFile, viewDocumentBytes } from "../../../server/backends/sharedApp/publicView.js";
@@ -73,6 +73,28 @@ describe("the file a published view names", () => {
   it("counts the whole document, not just the HTML", () => {
     const bytes = viewDocumentBytes({ html: "abc", publishedAt: STAMP });
     expect(bytes).toBeGreaterThan("abc".length);
+  });
+
+  it("refuses a path that climbs out of the repository", async () => {
+    // `path.join` normalises `..` away silently, and what is published lands on
+    // a document whose rule is `allow read: if true` — so this is not a broken
+    // page but somebody's secrets handed to the world.
+    writeFileSync(path.join(root, "..", "outside.html"), "<p>secret</p>");
+    const result = await readPublicViewFile(root, { path: "views/../../outside.html" }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("resolves outside this repository");
+  });
+
+  it("refuses a view that is a symlink out of the repository", async () => {
+    // No regex over the declaration can see this one: the path is a perfectly
+    // ordinary `views/<name>.html`, and the file system does the leaving.
+    const secret = path.join(root, "..", "secret.html");
+    writeFileSync(secret, "<p>secret</p>");
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    symlinkSync(secret, path.join(root, "views", "leak.html"));
+    const result = await readPublicViewFile(root, { path: "views/leak.html" }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("resolves outside this repository");
   });
 
   it("takes a page that only mentions the PUBLIC bridge", async () => {
@@ -211,6 +233,25 @@ describe("the keys that decide which document a submission claims", () => {
 
     const withoutMirrorOf = salon({ collections: { slots: {} } });
     expect((await frozenKeyProblems(withoutMirrorOf, live, handleWith({ [slotsPath]: 8 }))).join(" ")).toContain("mirrorOf: bookings → (absent)");
+  });
+
+  it("reads a reordered declaration as the same declaration", async () => {
+    // `idIn` is compared as text, and JSON.stringify keeps INSERTION order — so
+    // without canonicalising, tidying the keys in `app.json` would read as a
+    // moved identity key and refuse a re-publish that changes nothing.
+    const reordered = salon({
+      public: {
+        ...live.public,
+        submit: {
+          bookings: {
+            ...live.public.submit.bookings,
+            idIn: { where: { equals: "open", field: "state" }, collection: "slots" },
+          },
+        },
+      },
+    });
+    const problems = await frozenKeyProblems(reordered, live, handleWith({ [bookingsPath]: 5 }));
+    expect(problems).toEqual([]);
   });
 
   it("says nothing about a FIRST publish", async () => {

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -129,7 +129,22 @@ class LiveDocs implements FirestoreDocs {
   }
 }
 
+/** A handle whose listing fails, as a transient permission or network error
+ *  does. */
+class UnreadableDocs extends LiveDocs {
+  constructor() {
+    super({});
+  }
+  override async list(): Promise<FirestoreDoc[]> {
+    throw new Error("UNAVAILABLE: the backend is currently unavailable");
+  }
+}
+
 const handleWith = (items: Record<string, number>) => ({ docs: new LiveDocs(items), email: "me@example.com", uid: "uid-me" });
+
+/** What DEPLOY staged for the collections — the half publish promotes, and the
+ *  half this gate must judge (app.json's copy of it is not what goes live). */
+const PROMOTED = { slots: { mirrorOf: "bookings" } };
 const bookingsPath = `apps/${AID}/collections/bookings/items`;
 const slotsPath = `apps/${AID}/collections/slots/items`;
 
@@ -182,7 +197,7 @@ describe("the keys that decide which document a submission claims", () => {
     // First, because every refusal below is only meaningful against a
     // re-publish that must keep working: an app is published again for all
     // sorts of reasons that have nothing to do with its identity keys.
-    const problems = await frozenKeyProblems(salon(), live, handleWith({ [bookingsPath]: 12 }));
+    const problems = await frozenKeyProblems(salon(), PROMOTED, live, handleWith({ [bookingsPath]: 12 }));
     expect(problems).toEqual([]);
   });
 
@@ -192,7 +207,7 @@ describe("the keys that decide which document a submission claims", () => {
     const moved = salon({
       public: { ...live.public, submit: { bookings: { ...live.public.submit.bookings, idField: "slotId" } } },
     });
-    const problems = await frozenKeyProblems(moved, live, handleWith({}));
+    const problems = await frozenKeyProblems(moved, PROMOTED, live, handleWith({}));
     expect(problems).toEqual([]);
   });
 
@@ -203,7 +218,7 @@ describe("the keys that decide which document a submission claims", () => {
     const moved = salon({
       public: { ...live.public, submit: { bookings: { ...live.public.submit.bookings, idField: "slotId" } } },
     });
-    const problems = await frozenKeyProblems(moved, live, handleWith({ [bookingsPath]: 3 }));
+    const problems = await frozenKeyProblems(moved, PROMOTED, live, handleWith({ [bookingsPath]: 3 }));
     expect(problems.join(" ")).toContain("idField: slot → slotId");
     expect(problems.join(" ")).toContain("not something `confirm` overrides");
   });
@@ -215,7 +230,7 @@ describe("the keys that decide which document a submission claims", () => {
         submit: { bookings: { ...live.public.submit.bookings, idIn: { collection: "chairs" } } },
       },
     });
-    const problems = await frozenKeyProblems(moved, live, handleWith({ [bookingsPath]: 1 }));
+    const problems = await frozenKeyProblems(moved, PROMOTED, live, handleWith({ [bookingsPath]: 1 }));
     expect(problems.join(" ")).toContain("idIn:");
   });
 
@@ -229,10 +244,10 @@ describe("the keys that decide which document a submission claims", () => {
         submit: { bookings: { ...live.public.submit.bookings, mirror: undefined } },
       },
     });
-    expect((await frozenKeyProblems(withoutMirror, live, handleWith({ [bookingsPath]: 1 }))).join(" ")).toContain("mirror: slots → (absent)");
+    expect((await frozenKeyProblems(withoutMirror, PROMOTED, live, handleWith({ [bookingsPath]: 1 }))).join(" ")).toContain("mirror: slots → (absent)");
 
-    const withoutMirrorOf = salon({ collections: { slots: {} } });
-    expect((await frozenKeyProblems(withoutMirrorOf, live, handleWith({ [slotsPath]: 8 }))).join(" ")).toContain("mirrorOf: bookings → (absent)");
+    // The collection half comes from what DEPLOY staged, not from app.json.
+    expect((await frozenKeyProblems(salon(), { slots: {} }, live, handleWith({ [slotsPath]: 8 }))).join(" ")).toContain("mirrorOf: bookings → (absent)");
   });
 
   it("reads a reordered declaration as the same declaration", async () => {
@@ -250,14 +265,35 @@ describe("the keys that decide which document a submission claims", () => {
         },
       },
     });
-    const problems = await frozenKeyProblems(reordered, live, handleWith({ [bookingsPath]: 5 }));
+    const problems = await frozenKeyProblems(reordered, PROMOTED, live, handleWith({ [bookingsPath]: 5 }));
     expect(problems).toEqual([]);
+  });
+
+  it("judges the STAGED mirror, not the one in app.json", async () => {
+    // Deploy a changed mirror, revert the key locally, publish: the manifest
+    // agrees with the live document while the promotion does not, so a gate
+    // reading app.json would see nothing at all.
+    const problems = await frozenKeyProblems(salon(), { slots: { mirrorOf: "somewhere-else" } }, live, handleWith({ [slotsPath]: 2 }));
+    expect(problems.join(" ")).toContain("mirrorOf: bookings → somewhere-else");
+  });
+
+  it("refuses when it cannot tell whether anything is held", async () => {
+    // A failed listing is not an empty collection. Treating it as one lets a
+    // changed identity key through on a transient error and strands every
+    // existing claim — and the migration scan cannot cover for it, being a
+    // separate read that may have succeeded a moment earlier.
+    const moved = salon({
+      public: { ...live.public, submit: { bookings: { ...live.public.submit.bookings, idField: "slotId" } } },
+    });
+    const problems = await frozenKeyProblems(moved, PROMOTED, live, { docs: new UnreadableDocs(), email: "me@example.com", uid: "uid-me" });
+    expect(problems.join(" ")).toContain("could not be read");
+    expect(problems.join(" ")).toContain("not something `confirm` overrides");
   });
 
   it("says nothing about a FIRST publish", async () => {
     // There is no live declaration to have moved away from, and the app
     // document does not exist yet.
-    const problems = await frozenKeyProblems(salon(), null, handleWith({}));
+    const problems = await frozenKeyProblems(salon(), PROMOTED, null, handleWith({}));
     expect(problems).toEqual([]);
   });
 });

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -8,7 +8,7 @@
 // visitor "there is nothing here"; an id space that moved leaves old records
 // holding nothing, in an app that goes on working.
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { AuthoredApp, FirestoreDoc, FirestoreDocs } from "@mulmoclaude/core/collection/server";
 import { readPublicViewFile, viewDocumentBytes } from "../../../server/backends/sharedApp/publicView.js";
@@ -95,6 +95,18 @@ describe("the file a published view names", () => {
     const result = await readPublicViewFile(root, { path: "views/leak.html" }, STAMP);
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.problems.join(" ")).toContain("resolves outside this repository");
+  });
+
+  it("refuses, rather than throwing, when the file goes between stat and read", async () => {
+    // A delete or a permission change in that window. The gate's contract is
+    // problems and no writes; a rejection escaping it would surface as an
+    // exception out of publish, which is the one shape callers do not handle.
+    const declared = withView(root, "<p>here for now</p>");
+    chmodSync(path.join(root, "views", "booking.html"), 0o000);
+    const result = await readPublicViewFile(root, { path: declared }, STAMP);
+    chmodSync(path.join(root, "views", "booking.html"), 0o644);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("could not be read");
   });
 
   it("takes a page that only mentions the PUBLIC bridge", async () => {

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node
+//
+// The page a published app shows instead of the generated form, and the keys
+// that must not move once anything has claimed a document.
+//
+// Both are gates: they refuse before the first write, because everything they
+// guard against is invisible afterwards. A view that cannot be drawn shows a
+// visitor "there is nothing here"; an id space that moved leaves old records
+// holding nothing, in an app that goes on working.
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { AuthoredApp, FirestoreDoc, FirestoreDocs } from "@mulmoclaude/core/collection/server";
+import { readPublicViewFile, viewDocumentBytes } from "../../../server/backends/sharedApp/publicView.js";
+import { frozenKeyProblems } from "../../../server/backends/sharedApp/exclusivity.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const AID = "11111111-2222-3333-4444-555555555555";
+const STAMP = 1_700_000_000_000;
+
+const withView = (root: string, html: string): string => {
+  mkdirSync(path.join(root, "views"), { recursive: true });
+  writeFileSync(path.join(root, "views", "booking.html"), html);
+  return "views/booking.html";
+};
+
+describe("the file a published view names", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTempDir("mt-public-view-");
+  });
+
+  it("is read from the repository root, where app.json is", async () => {
+    // `public.view` is declared in `app.json`, which sits at the root, so a
+    // path written there is relative to it. Resolving inside a collection's
+    // skill folder would ask which collection owns a page belonging to the
+    // whole app — a question an app with three of them cannot answer.
+    const declared = withView(root, "<div id='grid'></div>");
+    const result = await readPublicViewFile(root, { path: declared }, STAMP);
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.view.html).toContain("<div id='grid'></div>");
+  });
+
+  it("refuses a path that names nothing", async () => {
+    // The failure it prevents is silent: the page renders, the HTML is empty,
+    // and the visitor is told there is nothing here.
+    const result = await readPublicViewFile(root, { path: "views/missing.html" }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("does not exist in this repository");
+  });
+
+  it("refuses a page written against the HOST's bridge", async () => {
+    // `__MC_VIEW` is the collection pane's contract, where a view holds a
+    // capability token and fetches its own data. The public page has neither,
+    // so this would publish cleanly and render blank.
+    const declared = withView(root, "<script>const t = window.__MC_VIEW.token;</script>");
+    const result = await readPublicViewFile(root, { path: declared }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("HOST's custom-view contract");
+  });
+
+  it("refuses a page too large to be a Firestore document", async () => {
+    // The limit is per DOCUMENT, so what is measured is the document — field
+    // names and UTF-8 lengths included. Measuring the file would be measuring
+    // the wrong thing, and the answer arrives as a refused write.
+    const declared = withView(root, "x".repeat(950_000));
+    const result = await readPublicViewFile(root, { path: declared }, STAMP);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("as a Firestore document");
+  });
+
+  it("counts the whole document, not just the HTML", () => {
+    const bytes = viewDocumentBytes({ html: "abc", publishedAt: STAMP });
+    expect(bytes).toBeGreaterThan("abc".length);
+  });
+
+  it("takes a page that only mentions the PUBLIC bridge", async () => {
+    // The neighbouring declaration that must still publish — otherwise the
+    // check above is satisfied by refusing everything.
+    const declared = withView(root, "<script>window.__MC_PUBLIC_VIEW.ready();</script>");
+    const result = await readPublicViewFile(root, { path: declared }, STAMP);
+    expect(result.ok).toBe(true);
+  });
+});
+
+/** The app document as Firestore has it, plus whatever records the test says
+ *  the collections hold. */
+class LiveDocs implements FirestoreDocs {
+  constructor(private readonly items: Record<string, number>) {}
+  async list(collectionPath: string): Promise<FirestoreDoc[]> {
+    const held = this.items[collectionPath] ?? 0;
+    return Array.from({ length: held }, (_unused, index) => ({ id: `row-${index}`, data: {} }));
+  }
+  async get(): Promise<unknown | null> {
+    return null;
+  }
+  async set(): Promise<void> {}
+  async create(): Promise<boolean> {
+    return true;
+  }
+  async delete(): Promise<boolean> {
+    return true;
+  }
+  watch(): () => void {
+    return () => {};
+  }
+}
+
+const handleWith = (items: Record<string, number>) => ({ docs: new LiveDocs(items), email: "me@example.com", uid: "uid-me" });
+const bookingsPath = `apps/${AID}/collections/bookings/items`;
+const slotsPath = `apps/${AID}/collections/slots/items`;
+
+const salon = (overrides: Record<string, unknown> = {}): AuthoredApp =>
+  ({
+    aid: AID,
+    members: { "me@example.com": { "*": "owner" } },
+    collections: { slots: { mirrorOf: "bookings" } },
+    public: {
+      enabled: true,
+      read: ["slots"],
+      submit: {
+        bookings: {
+          auth: "verifiedEmail",
+          emailField: "customerEmail",
+          createFields: ["slot", "customerName", "customerEmail", "status"],
+          idFrom: "field",
+          idField: "slot",
+          idIn: { collection: "slots", where: { field: "state", equals: "open" } },
+          mirror: "slots",
+        },
+      },
+    },
+    ...overrides,
+  }) as AuthoredApp;
+
+/** The app document as it stands after a publish of the declaration above. */
+const live = {
+  aid: AID,
+  collections: { slots: { mirrorOf: "bookings" } },
+  public: {
+    enabled: true,
+    read: ["slots"],
+    submit: {
+      bookings: {
+        auth: "verifiedEmail",
+        emailField: "customerEmail",
+        createFields: ["slot", "customerName", "customerEmail", "status"],
+        idFrom: "field",
+        idField: "slot",
+        idIn: { collection: "slots", where: { field: "state", equals: "open" } },
+        mirror: "slots",
+      },
+    },
+  },
+};
+
+describe("the keys that decide which document a submission claims", () => {
+  it("lets an unchanged declaration through, records or no records", async () => {
+    // First, because every refusal below is only meaningful against a
+    // re-publish that must keep working: an app is published again for all
+    // sorts of reasons that have nothing to do with its identity keys.
+    const problems = await frozenKeyProblems(salon(), live, handleWith({ [bookingsPath]: 12 }));
+    expect(problems).toEqual([]);
+  });
+
+  it("lets them move while nothing has been claimed", async () => {
+    // An empty collection has no rows whose claim could be stranded, which is
+    // exactly the window an author fixes a mistake in.
+    const moved = salon({
+      public: { ...live.public, submit: { bookings: { ...live.public.submit.bookings, idField: "slotId" } } },
+    });
+    const problems = await frozenKeyProblems(moved, live, handleWith({}));
+    expect(problems).toEqual([]);
+  });
+
+  it("refuses moving the field the id is built from", async () => {
+    // Every existing booking would stop holding the slot it was written for —
+    // and that slot becomes bookable again by somebody else, while the
+    // original booking sits there looking valid.
+    const moved = salon({
+      public: { ...live.public, submit: { bookings: { ...live.public.submit.bookings, idField: "slotId" } } },
+    });
+    const problems = await frozenKeyProblems(moved, live, handleWith({ [bookingsPath]: 3 }));
+    expect(problems.join(" ")).toContain("idField: slot → slotId");
+    expect(problems.join(" ")).toContain("not something `confirm` overrides");
+  });
+
+  it("refuses moving where the claimed record must be found", async () => {
+    const moved = salon({
+      public: {
+        ...live.public,
+        submit: { bookings: { ...live.public.submit.bookings, idIn: { collection: "chairs" } } },
+      },
+    });
+    const problems = await frozenKeyProblems(moved, live, handleWith({ [bookingsPath]: 1 }));
+    expect(problems.join(" ")).toContain("idIn:");
+  });
+
+  it("refuses dropping the mirror from either side", async () => {
+    // Half a mirror is the failure the pair exists to prevent: a staff delete
+    // consults the new destination, so the old slot is never returned to
+    // `open` and is unsellable for good.
+    const withoutMirror = salon({
+      public: {
+        ...live.public,
+        submit: { bookings: { ...live.public.submit.bookings, mirror: undefined } },
+      },
+    });
+    expect((await frozenKeyProblems(withoutMirror, live, handleWith({ [bookingsPath]: 1 }))).join(" ")).toContain("mirror: slots → (absent)");
+
+    const withoutMirrorOf = salon({ collections: { slots: {} } });
+    expect((await frozenKeyProblems(withoutMirrorOf, live, handleWith({ [slotsPath]: 8 }))).join(" ")).toContain("mirrorOf: bookings → (absent)");
+  });
+
+  it("says nothing about a FIRST publish", async () => {
+    // There is no live declaration to have moved away from, and the app
+    // document does not exist yet.
+    const problems = await frozenKeyProblems(salon(), null, handleWith({}));
+    expect(problems).toEqual([]);
+  });
+});

--- a/test/server/backends/sharedApp.spec.ts
+++ b/test/server/backends/sharedApp.spec.ts
@@ -326,7 +326,16 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(result.ok).toBe(true);
     expect(result.ok === true && result.publicOpen).toBe(true);
     // Promotion first, the projection next, and the authorization at the very end.
-    expect(docs.writes).toEqual([`set apps/${AID}/collections/bookings`, `set apps/${AID}/config/public`, `set apps/${AID}`, `set apps/${AID}`]);
+    // The `delete` is unconditional and that is the point: `config/{docId}` is world-readable
+    // forever, so a view withdrawn from the declaration and merely not rewritten stays fetchable.
+    // An app that never had one pays one idempotent delete for the guarantee.
+    expect(docs.writes).toEqual([
+      `set apps/${AID}/collections/bookings`,
+      `set apps/${AID}/config/public`,
+      `delete apps/${AID}/config/view`,
+      `set apps/${AID}`,
+      `set apps/${AID}`,
+    ]);
     expect(docs.doc(`apps/${AID}/collections`, "bookings")).toMatchObject({ publishedBy: OWNER.email });
     expect(docs.app()?.public).toMatchObject({ enabled: true });
   });
@@ -378,7 +387,8 @@ describe("shared app deploy / publish / unpublish", () => {
 
     const result = await unpublishSharedApp(root);
     expect(result.ok === true && result.wasOpen).toBe(true);
-    expect(docs.writes).toEqual([`set apps/${AID}`, `delete apps/${AID}/config/public`]);
+    // The page comes down with the settings, for the reason the publish above deletes it.
+    expect(docs.writes).toEqual([`set apps/${AID}`, `delete apps/${AID}/config/public`, `delete apps/${AID}/config/view`]);
     expect(docs.app()).not.toHaveProperty("public");
     // Nobody can read them while the app is closed, so they cost nothing — and re-publishing is
     // then a promotion rather than a rebuild.
@@ -492,6 +502,7 @@ describe("shared app deploy / publish / unpublish", () => {
     expect(docs.writes).toEqual([
       `set apps/${AID}/collections/bookings`,
       `set apps/${AID}/config/public`,
+      `delete apps/${AID}/config/view`,
       `set apps/${AID}`,
       "set appSlugs/sakura-hair",
       `set apps/${AID}`,
@@ -501,7 +512,7 @@ describe("shared app deploy / publish / unpublish", () => {
     await unpublishSharedApp(root);
     expect(docs.doc("appSlugs", "sakura-hair")).toEqual({ aid: AID, published: false });
     // Reversed: what grants is taken away first.
-    expect(docs.writes).toEqual([`set apps/${AID}`, "set appSlugs/sakura-hair", `delete apps/${AID}/config/public`]);
+    expect(docs.writes).toEqual([`set apps/${AID}`, "set appSlugs/sakura-hair", `delete apps/${AID}/config/public`, `delete apps/${AID}/config/view`]);
   });
 
   it("publishes the form the public page draws from", async () => {

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -63,7 +63,7 @@ function problemsFor(file: string, owner: string, extraCids: readonly string[]) 
 
 describe("the shared-app templates", () => {
   it("salon.md deploys as written", () => {
-    expect(problemsFor("salon.md", "owner@salon.jp", ["stylists", "services", "shifts"])).toEqual([]);
+    expect(problemsFor("salon.md", "owner@salon.jp", ["stylists", "services"])).toEqual([]);
   });
 
   it("gym.md deploys as written", () => {
@@ -73,7 +73,7 @@ describe("the shared-app templates", () => {
   it("each template shows every collection whose shape carries a decision", () => {
     // A guard on the guard: if a template stopped showing its schemas the
     // checks above would still pass, against nothing.
-    expect([...blocksOf("salon.md").keys()]).toContain(".claude/skills/bookings/schema.json");
+    expect([...blocksOf("salon.md").keys()]).toEqual(expect.arrayContaining([".claude/skills/bookings/schema.json", ".claude/skills/slots/schema.json"]));
     expect([...blocksOf("gym.md").keys()]).toEqual(expect.arrayContaining([".claude/skills/classes/schema.json", ".claude/skills/bookings/schema.json"]));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,10 +1897,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/common/-/common-1.2.0.tgz#ad2d696a6a06ea47c078e45d8d7f6f41b53d4aeb"
   integrity sha512-Y459jz/3fGY+QPSOtRUpq+JA1v839qlhaKmuz6LohoJp0nneP9Eot+gsn7Yl8RKhEGqxhfmJaCDa28bWK7RhCA==
 
-"@mulmoclaude/core@3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.12.0.tgz#0344e1ce8b92a4f276e37fa2b260532336ce8133"
-  integrity sha512-zrT17cW1kZ0p2EqKDgaUVI7GUx05WbTx8Dq+RhmnXgEBwS5ysZlJs1e14KXPSPxPQ86ogHZ2/bVf7iElj0J4KA==
+"@mulmoclaude/core@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-3.13.0.tgz#1ee5af942f80c44d93642d0adbf502b535cf6239"
+  integrity sha512-i9NsMdptZk8gM2sWNdmnaQpYSw+YQAtqmp1GvPwIZ6kx5gme67irWNhzN8Hh0FoAIMOXPl4lChqiFqx+xpYaFg==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"


### PR DESCRIPTION
`plans/feat-shared-app-public-view.md` の **MulmoTerminal 側**。これで 3 つとも揃います
（ルール = mulmoserver #164 deploy 済み、宣言 = core 3.13.0 公開済み、
ランタイム = mulmoserver #165 マージ済み）。

`@mulmoclaude/core` **3.12.0 → 3.13.0**。

## `config/view` の書き出しと、**撤去**

`public.view` があればページの HTML を `apps/{aid}/config/view` へ、`config/public` と
**同じ `publishedAt`** で書きます（ランタイムは版が食い違う組み合わせを描きません。
2 つは別の write で、publish は途中で止まりうるので）。

無ければ **消す**。ここは注意ではなく仕様です — `config/{docId}` は
`allow read: if true` なので、宣言から外して「書かないだけ」にすると、撤去したはずの
ページが誰でも取り出せるまま残ります。unpublish も同じ理由で消します。

publish のたびに 1 回の idempotent な delete を払いますが、その保証のためです。

## publish 前の検査

最初の write より前に。スキーマを promote してからでは取り返せないので。

| | なぜ |
|---|---|
| パスの実在 | 無ければ訪問者は「ここには何もありません」を見る。エラーはどこにも出ない |
| 1 MiB | 測るのは**ドキュメント**であってファイルではない（フィールド名も UTF-8 長も入る）。余白は測り間違いの分ではなく、余白 |
| `__MC_VIEW` の拒否 | あれはホスト側の契約で、公開ページにはトークンも `dataUrl` も無い。通せば真っ白なページが理由も無く出る |

パスは **リポジトリの root から**解決します（`app.json` がそこにあるので）。
コレクションの skill フォルダ内にしなかったのは、「アプリ全体のページはどのコレクションの
ものか」に答えが無いからです。

## 排他のキーの凍結（`exclusivity.ts`）

`idFrom` / `idField` / `idIn` / `mirror` / `mirrorOf` は、**対象コレクションに 1 行でも
あれば変えられません**。

`confirm` は効きません。記録の門の confirm は「これらの行が新しいスキーマに合わないと
分かって書く」— 見えている breakage です。ここで壊れるのは**排他の保証**で、
アプリは動いたまま、過去の予約が押さえていたはずの枠を押さえなくなり、**誰にも見えない**。
前に進む道はコレクションを空にするか、新しい cid で作り直すことです。

ルールには見えません（1 回の write しか見られず、過去の行を走査できない）。だから門の側に、
移行の走査の隣に置いています — 同じレコードについての、隣の質問なので。

## salon テンプレート

`slots` を実在させ、予約の id を枠の id にしました。公開するのは **`slots` だけ**で、
`bookings` は入れません（Firestore はフィールドを隠せないので、入れた瞬間に客の連絡先が
匿名の訪問者に全部渡る）。`views/booking.html` の例と、公開 bridge の 3 つの約束
（`ready()` を最後に / `submit()` の結果を見る / `customerEmail` は送らない）。

**利用者に先に言うこと** 3 点も gym.md と同じ位置に置きました:
公開されるのは枠だけ / 繰り上げは起きない / **客のキャンセルでは枠は空かない**。
最後のものは、書いていなければバグに見えます。

## 検証

- `yarn test`: **9905 件 pass**（新規 12 件: ビューのファイル検査と凍結の門）
- `yarn lint` / `yarn typecheck --force` / `yarn build`: エラー 0

既存の write 順の期待値を 4 か所更新しています（`config/view` の delete が入るため）。

work in mulmoterminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing optional custom HTML views with size and compatibility validation.
  * Published views are automatically removed when withdrawn or replaced.
  * Added safeguards against changing booking identity and exclusivity settings after records exist.

* **Improvements**
  * Updated the salon booking template to use real-time appointment slots with paired booking updates.
  * Added guidance for slot-based bookings, custom views, deadlines, and cancellation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->