### PR TITLE
docs(plans): 共有アプリのコンパイラを core から出す計画

### DIFF
--- a/plans/refactor-shared-app-module.md
+++ b/plans/refactor-shared-app-module.md
@@ -1,6 +1,8 @@
 # 共有アプリのコンパイラを `receptron/sharedapp` に出す
 
-**状態**: 提案（2026-08-13）。実装は未着手。
+**状態**: **実装済み**（2026-08-13）。`receptron/sharedapp` は作られ、4 リポジトリに
+PR が出ている — sharedapp（`1ece783`、main にマージ済み）、mulmoterminal#1675、
+mulmoclaude#2894、mulmoserver#175。
 [`refactor-shared-app-wire-contract.md`](./refactor-shared-app-wire-contract.md) の**決定 1 を
 差し替える**もの（あちらは射影の書き込み側だけを MT に引き取る案で、実装まで行ったが
 **保留にした** — mulmoclaude#2892 / mulmoterminal#1672 / mulmoserver#174 は draft）。
@@ -149,21 +151,51 @@ lockfile には
 
 0. **[済] スパイク**: `git+file://` の最小モジュールで、MT と MS の両方の
    install / typecheck / test / build が通ることを確認した（決定 3 の表）。
-   残るのは repo を private にするかどうかだけ。
-1. **sharedapp**: 4 ファイル + MT の `appViewProjection.ts` を入れ、テストを移す
+   repo は **public**。
+1. **[済] sharedapp**: 4 ファイル + MT の `appViewProjection.ts` を入れ、テストを移す
    （core の `test_appViews.ts` / `test_publishChecks.ts` などの該当分）。
-2. **core**: 移した分を削り、`index.ts` から外す。`test_sharedHostSurface.ts` は
+2. **[済] core**（mulmoclaude#2894）: 移した分を削り、`index.ts` から外す。`test_sharedHostSurface.ts` は
    「ホストが戻ってこなくて済むか」を測る装置なので、**共有アプリの分が丸ごと減るのが正しい**。
    `@mulmoclaude/core` **4.0.0**（1 回だけのメジャー）。
    同梱プラグイン 7 本の peer が `^3.6.0` なので、**7 本とも major を上げて publish する**
    （mulmoclaude#2892 で判明。レンジを直すだけでは足りない — npm に出ている版が
    `^3.6.0` と言っている以上、strict な peer 解決が新規 install を拒み得る）。
-3. **MT**: import を `@mulmoclaude/core/collection/server` から `sharedapp` に付け替える
+3. **[済] MT**（mulmoterminal#1675）: import を `@mulmoclaude/core/collection/server` から `sharedapp` に付け替える
    （33 シンボル）。`appViewProjection.ts` を消してモジュールを指す。
-4. **mulmoserver**: `rules_publish.ts` と `test_appViewRoundTrip.ts` を `sharedapp` に向ける。
+4. **[済] mulmoserver**（mulmoserver#175）: `rules_publish.ts` と `test_appViewRoundTrip.ts` を `sharedapp` に向ける。
 
 2 と 3 は **1 回の core リリース**を使う（前案と同じ「削るための最後の publish」）。
 以後、`app.json` のキーも publish ゲートも `{tier}/config` も、**core のリリース無しで動く**。
+
+## 実装して分かったこと
+
+**yarn 1 の `github:owner/repo#sha` 短縮形は `prepare` を走らせない。** codeload の
+tarball を取るだけなので、`dist` の無いパッケージが入る（`src/` と `test/` がそのまま
+`node_modules` に置かれ、import が解決できない）。**`git+https://github.com/…​.git#sha`
+と明示すると clone して prepare が走る。** スパイクを `git+file://` でやったせいで
+最初は気づかず、MT に入れて初めて出た。両リポジトリの `package.json` は明示形。
+
+**tsconfig の `moduleResolution` は core と同じ `Bundler` にするしかない。**
+core が配る `.d.ts` は相対 re-export に拡張子が無く、`NodeNext` では解決できない —
+バレルの `export *` が全部消え、`isValidCollectionName` も `CollectionSchema` も
+「そんな export は無い」になる。自分の emit は `src` の import に `.js` を明記して
+あるので、Node からは解ける。
+
+**`CollectionSchemaZ` は `@mulmoclaude/core/collection` からは出ていない**
+（`collection/server` から出ている）。`test_projectDeploy` がそれを使っていた。
+
+**`projectSubmit` を export する話は消えた。** 前案では `tierSubmit` が core に残る
+`projectSubmit` を必要としたので core 側で export したが、スタックごと移したので
+両方とも同じモジュールの中に入り、公開する必要が無くなった。
+
+**MT の PR は core の publish を待たない。** MT は `sharedapp` からしか import しない
+ので、`@mulmoclaude/core` は 3.15.0 のままで動く。core からの削除（4.0.0 +
+プラグイン 7 本）は独立にマージ・publish できる。前案では MT が publish 待ちで
+draft のままだった。
+
+**`test_sharedHostSurface.ts` は 16 シンボル短くなった。** あのファイルは
+「ホストが戻ってこなくて済むか」の帳簿なので、減るのが正しい。併せて
+「コンパイラは戻ってこない」ことを否定テストで固定した。
 
 ## やらないこと
 

--- a/plans/refactor-shared-app-module.md
+++ b/plans/refactor-shared-app-module.md
@@ -1,0 +1,175 @@
+# 共有アプリのコンパイラを `receptron/sharedapp` に出す
+
+**状態**: 提案（2026-08-13）。実装は未着手。
+[`refactor-shared-app-wire-contract.md`](./refactor-shared-app-wire-contract.md) の**決定 1 を
+差し替える**もの（あちらは射影の書き込み側だけを MT に引き取る案で、実装まで行ったが
+**保留にした** — mulmoclaude#2892 / mulmoterminal#1672 / mulmoserver#174 は draft）。
+ゴールデン文書（決定 2・3）はそのまま生きる。
+前提は [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)、
+決定は [`feat-shareable-collections.md`](./feat-shareable-collections.md) の D1–D10。
+
+---
+
+## 何が問題か
+
+**共有アプリの作業をするたびに MulmoClaude をリリースしている。**
+
+過去 90 日で core の共有アプリスタック
+（`publishManifest` / `publishProject` / `publishChecks` / `appViews`）に入った
+コミットは **24 本**。中身はほぼ全部が共有アプリそのものの作業で、
+**その全部が「core を直す → CI → マージ → 人手の npm publish → MT で bump」を通った**。
+
+```
+feat(collections): アプリのページを監査対象ごとに宣言できるようにする
+feat(collections): 行スコープの assignee ロールと、先着枠のための宣言を追加
+feat(collections): app.json が URL 名（slug）を宣言できるようにする
+feat(collections): 枠の排他と、公開ページのビューを宣言できるようにする
+fix (collections): publish が実際に promote する設定を検査する
+… 全 24 本
+```
+
+一番よく通るのは `AuthoredAppZ` — **`app.json` にキーを 1 つ増やすたびに core リリース**。
+`publishChecks.ts` は 90 日で 13 コミット、`publishProject.ts` は 16 コミット。
+
+前案（決定 1）が外せたのはこのうち 5 本程度で、上の 3 つはどれも残っていた。
+**細い 1 本ではなく、スタックごと出す。**
+
+## 先に確かめたこと
+
+**MulmoClaude はこのスタックを 1 行も使っていない。**
+`src/` `server/` を `AuthoredApp` / `projectApp` / `publishProblems` / `AppManifest` で
+grep して **0 件**。core の中でも、この 4 ファイルを import しているのは
+バレル（`index.ts`）だけ（`publishChecks` → `publishProject` の内部 import を除く）。
+
+**共有アプリのパス定数も core の他の場所からは使われていない。**
+`APPS_COLLECTION` / `appStagingPath` / `appConfigPath` / `appSchemasPath` /
+`appSlugDoc` / `appViewTierPath` / `viewDocId` / `viewConfigDocId` /
+`PUBLIC_CONFIG_DOC` を core 全体で grep すると、`publishProject.ts` /
+`appViews.ts` / `index.ts` 以外に出現しない。
+**したがって core → 新モジュールの依存は要らない。** 向きは一方通行になる。
+
+**MT が `collection/server` から使っている 73 シンボルは、きれいに 2 つに割れる。**
+33 が共有アプリのコンパイラ、40 が**コレクションのランタイム**
+（`configureCollectionHost`、`discoverCollections`、`storeFor`、`firestoreHandle`、
+`validateCollectionRecords`、`makeManageCollectionTool` …）。後者は MulmoClaude も使う。
+
+**mulmoserver が値として import している core のシンボルは 2 つだけ。**
+`test/rules/rules_publish.ts` の `AuthoredAppZ` と `projectApp`。
+他は全部 `import type`（`remote-view` / `remote-host`）でビルド時に消える。
+
+---
+
+## 決定 1. 出すのは**コンパイラ**。ランタイムは core に残る
+
+線は「宣言 → Firestore の文書」に引く。
+
+**`receptron/sharedapp` に出す**
+
+| ファイル | 行数 | 中身 |
+| --- | --- | --- |
+| `publishManifest.ts` | 416 | `AuthoredAppZ` — `app.json` が何を宣言できるか |
+| `appViews.ts` | 232 | `views[]` の正規化、参加者の読みスコープ、文書 id |
+| `publishProject.ts` | 551 | `projectApp` / `projectDeploy` / `projectPublish` / `projectSubmit`、パス定数 |
+| `publishChecks.ts` | 1002 | publish が何を拒否するか |
+| （MT の `appViewProjection.ts`） | 349 | 階層ごとの射影。前案で MT に移したもの |
+
+**core に残る** — コレクションのランタイム全部（`host` / `store` / `discovery` /
+`firestoreStore` / `collection-watchers` / `registry`）、`appManifest.ts`
+（`discovery.ts` が使う。90 日で **1 コミット**）、および
+`collectionKey` / `templatePath` / `schema`（core の他の場所に用途があり、動かない）。
+
+## 決定 2. 依存の向きは一方通行。モジュール → core は**動かない側だけ**
+
+新モジュールが core から使うのは 3 つだけ:
+
+- `isValidCollectionName`（`collection/core/collectionKey`）
+- `isSafeCustomViewPath`（`collection/core/templatePath`）
+- `CollectionSchema` / `CollectionFieldSpec`（型のみ）
+
+**これらを持ってこないこと。** どれも core の他の場所（`schemaZ`、`reconciler`、
+`skill-bridge`）が使っていて、持ってくると core → モジュール → core になる。
+複製もしない — 同じ検証が 2 つあるのは、まさに逃げたい種類の食い違い。
+
+**モジュールが core に依存しても目的は達成される。** 目的は
+「共有アプリの作業で MulmoClaude をリリースしない」であって「依存をゼロにする」ではない。
+モジュールは core を古いバージョンで固定したまま、`app.json` にキーを足し続けられる。
+
+`@mulmoclaude/common` の `isRecord` は 1 行なので、モジュール内に置いて依存を 1 つ減らす。
+
+## 決定 3. 配布は **git ref**。npm を通さない
+
+```json
+"receptron/sharedapp": "github:receptron/sharedapp#<sha>"
+```
+
+npm を通すと、逃げたはずの**人手の publish ゲートが戻ってくる**。
+**mulmoclaude の monorepo には置かない**（同じ理由でリリースを相続する）。
+**MT のモノレポ化もしない** — mulmoserver が `github:receptron/mulmoterminal#sha` を
+引くと、MT の CLI 全体が MS の dev ツリーに入る。
+
+名前に `mulmo` スコープを付けない。MulmoClaude のものではないことを名前で示す。
+
+**先に確かめること（スパイク）**: git 依存は**ビルド済み JS を配る**必要がある。
+yarn 1（MT）も vite（MS）も、`node_modules` の生 TS を素通しはしない。
+yarn は git 依存の `prepare` を install 時に走らせるので、そこで `tsc` すれば足りる
+はずだが、**MT（yarn 1.22）と MS（vite + vue-tsc）の両方で実際に通ることを、
+中身を移す前に空のモジュールで確かめる。** ここが通らないなら決定 3 を作り直す。
+
+## 決定 4. ゴールデン文書は残す。ただし役割が変わる
+
+[前案の決定 2・3](./refactor-shared-app-wire-contract.md) で作った
+`test/fixtures/sharedAppGolden/` は残す。**ただし mulmoserver は射影器を直接呼べる
+ようになる**ので、mulmoserver 側は「文書を読む」形に固定しなくてよくなり、
+**#1673 の手コピー問題は消える**。
+
+- MT: ゴールデンを再生成して diff（**残す** — 文書の形が変わったことを diff で見せる装置は、
+  依存の有無と関係なく有用）
+- mulmoserver: `projectAppViews` をモジュールから呼んで `writeOf` / `capabilitiesFor` に
+  食わせる（**#173 の元の形に戻す**）
+- mulmoserver `rules_publish.ts`: `projectApp` をモジュールから呼ぶ。**今のまま**
+
+---
+
+## リポジトリ横断と依存順
+
+0. **スパイク**: 空の `receptron/sharedapp` を作り、MT と MS の両方から git ref で
+   install してビルドが通ることを確かめる。**ここが最初。**
+1. **sharedapp**: 4 ファイル + MT の `appViewProjection.ts` を入れ、テストを移す
+   （core の `test_appViews.ts` / `test_publishChecks.ts` などの該当分）。
+2. **core**: 移した分を削り、`index.ts` から外す。`test_sharedHostSurface.ts` は
+   「ホストが戻ってこなくて済むか」を測る装置なので、**共有アプリの分が丸ごと減るのが正しい**。
+   `@mulmoclaude/core` **4.0.0**（1 回だけのメジャー）。
+   同梱プラグイン 7 本の peer が `^3.6.0` なので、**7 本とも major を上げて publish する**
+   （mulmoclaude#2892 で判明。レンジを直すだけでは足りない — npm に出ている版が
+   `^3.6.0` と言っている以上、strict な peer 解決が新規 install を拒み得る）。
+3. **MT**: import を `@mulmoclaude/core/collection/server` から `sharedapp` に付け替える
+   （33 シンボル）。`appViewProjection.ts` を消してモジュールを指す。
+4. **mulmoserver**: `rules_publish.ts` と `test_appViewRoundTrip.ts` を `sharedapp` に向ける。
+
+2 と 3 は **1 回の core リリース**を使う（前案と同じ「削るための最後の publish」）。
+以後、`app.json` のキーも publish ゲートも `{tier}/config` も、**core のリリース無しで動く**。
+
+## やらないこと
+
+- **ランタイムは動かさない。** `host.ts` / `store.ts` / `discovery.ts` /
+  `firestoreStore.ts` / `firestoreDocs.ts` は MulmoClaude も使う汎用のコレクション機構。
+- **`appManifest.ts` は動かさない。** `discovery.ts` が使っていて、churn しない。
+- **`collectionKey` / `templatePath` / `schema` は動かさない・複製しない**（決定 2）。
+- **mulmoserver → MulmoTerminal の依存は作らない。**
+- **MulmoClaude アプリ（`src/` / `server/`）には何も足さない・引かない。**
+  変わるのは同居している `packages/core` だけ。
+- **MT の core 依存全体を減らそうとしない。** MT は core の 21 サブパス
+  （wiki / scheduler / google / feeds / notifier / remote-host …）に乗っていて、
+  それは意図した設計。この計画が外すのは共有アプリの分だけ。
+
+## 開いている問い
+
+- **スパイクが通らなかったら。** git ref でビルド済みを配れないなら、
+  選択肢は (a) dist をリポジトリにコミットする、(b) npm に出す（publish ゲートが戻る）、
+  (c) MT に取り込んで mulmoserver は文書だけ読む（前案の形に戻る）。
+- **`sharedapp` 自体のバージョニング**: sha 固定か tag か。tag だと「リリース」が
+  復活しかねない。
+- **`sharedapp` の CI**: core のテストを移すので node:test をそのまま使えるが、
+  MT（vitest）と MS（node:test）のどちらの流儀に寄せるか。
+- **`PublishStamp` の置き場所**。今は `publishProject.ts` にあり、MT の deploy/publish が
+  作って渡す。モジュールの入口の型なので一緒に出るが、MT 側の型と重ならないか確認する。

--- a/plans/refactor-shared-app-module.md
+++ b/plans/refactor-shared-app-module.md
@@ -109,11 +109,26 @@ npm を通すと、逃げたはずの**人手の publish ゲートが戻って�
 
 名前に `mulmo` スコープを付けない。MulmoClaude のものではないことを名前で示す。
 
-**先に確かめること（スパイク）**: git 依存は**ビルド済み JS を配る**必要がある。
-yarn 1（MT）も vite（MS）も、`node_modules` の生 TS を素通しはしない。
-yarn は git 依存の `prepare` を install 時に走らせるので、そこで `tsc` すれば足りる
-はずだが、**MT（yarn 1.22）と MS（vite + vue-tsc）の両方で実際に通ることを、
-中身を移す前に空のモジュールで確かめる。** ここが通らないなら決定 3 を作り直す。
+**スパイク済み（2026-08-13）— 両方で通った。**
+`zod` を持つ最小モジュールをローカル git リポジトリにして、`prepare: tsc` を置き、
+`git+file://…#<sha>` で両リポジトリに install した。
+
+| | MulmoTerminal（yarn 1.22） | mulmoserver（vite + vue-tsc） |
+| --- | --- | --- |
+| install で `prepare` が走り `dist` が出る | 通る | 通る |
+| `--frozen-lockfile` でも `prepare` が走る | — | 通る（`Building fresh packages...`） |
+| 型が越える（`z.infer` 込み） | `vue-tsc -b` 通る | `tsc -p test/tsconfig.json` 通る |
+| 実行できる | vitest / tsx 通る | `node:test`（tsx）通る |
+| 本番ビルド | `vite build` 通る | `vue-tsc && vite build` 通る |
+| 推移的依存（`zod`）が解決される | 通る | 通る |
+
+lockfile には
+`"sharedapp@git+file://…#<sha>": resolved "…#<sha>"` と sha 付きで固定される。
+`files: ["dist"]` で `dist` だけが配られることも確認した。
+
+**残る 1 点**: 検証は `git+file://` で行った。CI が `github:receptron/sharedapp#sha` を
+引く場合、**repo が private だと認証情報が要る**（公開なら不要）。ここは repo を
+作るときに決める。
 
 ## 決定 4. ゴールデン文書は残す。ただし役割が変わる
 
@@ -132,8 +147,9 @@ yarn は git 依存の `prepare` を install 時に走らせるので、そこ�
 
 ## リポジトリ横断と依存順
 
-0. **スパイク**: 空の `receptron/sharedapp` を作り、MT と MS の両方から git ref で
-   install してビルドが通ることを確かめる。**ここが最初。**
+0. **[済] スパイク**: `git+file://` の最小モジュールで、MT と MS の両方の
+   install / typecheck / test / build が通ることを確認した（決定 3 の表）。
+   残るのは repo を private にするかどうかだけ。
 1. **sharedapp**: 4 ファイル + MT の `appViewProjection.ts` を入れ、テストを移す
    （core の `test_appViews.ts` / `test_publishChecks.ts` などの該当分）。
 2. **core**: 移した分を削り、`index.ts` から外す。`test_sharedHostSurface.ts` は
@@ -164,9 +180,10 @@ yarn は git 依存の `prepare` を install 時に走らせるので、そこ�
 
 ## 開いている問い
 
-- **スパイクが通らなかったら。** git ref でビルド済みを配れないなら、
-  選択肢は (a) dist をリポジトリにコミットする、(b) npm に出す（publish ゲートが戻る）、
-  (c) MT に取り込んで mulmoserver は文書だけ読む（前案の形に戻る）。
+- **`receptron/sharedapp` を public にするか private にするか。** private なら
+  両リポジトリの CI に GitHub の認証情報が要る（`git+ssh` かトークン）。
+  public なら何も要らない。中身は共有アプリの宣言スキーマとコンパイラで、
+  秘密は含まない。
 - **`sharedapp` 自体のバージョニング**: sha 固定か tag か。tag だと「リリース」が
   復活しかねない。
 - **`sharedapp` の CI**: core のテストを移すので node:test をそのまま使えるが、

--- a/plans/refactor-shared-app-module.md
+++ b/plans/refactor-shared-app-module.md
@@ -98,13 +98,33 @@ grep して **0 件**。core の中でも、この 4 ファイルを import し�
 
 `@mulmoclaude/common` の `isRecord` は 1 行なので、モジュール内に置いて依存を 1 つ減らす。
 
-## 決定 3. 配布は **git ref**。npm を通さない
+## 決定 3. 配布は **npm**（`@receptron/sharedapp`）
+
+**当初「git ref、npm を通さない」と決め、そう実装した。撤回する。**
+
+理由は MulmoTerminal 自身が **npm パッケージ**であること（`npx mulmoterminal`、4.8.2）。
+published tarball に `server/` を含み、そこがこのモジュールを**実行時に** import する。
+git 依存にすると、**エンドユーザー全員がこのリポジトリを clone して `tsc` を走らせてから**
+ターミナルが起動する。git とツールチェーンが要り、遅く、ネットワーク次第で失敗する。
+`dependencies` に入れた時点でそうなることを、決定を書くときに確かめていなかった。
+
+**ただし置き換わるゲートは、逃げようとしたゲートとは別物。** ここのリリースは
+**1 パッケージ**で、bump する依存も、プラグインの peer レンジも、changelog チェックも
+e2e も無い。`@mulmoclaude/core` のリリースは 8 パッケージと CI マトリクス全部で、
+`app.json` のキー 1 つごとにそれを払っていた。
+
+**mulmoclaude の monorepo には置かない**（そのリリースを相続するため）。
+**MT のモノレポ化もしない** — mulmoserver が MT の CLI 全体を dev ツリーに引く。
+
+### 旧・決定 3（git ref）のスパイク結果
 
 ```json
-"receptron/sharedapp": "github:receptron/sharedapp#<sha>"
+"@receptron/sharedapp": "^0.1.0"
 ```
 
-npm を通すと、逃げたはずの**人手の publish ゲートが戻ってくる**。
+git ref のときの検証は下に残す。**yarn 1 の `github:owner/repo#sha` 短縮形は
+`prepare` を走らせず、`dist` の無いパッケージが入る**（`git+https://…​.git#sha` と
+明示すれば clone して走る）という発見は、将来 git 依存を使うときのために有用。
 **mulmoclaude の monorepo には置かない**（同じ理由でリリースを相続する）。
 **MT のモノレポ化もしない** — mulmoserver が `github:receptron/mulmoterminal#sha` を
 引くと、MT の CLI 全体が MS の dev ツリーに入る。
@@ -168,6 +188,11 @@ lockfile には
 以後、`app.json` のキーも publish ゲートも `{tier}/config` も、**core のリリース無しで動く**。
 
 ## 実装して分かったこと
+
+**配布を npm に変えた。決定 3 を参照** — MulmoTerminal 自身が npm パッケージで、
+published tarball の `server/` がこれを実行時に import する。git 依存だと
+`npx mulmoterminal` のたびに clone + `tsc` が走る。`dependencies` に入れた時点で
+そうなることを、決定を書くときに確かめていなかった。
 
 **yarn 1 の `github:owner/repo#sha` 短縮形は `prepare` を走らせない。** codeload の
 tarball を取るだけなので、`dist` の無いパッケージが入る（`src/` と `test/` がそのまま

--- a/plans/refactor-shared-app-wire-contract.md
+++ b/plans/refactor-shared-app-wire-contract.md
@@ -1,0 +1,238 @@
+# 共有アプリ: 射影を MulmoTerminal に引き取り、ワイヤ契約を独立させる
+
+**状態**: **決定 1 は差し替え、決定 2・3 は生きている**（2026-08-13）。
+
+決定 1（射影の書き込み側だけを MT に引き取る）は実装まで行ったが、**範囲が狭すぎた**。
+数え直すと、過去 90 日で core の共有アプリスタックに入った 24 コミットのうち、
+この案が外せるのは 5 本程度で、一番よく通る `AuthoredAppZ`（`app.json` にキーを 1 つ
+足すたびに core リリース）と `publishChecks` は残っていた。
+**スタックごと出す**形に広げたのが [`refactor-shared-app-module.md`](./refactor-shared-app-module.md)。
+3 本の PR（mulmoclaude#2892 / mulmoterminal#1672 / mulmoserver#174）は **draft に戻して保留**。
+
+決定 2・3（ワイヤ契約をゴールデン文書で固定する）はそのまま生きている。
+ただし新モジュールができると mulmoserver が射影器を直接呼べるので、**#1673 の
+手コピー問題は消える**（新計画の決定 4）。
+
+以下は当時の記録として残す。
+
+**（以下、旧記述）** **決定 1 は実装済み**（2026-08-13）。射影の書き込み側は MulmoTerminal
+`server/backends/sharedApp/appViewProjection.ts` に移り、core からは消えた
+（mulmoclaude PR / `@mulmoclaude/core@4.0.0`、MT PR）。
+**決定 2・3（ワイヤ契約 = ゴールデン文書）も入った**が、**独立リポジトリにはしていない**
+（決定 4 は保留）。同じ 3 ファイルを両リポジトリに置き、それぞれのテストが生成側 /
+消費側から突く形にした。複製の同期の仕方は **#1673** で決める。
+[`feat-shared-app-member-write.md`](./feat-shared-app-member-write.md) を出した直後の
+振り返りから出た。前提は [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)、
+決定は [`feat-shareable-collections.md`](./feat-shareable-collections.md) の D1–D10。
+
+---
+
+## 何が問題か
+
+`{tier}/config` の射影を 1 フィールド増やすのに、3 リポジトリと **npm publish の
+人間ゲート**を通る。直近の `writers` / `rowWriters` はこうだった:
+
+1. mulmoclaude#2891 で `@mulmoclaude/core` を直す → CI → マージ → **npm に publish**
+2. mulmoterminal で core を bump
+3. mulmoserver は読み手を手で書く
+
+publish は人の操作なので、2 と 3 は「待ち」になる。しかも `publishProject.ts` は
+直近 60 日で 15 コミットあり、この経路は**今後も繰り返し通る**。
+
+## 先に確かめたこと
+
+計画の形はここで決まった。当初「MulmoClaude も同じドキュメントを書くので分けられない」
+と考えていたが、**二重に誤り**だった。
+
+**MulmoClaude は共有コレクションを書かない。**
+`projectApp` / `projectAppViews` の呼び出しは `packages/core` の外に 1 件も無い
+（あるのは core 自身のテストだけ）。core 自身がそう書いている —
+`packages/core/test/collection/test_sharedHostSurface.ts` の冒頭:
+
+> Shared collections are hosted by MulmoTerminal, which owns the operations
+> (deploy / publish / unpublish), their write ORDER, and the tool the agent calls.
+> This package owns the pure parts.
+
+**MulmoClaude は読みもしない。**
+`setSharedCollectionsSupport(true)` を本番で呼ぶのは
+`server/backends/sharedCollections.ts:36`（MT）だけで、mulmoclaude 側の出現は全部テスト。
+既定は false、`discovery.ts:141` はその時点で共有コレクションを **refuse** する
+（skip ではなく理由付きで拒否）。したがって `uiHost.ts` の `collection:app/<aid>/<cid>`
+購読は MulmoClaude では `appId` が届かず、死んだ枝でいる。
+
+**rules のラウンドトリップテストは、churn している側を踏んでいない。**
+mulmoserver `test/rules/rules_publish.ts` が import するのは `projectApp` と
+`AuthoredAppZ`。そして **`projectApp` は `projectAppViews` を呼ばない** — 別の入口
+（`publishProject.ts:675`）で、`projectApp` が作るのは app ドキュメント /
+`config/public` / schemas、emulator に流れるのもその 3 つだけ。
+
+**`projectAppViews` の呼び出し元は全リポジトリで 1 箇所**、
+`server/backends/sharedApp/appViews.ts:108`（MT）。
+
+**MS が core を型だけで使う先例は既にある。**
+`import type { RemoteViewMutateRequest } from "@mulmoclaude/core/remote-view"`、
+`import type { Channel, Command } from "@mulmoclaude/core/remote-host"`。
+`commandChannel.ts:5` に「The command-channel protocol types are owned by
+@mulmoclaude/core」と書いてある。共有ワイヤ型はこのリポジトリ群で確立した形。
+
+---
+
+## 決定 1. 移すのは射影の**書き込み側**だけ。ゲートと `projectApp` は core に残す
+
+`appViews.ts` は上下で性格が違い、そこが線になる。`publishChecks.ts`（ゲート）が
+import しているのは `normalizeViews` / `participantScope` / `NormalizedView` の 3 つだけで、
+`writeFor` は使っていない。
+
+**core に残す** — `normalizeViews`、`participantScope`、`NormalizedView`、
+`ProjectedViewCollection`、`VIEW_AUDIENCES`、`VIEW_ID_PATTERN`、および
+`projectApp` / `projectDeploy` / `projectPublish`。
+理由は 1 つ: **`rules_publish` が守っているのはこちら側**だから。ここを動かすと、
+射影とルールの一致を証明できる両リポジトリ唯一のテストが被写体を失う。
+
+**MT に移す** — `ProjectedViewWrite`、`writeFor`、`AppViewConfigDoc`、および
+`publishProject.ts` の `projectAppViews` / `tierConfig` / `tierWrites` / `tierViews` /
+`tierSubmit` / `PromotedRuleConfig`。**`feat-shared-app-member-write.md` で触ったのは
+この一覧そのもの**で、rules テストの守備範囲の外にいる。
+
+受け皿は既にある（`server/backends/sharedApp/appViews.ts`）。**新しい依存は増えず、
+mulmoserver は無変更、MT → MulmoClaude の依存もそのまま。**
+
+## 決定 2. 共有するのは「型」ではなく**ワイヤ契約**。ロジックは入れない
+
+型だけを共有しても、実際に出たバグは捕まらない。MS の読み手は
+`writeOf(value: unknown): ViewWrite | null` で**入口が `unknown`** なので、
+境界では何も型検査されない。共有型が効くのは「MT がフィールドを改名／削除したのに
+MS が読み続けている」ケースだけで、`rowWriters` が「空配列」か「配列が無い」か、
+どの階層が fail closed か、という**意味**の側には一言も触れない。
+
+新パッケージの中身を 3 つにする:
+
+1. **形** — append-only な interface 群。意味の規則（absent ≠ `[]`、階層ごとの
+   fail closed の向き）を doc コメントで併記する。**バグはここに出たので、ここに書く。**
+2. **定数** — パス、tier id、フィールド名の文字列リテラル。MS の寛容なパーサが
+   MT と同じリテラルを参照できるようにする。
+3. **ゴールデン文書** — 実際の `app.json` から MT が生成した `{tier}/config` を数本
+   コミットしておく。MT 側のテストが再生成して diff、MS 側のテストがそれを
+   `writeOf` / `capabilityOf` に食わせ、期待する能力が出ることを assert する。
+
+3 番が本体。改名は MT 側の golden diff で落ち、読み違いは MS 側の assertion で落ちる。
+`rules_publish` が「射影 ↔ ルール」に対してやっていることを、
+「射影 ↔ 読み手」に対してもう一段上でやる形。**この穴は今もあり、
+決定 1 だけでは塞がらない。**
+
+**射影器（`writeFor` など）を契約に入れないこと。** 入れた瞬間、両者がランタイムで
+バージョンを合わせる必要が生まれ、逃げたはずの publish ゲートに戻る。
+契約であってライブラリではない。
+
+## 決定 3. 形は **append-only・全部 optional**。ドキュメントは非同期な持続物
+
+3 か月前に publish されたアプリは、その日の形のまま Firestore に居座り、誰かが
+publish し直すまで書き換わらない。**MS は過去の MT が書いた全部を読む必要があり、
+共有型は今日の MT しか説明しない。**
+
+`ProjectedViewWrite` は `cid` 以外すでに全部 optional なので、その性質は保たれている。
+厳密な同期インターフェースにした瞬間、この型は嘘をつき始める。
+**MS の読み手は寛容なまま**にしておくこと — 共有型が固定するのはパーサの出力であって、
+入口ではない。
+
+なお MS が core を 3.7.0 で固定したまま平気なのは、型が消えるので**古くても
+何も壊れないから**。新しい契約パッケージも、片方だけ静かに古くなる。
+ゴールデンがあるとその古さが**テストとして落ちる**、というのが 3 番目の効用。
+
+## 決定 4. 置き場所は独立リポジトリ、**git ref 依存**。npm を通さない
+
+型 + JSON だけならビルドが要らない。両側が
+`"…": "github:receptron/<name>#<sha>"` で参照し、sha を bump する。
+**mulmoclaude の monorepo には置かない** — まさに避けたい npm リリースを相続するため。
+
+MulmoClaude は共有コレクションを読みも書きもしないので、このパッケージに関与しない。
+名前に `mulmoclaude` スコープを付けないほうが所有関係を誤らせない。
+
+---
+
+## 実装して分かったこと（決定 1）
+
+**`tierSubmit` は `projectSubmit` に依存していて、それは core に残る側だった。**
+計画の移動リストに入っていなかった。`public.submit` の window を ISO からミリ秒に
+落とす変換で、同じ宣言が `config/public`（ルールが読む・`rules_publish` が守る）にも
+射影される。二重実装は**申し込み期限が黙って閉じなくなるまで誰も気づかない**種類の
+食い違いなので、core から **export して共有**した。移動を 1 個増やすのではなく、
+逆向きに 1 個公開する形になった。
+
+**`test_sharedHostSurface.ts` から減らすものは無かった。** あの一覧に
+`projectAppViews` は載っていなかった（MT が import しているのに）。代わりに、
+移動後に MT が実際に import する分 — `normalizeViews` / `participantScope` /
+`projectSubmit` / `viewDocId` / `viewConfigDocId` / `VIEW_TIER` — を**足した**。
+併せて「射影はここに戻ってこない」ことを `publishApp` と同じ形の否定テストで固定した。
+
+**core は 4.0.0（メジャー）。** export を削るので semver 上そうなる。消費者は MT だけ。
+
+**`.sort()` は MT の lint（`sonarjs/no-alphabetical-sort`）に引っかかる。**
+`localeCompare` にはできない — この配列は Firestore に publish され順序で比較されるので、
+機械によって順が変わると「何も変えていない publish」が文書を書き換える。理由を書いて
+disable した。
+
+## リポジトリ横断と依存順
+
+決定 1 と決定 2 は**独立に出せる**。1 は依存が増えないので単体で先行できる。
+
+1. **[済]** **MT**: `writeFor` と tier 射影を `server/backends/sharedApp/` に引き取る。
+   core からの import を減らす。MT のテストで射影を固定する（今は core 側にある）。
+2. **[済]** **core**: 移した分を削る。`test_sharedHostSurface.ts` の一覧から該当分を外す
+   （あのファイルは「ホストが戻ってこなくて済むか」を測る装置なので、**減るのが正しい**）。
+   `projectApp` 側は無変更。
+3. **[変更して実施]** **ゴールデン文書を両リポジトリに置く**。独立リポジトリは作らず、
+   `test/fixtures/sharedAppGolden/` を MT と mulmoserver の両方に同じ内容で置いた。
+   形と定数は共有していない（下記）。
+4. **[済]** **MT / MS**: それぞれ生成側 / 消費側のテストを足した。
+   MT `test/server/backends/appViewGolden.spec.ts` は再生成して diff、
+   mulmoserver `test/composables/test_appViewGolden.ts` は `writeOf` →
+   `capabilitiesFor` に食わせて能力を assert する。
+5. **[未]** **複製の同期**。手コピーで、更新の合図が無い（**#1673**）。
+
+1 と 2 は 1 回の core リリースを使う（**削るための最後の publish**）。以後、
+`{tier}/config` の変更に core リリースは要らなくなる。
+
+## 決定 2・3 を出すときに形を変えたところ
+
+**独立リポジトリを作らず、両方に置いた。** 名前と「どちらの CI が知らせるか」が
+未決のまま repo を増やすより、**穴の大きい方から塞ぐ**ことを優先した。
+今まで「射影の出力が読み手と一致する」ことを証明するものは**どこにも無かった**。
+片方の複製が古くなる問題（#1673）は残るが、それは**塞いだ穴の中の小さい穴**で、
+以前は穴そのものが空いていた。
+
+**形（interface）と定数は共有していない。** 決定 2 の 3 点のうち 1 と 2 を落とした。
+理由は決定 2 自身が書いていること — mulmoserver の読み手は `writeOf(value: unknown)` で
+**入口が `unknown`**、境界では何も型検査されない。共有 interface が効くのは
+「MT が改名したのに MS が読み続けている」ケースだけで、それは**ゴールデンの diff で
+落ちる**。定数も同様。ファイル 3 本で足りるものに repo を 1 つ足す理由が無かった。
+
+**ゴールデンは両方の repo で prettier 無視にした。** 2 つの repo の formatter 設定が
+違うと、同一の文書が違って見える。生成は `JSON.stringify(_, null, 2)` が正典。
+
+**mulmoserver の `test_appViewRoundTrip.ts` はゴールデン版に置き換えた**
+（`test_appViewGolden.ts`）。あれは core の `projectAppViews` を直接呼んでいたので、
+決定 1 で消える。呼び出しをゴールデンの読み込みに替えただけで、能力の assertion は
+そのまま残した — **mulmoserver は core の射影に依存しなくなった**。
+
+## やらないこと
+
+- **`firestoreStore.ts` / `firestoreDocs.ts` は動かさない。** `store.ts` / `host.ts` に
+  組み込まれた汎用の Firestore バックエンドで、共有アプリ専用ではない。
+- **`paths.ts` は分割しない。** core 中が import していて churn しない。
+  MT からはそのまま使う。
+- **`projectApp` / `projectDeploy` / `projectPublish` は移さない**（決定 1 の理由）。
+- **mulmoserver → MulmoTerminal の依存は作らない。** 決定 1 の切り取り線なら不要で、
+  作ると CLI 全体が MS の dev ツリーに入る。
+- **MulmoClaude アプリ（`src/` / `server/`）には何も足さない・引かない。** 共有コレクションに
+  関与していない。変わるのは同じリポジトリに同居する `packages/core` だけ。
+
+## 開いている問い
+
+- **ゴールデンの更新をどちらの CI が走らせるか。** MT の PR で golden が変わったとき、
+  MS 側の bump が要ることを何が知らせるか。契約リポジトリの CI から両者に issue を
+  立てるのか、MS の定期ジョブで sha 差を見るのか。
+- **契約のバージョニング**: sha 固定か tag か。tag だと「リリース」が復活しかねない。
+- `VIEW_TIER` / `viewDocId` / `VIEW_CONFIG_ID` を契約に移すか core に残すか。
+  MS は今これらを手で写している（`sharedAppShape.ts:7` に「mirrored here」とある）。
+- 名前。


### PR DESCRIPTION
**共有アプリの作業をするたびに MulmoClaude をリリースしている。** それをやめる計画です。
コードの変更はありません（`plans/` のみ）。

## 数えた

過去 90 日で core の共有アプリスタック（`publishManifest` / `publishProject` /
`publishChecks` / `appViews`）に入ったコミットは **24 本**。中身はほぼ全部が共有アプリ
そのものの作業で、**その全部が「core を直す → CI → マージ → 人手の npm publish →
MT で bump」を通っています**。

一番よく通るのは `AuthoredAppZ` — **`app.json` にキーを 1 つ増やすたびに core リリース**。
`publishChecks.ts` は 90 日で 13 コミット、`publishProject.ts` は 16 コミット。

先に出した「射影の書き込み側だけを MT に引き取る」案（#1672）は、この 24 本のうち
**5 本程度しか外せていませんでした**。範囲をスタック全体に広げます。

## 線は「宣言 → Firestore の文書」に引く

**出す**（`receptron/sharedapp`）: `publishManifest`(416) / `appViews`(232) /
`publishProject`(551) / `publishChecks`(1002) と、#1672 で MT に移した
`appViewProjection`(349)。

**残す**: コレクションのランタイム（`host` / `store` / `discovery` / `registry` /
`firestoreStore`）。MulmoClaude が使うのはこちらで、コンパイラの方は
`src/` `server/` を grep して **使用箇所 0 件**でした。

MT が `collection/server` から使っている 73 シンボルも、33（コンパイラ）と
40（ランタイム）にきれいに割れます。

## 依存の向きは一方通行

共有アプリのパス定数（`APPS_COLLECTION` / `appStagingPath` / …）を core 全体で grep
すると、移動対象の 3 ファイル以外に出現しません。**core → モジュールの依存は要りません。**

モジュール → core は `isValidCollectionName` / `isSafeCustomViewPath` / `CollectionSchema`
の型だけ。**持ってこないし複製もしません** — どれも core の他の場所が使っていて、
持ってくると循環し、複製すると逃げたい種類の食い違いになります。

モジュールが core に依存しても目的は達成されます。目的は「依存をゼロにする」ではなく
**「共有アプリの作業で MulmoClaude をリリースしない」**で、動かない側への依存は
リリースを要求しません。

## 最初の一手はスパイク

git 依存は**ビルド済み JS を配る必要**があります（yarn 1 も vite も `node_modules` の
生 TS を素通ししない）。yarn は git 依存の `prepare` を install 時に走らせるので `tsc`
すれば足りるはずですが、**中身を移す前に、空のモジュールで MT（yarn 1.22）と
mulmoserver（vite + vue-tsc）の両方から通ることを確かめます**。ここが通らないなら
配布方法を作り直します（プランに 3 案）。

## 出ている PR

3 本とも **draft に戻して保留**しました。このまま進めると core のメジャーと
8 パッケージの publish が短期間に 2 回になるため、1 回にまとめます。

- mulmoclaude#2892 — core から射影を削除
- #1672 — MT が射影を引き取る
- receptron/mulmoserver#174 — ゴールデンを読み手に通す

ゴールデン文書の仕事は残りますが、mulmoserver が射影器を直接呼べるようになるので
**#1673 の手コピー問題は消えます**。

`plans/refactor-shared-app-wire-contract.md` も、当時の記録として先頭に差し替えの経緯を
書いたうえで同梱しています（main にはまだ入っていなかったため）。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the shared app architecture plan to reflect the current implementation and package distribution approach.
  - Documented the shared app wire contract, golden document validation, integration testing, and migration considerations.
  - Recorded remaining decisions around publishing scope, versioning, synchronization, and CI.

- **Refactor**
  - Documented clearer separation of shared app compilation and projection responsibilities while preserving existing validation and runtime behavior.

- **User Impact**
  - No immediate user-facing behavior changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->