### PR TITLE
fix(lint-summary): bar(0, max) が 1 ブロック描くのを直す

### DIFF
--- a/plans/fix-lint-summary-zero-bar.md
+++ b/plans/fix-lint-summary-zero-bar.md
@@ -1,0 +1,67 @@
+# `bar(0, max)` drew a block — #1656
+
+## What was wrong
+
+`scripts/lint-summary.mjs`:
+
+```js
+function bar(count, max) {
+  if (max === 0) return "";
+  const filled = Math.max(1, Math.round((count / max) * BAR_WIDTH));
+  return "█".repeat(filled);
+}
+```
+
+`Math.max(1, …)` is there so a rule with one finding still draws something beside a rule with five
+hundred, which rounds to nothing. Applied to a count of **zero** it invents a block, and that row
+then reads as the smallest non-empty row in the table rather than as empty.
+
+```
+bar(0, 5)   = "█"     <- one block for zero findings
+bar(1, 500) = "█"     <- the case max(1, …) exists for
+```
+
+## Latent, not live
+
+Nothing reaches it today. Every value arriving at `bar()` comes from `byRule`, `byArea` or
+`byDirectory`, and the only writer to any of them is `tally()`, which stores `(prev ?? 0) + 1` —
+so every stored count is at least 1.
+
+It becomes live the first time a bar is drawn from a value that can legitimately be zero: a
+per-area cell rather than the row total, a delta column against a previous run, or a row held at
+zero on purpose to show a rule that used to have findings.
+
+## Fix
+
+Catch zero before the `max(1, …)` floor:
+
+```js
+export function bar(count, max) {
+  if (count === 0 || max === 0) return "";
+  return "█".repeat(Math.max(1, Math.round((count / max) * BAR_WIDTH)));
+}
+```
+
+## Why `bar` is now exported
+
+It has to be, to be testable. `renderReport` cannot pass it a zero — that is the whole point of the
+section above — so a test driven through the report can never exercise the guard, and the guard
+exists precisely for a caller that does not exist yet. Exporting it is what lets the fix be pinned
+rather than asserted. `scripts/lint-summary.d.mts` gains the matching declaration.
+
+## Verified
+
+Old `bar` copied verbatim into a throwaway harness and run beside the new one over every
+`count` in 0..600 against `max` in {0, 1, 2, 3, 7, 24, 25, 100, 499, 500, 601}, skipping
+`count > max` (a count is only ever ranked against a max it is part of):
+
+```
+identical: 2362
+differing: 10
+```
+
+All ten differ at `count === 0` and nowhere else — old drew 1 block, new draws 0. So inlining
+`filled` changed nothing, and the report's real output is byte-for-byte what it was.
+
+`yarn format` / `lint` / `typecheck` / `test` all green; `yarn lint:summary` run against a real
+eslint run for the report itself.

--- a/scripts/lint-summary.d.mts
+++ b/scripts/lint-summary.d.mts
@@ -11,5 +11,6 @@ export interface EslintResult {
   messages: EslintMessage[];
 }
 
+export function bar(count: number, max: number): string;
 export function parseEslintJson(text: string): EslintResult[];
 export function renderReport(results: EslintResult[], cwd?: string): string;

--- a/scripts/lint-summary.mjs
+++ b/scripts/lint-summary.mjs
@@ -41,10 +41,14 @@ function cell(value) {
   return `\`${value.replaceAll("`", "'").replaceAll("|", "\\|").replaceAll("\n", " ")}\``;
 }
 
-function bar(count, max) {
-  if (max === 0) return "";
-  const filled = Math.max(1, Math.round((count / max) * BAR_WIDTH));
-  return "\u2588".repeat(filled);
+/**
+ * `max(1, \u2026)` keeps a rule with one finding visible beside one with five hundred,
+ * so zero has to be caught before it or an empty row draws the shortest bar rather
+ * than none. Exported because nothing here can pass a zero yet \u2014 only a test can.
+ */
+export function bar(count, max) {
+  if (count === 0 || max === 0) return "";
+  return "\u2588".repeat(Math.max(1, Math.round((count / max) * BAR_WIDTH)));
 }
 
 function tally(counts, key) {

--- a/test/scripts/lint-summary.spec.ts
+++ b/test/scripts/lint-summary.spec.ts
@@ -2,11 +2,32 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 
-import { parseEslintJson, renderReport } from "../../scripts/lint-summary.mjs";
+import { bar, parseEslintJson, renderReport } from "../../scripts/lint-summary.mjs";
 
 const result = (filePath: string, ruleId = "max-lines", severity = 2) => ({
   filePath,
   messages: [{ ruleId, severity }],
+});
+
+const BLOCK = "█";
+
+describe("bar", () => {
+  // `Math.max(1, …)` exists so one finding beside five hundred still draws
+  // something. Reached with a count of zero it invented a block, and the row read
+  // as the smallest non-empty one rather than as empty.
+  it("draws nothing for a count of zero", () => {
+    expect(bar(0, 5)).toBe("");
+    expect(bar(0, 0)).toBe("");
+  });
+
+  it("still draws one block for the smallest non-zero count", () => {
+    expect(bar(1, 500)).toBe(BLOCK);
+  });
+
+  it("scales the full width to the maximum", () => {
+    expect(bar(500, 500)).toBe(BLOCK.repeat(24));
+    expect(bar(250, 500)).toBe(BLOCK.repeat(12));
+  });
 });
 
 describe("parseEslintJson", () => {


### PR DESCRIPTION
## Summary

`scripts/lint-summary.mjs` の `bar()` が、count 0 のときに `█` を 1 個描いていた ( #1656 )。

```js
function bar(count, max) {
  if (max === 0) return "";
  const filled = Math.max(1, Math.round((count / max) * BAR_WIDTH));
  return "█".repeat(filled);
}
```

`Math.max(1, …)` は「500 件の隣で 1 件が丸められて消えない」ための下限で、そこは正しい。
count が 0 のときにも効いてしまうのが問題で、その行は **空** ではなく **非空の中で最小** として読まれる。

```
bar(0, 5)   = "█"     <- 0 件なのに 1 ブロック
bar(1, 500) = "█"     <- max(1, …) が存在する理由のケース
```

### 潜在バグであって、今動いている不具合ではない

これは「今どれくらい急ぐか」を決めるので明記します。**現時点では到達しません。**
`bar()` に届く値は `byRule` / `byArea` / `byDirectory` からしか来ず、その 3 つへの唯一の書き手が

```js
function tally(counts, key) { counts.set(key, (counts.get(key) ?? 0) + 1); }
```

なので、保存される count は必ず 1 以上です（呼び出し箇所だけでなくファイル内の `.set(` を全部確認済み）。

顕在化するのは、**正当に 0 になり得る値**を棒にした最初の瞬間 — 行の合計ではなく面ごとのセル、
前回実行との差分・トレンド列、あるいは「以前は findings があった rule」を見せるために意図的に 0 のまま残す行。

### 変更

0 を下限より **前** で弾く:

```js
export function bar(count, max) {
  if (count === 0 || max === 0) return "";
  return "█".repeat(Math.max(1, Math.round((count / max) * BAR_WIDTH)));
}
```

- `scripts/lint-summary.mjs` — ガード + 理由のコメント、`bar` を export
- `scripts/lint-summary.d.mts` — 対応する宣言を追加
- `test/scripts/lint-summary.spec.ts` — `describe("bar")` を 3 ケース追加
- `plans/fix-lint-summary-zero-bar.md` — 経緯と検証

## Items to Confirm / Review

1. **`bar` を export したこと** — ここだけレビューしてほしいです。テスト可能にするために必要でした:
   上の「潜在バグ」の節がそのまま理由で、`renderReport` 経由では 0 を渡せないため、レポート越しのテストでは
   このガードを一度も踏めません。ガードは「まだ存在しない呼び出し元」のためにあるので、
   export しないと **修正を pin できず主張するだけ** になります。
   テスト専用に公開面を広げるのが嫌なら、代案は「テストを諦める」か「`bar` を別ファイルに切り出す」です。
   なお knip の `exports` は `warn` 設定 + spec が entry なので、この export は CI を赤くしません。

2. **`Closes #1656` を付けています** — issue の内容はこの 1 ファイルの `bar()` に閉じているので全部塞げている認識です。
   issue が言及している「面ごとのセルを棒にする」等は将来の機能で、ここには含めていません。

3. 既存の rule x area 表の `0` セルは数字のままで、棒は描いていません（今回の変更前後で表の出力は同一）。

## 検証

**差分検証（`/refactor-safely` の手法）** — 旧 `bar` を捨てるハーネスに逐語コピーし、新 `bar` と並べて実行。
`count` は 0..600 の全整数、`max` は {0, 1, 2, 3, 7, 24, 25, 100, 499, 500, 601}、`count > max` はスキップ
（count は自分が含まれる max に対してしかランクされないため）:

```
identical: 2362
differing: 10
```

差が出た 10 件は **すべて `count === 0`**（旧 1 ブロック → 新 0 ブロック）。それ以外は完全一致なので、
`filled` をインライン化したリファクタは挙動を変えていません。ハーネスは削除済み。

**実際に走らせた ground truth** — `yarn lint:summary` をこのリポジトリの本物の eslint 出力に対して実行し、
16 findings のレポートが従来どおり描画されること、errors 0 なので exit 0 することを確認。

**format / lint / build / typecheck / test** — すべて green:

| コマンド | 結果 |
|---|---|
| `yarn format` | 済み（差分なし） |
| `yarn lint` | 0 errors, 16 warnings（すべて既存の `max-lines` 等。`lint-summary` 由来は 0 件） |
| `yarn typecheck` | clean |
| `yarn build` | ✓ built |
| `yarn test` | 692 files passed / 3 skipped、10013 tests passed（`lint-summary.spec.ts` は 11 passed） |

> 補足（自分の作業ミスの記録）: 最初に検証したとき lint 94 problems / typecheck 41 errors / test 73 failed が出て、
> これを「main 由来の既存の赤」と判断しましたが **誤り** でした。真因は `origin/main` に分岐したあと
> `yarn install` していなかったこと（この間に `@mulmoclaude/core` が 3.14 → 3.15 に上がっている）で、
> stale な `node_modules` が出していた嘘です。`main` の CI は分岐元 `29787ace` で green であり、それが ground truth。
> `yarn install` 後に上表のとおり全部 green になりました。`yarn.lock` に差分は出ていません。

## User Prompt

> なおして
> https://github.com/receptron/mulmoterminal/issues/1656

work in mulmoterminal3
