### PR TITLE
refactor: code scanning の duplicate-code アラート 4 件を抽出で解消する

### DIFF
--- a/plans/refactor-jscpd-duplicates-1678.md
+++ b/plans/refactor-jscpd-duplicates-1678.md
@@ -1,0 +1,106 @@
+# refactor: code scanning の duplicate-code アラート 4 件を抽出で解消する (#1678)
+
+`duplication-scan` (jscpd 5.0.12, minTokens=50 / minLines=5) の open アラートは 6 件。
+SARIF は**片側の位置しか持たない**ので、対を知るには CI と同じ引数でローカル実行する
+（`plans/refactor-jscpd-duplicates-1472.md` と同じ手順）:
+
+```
+npx jscpd@5.0.12 . --format "typescript,vue" \
+  --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" --reporters console
+```
+
+`a6db239c` で 6 clones。Code Scanning の open 6 件と一致する。この PR はうち **4 件**を扱う。
+
+| alert | 片側 | 対 | tokens |
+| --- | --- | --- | --- |
+| 154 | `src/components/CollectionsBrowseOverlay.vue` 52-68 | `src/components/CollectionsPane.vue` 169-185 | 92 |
+| 156 | `src/components/cellChromeBinding.ts` 58-65 | 同ファイル 79-86 | 62 |
+| 155 | `server/backends/remoteView.ts` 118-125 | 同ファイル 339-342 | 53 |
+| 161 | `server/backends/sharedApp/deploy.ts` 270-278 | `server/backends/sharedApp/publish.ts` 328-336 | 64 |
+
+## 161 — 共有ビルダーは既にあり、誰も呼んでいない
+
+`server/backends/sharedApp/context.ts` の `stampFor` が、まさにこの重複のために書かれている:
+
+> Who, when, and from which commit — resolved the same way by both operations.
+> Sharing the builder is what keeps the two from drifting into stamping different clocks, or
+> dropping `dirty` on one side
+
+にもかかわらず**呼び出し元が 0 件**で、deploy と publish は各々インラインで同じ 6 行を綴っている。
+返り値 `{ stamp, dirty }` は両者が実際に必要としているもの — 両ファイルとも後段で
+`stampSource.dirty === true` を結果に載せており、これは `stampFor` の `dirty` と同一式。
+よって**新しい API は作らず、既存の `stampFor` に繋ぐ**。`gitStamp` の import は
+両ファイルで不要になるので落とす（`PublishStamp` 型は別の箇所で使うので残る）。
+
+## 154 — 17 行が byte 一致。置き場所は新しい composable
+
+`diff` で完全一致。両者とも `../composables/collectionUi` から push/pop を import しており、
+`CollectionsPane.vue` のコメントは既に片方を参照で済ませようとしている
+（"same getRootNode() trick as CollectionsBrowseOverlay, which is where the comment explaining
+it lives"）。
+
+`src/composables/useCollectionTeleportTarget.ts` を新設し、probe の `Ref` を受けて
+登録・解除・巻き戻しを持つ。`collectionUi.ts` に足さないのは、あちらが
+`configureCollectionUi` を含む 382 行のホスト束ねで、Vue のライフサイクルを持つ関数の
+置き場ではないため。push/pop の実体はあちらに残す（この composable がそれを import する）。
+
+**`CollectionCardView.vue` は変えない。** 同じ登録をしているが `onMounted` で一度だけ行う形で、
+probe が後から現れる 2 つとはライフサイクルが違う。watch 版に寄せるのは純粋抽出ではなく
+挙動の変更なので、この PR では触らない（jscpd も 50 トークン閾値で拾っていない）。
+
+## 156 — 同じファイルが自分のコメントに反している
+
+`cellShellEvents` のコメントは "One object so the two callers do not each re-spell seven
+identical handlers — which is exactly what CellShell was extracted to stop" と書いているのに、
+その 10 行上で `cellChromeBinding` が同じ 6 件を綴っている。
+
+`toggle-*` 6 件だけを作る関数を出し、両方から spread する。`close` の扱いは**現状維持**:
+`cellChromeBinding` では引数（TerminalCell が破棄前に確認するため、#826）、
+`cellShellEvents` では固定の転送。`move` も `cellShellEvents` 側に残す。
+
+## 155 — 文面が 1 箇所で直らない
+
+`remoteViewFailureMessage` / `remoteViewItemsFailureMessage` / `mutateRemoteViewFailureMessage`
+の 3 つが `view-not-found` と `not-mobile` の同一文面を持つ。これらは電話側のエラー UI の全部で、
+片方だけ直ると同じ状況に別の説明が出る。共有している 2 文面を関数として出し、3 関数から呼ぶ。
+
+**文面だけ畳んでも足りなかった。** 最初は共有する 2 文面を関数に出したが、jscpd は
+55 tokens で依然として拾った（53 → 55）。残っていたのは文面ではなく、3 関数それぞれが
+同じ 2 分岐を綴っているという構造そのもの。
+
+そこで**2 つの kind を対で受ける 1 つの関数**にし、各呼び出し側は
+`if (result.kind === "view-not-found" || result.kind === "not-mobile") return sharedViewFailureMessage(result, slug);`
+の 1 行で両方を消す。kind ごとに関数を分けると 2 行残って畳みきれず、かつ後段の
+`unhandledFailure(result, slug)` が要求する `never` への絞り込みも壊れる。
+対で扱うことが網羅性検査を保つ条件になっている。
+
+## 扱わない 2 件
+
+| alert | 場所 | 理由 |
+| --- | --- | --- |
+| 160 | `sharedApp/deploy.ts` 247-268 ↔ `publish.ts` 298-309 | 早期 return を含む前置き。畳むと両経路の失敗の返り方が変わり得るので純粋抽出ではない |
+| 153 | `useTerminalConnections.ts` 829-842 ↔ 880-892 | `submitText` / `pasteAndSubmit` の実入力パス。60ms と `PASTE_SUBMIT_MS`、bracketed paste の有無、空文字ガードの有無が絡む。`/refactor-safely` + 実機確認を伴う別 PR |
+
+## 検証
+
+1. 上の jscpd コマンドで clone が **6 → 2**（残るのは 160 と 153 のみ）。
+   抽出が中途半端だと 50 トークンを割らずに残るので、目視ではなく実際に回して確認する
+2. `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
+3. 挙動の担保は既存 spec:
+   - 156 → `test/src/components/cellChromeForwarding.spec.ts`。期待値を
+     `CellChromeButtons` の宣言済み emits から**導出**しており、`Object.keys(chromeEvents)` の
+     集合と、各ハンドラが自分の名前で再 emit することの両方を見ている。spread 化はキー集合も
+     順序も変えないので、この spec がそのまま抽出の担保になる
+   - 161 → `test/server/backends/sharedApp/` の deploy / publish spec。`opts.now` と
+     `opts.resolveCommit` を注入して stamp を確かめているので、共有側に繋いだ後も
+     両経路から uid / email / publishedAt / commit / dirty を確認できる
+   - 155 → 文面を assert している既存 spec
+4. 154 は元々 spec を持たない。抽出で唯一壊れうるのは「composable の中で登録した
+   `onBeforeUnmount` がコンポーネントに紐づくか」で、これは型でも既存テストでも捕まらない。
+   `test/src/composables/collectionTeleportTarget.spec.ts` を新設して、jsdom の
+   `attachShadow` で probe を作り、①出現時の push ②差し替え時に前の root を先に pop
+   ③unmount 時の pop ④shadow root 外の probe を無視、の 4 点を見る。
+
+   **この spec が空回りしていないことを変異で確認済み**: `onBeforeUnmount` を外す /
+   watch 先頭の `unregister()` を外す / `instanceof ShadowRoot` ガードを外す、の 3 つの
+   壊し方それぞれが、対応する別々のテスト 1 件だけを落とす。

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -114,10 +114,24 @@ function unhandledFailure(result: never, slug: string): string {
   return `unhandled failure on collection '${slug}': ${JSON.stringify(result)}`;
 }
 
+/** The two kinds every one of the three operations below can hit, answered once.
+ *
+ * The sentence IS the error UI, so a wording fixed on one operation and not the others gives the
+ * same situation two explanations depending on which button the phone pressed. Taken as a pair
+ * rather than one function per kind so each caller spends a single branch on both — which is what
+ * leaves `result` narrowed to `never` at the end of each chain, and the exhaustiveness check
+ * (`unhandledFailure`) doing its job. */
+type SharedViewFailure = { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };
+
+function sharedViewFailureMessage(result: SharedViewFailure, slug: string): string {
+  return result.kind === "view-not-found"
+    ? `custom view '${result.viewId}' not found on collection '${slug}'`
+    : `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+}
+
 /** One message per failure kind, thrown by the channel handler. */
 export function remoteViewFailureMessage(result: Exclude<RemoteViewBuildResult, { kind: "ok" }>, slug: string): string {
-  if (result.kind === "view-not-found") return `custom view '${result.viewId}' not found on collection '${slug}'`;
-  if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  if (result.kind === "view-not-found" || result.kind === "not-mobile") return sharedViewFailureMessage(result, slug);
   // Names `.claude/skills`, not the workspace's `data/skills` staging tree. A view now belongs to
   // whichever FOLDER the collection is in, and outside the managed workspace there is no staging
   // mirror to write into — telling the author to use one would send them to a path nothing reads
@@ -328,17 +342,15 @@ export const remoteViewItemsFor = (scope: ProjectScope) =>
 
 /** Message per non-ok item-page kind, thrown by the channel handler. */
 export function remoteViewItemsFailureMessage(result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): string {
-  if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  if (result.kind === "view-not-found" || result.kind === "not-mobile") return sharedViewFailureMessage(result, slug);
   if (result.kind === "too-large")
     return `mobile view page is ${result.bytes} bytes — over the ${REMOTE_VIEW_ITEMS_MAX_BYTES}-byte command-channel budget; narrow \`fields\` (drop an embed column), lower \`limit\`, or slim the records`;
-  if (result.kind === "view-not-found") return `custom view '${result.viewId}' not found on collection '${slug}'`;
   return unhandledFailure(result, slug);
 }
 
 /** Message per non-ok mutate kind, thrown by the channel handler. */
 export function mutateRemoteViewFailureMessage(result: Exclude<MutateRemoteViewResult, { kind: "ok" }>, slug: string): string {
-  if (result.kind === "view-not-found") return `custom view '${result.viewId}' not found on collection '${slug}'`;
-  if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  if (result.kind === "view-not-found" || result.kind === "not-mobile") return sharedViewFailureMessage(result, slug);
   if (result.kind === "not-writable")
     return `mobile view '${result.viewId}' is read-only — declare editableFields and/or allowDelete in its views[] entry to allow writes`;
   if (result.kind === "read-only-collection")

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -16,7 +16,7 @@
 // until that document exists.
 import { ensureAid } from "./ensureAid.js";
 import { APPS_COLLECTION, appStagingPath, projectDeploy, type LoadedCollection, type PublishStamp } from "@mulmoclaude/core/collection/server";
-import { gitStamp, readCurrentApp, schemasOf, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { readCurrentApp, schemasOf, sharedAppContext, stampFor, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { allTierWrites, pageIdsOf, planTierWrites, type PlannedTier } from "./appViews.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { reserveSlug, retireSlug, type SlugResult } from "./slug.js";
@@ -267,14 +267,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   // is atomic, and only the declared owner may do it.
   const current = await readCurrentApp(handle, aid, "deploy", "Deploying again is safe — this read only decides whether the app is created or updated.");
   if (!current.ok) return current;
-  const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
-  const stamp: PublishStamp = {
-    uid: handle.uid,
-    email: handle.email,
-    publishedAt: (opts.now ?? Date.now)(),
-    commit: stampSource.commit,
-    dirty: stampSource.dirty,
-  };
+  const { stamp, dirty } = await stampFor(handle, root, opts);
   const existingApp = current.app;
   const deployed = projectDeploy(authored, schemasOf(collections), stamp, existingApp);
 
@@ -335,7 +328,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
     // reservation.
     created: existingApp === null || existingApp.deployedAt === undefined,
     commit: stamp.commit,
-    dirty: stampSource.dirty === true,
+    dirty,
     recordIssues: scan.records,
     recordIssuesCapped: scan.capped,
   };

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -39,7 +39,7 @@ import {
   type PublishStamp,
 } from "@mulmoclaude/core/collection/server";
 import { ensureAid } from "./ensureAid.js";
-import { gitStamp, sharedAppContext, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
+import { sharedAppContext, stampFor, type SharedAppFailure, type SharedAppHandle, type SharedAppOptions } from "./context.js";
 import { recordRefusal, scanRecords, type RecordScan } from "./records.js";
 import { readStaged, type StagedEntry } from "./staged.js";
 import { oversizeProblem, publicFormOf, publicInputProblems, type PublicForm } from "./publicForm.js";
@@ -325,14 +325,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
       ],
     };
   }
-  const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
-  const stamp: PublishStamp = {
-    uid: handle.uid,
-    email: handle.email,
-    publishedAt: (opts.now ?? Date.now)(),
-    commit: stampSource.commit,
-    dirty: stampSource.dirty,
-  };
+  const { stamp, dirty } = await stampFor(handle, root, opts);
   const existingApp = isRecord(existing) ? existing : null;
   const face = projectPublish(authored, staged.staged, stamp, existingApp);
 
@@ -377,7 +370,7 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
     participantPages: promotedIdsOf(pages.tiers, "roster"),
     slug,
     commit: stamp.commit,
-    dirty: stampSource.dirty === true,
+    dirty,
     recordIssues: scan.records,
     recordIssuesCapped: scan.capped,
   };

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -11,7 +11,7 @@ import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
 import { useCollectionBrowse, browseGotoDetail } from "../composables/useCollectionBrowse";
 import { useEscapeToClose } from "../composables/useEscapeToClose";
-import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+import { useCollectionTeleportTarget } from "../composables/useCollectionTeleportTarget";
 import { pushCollectionSurface, popCollectionSurface, type CollectionSurface } from "../composables/collectionSurface";
 import {
   browseGotoIndex,
@@ -45,27 +45,10 @@ const { view, isOpen, close } = useCollectionBrowse();
 const { shortcuts } = useShortcuts();
 const favActive = (s: Shortcut): boolean => view.value.mode === "detail" && view.value.kind === s.kind && view.value.slug === s.slug;
 
-// Register this overlay's shadow root as the record-modal teleport target while a
-// detail page is open (the package's CollectionRecordModal teleports there; the
-// global binding can't otherwise know which shadow root to use). Same getRootNode()
-// trick as CollectionCardView — the probe sits inside the PluginFrame shadow.
+// The probe sits inside the PluginFrame shadow, which is what lets the composable resolve
+// this overlay's shadow root as the record modal's teleport target.
 const probe = ref<HTMLElement>();
-let registered: HTMLElement | ShadowRoot | null = null;
-function unregister(): void {
-  if (registered) {
-    popCollectionTeleportTarget(registered);
-    registered = null;
-  }
-}
-watch(probe, (el) => {
-  unregister();
-  const root = el?.getRootNode();
-  if (root instanceof ShadowRoot) {
-    registered = root;
-    pushCollectionTeleportTarget(root);
-  }
-});
-onBeforeUnmount(unregister);
+useCollectionTeleportTarget(probe);
 
 // The overlay registers itself as a SURFACE while it is open, and that is not symmetry for its
 // own sake: a Collections pane may still be mounted behind it (panes are per cell and do not

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -11,7 +11,7 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { CollectionsIndexView, CollectionView, FeedsView } from "@mulmoclaude/collection-plugin/vue";
 import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
-import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+import { useCollectionTeleportTarget } from "../composables/useCollectionTeleportTarget";
 import { pushCollectionSurface, popCollectionSurface, type CollectionNavSurface, type CollectionSurface } from "../composables/collectionSurface";
 import { projectIdForCwd } from "../composables/collectionProject";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
@@ -164,25 +164,10 @@ const SEVERITY_CLASS: Record<SelfContainmentSeverity, string> = {
   info: "text-dim",
 };
 
-// Register this pane's shadow root as the record-modal teleport target — same getRootNode()
-// trick as CollectionsBrowseOverlay, which is where the comment explaining it lives.
+// The probe sits inside the PluginFrame shadow, which is what lets the composable resolve
+// this pane's shadow root as the record modal's teleport target.
 const probe = ref<HTMLElement>();
-let registered: HTMLElement | ShadowRoot | null = null;
-function unregister(): void {
-  if (registered) {
-    popCollectionTeleportTarget(registered);
-    registered = null;
-  }
-}
-watch(probe, (el) => {
-  unregister();
-  const root = el?.getRootNode();
-  if (root instanceof ShadowRoot) {
-    registered = root;
-    pushCollectionTeleportTarget(root);
-  }
-});
-onBeforeUnmount(unregister);
+useCollectionTeleportTarget(probe);
 </script>
 
 <template>

--- a/src/components/cellChromeBinding.ts
+++ b/src/components/cellChromeBinding.ts
@@ -31,6 +31,20 @@ export interface CellChromeProps {
 // in the spec pins the two lists together so the next button cannot repeat it.
 export type CellChromeEvent = "toggle-expand" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "toggle-collections" | "toggle-github" | "close";
 
+// Every event that is a PLAIN forward, which is all of them but `close` — the one a cell may want
+// to intercept. Spelling them once means a new button reaches both bindings together; when each
+// spelled its own set, the two could disagree and only the cell type nobody opened would show it.
+type CellChromeToggle = Exclude<CellChromeEvent, "close">;
+
+const toggleForwards = (emit: (event: CellChromeToggle) => void): Record<CellChromeToggle, () => void> => ({
+  "toggle-expand": () => emit("toggle-expand"),
+  "toggle-files": () => emit("toggle-files"),
+  "toggle-canvas": () => emit("toggle-canvas"),
+  "toggle-tools": () => emit("toggle-tools"),
+  "toggle-collections": () => emit("toggle-collections"),
+  "toggle-github": () => emit("toggle-github"),
+});
+
 // Bound as two objects rather than spelled out in each template.
 //
 // The command, launcher and terminal cells wired the same four props and the same five events, and
@@ -56,12 +70,7 @@ export function cellChromeBinding(
       collectionsAvailable: source.collectionsAvailable ?? false,
     })),
     chromeEvents: {
-      "toggle-expand": () => emit("toggle-expand"),
-      "toggle-files": () => emit("toggle-files"),
-      "toggle-canvas": () => emit("toggle-canvas"),
-      "toggle-tools": () => emit("toggle-tools"),
-      "toggle-collections": () => emit("toggle-collections"),
-      "toggle-github": () => emit("toggle-github"),
+      ...toggleForwards(emit),
       close,
     },
   };
@@ -77,12 +86,7 @@ export function cellShellEvents(emit: {
   (event: "move", dir: -1 | 1): void;
 }): Record<CellChromeEvent, () => void> & { move: (dir: -1 | 1) => void } {
   return {
-    "toggle-expand": () => emit("toggle-expand"),
-    "toggle-files": () => emit("toggle-files"),
-    "toggle-canvas": () => emit("toggle-canvas"),
-    "toggle-tools": () => emit("toggle-tools"),
-    "toggle-collections": () => emit("toggle-collections"),
-    "toggle-github": () => emit("toggle-github"),
+    ...toggleForwards(emit),
     close: () => emit("close"),
     move: (dir: -1 | 1) => emit("move", dir),
   };

--- a/src/composables/useCollectionTeleportTarget.ts
+++ b/src/composables/useCollectionTeleportTarget.ts
@@ -1,0 +1,35 @@
+import { onBeforeUnmount, watch, type Ref } from "vue";
+import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "./collectionUi";
+
+// Register a surface's shadow root as the record-modal teleport target while it is showing.
+//
+// The package's CollectionRecordModal teleports to the host-supplied target, and
+// configureCollectionUi sets ONE global binding — so it cannot statically know which shadow root
+// a given surface lives in. The probe element resolves it at runtime via getRootNode(), which
+// inside PluginFrame returns that frame's ShadowRoot; without it the modal lands on <body>,
+// outside the shadow root, and loses the injected plugin styles.
+//
+// Watched rather than registered once at mount: the probe rides a `v-if`ed detail page, so it
+// appears and disappears while the surface stays mounted. Each change unregisters the previous
+// root first, so a surface never holds two entries on the stack.
+export function useCollectionTeleportTarget(probe: Ref<HTMLElement | undefined>): void {
+  let registered: HTMLElement | ShadowRoot | null = null;
+
+  const unregister = (): void => {
+    if (registered) {
+      popCollectionTeleportTarget(registered);
+      registered = null;
+    }
+  };
+
+  watch(probe, (el) => {
+    unregister();
+    const root = el?.getRootNode();
+    if (root instanceof ShadowRoot) {
+      registered = root;
+      pushCollectionTeleportTarget(root);
+    }
+  });
+
+  onBeforeUnmount(unregister);
+}

--- a/test/src/composables/collectionTeleportTarget.spec.ts
+++ b/test/src/composables/collectionTeleportTarget.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { defineComponent, h, ref, type Ref } from "vue";
+import { mount } from "@vue/test-utils";
+
+// Mocked rather than exercised through the real module: collectionUi pulls the whole host binding
+// (configureCollectionUi and every /api/* helper) in on import, and none of it decides anything
+// here. What this spec is about is WHEN the composable pushes and pops.
+vi.mock("../../../src/composables/collectionUi", () => ({
+  pushCollectionTeleportTarget: vi.fn(),
+  popCollectionTeleportTarget: vi.fn(),
+}));
+
+const { useCollectionTeleportTarget } = await import("../../../src/composables/useCollectionTeleportTarget");
+const { pushCollectionTeleportTarget, popCollectionTeleportTarget } = await import("../../../src/composables/collectionUi");
+
+const push = vi.mocked(pushCollectionTeleportTarget);
+const pop = vi.mocked(popCollectionTeleportTarget);
+
+// A probe the composable can resolve a ShadowRoot from, the way PluginFrame's mount does.
+const probeInShadow = (): HTMLElement => {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const el = document.createElement("div");
+  host.attachShadow({ mode: "open" }).appendChild(el);
+  return el;
+};
+
+// The composable registers `onBeforeUnmount` from inside a function the component calls, so it is
+// only bound if it runs during setup — which is exactly what an extraction out of a component can
+// break without a single type or existing test noticing.
+const mountWithProbe = (probe: Ref<HTMLElement | undefined>) =>
+  mount(
+    defineComponent({
+      setup() {
+        useCollectionTeleportTarget(probe);
+        return () => h("div");
+      },
+    }),
+  );
+
+describe("useCollectionTeleportTarget", () => {
+  beforeEach(() => {
+    push.mockClear();
+    pop.mockClear();
+  });
+
+  it("registers the probe's shadow root once it appears", async () => {
+    const probe = ref<HTMLElement>();
+    mountWithProbe(probe);
+    expect(push).not.toHaveBeenCalled();
+
+    const el = probeInShadow();
+    probe.value = el;
+    await Promise.resolve();
+
+    expect(push).toHaveBeenCalledWith(el.getRootNode());
+  });
+
+  // The detail page this rides is `v-if`ed, so the probe comes and goes while the surface stays
+  // mounted. Without the unregister-first, a surface would leave an entry on the stack per swap.
+  it("drops the previous root before registering the next", async () => {
+    const probe = ref<HTMLElement>();
+    mountWithProbe(probe);
+
+    const first = probeInShadow();
+    probe.value = first;
+    await Promise.resolve();
+
+    const second = probeInShadow();
+    probe.value = second;
+    await Promise.resolve();
+
+    expect(pop).toHaveBeenCalledWith(first.getRootNode());
+    expect(push).toHaveBeenLastCalledWith(second.getRootNode());
+  });
+
+  it("drops it again on unmount, so a closed surface leaves nothing behind", async () => {
+    const probe = ref<HTMLElement>();
+    const wrapper = mountWithProbe(probe);
+
+    const el = probeInShadow();
+    probe.value = el;
+    await Promise.resolve();
+    pop.mockClear();
+
+    wrapper.unmount();
+
+    expect(pop).toHaveBeenCalledWith(el.getRootNode());
+  });
+
+  // A probe that is not inside a shadow root resolves to the document, and registering THAT would
+  // send the modal to a target that defeats the point — the styles live in the shadow root.
+  it("ignores a probe that is not inside a shadow root", async () => {
+    const probe = ref<HTMLElement>();
+    mountWithProbe(probe);
+
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    probe.value = el;
+    await Promise.resolve();
+
+    expect(push).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`duplication-scan` (jscpd) の open アラート 6 件のうち、**純粋な抽出で消える 4 件**を解消する。
clone は **6 → 2**（残り 2 件は下記の理由で別 PR）。

| alert | 片側 | 対 | tokens | やったこと |
| --- | --- | --- | --- | --- |
| 154 | `CollectionsBrowseOverlay.vue` 52-68 | `CollectionsPane.vue` 169-185 | 92 | `useCollectionTeleportTarget` を新設して 2 箇所を差し替え |
| 156 | `cellChromeBinding.ts` 58-65 | 同ファイル 79-86 | 62 | `toggleForwards` を出して両方から spread |
| 155 | `remoteView.ts` 118-125 | 同ファイル 339-342 | 53 | `sharedViewFailureMessage` に 2 kind を対で畳む |
| 161 | `sharedApp/deploy.ts` 270-278 | `sharedApp/publish.ts` 328-336 | 64 | **既にある** `stampFor` に両方を繋ぐ |

SARIF は片側の位置しか持たないので、対は CI と同じ引数のローカル実行で特定した。
設計と判断は `plans/refactor-jscpd-duplicates-1678.md`。

## Items to Confirm / Review

1. **161 は新しい API を作っていない。** `server/backends/sharedApp/context.ts` の `stampFor` は
   「両方の操作が同じ時計を押すため」と doc コメントに書かれていながら**呼び出し元が 0 件**で、
   deploy と publish が各々インラインで同じ stamp を組んでいた。返り値 `{ stamp, dirty }` は
   両者が実際に必要としているもの（両ファイルとも後段で `stampSource.dirty === true` を結果に
   載せており、`stampFor` の `dirty` と同一式）。**この読みが正しいか**を見てほしい。

2. **155 を「kind ごとに 1 関数」にしなかった理由。** 最初は共有する 2 文面を関数に出したが、
   jscpd は 55 tokens で依然として拾った（53 → 55）。残っていたのは文面ではなく、3 関数が
   同じ 2 分岐を綴る構造そのもの。かつ kind ごとに分けると各呼び出し側に 2 行残り、後段の
   `unhandledFailure(result, slug)` が要求する `never` への絞り込みも壊れる。
   **対で受けることが網羅性検査を保つ条件になっている**という判断の是非。

3. **`CollectionCardView.vue` を意図的に変えていない。** 同じ teleport 登録をしているが
   `onMounted` で一度だけ行う形で、probe が後から現れる 2 つとはライフサイクルが違う。
   watch 版に寄せるのは純粋抽出ではなく挙動変更なので触らなかった（jscpd も 50 トークン
   閾値で拾っていない）。**ここも寄せるべきかは判断を仰ぎたい。**

4. **156 の `close` / `move` は現状維持。** `cellChromeBinding` では引数（TerminalCell が
   破棄前に確認するため #826）、`cellShellEvents` では固定の転送のまま。

## 扱わない 2 件（別 PR にする理由）

| alert | 場所 | 理由 |
| --- | --- | --- |
| 160 | `sharedApp/deploy.ts` 247-268 ↔ `publish.ts` 298-309 | 早期 return を含む前置き。畳むと両経路の失敗の返り方が変わり得るので純粋抽出ではない |
| 153 | `useTerminalConnections.ts` 829-842 ↔ 880-892 | `submitText` / `pasteAndSubmit` の実入力パス。60ms と `PASTE_SUBMIT_MS`、bracketed paste の有無、空文字ガードの有無が絡む。CLAUDE.md の「"同じ挙動" は走らせて証明する」に当たるので `/refactor-safely` + 実機確認を伴う別 PR |

## 検証

すべて `rm -rf node_modules && yarn install --frozen-lockfile` の後に実行:

- jscpd (CI と同じ引数): **6 → 2 clones**。残るのは 160 と 153 のみ
- `yarn lint` 0 errors（16 warnings はすべて既存の max-lines / deprecated）
- `yarn typecheck` / `yarn build` 通過
- `yarn test` **693 files, 9972 passed**（+1 file / +4 tests）

### 挙動の担保

- **156** → 既存の `test/src/components/cellChromeForwarding.spec.ts`。期待値を
  `CellChromeButtons` の宣言済み emits から**導出**しており、`Object.keys(chromeEvents)` の
  集合と各ハンドラが自分の名前で再 emit することの両方を見ている。spread 化はキー集合も
  順序も変えないので、この spec がそのまま抽出の担保になる
- **161 / 155** → 既存の sharedApp / remoteView の spec
- **154** → 元々 spec が無い。抽出で唯一壊れうるのは「composable の中で登録した
  `onBeforeUnmount` がコンポーネントに紐づくか」で、型でも既存テストでも捕まらない。
  `test/src/composables/collectionTeleportTarget.spec.ts` を新設した。

  **この spec が空回りしていないことを変異で確認済み**: `onBeforeUnmount` を外す /
  watch 先頭の `unregister()` を外す / `instanceof ShadowRoot` ガードを外す、の 3 つの
  壊し方それぞれが、対応する別々のテスト 1 件だけを落とすことを実際に走らせて確認した。

### 補足（レビューには影響しない）

作業中、ローカルで `yarn lint` が 53 errors を出したが、原因は古い checkout の
`node_modules` を重ねていたこと（CI は同 commit で green）。`rm -rf node_modules` 後は 0 errors。
`~/ss/llm/CLAUDE.md` の「warm な node_modules は嘘をつく」そのものだった。

## User Prompt

- （前段）失敗した GitHub Actions run を直してほしい
- https://github.com/receptron/mulmoterminal/security/code-scanning の duplicate を減らせるか

6 件の内訳と危険度を提示したうえで、**低リスクの 4 件のみ**を対象とする選択を受けた。

Closes #1678

work in mulmoterminal2
