### PR TITLE
chore(lint): 警告 16 件を 0 にし、緩んでいた 4 ルールを error に上げる

### DIFF
--- a/common/gitlabHosts.ts
+++ b/common/gitlabHosts.ts
@@ -10,7 +10,18 @@ import { GITHUB_HOST, GITLAB_HOST } from "./repoEntry.js";
 // A hostname, lower case, with at least one dot. The dot is not cosmetic: `parseRepoEntry` reads a
 // leading segment as a host ONLY when it contains one, so a dotless declaration could never match
 // an entry and would sit in the config doing nothing.
-const HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+// Tested per label rather than as one hostname pattern: the single-regex form nested `[a-z0-9-]*`
+// inside the repeated dotted group, which is the shape that goes exponential on input that almost
+// matches. Measured, this one did not — but the per-label form removes the class instead of
+// depending on that, and reads as the rule it enforces.
+const LABEL_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+const isLabel = (label: string): boolean => LABEL_RE.test(label) && !label.endsWith("-");
+
+const isHostname = (host: string): boolean => {
+  const labels = host.split(".");
+  return labels.length > 1 && labels.every(isLabel);
+};
 
 const SCHEME_RE = /^https?:\/\//;
 
@@ -26,7 +37,7 @@ const GITLAB_HOSTS_MAX = 20;
 export function normalizeGitlabHost(input: unknown): string | null {
   if (typeof input !== "string") return null;
   const host = input.trim().toLowerCase().replace(SCHEME_RE, "").replace(/\/$/, "");
-  return HOSTNAME_RE.test(host) ? host : null;
+  return isHostname(host) ? host : null;
 }
 
 /** The declared hosts, de-duplicated and capped. Anything unusable is dropped rather than failing

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -423,7 +423,13 @@ export default [
     // The deliberate uses of a deprecated external API, listed here rather than silenced at the
     // scene, for the reason the max-lines list above gives: countable in one place, and deleting an
     // entry re-arms the rule for that file. Each one is explained where it is used.
-    files: ["server/mcp/broker.ts", "src/composables/useTerminalConnections.ts", "src/composables/useUnloadGuard.ts"],
+    //
+    // The exception is per FILE, so each entry has to be a file where the deprecated API is the
+    // SUBJECT — otherwise it also covers the next one added there by accident. That is why
+    // `writeTerminalSelection` was lifted out of useTerminalConnections.ts (several hundred lines,
+    // one deprecated call) into a file of its own. The other two are already that shape: broker.ts
+    // is the MCP server, and useUnloadGuard.ts is the beforeunload handler.
+    files: ["server/mcp/broker.ts", "src/utils/terminalSelectionClipboard.ts", "src/composables/useUnloadGuard.ts"],
     rules: {
       "sonarjs/deprecation": "off",
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,13 @@ import prettierRecommended from "eslint-plugin-prettier/recommended";
 
 export default [
   { ignores: ["dist/", "node_modules/"] },
+  {
+    // A disable comment that no longer suppresses anything is worse than none: it names a rule as
+    // the reason for the code below it, and that reason has stopped being true. ESLint reports
+    // these at warn by default, which is how one for `no-new-func` — a rule this config does not
+    // even enable — sat in a spec. At error the comment has to be narrowed when it goes stale.
+    linterOptions: { reportUnusedDisableDirectives: "error" },
+  },
   js.configs.recommended,
   ...tseslint.configs.strict,
   ...pluginVue.configs["flat/recommended"],
@@ -99,9 +106,11 @@ export default [
   },
   {
     // Complexity / size guards. Cognitive complexity is already covered by sonarjs
-    // (error@15). All ERRORS (enforced going forward) except max-params, which stays WARN
-    // for its one intentional offender: spawnClaudePty's 7 params (hot path, not worth
-    // churning 5 call sites into an options object) — flip it to error once resolved.
+    // (error@15). All ERRORS — including max-params, which spent long enough as a WARN to
+    // show what a warning is worth here: it was left at warn for spawnClaudePty's 7 params,
+    // that function became an options object and took itself off the list, nobody flipped the
+    // rule, and TWO new offenders arrived in its shadow (one at nine). A rule nothing enforces
+    // is a rule that documents the violation it invites.
     //
     // max-lines is per FILE and was the gap: the per-function guards were all passing while
     // TerminalCell.vue reached 2000 lines, because nothing was watching the file. Counted
@@ -113,7 +122,7 @@ export default [
       "max-lines-per-function": ["error", { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true }],
       complexity: ["error", 20],
       "max-depth": ["error", 4],
-      "max-params": ["warn", 6],
+      "max-params": ["error", 6],
       "max-nested-callbacks": ["error", 4],
     },
   },
@@ -228,13 +237,15 @@ export default [
       // arrow's `: void` body and none of them a promise; those are block bodies now.
       "sonarjs/void-use": "error",
       //
-      // WARN — the findings are external APIs we use ON PURPOSE, so this cannot reach zero, but a
-      // NEW deprecation is worth seeing. The five standing ones: `Server` from the MCP SDK (x3),
-      // whose own notice says to keep using it for the low-level `setRequestHandler` API we are on;
-      // `document.execCommand("copy")`, the synchronous copy that works on an existing selection
-      // where the async Clipboard API does not; and `e.returnValue`, which legacy Chrome/Edge still
-      // require to raise the beforeunload prompt.
-      "sonarjs/deprecation": "warn",
+      // ERROR, with the three files that hold the deliberate uses listed further down. It was a
+      // warning because "the findings are external APIs we use on purpose, so this cannot reach
+      // zero" — but that reasoning applies to those three files, not to the rule, and as a warning
+      // it could not tell a fourth file from the three. The five deliberate ones: `Server` from the
+      // MCP SDK (x3), whose own notice says to keep using it for the low-level `setRequestHandler`
+      // API we are on; `document.execCommand("copy")`, the synchronous copy that works on an
+      // existing selection where the async Clipboard API does not; and `e.returnValue`, which
+      // legacy Chrome/Edge still require to raise the beforeunload prompt.
+      "sonarjs/deprecation": "error",
       //
       // OFF — every finding was a false positive, and the reason is structural rather than
       // incidental, so the rule will keep producing them:
@@ -357,11 +368,12 @@ export default [
     rules: {
       "max-lines-per-function": "off",
       "max-nested-callbacks": "off",
-      // The FILE limit still applies here, but as a warning: a 1900-line spec is worth
-      // seeing, and yet splitting one moves assertions away from each other — the same
-      // trade-off the paragraph below describes for stubs. Warn says so without making a
-      // long-standing spec block anyone's CI.
-      "max-lines": ["warn", { max: 600, skipBlankLines: true, skipComments: true }],
+      // The FILE limit applies here at full strength. It was a warning, on the reasoning that
+      // splitting a spec moves assertions away from each other — true, and the reason the
+      // files already over it are listed below rather than split. But a warning let SEVEN
+      // specs cross the line, the worst at 2264, because nothing ever failed. The list below
+      // holds those seven; a spec written tomorrow gets the same 600 as everything else.
+      "max-lines": ["error", { max: 600, skipBlankLines: true, skipComments: true }],
       // Same reasoning for components: a spec defines throwaway stubs next to the case that
       // uses them (useCaptureKeydown, useNewTerminal). Splitting one-line stubs into their own
       // files would put the fixture further from the assertion, which is the opposite of what
@@ -377,6 +389,16 @@ export default [
     files: [
       "src/components/TerminalCell.vue", // 1078 — the launch form is out (#1122); the running cell's chrome (header chips, diff panel, close confirm, handoff menu) is what's left
       "src/components/TerminalGrid.vue", //  815 — layout state machine + its documented <style> exception (#1125)
+      // The specs that were already over the limit when it stopped being a warning. Splitting one
+      // moves assertions away from each other, so these are carried as debt rather than cut up —
+      // but they are the WHOLE debt, and the rule holds every other spec at 600.
+      "test/server/backends/collections.spec.ts", //  875
+      "test/server/config/app-config.spec.ts", //  648
+      "test/src/components/CellLaunchForm.spec.ts", //  902
+      "test/src/components/GridView.spec.ts", //  785
+      "test/src/components/TerminalCell.spec.ts", // 2264
+      "test/src/components/TerminalGrid.spec.ts", //  767
+      "test/src/components/gridTabs.spec.ts", //  921
     ],
     rules: {
       "max-lines": "off",
@@ -391,6 +413,19 @@ export default [
       "security/detect-non-literal-fs-filename": "off",
       "security/detect-object-injection": "off",
       "security/detect-non-literal-regexp": "off",
+      // `recommended` ships every rule at warn. This one is at zero and is worth keeping there:
+      // a quantifier inside a quantifier is a shape, not a judgement call, and the fix is always
+      // to say the rule a different way (gitlabHosts tests per label instead of per hostname).
+      "security/detect-unsafe-regex": "error",
+    },
+  },
+  {
+    // The deliberate uses of a deprecated external API, listed here rather than silenced at the
+    // scene, for the reason the max-lines list above gives: countable in one place, and deleting an
+    // entry re-arms the rule for that file. Each one is explained where it is used.
+    files: ["server/mcp/broker.ts", "src/composables/useTerminalConnections.ts", "src/composables/useUnloadGuard.ts"],
+    rules: {
+      "sonarjs/deprecation": "off",
     },
   },
   prettierRecommended,

--- a/plans/chore-1682-lint-zero-warnings.md
+++ b/plans/chore-1682-lint-zero-warnings.md
@@ -1,0 +1,58 @@
+# chore #1682 — lint の警告を 0 にして、緩んでいたルールを error に上げる
+
+## 出発点
+
+`yarn lint` は 0 errors / 16 warnings。警告は CI を止めないので、増えても誰も気づかない。実際に
+2 件それが起きていた。
+
+- **`max-params` の理由書きが実態とずれていた。** config には「唯一の意図的な違反者は
+  `spawnClaudePty` の 7 引数、解消したら error に上げる」とあるが、`spawnClaudePty` は既に
+  options オブジェクト化されて引数 4 個。error に上がらないまま、別の 2 ファイルが新たに違反した。
+- **`max-lines` は全ファイルで error なのに spec だけ warn。** そのため spec は 600 行を超え放題で、
+  現在 7 ファイル、最大 2264 行。`.vue` 側は超過ファイルを明示リストにして `off` にする方式
+  （数えられる負債）なのに、spec はその扱いになっていなかった。
+
+## 方針
+
+**減らせるものは減らす。減らせないものは、増えないように閉じる。**
+
+「明示リストに載せる」は silencing ではない。config の既存コメントが述べているとおり、
+`eslint-disable` コメントは現場に隠れるが、config の `files:` リストは 1 か所で数えられ、
+ファイルが基準を満たした時点でエントリを消せばルールがそのまま押さえてくれる。
+
+## 手順
+
+### 1. 減らす（副作用なし）
+
+1. `test/src/utils/customViewSrcdoc.spec.ts` — disable 指定から、何も報告していない `no-new-func`
+   を落とす。`sonarjs/code-eval` は残す。
+2. `common/gitlabHosts.ts` — `HOSTNAME_RE` の入れ子量指定子を外す。**等価性は旧実装との差分テストで
+   示す**（生成入力で全件比較し、件数を記録してから harness を捨てる）。
+3. `server/backends/sharedApp/deploy.ts` の `establishAndScan`（7 引数）と
+   `server/backends/sharedApp/publish.ts` の `publishSteps`（9 引数）を options オブジェクトに。
+   どちらもモジュール内ローカルで呼び出し元は 1 か所ずつ。
+
+   位置引数→名前付きの変換で唯一こわいのは**同じ型の引数の取り違え**（`establishAndScan` の
+   `aid` と `root` はどちらも `string` なので、入れ替えても型検査を通る）。だから旧シグネチャの
+   並びと新しい呼び出し側のキーの並びを 1 対 1 で突き合わせて確認する。変換後は名前で検査される
+   ので、この危険は恒久的に消える。
+
+### 2. 厳しくする
+
+4. `max-lines` — spec も `error` に戻し、現在超過している 7 ファイルだけを `.vue` と同じ明示リストへ。
+5. `max-params` — `warn` → `error`（手順 3 のあと）。停滞していた理由書きも実態に更新する。
+6. `security/detect-unsafe-regex` — `warn` → `error`（手順 2 のあと）。
+7. `sonarjs/deprecation` — `warn` → `error` にし、意図的な 5 件を抱える 3 ファイルだけを明示リストで
+   `off`。新しい非推奨 API の使用はどこでも CI を止める。
+8. `linterOptions.reportUnusedDisableDirectives: "error"`。今は既定の warn。
+
+## 完了条件
+
+`yarn lint` が 0 errors / 0 warnings。残る負債は全部 config 内の明示リストに載っていて数えられる。
+
+## やらないこと
+
+- **spec 7 ファイルの分割。** config 自身が「分割はアサーションを引き離す」と述べており、その判断を
+  覆さない。リスト化で「減らないが増えない」状態にする。
+- **意図的な非推奨 5 件の置き換え。** MCP SDK の `Server` は低レベル API のために公式に継続使用を
+  案内しており、`execCommand("copy")` と `e.returnValue` はそれぞれ代替が効かない場面のために置いてある。

--- a/server/backends/sharedApp/deploy.ts
+++ b/server/backends/sharedApp/deploy.ts
@@ -109,15 +109,25 @@ async function reserveHeldSlug(
  *  Split out for the line budget, but the two steps belong together anyway: the write is what
  *  makes the read possible, and doing them apart is what let a missing parent be mistaken for an
  *  empty store. */
-async function establishAndScan(
-  handle: SharedAppHandle,
-  aid: string,
-  appDoc: Record<string, unknown>,
-  established: boolean,
-  collections: readonly LoadedCollection[],
-  root: string,
-  confirm: boolean | undefined,
-): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
+interface EstablishAndScanInput {
+  handle: SharedAppHandle;
+  aid: string;
+  appDoc: Record<string, unknown>;
+  established: boolean;
+  collections: readonly LoadedCollection[];
+  root: string;
+  confirm: boolean | undefined;
+}
+
+async function establishAndScan({
+  handle,
+  aid,
+  appDoc,
+  established,
+  collections,
+  root,
+  confirm,
+}: EstablishAndScanInput): Promise<{ ok: true; scan: RecordScan } | SharedAppFailure> {
   if (established) {
     const claimed = await claimApp(handle, aid, appDoc);
     if (claimed) return claimed;
@@ -292,7 +302,7 @@ export async function deploySharedApp(root: string, opts: SharedAppOptions = {})
   // about to write anyway, and afterwards the records can be read. So the gate runs for real: on a
   // new app it finds nothing, and on a resurrected aid it finds whatever survived.
   const established = existingApp === null;
-  const gate = await establishAndScan(handle, aid, appDoc, established, collections, root, opts.confirm);
+  const gate = await establishAndScan({ handle, aid, appDoc, established, collections, root, confirm: opts.confirm });
   if (!gate.ok) return gate;
   const { scan } = gate;
 

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -122,17 +122,19 @@ function stagedForValidation(
 }
 
 /** The writes, in the order the design fixes: promote, project, then open. */
-function publishSteps(
-  handle: SharedAppHandle,
-  aid: string,
-  staged: readonly StagedEntry[],
-  stamp: PublishStamp,
-  face: ReturnType<typeof projectPublish>,
-  slug: string | undefined,
-  form: PublicForm,
-  view: ViewFile | null,
-  tiers: readonly TierPromotion[],
-): WriteStep[] {
+interface PublishStepsInput {
+  handle: SharedAppHandle;
+  aid: string;
+  staged: readonly StagedEntry[];
+  stamp: PublishStamp;
+  face: ReturnType<typeof projectPublish>;
+  slug: string | undefined;
+  form: PublicForm;
+  view: ViewFile | null;
+  tiers: readonly TierPromotion[];
+}
+
+function publishSteps({ handle, aid, staged, stamp, face, slug, form, view, tiers }: PublishStepsInput): WriteStep[] {
   return [
     ...staged.map(({ cid, doc }) => ({
       what: `the published schema for '${cid}' (apps/${aid}/collections/${cid})`,
@@ -353,7 +355,8 @@ export async function publishSharedApp(root: string, opts: SharedAppOptions = {}
   const pages = await promotableTiers(handle, aid, stamp, staged.staged);
   if (!pages.ok) return pages;
 
-  const failure = await runWrites(publishSteps(handle, aid, staged.staged, stamp, face, slug, form, page.view, pages.tiers), "publish");
+  const steps = publishSteps({ handle, aid, staged: staged.staged, stamp, face, slug, form, view: page.view, tiers: pages.tiers });
+  const failure = await runWrites(steps, "publish");
   if (failure) return failure;
 
   return {

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -55,6 +55,7 @@ import { isCopyOnSelectEnabled } from "./copyOnSelect";
 import { createFilePathLinkProvider } from "./terminalFilePathLinkProvider";
 import { tryOpenInPane } from "./filesPaneOpener";
 import { filesGotoFile } from "./useFilesView";
+import { writeTerminalSelection } from "../utils/terminalSelectionClipboard";
 import type { TerminalAgent } from "../../common/sessionAgent";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
@@ -241,36 +242,6 @@ const clipboardProvider: IClipboardProvider = {
     }
   },
 };
-
-// Put the terminal's selection on the system clipboard, by whichever route the browser allows.
-//
-// `navigator.clipboard` is the direct one, but it is secure-context-only: at `http://<lan-ip>` it
-// does not exist AT ALL, and reaching this app that way from a second machine is ordinary. The
-// fallback hands the job back to xterm — with its helper textarea focused, `execCommand("copy")`
-// fires xterm's own `copy` listener, which writes THE CURRENT SELECTION.
-//
-// Which is why this takes the terminal's host and not merely a string: it can only ever copy what
-// the terminal has selected, and must not be generalised into "write this text to the clipboard".
-async function writeTerminalSelection(host: HTMLDivElement, text: string): Promise<boolean> {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // document not focused, or permission refused — fall through instead of giving up
-    }
-  }
-  // Focus is NOT taken here. Reaching this line means the user just dragged inside this terminal,
-  // so xterm has already focused its textarea; if something else holds focus by now, stealing it
-  // back would be worse than not copying.
-  const textarea = host.querySelector(".xterm-helper-textarea");
-  if (!textarea || document.activeElement !== textarea) return false;
-  try {
-    return document.execCommand("copy");
-  } catch {
-    return false;
-  }
-}
 
 // How long the selection must hold still before it is copied. xterm fires onSelectionChange on
 // every coordinate change during a drag, so writing on each one would put every intermediate

--- a/src/utils/terminalSelectionClipboard.ts
+++ b/src/utils/terminalSelectionClipboard.ts
@@ -1,0 +1,33 @@
+// In a file of its own so the `sonarjs/deprecation` exception in eslint.config.js can name THIS
+// call. It used to sit in a composable of several hundred lines, and an exception that wide also
+// covers the next deprecated API somebody reaches for in there by accident.
+
+// Put the terminal's selection on the system clipboard, by whichever route the browser allows.
+//
+// `navigator.clipboard` is the direct one, but it is secure-context-only: at `http://<lan-ip>` it
+// does not exist AT ALL, and reaching this app that way from a second machine is ordinary. The
+// fallback hands the job back to xterm — with its helper textarea focused, `execCommand("copy")`
+// fires xterm's own `copy` listener, which writes THE CURRENT SELECTION.
+//
+// Which is why this takes the terminal's host and not merely a string: it can only ever copy what
+// the terminal has selected, and must not be generalised into "write this text to the clipboard".
+export async function writeTerminalSelection(host: HTMLDivElement, text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // document not focused, or permission refused — fall through instead of giving up
+    }
+  }
+  // Focus is NOT taken here. Reaching this line means the user just dragged inside this terminal,
+  // so xterm has already focused its textarea; if something else holds focus by now, stealing it
+  // back would be worse than not copying.
+  const textarea = host.querySelector(".xterm-helper-textarea");
+  if (!textarea || document.activeElement !== textarea) return false;
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  }
+}

--- a/test/common/gitlabHosts.spec.ts
+++ b/test/common/gitlabHosts.spec.ts
@@ -13,6 +13,12 @@ describe("normalizeGitlabHost", () => {
     ["a pasted https URL", "https://gitlab.hogefuga.com/", "gitlab.hogefuga.com"],
     ["a pasted http URL", "http://gitlab.internal.example", "gitlab.internal.example"],
     ["a hyphenated host", "git-lab.example.co.jp", "git-lab.example.co.jp"],
+    // The rest of this table and the one below pin what a LABEL may be, because the check reads
+    // labels one at a time: a hyphen is fine anywhere except at either end of one, and the shortest
+    // label is a single character. Nothing in the type system holds this.
+    ["doubled hyphens inside a label", "git--lab.example.com", "git--lab.example.com"],
+    ["single-character labels", "a.b", "a.b"],
+    ["a label of only digits", "12.example.com", "12.example.com"],
   ])("accepts %s", (_case, input, expected) => {
     expect(normalizeGitlabHost(input)).toBe(expected);
   });
@@ -29,6 +35,16 @@ describe("normalizeGitlabHost", () => {
     // host, so a declaration like this would sit in the config doing nothing.
     ["a dotless name", "gitlab"],
     ["a port", "gitlab.hogefuga.com:8443"],
+    ["a label starting with a hyphen", "-gitlab.example.com"],
+    ["a label ending with a hyphen", "gitlab-.example.com"],
+    ["a later label starting with a hyphen", "gitlab.-example.com"],
+    ["a last label ending with a hyphen", "gitlab.example-"],
+    // An empty label. Each of these is one `split(".")` away from looking like a valid host, and
+    // they are the three ways to spell it: in the middle, at the front, at the end.
+    ["a doubled dot", "gitlab..example.com"],
+    ["a leading dot", ".gitlab.example.com"],
+    ["a trailing dot", "gitlab.example.com."],
+    ["nothing but hyphens and a dot", "-.-"],
   ])("rejects %s", (_case, input) => {
     expect(normalizeGitlabHost(input)).toBeNull();
   });

--- a/test/src/utils/customViewSrcdoc.spec.ts
+++ b/test/src/utils/customViewSrcdoc.spec.ts
@@ -63,7 +63,7 @@ describe("buildCustomViewSrcdoc", () => {
     // The bootstrap only EXISTS as a string (it is inlined into the iframe's <script>), so running it
     // is the only way to assert what a view actually gets. The input is this repo's own literal, not
     // anything a user or collection author can influence.
-    // eslint-disable-next-line sonarjs/code-eval, no-new-func
+    // eslint-disable-next-line sonarjs/code-eval
     new Function("window", script)(win);
     return win.__MC_VIEW as ReturnType<typeof runBootstrap>;
   };

--- a/test/src/utils/terminalSelectionClipboard.spec.ts
+++ b/test/src/utils/terminalSelectionClipboard.spec.ts
@@ -1,0 +1,107 @@
+// The clipboard route the browser leaves us, and the conditions on the fallback. Worth pinning
+// because the fallback copies the SELECTION rather than the string it is handed: it fires xterm's
+// own `copy` listener, so it only does the right thing while xterm's helper textarea holds focus,
+// and "returned true" is the only signal the caller gets that anything was copied.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeTerminalSelection } from "../../../src/utils/terminalSelectionClipboard";
+
+const hostWithTextarea = (): HTMLDivElement => {
+  const host = document.createElement("div");
+  const textarea = document.createElement("textarea");
+  textarea.className = "xterm-helper-textarea";
+  host.appendChild(textarea);
+  document.body.appendChild(host);
+  return host;
+};
+
+const focusHelper = (host: HTMLDivElement): void => {
+  const textarea = host.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+  textarea?.focus();
+};
+
+const setClipboard = (value: { writeText: (text: string) => Promise<void> } | undefined): void => {
+  Object.defineProperty(navigator, "clipboard", { value, configurable: true, writable: true });
+};
+
+describe("writeTerminalSelection", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    setClipboard(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("uses navigator.clipboard when it is there, and does not touch the fallback", async () => {
+    const writeText = vi.fn(async () => {});
+    setClipboard({ writeText });
+    const execCommand = vi.fn(() => true);
+    document.execCommand = execCommand;
+
+    expect(await writeTerminalSelection(hostWithTextarea(), "copied")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("copied");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  // At `http://<lan-ip>` — an ordinary way to reach this app from a second machine — the API does
+  // not exist at all, which is the whole reason the fallback is there.
+  it("falls back to execCommand when there is no clipboard API and the helper textarea has focus", async () => {
+    setClipboard(undefined);
+    const execCommand = vi.fn(() => true);
+    document.execCommand = execCommand;
+    const host = hostWithTextarea();
+    focusHelper(host);
+
+    expect(await writeTerminalSelection(host, "copied")).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back when the clipboard API rejects (no focus / permission refused)", async () => {
+    setClipboard({
+      writeText: vi.fn(async () => {
+        throw new Error("not focused");
+      }),
+    });
+    const execCommand = vi.fn(() => true);
+    document.execCommand = execCommand;
+    const host = hostWithTextarea();
+    focusHelper(host);
+
+    expect(await writeTerminalSelection(host, "copied")).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  // Focus is the fallback's precondition, not something it takes: execCommand("copy") would copy
+  // whatever the FOCUSED element has selected, so firing it elsewhere copies the wrong thing.
+  it("refuses rather than copying when something else holds focus", async () => {
+    setClipboard(undefined);
+    const execCommand = vi.fn(() => true);
+    document.execCommand = execCommand;
+    const host = hostWithTextarea();
+    const elsewhere = document.createElement("input");
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+
+    expect(await writeTerminalSelection(host, "copied")).toBe(false);
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the host has no helper textarea at all", async () => {
+    setClipboard(undefined);
+    document.execCommand = vi.fn(() => true);
+
+    expect(await writeTerminalSelection(document.createElement("div"), "copied")).toBe(false);
+  });
+
+  it("reports failure instead of throwing when execCommand throws", async () => {
+    setClipboard(undefined);
+    document.execCommand = vi.fn(() => {
+      throw new Error("blocked");
+    });
+    const host = hostWithTextarea();
+    focusHelper(host);
+
+    expect(await writeTerminalSelection(host, "copied")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`yarn lint` は 0 errors / **16 warnings** だった。警告は CI を止めないので、増えても誰も気づかない。
実際に 2 件それが起きていた。

- **`max-params` の理由書きが実態とずれていた。** config には「唯一の意図的な違反者は
  `spawnClaudePty` の 7 引数、解消したら error に上げる」とあったが、`spawnClaudePty` は既に
  options オブジェクト化されて**引数 4 個**。誰も上げないうちに、その陰で別の 2 ファイルが違反した
  （うち 1 つは 9 引数）。
- **`max-lines` は全ファイルで error なのに spec だけ warn だった。** そのため spec は 600 行を
  超え放題で、7 ファイル、最大 2264 行。`.vue` は超過ファイルを明示リストにする方式なのに、spec は
  その扱いになっていなかった。

**これで `yarn lint` は 0 errors / 0 warnings。** 残る負債はすべて config 内の明示リストに載っていて
数えられる。

### 減らしたもの（副作用なし）

| 件数 | 内容 |
|---|---|
| 1 | `customViewSrcdoc.spec.ts` の disable 指定から、何も報告していない `no-new-func` を落とした |
| 1 | `gitlabHosts.ts` の `HOSTNAME_RE` を、ラベル単位の判定に置き換えて入れ子量指定子を外した |
| 2 | `establishAndScan`（7 引数）と `publishSteps`（9 引数）を options オブジェクトに |

### 厳しくしたもの

| ルール | before | after |
|---|---|---|
| `max-params` | warn | **error** |
| `max-lines`（spec） | warn | **error** + 超過 7 ファイルを明示リストへ |
| `sonarjs/deprecation` | warn | **error** + 意図的な 5 件を持つ 3 ファイルを明示リストへ |
| `security/detect-unsafe-regex` | warn | **error** |
| `reportUnusedDisableDirectives` | warn（既定） | **error** |

「明示リストに載せる」は silencing ではない。config の既存コメントが述べているとおり、
`eslint-disable` コメントは現場に隠れるが、config の `files:` リストは 1 か所で数えられ、ファイルが
基準を満たした時点でエントリを消せばルールがそのまま押さえてくれる。

## Items to Confirm / Review

- **`gitlabHosts.ts` の正規表現の書き換え。** 旧実装を逐語コピーした差分ハーネスで
  **272,596 入力を全件比較し、不一致 0**（英数・ハイフン・ドット・記号からなる語彙で長さ 5 までを
  網羅、加えて乱数 30 万件と手書きの境界例）。なお **実測では旧式は破綻していなかった** ので、
  コード内コメントもそう書いてある — 消したのは症状ではなく形。ここは判断が入るので見てほしい。
- **位置引数 → 名前付きの 2 件。** 唯一こわいのは同型引数の取り違えで、`establishAndScan` の
  `aid` と `root` はどちらも `string` なので入れ替えても型検査を通る。旧シグネチャの並びと新しい
  呼び出し側のキーを機械的に突き合わせ、**16 スロットすべてが 1 対 1、式も同一**だと確認した。
  変換後は名前で検査されるので、この危険は恒久的に消える。
- **`sonarjs/deprecation` を error にしてファイル単位で off にした判断。** 引き換えに、リスト内の
  3 ファイルで *新しい* 非推奨 API を使っても気づけなくなる。ルール単位の warn（どこでも見えるが
  どこでも止まらない）と、どちらを取るかの選択。
- **spec 7 ファイルは分割していない。** config 自身が「分割はアサーションを引き離す」と述べており、
  その判断は覆していない。リスト化で「減らないが増えない」状態にした。
- **意図的な非推奨 5 件も置き換えていない。** MCP SDK の `Server` は低レベル API のために公式に
  継続使用を案内しており、`execCommand("copy")` と `e.returnValue` はそれぞれ代替が効かない場面用。

## User Prompt

- 副作用無く減らせるものは減らして、規則を厳しくしてほしい（`yarn lint` の警告 16 件を貼付）
- max perline って全ファイル対象でエラーになってないのか。。。
- できるだけ全体厳しくしていくからね

## 検証

- `yarn format` / `yarn lint`（**0 errors / 0 warnings**）/ `yarn typecheck` / `yarn build`
- `yarn test` — 693 files / 9972 tests passed、3 files / 45 tests skipped
- **ラチェットが噛むことを実測**: 7 引数の関数、リスト外での `document.execCommand`、腐った
  disable 指定、601 行の新しい spec — いずれも error で落ちることを確認。負債リストに載っている
  `TerminalCell.spec.ts` は max-lines を 1 件も出さないことも確認。確認用ファイルは削除済み。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable terminal text copying with support for the native Clipboard API and a fallback method.

- **Bug Fixes**
  - Improved GitLab hostname validation to require properly formed multi-label hostnames and reject labels ending with hyphens.
  - Normalization now applies the same strengthened validation rules consistently.
  - Improved terminal copy behavior when clipboard access is unavailable or fails.

- **Documentation**
  - Added a plan for eliminating lint warnings and enforcing stricter code-quality checks.

- **Refactor**
  - Internal deployment and publishing workflows now use clearer structured inputs without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->