### PR TITLE
chore(plans): 共有アプリの済んだ計画 10 本を plans/done/ に移す

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -56,7 +56,7 @@ no dependents to bump, no plugin peer ranges, no changelog check and no e2e suit
 `test/fixtures/sharedAppGolden/` keeps a picture of the two `{tier}/config` documents, so a
 change to what a published app carries shows up as a diff rather than only as a test.
 
-Design: [`plans/refactor-shared-app-module.md`](https://github.com/receptron/mulmoterminal/blob/main/plans/refactor-shared-app-module.md).
+Design: [`plans/done/refactor-shared-app-module.md`](https://github.com/receptron/mulmoterminal/blob/main/plans/done/refactor-shared-app-module.md).
 
 ### The staff page can approve, and the people on the roster have an entrance of their own (#1671)
 
@@ -107,7 +107,7 @@ await window.__MC_APP_VIEW.assign(cid, itemId, address); // hand a row to a coll
   out and shows nothing of the app's internal vocabulary. The two are not exclusive — an owner who
   also books is on both, and each address shows one face.
 
-Design: `plans/feat-shared-app-member-write.md`.
+Design: `plans/done/feat-shared-app-member-write.md`.
 
 ### A shared app can have a page for its staff, not only for its visitors (#1667)
 
@@ -145,7 +145,7 @@ moving an owner's own data, and does not pretend to.
 
 Needs `@mulmoclaude/core@3.14.0`, the Firestore rules from mulmoserver#168 (deployed), and the
 `/m/{slug}` runtime from mulmoserver#169. Design and open questions:
-[`plans/feat-shared-app-member-view.md`](https://github.com/receptron/mulmoterminal/blob/main/plans/feat-shared-app-member-view.md).
+[`plans/done/feat-shared-app-member-view.md`](https://github.com/receptron/mulmoterminal/blob/main/plans/done/feat-shared-app-member-view.md).
 Writing from a member page — approving a booking, reassigning it — is not in this release.
 
 ## mulmoterminal@4.8.2 — 2026-08-13

--- a/docs/shared-app-principles.md
+++ b/docs/shared-app-principles.md
@@ -115,7 +115,7 @@ uid に正規表現メタ文字が入っても壊れないためであり、`<vi
   `allow read: if true` なので、受付の画面をそこに置くとアプリの内部語彙 — 状態名・査読メモの
   見出し・担当の付け方 — が世界に出る。そして**射影を分けるだけでは足りない**: participant は
   スタッフ用のドキュメントをパスで直接取得でき、語彙は HTML そのものに書いてある。
-  分けるものはルールで分ける（[`plans/feat-shared-app-member-view.md`](../plans/feat-shared-app-member-view.md)）
+  分けるものはルールで分ける（[`plans/done/feat-shared-app-member-view.md`](../plans/done/feat-shared-app-member-view.md)）
 
 **破れ方**: 個人情報を含む行を「公開の表に出したい」と言われて、注意書きを添えて `public.read` に
 足すこと。注意書きは強制ではない。**別コレクションに割る**のが唯一の答えである。
@@ -226,7 +226,7 @@ sandbox の中の HTML は自由に生成してよい（Firestore ハンドル�
 React アプリに戻っただけで、それはもう新しくない。
 
 守られている場所: View Bridge の分割（親が Firebase を持ち、ビューは受け取った値を描くだけ）と、
-公開ビューについては [`plans/feat-shared-app-public-view.md`](../plans/feat-shared-app-public-view.md)。
+公開ビューについては [`plans/done/feat-shared-app-public-view.md`](../plans/done/feat-shared-app-public-view.md)。
 公開ビューでは**`event.source` の検証では足りない** — それは「どのウィンドウか」を示すだけで
 「人が選んだ」を示さない。書くと決めるのは**親**であり、親が自分で描いた確認を挟む。
 
@@ -242,7 +242,7 @@ React アプリに戻っただけで、それはもう新しくない。
   渡すのは氏名・連絡先を含む本物のレコードである。**これは越えられる境界ではない**と判断している:
   ビューを書くのはオーナー、データもオーナーのもの、読むのはオーナーの名簿にいる人で、
   ビューを書かなくてもコレクションの画面から書き出せる。**ただし publish の出力がそう言う**
-- **名簿の人の書き込みには確認を挟まない**（[`plans/feat-shared-app-member-write.md`](../plans/feat-shared-app-member-write.md)）。
+- **名簿の人の書き込みには確認を挟まない**（[`plans/done/feat-shared-app-member-write.md`](../plans/done/feat-shared-app-member-write.md)）。
   公開側で確認が要るのは、ページを書いた人と責任を負う人が違うためで、メンバー側はそこが逆
   （店のページ・店のデータ・本人のロールが上限）。1 日に何十回押すボタンの前のモーダルは、
   安全性を上げずに使うのをやめさせる。**代わりに、何が起きたかを親が iframe の外に必ず出す** —

--- a/plans/done/feat-shareable-collections-step3-store.md
+++ b/plans/done/feat-shareable-collections-step3-store.md
@@ -4,7 +4,7 @@
 次のステップは [`feat-shareable-collections-step5-publish.md`](./feat-shareable-collections-step5-publish.md)。
 このファイルは着手する人への引き継ぎとして書かれ、いまは #2856 の設計記録も兼ねる。
 **日付**: 2026-08-10（#2856 の進行に合わせて更新）
-**親プラン**: [`plans/feat-shareable-collections.md`](./feat-shareable-collections.md) — **先に読むこと。**
+**親プラン**: [`plans/feat-shareable-collections.md`](../feat-shareable-collections.md) — **先に読むこと。**
 このファイルは親プランを前提に、ステップ 3 だけを切り出したもの。
 
 **作業リポジトリ**: `../mulmoclaude`（`@mulmoclaude/core`）。**MulmoTerminal のコードは 1 行も変わらない。**

--- a/plans/done/feat-shareable-collections-step5-publish.md
+++ b/plans/done/feat-shareable-collections-step5-publish.md
@@ -4,7 +4,7 @@
 `@mulmoclaude/core` 3.7.0 として公開済み）。以下は着手前に書かれた引き継ぎで、
 **実際に何が入り、この文書のどこが間違っていたかは末尾「着手した結果」を読むこと。**
 **日付**: 2026-08-11
-**親プラン**: [`plans/feat-shareable-collections.md`](./feat-shareable-collections.md) — **先に読むこと。**
+**親プラン**: [`plans/feat-shareable-collections.md`](../feat-shareable-collections.md) — **先に読むこと。**
 **前のステップ**: [`feat-shareable-collections-step3-store.md`](./feat-shareable-collections-step3-store.md)（完了、mulmoclaude #2856）
 
 **作業リポジトリ**: `../mulmoclaude`（`@mulmoclaude/core`）。**MulmoTerminal のコードは 1 行も変わらない。**

--- a/plans/done/feat-shared-app-assignee-role.md
+++ b/plans/done/feat-shared-app-assignee-role.md
@@ -1,8 +1,9 @@
 # 共有アプリ: 行スコープの書き手ロール `assignee`
 
-**状態**: 設計のみ。実装は未着手。2026-08-12 の議論から。
-全体設計は [`feat-shareable-collections.md`](./feat-shareable-collections.md)、
-流れは [`shared-collection-flow.md`](./shared-collection-flow.md)。
+**状態**: **完了**（2026-08-12）。ルール mulmoserver#162 / 宣言 mulmoclaude#2874 /
+MT 側の追従とテンプレート mulmoterminal#1655 — いずれもマージ済み。設計は 2026-08-12 の議論から。
+全体設計は [`feat-shareable-collections.md`](../feat-shareable-collections.md)、
+流れは [`shared-collection-flow.md`](../shared-collection-flow.md)。
 
 **この変更は 3 リポジトリにまたがる** — `../mulmoserver`（ルール）、
 `../mulmoclaude/packages/core`（宣言と検査）、ここ（MulmoTerminal）。順序が重要なので

--- a/plans/done/feat-shared-app-first-come.md
+++ b/plans/done/feat-shared-app-first-come.md
@@ -1,7 +1,9 @@
 # 共有アプリ: 先着枠つき予約（解禁時刻・申込み順・定員をビューで出す）
 
-**状態**: 設計のみ。実装は未着手。2026-08-12 の議論から。
-全体設計は [`feat-shareable-collections.md`](./feat-shareable-collections.md)、
+**状態**: **完了**（2026-08-12）。`assignee` と同じ 3 本（mulmoserver#162 /
+mulmoclaude#2874 / mulmoterminal#1655）で入り、解禁の瞬間の扱いは mulmoserver#163 で直した。
+設計は 2026-08-12 の議論から。
+全体設計は [`feat-shareable-collections.md`](../feat-shareable-collections.md)、
 行スコープの承認は [`feat-shared-app-assignee-role.md`](./feat-shared-app-assignee-role.md)。
 
 **追加する宣言は 2 つだけ**（`stampField` と相対的な解禁時刻）で、定員と繰り上げは

--- a/plans/done/feat-shared-app-member-view.md
+++ b/plans/done/feat-shared-app-member-view.md
@@ -6,10 +6,10 @@
 
 | | PR | 状態 |
 |---|---|---|
-| 1 ルール（`member` / `roster`） | mulmoserver#168 | レビュー中。マージ後に**手で deploy** |
-| 2 宣言（`views[]`、core 3.14.0） | mulmoclaude#2877 | レビュー中。npm 公開は 4 より先 |
-| 3 ランタイム（`/m/{slug}`） | mulmoserver#169 | レビュー中 |
-| 4 publish（階層への書き出し） | mulmoterminal#1667 | core 3.14.0 待ちで draft |
+| 1 ルール（`member` / `roster`） | mulmoserver#168 | **マージ済み**（2026-08-13）。deploy 済み（同日 12:25 のリリース） |
+| 2 宣言（`views[]`、core 3.14.0） | mulmoclaude#2877 | **マージ済み・npm 公開済み** |
+| 3 ランタイム（`/m/{slug}`） | mulmoserver#169 | **マージ済み・deploy 済み** |
+| 4 publish（階層への書き出し） | mulmoterminal#1667 | **マージ済み** |
 
 **書き込みはこの計画には無い。** メンバーの書き込みは投稿ではなく既存レコードの更新
 （承認・担当の付け替え）で、`public.submit` ではなくロールに対して判定される。

--- a/plans/done/feat-shared-app-member-view.md
+++ b/plans/done/feat-shared-app-member-view.md
@@ -1,6 +1,8 @@
 # 共有アプリ: 公開後のアプリに「名簿の人の顔」を作る
 
-**状態**: 実装中（2026-08-13 着手）。設計は 2026-08-13 の指摘から。
+**状態**: **完了**（2026-08-13）。下の 4 本はすべてマージ済みで、ルールは手で deploy 済み。
+のちに mulmoserver#170（拒否と「聞けなかった」の分離）と mulmoserver#179
+（`/m/{slug}/records/{cid}` のレコード表）が続いた。設計は 2026-08-13 の指摘から。
 
 | | PR | 状態 |
 |---|---|---|
@@ -15,8 +17,8 @@
 続きは [`feat-shared-app-member-write.md`](./feat-shared-app-member-write.md) —
 participant の入口（`/p/{slug}`）もそちらで決めた。
 
-前提: [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)（不変条件）、
-[`feat-shareable-collections.md`](./feat-shareable-collections.md)（D1–D10）、
+前提: [`docs/shared-app-principles.md`](../../docs/shared-app-principles.md)（不変条件）、
+[`feat-shareable-collections.md`](../feat-shareable-collections.md)（D1–D10）、
 [`feat-shared-app-public-view.md`](./feat-shared-app-public-view.md)（公開ビュー、実装済み）。
 
 ---

--- a/plans/done/feat-shared-app-member-write.md
+++ b/plans/done/feat-shared-app-member-write.md
@@ -1,8 +1,8 @@
 # 共有アプリ: 名簿の人が「書く」— 承認・担当の付け替えと、参加者の入口
 
-**状態**: 実装中（2026-08-13）。core mulmoclaude#2891 はマージ済み・**3.15.0 は npm 公開済み**
-（この PR が pin する）/ ランタイム mulmoserver#171・#172 はマージ済み・**deploy 未実施** /
-スキルとテンプレートはこの PR。**ルールの変更は無い**。
+**状態**: **完了**（2026-08-13）。core mulmoclaude#2891（3.15.0 は npm 公開済み）/
+ランタイム mulmoserver#171・#172 / スキルとテンプレート mulmoterminal#1671 —
+すべてマージ済み。**ルールの変更は無い**。
 残る前提は 2 つだけ: **mulmoserver の deploy** と、**アプリを publish し直すこと**。
 それまでスタッフ用ページは読み取り専用のまま（射影が `writers` を運ばないので
 member 階層は fail closed）。
@@ -11,8 +11,8 @@ member 階層は fail closed）。
 どちらも同じところに着地するので分けない: 「書く」の中身は participant にもあり
 （自分の予約を取り消す）、入口を決めないとその書き込みの置き場所が決まらない。
 
-前提: [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)（不変条件）、
-[`feat-shareable-collections.md`](./feat-shareable-collections.md)（D1–D10）、
+前提: [`docs/shared-app-principles.md`](../../docs/shared-app-principles.md)（不変条件）、
+[`feat-shareable-collections.md`](../feat-shareable-collections.md)（D1–D10）、
 [`feat-shared-app-member-view.md`](./feat-shared-app-member-view.md)（`/m/{slug}`、実装済み）。
 
 ---

--- a/plans/done/feat-shared-app-public-view.md
+++ b/plans/done/feat-shared-app-public-view.md
@@ -1,12 +1,14 @@
 # 共有アプリ: 公開ページを「予約サイト」にする（公開カスタムビュー + 枠の排他）
 
-**状態**: 設計のみ。実装は未着手。2026-08-12 の議論から。
+**状態**: **完了**（2026-08-13）。3 つとも入った — 1 枠の排他 mulmoclaude#2876 +
+mulmoserver#164、2 公開カスタムビュー mulmoserver#165（#167 で回答済みの再表示を修正）+
+mulmoterminal#1662（publish）、3 `salon.md` の更新 mulmoterminal#1662。設計は 2026-08-12 の議論から。
 レビュー（#1658）で見つかった 20 点を反映済み: id の不変性、宣言そのものの変更禁止、
 枠の実在**と状態**の確認（`untilField` を含む）、iframe の `event.source` 検証、
 bridge の `ready` / `submitResult`、`config/view` の撤去と版の一致、公開読み取りを
 `bookings` から `slots` に分離（`slots` と予約は対の batch でしか動かない）、ホスト用ビューとの契約の分離、publish の順序、
 顧客は delete できないこと。
-全体設計は [`feat-shareable-collections.md`](./feat-shareable-collections.md)、
+全体設計は [`feat-shareable-collections.md`](../feat-shareable-collections.md)、
 行スコープの承認は [`feat-shared-app-assignee-role.md`](./feat-shared-app-assignee-role.md)、
 先着枠は [`feat-shared-app-first-come.md`](./feat-shared-app-first-come.md)。
 

--- a/plans/done/memo-shared-collection-ids.md
+++ b/plans/done/memo-shared-collection-ids.md
@@ -1,8 +1,8 @@
 # メモ: 共有コレクションの識別子と置き場所
 
 **状態**: **本文への反映は完了**（2026-08-11）。
-[`feat-shareable-collections.md`](./feat-shareable-collections.md) と
-[`shared-collection-flow.md`](./shared-collection-flow.md) が正で、このメモは
+[`feat-shareable-collections.md`](../feat-shareable-collections.md) と
+[`shared-collection-flow.md`](../shared-collection-flow.md) が正で、このメモは
 **決定の理由**の記録として残す（本文は「何をするか」、ここは「なぜそう決めたか」）。
 **日付**: 2026-08-11
 **きっかけ**: mulmoclaude #2867 のレビューが「別アプリの同名コレクションが 1 つの一覧で

--- a/plans/done/refactor-shared-app-module.md
+++ b/plans/done/refactor-shared-app-module.md
@@ -7,8 +7,8 @@ mulmoclaude#2894、mulmoserver#175。
 差し替える**もの（あちらは射影の書き込み側だけを MT に引き取る案で、実装まで行ったが
 **保留にした** — mulmoclaude#2892 / mulmoterminal#1672 / mulmoserver#174 は draft）。
 ゴールデン文書（決定 2・3）はそのまま生きる。
-前提は [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)、
-決定は [`feat-shareable-collections.md`](./feat-shareable-collections.md) の D1–D10。
+前提は [`docs/shared-app-principles.md`](../../docs/shared-app-principles.md)、
+決定は [`feat-shareable-collections.md`](../feat-shareable-collections.md) の D1–D10。
 
 ---
 

--- a/plans/done/refactor-shared-app-wire-contract.md
+++ b/plans/done/refactor-shared-app-wire-contract.md
@@ -22,8 +22,8 @@
 （決定 4 は保留）。同じ 3 ファイルを両リポジトリに置き、それぞれのテストが生成側 /
 消費側から突く形にした。複製の同期の仕方は **#1673** で決める。
 [`feat-shared-app-member-write.md`](./feat-shared-app-member-write.md) を出した直後の
-振り返りから出た。前提は [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)、
-決定は [`feat-shareable-collections.md`](./feat-shareable-collections.md) の D1–D10。
+振り返りから出た。前提は [`docs/shared-app-principles.md`](../../docs/shared-app-principles.md)、
+決定は [`feat-shareable-collections.md`](../feat-shareable-collections.md) の D1–D10。
 
 ---
 

--- a/plans/feat-shareable-collections.md
+++ b/plans/feat-shareable-collections.md
@@ -2990,7 +2990,7 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
    `createFields`/`selfUpdate`/`selfTransitions`、`transitions`、`idFrom` の enum、`gateOn`、
    `immutable`、`peerVisibility`、`revealGated`（親を `get()` する形）、`mail` キュー
 3. **store を `(aid, cid)` で書き直す** — PR #2209 の中身がここに入る。
-   **引き継ぎ用の切り出し: [`feat-shareable-collections-step3-store.md`](./feat-shareable-collections-step3-store.md)**
+   **引き継ぎ用の切り出し: [`feat-shareable-collections-step3-store.md`](./done/feat-shareable-collections-step3-store.md)**
    （作業は `../mulmoclaude`。#2209 の再利用できる部分とプランと衝突する部分の地図つき）
 4. ~~**discovery の 2 ソース化 + skill materialize**~~ — **落とした**（mulmoclaude #2867 を
    クローズ済み）。**使う人は Web から使い、自分の MulmoTerminal では扱わない**ので、
@@ -3000,10 +3000,10 @@ firebase firestore:delete "apps/<aid>" --recursive --project <project>
 5. ~~**publish**（git → Firestore、記名 + 事前検証 + 前版保持）~~ — **完了**
    （mulmoclaude #2860 + mulmoserver #156、`@mulmoclaude/core` 3.7.0）。
    起動は `manageCollection` の `publishApp`。**何が入り、この計画のどこが間違っていたかは
-   [`feat-shareable-collections-step5-publish.md`](./feat-shareable-collections-step5-publish.md)
+   [`feat-shareable-collections-step5-publish.md`](./done/feat-shareable-collections-step5-publish.md)
    の「着手した結果」**。残った穴は mulmoclaude #2866（同時 publish の版混在）。以下は当初の記述:
    **publish**（git → Firestore、記名 + 事前検証 + 前版保持）。
-   **引き継ぎ用の切り出し: [`feat-shareable-collections-step5-publish.md`](./feat-shareable-collections-step5-publish.md)**
+   **引き継ぎ用の切り出し: [`feat-shareable-collections-step5-publish.md`](./done/feat-shareable-collections-step5-publish.md)**
    （ルールが実際に読むフィールドの正解表、authored → published 変換表、publish が拒否する不変条件つき）。**`submitOnly` の不変条件を
    ここで拒否する**（「`audience` は投稿経路しか縛らない」参照）— リンターは作者の手元でしか
    走らないので、保証はこちらに置く

--- a/plans/feat-shared-app-platform.md
+++ b/plans/feat-shared-app-platform.md
@@ -47,7 +47,7 @@
 
 ## 0. 決定済み・未実装（先にこれ）
 
-[`plans/feat-shared-app-public-view.md`](./feat-shared-app-public-view.md)（#1658、マージ済み）の
+[`plans/done/feat-shared-app-public-view.md`](./done/feat-shared-app-public-view.md)（#1658、マージ済み）の
 3 つ。レビューを 20 件通した設計で、**この計画はそれを前提にする**。要点だけ:
 
 1. **`idFrom: "field"` + `idIn` + `window.untilField`** — 枠 id を予約の id にして、

--- a/plans/shared-collection-flow.md
+++ b/plans/shared-collection-flow.md
@@ -1,7 +1,7 @@
 # 共有コレクション: 作成から公開までの流れ
 
 **状態**: 2026-08-11 の設計議論を反映したシナリオ。決定の根拠は
-[`memo-shared-collection-ids.md`](./memo-shared-collection-ids.md)、
+[`memo-shared-collection-ids.md`](./done/memo-shared-collection-ids.md)、
 全体設計は [`feat-shareable-collections.md`](./feat-shareable-collections.md)。
 **実装済みと未実装が混在している** — 各ステップ末尾と最後の表を参照。
 

--- a/test/server/backends/appViewGolden.spec.ts
+++ b/test/server/backends/appViewGolden.spec.ts
@@ -21,7 +21,7 @@
 // from `sharedapp`, and mulmoserver generates its own documents again
 // (`test/composables/test_appViewRoundTrip.ts`). #1673 closed with that.
 //
-// Design: plans/refactor-shared-app-module.md
+// Design: plans/done/refactor-shared-app-module.md
 import { describe, it, expect } from "vitest";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/test/server/backends/appViewTiers.spec.ts
+++ b/test/server/backends/appViewTiers.spec.ts
@@ -15,7 +15,7 @@
 // somebody presses it. Declaration and enforcement disagreeing is exactly what
 // the write projection exists to prevent.
 //
-// Design: plans/feat-shared-app-member-write.md
+// Design: plans/done/feat-shared-app-member-write.md
 import { describe, it, expect, beforeEach } from "vitest";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";


### PR DESCRIPTION
## 何をしたか

`plans/` 直下の共有アプリ系列 13 本を triage し、実装が 3 リポジトリともマージ済みの **10 本**を `plans/done/` に移した。完了日と PR 番号は LLM の推測ではなく `gh pr view --json mergedAt` の実値。

## アーカイブした 10 本

| plan | 実装 PR | 完了日 (UTC) |
|---|---|---|
| `feat-shareable-collections-step3-store.md` | mulmoclaude#2855 / #2856（core 3.6.0） | 2026-08-10 |
| `feat-shareable-collections-step5-publish.md` | mulmoclaude#2860 + mulmoserver#156（core 3.7.0） | 2026-08-11 |
| `memo-shared-collection-ids.md` | 本文への反映が仕事。チェックリスト全項目済み | 2026-08-11 |
| `feat-shared-app-assignee-role.md` | mulmoserver#162 / mulmoclaude#2874 / #1655 | 2026-08-12 |
| `feat-shared-app-first-come.md` | 同上（+ mulmoserver#163） | 2026-08-12 |
| `feat-shared-app-public-view.md` | mulmoclaude#2876 + mulmoserver#164 / #165・#167 / #1662 | 2026-08-13 |
| `feat-shared-app-member-view.md` | mulmoserver#168 / mulmoclaude#2877 / mulmoserver#169 / #1667 | 2026-08-13 |
| `feat-shared-app-member-write.md` | mulmoclaude#2891 / mulmoserver#171・#172 / #1671 | 2026-08-13 |
| `refactor-shared-app-module.md` | sharedapp `1ece783` / mulmoclaude#2894 / #1675 / mulmoserver#175 | 2026-08-13 |
| `refactor-shared-app-wire-contract.md` | 決定 1 は差し替えで CLOSED（#1672 / mulmoclaude#2892）、決定 2・3 は実装済み | 2026-08-13 |

## 状態の行を直した 5 本

**ヘッダーが実態と食い違っていた。** `assignee-role` / `first-come` / `public-view` は冒頭が「設計のみ。実装は未着手」のままだったが、3 リポジトリとも入っている — `server/backends/sharedApp/exclusivity.ts` と `publicView.ts` の実在、`templates/salon.md` の `slots` / `idFrom` / `"bookings": "assignee"` で確認した。`member-view` / `member-write` の「実装中」も同様。done/ に「未着手」と書かれたファイルが並ぶのは誤解のもとなので、実際の PR に直した。

逆向きの罠も 1 つ: `member-write` の実装を運んだのは、タイトルが `docs(plans):` の #1671（skill・テンプレート・`appViewTiers.spec.ts` が入っている）。

## active のまま残した 3 本

| plan | 理由 |
|---|---|
| `feat-shareable-collections.md` | 実装順 6・10・11・13〜20 が未着手、「未解決の論点」も 4 件。**CLAUDE.md が D1–D10 の出典として名指している** |
| `feat-shared-app-platform.md` | 「状態: 提案（着手前）」。CLAUDE.md から参照 |
| `shared-collection-flow.md` | シナリオ文書。ただし末尾の「実装状況（2026-08-11）」の表が**丸ごと古い**（deploy/publish 分割・aid 自動生成・slug 確保・staging・公開ページが全部「未実装」のまま）。archive ではなく**更新**が要る — この PR の範囲外 |

## 参照の書き換え

`plans/<name>.md` → `plans/done/<name>.md` を全 sweep（`find + xargs + grep`、`grep -r --exclude-dir` はフィルタが参照側にも当たるので使わない）:

- `docs/ChangeLog.md` 3 箇所（GitHub の blob URL も。放っておくと 404）
- `docs/shared-app-principles.md` 3 箇所
- `plans/feat-shared-app-platform.md` 1 箇所
- `test/server/backends/appViewGolden.spec.ts` / `appViewTiers.spec.ts` の `// Design:` コメント

移した側の相対リンクも 1 段深くした — `plans/` に残る計画へは `./` → `../`、`docs/` へは `../` → `../../`。移した 10 本の**相互**参照は `./` のまま正しい。

## Test plan

- sweep 再実行で stale **0 件**
- 移した 10 本と参照元の相対リンクを全部 `[ -e ]` で解決確認 — 壊れ **0 件**
- `yarn format` / `yarn lint`（0 errors）/ `yarn test` **10039 passed, 45 skipped**
- `plans/` 直下 409 → **399**、`plans/done/` 65 → **75**

## Items to Confirm

- `docs/ChangeLog.md` は履歴なので触らない選択もある。ただしリンク先が 404 になるので書き換えた
- `shared-collection-flow.md` の古い実装状況表は別 PR で直したい

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated design-plan links to their correct completed-plan locations.
  - Corrected relative links across shared app, collection, and wire-contract documentation.
  - Marked several completed plans as finished and recorded related implementation and review details.

- **Tests**
  - Updated test references to point to the current completed design documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->