### PR TITLE
fix: 電話からの回答が Firestore に載らない形だった

### DIFF
--- a/server/session/answerQuestionOnHost.ts
+++ b/server/session/answerQuestionOnHost.ts
@@ -16,11 +16,17 @@ const pause = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 // command is a Firestore document, and Firestore cannot store an array inside an array — a
 // `number[][]` is rejected outright by addDoc, so the phone wraps each row one map deep.
 // Same meaning, and both are read into the same `number[]`.
-const readRow = (row: unknown): number[] | null => {
-  if (isRecord(row)) return readRow(row.options);
+const readIndexes = (row: unknown): number[] | null => {
   if (!isUnknownArray(row)) return null;
   if (!row.every((idx) => typeof idx === "number")) return null;
   return row.filter((idx): idx is number => typeof idx === "number");
+};
+
+// Exactly one wrapper deep, never more: `{ options: { options: [1] } }` is not a shape either
+// client sends, and reading it would be guessing at what somebody meant.
+const readRow = (row: unknown): number[] | null => {
+  if (isRecord(row)) return readIndexes(row.options);
+  return readIndexes(row);
 };
 
 // The picks as they arrive from a client, read rather than trusted. Only the SHAPE is decided

--- a/server/session/answerQuestionOnHost.ts
+++ b/server/session/answerQuestionOnHost.ts
@@ -2,6 +2,7 @@ import { answerQuestion } from "./answerQuestion.js";
 import type { AnswerResult } from "../../common/askQuestion.js";
 import { otherWriteCount, writeAnswerKey } from "./write-to-session.js";
 import { isUnknownArray } from "../../common/isUnknownArray.js";
+import { isRecord } from "../../common/isRecord.js";
 import { sanitizeTerminalInput } from "../backends/remoteHost/terminalInput.js";
 
 // Between the keystrokes that answer a dialog: it rebuilds itself between questions, so a burst
@@ -10,13 +11,25 @@ const QUESTION_KEY_GAP_MS = 30;
 
 const pause = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+// One question's chosen indexes. Two shapes reach here because two transports do, and one of them
+// cannot carry the other's: the pane POSTs JSON and sends the row as `number[]`, while the phone's
+// command is a Firestore document, and Firestore cannot store an array inside an array — a
+// `number[][]` is rejected outright by addDoc, so the phone wraps each row one map deep.
+// Same meaning, and both are read into the same `number[]`.
+const readRow = (row: unknown): number[] | null => {
+  if (isRecord(row)) return readRow(row.options);
+  if (!isUnknownArray(row)) return null;
+  if (!row.every((idx) => typeof idx === "number")) return null;
+  return row.filter((idx): idx is number => typeof idx === "number");
+};
+
 // The picks as they arrive from a client, read rather than trusted. Only the SHAPE is decided
 // here — whether the indexes fit the dialog is keysForAnswers' call, made against the questions
 // the host itself recorded. A body that is not this shape is refused as bad-picks rather than
 // coerced, because a coerced pick is a keystroke aimed at a row nobody chose.
 const readPicks = (picks: unknown): number[][] | null => {
   if (!isUnknownArray(picks)) return null;
-  const rows = picks.map((row) => (isUnknownArray(row) && row.every((idx) => typeof idx === "number") ? row.filter((idx) => typeof idx === "number") : null));
+  const rows = picks.map(readRow);
   return rows.some((row) => row === null) ? null : rows.filter((row) => row !== null);
 };
 

--- a/test/server/session/answerQuestionOnHost.spec.ts
+++ b/test/server/session/answerQuestionOnHost.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+// The wire shape of an answer, which is not the same on both transports (#182).
+//
+// The pane POSTs JSON and sends each question's chosen indexes as a plain `number[]`. The phone's
+// command is a Firestore DOCUMENT, and Firestore cannot store an array inside an array: addDoc
+// rejects a `number[][]` outright with "Nested arrays are not supported", so the whole command
+// never leaves the phone. Its rows therefore arrive wrapped one map deep.
+//
+// Both must end up as the same indexes, and anything else must still be refused — a coerced pick
+// is a keystroke aimed at a row nobody chose.
+import { describe, it, expect, vi } from "vitest";
+
+const write = vi.fn<(sessionId: string, key: string) => boolean>(() => true);
+vi.mock("../../../server/session/write-to-session.js", () => ({
+  writeAnswerKey: (sessionId: string, key: string) => write(sessionId, key),
+  otherWriteCount: () => 0,
+}));
+
+const { answerQuestionOnHost } = await import("../../../server/session/answerQuestionOnHost");
+
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+
+const CALLS = (multiSelect = false) => [
+  {
+    toolUseId: "t1",
+    toolName: "AskUserQuestion",
+    status: "running",
+    toolInput: {
+      questions: [{ question: "Red or blue?", header: "Color", options: [{ label: "Red" }, { label: "Blue" }], multiSelect }],
+    },
+  },
+];
+
+// A fresh session per call: an answered dialog is claimed until it is reaped, so reusing one id
+// would refuse every case after the first as "closed".
+let sessions = 0;
+
+const answer = async (picks: unknown, multiSelect = false) => {
+  write.mockClear();
+  sessions += 1;
+  const result = await answerQuestionOnHost(`sess${sessions}`, "t1", picks, async () => CALLS(multiSelect));
+  return { result, keys: write.mock.calls.map((call) => call[1]) };
+};
+
+describe("answerQuestionOnHost picks", () => {
+  it("reads the pane's rows", async () => {
+    expect(await answer([[1]])).toEqual({ result: { ok: true }, keys: [DOWN, ENTER] });
+  });
+
+  // The phone's shape. Identical keystrokes, or the two clients disagree about what the user chose.
+  it("reads the phone's wrapped rows the same way", async () => {
+    expect(await answer([{ options: [1] }])).toEqual({ result: { ok: true }, keys: [DOWN, ENTER] });
+  });
+
+  it("reads a multi-select row from either shape", async () => {
+    const pane = await answer([[0, 1]], true);
+    const phone = await answer([{ options: [0, 1] }], true);
+    expect(pane.result).toEqual({ ok: true });
+    expect(phone.keys).toEqual(pane.keys);
+  });
+
+  it("refuses a wrapper holding something that is not indexes", async () => {
+    expect(await answer([{ options: ["1"] }])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+    expect(await answer([{ options: "1" }])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+    expect(await answer([{ nope: [1] }])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+  });
+
+  it("still refuses what neither shape allows", async () => {
+    expect(await answer("1")).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+    expect(await answer([1])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+  });
+});

--- a/test/server/session/answerQuestionOnHost.spec.ts
+++ b/test/server/session/answerQuestionOnHost.spec.ts
@@ -66,6 +66,11 @@ describe("answerQuestionOnHost picks", () => {
     expect(await answer([{ nope: [1] }])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
   });
 
+  // Neither client sends this, so reading it would be guessing at what somebody meant.
+  it("refuses a wrapper inside a wrapper", async () => {
+    expect(await answer([{ options: { options: [1] } }])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
+  });
+
   it("still refuses what neither shape allows", async () => {
     expect(await answer("1")).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });
     expect(await answer([1])).toEqual({ result: { ok: false, reason: "bad-picks" }, keys: [] });


### PR DESCRIPTION
## Summary

スマホから選択肢を押しても回答が届かなかった。原因はホストでも権限でもなく、**運搬経路**。

スマホの回答コマンドは Firestore の**ドキュメント**として書き込まれる。Firestore は配列の中に配列を
保存できないので、`picks: number[][]` は `addDoc` の時点で弾かれる:

```
Function addDoc() called with invalid data. Nested arrays are not supported
(found in document users/…/hosts/mulmoterminal/commands/…)
```

つまりコマンドは端末に届く以前に、スマホから出ていなかった。

そこでホスト側の受け口が、各行を map で1枚くるんだ形 `{ options: number[] }` も読めるようにした。
ペインは JSON を POST するので今までどおり素の `number[]` を送る。

## Items to Confirm / Review

- **形が二つあること自体をどう見るか。** 理由は「運搬経路が二つあり、片方がもう片方の形を運べない」
  ことだけで、それを `readRow` のコメントに書いた。統一するならペイン側も包む形に変える必要があり、
  動いている経路を対称性のためだけに変えることになるので、今回は取らなかった。
- **拒否の範囲。** `{ options: ["1"] }` / `{ options: "1" }` / `{ nope: [1] }` はすべて bad-picks。
  強制変換したピックは、誰も選んでいない行を狙う打鍵になるので、緩めていない。
- スマホ側の送信形は mulmoserver 側の PR (receptron/mulmoserver#183) で合わせる。**両方入って
  初めて動く**。

## 検証

- 実機（iPhone / mulmoserver 本番）で上記エラーを観測して特定。カード表示自体は同時に直っている。
- 新規 spec `test/server/session/answerQuestionOnHost.spec.ts` が、両方の形が**同じ打鍵**になること、
  および壊れた包みを拒否することを固定（5件）。
- `yarn format` / `lint` / `typecheck` / `build` / `test`（10103 passed）すべて green。

## User Prompt

> スマホで選択肢を出して答えられるようにしたい。UI は出たが Firebase のエラーになる。

（原因調査から修正まで。エラーの読み違い「権限」ではなく、Firestore の入れ子配列制約だった。）

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of question selections received in different supported data formats, including wrapped and numeric array values.
  * Preserved validation for malformed, nested, invalid, or unsupported answer values.
  * Ensured single-select and multi-select answers continue to produce equivalent results across supported input methods.

* **Tests**
  * Added coverage for pane and phone answer formats, equivalent keystrokes, invalid values, unsupported inputs, and session updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->