### PR TITLE
fix: ロケール名が無い環境では pty に UTF-8 の LANG を渡す

### DIFF
--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -73,6 +73,37 @@ export function sanitizePathEntries(pathValue: string, delimiter: string): strin
     .join(delimiter);
 }
 
+// The locale variables, in the precedence the C library resolves them by.
+const LOCALE_NAMES = ["LC_ALL", "LC_CTYPE", "LANG"] as const;
+
+// The one we write. Only the CODESET half of it matters here — every consumer below asks
+// "is this UTF-8", not "what language" — but a locale has to be spelled in full to be one.
+const FALLBACK_LOCALE = "en_US.UTF-8";
+
+/** A copy of `env` with a UTF-8 `LANG` when — and only when — it names no locale at all.
+ *
+ *  Not cosmetic. An embedder launched from the macOS GUI (a .app, a LaunchAgent) inherits
+ *  launchd's environment, which carries no locale whatsoever, and nothing between there and here
+ *  puts one back. Our terminals then run under C/POSIX, and the tmux client we spawn switches to
+ *  its non-UTF-8 output path: it writes ONE UNDERSCORE PER CELL for any character it has no DEC
+ *  ACS equivalent for. Claude Code's banner logo is block elements (U+2588 and friends), which
+ *  have none, so it reached the browser as `_______` — while the box drawing around it, which
+ *  tmux DOES have ACS for (─ -> `q`), looked perfectly fine and sent the first investigation
+ *  chasing a WebKit canvas-renderer bug that was never there. Same story for anything else that
+ *  reads the locale before choosing an output encoding (Python's stdout, ncurses TUIs).
+ *
+ *  Only when nothing is set. LC_ALL and LC_CTYPE both outrank LANG, so writing LANG could not
+ *  override them anyway, and a user who exported `LANG=ja_JP.UTF-8` keeps their own. An empty
+ *  value does not count — a login shell can export a bare `LANG=` alongside a real LC_ALL.
+ *
+ *  Windows is left alone: it has no such convention and no tmux, and git-bash reads LANG, so
+ *  introducing a variable that platform never had is its own bug waiting to be filed. */
+export function withFallbackLocale(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): NodeJS.ProcessEnv {
+  if (platform === "win32") return { ...env };
+  const named = LOCALE_NAMES.some((name) => (envValue(env, name) ?? "") !== "");
+  return named ? { ...env } : { ...env, LANG: FALLBACK_LOCALE };
+}
+
 // A copy of `env` safe to hand to a spawned PTY: launcher vars dropped, PATH
 // (any casing — Windows uses "Path") cleaned. Never mutates the input.
 export function sanitizePtyEnv(env: NodeJS.ProcessEnv, delimiter: string): NodeJS.ProcessEnv {

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -5,7 +5,7 @@
 import pty from "node-pty";
 import type { IPty } from "node-pty";
 import path from "node:path";
-import { sanitizePtyEnv } from "../infra/pty-env.js";
+import { sanitizePtyEnv, withFallbackLocale } from "../infra/pty-env.js";
 import { resolvePtyLaunchForEnv } from "../infra/resolve-bin.js";
 import { binaryProblemMessage, diagnoseBinary, type BinaryDiagnosis } from "../infra/has-binary.js";
 import { cwdProblemMessage, diagnoseSpawnCwd, type CwdDiagnosis } from "../infra/spawn-cwd.js";
@@ -27,8 +27,18 @@ const PTY_ROWS = 30;
 // the settings `env` block, which can set a variable but not remove one.
 // `extra` is set on the spawned process ON TOP of the sanitized inherited environment —
 // per-session values the child needs and our own process cannot carry (a session id).
+//
+// withFallbackLocale runs INSIDE `unset`, so an explicit unset still wins: it supplies a UTF-8
+// LANG only when our own environment names no locale, which is what an embedder launched from
+// the macOS GUI hands us — and what made the tmux client we spawn below render Claude Code's
+// block-element banner as rows of underscores. See infra/pty-env.ts for the mechanism.
+//
+// This reaches the tmux CLIENT, which is what decides that rendering, and any direct pty. A tmux
+// PANE takes its environment from the tmux SERVER instead, and the server inherits from whichever
+// client first started it — so panes are covered too from the next server start onward, but a
+// server already running under no locale keeps handing panes the old one until it is restarted.
 export function ptyEnv(unset: readonly string[] = [], extra: Readonly<Record<string, string>> = {}): NodeJS.ProcessEnv {
-  return { ...withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset), ...extra };
+  return { ...withoutUnset(withFallbackLocale(sanitizePtyEnv(process.env, path.delimiter), process.platform), unset), ...extra };
 }
 
 /** What a terminal opened in `cwd` is given on top of the inherited environment: the per-tree

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { isLauncherEnvVar, isPathVar, pathFromEnv, sanitizePathEntries, sanitizePtyEnv } from "../../../server/infra/pty-env";
+import { isLauncherEnvVar, isPathVar, pathFromEnv, sanitizePathEntries, sanitizePtyEnv, withFallbackLocale } from "../../../server/infra/pty-env";
 
 describe("isLauncherEnvVar", () => {
   it("flags the vars package-manager launchers inject", () => {
@@ -119,6 +119,44 @@ describe("sanitizePtyEnv", () => {
   it("cleans a windows-cased Path key", () => {
     const out = sanitizePtyEnv({ Path: "C:\\repo\\node_modules\\.bin;C:\\Windows" }, ";");
     expect(out.Path).toBe("C:\\Windows");
+  });
+});
+
+describe("withFallbackLocale", () => {
+  // The bug this exists for: an embedder launched from the macOS GUI (a .app, a LaunchAgent)
+  // inherits launchd's environment, which names NO locale at all. Our tmux client then runs
+  // under C/POSIX, where tmux writes ONE UNDERSCORE PER CELL for any character it cannot map —
+  // so Claude Code's block-element banner logo (▐▛███▜▌) arrived as _______.
+  it("names a UTF-8 locale when the environment names none", () => {
+    expect(withFallbackLocale({ HOME: "/Users/u" }, "darwin").LANG).toBe("en_US.UTF-8");
+  });
+
+  it("treats an empty value as naming no locale (a login shell can export a bare LANG=)", () => {
+    expect(withFallbackLocale({ LANG: "" }, "darwin").LANG).toBe("en_US.UTF-8");
+    expect(withFallbackLocale({ LC_ALL: "", LC_CTYPE: "", LANG: "" }, "darwin").LANG).toBe("en_US.UTF-8");
+  });
+
+  // LC_ALL and LC_CTYPE both outrank LANG, so writing one could not override them anyway.
+  it.each([
+    ["LC_ALL", { LC_ALL: "en_US.UTF-8", LANG: "" }],
+    ["LC_CTYPE", { LC_CTYPE: "en_US.UTF-8" }],
+    ["LANG", { LANG: "ja_JP.UTF-8" }],
+  ])("leaves the environment alone when %s already names a locale", (_case, env) => {
+    expect(withFallbackLocale(env, "darwin")).toEqual(env);
+  });
+
+  // Windows has no such convention and no tmux; introducing a variable it never had is its
+  // own bug waiting to be reported (git-bash reads LANG).
+  it("adds nothing on Windows", () => {
+    expect(withFallbackLocale({ HOME: "C:\\Users\\u" }, "win32")).toEqual({ HOME: "C:\\Users\\u" });
+  });
+
+  it("returns a copy without mutating the input", () => {
+    const env: NodeJS.ProcessEnv = { HOME: "/Users/u" };
+    const out = withFallbackLocale(env, "linux");
+    expect(env.LANG).toBeUndefined();
+    expect(out).not.toBe(env);
+    expect(out.HOME).toBe("/Users/u");
   });
 });
 


### PR DESCRIPTION
## 症状

MulmoTerminal を `.app` として GUI から起動したとき、ターミナル内の Claude Code の
バナーロゴが `_` の羅列になる。

```
  ▐▛███▜▌   Claude Code v2.1.220          _______   Claude Code v2.1.220
 ▝▜█████▛▘  Opus 5 · Claude Pro    ->    _________  Opus 5 · Claude Pro
   ▘▘ ▝▝    ~/projects/…                   __ __    ~/projects/…
```

以前 `いたる所に _ が出る` として報告されたものと同じ現象です。

## 原因

**tmux です。** WebKit でも xterm.js でもフォントでもありません。

tmux クライアントのロケールが UTF-8 に解決できないと、tmux は非 UTF-8 の出力経路に
切り替わり、**マップできない文字を「1セルにつき `_` 1個」で書き出します。**

| 元 | UTF-8 クライアント | ロケール無しクライアント |
|---|---|---|
| `▐▛█▜▌` (ブロック要素) | `▐▛█▜▌` | `_____` |
| `─│` (罫線) | `─│` | `qx` → xterm.js が `─│` として正しく描画 |
| `·` | `·` | `~` → 正しく描画 |
| `🐟` | `🐟` | `__` |

罫線と `·` だけ無事なのは tmux に DEC ACS の代替があるからで、ブロック要素には
ありません。この非対称性のせいで、最初の調査は実在しない WebKit canvas レンダラの
バグを追うことになりました。**`_` は tmux が書き出すバイト列の時点で既に入っており、
描画側では原因になりようがありません。**

ロケールが消える経路:

1. GUI から起動された `.app` は launchd の環境を継承する。`launchctl getenv LANG` は
   空で、`LC_ALL` も `LC_CTYPE` も無い
2. 間に入る誰もそれを補わないため、こちらが spawn する pty は C/POSIX で動く

実行中プロセスの環境を `ps eww` で確認し、Tauri プロセス・node サーバ・tmux
クライアントの全てにロケール変数が無いことを実測しています。

## 修正

`server/infra/pty-env.ts` に `withFallbackLocale(env, platform)` を追加し、
`server/session/pty-spawn.ts` の `ptyEnv()` に配線しました。ここが全ての pty
(tmux クライアント / 直接 pty) が通るチョークポイントです。

- **ロケール名が一つも無いときだけ** `LANG=en_US.UTF-8` を補います。`LC_ALL` と
  `LC_CTYPE` は `LANG` より優先されるので上書きはできず、`LANG=ja_JP.UTF-8` を
  設定したユーザの指定はそのまま残ります
- 空文字は名前として数えません。ログインシェルが実際の `LC_ALL` と一緒に空の
  `LANG=` を export することがあります
- `withoutUnset` の内側に置いたので、明示的な unset が優先されます
- **Windows は対象外**。同種の慣習も tmux も無く、git-bash が `LANG` を読むため、
  元々無かった変数を持ち込むのは別の不具合の種になります

## 検証

再現は決定的です。ロケール無しの pty で

```
tmux -L scratch new-session "printf '▐▛█▜▌ | ─│ | ·\n'"
```

は `_____ | qx | ~` を出力し、同じ環境に `LANG=en_US.UTF-8` を足すと
`▐▛█▜▌ | ─│ | ·` になります。

実際の `ptyEnv()` を3つの環境で呼んだ結果:

| 環境 | pty に渡る LANG |
|---|---|
| ロケール無し (GUI 起動相当) | `en_US.UTF-8` ← 注入 |
| `LC_ALL=en_US.UTF-8` (ターミナル起動相当) | なし ← 触らない |
| `LANG=ja_JP.UTF-8` (ユーザ設定) | `ja_JP.UTF-8` ← 保持 |

その他: `pty-env.spec.ts` 26件パス (新規7件は実装前に失敗を確認済み)、
`vue-tsc` パス、prettier / eslint クリーン。

`yarn test` はテスト 6308 件全てパスします。269 ファイルがファイルレベルで失敗
しますが、これは本 PR とは無関係の既存問題です (`src/composables/uiLanguage.ts:31`
で vitest の node 環境に `localStorage` が無い)。main を stash して同一の失敗を
確認しています。

## 残る限界

tmux の**ペイン**の環境は tmux **サーバ**から来ます。サーバは最初にそれを起動した
クライアントの環境を継承するので、次にサーバが起動する分から効きます。既に
ロケール無しで動いているサーバは、再起動されるまで古い環境をペインに渡し続けます。
本 PR が直すクライアント側の描画には影響しません。
