### PR TITLE
fix(push): 通知の本文を、フックが渡してくる答えから作る (#1696)

### DIFF
--- a/plans/fix-1696-push-body-from-hook.md
+++ b/plans/fix-1696-push-body-from-hook.md
@@ -1,0 +1,96 @@
+# push 通知の本文が、ユーザー自身のプロンプトになる (#1696)
+
+**状態**: 実装対象。原因はフックの実ペイロードを取って確定させた。
+
+---
+
+## 症状
+
+スマホの push 通知の本文が、直前に自分が入力したプロンプトそのものになる。`finished` でも
+`waiting` でも起きる、と外部から報告された (#1696)。
+
+## 本文はどう決まっているか
+
+```
+server/session/taskPushRules.ts
+  buildPushDetail = reply || lastPrompt || aiTitle || ""
+
+server/session/activity-hook.ts
+  finished: detail || "タスクが完了しました"
+  waiting:  message || detail || "入力待ちです"
+```
+
+`reply` が取れず `message` も空なら、**必ず** `lastPrompt` = ユーザー自身のプロンプトが本文に
+なる。これは push 機能の初版からある設計で、#1666 とは無関係。
+
+## 実ペイロードで分かったこと (claude 2.1.232)
+
+使い捨ての claude セッションを立て、フックの POST 先を専用リスナーに向けて生のまま記録した。
+
+**Stop** は応答そのものを持っている。
+
+```json
+{ "hook_event_name": "Stop", "last_assistant_message": "ok",
+  "session_id": "…", "cwd": "…", "permission_mode": "default", "stop_hook_active": false }
+```
+
+**Notification** は `message` を持っている(許可ダイアログ / AskUserQuestion とも同じ)。
+
+```json
+{ "hook_event_name": "Notification", "message": "Claude needs your permission",
+  "notification_type": "permission_prompt" }
+```
+
+そして `last_assistant_message` は、この repo のどこからも読まれていなかった
+(`server/` `common/` `src/` `test/` で参照 0)。**手渡されている答えを捨てて、transcript を
+自力で tail 読みしている**、というのが現状。
+
+## reply が取れない割合(手元の実測)
+
+| 測り方 | 取れない割合 |
+|---|---|
+| ファイル末尾 (600 本) | 7.0% |
+| ターン境界ごと・tail 読み (1088 境界) | 6.5% |
+| ターン境界ごと・全文読み (540 境界) | 13.5% |
+
+取れなかった 73 件のうち 42 件は、プロンプトの後に assistant の散文が 1 つも無いターン
+(ESC 中断・ツール呼び出しだけで終了)。**読みの失敗ではなく、応答が存在しない**。
+
+報告者の「ほぼ毎回」はこの数字では説明できない。ただし **`/clear` したセッションは別**で、
+そちらは毎回になる（下記）。
+
+## `/clear` の後は、毎回プロンプトになる
+
+`notifyTaskFinished` は `clearedTranscripts.has(id)` のとき transcript を読まない (#1085 —
+`/clear` 後の `${id}.jsonl` は、ユーザーが終わらせた会話で凍結されているため)。そしてこの印は
+**そのファイルが伸びるまで消えない**。`/clear` すると claude は別ファイルに書くので、印は
+実質ずっと残る。つまり **一度 `/clear` したセッションは、以後すべての `finished` push が
+`lastPrompt` に落ちる**。
+
+`last_assistant_message` はライブのイベントが持つ値なので、凍結された transcript とは無関係に
+正しい。この経路はそこも直る。
+
+## 変更
+
+1. **`finished` の本文は Stop の `last_assistant_message` から取る。**
+   `hookFields()` に 1 フィールド足し、`notifyTaskFinished` まで運ぶ。取れないとき(古い
+   Claude Code / codex)は今までどおり transcript 読みにフォールバック。
+   - フック由来の値は `cwd` も `clearedTranscripts` も**問わない**。ファイルではなく
+     イベントが持っている値なので、凍結の理屈が当てはまらない。
+2. **`lastPrompt` をフォールバックの連鎖から外す。**
+   `buildPushDetail` は `reply || aiTitle || ""` になる。頻度に関係なく症状が消える。
+
+## 変えないこと
+
+- transcript 読み (`claudeCurrentTurnReply`) は残す。古い Claude Code には
+  `last_assistant_message` が無く、codex はそもそもフックを持たない。
+- `waiting` の `message` 優先はそのまま。実測で `message` は来ている。
+- `aiTitle` は残す。「そのセッションが何の話か」は、プロンプトの読み返しとは違って通知として
+  意味がある。
+
+## 未確認
+
+- 報告者の claude 2.1.223 に `last_assistant_message` があるか。無ければフォールバック側で
+  従来どおり動く。
+- `idle_prompt` の Notification は 150 秒放置しても発火せず、ペイロードを捕まえられていない。
+  この型が `message` を持つかは不明。

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -39,7 +39,8 @@ export interface HookDeps extends SessionActivityDeps {
 // Activity hooks update a session's working / needs-attention flags. `active` (this
 // session is the user's actively-viewed pane) suppresses the attention flag — see
 // activityHookEffects for why a mere attached socket doesn't count in the grid.
-function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, fields: HookFields) {
+function handleActivityHook(deps: HookDeps, sessionId: string, active: boolean, fields: HookFields) {
+  const { event } = fields;
   for (const eff of activityHookEffects(event, active, fields.notificationType)) {
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
@@ -226,7 +227,7 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     // pty — so tracking an id with no pty (any well-formed uuid may be posted here) would never be
     // reclaimed. A session whose pty is gone simply reports no phase, as it does before its first tool.
     if (entry) deps.noteWorkPhase(sessionId, event, toolName);
-    handleActivityHook(deps, sessionId, event, active, fields);
+    handleActivityHook(deps, sessionId, active, fields);
     await handleToolHook(deps, sessionId, event, toolPayload(body), cwd);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -39,8 +39,8 @@ export interface HookDeps extends SessionActivityDeps {
 // Activity hooks update a session's working / needs-attention flags. `active` (this
 // session is the user's actively-viewed pane) suppresses the attention flag — see
 // activityHookEffects for why a mere attached socket doesn't count in the grid.
-function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, message: string, notificationType?: string) {
-  for (const eff of activityHookEffects(event, active, notificationType)) {
+function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, fields: HookFields) {
+  for (const eff of activityHookEffects(event, active, fields.notificationType)) {
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
   }
@@ -48,8 +48,12 @@ function handleActivityHook(deps: HookDeps, sessionId: string, event: string, ac
   // A finished turn (Stop) and a blocked one (Notification) both reach here; the kind
   // decides the wording. Stop is one event per finished turn, so this fires once even
   // though a background Stop publishes twice.
-  const kind = pushKindFor(event, notificationType);
-  if (kind) void notifyTaskFinished(sessionId, kind, message, deps.uiPort);
+  //
+  // The payload is handed over whole: what a push can say about this moment is what the hook
+  // reported about it, and reading either half back off disk is what put the user's own prompt
+  // on their phone (#1696).
+  const kind = pushKindFor(event, fields.notificationType);
+  if (kind) void notifyTaskFinished(sessionId, kind, { message: fields.message, reply: fields.lastAssistantMessage }, deps.uiPort);
   // A finished turn is the ONLY success signal a PTY-hosted agent gives us (#1070). It is not
   // a process exit — `claude` sits at its prompt afterwards — so a worker that never reaches
   // Stop (blocked on a permission dialog nobody can answer, or dead before its first turn) is
@@ -185,11 +189,17 @@ function hookFields(body: Record<string, unknown>) {
     event: typeof body.hook_event_name === "string" ? body.hook_event_name : "",
     toolName: typeof body.tool_name === "string" ? body.tool_name : undefined,
     message: typeof body.message === "string" ? body.message : "",
+    // What a Stop says the turn ended with. Claude Code hands the reply to the very event that
+    // reports the turn, so the push no longer has to reconstruct it from the transcript (#1696).
+    // Absent on a Claude Code that predates the field, which is why nothing downstream requires it.
+    lastAssistantMessage: typeof body.last_assistant_message === "string" ? body.last_assistant_message : undefined,
     // Which KIND of notification — a subagent finishing arrives here as `agent_completed`, and
     // must not be read as the agent waiting on the user (#874).
     notificationType: typeof body.notification_type === "string" ? body.notification_type : undefined,
   };
 }
+
+type HookFields = ReturnType<typeof hookFields>;
 
 // Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
 // we can flag which background sessions have new activity / build tool history.
@@ -198,7 +208,8 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
   // this is a request body from outside, not a shape anything has verified.
   const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
   const sessionId = resolveHookSessionId(req.headers["x-mt-session"], body.session_id, (id) => SESSION_ID_RE.test(id));
-  const { event, toolName, message, notificationType } = hookFields(body);
+  const fields = hookFields(body);
+  const { event, toolName } = fields;
   if (!sessionId && body.session_id) {
     // Rejecting silently would make hooks look simply broken; the id shape is the
     // precondition for using it as a Firestore doc id and as push routing.
@@ -215,7 +226,7 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     // pty — so tracking an id with no pty (any well-formed uuid may be posted here) would never be
     // reclaimed. A session whose pty is gone simply reports no phase, as it does before its first tool.
     if (entry) deps.noteWorkPhase(sessionId, event, toolName);
-    handleActivityHook(deps, sessionId, event, active, message, notificationType);
+    handleActivityHook(deps, sessionId, event, active, fields);
     await handleToolHook(deps, sessionId, event, toolPayload(body), cwd);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -49,9 +49,9 @@ function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: Cod
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
   }
-  // `message` is empty: codex has no Notification equivalent, and a finished turn's body
-  // comes from its reply, not from a hook payload.
-  if (push) void notifyTaskFinished(sessionId, push, "", deps.uiPort);
+  // Nothing to hand over: codex has no Notification equivalent, and no hook that could carry a
+  // finished turn's reply — that one is read back out of the rollout.
+  if (push) void notifyTaskFinished(sessionId, push, { message: "" }, deps.uiPort);
 }
 
 // Start tailing; it stops on its own once the session is gone. `startAtEnd` skips a

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -9,13 +9,25 @@ import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText } from "./activity-hook.js";
 import type { PushKind } from "../../common/pushKinds.js";
 import { asTerminalAgent } from "../../common/sessionAgent.js";
-import { aiTitles, lastPrompts, lastResponses, ptys, pushClassification, translationWorkerIds } from "./registry.js";
+import { aiTitles, lastResponses, ptys, pushClassification, translationWorkerIds } from "./registry.js";
 import { clearedTranscripts } from "./cleared-transcripts.js";
 import { claudeCurrentTurnReply, sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
 import { buildPushDetail, pushWhere, shouldSuppressPush, wantsPushKind } from "./taskPushRules.js";
 
 const PUSH_TITLE_MAX = 80;
 const PUSH_BODY_MAX = 160;
+
+/** What the event that triggered this push already carried, so the body doesn't have to be
+ *  reconstructed from a file the event has outrun. */
+export interface PushHookText {
+  /** The Notification hook's own text ("Claude needs your permission"). Empty for a finished
+   *  turn, and for codex, which reaches this from a rollout rather than a hook. */
+  message: string;
+  /** Stop's `last_assistant_message`: the reply the turn ended with, from the very event that
+   *  reports the turn ending. Absent on a Claude Code that doesn't send it, and on every other
+   *  agent. */
+  reply?: string | undefined;
+}
 
 // A finished turn should say what the agent DID — the prompt is what the user already
 // knows, and reading it back tells them nothing about the outcome. Read it HERE instead
@@ -32,15 +44,35 @@ const PUSH_BODY_MAX = 160;
 async function latestReply(sessionId: string, cwd: string): Promise<string | null> {
   const agent = asTerminalAgent(ptys.get(sessionId)?.agent);
   const turnReply = agent === "claude" ? await claudeCurrentTurnReply(cwd, sessionId) : (await sessionLastTurn(cwd, sessionId, agent)).reply;
-  const reply = turnReply?.trim();
-  // Capped like every other writer of lastResponses — the map is declared as holding
-  // truncated text, and it is served in the roster payload for every listed session.
+  return capped(turnReply);
+}
+
+// Capped like every other writer of lastResponses — the map is declared as holding truncated
+// text, and it is served in the roster payload for every listed session.
+function capped(text: string | null | undefined): string | null {
+  const reply = text?.trim();
   return reply ? reply.slice(0, LAST_RESPONSE_MAX) : null;
+}
+
+// What the finished turn actually said. The hook's own `last_assistant_message` is the same fact
+// the read below reconstructs, from the event that reports the turn — so it cannot race the
+// transcript write, guess the wrong project directory, or miss a session id claude reissued.
+//
+// It is asked FIRST and asked without either gate: a session with no cwd, and one whose transcript
+// is frozen by a `/clear` (#1085), both still get a correct answer here, because the value never
+// came from that file. The frozen case is not a corner — the mark lifts only when that transcript
+// grows, and after a `/clear` claude writes to a different one, so every later turn of that session
+// fell through to the prompt (#1696).
+async function finishedReply(sessionId: string, cwd: string | null, hookReply: string | undefined): Promise<string | null> {
+  const fromHook = capped(hookReply);
+  if (fromHook) return fromHook;
+  if (!cwd || clearedTranscripts.has(sessionId)) return null;
+  return latestReply(sessionId, cwd);
 }
 
 // Notify the user's devices that a turn finished or is blocked, when Web Push is enabled.
 // Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
-export async function notifyTaskFinished(sessionId: string, kind: PushKind, message: string, uiPort: string): Promise<void> {
+export async function notifyTaskFinished(sessionId: string, kind: PushKind, hookText: PushHookText, uiPort: string): Promise<void> {
   if (!wantsPushKind(getPushEnabled(), getPushKinds(), kind)) return;
   // Internal helper turns flow through /api/hook with active=false too — the suppression gate
   // keeps those (background workers, translation workers) from ever reaching the phone. Asked
@@ -53,12 +85,10 @@ export async function notifyTaskFinished(sessionId: string, kind: PushKind, mess
   if (shouldSuppressPush(background, translationWorkerIds.has(sessionId), userScheduled)) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = pushWhere(cwd);
-  // Not after a `/clear`: our transcript is frozen on the conversation the user just ended, so
-  // what it holds is neither this turn's reply nor anything to put back in the roster (#1085).
-  const reply = kind === "finished" && cwd && !clearedTranscripts.has(sessionId) ? await latestReply(sessionId, cwd) : null;
+  const reply = kind === "finished" ? await finishedReply(sessionId, cwd, hookText.reply) : null;
   if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
-  const detail = buildPushDetail({ reply, lastPrompt: lastPrompts.get(sessionId), aiTitle: aiTitles.get(sessionId) });
-  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
+  const detail = buildPushDetail({ reply, aiTitle: aiTitles.get(sessionId) });
+  const { title, body } = buildPushText(kind, where, detail, hookText.message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
   // The session id is what lets the phone open this session from the notification;
   // the host id is what lets it know WHOSE session. Without it the phone opens with
   // no host selected — it never persists one — and can only offer the picker, which

--- a/server/session/taskPushRules.ts
+++ b/server/session/taskPushRules.ts
@@ -7,18 +7,21 @@ import type { PushKind } from "../../common/pushKinds.js";
 
 export interface PushDetailInput {
   reply: string | null;
-  lastPrompt: string | undefined;
   aiTitle: string | undefined;
 }
 
 export const NO_CWD_LABEL = "session";
 
-// A finished turn should say what the agent DID, so the reply wins; the last prompt and the AI
-// title are fallbacks for when there is no reply (a blocked turn, or a read that came back
-// empty). `||`, not `??`: every tier is a string that must be SKIPPED when empty — an empty
-// reply means "nothing to report about the outcome", not a value to pin as the body.
+// A finished turn should say what the agent DID, so the reply wins; the AI title is the fallback
+// for when there is no reply (a blocked turn, or a read that came back empty).
+//
+// The last PROMPT used to sit between them, and it is what the phone showed whenever the reply was
+// missing: the user's own words read back to them, saying nothing about the turn that just ended
+// (#1696). The title at least names what the session is about. `||`, not `??`: every tier is a
+// string that must be SKIPPED when empty — an empty reply means "nothing to report about the
+// outcome", not a value to pin as the body.
 export function buildPushDetail(input: PushDetailInput): string {
-  return input.reply || input.lastPrompt || input.aiTitle || "";
+  return input.reply || input.aiTitle || "";
 }
 
 // Background workers and translation workers aren't real user tasks, so a turn ending on one

--- a/test/server/routes/hook-push-body.spec.ts
+++ b/test/server/routes/hook-push-body.spec.ts
@@ -28,11 +28,13 @@ vi.mock("../../../server/config/config-routes.js", async (importOriginal) => ({
   getPushKinds: () => ["finished", "waiting"],
 }));
 
-// No transcript on disk — which is the case the hook payload now answers on its own, and the case
-// that used to fall through to the prompt.
+// The transcript read that a payload without `last_assistant_message` still falls back to. Null is
+// the default because "no reply anywhere" is the case that used to fall through to the prompt; the
+// tests that are ABOUT the fallback set it.
+const transcript = vi.hoisted(() => ({ reply: null as string | null }));
 vi.mock("../../../server/session/session-reads.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../server/session/session-reads")>()),
-  claudeCurrentTurnReply: async () => null,
+  claudeCurrentTurnReply: async () => transcript.reply,
   latestUserPrompt: async () => null,
 }));
 
@@ -71,6 +73,7 @@ const nextPush = async (): Promise<{ title: string; body: string }> => {
 
 beforeEach(() => {
   pushes.length = 0;
+  transcript.reply = null;
   lastPrompts.set(ID, PROMPT);
   aiTitles.delete(ID);
   lastResponses.delete(ID);
@@ -113,6 +116,41 @@ describe("a finished turn", () => {
     await postHook({ hook_event_name: "Stop", last_assistant_message: "clear のあとの返事です" });
 
     expect((await nextPush()).body).toBe("clear のあとの返事です");
+  });
+});
+
+// A Claude Code that predates `last_assistant_message`, and every non-claude agent, reach the push
+// with nothing but the event — so the transcript read stays, and stays gated. This is the half the
+// change must not regress, and moving the gates into finishedReply is exactly where it could.
+describe("a finished turn with no reply in the payload", () => {
+  it("falls back to the transcript", async () => {
+    transcript.reply = "前のターンで読み取った結論";
+
+    await postHook({ hook_event_name: "Stop" });
+
+    expect((await nextPush()).body).toBe("前のターンで読み取った結論");
+    expect(lastResponses.get(ID)).toBe("前のターンで読み取った結論");
+  });
+
+  it("prefers the payload over the transcript when both have something to say", async () => {
+    transcript.reply = "ディスクから読んだ古いほう";
+
+    await postHook({ hook_event_name: "Stop", last_assistant_message: "イベントが持っていたほう" });
+
+    expect((await nextPush()).body).toBe("イベントが持っていたほう");
+  });
+
+  // The gate the payload is exempt from, still holding for the read it was written for: after a
+  // `/clear` that file is the conversation the user ENDED, so its reply belongs to no turn (#1085).
+  it("does not read a transcript a /clear froze", async () => {
+    transcript.reply = "clear する前の、もう終わった会話の返事";
+    clearedTranscripts.add(ID);
+
+    await postHook({ hook_event_name: "Stop" });
+
+    const { body } = await nextPush();
+    expect(body).not.toContain("clear する前");
+    expect(body).toBe("タスクが完了しました");
   });
 });
 

--- a/test/server/routes/hook-push-body.spec.ts
+++ b/test/server/routes/hook-push-body.spec.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+// What the phone is TOLD, pinned at the route the hook posts to.
+//
+// The pieces have their own specs — buildPushDetail decides the tiers, buildPushText the wording —
+// but the seam where the user-visible bug lived (#1696) is here: the route held the answer in its
+// hands (`last_assistant_message`) and threw it away, then rebuilt it from a transcript it could
+// not always read, and printed the user's own prompt whenever that failed.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { mountHookRoute } from "../../../server/routes/hook-routes";
+import { aiTitles, lastPrompts, lastResponses, ptys } from "../../../server/session/registry";
+import { clearedTranscripts } from "../../../server/session/cleared-transcripts";
+
+const pushes: Array<{ title: string; body: string }> = [];
+vi.mock("../../../server/infra/web-push.js", () => ({
+  sendWebPush: async (title: string, body: string) => {
+    pushes.push({ title, body });
+    return null;
+  },
+}));
+
+// The user's real config decides whether a push is sent at all; these tests are about what it
+// says, so both switches are held on.
+vi.mock("../../../server/config/config-routes.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/config/config-routes")>()),
+  getPushEnabled: () => true,
+  getPushKinds: () => ["finished", "waiting"],
+}));
+
+// No transcript on disk — which is the case the hook payload now answers on its own, and the case
+// that used to fall through to the prompt.
+vi.mock("../../../server/session/session-reads.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/session/session-reads")>()),
+  claudeCurrentTurnReply: async () => null,
+  latestUserPrompt: async () => null,
+}));
+
+const ID = "11111111-2222-4333-8444-555555555555";
+const PROMPT = "通知の本文がおかしいので直して";
+
+const deps = {
+  setWorking: vi.fn(),
+  setWaiting: vi.fn(),
+  publishActivity: vi.fn(),
+  forgetTitle: vi.fn(),
+  noteTitleTurn: vi.fn(),
+  noteWorkPhase: vi.fn(),
+  maybeGenerateTitle: vi.fn(async () => {}),
+  recordToolCallStart: vi.fn(async () => {}),
+  recordToolCallEnd: vi.fn(async () => {}),
+  publishDirConfig: vi.fn(),
+  publishFileWrite: vi.fn(),
+  publishQuestion: vi.fn(),
+  uiPort: "34567",
+};
+
+const app = express();
+app.use(express.json());
+mountHookRoute(app, deps);
+
+const postHook = (body: Record<string, unknown>) => request(app).post("/api/hook").set("x-mt-session", ID).send(body);
+
+// The push is fire-and-forget, so the route answers before it is sent.
+const nextPush = async (): Promise<{ title: string; body: string }> => {
+  await vi.waitFor(() => expect(pushes).toHaveLength(1));
+  const sent = pushes[0];
+  if (!sent) throw new Error("no push was sent");
+  return sent;
+};
+
+beforeEach(() => {
+  pushes.length = 0;
+  lastPrompts.set(ID, PROMPT);
+  aiTitles.delete(ID);
+  lastResponses.delete(ID);
+  clearedTranscripts.delete(ID);
+  ptys.set(ID, { term: { kill: () => undefined }, ws: null, buffer: "", cwd: "/work/mulmoterminal", active: false, agent: "claude" } as never);
+});
+
+describe("a finished turn", () => {
+  it("says what the turn ended with, taken from the Stop payload", async () => {
+    await postHook({ hook_event_name: "Stop", last_assistant_message: "直しました。テストも足しています。" });
+
+    expect((await nextPush()).body).toBe("直しました。テストも足しています。");
+    // The roster shows the same text, so the cell and the phone cannot disagree about the turn.
+    expect(lastResponses.get(ID)).toBe("直しました。テストも足しています。");
+  });
+
+  // A turn the user interrupted has no reply anywhere — not in the payload, not in the transcript.
+  it("says nothing about the outcome rather than reading the prompt back", async () => {
+    await postHook({ hook_event_name: "Stop" });
+
+    const { body } = await nextPush();
+    expect(body).not.toContain(PROMPT);
+    expect(body).toBe("タスクが完了しました");
+  });
+
+  it("names the session instead, when it has a title", async () => {
+    aiTitles.set(ID, "push 通知の調査");
+
+    await postHook({ hook_event_name: "Stop" });
+
+    expect((await nextPush()).body).toBe("push 通知の調査");
+  });
+
+  // `/clear` freezes our copy of the transcript, and the mark lifts only when THAT file grows —
+  // which it never does, because claude has moved to another one. So every later turn of a cleared
+  // session used to reach the phone as the user's own prompt. The payload is not that file.
+  it("still reports the reply after a /clear froze the transcript", async () => {
+    clearedTranscripts.add(ID);
+
+    await postHook({ hook_event_name: "Stop", last_assistant_message: "clear のあとの返事です" });
+
+    expect((await nextPush()).body).toBe("clear のあとの返事です");
+  });
+});
+
+describe("a blocked turn", () => {
+  it("says what the agent is asking for", async () => {
+    await postHook({ hook_event_name: "Notification", message: "Claude needs your permission", notification_type: "permission_prompt" });
+
+    expect((await nextPush()).body).toBe("Claude needs your permission");
+  });
+
+  it("falls back to the fixed wording, never to the prompt, when the hook carries no message", async () => {
+    await postHook({ hook_event_name: "Notification", notification_type: "permission_prompt" });
+
+    const { body } = await nextPush();
+    expect(body).not.toContain(PROMPT);
+    expect(body).toBe("入力待ちです");
+  });
+});

--- a/test/server/session/taskPushRules.spec.ts
+++ b/test/server/session/taskPushRules.spec.ts
@@ -4,34 +4,34 @@ import { describe, it, expect } from "vitest";
 import { buildPushDetail, pushWhere, shouldSuppressPush, wantsPushKind, NO_CWD_LABEL } from "../../../server/session/taskPushRules.js";
 
 describe("buildPushDetail", () => {
-  it("prefers the reply over the last prompt and the AI title", () => {
-    expect(buildPushDetail({ reply: "did the thing", lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("did the thing");
+  it("prefers the reply over the AI title", () => {
+    expect(buildPushDetail({ reply: "did the thing", aiTitle: "the thing" })).toBe("did the thing");
   });
 
-  it("falls back to the last prompt when there is no reply", () => {
-    expect(buildPushDetail({ reply: null, lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("do the thing");
-  });
-
-  it("falls back to the AI title when there is neither reply nor last prompt", () => {
-    expect(buildPushDetail({ reply: null, lastPrompt: undefined, aiTitle: "the thing" })).toBe("the thing");
+  it("falls back to the AI title when there is no reply", () => {
+    expect(buildPushDetail({ reply: null, aiTitle: "the thing" })).toBe("the thing");
   });
 
   // `||`, not `??`: an empty string at any tier means "nothing usable here", so it is skipped
   // rather than pinned as the body.
-  it("skips an empty-string reply and takes the last prompt", () => {
-    expect(buildPushDetail({ reply: "", lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("do the thing");
-  });
-
-  it("skips an empty-string last prompt and takes the AI title", () => {
-    expect(buildPushDetail({ reply: null, lastPrompt: "", aiTitle: "the thing" })).toBe("the thing");
+  it("skips an empty-string reply and takes the AI title", () => {
+    expect(buildPushDetail({ reply: "", aiTitle: "the thing" })).toBe("the thing");
   });
 
   it("returns the empty string when nothing is present", () => {
-    expect(buildPushDetail({ reply: null, lastPrompt: undefined, aiTitle: undefined })).toBe("");
+    expect(buildPushDetail({ reply: null, aiTitle: undefined })).toBe("");
   });
 
   it("returns the empty string when every tier is empty", () => {
-    expect(buildPushDetail({ reply: "", lastPrompt: "", aiTitle: "" })).toBe("");
+    expect(buildPushDetail({ reply: "", aiTitle: "" })).toBe("");
+  });
+
+  // The user's own prompt was a tier here, between the reply and the title, and it is what the
+  // phone showed whenever the reply could not be read — their words read back to them, saying
+  // nothing about the turn (#1696). Nothing may put it back: the type no longer carries it, and
+  // this pins the reason so a later "the body is empty, use what we have" doesn't re-add it.
+  it("says nothing rather than reading the user's own prompt back to them", () => {
+    expect(buildPushDetail({ reply: null, aiTitle: undefined })).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

スマホの push の本文が、直前に自分が入力したプロンプトそのものになる問題 (#1696) を直します。

本文は `reply || lastPrompt || aiTitle` で決まっていて、**reply が取れず message も空のとき、
必ずユーザー自身のプロンプトが本文になる**。これは push 機能の初版からある設計で、#1666 とは
無関係でした。

原因を確定させるために、使い捨ての claude セッションを立ててフックの生ペイロードを記録しました
(claude 2.1.232)。**Stop はそのターンの応答そのものを持っていました。**

```json
{ "hook_event_name": "Stop", "last_assistant_message": "ok", "stop_hook_active": false, … }
{ "hook_event_name": "Notification", "message": "Claude needs your permission",
  "notification_type": "permission_prompt" }
```

そして `last_assistant_message` は **この repo のどこからも読まれていませんでした**
(`server/` `common/` `src/` `test/` で参照 0)。手渡されている答えを捨てて、transcript を自力で
tail 読みしていた、という構図です。

変更は 2 つ。

1. **`finished` の本文は Stop の `last_assistant_message` から取る。** ターンの終了を告げる
   イベント自身が持つ値なので、transcript の書き込みと競合せず、プロジェクトディレクトリの
   推測も、claude が付け替える session id も関係ない。取れないとき(古い Claude Code / codex)は
   従来どおり transcript 読みにフォールバック。
2. **`lastPrompt` をフォールバックの連鎖から外す。** `buildPushDetail` は
   `reply || aiTitle || ""` に。頻度に関係なく症状が消えます。

## Items to Confirm / Review

1. **`issue はまだ閉じないでください`。** 報告者の「ほぼ毎回」の再現条件がまだ掴めていません
   (下記)。この PR は症状の経路を塞ぎますが、報告者の環境で本当に消えたかの確認は取れていません。
   あえて `Closes` を書いていません。
2. **フック由来の値だけ、`cwd` と `clearedTranscripts` のゲートを通していません。** これは
   意図的で、しかも `/clear` のバグを直します(下記)。ファイルではなくイベントが持つ値なので
   凍結の理屈が当てはまらない、という判断です。ここは #1085 の周辺なので見てください。
3. **`aiTitle` は残しました。** 「そのセッションが何の話か」は、プロンプトの読み返しとは違って
   通知として意味がある、という判断です。全部落として「タスクが完了しました」に寄せる案もあります。
4. **`notifyTaskFinished` の引数を `message: string` から `hookText: PushHookText` に変えました。**
   Stop の応答と Notification のテキストは「そのイベントが持っていたもの」という同じ性質なので、
   1 つにまとめています。呼び出しは 2 箇所(hook-routes / codex-activity-track)。
5. **`idle_prompt` の Notification は捕まえられていません。** 150 秒放置しても発火しませんでした。
   この型が `message` を持つかは不明で、持たないなら `waiting` は「入力待ちです」になります。

## `/clear` したセッションは、以後ずっとプロンプトが出ていた

調査中に見つかった、確定的に再現するケースです。

`notifyTaskFinished` は `clearedTranscripts.has(id)` のとき transcript を読みません
(#1085 — `/clear` 後の `${id}.jsonl` はユーザーが終わらせた会話で凍結されているため)。そして
この印は **そのファイルが伸びるまで消えません**。`/clear` すると claude は別ファイルに書くので、
印は実質ずっと残ります。つまり **一度 `/clear` したセッションは、以後すべての `finished` push が
`lastPrompt` に落ちていました**。

`last_assistant_message` はライブのイベントが持つ値なので、この経路も同時に直ります。
spec で固定しました。

## 検証

### 新旧の並走 — 旧コードで症状が再現する

新しい spec (`test/server/routes/hook-push-body.spec.ts`) をサーバ側だけ元に戻して走らせると、
**6 件中 5 件が「本文 = ユーザーのプロンプト」で落ちます**。報告された症状そのものです。

```
× says what the turn ended with, taken from the Stop payload
    expected '通知の本文がおかしいので直して' to be '直しました。テストも足しています。'
× says nothing about the outcome rather than reading the prompt back
    expected '通知の本文がおかしいので直して' not to contain '通知の本文がおかしいので直して'
× names the session instead, when it has a title
× still reports the reply after a /clear froze the transcript
× falls back to the fixed wording, never to the prompt, when the hook carries no message
Tests  5 failed | 1 passed (6)
```

### reply が取れない割合(手元の実トランスクリプト)

| 測り方 | 取れない割合 |
|---|---|
| ファイル末尾 (600 本) | 7.0% |
| ターン境界ごと・tail 読み (1088 境界) | 6.5% |
| ターン境界ごと・全文読み (540 境界) | 13.5% |

取れなかった 73 件のうち 42 件は、プロンプトの後に assistant の散文が 1 つも無いターン
(ESC 中断・ツール呼び出しだけで終了)。**読みの失敗ではなく、応答が存在しない**。報告者の
「ほぼ毎回」はこの数字では説明できず、`/clear` のケースが有力です。

### ゲート

`yarn format` / `lint` / `build` / `typecheck` / `test` すべて green
(**704 files / 10127 tests passed**)。

**未確認**: 実機のスマホで push を受け取るところまでは確認していません。確認したのは本文を
決める経路と、実際のフックペイロードです。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1696 これって今日直した push の変更で直る？
- https://github.com/receptron/mulmoterminal/pull/1700 これって関係ないの？
- 「差は 1%」「報告者の 89% は旧ロジックでの計測」ってどういうこと？この問題って申告？
  「ほぼ毎回」って発生するの？
- `reply が取れない` or `Notification の message が空` — これってどれくらいの割合で起こる？
  ここがバグの本質？それとも本当にそれって取れないの？
- ログ取って、、かな。
- issue にコメントとして追加し、PR かな。

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Push notifications now use the assistant’s latest reply as the notification body.
  * Prevented user prompts from appearing in finished-task notifications.
  * Added reliable fallbacks for missing replies, including session titles and status messages.
  * Preserved notification behavior for blocked tasks and sessions with cleared transcripts.

* **Tests**
  * Added coverage for notification content, fallback behavior, and prompt-leak prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->