### PR TITLE
fix(shared-app): 公開ビューのリンク拒否を、O_NOFOLLOW の無い場所でも効かせる

### DIFF
--- a/plans/fix-1709-windows-symlink-view.md
+++ b/plans/fix-1709-windows-symlink-view.md
@@ -1,0 +1,64 @@
+# fix #1709 — 公開ビューの symlink 防御が Windows で効いていない
+
+## 症状
+
+`windows-daily` が 2026-08-13T20:02 から赤。`publicView.spec.ts` の 3 件が
+`expected true to be false` で落ちる — `readAppViewFile` が拒否せず成功している。
+
+## 原因は 2 つある
+
+### 1. symlink 防御が Windows で無効 (実装の穴)
+
+`openContained` の防御は `O_NOFOLLOW` 一本:
+
+```ts
+handle = await open(full, constants.O_RDONLY | constants.O_NOFOLLOW);
+```
+
+`O_NOFOLLOW` は Windows に存在しない。`constants.O_NOFOLLOW` が `undefined` になり、
+`|` は `undefined` を 0 として扱うので、この式は**素の `O_RDONLY` に黙って劣化する**
+(macOS では 256、`O_RDONLY | undefined === 0` を実測)。エラーも警告も出ない。
+
+**同じファイルの中に決定的な傍証がある**: 中間ディレクトリのリンクを見る
+`symlinkedAncestor` は `lstat` ベースで、その spec は **Windows で通っている**。
+落ちているのは最終要素、つまり `O_NOFOLLOW` に頼っている方だけ。
+
+これはテストだけの問題ではない。公開先は `allow read: if true` のドキュメントで、
+`publicView.ts` 自身が「what gets published is world-readable」と書いている。
+Windows では `views/leak.html` がリポジトリ外を指すリンクなら、その中身が世界に出る。
+
+### 2. `chmod 0o000` は Windows で読めるまま (テストの前提が作れない)
+
+`docs/windows-gotchas.md` が既に処方済み。NTFS に POSIX パーミッションビットは無く、
+`chmodSync(f, 0o000)` は read-only 属性を動かすだけで**読めてしまう**。
+前提が作れない以上そこでは何も検証していないので、#1484 と同じく win32 で skip する。
+
+## 直し方
+
+### 最終要素も `lstat` で見る (全プラットフォーム)
+
+`openContained` の open の前に `lstat` し、symlink なら拒否する。
+
+- **POSIX**: `O_NOFOLLOW` は従来どおり残す。race まで塞ぐ本命はそちらで、この `lstat`
+  は上積み。効果はメッセージが具体的になること (「開けなかった」ではなく「リンクだ」)
+- **Windows**: これが唯一の防御になる。race は残るが、それは同ファイルが中間
+  ディレクトリについて既に受け入れ・明記している制約と同じもの — MISTAKE
+  (誰かが置いた迷子のリンク) は完全に塞ぎ、リポジトリへの書き込み権を持つプロセスとの
+  race は塞がない
+- **プラットフォーム分岐にしない**。分岐にすると Windows 側の経路が macOS/Linux の CI で
+  一度も実行されず、壊れても daily まで誰も気づかない
+
+あわせて `constants.O_NOFOLLOW ?? 0` と名前付き定数にし、**フラグが黙って消えることを
+コードの上で見えるようにする**。0 になる事実そのものが今回の原因なので、無名の 0 に
+戻してはいけない。
+
+### メッセージ
+
+新しい拒否は「リンクである」ことを言う。既存テストが期待する
+`without following links` は引き続き含める。generic な
+`could not be opened as a plain file` は「パスが何も指していない」ケース専用のまま残す。
+
+## 検証
+
+**手元の macOS では 3 件とも通ってしまい、何も見えない。** `windows-daily.yaml` は
+`workflow_dispatch` を持つので、feature ブランチに対して実機で実行して確認する。

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -146,10 +146,38 @@ async function symlinkedAncestor(root: string, dir: string): Promise<string | nu
   return null;
 }
 
+/** `O_NOFOLLOW` where the platform has it, 0 where it does not.
+ *
+ *  Windows has no such flag, so `constants.O_NOFOLLOW` is undefined there — and
+ *  `O_RDONLY | undefined` is plain `O_RDONLY`, which follows the link with
+ *  nothing anywhere to say the guard had gone (#1709). Named rather than left
+ *  as a bare `0` because that silent 0 IS the bug: the constant vanishing has
+ *  to be visible in the source, next to the check that stands in for it. */
+const NOFOLLOW_IF_SUPPORTED = constants.O_NOFOLLOW ?? 0;
+
 async function openContained(full: string, declared: string, where: string): Promise<{ ok: true; html: string } | { ok: false; problems: string[] }> {
+  // `lstat` first, on every platform. Where `O_NOFOLLOW` works this only makes the
+  // refusal say what is actually wrong; where it does not, it is the whole defence
+  // — and it is deliberately not behind a platform branch, since a Windows-only
+  // path would never run in the CI that gates a merge.
+  //
+  // What it closes is the MISTAKE, completely: a link somebody left in the tree.
+  // The race it does not close is the one `symlinkedAncestor` already names above,
+  // and it is bounded the same way — winning it needs write access to the
+  // repository being published, which needs no symlink to leak anything.
+  const itself = await lstat(full).catch(() => null);
+  if (itself?.isSymbolicLink() === true) {
+    return {
+      ok: false,
+      problems: [
+        `${where}.path names '${declared}', which is a symbolic link. ` +
+          "A published view is read without following links — what gets published is world-readable, so the file checked and the file read have to be the same one.",
+      ],
+    };
+  }
   let handle;
   try {
-    handle = await open(full, constants.O_RDONLY | constants.O_NOFOLLOW);
+    handle = await open(full, constants.O_RDONLY | NOFOLLOW_IF_SUPPORTED);
   } catch {
     return {
       ok: false,

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -24,6 +24,7 @@ import { constants, lstat, open, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import { normalizeViews, type AuthoredApp } from "@receptron/sharedapp";
+import { hasErrnoCode } from "../../errors.js";
 import { modalCallIn } from "./modalCall.js";
 
 /** The document the public page reads the HTML from. Beside core's
@@ -155,6 +156,22 @@ async function symlinkedAncestor(root: string, dir: string): Promise<string | nu
  *  to be visible in the source, next to the check that stands in for it. */
 const NOFOLLOW_IF_SUPPORTED = constants.O_NOFOLLOW ?? 0;
 
+/** What the last component is, without following it.
+ *
+ *  `"gone"` is the ONLY failure allowed through to the open below, which owns
+ *  that message and says it better. Every other `lstat` error refuses here: a
+ *  Windows reparse point libuv cannot classify answers an error rather than
+ *  "symbolic link", and reading that as "not a link" would leave `open` as the
+ *  only judge — which, without `O_NOFOLLOW`, it is not. A gate whose failure
+ *  mode is a world-readable document fails closed. */
+async function finalComponent(full: string): Promise<"link" | "plain" | "gone" | "unreadable"> {
+  try {
+    return (await lstat(full)).isSymbolicLink() ? "link" : "plain";
+  } catch (reason) {
+    return hasErrnoCode(reason) && reason.code === "ENOENT" ? "gone" : "unreadable";
+  }
+}
+
 async function openContained(full: string, declared: string, where: string): Promise<{ ok: true; html: string } | { ok: false; problems: string[] }> {
   // `lstat` first, on every platform. Where `O_NOFOLLOW` works this only makes the
   // refusal say what is actually wrong; where it does not, it is the whole defence
@@ -165,13 +182,22 @@ async function openContained(full: string, declared: string, where: string): Pro
   // The race it does not close is the one `symlinkedAncestor` already names above,
   // and it is bounded the same way — winning it needs write access to the
   // repository being published, which needs no symlink to leak anything.
-  const itself = await lstat(full).catch(() => null);
-  if (itself?.isSymbolicLink() === true) {
+  const itself = await finalComponent(full);
+  if (itself === "link") {
     return {
       ok: false,
       problems: [
         `${where}.path names '${declared}', which is a symbolic link. ` +
           "A published view is read without following links — what gets published is world-readable, so the file checked and the file read have to be the same one.",
+      ],
+    };
+  }
+  if (itself === "unreadable") {
+    return {
+      ok: false,
+      problems: [
+        `${where}.path names '${declared}', which could not be checked for being a link. ` +
+          "A published view is read without following links — what gets published is world-readable, so anything that cannot be shown NOT to be one is refused rather than opened. Nothing was written.",
       ],
     };
   }

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -220,6 +220,12 @@ describe("the file a published view names", () => {
     const result = await readAppViewFile(root, { path: "views/booking.html" }, STAMP);
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.problems.join(" ")).toContain("without following links");
+    // Named, not merely refused. `O_NOFOLLOW` alone would answer "could not be
+    // opened", which sends the author looking for a file that is right there —
+    // and on Windows, where the flag does not exist, it answers nothing at all
+    // (#1709). Asserted here so the lstat that stands in for it is pinned on
+    // every platform, not only the one where it is the sole defence.
+    expect(result.ok === false && result.problems.join(" ")).toContain("which is a symbolic link");
   });
 
   it("refuses a page written against the HOST's bridge", async () => {
@@ -271,9 +277,17 @@ describe("the file a published view names", () => {
     const result = await readAppViewFile(root, { path: "views/leak.html" }, STAMP);
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.problems.join(" ")).toContain("without following links");
+    expect(result.ok === false && result.problems.join(" ")).toContain("which is a symbolic link");
+    // The secret is what this is guarding, so say so: nothing of it may appear
+    // in what the refusal hands back either.
+    expect(JSON.stringify(result)).not.toContain("secret</p>");
   });
 
-  it("refuses, rather than throwing, when the file goes between stat and read", async () => {
+  // Skipped on Windows because the SETUP cannot happen there: NTFS has no POSIX
+  // permission bits, so `chmod 0o000` moves the read-only attribute and the file
+  // stays perfectly readable — the read succeeds and the assertion is about
+  // nothing (docs/windows-gotchas.md, same shape as #1484).
+  it.skipIf(process.platform === "win32")("refuses, rather than throwing, when the file goes between stat and read", async () => {
     // A delete or a permission change in that window. The gate's contract is
     // problems and no writes; a rejection escaping it would surface as an
     // exception out of publish, which is the one shape callers do not handle.

--- a/test/server/backends/publicViewUnreadableLink.spec.ts
+++ b/test/server/backends/publicViewUnreadableLink.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+//
+// What the published-view gate does when it cannot TELL whether the file is a link.
+//
+// Its own file covers this because the answer needs `lstat` to fail, which needs the
+// module mocked — and mocking it for the whole of publicView.spec.ts would take the
+// real filesystem away from every symlink case there, which is the thing those cases
+// are about.
+import { describe, it, expect, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Fails the way a Windows reparse point libuv cannot classify does: an error that is
+// NOT "there is nothing here", on a path `open` would go on reading perfectly well.
+// Only this one basename, so the ancestor walk above it keeps the real filesystem.
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...real,
+    lstat: (target: string) =>
+      path.basename(String(target)) === "uninspectable.html"
+        ? Promise.reject(Object.assign(new Error("EPERM: operation not permitted, lstat"), { code: "EPERM" }))
+        : real.lstat(target),
+  };
+});
+
+const STAMP = 1_700_000_000_000;
+
+describe("a view whose last component cannot be inspected", () => {
+  it("is refused rather than opened, though opening it would have worked", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "mt-public-view-uninspectable-"));
+    mkdirSync(path.join(root, "views"));
+    writeFileSync(path.join(root, "views", "uninspectable.html"), "<p>would have been published</p>");
+
+    const { readAppViewFile } = await import("../../../server/backends/sharedApp/publicView.js");
+    const result = await readAppViewFile(root, { path: "views/uninspectable.html" }, STAMP);
+
+    // Fails CLOSED. Treating the error as "not a link" would hand the decision to
+    // `open`, which on a platform without O_NOFOLLOW makes no such decision (#1709).
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.problems.join(" ")).toContain("could not be checked for being a link");
+    expect(result.ok === false && result.problems.join(" ")).toContain("without following links");
+    // And nothing of the file it declined to judge comes back with the refusal.
+    expect(JSON.stringify(result)).not.toContain("would have been published");
+  });
+});


### PR DESCRIPTION
## Summary

`windows-daily` が 2026-08-13T20:02 から赤で、原因は `publicView.spec.ts` の 3 件です。
うち **2 件はテストの都合ではなく実装の穴**でした。

`openContained` の symlink 防御は `O_NOFOLLOW` 一本です。

```ts
handle = await open(full, constants.O_RDONLY | constants.O_NOFOLLOW);
```

**`O_NOFOLLOW` は Windows に存在しません。** `constants.O_NOFOLLOW` が `undefined` になり、
JavaScript の `|` は `undefined` を 0 として扱うので、この式は**素の `O_RDONLY` に黙って
劣化**します(macOS では 256、`O_RDONLY | undefined === 0` を実測)。エラーも警告も出ません。

これはテストだけの問題ではありません。公開ビューが載る先は `allow read: if true` の
ドキュメントで、`publicView.ts` 自身がこう書いています:

> what gets published is world-readable, so the file checked and the file read have to be the same one

Windows では `views/leak.html` がリポジトリ外を指す symlink だった場合、その中身が
そのまま世界に公開されていました。

**同じファイルの中に決定的な傍証があります。** 中間ディレクトリのリンクを見る
`symlinkedAncestor` は `lstat` ベースで、その spec は **Windows でも通っています**。
落ちているのは最終要素、つまり `O_NOFOLLOW` に頼っている方だけ — 予測どおりの割れ方です。

## 変更

1. **最終要素も open の前に `lstat` で見る**(全プラットフォーム)。POSIX では
   `O_NOFOLLOW` が引き続き race まで塞ぐ本命で、この `lstat` の効果は拒否の理由が
   具体的になること(「開けなかった」ではなく「リンクだ」)。Windows ではこれが唯一の防御。
2. **`NOFOLLOW_IF_SUPPORTED` として名前を付けた** — 黙って 0 になることが今回の原因なので、
   無名の 0 に戻さないため。
3. **`lstat` が答えられないときは fail closed**(CodeRabbit の指摘を受けて追加)。
   `lstat` のエラーを `null` に潰していたため、「存在しない」以外の理由で答えられなかった
   場合も「リンクではない」と読んで `open` に進んでいました。`O_NOFOLLOW` の無い環境では
   そこに判定者が居ないので、そのまま公開されます(libuv が分類できない Windows の
   reparse point がまさにその形)。`ENOENT` だけは従来どおり `open` に渡して良いメッセージを
   出させ、それ以外は拒否します。
4. **`chmod 0o000` のテストは win32 で skip** — NTFS に POSIX パーミッションビットは無く、
   前提そのものが作れません(`docs/windows-gotchas.md` が処方済み、#1484 と同型)。

## Items to Confirm / Review

- **プラットフォーム分岐にしなかったこと。** `lstat` は全プラットフォームで走ります。
  Windows だけの経路にすると macOS/Linux の CI で一度も実行されず、壊れても daily まで
  誰も気づかないためです。コストは publish 1 回につき syscall 1 回。
- **残る race の扱い。** Windows では `lstat` → `open` の間に差し替えられる窓が残ります。
  これは `symlinkedAncestor` が中間ディレクトリについて既に受け入れ・明記している制約と
  同じもので、勝つにはリポジトリへの書き込み権が要り、それがあれば symlink は不要です
  (`views/booking.html` に直接書けばよい)。同ファイルのコメントの立て付けに合わせています。
- **メッセージを変えたこと。** symlink の拒否が generic な「could not be opened as a plain
  file」ではなく「which is a symbolic link」を返すようになります。既存テストが期待する
  `without following links` は引き続き含みます。

## 検証

**手元の macOS では 3 件とも通ってしまい、この不具合は何も見えません。** そこで:

1. **新しい assertion が実装なしで落ちることを確認** — `publicView.ts` を stash して macOS で
   実行し、symlink 2 件が `expected ... to contain 'which is a symbolic link'` で fail することを
   確認しました。これで新しい経路が全プラットフォームで固定されます(旧メッセージでも
   `without following links` は含まれるため、従来の assertion だけでは macOS で何も守れていません)。
2. **Windows 実機で確認** — `windows-daily` を本ブランチに対して `workflow_dispatch` で実行。
   **22.x / 24.x とも success**(修正前は同じ 3 件が両 leg で fail):
   - 初回: https://github.com/receptron/mulmoterminal/actions/runs/31835082717
   - fail-closed 対応後の最終 HEAD: https://github.com/receptron/mulmoterminal/actions/runs/31836805177
3. `format` / `lint` / `typecheck` / `build` パス。`yarn test` は `skillTemplates.spec.ts` の
   1 件のみ fail で、これは私の作業コピーの `@receptron/sharedapp` が **0.1.0**(lockfile は
   **0.2.1**)という stale install が原因です。CI はクリーン install なので緑です。

## 経緯についての注記

前回の赤(#1653)がクローズされた **58 分後**に、別原因で赤に戻っていました。#1653 が最後に
書いた「赤いジョブは次の破損を隠す」がそのまま起きた形です。今回の 2 件が product bug
だったことも、赤が続くと product bug と環境差が見分けられなくなることを示しています。

## User Prompt

- https://github.com/receptron/mulmoterminal/actions/runs/31831129240 を fix してほしい。

work in mulmoterminal
