### PR TITLE
chore: bump codeql-action to v4.37.7

### DIFF
--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -52,7 +52,7 @@ jobs:
             --output report
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: report/jscpd-report.sarif
           category: jscpd


### PR DESCRIPTION
## Summary

`duplication-scan` ワークフローの `github/codeql-action/upload-sarif` のピンを **v3.37.1 → v4.37.7**（現時点の最新）に上げる。変更は 1 行。

```
- uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+ uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
```

SHA は tag から解決した（annotated tag `v4.37.7` = `faaa5d80…` → commit `ff2f1c62…`）。リポジトリ内で `codeql-action` を参照しているのはこの 1 箇所だけ。

**v3 → v4 のメジャー差分はランタイムだけ。** upstream の CHANGELOG 4.30.7 が `[v4+ only] The CodeQL Action now runs on Node.js v24.` と書いているのが v3 系との唯一の分岐で、それ以降 v4.37.7 まで `upload-sarif` の入力仕様（`sarif_file` / `category`）に変更はない。`ubuntu-latest` は node24 対応済みなので、ジョブ定義側の追随は不要。

## Items to Confirm / Review

- **実際に動くのは merge 後の CI。** 手元で確認したのは「差分が 1 行であること」「SHA が v4.37.7 の commit であること」「YAML がパースできること」「Prettier がクリーンなこと」まで。SARIF アップロードが v4 で通るかは、この PR の `duplication-scan` ジョブが green になるかで判断してほしい。
- ピン先が **v4 系の最新** であることは `repos/github/codeql-action/tags` で確認済み（v4.37.0〜v4.37.7 のうち v4.37.7 が最新）。v5 は存在しない。
- `yarn.lock` にはこのブランチと無関係な未コミット差分がローカルにあったが、**この PR には含めていない**（コミットはワークフロー 1 ファイルのみ）。

## User Prompt

- knip は clean（exit 0）だった。
- `codeql-action` は mulmoterminal の v3.37.1 からメジャーが 1 つ進んで v4.37.7 が最新なので、そちらの commit SHA を解決してピンする。
- 適用先はこの checkout（mulmoterminal5）。commit → push → PR まで進める。

work in mulmoterminal5
