### PR TITLE
fix(skills): claude が off にした Skill をメニューに出さない (#1698)

### DIFF
--- a/server/backends/remoteHost/skillOverrides.spec.ts
+++ b/server/backends/remoteHost/skillOverrides.spec.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { hiddenSkills, hiddenSkillsFromSettings } from "./skillOverrides.js";
+
+// Only `"off"` makes a skill unrunnable. The other three states change what claude is told about a
+// skill, not whether a person can invoke it, so hiding them would remove working buttons.
+describe("hiddenSkillsFromSettings", () => {
+  it("hides only the skills turned off", () => {
+    const settings = { skillOverrides: { gone: "off", terse: "name-only", handsOff: "user-invocable-only", fine: "on" } };
+    expect([...hiddenSkillsFromSettings([settings])]).toEqual(["gone"]);
+  });
+
+  it("hides nothing when the setting is absent", () => {
+    expect(hiddenSkillsFromSettings([{ theme: "dark" }, null, undefined]).size).toBe(0);
+  });
+
+  // A hand-edited settings file can hold anything. A malformed entry must not hide a skill —
+  // the user would see it vanish from the menu with nothing to point at.
+  it("ignores entries that are not strings, and a skillOverrides that is not a map", () => {
+    expect(hiddenSkillsFromSettings([{ skillOverrides: { a: ["off"], b: null, c: 0 } }]).size).toBe(0);
+    expect(hiddenSkillsFromSettings([{ skillOverrides: "off" }, { skillOverrides: [] }]).size).toBe(0);
+  });
+
+  // Later scopes win per KEY, not per file: a project file naming one skill must not discard the
+  // user file's other entries.
+  it("lets a later scope override one entry without dropping the rest", () => {
+    const user = { skillOverrides: { deploy: "off", legacy: "off" } };
+    const project = { skillOverrides: { deploy: "on" } };
+    expect([...hiddenSkillsFromSettings([user, project])]).toEqual(["legacy"]);
+  });
+
+  it("lets a later scope turn one off that an earlier scope allowed", () => {
+    expect([...hiddenSkillsFromSettings([{ skillOverrides: { deploy: "on" } }, { skillOverrides: { deploy: "off" } }])]).toEqual(["deploy"]);
+  });
+});
+
+describe("hiddenSkills", () => {
+  let userHome: string; // stands in for ~ (its .claude/skills is the user root)
+  let ws: string;
+
+  beforeEach(() => {
+    userHome = mkdtempSync(path.join(tmpdir(), "mt-overrides-user-"));
+    ws = mkdtempSync(path.join(tmpdir(), "mt-overrides-ws-"));
+  });
+  afterEach(() => {
+    rmSync(userHome, { recursive: true, force: true });
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const userSkillsDir = () => path.join(userHome, ".claude", "skills");
+  const writeSettings = (root: string, file: string, contents: string): void => {
+    mkdirSync(path.join(root, ".claude"), { recursive: true });
+    writeFileSync(path.join(root, ".claude", file), contents);
+  };
+  const read = () => hiddenSkills({ workspaceRoot: ws, userSkillsDir: userSkillsDir() });
+
+  it("reads the user settings file as the sibling of the skills root", async () => {
+    writeSettings(userHome, "settings.json", JSON.stringify({ skillOverrides: { deploy: "off" } }));
+    expect([...(await read())]).toEqual(["deploy"]);
+  });
+
+  it("reads the project file and the local one", async () => {
+    writeSettings(ws, "settings.json", JSON.stringify({ skillOverrides: { fromProject: "off" } }));
+    writeSettings(ws, "settings.local.json", JSON.stringify({ skillOverrides: { fromLocal: "off" } }));
+    expect([...(await read())].sort()).toEqual(["fromLocal", "fromProject"]);
+  });
+
+  // claude's own `/skills` menu writes settings.local.json, so it has to beat the file a repo
+  // checked in — otherwise turning a shared project's skill back on in the menu does nothing here.
+  it("lets the local file win over the project one", async () => {
+    writeSettings(ws, "settings.json", JSON.stringify({ skillOverrides: { deploy: "off" } }));
+    writeSettings(ws, "settings.local.json", JSON.stringify({ skillOverrides: { deploy: "on" } }));
+    expect((await read()).size).toBe(0);
+  });
+
+  it("lets a project file win over the user one", async () => {
+    writeSettings(userHome, "settings.json", JSON.stringify({ skillOverrides: { deploy: "on" } }));
+    writeSettings(ws, "settings.json", JSON.stringify({ skillOverrides: { deploy: "off" } }));
+    expect([...(await read())]).toEqual(["deploy"]);
+  });
+
+  // The ordinary case: most machines have no settings file at either scope.
+  it("hides nothing when no settings file exists", async () => {
+    expect((await read()).size).toBe(0);
+  });
+
+  it("hides nothing when a settings file is not valid JSON", async () => {
+    writeSettings(userHome, "settings.json", "{ this is not json");
+    expect((await read()).size).toBe(0);
+  });
+});

--- a/server/backends/remoteHost/skillOverrides.ts
+++ b/server/backends/remoteHost/skillOverrides.ts
@@ -1,0 +1,75 @@
+// Which skills claude will REFUSE to run, read from `skillOverrides` in its settings.
+//
+// A skill set to `"off"` is hidden from claude's own `/` menu and, since 2.1.199, from the command
+// lists it advertises to Remote Control and Agent SDK clients — and invoking one by name returns
+// the skillOverrides error instead of running it. Our Skill menu types that name into the cell, so
+// listing an `"off"` skill offers a button that cannot work (#1698).
+//
+// Only `"off"` hides. `"name-only"` and `"user-invocable-only"` change what claude is TOLD about a
+// skill, not whether a person can run it, so both stay in the menu.
+//
+// Plugin skills are deliberately not a concern here: claude states they are unaffected by
+// skillOverrides (`/plugin` manages those), and this repo does not discover them at all.
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { isRecord } from "../../../common/isRecord.js";
+
+/** The one state that makes a skill unrunnable. */
+const HIDDEN_STATE = "off";
+
+const SETTINGS_FILE = "settings.json";
+const LOCAL_SETTINGS_FILE = "settings.local.json";
+
+/** The `skillOverrides` map of one settings file, or an empty one for anything that isn't a map of
+ *  strings — a hand-edited file may hold anything, and a malformed entry must not hide a skill. */
+function overridesOf(settings: unknown): Record<string, string> {
+  if (!isRecord(settings) || !isRecord(settings.skillOverrides)) return {};
+  const entries = Object.entries(settings.skillOverrides).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return Object.fromEntries(entries);
+}
+
+/** The slugs claude would refuse, given each scope's parsed settings **in precedence order,
+ *  lowest first**. Merged per key rather than per file: claude's scopes override one setting at a
+ *  time, so a project file naming one skill does not discard the user file's other entries. */
+export function hiddenSkillsFromSettings(layers: readonly unknown[]): Set<string> {
+  const effective = new Map<string, string>();
+  layers.forEach((layer) => Object.entries(overridesOf(layer)).forEach(([slug, state]) => effective.set(slug, state)));
+  return new Set([...effective].filter(([, state]) => state === HIDDEN_STATE).map(([slug]) => slug));
+}
+
+/** A settings file's contents, or null when it is absent or not JSON. Absent is the ordinary
+ *  case — most machines have no project settings at all. */
+async function readSettings(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export interface HiddenSkillsOptions {
+  /** Project scope: `<workspaceRoot>/.claude/settings{,.local}.json`. */
+  workspaceRoot: string;
+  /** `~/.claude/skills`, or a test's stand-in. The user settings file is its SIBLING — claude
+   *  keeps both under `~/.claude` — so deriving it here means a test that already redirects the
+   *  skills root cannot accidentally read the developer's real settings. */
+  userSkillsDir: string;
+}
+
+/**
+ * The slugs to leave out of the Skill menu. Read from the three scopes a user can write, lowest
+ * precedence first: user, then project, then project-local (which is where claude's own `/skills`
+ * menu writes).
+ *
+ * Enterprise MANAGED settings are NOT read. On macOS and Windows they are an MDM preferences
+ * domain rather than a file, so reading the Linux file alone would answer differently per platform
+ * for the same policy. The gap shows only where a managed policy turns a skill back ON that the
+ * user turned off — the rarer half of a rare setting — and it fails toward listing a skill, which
+ * is what this whole module is narrowing.
+ */
+export async function hiddenSkills(opts: HiddenSkillsOptions): Promise<Set<string>> {
+  const projectDir = path.join(opts.workspaceRoot, ".claude");
+  const files = [path.join(path.dirname(opts.userSkillsDir), SETTINGS_FILE), path.join(projectDir, SETTINGS_FILE), path.join(projectDir, LOCAL_SETTINGS_FILE)];
+  return hiddenSkillsFromSettings(await Promise.all(files.map(readSettings)));
+}

--- a/server/backends/remoteHost/skills.spec.ts
+++ b/server/backends/remoteHost/skills.spec.ts
@@ -170,3 +170,58 @@ describe("applySkillFilter", () => {
     expect(applySkillFilter(skills, ["nope"])).toEqual([]);
   });
 });
+
+// A skill claude's `skillOverrides` turns `"off"` cannot be run: picking it types its name into
+// the cell, and claude answers with the skillOverrides error. Listing it offers a button that
+// always fails (#1698). The precedence between the settings scopes is pinned in
+// skillOverrides.spec.ts; what these pin is that discovery consults it at all — for the menu
+// (`discoverSkills`) and for the ids advertised to Remote Control (`discoverSkillNames`).
+describe("skills turned off in claude's settings", () => {
+  let userHome: string;
+  let ws: string;
+
+  beforeEach(() => {
+    userHome = mkdtempSync(path.join(tmpdir(), "mt-skills-user-"));
+    ws = mkdtempSync(path.join(tmpdir(), "mt-skills-ws-"));
+  });
+  afterEach(() => {
+    rmSync(userHome, { recursive: true, force: true });
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const userDir = () => path.join(userHome, ".claude", "skills");
+  const writeUserSettings = (contents: unknown): void => {
+    mkdirSync(path.join(userHome, ".claude"), { recursive: true });
+    writeFileSync(path.join(userHome, ".claude", "settings.json"), JSON.stringify(contents));
+  };
+
+  it("leaves an off user skill out of the menu", async () => {
+    writeSkill(userHome, "kept", SKILL_MD);
+    writeSkill(userHome, "gone", SKILL_MD);
+    writeUserSettings({ skillOverrides: { gone: "off" } });
+    expect((await discoverSkills({ workspaceRoot: ws, userDir: userDir() })).map((s) => s.slug)).toEqual(["kept"]);
+  });
+
+  it("leaves an off project skill out too", async () => {
+    writeSkill(ws, "gone", SKILL_MD);
+    writeUserSettings({ skillOverrides: { gone: "off" } });
+    expect(await discoverSkills({ workspaceRoot: ws, userDir: userDir() })).toEqual([]);
+  });
+
+  it("leaves it out of the ids advertised to Remote Control", async () => {
+    writeSkill(userHome, "kept", SKILL_MD);
+    writeSkill(userHome, "gone", SKILL_MD);
+    writeUserSettings({ skillOverrides: { gone: "off" } });
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["kept"]);
+  });
+
+  // The states that are not "off" leave a skill runnable, so removing them would take away
+  // working buttons.
+  it("keeps a skill in the other three states", async () => {
+    writeSkill(userHome, "terse", SKILL_MD);
+    writeSkill(userHome, "handsOff", SKILL_MD);
+    writeSkill(userHome, "plain", SKILL_MD);
+    writeUserSettings({ skillOverrides: { terse: "name-only", handsOff: "user-invocable-only", plain: "on" } });
+    expect((await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).sort()).toEqual(["handsOff", "plain", "terse"]);
+  });
+});

--- a/server/backends/remoteHost/skills.ts
+++ b/server/backends/remoteHost/skills.ts
@@ -16,6 +16,7 @@ import { join, resolve } from "node:path";
 
 import { userSkillsDir, projectSkillsDir } from "../collections.js";
 import { SLUG_RE } from "../../agents/codex-skills.js";
+import { hiddenSkills } from "./skillOverrides.js";
 
 const SKILL_FILE = "SKILL.md";
 
@@ -116,13 +117,21 @@ const bySlugAsc = (left: DiscoveredSkill, right: DiscoveredSkill): number => lef
  * (working-dir) skills lead the list**, then user-scope ones, alphabetical within
  * each group. A project skill also shadows a user skill of the same slug (its
  * description wins). Map insertion order gives the project-first ordering.
+ *
+ * A skill claude's `skillOverrides` turns `"off"` is left out: picking it types its name into the
+ * cell, and claude answers that with an error rather than running it (#1698).
  */
 export const discoverSkills = async (opts: DiscoverSkillNamesOptions): Promise<DiscoveredSkill[]> => {
-  const [userSkills, projectSkills] = await Promise.all([collectSkills(opts.userDir ?? userSkillsDir()), collectSkills(projectSkillsDir(opts.workspaceRoot))]);
+  const userDir = opts.userDir ?? userSkillsDir();
+  const [userSkills, projectSkills, hidden] = await Promise.all([
+    collectSkills(userDir),
+    collectSkills(projectSkillsDir(opts.workspaceRoot)),
+    hiddenSkills({ workspaceRoot: opts.workspaceRoot, userSkillsDir: userDir }),
+  ]);
   const bySlug = new Map<string, DiscoveredSkill>();
   for (const skill of [...projectSkills].sort(bySlugAsc)) bySlug.set(skill.slug, skill); // project first + shadows user
   for (const skill of [...userSkills].sort(bySlugAsc)) if (!bySlug.has(skill.slug)) bySlug.set(skill.slug, skill);
-  return [...bySlug.values()];
+  return [...bySlug.values()].filter((skill) => !hidden.has(skill.slug));
 };
 
 /**


### PR DESCRIPTION
## Summary

`skillOverrides` で `"off"` にした Skill が、Skill メニューと `GET /api/skills` に出ていました
（#1698 の 2 点目）。**1 点目のプラグイン由来 Skill は仕様として別扱い**で、この PR には含みません。

これは表示のずれではなく、**押すと必ず失敗するボタン**でした。

- claude の公式ドキュメント: 2.1.199 以降、`"off"` は自身の `/` メニューに加えて
  **Remote Control / Agent SDK に広告するコマンド一覧からも消える**。MulmoTerminal はまさにその
  外部クライアントの位置にいます
- 同ドキュメント: **"Invoking a hidden skill by its full name still returns the `skillOverrides`
  error instead of running it."** メニューは選ばれた slug を `skillSeed()` でセルに打ち込む
  （`Terminal.vue:194`）ので、選ぶと必ずエラーになります
- `server/` に `skillOverrides` の参照は **0 件**でした。読んでいない以上、設定した人には確実に起きます

`skillOverrides` が実在することは、公式ドキュメントの節と、インストール済み claude 2.1.233 の
バイナリ内の文字列（14 箇所）の両方で確認しています。

## Items to Confirm / Review

1. **落とすのは `"off"` だけです。** 値は 4 状態あり、`"name-only"` と `"user-invocable-only"` は
   claude 側でも `/` メニューに残って**起動できます**。落とすと動くボタンを取り上げることになるので
   残しました（spec で固定）
2. **企業の managed settings は読んでいません。** macOS と Windows では MDM の preferences domain /
   レジストリであってファイルではないため、Linux のファイルだけ読むと同じポリシーがプラットフォーム
   ごとに違う答えになります。抜けが出るのは「ユーザーが off にした Skill を managed ポリシーが on に
   戻している」場合だけで、そのときの挙動は**現状と同じ（メニューに出る）**です。理由はモジュール
   冒頭のコメントに書きました
3. **user 設定ファイルの場所を `userDir` から導出しています**（`~/.claude/skills` の兄弟が
   `~/.claude/settings.json`）。オプションを増やすより、**既存の spec が自動的に隔離される**方を
   取りました — テストが tmp の skills root を渡している時点で、開発者の実設定を読むことはありません
4. **プラグイン由来の Skill には `skillOverrides` が適用されません**（claude の仕様）。この repo は
   プラグインを走査していないので今は無関係ですが、#1698 の 1 点目を将来実装するときの罠なので
   コメントに残しました

## 検証

- 新規 spec `skillOverrides.spec.ts`（12 件）— 4 状態の切り分け、scope の優先順位（キー単位で後勝ち、
  local > project > user）、壊れた JSON / 壊れたエントリ
- `skills.spec.ts` に 4 件追加 — `discoverSkills`（メニュー）と `discoverSkillNames`
  （Remote Control が広告する id）の両方で `"off"` が落ちること、他の 3 状態が残ること
- **フィルタを外すと新規 3 件だけが落ちる**ことを確認済み（テストが実際に守っている）
- `yarn format` / `lint` / `build` / `typecheck` / `test` すべて green（**706 files / 10146 tests**）

**未確認**: 実際に `skillOverrides` を設定した環境でメニューを開くところまでは確認していません。
確認したのは設定の読み取りと除外のロジックです。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1698 これバグ？
- bugだけなおして、もう１つは仕様ですととりあえず返してcloseかな。

work in mulmoterminal2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skills configured as “off” are now hidden from the Skill menu.
  - Skill visibility settings are supported across user, project, and local project configuration scopes.
  - Other skill states, including “on,” “name-only,” and “user-invocable-only,” remain discoverable.

- **Bug Fixes**
  - Invalid or missing settings no longer disrupt skill discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->