### PR TITLE
chore: issue テンプレートを置く（バグ報告 / 課題・ユースケース、英語）

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,165 @@
+name: Bug report
+description: Something in MulmoTerminal behaves in a way you believe is a defect.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Run the bug report skill first
+
+        In any Claude Code session that MulmoTerminal started, type:
+
+        ```
+        /mulmoterminal-bug-report
+        ```
+
+        The skill reads your real configuration file, the schema in the source, and the version
+        you are running, so it can tell you when the behaviour is a setting or is working as
+        designed. That is the outcome you actually want, because it unblocks you today instead
+        of in a future release. It also searches the existing issues, collects the environment
+        details, and replaces anything that looks like a key or a token with `***` before it
+        shows you the report.
+
+        The fields below are the headings the skill produces, in the same order, so you can
+        paste its output straight in.
+
+        Cannot run it — because you are writing this from a browser, or because MulmoTerminal
+        will not start at all? Say so in **Anything else** at the bottom, and fill in as much
+        as you can by hand.
+
+        ## Write every word out in full
+
+        Do not use abbreviations or short forms. Write "MulmoTerminal", not "MT". Write "steps
+        to reproduce", not "repro". Write "configuration file", not "conf". Issues here are read
+        by people and by coding agents, and a short form that is obvious to you is a guess for
+        whoever picks this up.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you submit
+      options:
+        - label: I ran the `mulmoterminal-bug-report` skill, or I have said below why I could not.
+          required: true
+        - label: I searched the existing issues, open and closed, and this is not one of them.
+          required: true
+        - label: I removed every key, token, password and credential from what I pasted below.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, in the order you saw it. Describe the behaviour rather than your explanation of it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected instead
+      description: What you thought would happen, and what made you think so — the guide, an earlier version, another terminal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps, starting from a freshly started MulmoTerminal. Someone who has never seen your setup has to be able to follow them.
+      placeholder: |
+        1. Start MulmoTerminal in a directory that has no worktree.
+        2. Open the enlarged view and switch to the roster.
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: MulmoTerminal version
+      description: Open Settings and read the version under the title, or run `npx mulmoterminal --version`.
+      placeholder: "4.8.4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: how-started
+    attributes:
+      label: How you started it
+      options:
+        - npx mulmoterminal
+        - A global installation
+        - From a clone of this repository, with yarn dev
+        - Something else, described below
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: The skill collects all of this. Each supporting command may be absent on your machine, and that is worth saying too.
+      value: |
+        - Operating system:
+        - Node.js version:
+        - Browser and version:
+        - tmux:
+        - GitHub command line (gh):
+        - claude:
+        - codex:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where it happens
+      options:
+        - A cell in the tiled grid
+        - The enlarged view — the roster
+        - The enlarged view — the filmstrip
+        - The single view
+        - The file browser
+        - Settings
+        - On a phone
+        - While starting up, before anything is drawn
+        - Somewhere else, or not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Which agent the cell was running
+      options:
+        - claude
+        - codex
+        - A plain shell
+        - A launcher chip
+        - Not specific to one agent, or no agent involved
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often it happens
+      options:
+        - Every time
+        - Sometimes
+        - It happened once
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: |
+        Screenshots, red errors from the browser console, the part of your configuration file that
+        matters. A terminal screenshot carries your prompt text and your directory paths — look at
+        it before you attach it.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Blank issues stay enabled on purpose. Maintainers file internal work — lint sweeps,
+# performance, refactors — that fits neither template, and forcing a form on those only
+# creates headings nobody fills in.
+blank_issues_enabled: true
+
+contact_links:
+  - name: How is this supposed to work? (documentation)
+    url: https://receptron.github.io/mulmoterminal/guide/en/
+    about: Installation, configuration files, keyboard shortcuts and the view modes are covered in the guide. Read it before opening an issue about intended behaviour.
+  - name: Question, or an idea that is not yet a problem statement (discussion)
+    url: https://github.com/receptron/mulmoterminal/discussions
+    about: Start a discussion for questions, for anything you are not sure is a defect, and for ideas you want to talk through before writing them up.

--- a/.github/ISSUE_TEMPLATE/problem_or_use_case.yml
+++ b/.github/ISSUE_TEMPLATE/problem_or_use_case.yml
@@ -1,0 +1,105 @@
+name: Problem or use case
+description: Something you were trying to get done, and what got in the way.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Describe the problem, not the feature
+
+        Write about the situation you were in, what you were trying to get done, and what got in
+        the way. Leave the feature you have in mind out of it wherever you can.
+
+        That is not modesty, it is what gets the problem solved. A proposal narrows the answer to
+        the one you already thought of, and someone who knows how the pieces fit together often
+        has a cheaper answer — or finds the thing already exists under a name you did not search
+        for. A proposal also buries the problem: when a proposal is turned down, the problem it
+        came from is thrown away with it, and nobody ever solves it.
+
+        If you cannot leave your idea out, put it in the second to last field, where it sits as
+        one idea among others rather than as the thing being asked for.
+
+        ## Do not write code
+
+        No patch, no difference against a file, no file-by-file implementation plan, no "change
+        this function so that". How it gets built is decided after the problem is understood, in
+        a plan file and a pull request.
+
+        ## Write every word out in full
+
+        Do not use abbreviations or short forms. Write "MulmoTerminal", not "MT". Write
+        "configuration file", not "conf". Issues here are read by people and by coding agents,
+        and a short form that is obvious to you is a guess for whoever picks this up.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you submit
+      options:
+        - label: I described the situation I was in and what got in the way, rather than a design.
+          required: true
+        - label: This issue contains no code, no patch and no difference against a file.
+          required: true
+        - label: I checked the guide and Settings, and this is not something I can already configure.
+          required: true
+        - label: I searched the existing issues, open and closed, and this is not one of them.
+          required: true
+
+  - type: textarea
+    id: trying-to-do
+    attributes:
+      label: What were you trying to get done
+      description: The actual task, told concretely. Name the real work, not a generic version of it.
+      placeholder: |
+        I keep six cells open across two repositories, and I was going through them one by one to
+        see which ones had finished and were waiting on me.
+    validations:
+      required: true
+
+  - type: textarea
+    id: got-in-the-way
+    attributes:
+      label: What got in the way
+      description: What happened at the point you got stuck, and why it stopped you.
+      placeholder: |
+        The roster shows every cell, but I could not tell a finished cell from one still working
+        without opening each one, so I opened all six and lost my place twice.
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: What you do about it today
+      description: The workaround you use now, however clumsy — or say that you gave up on it. This is what says how much the problem costs.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often you run into this
+      options:
+        - Several times a day
+        - A few times a week
+        - Occasionally
+        - Once so far
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: If you already have an idea, it goes here
+      description: Optional, and deliberately last. One idea among others, in behaviour a person could see — still no code.
+    validations:
+      required: false
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: Screenshots, the other tool that solves this well, anyone else you know who hits the same thing.
+    validations:
+      required: false

--- a/plans/chore-1715-issue-templates.md
+++ b/plans/chore-1715-issue-templates.md
@@ -1,0 +1,106 @@
+# chore: GitHub issue テンプレートを追加する (#1715)
+
+## 背景
+
+`.github/` の下は `workflows/` だけで、issue テンプレートが 1 つも無い。New issue は白紙から
+書く形なので、報告に含まれる情報が毎回ばらつく。バージョン・OS・起動方法（npx か `yarn dev` か）
+の無い報告、再現手順の無い報告が実際に届いている。
+
+## 形式は Issue Forms（YAML）
+
+Markdown テンプレート（`.md`）は本文のひな形を挿入するだけで、空のまま submit できる。
+Issue Forms（`.yml`）は `validations.required: true` を付けた項目を空にできないので、
+バージョンや再現手順の欠落を、お願いではなく構造で防げる。
+
+## ファイル
+
+```
+.github/ISSUE_TEMPLATE/
+  config.yml                 白紙 issue は残し、使い方の質問を Discussions と guide へ逃がす
+  bug_report.yml             バグ報告
+  problem_or_use_case.yml    課題・ユースケース（旧「機能提案」）
+```
+
+言語は英語のみ。
+
+## テンプレートに載せる 3 つのルール
+
+### 1. 略語を使わない（両方）
+
+"MT" ではなく "MulmoTerminal"、"repro" ではなく "steps to reproduce"。この repository の issue は
+人間とコーディングエージェントの両方が読むので、書き手には自明な略語が読み手には推測になる。
+両テンプレートの先頭の `markdown` ブロックに置く。
+
+### 2. バグ報告は `mulmoterminal-bug-report` skill を通す
+
+required checkbox で先に skill を実行してもらう。skill は実際の config / schema / version を
+読んで「設定か仕様どおりの動作か」を判定し、既存 issue を検索し、環境情報を集めて鍵に見えるものを
+マスクしたうえで、残ったものだけを起票する。
+
+**フォームの項目は skill の報告本文と 1 対 1 で対応させる。** skill 側（`server/skills/
+mulmoterminal-bug-report/SKILL.md` の Step 4）が出す見出しは
+What happened / What I expected / Steps to reproduce / Environment / Attachments。
+ここがずれると、skill が作った本文をフォームに貼り直す作業が発生して、skill を通す動機が消える。
+
+skill を使えない人（GitHub の Web から直接書く人）を締め出さないよう、checkbox は
+「skill を実行した」と「skill を使わなかったので自分で確認した」の 2 択ではなく、
+skill を実行したことの確認 1 つ + 使えない場合の代替手順を `markdown` で案内する形にする。
+
+### 3. 機能提案ではなく、課題とユースケースを書いてもらう
+
+テンプレート名を "Feature request" ではなく **"Problem or use case"** にする。聞くのは
+「どういう状況で、何をしようとして、何に阻まれたか」であって、どんな機能が欲しいかではない。
+
+理由は 2 つあり、どちらもテンプレート本文に書く。
+
+- **提案は答えを狭める。** 報告者が思いついた 1 つの形に議論が固定され、view mode や session 層の
+  実際の組み合わせを知っている側が持っている、もっと安い答え（あるいは「それは別名で既にある」）に
+  届かなくなる。
+- **提案は課題を巻き込んで捨てられる。** 提案が却下されると、その提案が生まれた元の困りごとまで
+  一緒に閉じられ、誰も解かないまま残る。
+
+アイデアがある人を黙らせるわけではない。「もし既にアイデアがあるならここ」という **optional の欄を
+最後から 2 番目に置く**。位置そのものが「これは数ある案の 1 つ」という意味になる。
+
+コードは書かない。パッチ・diff・ファイル単位の実装計画を入れない。required checkbox で明示する。
+実装をどうするかは、採択後に `plans/` と pull request で決める。
+
+聞く項目は、課題の実在と大きさを測れるものに絞る。
+
+| 項目 | 必須 | なぜ聞くか |
+| --- | --- | --- |
+| What were you trying to get done | 必須 | ユースケース。具体的な作業名で書いてもらう |
+| What got in the way | 必須 | 詰まった地点そのもの |
+| What you do about it today | 必須 | 今の回避策。無いなら「諦めた」と書く。課題の値段がここに出る |
+| How often you run into this | 必須 | 頻度。優先度の材料 |
+| If you already have an idea | 任意 | 逃がし弁。最後から 2 番目 |
+
+## 決めたこと
+
+- **白紙 issue は無効にしない**（`blank_issues_enabled: true`）。メンテナが立てる内部タスク
+  （lint、perf、refactor など）はどちらのテンプレートにも当てはまらない。テンプレートを強制すると
+  そのたびに noise を消す作業が要る。
+- ラベルは既存の `bug` / `enhancement` を自動付与。新しいラベルは作らない。
+- タイトルの既定プレフィックスは既存 issue の慣習に合わせて `bug: ` / `feat: `。
+  課題テンプレートに `feat: ` を付けるのは「解は機能である」と先取りしていて、上のルール 3 と
+  わずかに矛盾する。それでも既存 issue 一覧の見た目を揃える方を採った。
+- dropdown の選択肢は skill の Step 1（What kind / Where / Which agent / How often）から取る。
+  skill を通ってきた人が同じ語彙で答えられる。
+
+## 検証
+
+Issue Forms は GitHub 側でしか描画されないので、ローカルで確認できるのは構文まで。
+
+1. YAML として parse できるか。
+2. **GitHub の公式 schema に対して妥当か。** 自分で書いた規則ではなく、SchemaStore が配っている
+   `github-issue-forms.json` / `github-issue-config.json` を落として ajv で当てる。外部の権威に
+   照らすのであって、自分の理解と突き合わせるのではない。
+3. **その検証器が実際に効いていることを、壊した写しで確かめる。** 何を入れても PASS する検証器は
+   何も証明しない。`name` を消す / 未知の `type` / `markdown` に `validations` / `dropdown` から
+   `options` を消す / `textarea` から `label` を消す、を注入して捕まることを見る。
+4. push 後、GitHub の New issue 画面で 3 つとも描画されること、required を空にすると submit
+   できないことを実際に見る。これが最終的な ground truth。
+
+**注意: issue テンプレートは default branch のものしか使われない。** feature branch に置いた
+状態では New issue 画面には出てこないので、4 は merge 後にしか確認できない。1〜3 を merge 前に
+必ず通しておく理由がこれ。


### PR DESCRIPTION
## Summary

`.github/ISSUE_TEMPLATE/` が空だったので、New issue は白紙から書く形だった。報告ごとに含まれる情報がばらつき、バージョン・起動方法・再現手順の無い報告が実際に届いている。GitHub Issue Forms（YAML）を 3 本置いて、欠落をお願いではなく `required` で防ぐ。言語は英語のみ。

| ファイル | 何 |
| --- | --- |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | バグ報告。`bug` ラベル、タイトル既定 `bug: ` |
| `.github/ISSUE_TEMPLATE/problem_or_use_case.yml` | 課題・ユースケース。`enhancement` ラベル、タイトル既定 `feat: ` |
| `.github/ISSUE_TEMPLATE/config.yml` | 白紙 issue は残し、使い方の質問を guide と Discussions へ逃がす |

依頼された 3 つのルールをテンプレート本文に埋めた。

1. **略語を使わない**（両方）。"MT" ではなく "MulmoTerminal"、"repro" ではなく "steps to reproduce"。この repository の issue は人間とコーディングエージェントの両方が読むので、書き手に自明な短縮形は読み手には推測になる、という理由まで書いてある。
2. **バグ報告は `mulmoterminal-bug-report` skill を先に通す**。required checkbox で確認する。フォームの項目は skill の報告本文（`server/skills/mulmoterminal-bug-report/SKILL.md` Step 4）と**同じ見出し・同じ順**にしたので、skill の出力をそのまま貼れる。ここがずれると貼り直す手間が生まれ、skill を通す動機が消える。skill を使えない人（ブラウザから書く人、そもそも起動しない人）向けの代替も案内した。
3. **機能提案ではなく課題を書いてもらう**。名前を "Feature request" ではなく **"Problem or use case"** にし、聞くのは「どういう状況で、何をしようとして、何に阻まれたか」にした。コードは書かない（パッチ・diff・実装計画）ことも required checkbox で明示。

## Items to Confirm / Review

1. **`problem_or_use_case.yml` のタイトル既定を `feat: ` にしたのは、ルール 3 とわずかに矛盾している。** 「解は機能である」と先取りしてしまうため。既存 issue 一覧の見た目を揃える方を優先したが、空にする（報告者が課題そのもので題を付ける）方が筋は通る。**どちらが良いか判断してほしい。**
2. **必須項目の数。** バグ報告は required フィールド 9 + required checkbox 3 で、正直重い。skill が全部埋める前提での設計。skill を使わずブラウザから書く人を弾きすぎると判断するなら、`where` / `agent` / `frequency` の 3 つの dropdown を optional に落とすのが最初に削る候補。
3. **`/mulmoterminal-bug-report` という起動の書き方が実際のものか。** skill は `~/.claude/skills/` に mirror される前提でこう書いたが、ユーザーが実際に打つ形と一致しているか確認してほしい。
4. **view mode の呼び名。** dropdown に "The enlarged view — the roster" / "— the filmstrip" と書いた。`docs/grid-view-modes.md` の区別に対応させたつもりだが、報告者がその語で自分の画面を選べるかは自信がない。
5. **白紙 issue を有効のまま残した**（`blank_issues_enabled: true`）。lint / perf / refactor の内部タスクはどちらのテンプレートにも当てはまらないため。テンプレートを強制したいなら `false`。
6. **ファイル名を `feature_request.yml` ではなく `problem_or_use_case.yml` にした。** New issue の選択画面に出るのは `name:` なので利用者からは見えず、影響するのは repository を読む人だけ。慣習名に戻したいなら言ってほしい。

## User Prompt

- バグレポートの skill はあったか（→ `mulmoterminal-bug-report`）。
- issue の template は作れるか。
- 一般的なテンプレートにしつつ、次の 3 つを入れてほしい。**略語を使わない**。**バグの場合は skill を使ってレポートすること**。**機能提案の場合はコードを書かない**。
- 言語は英語のみ。
- 機能提案については、提案よりも**課題**を書く方がよい。できる限り「どういうユースケースで何に困っているか」を書いてもらい、機能提案は極力しない形にする。

## 実装と決定

### なぜ Markdown テンプレートではなく Issue Forms か

Markdown テンプレート（`.md`）は本文のひな形を挿入するだけで、全部消して submit できる。Issue Forms（`.yml`）は `validations.required: true` の項目を空にできない。「バージョンを書いてください」というお願いを、構造にした。

### 「課題を書く」をテンプレートでどう強制したか

名前と説明文を課題側に振ったうえで、本文に理由を 2 つ書いた。

- **提案は答えを狭める。** 報告者が思いついた 1 つの形に議論が固定され、view mode や session 層の実際の組み合わせを知っている側が持っている、もっと安い答え（あるいは「それは別名で既にある」）に届かなくなる。
- **提案は課題を巻き込んで捨てられる。** 提案が却下されると、その提案が生まれた元の困りごとまで一緒に閉じられ、誰も解かないまま残る。

アイデアがある人を黙らせはしない。"If you already have an idea, it goes here" を optional で、**最後から 2 番目**に置いた。位置そのものが「数ある案の 1 つ」という意味になる。

聞く項目は、課題の実在と大きさを測れるものに絞った。

| 項目 | 必須 | なぜ聞くか |
| --- | --- | --- |
| What were you trying to get done | 必須 | ユースケース。具体的な作業名で書いてもらう |
| What got in the way | 必須 | 詰まった地点そのもの |
| What you do about it today | 必須 | 今の回避策。無いなら「諦めた」と書く。課題の値段がここに出る |
| How often you run into this | 必須 | 頻度。優先度の材料 |
| If you already have an idea | 任意 | 逃がし弁 |

### 検証

**Issue Forms は GitHub 側でしか描画されないので、merge 前に確認できるのは構文まで。** しかも **issue テンプレートは default branch のものしか使われない**ため、この branch に置いた状態では New issue 画面に出てこない。実描画の確認は merge 後にしかできない。そのぶん構文は外部の権威で固めた。

1. **公式 schema に当てた。** 自分の理解した規則ではなく、SchemaStore の `github-issue-forms.json`（84KB）と `github-issue-config.json` を落として ajv で検証。3 本とも PASS。id の重複も 0。
2. **その検証器が効いていることを、壊した写しで確かめた。** 何を入れても PASS する検証器は何も証明しない。6 つの変異を注入して 5 つが捕捉された（`name` を消す / 未知の `type: radio` / `markdown` に `validations` / `dropdown` から `options` を消す / `textarea` から `label` を消す）。捕まらなかったのは `labels` を配列でなく文字列にした場合だけで、これは schema 側が両方許しているため。本 PR は配列を使っているので無関係。
3. `yarn format` が 3 本とも読んで無変更（`prettier --write .` は `.github/` も対象）。

コードには一切触れていないので lint / build / typecheck の対象外。

Closes #1715

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured templates for reporting bugs and describing problems or use cases.
  * Added guided fields for reproduction details, environment, impact, workarounds, and supporting context.
  * Added links to documentation and discussions while keeping blank issue creation available.

* **Documentation**
  * Added planning documentation covering issue-form content, terminology, labels, validation, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->