### PR TITLE
fix: Windows で Shell セルが起動しない — 空白を含む shell パスを PowerShell が分割していた (#1717)

### DIFF
--- a/plans/fix-1717-windows-shell-path.md
+++ b/plans/fix-1717-windows-shell-path.md
@@ -1,0 +1,125 @@
+# fix: Windows で Shell セルが起動しない — 空白を含む shell パスが PowerShell に素で渡る (#1717)
+
+## 症状
+
+Windows で Shell セルを起動すると即座に落ちる。
+
+```
+C:\Program : 用語 'C:\Program' は、コマンドレット、関数、スクリプト ファイル、または操作可能な
+プログラムの名前として認識されません。
+```
+
+Claude / Codex セルは同じ環境で正常に起動する。Shell セルだけが落ちる。
+
+## 根本原因
+
+2 つの独立した箇所が合流して壊れている。
+
+**1. `server/routes/ws-routes.ts:107`**
+
+```ts
+const DEFAULT_LAUNCH_CMD = process.env.SHELL || "/bin/sh";
+```
+
+これは**実行ファイルのパス**であって、コマンドラインではない。Git for Windows が入っていると
+`process.env.SHELL` は `C:\Program Files\Git\usr\bin\bash.exe` になる。
+
+**2. `server/session/shell-command.ts:19`**
+
+```ts
+if (platform === "win32") return { shell: "powershell.exe", args: ["-NoLogo", "-Command", command] };
+```
+
+`-Command` の引数は PowerShell が**コードとして解析する**。渡ったのが素のパスなので、
+最初の空白で切れて `C:\Program` がコマンド名、`Files\Git\usr\bin\bash.exe` が引数になる。
+
+POSIX 側は `$SHELL` に空白が無いという偶然で通っていただけで、設計としては同じ穴が空いている。
+
+さらに `/bin/sh` フォールバックは Windows では `<drive>:\bin\sh` に解決され、何も指さない
+（`windows-gotchas.md` の「POSIX absolute paths silently become drive-relative」そのもの）。
+
+## いちばん危険な罠 — 引用符だけでは直らない
+
+PowerShell で `'C:\Program Files\...\bash.exe'` は**ただの文字列式**で、実行されずにパスが
+表示されるだけ。実行するには**呼び出し演算子 `&` が要る**。
+
+| `-Command` に渡すもの | 起きること |
+| --- | --- |
+| `C:\Program Files\...\bash.exe` | 空白で分割され `CommandNotFoundException`（現状のバグ） |
+| `'C:\Program Files\...\bash.exe'` | **パスが表示されるだけでシェルは起動しない** |
+| `& 'C:\Program Files\...\bash.exe'` | 起動する |
+
+真ん中が「引用符を足す」という素直な修正の結果で、**エラーが出ないぶん今より悪い**
+（セルは開くがシェルが無い＝ハングに見える）。ここを外すと直したつもりで壊れる。
+
+## 直し方
+
+**空白を含むかどうかで分岐しない。** 常に `&` + 引用符を通す。分岐はユーザーの書いた文字列を
+推測する行為で、CLAUDE.md がランチャーチップで禁じているのと同じ間違いになる。
+
+### 1. `server/infra/shell-quote.ts`（新規）
+
+PowerShell の単一引用符エスケープは**既に `server/config/header-resolve.ts` の `shellQuoteFor` に
+ある**（ヘッダーボタンの `${branch}` 置換用）。2 つ目のコピーを書かない。`cmd-escape.ts` の隣、
+infra に移してどちらからも使う。セキュリティに関わる引用規則の定義は 1 つでなければならない。
+
+```ts
+export function shellQuoteFor(platform)          // header-resolve から移動
+export function runExecutableCommand(execPath, platform)  // 新規: & 'path' / 'path'
+```
+
+`header-resolve.ts` は再エクスポートしない（CLAUDE.md）。import 元を全て書き換える。
+
+### 2. `server/session/shell-command.ts`
+
+```ts
+export function defaultShellCommand(platform, env): string
+```
+
+- win32 以外: `SHELL` → `/bin/sh`
+- win32: `SHELL` → `ComSpec` → `powershell.exe` を `runExecutableCommand` に通す
+
+env の読み出しは `pty-env.ts` の `envValue`（大文字小文字を無視）を使う。Windows の
+`process.env` は case-insensitive だが、テストが渡す素のオブジェクトはそうではない。
+
+**どのシェルが起動するかは変えない。** `SHELL` が設定されていればそれを尊重する。報告者は
+bash が起動しないことを問題にしているのであって、bash であることを問題にしていない。
+Windows で常に PowerShell を起動する案もあるが、それは別の判断なので PR で提起する。
+
+### 3. `server/routes/ws-routes.ts`
+
+`DEFAULT_LAUNCH_CMD` を `defaultShellCommand(process.platform, process.env)` に置き換える。
+
+## 検証
+
+**このホストに PowerShell が無い。** ローカルで確認できるのは純粋関数の出力だけで、
+「PowerShell が実際にどう解釈するか」は推測になる。上の表の真ん中の行こそが推測で外しやすい
+ところなので、**実機で確かめないまま直したと言わない**。
+
+**`windows-daily.yaml` は `pull_request` で走らない**（`schedule` / `push: main` /
+`workflow_dispatch` のみ）。PR が緑でも Windows については何も証明していない。
+
+1. 純粋関数のテスト（どのホストでも走る）— `test/server/session/shell-command.spec.ts`
+   - 空白入りパス / 引用符入りパス / `SHELL` 未設定 / POSIX 側が変わらないこと
+2. **実 PTY テスト（Windows のみ）** — `test/server/session/shell-spawn-win.spec.ts` に追加。
+   既に PowerShell を実 PTY で回す基盤がある。
+   - ランナーのイメージに依存しない決定的な再現を作る: `mkdtemp` の下に**空白を含む名前の
+     ディレクトリ**を作り、トークンを出力する `.cmd` を置き、そこを `SHELL` に見立てる
+   - **素のパスが失敗することも同時に固定する。** 直った側だけ見ても、バグが本当にそれだったか
+     は分からない
+3. `gh workflow run windows-daily.yaml --ref fix/1717-windows-shell-path` を**修正前に一度**
+   走らせて赤を確認し、修正後にもう一度走らせて緑を確認する。
+
+## 併せて洗った Windows 関連箇所（結果: 追加修正なし）
+
+| 箇所 | 判定 |
+| --- | --- |
+| `server/infra/cmd-escape.ts` | cmd.exe 用の引用。`resolve-bin` 経由でバッチシムに使われる。健全 |
+| `server/infra/resolve-bin.ts` | `namesAPath` で分岐し、パスは argv として渡す。第 2 パーサを通さない |
+| `server/config/header-resolve.ts` | `shellQuoteFor` で値を引用済み。実行ファイルパスは扱わない |
+| `server/files/pick-file.ts` / `win-folder-dialog.ts` | `powershell -Command <script>` だが、パスはスクリプト内で引用済み |
+| `server/files/open-dir.ts` | `explorer` を argv で spawn |
+| `server/session/session-settings.ts` | `escapeBatchArgument` 経由 |
+| `shell: true` の spawn | **ゼロ**（第 2 パーサを勝手に挟んでいる箇所は無い） |
+
+`process.env.SHELL` を読むのは 3 箇所だけで、いずれも本 PR が触る 2 ファイル。

--- a/server/config/header-resolve.ts
+++ b/server/config/header-resolve.ts
@@ -128,10 +128,3 @@ export function resolveHeader(config: HeaderConfig, ctx: HeaderContext): Resolve
   const chips = config.chips === null ? null : config.chips.map((c) => resolveChip(c, ctx)).filter((c): c is ResolvedChip => c !== null);
   return { buttons, chips, env: ctx.worktreeEnv };
 }
-
-// POSIX/PowerShell single-arg quoting, so a substituted ${branch}/${repo}/${task} can't break out of the
-// command string. POSIX closes the quote, escapes the literal quote, reopens; PowerShell doubles quotes.
-export function shellQuoteFor(platform: NodeJS.Platform): (value: string) => string {
-  if (platform === "win32") return (value) => `'${value.replace(/'/g, "''")}'`;
-  return (value) => `'${value.replace(/'/g, "'\\''")}'`;
-}

--- a/server/infra/shell-quote.ts
+++ b/server/infra/shell-quote.ts
@@ -1,0 +1,26 @@
+// Making a value, or an executable path, survive a shell that will parse the string AGAIN.
+// Beside cmd-escape.ts, which does the same job for cmd.exe's very different rules. One
+// definition each: a quoting rule that exists twice is a quoting rule that gets fixed once.
+
+/** POSIX/PowerShell single-arg quoting, so a substituted ${branch}/${repo}/${task} can't break out
+ *  of the command string. POSIX closes the quote, escapes the literal quote, reopens; PowerShell
+ *  doubles quotes. */
+export function shellQuoteFor(platform: NodeJS.Platform): (value: string) => string {
+  if (platform === "win32") return (value) => `'${value.replace(/'/g, "''")}'`;
+  return (value) => `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** A command string that RUNS the program at `execPath`, for a shell that parses the string.
+ *
+ *  On PowerShell, quoting alone is not enough and it fails SILENTLY: `'C:\Program Files\…\x.exe'`
+ *  is a string expression, so the path is echoed and nothing starts — a terminal that opens onto
+ *  no shell, which reads as a hang rather than an error. The call operator `&` is what executes
+ *  it. Left unquoted it splits at the first space instead (#1717).
+ *
+ *  Applied unconditionally, never only when the path "looks like it needs it": deciding from the
+ *  text is the guess this repo refuses elsewhere, and `& 'x.exe'` is correct for a path with no
+ *  space too. */
+export function runExecutableCommand(execPath: string, platform: NodeJS.Platform): string {
+  const quoted = shellQuoteFor(platform)(execPath);
+  return platform === "win32" ? `& ${quoted}` : quoted;
+}

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -14,9 +14,11 @@ import { CLAUDE_CWD, SESSION_ID_RE } from "../config/env.js";
 import { workspaceRequest } from "../config/workspace.js";
 import { getHeaderConfig } from "../config/config-routes.js";
 import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.js";
-import { resolveButtonCommand, shellQuoteFor } from "../config/header-resolve.js";
+import { resolveButtonCommand } from "../config/header-resolve.js";
 import { resolveScript } from "../files/scripts.js";
+import { shellQuoteFor } from "../infra/shell-quote.js";
 import { tmuxHasSession } from "../infra/tmux.js";
+import { defaultShellCommand } from "../session/shell-command.js";
 import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
@@ -101,10 +103,11 @@ export interface WsRouteDeps {
 // resume an on-disk transcript, attach a live tmux session, else a fresh id. The flag
 // decision lives in resolveSession (pure/tested); this only gathers the live facts —
 // lazily, so a live pty short-circuits the tmux + disk probes.
-// The command a launcher runs when spawned fresh. On a tmux reattach it's ignored
-// (tmux new-session -A attaches the running program), so a surviving session with no
-// resolvable launcher index still reattaches via this harmless fallback.
-const DEFAULT_LAUNCH_CMD = process.env.SHELL || "/bin/sh";
+// The command a launcher runs when spawned fresh — and what the Shell cell in the Agent Picker
+// runs, since it carries no launcher index. On a tmux reattach it's ignored (tmux new-session -A
+// attaches the running program), so a surviving session with no resolvable launcher index still
+// reattaches via this harmless fallback.
+const DEFAULT_LAUNCH_CMD = defaultShellCommand(process.platform, process.env);
 
 function resolveClaudeSession(requested: string | null, cwd: string): SessionResolution {
   const hasLivePty = !!requested && ptys.has(requested);

--- a/server/session/shell-command.ts
+++ b/server/session/shell-command.ts
@@ -1,8 +1,10 @@
-// The two decisions spawn-shell.ts makes before it touches a PTY: which shell invocation
-// runs a command, and which configured launcher an index refers to. Both are pure and both
-// are load-bearing — the invocation differs per platform (and only Windows CI would catch
-// a mistake), and the index guard is what stops a browser-supplied number from reaching
-// outside the configured allowlist.
+// The decisions spawn-shell.ts and the launch route make before they touch a PTY: which shell
+// invocation runs a command, what a Shell cell runs when no launcher is configured, and which
+// configured launcher an index refers to. All pure and all load-bearing — the invocation differs
+// per platform (and only Windows CI would catch a mistake), and the index guard is what stops a
+// browser-supplied number from reaching outside the configured allowlist.
+import { envValue } from "../infra/pty-env.js";
+import { runExecutableCommand } from "../infra/shell-quote.js";
 
 export interface ShellInvocation {
   shell: string;
@@ -18,6 +20,29 @@ export interface ShellInvocation {
 export function shellInvocation(command: string, replaceShell: boolean, platform: string, shellPath: string | undefined): ShellInvocation {
   if (platform === "win32") return { shell: "powershell.exe", args: ["-NoLogo", "-Command", command] };
   return { shell: shellPath || "/bin/bash", args: ["-lc", replaceShell ? `exec ${command}` : command] };
+}
+
+const POSIX_FALLBACK_SHELL = "/bin/sh";
+// Not `/bin/sh`: on Windows that resolves to `<drive>:\bin\sh` and names nothing, so the fallback
+// looked present and protected nobody. ComSpec is where Windows itself records its command
+// processor; powershell.exe is the last resort because it is what runs the command anyway.
+const WINDOWS_FALLBACK_SHELL = "powershell.exe";
+
+/** What a Shell cell runs when no launcher is configured.
+ *
+ *  `$SHELL` is an executable PATH, and the value it feeds is parsed AGAIN by the shell that runs
+ *  it — so it has to arrive as one quoted, invoked thing. Git for Windows sets it to
+ *  `C:\Program Files\Git\usr\bin\bash.exe`, which PowerShell split at the first space and reported
+ *  as an unknown command `C:\Program` (#1717). POSIX only escaped that by the accident of `$SHELL`
+ *  having no space in it.
+ *
+ *  The shell itself is unchanged — a configured `$SHELL` is still honoured on both platforms.
+ *  `env` and `platform` are parameters so both arms are checkable from any host, and the lookup is
+ *  case-insensitive because Windows spells these names however it likes. */
+export function defaultShellCommand(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+  const configured = envValue(env, "SHELL");
+  if (platform !== "win32") return runExecutableCommand(configured || POSIX_FALLBACK_SHELL, platform);
+  return runExecutableCommand(configured || envValue(env, "ComSpec") || WINDOWS_FALLBACK_SHELL, platform);
 }
 
 /** The entry at `index`, or null when the index is not a real position in the list. The

--- a/test/server/config/header-resolve.spec.ts
+++ b/test/server/config/header-resolve.spec.ts
@@ -1,14 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import {
-  substitute,
-  substituteShell,
-  evalWhen,
-  resolveHeader,
-  resolveButtonCommand,
-  headerHasPrButton,
-  shellQuoteFor,
-} from "../../../server/config/header-resolve.js";
+import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "../../../server/config/header-resolve.js";
+import { shellQuoteFor } from "../../../server/infra/shell-quote.js";
 import type { HeaderConfig, HeaderContext } from "../../../server/config/header-config.js";
 
 // POSIX single-quote escaping, matching the server's shellQuoteFor(non-win32).

--- a/test/server/session/shell-command.spec.ts
+++ b/test/server/session/shell-command.spec.ts
@@ -79,6 +79,16 @@ describe("defaultShellCommand", () => {
       expect(defaultShellCommand("win32", {})).toBe(`& 'powershell.exe'`);
     });
 
+    // Set-but-empty, not absent: `envValue` answers "" for that, and "" as a shell path would
+    // spawn nothing. The sibling shellInvocation spec pins the same case, so this one does too.
+    it("treats an empty SHELL as unset and moves on to ComSpec", () => {
+      expect(defaultShellCommand("win32", { SHELL: "", ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
+    });
+
+    it("treats an empty ComSpec as unset too", () => {
+      expect(defaultShellCommand("win32", { SHELL: "", ComSpec: "" })).toBe(`& 'powershell.exe'`);
+    });
+
     it("reads the environment case-insensitively, the way Windows spells it", () => {
       expect(defaultShellCommand("win32", { COMSPEC: "C:\\Windows\\system32\\cmd.exe" })).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
     });
@@ -100,6 +110,10 @@ describe("defaultShellCommand", () => {
 
     it("falls back to /bin/sh", () => {
       expect(defaultShellCommand("linux", {})).toBe("'/bin/sh'");
+    });
+
+    it("treats an empty SHELL as unset", () => {
+      expect(defaultShellCommand("linux", { SHELL: "" })).toBe("'/bin/sh'");
     });
   });
 

--- a/test/server/session/shell-command.spec.ts
+++ b/test/server/session/shell-command.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { shellInvocation, launcherAt } from "../../../server/session/shell-command.js";
+import { shellInvocation, launcherAt, defaultShellCommand } from "../../../server/session/shell-command.js";
 
 // platform and SHELL are parameters, so both branches are exercised on every runner —
 // otherwise the Windows arm would only ever be checked by the Windows CI job.
@@ -41,6 +41,76 @@ describe("shellInvocation", () => {
     it("has no exec form — powershell -Command already runs the one command", () => {
       expect(shellInvocation("codex", true, "win32", undefined)).toEqual(shellInvocation("codex", false, "win32", undefined));
     });
+  });
+});
+
+// What a Shell cell runs with no launcher configured. The value is an executable PATH that the
+// shell parses again, so the only thing under test is that it arrives as one invoked thing —
+// #1717, where `C:\Program Files\Git\usr\bin\bash.exe` reached PowerShell bare and was reported
+// as an unknown command `C:\Program`.
+describe("defaultShellCommand", () => {
+  const GIT_BASH = "C:\\Program Files\\Git\\usr\\bin\\bash.exe";
+
+  describe("windows", () => {
+    it("quotes AND invokes a shell path containing a space", () => {
+      // The `&` is not decoration: without it PowerShell evaluates the quoted path as a string
+      // expression, prints it, and starts no shell at all — a worse failure than the bug, because
+      // nothing errors.
+      expect(defaultShellCommand("win32", { SHELL: GIT_BASH })).toBe(`& 'C:\\Program Files\\Git\\usr\\bin\\bash.exe'`);
+    });
+
+    it("invokes a path with no space the same way", () => {
+      // No branch on "does it look like it needs quoting" — that is a guess about text.
+      expect(defaultShellCommand("win32", { SHELL: "C:\\tools\\bash.exe" })).toBe(`& 'C:\\tools\\bash.exe'`);
+    });
+
+    it("closes a single quote in the path instead of letting it end the literal", () => {
+      expect(defaultShellCommand("win32", { SHELL: "C:\\o'brien\\sh.exe" })).toBe(`& 'C:\\o''brien\\sh.exe'`);
+    });
+
+    it("falls back to ComSpec, never to /bin/sh", () => {
+      // `/bin/sh` resolves to <drive>:\bin\sh on Windows and names nothing.
+      const command = defaultShellCommand("win32", { ComSpec: "C:\\Windows\\system32\\cmd.exe" });
+      expect(command).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
+      expect(command).not.toContain("/bin/sh");
+    });
+
+    it("falls back to powershell.exe when the environment names nothing", () => {
+      expect(defaultShellCommand("win32", {})).toBe(`& 'powershell.exe'`);
+    });
+
+    it("reads the environment case-insensitively, the way Windows spells it", () => {
+      expect(defaultShellCommand("win32", { COMSPEC: "C:\\Windows\\system32\\cmd.exe" })).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
+    });
+
+    it("prefers a configured SHELL over ComSpec", () => {
+      expect(defaultShellCommand("win32", { SHELL: GIT_BASH, ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toContain("bash.exe");
+    });
+  });
+
+  describe("posix", () => {
+    it("quotes the shell path", () => {
+      // POSIX had the same hole and only escaped it because $SHELL has no space in practice.
+      expect(defaultShellCommand("darwin", { SHELL: "/bin/zsh" })).toBe("'/bin/zsh'");
+    });
+
+    it("has no call operator — quoting alone runs it", () => {
+      expect(defaultShellCommand("linux", { SHELL: "/opt/my shell/bash" })).toBe("'/opt/my shell/bash'");
+    });
+
+    it("falls back to /bin/sh", () => {
+      expect(defaultShellCommand("linux", {})).toBe("'/bin/sh'");
+    });
+  });
+
+  // The whole point is what shellInvocation then does with it: the command must stay ONE argv
+  // element on both platforms, or the space is re-split a layer later.
+  it("survives shellInvocation as a single argument", () => {
+    const windows = shellInvocation(defaultShellCommand("win32", { SHELL: GIT_BASH }), true, "win32", undefined);
+    expect(windows.args).toEqual(["-NoLogo", "-Command", `& 'C:\\Program Files\\Git\\usr\\bin\\bash.exe'`]);
+
+    const posix = shellInvocation(defaultShellCommand("darwin", { SHELL: "/bin/zsh" }), true, "darwin", "/bin/zsh");
+    expect(posix.args).toEqual(["-lc", "exec '/bin/zsh'"]);
   });
 });
 

--- a/test/server/session/shell-spawn-win.spec.ts
+++ b/test/server/session/shell-spawn-win.spec.ts
@@ -9,12 +9,12 @@
 // survived cmd.exe and was then dropped by the receiving program. A command carrying quotes
 // or a shell metacharacter is the case to watch, so those are the cases here.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { IPty } from "node-pty";
 import { spawnPty } from "../../../server/session/pty-spawn";
-import { shellInvocation } from "../../../server/session/shell-command";
+import { shellInvocation, defaultShellCommand } from "../../../server/session/shell-command";
 
 const isWindows = process.platform === "win32";
 
@@ -121,5 +121,66 @@ describe.skipIf(!isWindows)("a shell terminal on Windows", () => {
     const { output } = await runShell("Write-Output (Get-Location).Path", dir);
     // The conpty may wrap a long path, so compare on the leaf.
     expect(output).toContain(path.basename(dir));
+  });
+});
+
+// #1717: a Shell cell with no launcher runs `$SHELL`, and Git for Windows sets that to
+// `C:\Program Files\Git\usr\bin\bash.exe`. PowerShell split it at the first space and reported an
+// unknown command `C:\Program`, so the cell died on launch while Claude and Codex cells beside it
+// were fine.
+//
+// The shell under test is one we WRITE, not one the runner image happens to ship: a `.cmd` inside
+// a directory whose name contains a space. That makes the repro deterministic, and it exits on its
+// own — pointing this at a real interactive shell would just hang the pty.
+describe.skipIf(!isWindows)("a shell path containing a space", () => {
+  const TOKEN = "MTOK-spaced-shell";
+  let root = "";
+  let shellPath = "";
+
+  beforeAll(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-spaced-"));
+    const spaced = path.join(root, "Program Files Like");
+    mkdirSync(spaced);
+    shellPath = path.join(spaced, "fake-shell.cmd");
+    writeFileSync(shellPath, `@echo off\r\necho ${TOKEN}\r\n`);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  // The bug itself, pinned. Without this the passing case below proves only that SOMETHING works —
+  // not that what was broken was the missing quoting.
+  it("does not run when the bare path is handed to PowerShell", async () => {
+    const { output } = await runShell(shellPath, root);
+    expect(output).not.toContain(TOKEN);
+  });
+
+  // Quoting alone is the trap: PowerShell evaluates `'C:\…\x.cmd'` as a string expression, echoes
+  // it, and starts nothing. That failure is silent, so it is worth its own case.
+  it("only echoes the path when it is quoted without the call operator", async () => {
+    const { output } = await runShell(`'${shellPath}'`, root);
+    expect(output).not.toContain(TOKEN);
+    expect(output).toContain("fake-shell.cmd");
+  });
+
+  it("runs when defaultShellCommand builds the command", async () => {
+    const { output, exitCode } = await runShell(defaultShellCommand("win32", { SHELL: shellPath }), root);
+    expect(output).toContain(TOKEN);
+    expect(exitCode).toBe(0);
+  });
+
+  // The launcher path is the persistent variant and reaches the same place (#1717 was reported
+  // against the Shell cell, which spawns through it).
+  it("runs the same way on the launcher path", async () => {
+    const { output, exitCode } = await runShell(defaultShellCommand("win32", { SHELL: shellPath }), root, true);
+    expect(output).toContain(TOKEN);
+    expect(exitCode).toBe(0);
+  });
+
+  // ComSpec is the fallback when nothing sets SHELL, and it is the one path a Windows box always
+  // has. `/c exit 0` keeps it non-interactive so the pty ends.
+  it("invokes the ComSpec fallback rather than a posix path", async () => {
+    const command = defaultShellCommand("win32", {});
+    expect(command).not.toContain("/bin/sh");
+    const { exitCode } = await runShell(`${defaultShellCommand("win32", { ComSpec: process.env.ComSpec ?? "cmd.exe" })} /c exit 0`, root);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Windows で Shell セルだけが起動に失敗し、`C:\Program` が不明なコマンドだと言われて即死していた（#1717）。Claude / Codex セルは同じ環境で動く。

原因は独立した 2 箇所の合流。

**`server/routes/ws-routes.ts:107`** — `const DEFAULT_LAUNCH_CMD = process.env.SHELL || "/bin/sh"`。これは**実行ファイルのパス**であって、コマンドラインではない。Git for Windows が入っていると `C:\Program Files\Git\usr\bin\bash.exe` になる。

**`server/session/shell-command.ts`** — win32 では `powershell.exe -NoLogo -Command <command>` に渡す。`-Command` の引数は PowerShell が**コードとして解析する**ので、素のパスは最初の空白で切れる。

POSIX 側は `$SHELL` に空白が無いという偶然で通っていただけで、設計上は同じ穴が空いていた。

### 引用符だけでは直らない（この PR でいちばん重要な点）

| `-Command` に渡すもの | 起きること |
| --- | --- |
| `C:\Program Files\...\bash.exe` | 空白で分割され `CommandNotFoundException`（報告されたバグ） |
| `'C:\Program Files\...\bash.exe'` | **パスが表示されるだけでシェルは起動しない** |
| `& 'C:\Program Files\...\bash.exe'` | 起動する |

真ん中が「引用符を足す」という素直な修正の結果です。PowerShell では引用符付き文字列は**ただの文字列式**で、実行するには呼び出し演算子 `&` が要る。**エラーが出ないぶん今より悪い**（セルは開くがシェルが無く、ハングに見える）。テストで独立した 1 ケースとして固定しました。

### 変更

- **`server/infra/shell-quote.ts`（新規）** — `runExecutableCommand(execPath, platform)`。**空白の有無で分岐しない**、常に `&` + 引用符。分岐はユーザーの書いた文字列の推測になり、この repository がランチャーチップで捨てた振る舞いと同種です。
- **`shellQuoteFor` を `header-resolve.ts` から infra へ移動。** PowerShell の単一引用符エスケープは既にそこにありました。2 つ目のコピーを書かずに済ませています — セキュリティに関わる引用規則の定義が 2 つあると、直るのは片方だけになる。再エクスポートはせず import 元を書き換えました。
- **`defaultShellCommand(platform, env)`** を `shell-command.ts` に新設し、`ws-routes.ts` から呼ぶ。`/bin/sh` フォールバックは Windows では `<drive>:\bin\sh` に解決されて何も指さない（`windows-gotchas.md` の「POSIX absolute paths silently become drive-relative」）ので、`ComSpec` → `powershell.exe` に変更。env は大文字小文字を無視して読む。
- **どのシェルが起動するかは変えていない。** `$SHELL` があれば従来どおり尊重します。

## Items to Confirm / Review

1. **Windows でどのシェルを起動するのが正か。** 挙動温存を選び、`$SHELL` を尊重しました（報告者は bash が**起動しない**ことを問題にしていて、bash であることは問題にしていない）。「Windows では常に PowerShell」という設計もあり得ます — その場合 `$SHELL` を無視することになるので、**判断してほしい**です。
2. **POSIX 側も引用するようになりました。** `exec /bin/zsh` → `exec '/bin/zsh'`。空白の無い実在のパスでは挙動不変で、同じ穴を塞ぐ変更です。ただし POSIX の挙動に触っているので明示します。
3. **`shellQuoteFor` の移動が `test/server/config/header-resolve.spec.ts` の import に波及**しています。バグ修正の diff としては広がるので、許容かどうか。
4. **Windows CI は `pull_request` で走りません。** `windows-daily.yaml` は `schedule` / `push: main` / `workflow_dispatch` のみで、これはコストを理由に**意図的**とヘッダーに書かれています。なので branch ref に手で dispatch して確認しました（下記）。PR CI に狭い Windows ジョブを足すかどうかは別の判断だと思い、この PR では workflow に触れていません。
5. **テストの「偽シェル」方式。** ランナーのイメージに依存しないよう、空白を含む名前のディレクトリと `.cmd` をその場で作って `$SHELL` に見立てています。実在の対話シェルを指すと pty が終わらずテストが吊るためです。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1717 は Windows の問題。**Windows で関連する部分も全て調べ**、**関数化して安全にし**、**CI で動作テストして**直す。

## 検証

**このホストに PowerShell が無い**ので、ローカルで確認できるのは純粋関数の出力までです。上の表の真ん中の行こそ推測で外しやすいところなので、実機で確かめない限り直ったとは言えません。

- ローカル: `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`（710 files, 10212 tests passed）。Windows spec は macOS では skip されます。
- **Windows 実機**: `gh workflow run windows-daily.yaml --ref fix/1717-windows-shell-path` を実行。node 22.x / 24.x の 2 レグ。

追加した実 PTY テスト（Windows のみ、PowerShell を実際に起動）:

| ケース | 何を固定するか |
| --- | --- |
| 素のパスを渡す | トークンが出ない = **バグそのものの再現** |
| 引用符のみ | トークンが出ず、パスが表示される = 沈黙する失敗 |
| `defaultShellCommand` 経由 | トークンが出て exit 0 = 修正 |
| ランチャー経路でも同じ | 永続側も同じ場所を通る |
| `ComSpec` フォールバック | `/bin/sh` を含まず、実際に起動する |

**片方だけ緑にしても、壊れていたのが本当にそれだったかは分からない**ので、失敗する形も同じ spec に入れてあります。

## 併せて洗った Windows 関連箇所（追加修正なし）

| 箇所 | 判定 |
| --- | --- |
| `server/infra/cmd-escape.ts` | cmd.exe 用の引用。`resolve-bin` 経由でバッチシムに使われる。健全 |
| `server/infra/resolve-bin.ts` | `namesAPath` で分岐し、パスは argv で渡す。第 2 パーサを通さない |
| `server/config/header-resolve.ts` | 値は `shellQuoteFor` で引用済み。実行ファイルパスは扱わない |
| `server/files/pick-file.ts` / `win-folder-dialog.ts` | `powershell -Command <script>` だが、パスはスクリプト内で引用済み |
| `server/files/open-dir.ts` | `explorer` を argv で spawn |
| `server/session/session-settings.ts` | `escapeBatchArgument` 経由 |
| `shell: true` の spawn | **ゼロ**。第 2 パーサを勝手に挟んでいる箇所は無い |

`process.env.SHELL` を読むのは repository 全体で 3 箇所だけで、いずれもこの PR が触る 2 ファイルです。

Closes #1717

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows shell startup when the configured shell path contains spaces.
  - Improved command quoting for PowerShell and POSIX shells, including paths with embedded quotes.
  - Added more reliable fallback behavior using the appropriate platform shell when configuration is unavailable.
  - Improved launcher execution consistency across Windows and POSIX environments.
  - Improved handling of shell configuration across supported environment variable formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->