### PR TITLE
fix: windows-daily の SharedAppPreview を直す — 待ちのフェーズが 1 つ足りない (#1719)

### DIFF
--- a/plans/fix-1719-preview-settle.md
+++ b/plans/fix-1719-preview-settle.md
@@ -1,0 +1,63 @@
+# fix: windows-daily の SharedAppPreview が落ちる — 待ちのフェーズが 1 つ足りない (#1719)
+
+## 症状
+
+`windows-daily` が main で赤。落ちるのは 1 件だけ。
+
+```
+FAIL test/src/components/SharedAppPreview.spec.ts > SharedAppPreview > hands a page only ITS OWN records
+AssertionError: expected undefined to deeply equal { notes: [ { id: '1' } ] }
+```
+
+値が違うのではなく、`mc-public-view:state` のメッセージが **1 件もチャンネルを渡ってきていない**。
+ubuntu / macOS / ローカルは緑で、**Windows だけ**。
+
+## 真因
+
+`connect(wrapper)` の呼び出しは 9 箇所あり、**8 箇所は直後に `await settle()` を置いていて、
+落ちている 1 箇所だけが置いていない。**
+
+| 行 | `await settle()` |
+| --- | --- |
+| 361, 377, 398, 418, 470, 498, 514, 525 | ある |
+| **581** | **無い**（落ちている 583 行の直前） |
+
+`connect()` の最後の待ちは `flushPromises()` だけ。`@vue/test-utils` の実装は
+
+```js
+const scheduler = typeof setImmediate === "function" ? setImmediate : setTimeout;
+function flushPromises() { return new Promise((resolve) => { scheduler(resolve, 0); }); }
+```
+
+つまり **`setImmediate` 1 回 = check フェーズだけ**。対して `settle()` は
+
+```ts
+const settle = async () => { await new Promise((resolve) => setTimeout(resolve, 0)); await flushPromises(); };
+```
+
+で **timers フェーズ + check フェーズの両方**を回す。
+
+**MessagePort の配送はマイクロタスクではない。** 片方のフェーズしか回さない待ち方では、
+配送がどちらのフェーズに載るかと負荷次第で、間に合ったり間に合わなかったりする。速いランナーでは
+間に合っていて、遅い Windows ランナーでは間に合っていない。
+
+製品コードは正しい。テスト側の待ちの不足。
+
+## 直し方
+
+581 行の直後に `await settle()` を足す。兄弟 8 箇所と同じ形になる。
+
+## 「`settle()` も時間頼みでは」への答え
+
+当たらない。`settle()` は「N ミリ秒待つ」ではなく**タスクキューを 1 巡させる**ためのもので、
+同じ Windows ランナー上で 8 箇所が安定して緑。足りていないのは**フェーズ**であって時間ではない。
+
+将来同じクラスが再発したら、そのときは「条件が満たされるまで `settle()` を繰り返す」形にする。
+今それを入れないのは、1 箇所のために 9 箇所と違う待ち方を持ち込む方が読みにくいから。
+
+## 検証
+
+macOS では修正前も緑なので、**ローカルでは修正の効果を確認できない**。
+
+`gh workflow run windows-daily.yaml --ref fix/1719-preview-settle` で実機を回して、
+`SharedAppPreview.spec.ts` が緑になることを確認する（`windows-daily` は `pull_request` では走らない）。

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -579,6 +579,10 @@ describe("SharedAppPreview", () => {
     // direction it must never fail in. Asserted on what crosses the channel: the srcdoc only proves
     // which HTML was chosen, so a test that stopped there would pass on every dataset map there is.
     const { answers } = await connect(wrapper);
+    // `connect` ends on flushPromises, which is one `setImmediate` — the check phase only. A port
+    // message is not a microtask, so reading `answers` here catches it or misses it depending on
+    // which phase it landed in and how loaded the runner is. Green on ubuntu/macOS, red on Windows.
+    await settle();
     const state = answers.find((answer) => answer.type === "mc-public-view:state");
     expect(state?.collections).toEqual({ notes: [{ id: "1" }] });
   });


### PR DESCRIPTION
## Summary

`windows-daily` が main で赤（#1719）。落ちるのは 1 件だけで、`SharedAppPreview > hands a page only ITS OWN records` が `mc-public-view:state` を 1 件も受け取れていませんでした。**Windows だけ**で、ubuntu / macOS / ローカルは緑。

**製品コードは正しく、テスト側の待ちが 1 フェーズ足りないだけ**でした。

### 決め手

`connect(wrapper)` の呼び出しは 9 箇所あり、**8 箇所は直後に `await settle()` を置いていて、落ちている 1 箇所だけが置いていません。**

| 行 | `await settle()` |
| --- | --- |
| 361, 377, 398, 418, 470, 498, 514, 525 | ある（364, 380, 401, 421, 474, 501, 517, 528） |
| **581** | **無い** ← 落ちている 583 行の直前 |

### なぜそれで落ちるか

`connect()` の最後の待ちは `flushPromises()` だけです。`@vue/test-utils` の実装は

```js
const scheduler = typeof setImmediate === "function" ? setImmediate : setTimeout;
function flushPromises() { return new Promise((resolve) => { scheduler(resolve, 0); }); }
```

**`setImmediate` 1 回 = check フェーズだけ**。対して同ファイルの `settle()` は

```ts
const settle = async () => { await new Promise((resolve) => setTimeout(resolve, 0)); await flushPromises(); };
```

で **timers フェーズ + check フェーズの両方**を回します。**MessagePort の配送はマイクロタスクではない**ので、片方のフェーズしか回さない待ち方だと、配送がどちらのフェーズに載るかと負荷次第で間に合わなくなります。速いランナーでは間に合っていて、遅い Windows ランナーでは間に合っていなかった、というだけです。

## Items to Confirm / Review

1. **`settle()` も時間頼みではないか、という懸念。** 当たらないと判断しました。`settle()` は「N ミリ秒待つ」ではなく**タスクキューを 1 巡させる**ためのもので、同じ Windows ランナー上で兄弟 8 箇所が安定して緑です。**足りていないのはフェーズであって時間ではありません。**
2. **条件ベースの待ち（メッセージが来るまで `settle()` を繰り返す）にしなかった理由。** 1 箇所のために 9 箇所と違う待ち方を持ち込む方が読みにくいためです。同じクラスが再発したら、そのときはファイル全体をその形に寄せるのが筋だと思います。
3. **コメントを添えた**ので、次に誰かがこの行を触ったときに `settle()` を消さないはずです。

## User Prompt

- #1719 を含む残りの課題を進める。修正 → PR → review → merge を、問題が無ければノンストップで。

## 検証

**macOS では修正前から緑なので、ローカルでは修正の効果を確認できません。** `SharedAppPreview.spec.ts` 26 tests、全体 10215 tests、lint / typecheck / build すべて緑ですが、これは「壊していない」ことしか言っていません。

**実機 Windows で確認します** — `gh workflow run windows-daily.yaml --ref fix/1719-preview-settle`（`windows-daily` は `pull_request` では走らないため）。結果は PR にコメントします。

Closes #1719

work in mulmoterminal
