### PR TITLE
refactor: 自分で決めたシェルは argv で渡す — Windows だけ、理由付きで非対称に (#1720)

### DIFF
--- a/plans/refactor-1720-launch-target.md
+++ b/plans/refactor-1720-launch-target.md
@@ -1,0 +1,82 @@
+# refactor: 自分で決めたシェルは argv で渡す (#1720)
+
+## 背景
+
+#1717 / #1718 で Windows の Shell セルを直したが、**第 2 のパーサー（PowerShell）を通したまま、
+その規則に正しく従う**という解き方だった。`& '<path>'` は正しいが、正しさを維持し続けなければ
+ならない構造が残っている。
+
+## 根
+
+**自分たちが決めた値を、誰かが再パースするテキストに変換している。**
+
+`shellInvocation` がコマンド**文字列**を取るのは正しい。ランチャーチップはユーザーが書いた
+コマンドラインで、パイプも `&&` も `$VAR` の展開も期待されている。**そこは文字列でなければならない。**
+
+`DEFAULT_LAUNCH_CMD` は違う。ユーザーのコマンドラインではなく、こちらが `$SHELL` から取った
+**ファイルパス**。パースされる必要が無い。
+
+## 調べて分かったこと — issue の案そのままでは POSIX が壊れる
+
+issue には「argv で渡す」と書いたが、**両プラットフォームで一律にやると POSIX が壊れる。**
+
+`shellInvocation` の POSIX 分岐は `$SHELL -lc "exec <command>"` で、この **`-l` が load-bearing**。
+ログインシェルとして `.zprofile` / `.bash_profile` を読み、そこで足された PATH を、`exec` した
+先の対話シェルが引き継ぐ。
+
+`/bin/zsh` を直接 spawn すると読まれるのは `.zshrc` だけになり、**ユーザーのログイン PATH が
+黙って消える**。しかもこれは開発者自身の dotfiles に依存するので、**テストでは捕まらない。**
+
+Windows 側は逆に、ラッパーが何も買っていない。`powershell -Command "& '<path>'"` は PowerShell を
+起動して本命のシェルを起動させるだけで、間の文字列がパーサーとして事故を起こしていた。
+**取り除いて失うものが無い**（プロセスが 1 つ減る）。
+
+なので **Windows だけ argv 化し、POSIX はそのまま**にする。対称性ではなく、ラッパーが何のために
+あるかで分ける。
+
+## 変更
+
+`server/session/shell-command.ts`:
+
+```ts
+export type LaunchTarget =
+  | { kind: "command"; command: string }              // ユーザーが書いた行 — シェルが読む、verbatim
+  | { kind: "program"; file: string; args: string[] }; // こちらが選んだファイル — 直接 spawn
+
+export function defaultShellPath(platform, env): string       // パスを決めるだけ
+export function defaultShellTarget(platform, env): LaunchTarget // win32 → program / posix → command
+export function launchInvocation(target, platform, shellPath): ShellInvocation
+export const launchTargetLabel = (target) => string             // ログ行用
+```
+
+`defaultShellCommand` は `defaultShellPath` + `defaultShellTarget` に分割。
+
+`spawn-shell.ts` / `routes/ws-routes.ts` は `command: string` の代わりに `LaunchTarget` を通す
+（`resolveLaunchSession` → `startLaunchEntry` → `spawnLauncherPty`）。
+
+**ランチャーチップの経路は一切変えていない。** `{ kind: "command" }` として今までどおり
+`$SHELL -lc "exec <ユーザーの行>"` を通る。
+
+## 副産物 — 「$SHELL が無いときの既定」の不一致が消える
+
+| 場所 | 既定 |
+| --- | --- |
+| `shellInvocation` の POSIX 分岐 | `/bin/bash` |
+| 旧 `defaultShellCommand` の POSIX 分岐 | `/bin/sh` |
+
+同じ問いに 2 つの答えがあった。`defaultShellPath` が唯一の決定点になり、`shellInvocation` 側の
+`/bin/bash` は「コマンドを走らせるシェル」の既定として意味が分かれる。
+
+## 検証
+
+- 純粋関数: `defaultShellPath` / `defaultShellTarget` / `launchInvocation` / `launchTargetLabel` を
+  両プラットフォーム分、どのホストからでも
+- **実 PTY（Windows のみ）**: 空白を含むディレクトリに `.cmd` を作り、
+  - 素のパスを PowerShell に渡すと動かないこと（旧バグの保存）
+  - 引用符だけだと表示するだけで起動しないこと（沈黙する失敗の保存）
+  - **`launchInvocation(defaultShellTarget(...))` で spawn すると動くこと**（新しい経路）
+- `windows-daily.yaml` を branch ref に dispatch（`pull_request` では走らないため）。
+  #1721 がマージされていれば PR 側でも `Windows (PR)` が回る。
+
+`.cmd` は `resolve-bin` / `cmd-escape` 経由で cmd.exe に渡る。そこは既存のテスト済み経路で、
+**ユーザーの PATH が空白を混ぜられる文字列ではなく、こちらが組む argv**である点が違う。

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -18,7 +18,7 @@ import { resolveButtonCommand } from "../config/header-resolve.js";
 import { resolveScript } from "../files/scripts.js";
 import { shellQuoteFor } from "../infra/shell-quote.js";
 import { tmuxHasSession } from "../infra/tmux.js";
-import { defaultShellCommand } from "../session/shell-command.js";
+import { defaultShellTarget, type LaunchTarget } from "../session/shell-command.js";
 import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
@@ -107,7 +107,7 @@ export interface WsRouteDeps {
 // runs, since it carries no launcher index. On a tmux reattach it's ignored (tmux new-session -A
 // attaches the running program), so a surviving session with no resolvable launcher index still
 // reattaches via this harmless fallback.
-const DEFAULT_LAUNCH_CMD = defaultShellCommand(process.platform, process.env);
+const DEFAULT_LAUNCH_TARGET = defaultShellTarget(process.platform, process.env);
 
 function resolveClaudeSession(requested: string | null, cwd: string): SessionResolution {
   const hasLivePty = !!requested && ptys.has(requested);
@@ -417,9 +417,9 @@ function resolveResumableSession(
 // Reattach a same-process live PTY, else spawn a launcher (which itself reattaches a
 // surviving tmux session or creates one). `command` is the resolved launcher command,
 // or the fallback for a tmux reattach with no launcher index.
-function startLaunchEntry(deps: WsRouteDeps, sessionId: string, ws: WebSocket, live: PtyEntry | undefined, command: string, cwd: string): PtyEntry {
+function startLaunchEntry(deps: WsRouteDeps, sessionId: string, ws: WebSocket, live: PtyEntry | undefined, target: LaunchTarget, cwd: string): PtyEntry {
   if (live) return deps.reattachPty(live, ws, sessionId);
-  return deps.spawnLauncherPty(sessionId, ws, command, cwd);
+  return deps.spawnLauncherPty(sessionId, ws, target, cwd);
 }
 
 // Resolve a launcher ws request to a session: reattach a live pty / surviving tmux
@@ -431,14 +431,14 @@ function resolveLaunchSession(
   requested: string | null,
   index: number,
   shell: boolean,
-): { sessionId: string; live: PtyEntry | undefined; command: string } | null {
+): { sessionId: string; live: PtyEntry | undefined; target: LaunchTarget } | null {
   const { hasLivePty, live, tmuxAlive } = liveSessionFacts(requested);
   // A live PTY / surviving tmux session reattaches regardless of the index; only a fresh
   // spawn needs the launcher resolved (the pty already IS the chosen program on reattach).
   const launcher = live || tmuxAlive ? null : deps.resolveLauncher(index);
   if (!canStartLauncher({ hasLivePty, tmuxAlive, hasLauncher: !!launcher, isShell: shell })) return null;
   const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: false }, randomUUID);
-  return { sessionId, live, command: launcher?.command ?? DEFAULT_LAUNCH_CMD };
+  return { sessionId, live, target: launcher ? { kind: "command", command: launcher.command } : DEFAULT_LAUNCH_TARGET };
 }
 
 // codex is a first-class agent like claude, but it mints its own session id (no --session-id),
@@ -710,7 +710,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
 
   const resolved = resolveLaunchSession(deps, requested, index, shell);
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
-  const { sessionId, live: resolvedLive, command } = resolved;
+  const { sessionId, live: resolvedLive, target } = resolved;
   // Never worktree-limited. The rule is one AGENT SESSION per worktree, and a launcher is not one:
   // it is a command line this app does not read. It used to read it — a command starting with the
   // word `codex` was held to the limit (#1207, #1208) — but that is a guess about someone else's
@@ -751,7 +751,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
     const settled = settledEntry(ws, "launch", sessionId, !!live, early);
     if (!settled) return;
     startAndWire(deps, ws, { id: sessionId, tag: "launch", early, startFailureMessage, size }, () =>
-      startLaunchEntry(deps, sessionId, ws, settled.entry, command, cwd),
+      startLaunchEntry(deps, sessionId, ws, settled.entry, target, cwd),
     );
   });
 }

--- a/server/session/shell-command.ts
+++ b/server/session/shell-command.ts
@@ -28,22 +28,51 @@ const POSIX_FALLBACK_SHELL = "/bin/sh";
 // processor; powershell.exe is the last resort because it is what runs the command anyway.
 const WINDOWS_FALLBACK_SHELL = "powershell.exe";
 
-/** What a Shell cell runs when no launcher is configured.
+/** What a launch starts. The two arms differ in WHO wrote the thing being started, which is what
+ *  decides whether a shell may parse it:
  *
- *  `$SHELL` is an executable PATH, and the value it feeds is parsed AGAIN by the shell that runs
- *  it — so it has to arrive as one quoted, invoked thing. Git for Windows sets it to
- *  `C:\Program Files\Git\usr\bin\bash.exe`, which PowerShell split at the first space and reported
- *  as an unknown command `C:\Program` (#1717). POSIX only escaped that by the accident of `$SHELL`
- *  having no space in it.
- *
- *  The shell itself is unchanged — a configured `$SHELL` is still honoured on both platforms.
- *  `env` and `platform` are parameters so both arms are checkable from any host, and the lookup is
- *  case-insensitive because Windows spells these names however it likes. */
-export function defaultShellCommand(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+ *  - `command` is the user's own launcher line. It has to reach a shell as text, because that is
+ *    what it is — a pipeline, a `&&`, a `$VAR` the user expects to expand. Run verbatim.
+ *  - `program` is a file WE chose. Nothing about it needs parsing, so it is spawned directly and
+ *    no shell sees it. A path with a space cannot be mis-split if nothing splits it. */
+export type LaunchTarget = { kind: "command"; command: string } | { kind: "program"; file: string; args: string[] };
+
+/** Which executable a Shell cell starts when no launcher is configured. Case-insensitive because
+ *  Windows spells these names however it likes. */
+export function defaultShellPath(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
   const configured = envValue(env, "SHELL");
-  if (platform !== "win32") return runExecutableCommand(configured || POSIX_FALLBACK_SHELL, platform);
-  return runExecutableCommand(configured || envValue(env, "ComSpec") || WINDOWS_FALLBACK_SHELL, platform);
+  if (configured) return configured;
+  return platform === "win32" ? envValue(env, "ComSpec") || WINDOWS_FALLBACK_SHELL : POSIX_FALLBACK_SHELL;
 }
+
+/** What a Shell cell runs when no launcher is configured — and the reason the two platforms differ
+ *  is not symmetry, it is what the wrapper is FOR.
+ *
+ *  On Windows the wrapper bought nothing. `powershell -Command "& '<path>'"` starts PowerShell only
+ *  to have it start the real shell, and the string in between is a parser that split
+ *  `C:\Program Files\Git\usr\bin\bash.exe` at the first space (#1717). Spawning the file removes
+ *  the parser rather than satisfying it, and costs one process less.
+ *
+ *  On POSIX the wrapper is LOAD-BEARING and stays. `shellInvocation` runs the command under
+ *  `$SHELL -lc`, and the `-l` is a login shell: it sources `.zprofile` / `.bash_profile`, whose
+ *  PATH edits the interactive shell then inherits across the `exec`. Spawning `/bin/zsh` directly
+ *  would source only `.zshrc`, so a user's login PATH would quietly go missing — a regression no
+ *  test here would catch, because it depends on the developer's own dotfiles. */
+export function defaultShellTarget(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): LaunchTarget {
+  const path = defaultShellPath(platform, env);
+  if (platform === "win32") return { kind: "program", file: path, args: [] };
+  return { kind: "command", command: runExecutableCommand(path, platform) };
+}
+
+/** How to start a `LaunchTarget`. A program is handed to the PTY as file + argv; a command goes
+ *  through the platform's shell under `exec`, the way a launcher chip always has. */
+export function launchInvocation(target: LaunchTarget, platform: string, shellPath: string | undefined): ShellInvocation {
+  if (target.kind === "program") return { shell: target.file, args: target.args };
+  return shellInvocation(target.command, true, platform, shellPath);
+}
+
+/** What the start/exit log line names. A launcher's own text, or the file we picked for it. */
+export const launchTargetLabel = (target: LaunchTarget): string => (target.kind === "program" ? target.file : target.command);
 
 /** The entry at `index`, or null when the index is not a real position in the list. The
  *  browser sends only an index — the configured list is the allowlist — so a fractional,

--- a/server/session/spawn-shell.ts
+++ b/server/session/spawn-shell.ts
@@ -6,7 +6,7 @@ import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
 import { handlePtyExit } from "./pty-exit.js";
 import { getLaunchers } from "../config/config-routes.js";
-import { launcherAt, shellInvocation } from "./shell-command.js";
+import { launcherAt, launchInvocation, launchTargetLabel, shellInvocation, type LaunchTarget } from "./shell-command.js";
 import { ptys } from "./registry.js";
 import { ptySpawn, spawnPty } from "./pty-spawn.js";
 import { ptyExitLine, ptyStartLine } from "./pty-exit-log.js";
@@ -42,19 +42,21 @@ export function createShellSpawners(deps: SpawnDeps) {
     return launcherAt(getLaunchers(), index);
   }
 
-  // Spawn a configured launcher command as a PERSISTENT, reattachable PTY that shares
-  // the Claude session lifecycle (ptys map, reattach, reap grace) but has NO hooks,
-  // transcript, or resume. The command is run via the login shell with `exec` so it
-  // becomes the single foreground process ($SHELL, codex, etc.) — env vars in the
-  // command (e.g. $SHELL) expand, and the process stays interactive in the PTY.
-  function spawnLauncherPty(sessionId: string, ws: WebSocket, command: string, cwd: string): PtyEntry {
-    // Persistent: reattaches a surviving tmux session (command ignored) or creates one.
-    const { shell, args } = shellInvocation(command, true, process.platform, process.env.SHELL);
+  // Spawn a configured launcher as a PERSISTENT, reattachable PTY that shares the Claude session
+  // lifecycle (ptys map, reattach, reap grace) but has NO hooks, transcript, or resume.
+  //
+  // A launcher CHIP is a command line the user wrote, so it runs via the login shell with `exec`:
+  // it becomes the single foreground process, its env vars expand, and it stays interactive. The
+  // Shell cell's default is not that — it is a file this app picked, and on Windows it is handed
+  // to the PTY directly with no shell in between (see LaunchTarget).
+  function spawnLauncherPty(sessionId: string, ws: WebSocket, target: LaunchTarget, cwd: string): PtyEntry {
+    // Persistent: reattaches a surviving tmux session (target ignored) or creates one.
+    const { shell, args } = launchInvocation(target, process.platform, process.env.SHELL);
     const { term, tmux, reattached } = ptySpawn(sessionId, shell, args, cwd, true);
     const spawnedAtMs = Date.now();
     // The command is only what a FRESH session runs — an attach picked up whatever was already
     // there — so naming it on that line would describe a program nobody started.
-    console.log(ptyStartLine({ agent: "launcher", pid: term.pid, cwd, tmux, reattached, sessionId, note: reattached ? null : command }));
+    console.log(ptyStartLine({ agent: "launcher", pid: term.pid, cwd, tmux, reattached, sessionId, note: reattached ? null : launchTargetLabel(target) }));
 
     // Always "shell", whatever the command line names. A launcher is a command the user wrote and
     // this app does not read it: it once recorded `codex` for a command that started with the word

--- a/test/server/session/shell-command.spec.ts
+++ b/test/server/session/shell-command.spec.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { shellInvocation, launcherAt, defaultShellCommand } from "../../../server/session/shell-command.js";
+import {
+  shellInvocation,
+  launcherAt,
+  defaultShellPath,
+  defaultShellTarget,
+  launchInvocation,
+  launchTargetLabel,
+} from "../../../server/session/shell-command.js";
 
 // platform and SHELL are parameters, so both branches are exercised on every runner —
 // otherwise the Windows arm would only ever be checked by the Windows CI job.
@@ -44,87 +51,86 @@ describe("shellInvocation", () => {
   });
 });
 
-// What a Shell cell runs with no launcher configured. The value is an executable PATH that the
-// shell parses again, so the only thing under test is that it arrives as one invoked thing —
-// #1717, where `C:\Program Files\Git\usr\bin\bash.exe` reached PowerShell bare and was reported
-// as an unknown command `C:\Program`.
-describe("defaultShellCommand", () => {
+// What a Shell cell runs with no launcher configured. The value is an executable PATH, and the
+// two platforms reach it differently on purpose: Windows spawns the file, POSIX keeps the login
+// shell wrapper because `-l` is what sources the user's profile (#1717, #1720).
+describe("defaultShellPath", () => {
   const GIT_BASH = "C:\\Program Files\\Git\\usr\\bin\\bash.exe";
 
-  describe("windows", () => {
-    it("quotes AND invokes a shell path containing a space", () => {
-      // The `&` is not decoration: without it PowerShell evaluates the quoted path as a string
-      // expression, prints it, and starts no shell at all — a worse failure than the bug, because
-      // nothing errors.
-      expect(defaultShellCommand("win32", { SHELL: GIT_BASH })).toBe(`& 'C:\\Program Files\\Git\\usr\\bin\\bash.exe'`);
-    });
-
-    it("invokes a path with no space the same way", () => {
-      // No branch on "does it look like it needs quoting" — that is a guess about text.
-      expect(defaultShellCommand("win32", { SHELL: "C:\\tools\\bash.exe" })).toBe(`& 'C:\\tools\\bash.exe'`);
-    });
-
-    it("closes a single quote in the path instead of letting it end the literal", () => {
-      expect(defaultShellCommand("win32", { SHELL: "C:\\o'brien\\sh.exe" })).toBe(`& 'C:\\o''brien\\sh.exe'`);
-    });
-
-    it("falls back to ComSpec, never to /bin/sh", () => {
-      // `/bin/sh` resolves to <drive>:\bin\sh on Windows and names nothing.
-      const command = defaultShellCommand("win32", { ComSpec: "C:\\Windows\\system32\\cmd.exe" });
-      expect(command).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
-      expect(command).not.toContain("/bin/sh");
-    });
-
-    it("falls back to powershell.exe when the environment names nothing", () => {
-      expect(defaultShellCommand("win32", {})).toBe(`& 'powershell.exe'`);
-    });
-
-    // Set-but-empty, not absent: `envValue` answers "" for that, and "" as a shell path would
-    // spawn nothing. The sibling shellInvocation spec pins the same case, so this one does too.
-    it("treats an empty SHELL as unset and moves on to ComSpec", () => {
-      expect(defaultShellCommand("win32", { SHELL: "", ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
-    });
-
-    it("treats an empty ComSpec as unset too", () => {
-      expect(defaultShellCommand("win32", { SHELL: "", ComSpec: "" })).toBe(`& 'powershell.exe'`);
-    });
-
-    it("reads the environment case-insensitively, the way Windows spells it", () => {
-      expect(defaultShellCommand("win32", { COMSPEC: "C:\\Windows\\system32\\cmd.exe" })).toBe(`& 'C:\\Windows\\system32\\cmd.exe'`);
-    });
-
-    it("prefers a configured SHELL over ComSpec", () => {
-      expect(defaultShellCommand("win32", { SHELL: GIT_BASH, ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toContain("bash.exe");
-    });
+  it("honours a configured SHELL on either platform", () => {
+    expect(defaultShellPath("win32", { SHELL: GIT_BASH })).toBe(GIT_BASH);
+    expect(defaultShellPath("darwin", { SHELL: "/bin/zsh" })).toBe("/bin/zsh");
   });
 
-  describe("posix", () => {
-    it("quotes the shell path", () => {
-      // POSIX had the same hole and only escaped it because $SHELL has no space in practice.
-      expect(defaultShellCommand("darwin", { SHELL: "/bin/zsh" })).toBe("'/bin/zsh'");
-    });
-
-    it("has no call operator — quoting alone runs it", () => {
-      expect(defaultShellCommand("linux", { SHELL: "/opt/my shell/bash" })).toBe("'/opt/my shell/bash'");
-    });
-
-    it("falls back to /bin/sh", () => {
-      expect(defaultShellCommand("linux", {})).toBe("'/bin/sh'");
-    });
-
-    it("treats an empty SHELL as unset", () => {
-      expect(defaultShellCommand("linux", { SHELL: "" })).toBe("'/bin/sh'");
-    });
+  it("falls back to ComSpec on Windows, never to /bin/sh", () => {
+    // `/bin/sh` resolves to <drive>:\bin\sh on Windows and names nothing.
+    const path = defaultShellPath("win32", { ComSpec: "C:\\Windows\\system32\\cmd.exe" });
+    expect(path).toBe("C:\\Windows\\system32\\cmd.exe");
+    expect(path).not.toContain("/bin/sh");
   });
 
-  // The whole point is what shellInvocation then does with it: the command must stay ONE argv
-  // element on both platforms, or the space is re-split a layer later.
-  it("survives shellInvocation as a single argument", () => {
-    const windows = shellInvocation(defaultShellCommand("win32", { SHELL: GIT_BASH }), true, "win32", undefined);
-    expect(windows.args).toEqual(["-NoLogo", "-Command", `& 'C:\\Program Files\\Git\\usr\\bin\\bash.exe'`]);
+  it("reads the environment case-insensitively, the way Windows spells it", () => {
+    expect(defaultShellPath("win32", { COMSPEC: "C:\\Windows\\system32\\cmd.exe" })).toBe("C:\\Windows\\system32\\cmd.exe");
+  });
 
-    const posix = shellInvocation(defaultShellCommand("darwin", { SHELL: "/bin/zsh" }), true, "darwin", "/bin/zsh");
-    expect(posix.args).toEqual(["-lc", "exec '/bin/zsh'"]);
+  it("falls back to powershell.exe when the Windows environment names nothing", () => {
+    expect(defaultShellPath("win32", {})).toBe("powershell.exe");
+  });
+
+  it("falls back to /bin/sh off Windows", () => {
+    expect(defaultShellPath("linux", {})).toBe("/bin/sh");
+  });
+
+  // Set-but-empty, not absent: envValue answers "" for that, and "" as a shell path spawns nothing.
+  it("treats an empty value as unset", () => {
+    expect(defaultShellPath("win32", { SHELL: "", ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toBe("C:\\Windows\\system32\\cmd.exe");
+    expect(defaultShellPath("win32", { SHELL: "", ComSpec: "" })).toBe("powershell.exe");
+    expect(defaultShellPath("linux", { SHELL: "" })).toBe("/bin/sh");
+  });
+
+  it("prefers a configured SHELL over ComSpec", () => {
+    expect(defaultShellPath("win32", { SHELL: GIT_BASH, ComSpec: "C:\\Windows\\system32\\cmd.exe" })).toBe(GIT_BASH);
+  });
+});
+
+describe("defaultShellTarget", () => {
+  const GIT_BASH = "C:\\Program Files\\Git\\usr\\bin\\bash.exe";
+
+  // The point of the whole change: on Windows nothing parses the path, so a space in it cannot be
+  // mis-split. PowerShell used to sit in the middle and split it at `C:\Program` (#1717).
+  it("spawns the file itself on Windows, with no shell in between", () => {
+    expect(defaultShellTarget("win32", { SHELL: GIT_BASH })).toEqual({ kind: "program", file: GIT_BASH, args: [] });
+  });
+
+  // POSIX keeps the wrapper because `-l` sources the login profile; spawning the shell directly
+  // would drop the user's `.zprofile` PATH. Quoted, so a space there is safe too.
+  it("keeps the login shell wrapper off Windows", () => {
+    expect(defaultShellTarget("darwin", { SHELL: "/opt/my shell/bash" })).toEqual({ kind: "command", command: "'/opt/my shell/bash'" });
+  });
+});
+
+describe("launchInvocation", () => {
+  it("hands a program to the PTY as file and argv, untouched", () => {
+    const target = defaultShellTarget("win32", { SHELL: "C:\\Program Files\\Git\\usr\\bin\\bash.exe" });
+    expect(launchInvocation(target, "win32", undefined)).toEqual({ shell: "C:\\Program Files\\Git\\usr\\bin\\bash.exe", args: [] });
+  });
+
+  it("runs a launcher's own command line through the login shell under exec", () => {
+    // A chip is the user's text and must stay text — a pipeline, a `&&`, a `$VAR` to expand.
+    const target = { kind: "command", command: "yarn dev | tee log" } as const;
+    expect(launchInvocation(target, "darwin", "/bin/zsh")).toEqual({ shell: "/bin/zsh", args: ["-lc", "exec yarn dev | tee log"] });
+  });
+
+  it("still routes a POSIX default shell through the wrapper", () => {
+    const target = defaultShellTarget("linux", { SHELL: "/bin/zsh" });
+    expect(launchInvocation(target, "linux", "/bin/zsh")).toEqual({ shell: "/bin/zsh", args: ["-lc", "exec '/bin/zsh'"] });
+  });
+});
+
+describe("launchTargetLabel", () => {
+  it("names the file for a program and the text for a command", () => {
+    expect(launchTargetLabel({ kind: "program", file: "C:\\sh.exe", args: [] })).toBe("C:\\sh.exe");
+    expect(launchTargetLabel({ kind: "command", command: "yarn dev" })).toBe("yarn dev");
   });
 });
 

--- a/test/server/session/shell-spawn-win.spec.ts
+++ b/test/server/session/shell-spawn-win.spec.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { IPty } from "node-pty";
 import { spawnPty } from "../../../server/session/pty-spawn";
-import { shellInvocation, defaultShellCommand } from "../../../server/session/shell-command";
+import { shellInvocation, defaultShellTarget, launchInvocation, type LaunchTarget, type ShellInvocation } from "../../../server/session/shell-command";
 
 const isWindows = process.platform === "win32";
 
@@ -26,8 +26,7 @@ const plainText = (data: string): string =>
     .replace(/\u001b\[[0-9;?]*[a-zA-Z]/g, "")
     .replace(/[\r\n]/g, "");
 
-function runShell(command: string, cwd: string, replaceShell = false): Promise<{ output: string; exitCode: number }> {
-  const { shell, args } = shellInvocation(command, replaceShell, "win32", undefined);
+function run({ shell, args }: ShellInvocation, cwd: string): Promise<{ output: string; exitCode: number }> {
   const term: IPty = spawnPty(shell, args, cwd);
   let output = "";
   term.onData((data) => {
@@ -35,6 +34,11 @@ function runShell(command: string, cwd: string, replaceShell = false): Promise<{
   });
   return new Promise((resolve) => term.onExit(({ exitCode }) => resolve({ output: plainText(output), exitCode })));
 }
+
+const runShell = (command: string, cwd: string, replaceShell = false) => run(shellInvocation(command, replaceShell, "win32", undefined), cwd);
+
+/** The path a Shell cell actually takes: a LaunchTarget, resolved the way spawnLauncherPty does. */
+const runTarget = (target: LaunchTarget, cwd: string) => run(launchInvocation(target, "win32", undefined), cwd);
 
 describe.skipIf(!isWindows)("a shell terminal on Windows", () => {
   let dir = "";
@@ -124,10 +128,10 @@ describe.skipIf(!isWindows)("a shell terminal on Windows", () => {
   });
 });
 
-// #1717: a Shell cell with no launcher runs `$SHELL`, and Git for Windows sets that to
-// `C:\Program Files\Git\usr\bin\bash.exe`. PowerShell split it at the first space and reported an
-// unknown command `C:\Program`, so the cell died on launch while Claude and Codex cells beside it
-// were fine.
+// #1717 / #1720: a Shell cell with no launcher runs `$SHELL`, and Git for Windows sets that to
+// `C:\Program Files\Git\usr\bin\bash.exe`. It used to go through `powershell -Command`, which
+// split it at the first space and reported an unknown command `C:\Program`. Now nothing parses it
+// at all — the file is handed to the PTY.
 //
 // The shell under test is one we WRITE, not one the runner image happens to ship: a `.cmd` inside
 // a directory whose name contains a space. That makes the repro deterministic, and it exits on its
@@ -146,41 +150,34 @@ describe.skipIf(!isWindows)("a shell path containing a space", () => {
   });
   afterAll(() => rmSync(root, { recursive: true, force: true }));
 
-  // The bug itself, pinned. Without this the passing case below proves only that SOMETHING works —
-  // not that what was broken was the missing quoting.
+  // The original bug, kept: this is what the Shell cell used to do. Without it the passing case
+  // below proves only that SOMETHING works, not that what was broken was the parser in the middle.
   it("does not run when the bare path is handed to PowerShell", async () => {
     const { output } = await runShell(shellPath, root);
     expect(output).not.toContain(TOKEN);
   });
 
-  // Quoting alone is the trap: PowerShell evaluates `'C:\…\x.cmd'` as a string expression, echoes
-  // it, and starts nothing. That failure is silent, so it is worth its own case.
+  // And quoting alone would not have fixed it: PowerShell evaluates `'C:\…\x.cmd'` as a string
+  // expression, echoes it, and starts nothing. A silent failure is worse than the loud one, which
+  // is why the answer was to remove the parser rather than to satisfy it.
   it("only echoes the path when it is quoted without the call operator", async () => {
     const { output } = await runShell(`'${shellPath}'`, root);
     expect(output).not.toContain(TOKEN);
     expect(output).toContain("fake-shell.cmd");
   });
 
-  it("runs when defaultShellCommand builds the command", async () => {
-    const { output, exitCode } = await runShell(defaultShellCommand("win32", { SHELL: shellPath }), root);
+  // What ships: no shell in between at all.
+  it("runs when the launch target is spawned as a program", async () => {
+    const { output, exitCode } = await runTarget(defaultShellTarget("win32", { SHELL: shellPath }), root);
     expect(output).toContain(TOKEN);
     expect(exitCode).toBe(0);
   });
 
-  // The launcher path is the persistent variant and reaches the same place (#1717 was reported
-  // against the Shell cell, which spawns through it).
-  it("runs the same way on the launcher path", async () => {
-    const { output, exitCode } = await runShell(defaultShellCommand("win32", { SHELL: shellPath }), root, true);
-    expect(output).toContain(TOKEN);
-    expect(exitCode).toBe(0);
-  });
-
-  // ComSpec is the fallback when nothing sets SHELL, and it is the one path a Windows box always
-  // has. `/c exit 0` keeps it non-interactive so the pty ends.
-  it("invokes the ComSpec fallback rather than a posix path", async () => {
-    const command = defaultShellCommand("win32", {});
-    expect(command).not.toContain("/bin/sh");
-    const { exitCode } = await runShell(`${defaultShellCommand("win32", { ComSpec: process.env.ComSpec ?? "cmd.exe" })} /c exit 0`, root);
-    expect(exitCode).toBe(0);
+  // A `.cmd` still reaches cmd.exe — but through resolve-bin/cmd-escape, on argv this app controls,
+  // rather than through a command string a user's PATH could have put a space in.
+  it("carries the spaced path through the batch-shim layer", async () => {
+    const { shell, args } = launchInvocation(defaultShellTarget("win32", { SHELL: shellPath }), "win32", undefined);
+    expect(shell).toBe(shellPath);
+    expect(args).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

#1718 は Windows の Shell セルを直しましたが、**第 2 のパーサー（PowerShell）を通したまま、その規則に正しく従う**という解き方でした。`& '<path>'` は正しいものの、正しさを維持し続けなければならない構造が残っています。

`LaunchTarget` を導入して、**「ユーザーが書いた行」と「こちらが選んだファイル」を型で分けます。**

```ts
export type LaunchTarget =
  | { kind: "command"; command: string }               // ユーザーの行 — シェルが読む、verbatim
  | { kind: "program"; file: string; args: string[] }; // こちらのファイル — 直接 spawn
```

前者はシェルが読む**必要がある**（パイプ、`&&`、`$VAR` の展開）。後者はパースされる必要が無い。**空白で誤分割されないのは、分割する者が居ないからです。**

```
今まで:  spawnPty("powershell.exe", ["-NoLogo", "-Command", "& 'C:\\Program Files\\...\\bash.exe'"])
これから: spawnPty("C:\\Program Files\\Git\\usr\\bin\\bash.exe", [])
```

## 調べて分かったこと — issue の案そのままでは POSIX が壊れます

**#1720 には「argv で渡す」とだけ書きましたが、両プラットフォームで一律にやると POSIX が壊れます。**

`shellInvocation` の POSIX 分岐は `$SHELL -lc "exec <command>"` で、**この `-l` が load-bearing** です。ログインシェルとして `.zprofile` / `.bash_profile` を読み、そこで足された PATH を `exec` した先の対話シェルが引き継ぎます。

`/bin/zsh` を直接 spawn すると読まれるのは `.zshrc` だけになり、**ユーザーのログイン PATH が黙って消えます。** しかもこれは開発者自身の dotfiles に依存するので、**このリポジトリのテストでは絶対に捕まりません。**

Windows 側は逆で、ラッパーが何も買っていません。`powershell -Command "& '<path>'"` は PowerShell を起動して本命のシェルを起動させるだけ、間の文字列がパーサーとして事故を起こしていただけです。取り除いて失うものが無く、プロセスが 1 つ減ります。

**なので Windows だけ argv 化し、POSIX はそのままにしました。対称性ではなく、ラッパーが何のためにあるかで分けています。**

## Items to Confirm / Review

1. **左右非対称にしたことが最大の判断です。** 「Windows は program、POSIX は command」は一見ちぐはぐで、レビューで「揃えては」と言われる形をしています。揃えると POSIX の `.zprofile` が飛ぶ、というのが理由の全部です。コードのコメントにも書きましたが、**この判断が妥当か見てほしい**です。
2. **ランチャーチップの経路は 1 行も変えていません。** `{ kind: "command" }` として今までどおり `$SHELL -lc "exec <ユーザーの行>"` を通ります。CLAUDE.md の「チップはユーザーの書いた行を verbatim で走らせる」は保たれています。
3. **`resolveLaunchSession` → `startLaunchEntry` → `spawnLauncherPty` の型が `string` から `LaunchTarget` に変わります。** 波及は 8 箇所で、すべて機械的です。
4. **副産物**: 「`$SHELL` が無いときの既定」が `shellInvocation` の `/bin/bash` と旧 `defaultShellCommand` の `/bin/sh` の 2 つありました。決定点が `defaultShellPath` 1 つになって消えます。

## User Prompt

- 残りの課題（#1719 / #1720 / #1721）を進める。修正 → PR → review → merge を、問題が無ければノンストップで。

## 検証

- **純粋関数**（どのホストでも）: `defaultShellPath` / `defaultShellTarget` / `launchInvocation` / `launchTargetLabel` を両プラットフォーム分
- **実 PTY（Windows のみ）**: 空白を含むディレクトリに `.cmd` を作り、
  - **素のパスを PowerShell に渡すと動かない**こと（旧バグを保存 — これが消えると「何かが動いた」しか言えなくなる）
  - **引用符だけだと表示するだけで起動しない**こと（沈黙する失敗を保存）
  - **`launchInvocation(defaultShellTarget(...))` で spawn すると動く**こと（新しい経路）
- ローカル: format / lint / typecheck / build / test すべて緑（10214 tests）
- **Windows 実機**: `windows-daily.yaml` を branch ref に dispatch します。結果は PR にコメントします

Closes #1720

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell and launcher startup behavior across Windows and POSIX systems.
  * Windows launches now preserve executable arguments more reliably, including paths containing spaces.
  * POSIX launches continue loading the login-shell environment while preserving configured commands.

* **Tests**
  * Expanded coverage for shell selection, fallback behavior, environment settings, and platform-specific launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->