### PR TITLE
fix(shared-app): サンドボックスが黙って壊す 2 つを warning にし、プレビューを手順に組み込む

### DIFF
--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -18,6 +18,7 @@ import { APPS_COLLECTION, parseAuthoredApp } from "@receptron/sharedapp";
 import { isRecord } from "../../../common/isRecord.js";
 import { declarationProblems, sharedCollections, type SharedAppFailure } from "./context.js";
 import { createManifest, newAid, updateManifest } from "./manifestWrite.js";
+import { viewFilesReport } from "./publicView.js";
 
 /** The roster key that means "every collection". A member's roles map is keyed by cid, with this
  *  as the fallback the rules drop to (`role()` reads `cid` first, then this). */
@@ -362,6 +363,9 @@ export interface CheckReport {
   /** The address the declaration names as app-wide owner, when it names one. */
   declaredOwner: string | undefined;
   problems: string[];
+  /** What the pages it names will probably get wrong, without stopping a deploy. See
+   *  `viewWarnings`. */
+  warnings: string[];
 }
 
 /** Everything wrong with the declaration and this repository's collections, WITHOUT writing
@@ -375,7 +379,7 @@ export async function checkSharedApp(root: string): Promise<CheckReport | Shared
   const raw = await readManifest(root);
   if (!raw.ok) return raw;
   const parsed = parseAuthoredApp(raw.text);
-  if (!parsed.ok) return { ok: true, aid: undefined, collections: [], checkedAs: null, declaredOwner: undefined, problems: parsed.problems };
+  if (!parsed.ok) return { ok: true, aid: undefined, collections: [], checkedAs: null, declaredOwner: undefined, problems: parsed.problems, warnings: [] };
 
   const collections = await sharedCollections(root);
   const handle = firestoreHandle();
@@ -384,13 +388,18 @@ export async function checkSharedApp(root: string): Promise<CheckReport | Shared
   // used to miss the `owner` uid mismatch and call a declaration deployable that deploy then
   // refused.
   const problems = declarationProblems(parsed.app, collections, handle);
+  // The PAGES too, read from disk. A `path` naming nothing, a page too large, a page written
+  // against the host's bridge: each of those refuses a deploy, and answering "deployable" without
+  // having opened them is the answer this action exists not to give.
+  const pages = await viewFilesReport(root, parsed.app);
   return {
     ok: true,
     aid: parsed.app.aid,
     collections: collections.map((collection) => collection.slug),
     checkedAs: handle?.email ?? null,
     declaredOwner: ownerFromRoster(parsed.app),
-    problems,
+    problems: [...problems, ...pages.problems],
+    warnings: pages.warnings,
   };
 }
 

--- a/server/backends/sharedApp/modalCall.ts
+++ b/server/backends/sharedApp/modalCall.ts
@@ -256,7 +256,7 @@ const runsAsScript = (attributes: string): boolean => {
  *  Raw-text elements go the same way for the opposite reason: `<textarea><button
  *  onclick="prompt()"></textarea>` draws no button — the parser reads that as the textarea's TEXT —
  *  and reading it as live markup refuses a page whose only crime is showing an example. */
-const withoutScriptBodies = (html: string): string => html.replace(RAW_TEXT_ELEMENT, "$1 ");
+export const withoutScriptBodies = (html: string): string => html.replace(RAW_TEXT_ELEMENT, "$1 ");
 
 const scriptsOf = (html: string): string[] => [
   ...[...html.matchAll(SCRIPT_BODY)].filter((hit) => runsAsScript(hit[1] ?? "") && !hasSource(hit[1] ?? "")).map((hit) => hit[2] ?? ""),
@@ -481,6 +481,18 @@ const boundAtTopLevel = (code: string): Set<string> => {
   }
   return own;
 };
+
+/** The page's CODE as one string: every script and handler, with comments and string contents
+ *  removed, so a name that only appears inside a string or a comment is not read as a call.
+ *
+ *  For questions that are answered by a name being PRESENT or ABSENT anywhere in the page —
+ *  `viewDefects` asks two of them. `modalCallIn` does not use it, because its answer depends on
+ *  what each script binds at ITS OWN top level, and joining them would let one script's `const
+ *  prompt` exempt another script's call. */
+export const viewScriptCode = (html: string): string =>
+  scriptsOf(html)
+    .map((script) => bare(asMemberAccess(script)))
+    .join("\n;\n");
 
 /** The name of the first modal call in this page's code, or null. */
 export const modalCallIn = (html: string): string | null => {

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 import { normalizeViews, type AuthoredApp } from "@receptron/sharedapp";
 import { hasErrnoCode } from "../../errors.js";
 import { modalCallIn } from "./modalCall.js";
+import { formElementIn, readyNeverCalled } from "./viewDefects.js";
 
 /** The document the public page reads the HTML from. Beside core's
  *  `PUBLIC_CONFIG_DOC` ("public") under `apps/{aid}/config`. */
@@ -271,9 +272,10 @@ async function containedPath(root: string, declared: string, where: string): Pro
 
 /** What this page will probably get wrong, said WITHOUT stopping it.
  *
- *  A modal call is a real defect — the frame runs sandboxed with no `allow-modals`, so `alert`,
- *  `confirm` and `prompt` are ignored, nothing throws, and `confirm` answers `false` — but reading
- *  a page for one means reading HTML and JavaScript with something that is not a parser for either.
+ *  Each of these is a real defect — the sandbox eats a modal, blocks a `<form>` submission, and
+ *  sends a view nothing until it says `ready()`; in every case nothing throws and nothing is drawn,
+ *  so the page looks finished — but reading a page for one means reading HTML and JavaScript with
+ *  something that is not a parser for either.
  *  Over one review of this check that produced 12 misses and 9 FALSE ALARMS, and the false alarms
  *  were the expensive half: each refused a page that works, and several refused the very shape the
  *  skill tells authors to write (`const alert = (m) => …`, an `alert()` mentioned in prose, a
@@ -282,15 +284,38 @@ async function containedPath(root: string, declared: string, where: string): Pro
  *  So this reports and publish goes on. What the author cannot be told at all is the far worse
  *  case, and that belongs to the runtime instead — see `plans/feat-shared-app-view-diagnostics.md`. */
 export function viewWarnings(html: string, declared: string, where: string): string[] {
+  const names = `${where}.path names '${declared}'`;
+  const caveat = "(Published anyway: this is read without parsing the page, so it can be wrong.)";
+  const warnings: string[] = [];
   const modal = modalCallIn(html);
-  if (modal === null) return [];
-  return [
-    `${where}.path names '${declared}', which appears to call \`${modal}()\`. Views run sandboxed with no \`allow-modals\`, so the browser ignores all three of ` +
-      "`alert`, `confirm` and `prompt` — nothing appears, nothing throws, and `confirm` answers `false`. " +
-      "A page built on one asks nobody for the value it then sends, or draws a button that silently does nothing. " +
-      "Ask with an `<input>` in the page, answer in an element of its own, and make a confirmation a second press rather than a modal. " +
-      "(Published anyway: this is read without parsing the page, so it can be wrong.)",
-  ];
+  if (modal !== null) {
+    warnings.push(
+      `${names}, which appears to call \`${modal}()\`. Views run sandboxed with no \`allow-modals\`, so the browser ignores all three of ` +
+        "`alert`, `confirm` and `prompt` — nothing appears, nothing throws, and `confirm` answers `false`. " +
+        "A page built on one asks nobody for the value it then sends, or draws a button that silently does nothing. " +
+        "Ask with an `<input>` in the page, answer in an element of its own, and make a confirmation a second press rather than a modal. " +
+        caveat,
+    );
+  }
+  if (formElementIn(html)) {
+    warnings.push(
+      `${names}, which contains a \`<form>\`. Views run sandboxed with no \`allow-forms\`, so the browser blocks the submission ` +
+        "BEFORE it fires the `submit` event — an `onsubmit` handler never runs, `e.preventDefault()` included, and the console says " +
+        "\"Blocked form submission to ''\". The Submit button does nothing, and so does Enter in a text field; `required` stops working " +
+        "with them, since constraint validation is part of submitting. " +
+        'Use a `<div>` and a `<button type="button">` whose CLICK sends through the bridge, and check the values yourself. ' +
+        caveat,
+    );
+  }
+  if (readyNeverCalled(html)) {
+    warnings.push(
+      `${names}, which registers \`onState\` but never calls \`ready()\`. The parent sends NOTHING until the view answers that handshake, ` +
+        "so `onState` never fires: the page draws its loading state and stays there forever, with no error anywhere. " +
+        "Call `ready()` once, after the listener is registered. " +
+        caveat,
+    );
+  }
+  return warnings;
 }
 
 function contentProblems(html: string, bytes: number, declared: string, where: string): { ok: false; problems: string[] } | null {

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -343,6 +343,33 @@ function contentProblems(html: string, bytes: number, declared: string, where: s
   return null;
 }
 
+/** Every page the declaration names, read the way deploy will read it — for `check`, which writes
+ *  nothing and needs no connection.
+ *
+ *  `check` answers "would a deploy be refused?", and until this existed it answered that from the
+ *  declaration alone: a `path` naming a file that is not there, a page over the document limit, or
+ *  a page written against the host's bridge all passed `check` and were refused by the deploy
+ *  afterwards — which is exactly the point in the flow this action exists to move earlier. The
+ *  warnings come with it for the same reason: they are what the author still has time to act on.
+ *
+ *  A declaration that cannot be normalized returns nothing; the gate that reports THAT runs
+ *  alongside this one and would otherwise say it twice. */
+export async function viewFilesReport(root: string, authored: AuthoredApp): Promise<{ problems: string[]; warnings: string[] }> {
+  const normalized = normalizeViews(authored);
+  if (!normalized.ok) return { problems: [], warnings: [] };
+  const problems: string[] = [];
+  const warnings: string[] = [];
+  // The stamp only sizes the document this page would become. `check` has none — it is not
+  // publishing — and the clock is close enough for a limit with a 100 KB margin under it.
+  const publishedAt = Date.now();
+  for (const view of normalized.views) {
+    const read = await readAppViewFile(root, view, publishedAt, view.where);
+    if (read.ok) warnings.push(...read.view.warnings);
+    else problems.push(...read.problems);
+  }
+  return { problems, warnings };
+}
+
 /** The PUBLIC page the declaration asks to publish, if any. Null for an app
  *  with none — which is most of them, and is not a problem.
  *

--- a/server/backends/sharedApp/viewDefects.ts
+++ b/server/backends/sharedApp/viewDefects.ts
@@ -36,18 +36,62 @@ const COMMENT = /<!--[\s\S]*?(?:-->|$)/g;
 
 export const formElementIn = (html: string): boolean => FORM_START_TAG.test(withoutScriptBodies(html).replace(COMMENT, " "));
 
-/** Asking for state — `onState(…)` — with the handshake it depends on nowhere in the page.
+/** Asking for state — `onState(…)` — with no `ready()` the page can actually REACH.
  *
- *  Only ever reported TOGETHER: a page with neither is a static view that wants no data, and
- *  warning at it would be warning at something that works. A page calling `ready` without
- *  `onState` is odd but harmless, so it is left alone too.
+ *  Not merely "the word is absent". `ready()` written INSIDE the `onState` callback deadlocks in
+ *  exactly the same way and is the likelier mistake, because it is what "call `ready` after
+ *  registering the listener" sounds like:
+ *
+ *      view.onState((data) => { draw(data); view.ready(); });   // ← never runs
+ *
+ *  The parent sends no state until `ready` arrives, so the callback never fires, so `ready` is
+ *  never sent. A check that only asked whether the name appears called that page clean.
+ *
+ *  So the `onState` ARGUMENTS are cut out of the code first, and what is looked at is the call
+ *  that survives. Only ever reported together with an `onState`: a page with neither is a static
+ *  view that wants no data, and warning at it would be warning at something that works.
  *
  *  Read off the page's code with strings and comments removed, so the word appearing in prose or
  *  in a message the page shows is not mistaken for the call. */
-const ON_STATE = /\.\s*onState\s*\(/;
+const ON_STATE = /\.\s*onState\s*\(/g;
 const READY = /\.\s*ready\s*\(/;
+
+/** Where the argument list opened at `from` (the index OF its `(`) ends, or the end of the code
+ *  for an unbalanced one — which is what a browser would run to as well. Strings and comments are
+ *  already gone, so a parenthesis here is a parenthesis. */
+const closingParen = (code: string, from: number): number => {
+  let depth = 0;
+  for (let i = from; i < code.length; i += 1) {
+    if (code[i] === "(") depth += 1;
+    else if (code[i] === ")") {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return code.length;
+};
+
+/** The page's code with every `onState(…)` argument list removed — so a `ready()` that is only
+ *  reachable from inside the listener is not there to find.
+ *
+ *  The matches are passed IN rather than found here: `ON_STATE` is global, and a `test()` on a
+ *  global regex leaves `lastIndex` past the match — which a later `matchAll` inherits, so the
+ *  scan found nothing and every page looked as if it called `ready` outside. Scanning once and
+ *  sharing the result is the fix and also the only reading of it that cannot drift. */
+const outsideOnState = (code: string, listeners: readonly RegExpMatchArray[]): string => {
+  let out = "";
+  let cursor = 0;
+  for (const hit of listeners) {
+    const open = (hit.index ?? 0) + hit[0].length - 1;
+    if (open < cursor) continue;
+    out += code.slice(cursor, open);
+    cursor = closingParen(code, open);
+  }
+  return out + code.slice(cursor);
+};
 
 export const readyNeverCalled = (html: string): boolean => {
   const code = viewScriptCode(html);
-  return ON_STATE.test(code) && !READY.test(code);
+  const listeners = [...code.matchAll(ON_STATE)];
+  return listeners.length > 0 && !READY.test(outsideOnState(code, listeners));
 };

--- a/server/backends/sharedApp/viewDefects.ts
+++ b/server/backends/sharedApp/viewDefects.ts
@@ -1,0 +1,53 @@
+// The two things a view does that the SANDBOX eats silently, beside the modals in `modalCall.ts`.
+//
+// Same failure shape as those, and the same answer: the browser neither throws nor draws anything,
+// so the only sign is a console line the author is not looking at — and the page looks finished.
+// Both of these shipped in one real app (a lunch sign-up, published TWICE before anybody pressed
+// the button), and both were found by building a copy of the parent page by hand.
+//
+//   A `<form>` CANNOT SUBMIT. The frame is `sandbox="allow-scripts"` with no `allow-forms`, and
+//   Chrome blocks the submission BEFORE firing the `submit` event — so an `onsubmit` handler with
+//   `e.preventDefault()` as its first line never runs at all. The console says "Blocked form
+//   submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not
+//   set", and the page shows a Submit button that does nothing. The same block takes Enter-in-a-
+//   text-field with it, and `required` — constraint validation is part of form submission.
+//
+//   A VIEW THAT NEVER SAYS `ready()` IS NEVER SENT ANYTHING. The parent holds its data until the
+//   view answers the handshake, so a page that registers `onState` and does not call `ready` waits
+//   forever on data that was never sent. It renders its loading state and stays there.
+//
+// Warnings, not refusals, for the reason `viewWarnings` gives: this reads HTML and JavaScript with
+// something that is not a parser for either, and a refusal an author cannot act on is the more
+// expensive way to be wrong.
+import { viewScriptCode, withoutScriptBodies } from "./modalCall.js";
+
+/** A `<form>` START TAG in markup the browser will draw.
+ *
+ *  Read off the page with every script body and raw-text element CONTENT already gone — a
+ *  `<form>` inside a `<textarea>` showing an example draws nothing, and one written in a string is
+ *  not markup — and with comments dropped, since a widget commented out while it was being written
+ *  is ordinary.
+ *
+ *  Any `<form>` is reported, including one used only for layout. That is deliberate: it is the
+ *  ELEMENT that carries implicit submission, so a `<div>` with a `type="button"` is the shape that
+ *  works, and there is no `<form>` here whose submission the sandbox permits. */
+const FORM_START_TAG = /<form[\s/>]/i;
+const COMMENT = /<!--[\s\S]*?(?:-->|$)/g;
+
+export const formElementIn = (html: string): boolean => FORM_START_TAG.test(withoutScriptBodies(html).replace(COMMENT, " "));
+
+/** Asking for state — `onState(…)` — with the handshake it depends on nowhere in the page.
+ *
+ *  Only ever reported TOGETHER: a page with neither is a static view that wants no data, and
+ *  warning at it would be warning at something that works. A page calling `ready` without
+ *  `onState` is odd but harmless, so it is left alone too.
+ *
+ *  Read off the page's code with strings and comments removed, so the word appearing in prose or
+ *  in a message the page shows is not mistaken for the call. */
+const ON_STATE = /\.\s*onState\s*\(/;
+const READY = /\.\s*ready\s*\(/;
+
+export const readyNeverCalled = (html: string): boolean => {
+  const code = viewScriptCode(html);
+  return ON_STATE.test(code) && !READY.test(code);
+};

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -249,9 +249,15 @@ async function narrateCheck(root: string): Promise<string> {
       ? `Checked as the declared owner (${report.declaredOwner ?? "none named"}) — not signed in, so it could not be checked against your address.`
       : `Checked as ${report.checkedAs}.`;
   if (report.problems.length === 0) {
-    return [`The declaration is deployable. ${found}.`, as, "Nothing was written or deployed — this only reads."].join("\n");
+    return [`The declaration is deployable. ${found}.`, ...warningNote(report.warnings), as, "Nothing was written or deployed — this only reads."].join("\n");
   }
-  return [`The declaration would be refused (${found}):`, ...report.problems.map((problem) => `  - ${problem}`), as, "Nothing was written."].join("\n");
+  return [
+    `The declaration would be refused (${found}):`,
+    ...report.problems.map((problem) => `  - ${problem}`),
+    ...warningNote(report.warnings),
+    as,
+    "Nothing was written.",
+  ].join("\n");
 }
 
 async function narrateInvite(root: string, body: Record<string, unknown>): Promise<string> {

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -155,7 +155,14 @@ would be a machine for producing "it worked on my machine".
 
 **You cannot open it yourself — ask the user to, and say what to press.** In the cell open on this
 repository: the **Collections pane** → the **"Preview the shared app"** button at the top → the
-page appears, drawn from the working tree. Nothing is written and no URL name is taken.
+page appears, drawn from the working tree. Opening it reads only: nothing is written and no URL
+name is taken.
+
+**Accepting a submission there DOES write a real record**, as the signed-in author, into the live
+app — the pane says so at the button and lists what it made with an Undo beside it. So it is a
+real answer in the app's data, not a rehearsal: tell the user that before they press *Send it*,
+and offer to remove it afterwards. Reaching the CONFIRMATION is what proves the page works;
+accepting is only needed when you want to see the record land.
 
 Ask them to confirm, in these terms:
 
@@ -167,14 +174,17 @@ Ask them to confirm, in these terms:
 Do this **before deploy** and again after any change to a page. If the user cannot look right now,
 say plainly that the page is untested rather than reporting it as ready.
 
-**Read the tool's `warnings` back to the user too.** `check`, `deploy` and `publish` report what
-the page will probably get wrong — a modal call, a `<form>`, an `onState` with no `ready()`. They
-are hints and they do not stop a publish: a page they are silent about can still be broken, which
-is why they are not a substitute for the paragraph above.
+**Read the tool's `warnings` back to the user too.** `check`, `deploy` and `publish` all read the
+pages the declaration names and report what one will probably get wrong — a modal call, a
+`<form>`, an `onState` with no reachable `ready()` — as well as refusing a `path` that names
+nothing. They are hints and they do not stop a publish: a page they are silent about can still be
+broken, which is why they are not a substitute for the paragraph above.
 
-**What the preview does NOT prove**, so do not claim it: the Firestore rules do not run there, so
-what a role may WRITE is untested; nobody else exists, so nothing is concurrent; and it cannot tell
-whether the rules a new declaration needs have been deployed at all.
+**What the preview does NOT prove**, so do not claim it: the write it performs is made **as the
+author**, who may write anything in their own app — so a visitor's or a participant's permission
+is untested, and a page that works here can still be refused for the person it was built for.
+Nobody else exists, so nothing is concurrent. And it cannot tell whether the rules a new
+declaration needs have been deployed at all.
 
 ### 4. Invite
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -137,6 +137,45 @@ never open the app to the public.
 
 Tell the user they can look at it now, and give them the address the tool reports.
 
+### 3b. RUN THE PAGE. Not reading it — running it.
+
+**A page you have not seen work does not work.** Everything a view does that is broken by the
+sandbox fails the same way: nothing is drawn, nothing throws, and the HTML reads perfectly. You
+cannot find these by looking at your own code, because the code is not wrong — the frame it runs
+in is stricter than the one you pictured. The only thing that finds them is pressing the button.
+
+**That is what the Collections pane's preview is FOR.** It is not a convenience and it is not a
+rough approximation. Before it existed, an LLM wrote the page and it went to a public URL without
+anybody ever having loaded it once — which is exactly how a sign-up form was published twice with
+a Submit button that did nothing at all. So the preview runs **the same parent as
+`/a/{slug}`** (`@receptron/sharedapp/view`, the code mulmoserver itself runs), with the same
+`sandbox="allow-scripts"`, the same CSP, the same private-port handshake and the same confirmation
+dialog. **It is deliberately not looser than production**: a preview kinder than the real page
+would be a machine for producing "it worked on my machine".
+
+**You cannot open it yourself — ask the user to, and say what to press.** In the cell open on this
+repository: the **Collections pane** → the **"Preview the shared app"** button at the top → the
+page appears, drawn from the working tree. Nothing is written and no URL name is taken.
+
+Ask them to confirm, in these terms:
+
+- the page **draws its data** (a grid that stays on "loading…" means `ready()` was never called);
+- pressing the **submit button raises the confirmation dialog**, with the right values in it (no
+  dialog = the message never left the frame — a `<form>`, or a handler that never ran);
+- the **error paths** say something: an empty required field, an unchosen option.
+
+Do this **before deploy** and again after any change to a page. If the user cannot look right now,
+say plainly that the page is untested rather than reporting it as ready.
+
+**Read the tool's `warnings` back to the user too.** `check`, `deploy` and `publish` report what
+the page will probably get wrong — a modal call, a `<form>`, an `onState` with no `ready()`. They
+are hints and they do not stop a publish: a page they are silent about can still be broken, which
+is why they are not a substitute for the paragraph above.
+
+**What the preview does NOT prove**, so do not claim it: the Firestore rules do not run there, so
+what a role may WRITE is untested; nobody else exists, so nothing is concurrent; and it cannot tell
+whether the rules a new declaration needs have been deployed at all.
+
 ### 4. Invite
 
 `manageSharedApp` with `action: "invite"`, `email`, and `role` (omit `role` to remove them). It
@@ -183,6 +222,10 @@ files to recover.
 
 Publishing is the one dangerous step: it changes what everybody outside sees, immediately. Do it
 when the user asks for it in those terms, not as the last step of building.
+
+**Do not publish a page nobody has run** (step 3b). Publishing is immediate and anonymous: a
+broken page is broken for everybody holding the link, and it stays that way until somebody
+happens to press the button and tell you.
 
 What being public MEANS is declared in `app.json`, and it is worth reading back to the user before
 you publish. This is a survey anyone may answer once they sign in:
@@ -295,6 +338,10 @@ an update, which the public submission path never allows. Firestore decides that
 
 ### If a form is not enough to choose from
 
+**Every page you write here goes through step 3b before it is published.** A view is code running
+in a frame stricter than the one you are picturing, and its failures are silent — read the two
+rules below, then have the user press the button in the preview.
+
 A form ANSWERS something. Choosing from what is available — a stylist-by-hour grid — is not the
 far end of a table, so an app may publish HTML pages instead. They are declared in `views`, one
 entry per page, each naming **who it is for**:
@@ -368,6 +415,16 @@ entry per page, each naming **who it is for**:
   keyword is not set."* Nothing throws, so a page that asks for a name with `prompt` submits an
   empty one, or looks like a button that does nothing. Ask with an `<input>` in the page and
   answer in an element of its own; that is the only thing that works here.
+- **A `<form>` CANNOT SUBMIT — draw a `<div>` and a `<button type="button">` instead.** (`deploy`
+  and `publish` warn about a `<form>` for the same reason they warn about a modal, and go through
+  anyway.) The frame is `sandbox="allow-scripts"` with no `allow-forms`, and the browser blocks the
+  submission **before** it fires the `submit` event — so an `onsubmit` handler never runs at all,
+  `e.preventDefault()` on its first line included, and the only sign is *"Blocked form submission
+  to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set"* in a
+  console nobody is reading. What the author sees is a Submit button that does nothing. The same
+  block takes Enter-in-a-text-field with it, and `required` stops working — constraint validation
+  is part of submitting a form. So: no `<form>` element at all, a `type="button"` whose **click**
+  calls `submit(...)`, and every check the page needs written out in that handler.
 - The view asks for writes through `window.__MC_APP_VIEW` — see the next section.
   (`window.__MC_PUBLIC_VIEW` is the same object under its former name, kept for one release.)
 - **`public.view` is the older spelling** of the first row above. It still works and normalizes to
@@ -412,6 +469,17 @@ await window.__MC_APP_VIEW.withdraw(cid, itemId);        // take the reader's OW
 collection has a `mirror` the parent reopens it in the same batch. It works only where
 `selfDelete` names the row's current status, only on a participant's page, and (like the two
 above) only on a runtime that has it.
+
+**Call `ready()` once, after registering `onState` — nothing arrives until you do.** The parent
+holds the app's data until the view answers the handshake, so a page that listens and never says
+`ready()` waits on a send that was never made: it draws its loading line and stays on it forever,
+with no error at either end. (`deploy` and `publish` warn when a page registers `onState` and
+calls no `ready`.)
+
+```js
+window.__MC_APP_VIEW.onState((data, viewer) => { draw(data); });
+window.__MC_APP_VIEW.ready();   // ← without this, the callback above never fires
+```
 
 Each returns `{ ok, error }`. The page is told **who the reader is and what they may actually do**
 in the second argument to `onState`:

--- a/server/skills/mulmoterminal-shared-app/templates/gym.md
+++ b/server/skills/mulmoterminal-shared-app/templates/gym.md
@@ -44,6 +44,7 @@
     "bookings": {
       "submitOnly": true,
       "statusField": "status",
+      "peerVisibility": "public",
       "transitions": { "initial": ["requested"], "requested": ["cancelled"] }
     }
   },
@@ -63,9 +64,23 @@
         "window": { "fromField": { "ref": "classId", "collection": "classes", "field": "opensAt" } }
       }
     }
-  }
+  },
+  "views": [
+    { "id": "public", "audience": "public", "path": "views/signup.html", "collections": ["classes"] },
+    { "id": "mine", "audience": "participant", "path": "views/mine.html", "collections": ["classes", "bookings"] }
+  ]
 }
 ```
+
+**`views` は省けません。順位は生成フォームには出せません** — フォームは 1 件書くだけで、
+何番目かを知らないからです。そして**順位のページは公開ページではありません**:
+
+- **公開の `views/signup.html`** が読めるのは `public.read` にあるものだけ、つまり `classes` です。
+  `bookings` をここの `collections` に書くと publish が拒否します（訪問者の権限で読むので、
+  ルールが拒否して**空のページが描かれる** — 一番たちの悪い壊れ方だからです）。
+- **順位は `audience: "participant"` の `views/mine.html`**、入口は `/p/{slug}`。ここで初めて
+  他の人の申込みが読め、`peerVisibility: "public"` がそれを許しています。**名簿に載っている
+  人どうしで名前が見える**ということなので、作る前に利用者へ確認してください（下の表）。
 
 ## .claude/skills/classes/schema.json
 
@@ -158,13 +173,33 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
 
 ---
 
-## view が描くもの
+## views/signup.html と views/mine.html
 
-カスタムビュー（`views/*.html`）が、読めた行から:
+**`signup.html`（公開）** は `classes` を並べて、申込みを 1 件 `submit()` するだけです。
+順位はここには出せません（読めないので）。
+
+**`mine.html`（participant）** が、読めた行から:
 
 1. `status != "cancelled"` を `createdAt` 昇順に並べる
 2. 先頭 `capacity` 件を「確定」、次の `waitlist` 件を「待機 N 番」、それ以降も待機として続ける
 3. 自分の行を強調して「あなたは待機 1 番です」と出す
+
+**書き方の契約は [salon.md](./salon.md) の `views/booking.html` と同じです。** 動くコードは
+そちらを見てください。守る点はこの 3 つで、どれも破っても**例外が出ず、画面も変わりません**:
+
+- **`<form>` は使えない。** `sandbox="allow-scripts"` に `allow-forms` が無いので、ブラウザは
+  `submit` イベントを**発火する前に**送信を止めます。`onsubmit` の中の `e.preventDefault()` すら
+  走らず、「押しても何も起きないボタン」になります。`<div>` と `type="button"` のボタンにして、
+  **click** で `submit()` を呼びます。テキスト入力での Enter と `required` も同じ理由で効きません。
+- **`prompt` / `alert` / `confirm` は無視される**（`allow-modals` が無い）。訊くのはページの中の
+  `<input>`、報せるのはページの中の要素です。
+- **`onState` を張ったら最後に `ready()` を呼ぶ。** 呼ばないとデータは永久に来ず、ページは
+  「読み込み中」のまま止まります。
+
+**そして deploy の前に、プレビューで実際に押してもらってください**（[SKILL.md](../SKILL.md) の
+「3b. RUN THE PAGE」）。このページの不具合は読んでも見つかりません。とくにこの形は、申込み
+ボタンを 1 回押して**確認ダイアログが出るところまで**見てもらう価値があります — 出なければ、
+メッセージは iframe から出ていません。
 
 定員（8 と 2）は**クラスのレコード**に持たせてあります。クラスごとに変えられ、
 ルールは読みません。**これは表示上の定員です** — 9 番目の人が現場に来ることは

--- a/server/skills/mulmoterminal-shared-app/templates/gym.md
+++ b/server/skills/mulmoterminal-shared-app/templates/gym.md
@@ -136,6 +136,14 @@
 ただし**入力欄としては描かれません** — 公開フォームの射影がこの名前を
 `stampField` として別に伝えるので、ページはサーバ時刻のセンチネルを入れます。
 
+**確認されている制約（2026-08-14）**: そのセンチネルを実際に入れる側が、まだどのホストにも
+ありません。公開ページも手元のプレビューも `@receptron/sharedapp/view` の `recordOf` で
+レコードを組み立てますが、そこは `stampField` を読んでおらず、書き込みにこのキーが入りません。
+ルール（`firestore.rules`、create の `data[stampField] == request.time`）はキーがあることを
+要求するので、**この形の公開申込みは今のところ拒否されます**。ページ側で回避しようとしないで
+ください — ビューが送れるのは文字列だけで、文字列の日時は `== request.time` を満たしません。
+先着枠のアプリを作る前に、`recordOf` にサーバ時刻を入れる修正が入っているかを確かめること。
+
 キャンセルしても時刻は動きません（更新側は「値が動いていないこと」を見ます）。
 動かす仕様にすると、離脱する列の最後尾に飛ばされてしまいます。
 
@@ -173,7 +181,7 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
 
 ---
 
-## views/signup.html と views/mine.html
+## ページは 2 枚書きます
 
 **`signup.html`（公開）** は `classes` を並べて、申込みを 1 件 `submit()` するだけです。
 順位はここには出せません（読めないので）。
@@ -184,8 +192,7 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
 2. 先頭 `capacity` 件を「確定」、次の `waitlist` 件を「待機 N 番」、それ以降も待機として続ける
 3. 自分の行を強調して「あなたは待機 1 番です」と出す
 
-**書き方の契約は [salon.md](./salon.md) の `views/booking.html` と同じです。** 動くコードは
-そちらを見てください。守る点はこの 3 つで、どれも破っても**例外が出ず、画面も変わりません**:
+守る点はこの 3 つで、どれを破っても**例外が出ず、画面も変わりません**:
 
 - **`<form>` は使えない。** `sandbox="allow-scripts"` に `allow-forms` が無いので、ブラウザは
   `submit` イベントを**発火する前に**送信を止めます。`onsubmit` の中の `e.preventDefault()` すら
@@ -195,6 +202,130 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
   `<input>`、報せるのはページの中の要素です。
 - **`onState` を張ったら最後に `ready()` を呼ぶ。** 呼ばないとデータは永久に来ず、ページは
   「読み込み中」のまま止まります。
+
+### views/signup.html
+
+読めるのは `classes` だけ。`memberEmail` と `status` は親が入れるので送りません。
+
+```html
+<label>お名前 <input id="who" maxlength="40" /></label>
+<p id="say" role="status"></p>
+<div id="list"></div>
+<script>
+  const view = window.__MC_APP_VIEW;
+  const list = document.getElementById("list");
+  const who = document.getElementById("who");
+  const say = document.getElementById("say");
+
+  view.onState(({ classes = [] }) => {
+    const rows = classes.slice().sort((a, b) => String(a.startsAt ?? "").localeCompare(String(b.startsAt ?? "")));
+    list.replaceChildren(
+      ...rows.map((klass) => {
+        // textContent と dataset で組み立てること。クラス名は人が入力するもので、
+        // 文字列連結で innerHTML に入れると公開ページでそれが動きます。
+        const row = document.createElement("div");
+        const name = document.createElement("span");
+        name.textContent = `${klass.startsAt ?? ""} ${klass.title ?? klass.id}`;
+        const go = document.createElement("button");
+        // type を書くこと。省略した <button> は submit ボタンで、サンドボックスが
+        // 送信を止める側の形です。
+        go.type = "button";
+        go.dataset.klass = klass.id;
+        go.textContent = "申し込む";
+        row.append(name, go);
+        return row;
+      }),
+    );
+  });
+
+  list.addEventListener("click", async (event) => {
+    const classId = event.target.dataset?.klass;
+    if (!classId) return;
+    const memberName = who.value.trim();
+    if (memberName === "") {
+      say.textContent = "お名前を入れてください。";
+      who.focus();
+      return;
+    }
+    // 送るのは文字列だけ。数値や真偽値が 1 つでも混ざると、そのキーが落ちるのではなく
+    // メッセージ全体が申込みでなくなり、not-a-submission として拒否されます。
+    const result = await view.submit("bookings", { classId, memberName });
+    // 失敗は「満席」ではありません — このアプリに満席という状態はない。解禁前
+    // （window）、サインインしていない、二重申込み（idFrom）のどれかです。
+    say.textContent = result.ok ? "受け付けました。順位は「自分の申込み」で見られます。" : `申し込めませんでした: ${result.error ?? "unknown"}`;
+  });
+
+  view.ready();
+</script>
+```
+
+### views/mine.html
+
+`audience: "participant"`、入口は `/p/{slug}`。順位はここでしか出せません。
+
+```html
+<div id="mine"></div>
+<p id="say" role="status"></p>
+<script>
+  const view = window.__MC_APP_VIEW;
+  const mine = document.getElementById("mine");
+  const say = document.getElementById("say");
+
+  // 順位は「読めた行から数えるもの」。cancelled を除いて createdAt の昇順に並べ、
+  // 何番目かを見るだけで、どこにも保存しません。
+  const ranked = (bookings, classId) =>
+    bookings
+      .filter((row) => row.classId === classId && row.status !== "cancelled")
+      .sort((a, b) => String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? "")));
+
+  const standing = (rank, klass) => {
+    const capacity = Number(klass.capacity ?? 0);
+    if (rank < capacity) return "確定";
+    return `待機 ${rank - capacity + 1} 番`;
+  };
+
+  view.onState(({ classes = [], bookings = [] }, viewer = {}) => {
+    const rows = classes.flatMap((klass) => {
+      const queue = ranked(bookings, klass.id);
+      const rank = queue.findIndex((row) => row.memberEmail === viewer.me);
+      return rank === -1 ? [] : [{ klass, row: queue[rank], text: standing(rank, klass) }];
+    });
+
+    mine.replaceChildren(
+      ...rows.map(({ klass, row, text }) => {
+        const box = document.createElement("div");
+        const name = document.createElement("span");
+        name.textContent = `${klass.startsAt ?? ""} ${klass.title ?? klass.id} — ${text}`;
+        const off = document.createElement("button");
+        off.type = "button";
+        off.dataset.booking = row.id;
+        // 確認はページの中で。confirm() はサンドボックスに無視され、false が
+        // 返るので「押しても何も起きないボタン」になります。
+        off.textContent = off.dataset.armed === "yes" ? "取り消す？" : "キャンセル";
+        box.append(name, off);
+        return box;
+      }),
+    );
+    if (rows.length === 0) mine.textContent = "申込みはありません。";
+  });
+
+  mine.addEventListener("click", async (event) => {
+    const button = event.target;
+    const id = button.dataset?.booking;
+    if (!id) return;
+    if (button.dataset.armed !== "yes") {
+      button.dataset.armed = "yes";
+      button.textContent = "取り消す？";
+      return;
+    }
+    // selfTransitions で本人に許されているのは requested → cancelled だけ。
+    const result = await view.transition("bookings", id, "cancelled");
+    say.textContent = result.ok ? "取り消しました。" : `取り消せませんでした: ${result.error ?? "unknown"}`;
+  });
+
+  view.ready();
+</script>
+```
 
 **そして deploy の前に、プレビューで実際に押してもらってください**（[SKILL.md](../SKILL.md) の
 「3b. RUN THE PAGE」）。このページの不具合は読んでも見つかりません。とくにこの形は、申込み

--- a/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
+++ b/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
@@ -288,6 +288,55 @@ publish されます。総務の Mac が閉じたままでも、受付が自分�
 契約は公開ビューと同じ（`window.__MC_APP_VIEW` / `onState` / `ready`）。渡されるものだけが
 違い、`collections` に書いたものが**その人の資格情報で**読まれます。
 
+このアプリの受付は**読む画面**です。予約の状態は `booked` 一つで、`transitions` は `initial`
+だけ — つまり受付が押すボタンはありません（枠を空けるのは本人の取り下げ、下記）。
+
+```html
+<label>日付 <input id="day" type="date" /></label>
+<p id="count" role="status"></p>
+<div id="rows"></div>
+<script>
+  const view = window.__MC_APP_VIEW;
+  const rows = document.getElementById("rows");
+  const count = document.getElementById("count");
+  const day = document.getElementById("day");
+  let latest = { bookings: [], slots: [] };
+
+  const draw = () => {
+    const when = day.value;
+    const slot = Object.fromEntries(latest.slots.map((row) => [row.id, row]));
+    const shown = latest.bookings
+      .filter((booking) => when === "" || String(slot[booking.slot]?.startAt ?? "").startsWith(when))
+      .sort((a, b) => String(slot[a.slot]?.startAt ?? "").localeCompare(String(slot[b.slot]?.startAt ?? "")));
+
+    count.textContent = `${shown.length} 件`;
+    rows.replaceChildren(
+      ...shown.map((booking) => {
+        // textContent。用件も名前も人が入力するもので、文字列連結で innerHTML に
+        // 入れると受付の画面でそれが動きます。
+        const row = document.createElement("div");
+        const time = document.createElement("span");
+        time.textContent = slot[booking.slot]?.startAt ?? booking.slot;
+        const who = document.createElement("span");
+        who.textContent = `${booking.requesterName ?? ""}（${booking.requesterEmail ?? ""}）`;
+        const why = document.createElement("span");
+        why.textContent = booking.purpose ?? "";
+        row.append(time, who, why);
+        return row;
+      }),
+    );
+  };
+
+  view.onState(({ bookings = [], slots = [] }) => {
+    latest = { bookings, slots };
+    draw();
+  });
+  // 絞り込みは手元だけの操作。onState を待つ必要はなく、待つと最初の描画が出ません。
+  day.addEventListener("change", draw);
+  view.ready();
+</script>
+```
+
 ---
 
 ## 取り消しには 2 通りある — **混ぜないこと**

--- a/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
+++ b/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
@@ -138,6 +138,12 @@
 出るだけで、例外にはなりません）。名前は**ページの中の `<input>`** で訊き、結果は**ページの中の
 要素**に書きます。
 
+**`<form>` も使えません。** `allow-forms` が無いので、ブラウザは `submit` イベントを**発火する
+前に**送信ごと止めます — `onsubmit` の中の `e.preventDefault()` すら走らないので、「押しても
+何も起きないボタン」になります（コンソールに `Blocked form submission to ''` と出るだけ）。
+テキスト入力での Enter も、`required` の検証も同じ理由で効きません。`<form>` は使わず、`<div>` と
+`type="button"` のボタンにして、**click** で送信し、入力チェックは自分で書きます。
+
 ```html
 <label>お名前 <input id="who" maxlength="40" /></label>
 <label>用件 <input id="why" maxlength="60" /></label>
@@ -159,6 +165,9 @@
           // 入れないこと — 部屋名は人が入力するもので、そこに <script> と
           // 書かれたら公開ページで動きます。
           const button = document.createElement("button");
+          // type を書くこと。省略した <button> は submit ボタンで、サンドボックスが
+          // 送信を止める側の形です。
+          button.type = "button";
           button.dataset.slot = slot.id;
           button.textContent = `${slot.startAt} ${name[slot.room] ?? ""}`;
           return button;
@@ -202,6 +211,11 @@
   返ります。全部を「その枠は取られました」と言うと、直せる失敗が直せなくなる — 理由は
   `result.error` にあります
 - **`requesterEmail` は送らない。** サインインした訪問者のアドレスを親が入れます
+
+**deploy の前に、プレビューで実際に押してもらってください** — Collections ペインの
+「Preview the shared app」で、`/a/{slug}` と**同じ親・同じサンドボックス**のままこのページが
+動きます（[SKILL.md](../SKILL.md) の「3b. RUN THE PAGE」）。ここの不具合は読んでも見つからず、
+押すと確認ダイアログが出るところまで見て初めて分かります。
 
 **押した瞬間には書き込まれません。** 親が値を iframe の外に描いて確認を取り、訪問者が
 押してから書きます。ビューの HTML は信頼されていないためで、読み込んだ瞬間に `submit()` を

--- a/server/skills/mulmoterminal-shared-app/templates/salon.md
+++ b/server/skills/mulmoterminal-shared-app/templates/salon.md
@@ -304,10 +304,61 @@ view.onState((data, viewer) => {
 `audience: "participant"`。入口は **`/p/{slug}`** で、公開ページの下にリンクがあります。
 自分の行しか読めないので `collections` に書けるのは `bookings` だけ、渡るのも自分の予約だけです。
 
-キャンセルは同じ `transition` で、**表が違うだけ**です:
+キャンセルは同じ `transition` で、**表が違うだけ**です（本人に許されている遷移は
+`public.submit.bookings.selfTransitions`、スタッフのそれは `collections.bookings.transitions`）。
 
-```js
-await view.transition("bookings", booking.id, "cancelled");
+```html
+<div id="rows"></div>
+<p id="say" role="status"></p>
+<script>
+  const view = window.__MC_APP_VIEW;
+  const rows = document.getElementById("rows");
+  const say = document.getElementById("say");
+
+  view.onState(({ bookings = [] }) => {
+    const mine = bookings.slice().sort((a, b) => String(a.slot ?? "").localeCompare(String(b.slot ?? "")));
+    rows.replaceChildren(
+      ...mine.map((booking) => {
+        const row = document.createElement("div");
+        const what = document.createElement("span");
+        // textContent。担当者名もメニュー名も人が入力するものです。
+        what.textContent = `${booking.slot ?? ""} ${booking.service ?? ""} — ${booking.status ?? ""}`;
+        row.appendChild(what);
+        // `selfTransitions` は pending からの cancelled だけ。approved を取り消せるのは
+        // 受付（`collections.bookings.transitions`）なので、ここに出すと必ず断られる
+        // ボタンになります。宣言に無い遷移は描かないこと。
+        if (booking.status === "pending") {
+          const off = document.createElement("button");
+          // type を書くこと。省略した <button> は submit ボタンで、サンドボックスが
+          // 送信を止める側の形です。
+          off.type = "button";
+          off.dataset.booking = booking.id;
+          off.textContent = "キャンセル";
+          row.appendChild(off);
+        }
+        return row;
+      }),
+    );
+    if (mine.length === 0) rows.textContent = "予約はありません。";
+  });
+
+  rows.addEventListener("click", async (event) => {
+    const button = event.target;
+    const id = button.dataset?.booking;
+    if (!id) return;
+    // 確認はページの中で 2 度押しにします。confirm() はサンドボックスに無視され、
+    // false が返るので「押しても何も起きないボタン」になります。
+    if (button.dataset.armed !== "yes") {
+      button.dataset.armed = "yes";
+      button.textContent = "取り消す？";
+      return;
+    }
+    const result = await view.transition("bookings", id, "cancelled");
+    say.textContent = result.ok ? "取り消しました。" : `取り消せませんでした: ${result.error ?? "unknown"}`;
+  });
+
+  view.ready();
+</script>
 ```
 
 ---

--- a/server/skills/mulmoterminal-shared-app/templates/salon.md
+++ b/server/skills/mulmoterminal-shared-app/templates/salon.md
@@ -143,6 +143,12 @@
 `allow-modals` が無い呼び出しは無視されます（コンソールに `Ignored call to 'prompt()'.` と
 出るだけ）。訊くのはページの中の `<input>`、報せるのはページの中の要素です。
 
+**`<form>` も使えません。** `allow-forms` が無いので、ブラウザは `submit` イベントを**発火する
+前に**送信ごと止めます — `onsubmit` の中の `e.preventDefault()` すら走らないので、「押しても
+何も起きないボタン」になります（コンソールに `Blocked form submission to ''` と出るだけ）。
+テキスト入力での Enter も、`required` の検証も同じ理由で効きません。`<form>` は使わず、`<div>` と
+`type="button"` のボタンにして、**click** で送信し、入力チェックは自分で書きます。
+
 ```html
 <label>お名前 <input id="who" maxlength="40" /></label>
 <p id="say" role="status"></p>
@@ -160,6 +166,9 @@
         .filter((slot) => slot.state === "open")
         .map((slot) => {
           const button = document.createElement("button");
+          // type を書くこと。省略した <button> は submit ボタンで、サンドボックスが
+          // 送信を止める側の形です。
+          button.type = "button";
           button.dataset.slot = slot.id;
           button.textContent = `${slot.startAt} ${slot.stylist ?? ""}`;
           return button;
@@ -193,6 +202,11 @@
   ではなく**メッセージ全体が申込みでなくなり**、`not-a-submission` として拒否されます
 - **`customerEmail` は送らない。** サインインした訪問者のアドレスを親が入れます
   （ルールがトークンと突き合わせるので、入力欄にすると間違えられるだけの欄になります）
+
+**deploy の前に、プレビューで実際に押してもらってください** — Collections ペインの
+「Preview the shared app」で、`/a/{slug}` と**同じ親・同じサンドボックス**のままこのページが
+動きます（[SKILL.md](../SKILL.md) の「3b. RUN THE PAGE」）。ここの不具合は読んでも見つからず、
+押すと確認ダイアログが出るところまで見て初めて分かります。
 
 **押した瞬間には書き込まれません。** 親が送られてきた値を iframe の外に描いて確認を
 取り、訪問者が押してから書きます。これはビューの HTML が信頼されていないためで、

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -172,10 +172,20 @@ describe("the file a published view names", () => {
     // The other half of the same app's day. The parent holds the data until the view answers the
     // handshake, so this page renders its loading line and stays on it — no error, no empty state,
     // nothing to tell the author which end is at fault.
-    const html = "<script>window.__MC_APP_VIEW.onState(function (data) { draw(data); });</script>";
-    const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
-    expect(result.ok).toBe(true);
-    expect(result.ok && result.view.warnings.join(" ")).toContain("ready()");
+    for (const html of [
+      "<script>window.__MC_APP_VIEW.onState(function (data) { draw(data); });</script>",
+      // The likelier mistake, and the one a presence check called clean: `ready()` IS written, but
+      // inside the listener that only runs once `ready()` has been sent. Same deadlock, and it is
+      // what "call ready after registering onState" sounds like.
+      "<script>view.onState((data) => { draw(data); view.ready(); });</script>",
+      // …including when the callback nests calls of its own, so the argument list cannot be cut at
+      // the first `)`.
+      "<script>view.onState((d) => { draw(rows(d, top(1))); view.ready(); });</script>",
+    ]) {
+      const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
+      expect(result.ok).toBe(true);
+      expect(result.ok && result.view.warnings.join(" ")).toContain("ready()");
+    }
   });
 
   it("says nothing when the page either completes the handshake or wants no data", async () => {
@@ -183,6 +193,9 @@ describe("the file a published view names", () => {
     // state is not missing a handshake — it has nothing to be handed.
     for (const html of [
       "<script>const b = window.__MC_APP_VIEW; b.onState(draw); b.ready();</script>",
+      // Calling it inside the listener TOO is fine — the one outside is what starts the
+      // conversation, and this is the shape a page that re-announces itself takes.
+      "<script>view.onState((d) => { draw(d); view.ready(); }); view.ready();</script>",
       "<script>document.getElementById('go').addEventListener('click', send);</script>",
       "<p>ready() の話をしているだけ</p>",
     ]) {

--- a/test/server/backends/publicView.spec.ts
+++ b/test/server/backends/publicView.spec.ts
@@ -134,6 +134,63 @@ describe("the file a published view names", () => {
     }
   });
 
+  it("WARNS about a `<form>`, which a sandboxed frame may not submit", async () => {
+    // The one that shipped. `sandbox="allow-scripts"` carries no `allow-forms`, and the browser
+    // blocks the submission BEFORE firing the `submit` event — so a handler whose first line is
+    // `e.preventDefault()` never runs, and the Submit button does nothing at all. The console line
+    // is the only sign, and the author was not looking at a console: the page was deployed and
+    // published twice before anybody pressed it.
+    for (const html of [
+      '<form id="f"><button type="submit">go</button></form>',
+      // The element is what carries implicit submission, so a form used "only for layout" is the
+      // same trap one Enter keypress later.
+      "<form>\n<input />\n</form>",
+      "<FORM><input /></FORM>",
+      "<form/>",
+    ]) {
+      const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
+      expect(result.ok).toBe(true);
+      expect(result.ok && result.view.warnings.join(" ")).toContain("allow-forms");
+    }
+  });
+
+  it("says nothing about a `<form>` that is text rather than markup", async () => {
+    // The expensive direction again: a page explaining the rule, or showing the shape it replaced,
+    // draws no form and must not be warned at.
+    const html = [
+      "<p>Do not use a &lt;form&gt; here.</p>",
+      "<textarea><form><button type=submit>go</button></form></textarea>",
+      "<!-- <form id=old><input /></form> -->",
+      '<script>const sample = "<form>";</script>',
+      '<div id="form"><button type="button" id="go">go</button></div>',
+    ].join("\n");
+    const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
+    expect(result.ok && result.view.warnings).toEqual([]);
+  });
+
+  it("WARNS about a view that listens for state and never says it is ready", async () => {
+    // The other half of the same app's day. The parent holds the data until the view answers the
+    // handshake, so this page renders its loading line and stays on it — no error, no empty state,
+    // nothing to tell the author which end is at fault.
+    const html = "<script>window.__MC_APP_VIEW.onState(function (data) { draw(data); });</script>";
+    const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.view.warnings.join(" ")).toContain("ready()");
+  });
+
+  it("says nothing when the page either completes the handshake or wants no data", async () => {
+    // Both directions: a view that calls `ready` is correct, and a STATIC page that never asks for
+    // state is not missing a handshake — it has nothing to be handed.
+    for (const html of [
+      "<script>const b = window.__MC_APP_VIEW; b.onState(draw); b.ready();</script>",
+      "<script>document.getElementById('go').addEventListener('click', send);</script>",
+      "<p>ready() の話をしているだけ</p>",
+    ]) {
+      const result = await readAppViewFile(root, { path: withView(root, html) }, STAMP);
+      expect(result.ok && result.view.warnings).toEqual([]);
+    }
+  });
+
   it("does not read a page's PROSE as code", async () => {
     // The other direction, and the more expensive one: a refusal the author cannot act on. The
     // words are allowed to appear — in markup that explains the rule, and in a string that is

--- a/test/server/backends/sharedAppCheck.spec.ts
+++ b/test/server/backends/sharedAppCheck.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+//
+// `check` opens the PAGES, not only the declaration.
+//
+// It exists to answer "would a deploy be refused?" before anything is written, and a `path` naming
+// a file that is not there is one of the ways a deploy IS refused. Answering that question from
+// `app.json` alone called such an app deployable and left the refusal for the deploy — the exact
+// point in the flow this action exists to move earlier. The warnings ride along for the same
+// reason: they are what an author still has time to act on.
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setSharedCollectionsSupport } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { checkSharedApp } from "../../../server/backends/sharedApp/declare.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const AID = "11111111-2222-3333-4444-555555555555";
+
+/** An app that declares one public page, and whatever HTML the test wants behind it. */
+const withApp = (root: string, html: string | null): void => {
+  writeFileSync(
+    path.join(root, "app.json"),
+    JSON.stringify({
+      aid: AID,
+      name: "Sign-ups",
+      slug: "sign-ups",
+      members: { "owner@example.com": { "*": "owner" } },
+      collections: { signups: { submitOnly: true, statusField: "status" } },
+      public: {
+        enabled: true,
+        read: ["menu"],
+        submit: { signups: { auth: "verifiedEmail", emailField: "email", createFields: ["name", "email", "status"], initialStatus: "submitted" } },
+      },
+      views: [{ id: "public", audience: "public", path: "views/signup.html", collections: ["menu"] }],
+    }),
+  );
+  if (html === null) return;
+  mkdirSync(path.join(root, "views"), { recursive: true });
+  writeFileSync(path.join(root, "views", "signup.html"), html);
+};
+
+describe("check", () => {
+  let root: string;
+
+  beforeAll(() => {
+    // `check` discovers this repository's collections on the way, and discovery needs the host
+    // binding. ONE per file — a second call with a different host is refused.
+    initCollectionsBackend({ workspace: makeTempDir("mt-shared-app-check-ws-") });
+    setSharedCollectionsSupport(true);
+  });
+
+  beforeEach(() => {
+    root = makeTempDir("mt-shared-app-check-");
+  });
+
+  it("refuses a view whose file is not there", async () => {
+    // The template that declared two pages and shipped neither passed `check` and failed at
+    // deploy, which is the one thing this action promises not to let happen.
+    withApp(root, null);
+    const report = await checkSharedApp(root);
+    expect(report.ok).toBe(true);
+    expect(report.ok && report.problems.join(" ")).toContain("could not be opened as a plain file");
+  });
+
+  it("carries the page's warnings, without making them refusals", async () => {
+    // A `<form>` cannot submit in the sandbox and an `onState` with no reachable `ready()` is never
+    // sent anything — both silent, both survivable, so they are said and the deploy goes on.
+    withApp(root, '<form id="f"><button type="submit">go</button></form><script>view.onState((d) => { draw(d); view.ready(); });</script>');
+    const report = await checkSharedApp(root);
+    expect(report.ok).toBe(true);
+    expect(report.ok && report.warnings.join(" ")).toContain("allow-forms");
+    expect(report.ok && report.warnings.join(" ")).toContain("ready()");
+    expect(report.ok && report.problems.join(" ")).not.toContain("allow-forms");
+  });
+
+  it("says nothing about a page that is fine", async () => {
+    withApp(root, '<div id="grid"></div><script>view.onState((d) => draw(d)); view.ready();</script>');
+    const report = await checkSharedApp(root);
+    expect(report.ok && report.warnings).toEqual([]);
+  });
+});

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -15,6 +15,7 @@ import type { CollectionSchema } from "@mulmoclaude/core/collection";
 import { declarationProblems } from "../../../server/backends/sharedApp/context.js";
 import { parseAuthoredApp } from "@receptron/sharedapp";
 import { modalCallIn } from "../../../server/backends/sharedApp/modalCall.js";
+import { formElementIn, readyNeverCalled } from "../../../server/backends/sharedApp/viewDefects.js";
 import { readdirSync } from "node:fs";
 
 const TEMPLATES = path.join(process.cwd(), "server", "skills", "mulmoterminal-shared-app", "templates");
@@ -77,13 +78,18 @@ describe("the shared-app templates", () => {
   });
 
   it("shows no page the sandbox would silently break", () => {
-    // Publish refuses `alert` / `confirm` / `prompt` in a view, because the frame has no
-    // `allow-modals` and eats all three. A template is copied verbatim, so a sample using one
-    // teaches a page that publish rejects — and before that refusal existed, it taught the page
-    // an author shipped and reported as broken: "Ignored call to 'prompt()'".
+    // The frame has no `allow-modals` and no `allow-forms`, and the parent sends nothing until the
+    // view says `ready()`. All three fail the same way — nothing drawn, nothing thrown — and a
+    // template is copied VERBATIM, so a sample carrying one teaches the exact page an author then
+    // ships and reports as broken. That is not hypothetical for any of them: `prompt()` was in
+    // these samples once, and a `<form>` written from scratch (because no sample showed the
+    // alternative) went to a public URL with a Submit button that did nothing.
     for (const file of readdirSync(TEMPLATES).filter((name) => name.endsWith(".md"))) {
-      for (const [, html] of readFileSync(path.join(TEMPLATES, file), "utf8").matchAll(/^```html\n([\s\S]*?)\n```/gm)) {
-        expect(`${file}: ${modalCallIn(html ?? "") ?? ""}`).toBe(`${file}: `);
+      for (const [, block] of readFileSync(path.join(TEMPLATES, file), "utf8").matchAll(/^```html\n([\s\S]*?)\n```/gm)) {
+        const html = block ?? "";
+        expect(`${file}: ${modalCallIn(html) ?? ""}`).toBe(`${file}: `);
+        expect(`${file}: form=${formElementIn(html)}`).toBe(`${file}: form=false`);
+        expect(`${file}: readyMissing=${readyNeverCalled(html)}`).toBe(`${file}: readyMissing=false`);
       }
     }
   });

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -94,6 +94,34 @@ describe("the shared-app templates", () => {
     }
   });
 
+  it("ships an HTML block for every page its app.json declares", () => {
+    // A declared `path` is READ at deploy: `planAppViewTiers` opens each one and refuses the whole
+    // operation when a file is missing. So a template that names two pages and shows neither does
+    // not merely teach less — it teaches a declaration whose first deploy fails, and the author is
+    // then editing files to recover. (Which is what the gym template did: it described a view in
+    // prose, declared nothing, and its ranking was unbuildable from what it showed.)
+    for (const file of readdirSync(TEMPLATES).filter((name) => name.endsWith(".md"))) {
+      const text = readFileSync(path.join(TEMPLATES, file), "utf8");
+      const manifest = blocksOf(file).get("app.json") as { views?: { path?: string }[] } | undefined;
+      const declared = (manifest?.views ?? []).map((view) => view.path).filter((value): value is string => typeof value === "string");
+      const lines = text.split("\n");
+      const isHeading = (line: string): boolean => /^#{2,3} /.test(line);
+      for (const declaredPath of declared) {
+        // The section that introduces the page — a heading STARTING with the path, because that
+        // heading is the template's own instruction about which file the author writes — and the
+        // fenced html block that must be inside it, before the next heading.
+        const start = lines.findIndex((line) => isHeading(line) && line.replace(/^#{2,3} /, "").startsWith(declaredPath));
+        const rest = start === -1 ? [] : lines.slice(start + 1);
+        const end = rest.findIndex(isHeading);
+        const body = (end === -1 ? rest : rest.slice(0, end)).join("\n");
+        const heading = start === -1 ? "has no section" : "has a section";
+        expect(`${file}: ${declaredPath} ${heading}`).toBe(`${file}: ${declaredPath} has a section`);
+        const shown = body.includes("```html") ? "shows HTML" : "shows no HTML";
+        expect(`${file}: ${declaredPath} ${shown}`).toBe(`${file}: ${declaredPath} shows HTML`);
+      }
+    }
+  });
+
   it("each template shows every collection whose shape carries a decision", () => {
     // A guard on the guard: if a template stopped showing its schemas the
     // checks above would still pass, against nothing.


### PR DESCRIPTION
実際に公開したアプリ（9/5 ミーティングの弁当予約）で、**Submit を押しても何も起きない**状態のものが 2 回 publish された。その原因と、同じことが繰り返される経路を塞ぐ。

## 何が起きたか

`<form>` + `type="submit"` で組んでいた。公開ビューのフレームは `sandbox="allow-scripts"` で `allow-forms` が無く、ブラウザは **submit イベントを発火する前に**送信ごとブロックする。つまり `e.preventDefault()` を先頭に書いたハンドラが**一度も走らない** — 送信も、エラー表示も、確認ダイアログも出ない。コンソールに `Blocked form submission to ''` と出るだけ。

同じセッションで `ready()` の呼び忘れも踏んでいる（親はハンドシェイクまでデータを送らないので、メニューが永久に「読み込み中」）。

どちらも**例外が出ず、画面も変わらない**。そして:

- SKILL.md はモーダル（`alert`/`confirm`/`prompt`）しか警告しておらず、`<form>` については何も言っていなかった
- `ready()` は `templates/salon.md` と `meeting-room.md` の中にしか書かれておらず、テンプレートを使わず一から書いた著者には届かなかった
- `check` / `deploy` / `publish` はページを一切見ない。3 つとも「成功」と答えた
- **Collections ペインのプレビューはまさにこれを防ぐために作られたのに、SKILL.md がその存在を一度も書いていなかった**ので使われなかった

## 変更

**1. `viewDefects.ts`（新規）** — 生きた `<form>` 開始タグと、「`onState` を張って `ready()` を呼んでいない」の検出。判定はモーダルと同じ **warning（publish は止めない）**。`modalCall.ts` の走査（スクリプト本体の除去、文字列・コメントの除去）を共有しているので、`<textarea>` 内の例・コメントアウト・文字列中の `"<form>"`・散文の `ready()` では鳴らない。

**2. SKILL.md に「3b. RUN THE PAGE」** — プレビューが何のためにあるのかを書く: `/a/{slug}` と**同じ親**（`@receptron/sharedapp/view`）・同じサンドボックス・同じ CSP・同じ確認ダイアログで、**意図的に本番より緩くない**。LLM は自分で押せないので、ユーザーに Collections ペインの「Preview the shared app」を押してもらい、**送信ボタンで確認ダイアログが出るところまで**見てもらう。プレビューが証明しないこと（ルールは動かない・同時実行は無い・ルールが deploy 済みかは分からない）も明記。publish のステップにも「誰も動かしていないページを publish しない」を追加。

**3. テンプレート 3 本のレビュー**

- **gym.md** — view の契約も HTML サンプルも無く、`views` の宣言自体が無かった。順位を出すアプリなので生成フォームでは成立しない。公開ページ（`classes` のみ）と participant ページ（`/p/{slug}`、`bookings` を読む）に分け、`peerVisibility: "public"` を宣言。サンドボックスの 3 つの制約とプレビューへの導線を追加。最初に書いた `views` は `skillTemplates.spec.ts` の**本物のゲート**が弾いた（`bookings` が `public.read` に無い）
- **salon.md / meeting-room.md** — 生成する `<button>` に `type` が無かった。省略した `<button>` は submit ボタンで、まさに今回止まった形。`button.type = "button"` を明示し、`<form>` の禁止とプレビューへの導線を追加

**4. テンプレートのサンプル HTML を `<form>` と `ready()` でも検査**（既存のモーダル検査と同じループ）。

## 確認

- 壊れていた版を食わせると両方検出、公開中の修正版は無警告
- `yarn format` / `lint` / `typecheck` 通過、`test/server` 5433 件パス

## 残っている穴（このPRの範囲外）

ターミナルから publish 前にページを**動かす**手段が無い。プレビューはブラウザの UI からしか触れず、iframe のコンソールも親に転送していない。`plans/feat-shared-app-preview.md` の P5（ヘッドレスの `action: "preview"`）がそれ。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings for unsupported forms and views missing the required loading handshake.
  - Improved executable-script detection while ignoring comments and strings.
  - Added gym template views for public class listings and participant rankings.
  - Added clearer validation reports for missing or problematic public pages.

- **Documentation**
  - Added preview and validation guidance before publishing shared-app pages.
  - Documented sandbox limitations, form alternatives, state-handshake requirements, and template-specific usage guidance.

- **Bug Fixes**
  - Public-view checks can now report multiple compatibility warnings on the same page.
  - Added validation to prevent unsupported forms and incomplete handshakes in templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->