### PR TITLE
fix(remote-host): firebase を 12.16.0 にピン留めする — mulmoclaude #2912 の伝播漏れ (#1731)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "dompurify": "^3.4.13",
     "echarts": "^6.0.0",
     "express": "^5.2.1",
-    "firebase": "^12.17.1",
+    "firebase": "12.16.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "marked": "^18.0.9",

--- a/plans/fix-1731-pin-firebase.md
+++ b/plans/fix-1731-pin-firebase.md
@@ -1,0 +1,82 @@
+# fix: firebase を 12.16.0 にピン留めする (#1731)
+
+## 背景 — 参照実装からの伝播漏れ
+
+`package.json` の `dependencies` が `"firebase": "^12.17.1"` で、入るのは
+**firebase 12.17.1 = `@firebase/auth` 1.13.4**。これは既知のリグレッション版で、
+参照実装の mulmoclaude では既にピン留めで回避済み（mulmoclaude #2835 / #2912）。
+
+| | firebase | `@firebase/auth` |
+| --- | --- | --- |
+| mulmoclaude main | `12.16.0`（キャレット無し） | 1.13.3 |
+| mulmoterminal main（本 PR 前） | **`^12.17.1`** | **1.13.4** |
+
+CLAUDE.md の「MulmoClaude is the reference host」に該当する。同じ SDK を同じ形で呼んでいて
+（`RemoteHostControl.vue:141` ↔ `useRemoteHost.ts:151`）、あちらで直った不具合がこちらに来ていなかった。
+
+## 何が壊れるか
+
+1.13.4 が `IndexedDBLocalPersistence` に `visibilitychange` リスナを足し、
+`document.visibilityState === 'hidden'` をページ teardown と同じ扱いにした。サインインの
+ポップアップが元ウィンドウを背面に回した状態で認証情報を永続化しようとすると `_openDb()` が throw する。
+
+```
+signInWithPopup → PopupOperation → _signIn → _signInWithCredential
+  → auth._updateCurrentUser → directlySetCurrentUser
+  → assertedPersistence.setCurrentUser → IndexedDBLocalPersistence._set
+  → _withRetries → _openDb → throw new Error('Database is closing/hidden')
+```
+
+`_withRetries()` は `isHiding` のときリトライせず rethrow するので回復経路が無い。
+**読み取り（`_poll()`）は `isHiding` を見て `[]` を返して握りつぶすのに、書き込みだけ例外を上げる**
+という非対称が芯。
+
+上流 [firebase-js-sdk#10264](https://github.com/firebase/firebase-js-sdk/issues/10264)。
+修正 [#10300](https://github.com/firebase/firebase-js-sdk/pull/10300) は 2026-08-13 マージ済みだが
+**npm に出ていない**（`@firebase/auth` の latest は 1.13.4 のまま）。**上げても直らないので待てない。**
+
+## 直し方
+
+`"firebase": "12.16.0"` — **キャレット無し**。`^12.16.0` だと 12.17.x に浮いて 1.13.4 に戻る。
+12.16.0 は `@firebase/auth` 1.13.3 を同梱する最新の 12.x。
+
+mulmoclaude は monorepo で 2 箇所必要だったが、こちらは `package.json` 1 つだけ。
+`firebase` は `dependencies` にあり、ブラウザ束（`src/config/firebase.ts`）と server 実行時
+（`server/backends/remoteHost/*` が `firebase/firestore` / `firebase/storage` を import）の
+両方で使われるので、npm 利用者にもそのまま届く。
+
+## #1661 との関係 — 別問題
+
+#1661（Chrome で Connect が Offline のまま）の報告には
+「`accounts:signInWithIdp` → 200 OK」かつ「`firebaseLocalStorageDb` が空のまま」とあり、
+**これはこのリグレッションの症状そのもの**。
+
+ただし #1661 のもう一方の証拠 `auth/popup-blocked` は別経路で、`window.open()` が null を
+返した時点のエラー（`_assert(newWin, auth, "popup-blocked")`）なので永続化まで到達していない。
+**別問題として扱い、こちらは独立に直す。** ピン留め後に #1661 の報告者へ再確認すれば、
+残る症状が `popup-blocked` だけに絞れる。
+
+## 検証
+
+依存を動かす変更なので、warm な `node_modules` では確かめない（そこは「ローカル緑・CI 赤」の温床）。
+
+1. `rm -rf node_modules && yarn install --frozen-lockfile` → 成功。
+   解決結果 firebase **12.16.0** / `@firebase/auth` **1.13.3**
+2. lint / typecheck / build / test → すべて緑（710 files, 10217 tests）
+3. lockfile 差分は 224 行の入れ替え。`@firebase` 系以外で動いたのは `re2js` の 1 件だけで、
+   削除ではなく `@firebase/firestore` 12.16.0 の要求範囲に合わせた `^2.8.3` → `^0.4.2`（0.4.3 が入る）
+4. **出荷される束から回帰コードが消えたことを直接確認**
+
+   | マーカー | `dist/assets/*.js` |
+   | --- | --- |
+   | `Database is closing/hidden` | **0** |
+   | `isHiding` | **0** |
+   | `signInWithPopup` / `popup-blocked` | 1（firebase auth 自体は入っている） |
+
+   ビルドが通ること自体も検証の一部で、`firebase/app` `firebase/auth` `firebase/firestore`
+   `firebase/storage` の subpath export がバージョン間で変わっていないことを示す。
+
+## 戻すとき
+
+上流 1.13.5 以降が npm に出たら、`^` を戻すか新しい版にピンを移す。
+**その判断は mulmoclaude と揃えること** — 片方だけ動かすと、また今回のような伝播漏れになる。

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,26 +710,26 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
   integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
 
-"@firebase/ai@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@firebase/ai/-/ai-2.14.0.tgz#292789b4dfa817ac17c25fef36bc7b7ffd710c31"
-  integrity sha512-TYEQqCQUTyVHuG/HVi9vau6F9kvEaS49o/hmdn/yUuN6ZXQkwIml2nNJTIBfjNl/r9LOxwUNILgcOY16nxObug==
+"@firebase/ai@2.13.1":
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/@firebase/ai/-/ai-2.13.1.tgz#15dc946a793bc8ea35e1aba03ec3cf50c9443ba9"
+  integrity sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/analytics-compat@0.2.29":
-  version "0.2.29"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.29.tgz#9a13c73db2c6ad63a854a5ce3a7b16ff74cd7630"
-  integrity sha512-allztvCvCUlItZzD97TiRAtGoFJzR1FQFmLxbaLc6PvgscqD9cl5NdKPTtka6keShVYXvCZJpzWcRoH4TME8rw==
+"@firebase/analytics-compat@0.2.28":
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz#fb8f18e40a019dd9ea005859fe71ccf3d0867ee9"
+  integrity sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==
   dependencies:
-    "@firebase/analytics" "0.10.23"
+    "@firebase/analytics" "0.10.22"
     "@firebase/analytics-types" "0.8.4"
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/analytics-types@0.8.4":
@@ -737,27 +737,27 @@
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.8.4.tgz#194ee289e7293e47b1bd6221147f0dcc02f92e3d"
   integrity sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==
 
-"@firebase/analytics@0.10.23":
-  version "0.10.23"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.10.23.tgz#ec92235e1b35ef0f22b286194e458f5640570b00"
-  integrity sha512-34ALWXzWA6PTRUA5hipZmsm1RKzeecw5J1+qTCXsiMzwLqONC+GuTIQSdmm91MmTAEA+wG1Q5t0IFahcYQOqAA==
+"@firebase/analytics@0.10.22":
+  version "0.10.22"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.10.22.tgz#20f3a6431ed51c4590cf898455de7fd40b2163f0"
+  integrity sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/app-check-compat@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.4.6.tgz#78af8bcd3cbbbf857541926d0dc63f899b22f037"
-  integrity sha512-2pzNEZEkX84jSqy6TH6FI1HSLA1lc7kakRUybBbKjg9YhIttPlW/XX3N9CDtChji2PTTPWVPZiWhB10exHfA+A==
+"@firebase/app-check-compat@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz#f136a07e5bcdef81aaad1b82b49557d5d1329ee8"
+  integrity sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==
   dependencies:
-    "@firebase/app-check" "0.13.0"
+    "@firebase/app-check" "0.12.0"
     "@firebase/app-check-types" "0.5.4"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/app-check-interop-types@0.3.4":
@@ -770,25 +770,25 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-check-types/-/app-check-types-0.5.4.tgz#8001732e81332dd77d898d82fe773761cf2f023b"
   integrity sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==
 
-"@firebase/app-check@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.13.0.tgz#de1d1e4671172b55eda2ad6b0a6182d763926b73"
-  integrity sha512-AbMttBKazQvGVXBZhQdVAdPzRhwHyJAY3Ghu5y2C7IZKIDIppzNYz0shTZ1mP4FBJa+28BuC4t+5h1Q6pT3Asg==
+"@firebase/app-check@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.12.0.tgz#8fb9bdfa426b110169efc7446f84a9c54ef5bdd0"
+  integrity sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.5.16":
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.5.16.tgz#2c2f87fb29f298dd220b66b7b28493ff9f2e7ff7"
-  integrity sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==
+"@firebase/app-compat@0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.5.15.tgz#6db6d3a5cc35dba7c4fbcc985c5a8bff4f2fab01"
+  integrity sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==
   dependencies:
-    "@firebase/app" "0.16.0"
-    "@firebase/component" "0.7.4"
+    "@firebase/app" "0.15.1"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/app-types@0.9.5":
@@ -798,26 +798,26 @@
   dependencies:
     "@firebase/logger" "0.5.1"
 
-"@firebase/app@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.16.0.tgz#9521de87efb74eed879f201be1abc8df92364b37"
-  integrity sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==
+"@firebase/app@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.15.1.tgz#2d5eb26abf388dc32aea5763eb26e0698d5401ca"
+  integrity sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
-"@firebase/auth-compat@0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.6.9.tgz#16db5b6f14f4a09c861aa643310e421db488e528"
-  integrity sha512-/hHeTBmQ61+N5J1RECls+WfskZTY78JXr7aO5EMOfUpqJvDqvoS+568k0rp6Ss/4UWwBjadILs+H+SGy1zCS3A==
+"@firebase/auth-compat@0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.6.8.tgz#09d828421a9ec1edcde60cd86785a29cad9b5720"
+  integrity sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==
   dependencies:
-    "@firebase/auth" "1.13.4"
+    "@firebase/auth" "1.13.3"
     "@firebase/auth-types" "0.13.1"
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/auth-interop-types@0.2.5":
@@ -830,77 +830,77 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.13.1.tgz#eb5abafdaa40dd3b6badfab111dd94f7e196ea66"
   integrity sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==
 
-"@firebase/auth@1.13.4":
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.13.4.tgz#440862edc7782cbd28ce6606cb31249e009efff9"
-  integrity sha512-s+NS1aV0DDyyfoIMeSz53HXnVTv7ufJjJfrP63XyaWHweJ5vOoxKWrTm5tO7S7PDqvyOa/Wi3oP0dgAo6JTMMA==
+"@firebase/auth@1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.13.3.tgz#5cad74ce656c9b4f8ffb2a026fab98d4b40c4a96"
+  integrity sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/component@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.7.4.tgz#1c7942806ba03334e5ef432e088a07efad787cf3"
-  integrity sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==
-  dependencies:
-    "@firebase/util" "1.15.2"
-    tslib "^2.1.0"
-
-"@firebase/data-connect@0.7.3":
+"@firebase/component@0.7.3":
   version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@firebase/data-connect/-/data-connect-0.7.3.tgz#61c3d07bf8a2c9eb3928440230c3a0d88c1176b7"
-  integrity sha512-nHBFk3Ntl+NZCRIUG2d5j7I69P0otjyQ/duhVKLbw4+5cNke/F6RK1pdE5Jnf831/QOTs2Bd00LlxlZ+jNsb9w==
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.7.3.tgz#900c9720f7e5abb2a23975f90f96366d62d085b9"
+  integrity sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==
+  dependencies:
+    "@firebase/util" "1.15.1"
+    tslib "^2.1.0"
+
+"@firebase/data-connect@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@firebase/data-connect/-/data-connect-0.7.1.tgz#3ae9235525b5b0438968c4bf1ea1afc8816944b3"
+  integrity sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==
   dependencies:
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/database-compat@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.6.tgz#a5ee25d381864d19d64e5241ecd241bd7128373a"
-  integrity sha512-mu7S/75UIajB1A5M9Vfojk69LttW55uABp9nHEtWrV/mIaSEwvoaIe9GySsEzS2EKFK5/3f5okcAuUbihhYeJg==
+"@firebase/database-compat@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.4.tgz#8ea753bef91d2dfbd81853479799f3ab17ddbbbe"
+  integrity sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/database" "1.1.4"
-    "@firebase/database-types" "1.0.21"
+    "@firebase/component" "0.7.3"
+    "@firebase/database" "1.1.3"
+    "@firebase/database-types" "1.0.20"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/database-types@1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-1.0.21.tgz#a571c6491bb7d2e0b71b8eac0511acf7f87d5a24"
-  integrity sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==
+"@firebase/database-types@1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-1.0.20.tgz#2050c3c13a4b71d92797e1475a297c0b5e0c9f5d"
+  integrity sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==
   dependencies:
     "@firebase/app-types" "0.9.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
 
-"@firebase/database@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-1.1.4.tgz#af9ada837b44e5b65b93d185ce950a1501877172"
-  integrity sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==
+"@firebase/database@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-1.1.3.tgz#ae3b1c906c45d70381359e61b4add6fc4beaa51e"
+  integrity sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     faye-websocket "0.11.4"
     tslib "^2.1.0"
 
-"@firebase/firestore-compat@0.4.12":
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.4.12.tgz#bfe962327a06ddb7df2d7262ebb045d6ed976ca3"
-  integrity sha512-k2uX81Ao/S0jnFcWGPOQpKK1cPlJHvD9WIqh/RE1XBDP2yg5zhE4rHhSg1rtB11k39q3nKon9XLNDDrPjGclag==
+"@firebase/firestore-compat@0.4.11":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz#f382491377bad53e0aec888c62dfe400865266b5"
+  integrity sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/firestore" "4.17.0"
+    "@firebase/component" "0.7.3"
+    "@firebase/firestore" "4.16.0"
     "@firebase/firestore-types" "3.0.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/firestore-types@3.0.4":
@@ -908,29 +908,29 @@
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-3.0.4.tgz#a7205638195de1d356fbd39a620fd2d93c11d792"
   integrity sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==
 
-"@firebase/firestore@4.17.0":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.17.0.tgz#5bc6c8ed1bbf9c30c91bb3df2ae143faede78d15"
-  integrity sha512-P9tof6pyO1bnLlMWbux+5O7WFJqlb7OTPMKxxOiXKYiQl7mxykAvxr1BFCgWeEXUU7DZxQncyJ040B0IhFVZCg==
+"@firebase/firestore@4.16.0":
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.16.0.tgz#502b35d7ed4cdc61d62a02311a67145192c804f6"
+  integrity sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     "@firebase/webchannel-wrapper" "1.0.6"
     "@grpc/grpc-js" "~1.9.0"
     "@grpc/proto-loader" "^0.7.8"
-    re2js "^2.8.3"
+    re2js "^0.4.2"
     tslib "^2.1.0"
 
-"@firebase/functions-compat@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.4.6.tgz#97a2c833d4a772694fa4a2c4e7358443bd98f4c2"
-  integrity sha512-dj9sOet+FIU91jeU4A3vGJoXHty7NqkSfjRLCwLgJXPDk1m72KFuxD3nlFgw/yXx/Fr7UjqzbxZ0LrIOdpx7+w==
+"@firebase/functions-compat@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.4.5.tgz#5e22c71c5b11c7d49177fd7b0ff62d8583567604"
+  integrity sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/functions" "0.13.6"
+    "@firebase/component" "0.7.3"
+    "@firebase/functions" "0.13.5"
     "@firebase/functions-types" "0.6.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/functions-types@0.6.4":
@@ -938,27 +938,27 @@
   resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.6.4.tgz#bb73ed93aa396419f907967202572ea55a605a40"
   integrity sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==
 
-"@firebase/functions@0.13.6":
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.13.6.tgz#72d19d9b7d5a4136505333cd731a5f5aa8bbb59f"
-  integrity sha512-9obLnzeQUivK5lmtGFOU2ucQ38BjTp+jpPtbfFp/mDsdVCvEpRqdWNvMMQ6aQwR4vcVc/utsvngm5BRkXbc7ZA==
+"@firebase/functions@0.13.5":
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.13.5.tgz#a4e099c072d7eac32b0f835438c45fa29a531e93"
+  integrity sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/messaging-interop-types" "0.2.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/installations-compat@0.2.23":
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/@firebase/installations-compat/-/installations-compat-0.2.23.tgz#4eeeb1c14c1bd193c802a1b0d161d1dfbf76ff5f"
-  integrity sha512-isaXmjb9roM83eVeXAe+ZRNKYNsSo2s0aNM+cy04AAGEyVL/d8Aa11GwEXovRFeYjl9+1yRAOxRDTOukZRwTxA==
+"@firebase/installations-compat@0.2.22":
+  version "0.2.22"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-compat/-/installations-compat-0.2.22.tgz#d8287cef67879b3d3e796fc7e81256e1b75c8c8a"
+  integrity sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/installations-types" "0.5.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/installations-types@0.5.4":
@@ -966,13 +966,13 @@
   resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.5.4.tgz#3b1e41ae7d1b89eb3b4a1c9cc583a12bed83aa27"
   integrity sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==
 
-"@firebase/installations@0.6.23":
-  version "0.6.23"
-  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.6.23.tgz#687c03a51e8d30936d7673f879c388e8ac3593c8"
-  integrity sha512-MBkbcQfd+3qHjW+slsH4s7jH5qTdGlYpwqmxEZ7QcIpgDxu1SKyU0f+mCZhCt1BCacLNiOWF5L0R06N0LtlfMg==
+"@firebase/installations@0.6.22":
+  version "0.6.22"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.6.22.tgz#f5e7d2f51e58d22f8fd5c44901e56e3555d58837"
+  integrity sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
@@ -983,14 +983,14 @@
   dependencies:
     tslib "^2.1.0"
 
-"@firebase/messaging-compat@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.28.tgz#f623183ca7ad1dddc50a1d4ab623b2bf937974bb"
-  integrity sha512-/AmMqHRnSQhPsdeED3ocs+s30/tpFvZDiiwIYY2uXFRvLujo1fnbPOeCFoe4Y+dRy1LCSjpvJf+dy5ZTsxi1yg==
+"@firebase/messaging-compat@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz#55a5d0754f54ecf9befac7c0574a2c8f6899b208"
+  integrity sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/messaging" "0.13.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/messaging" "0.13.0"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/messaging-interop-types@0.2.5":
@@ -998,28 +998,28 @@
   resolved "https://registry.yarnpkg.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz#078657f9be789bfaa31156a969630ecc4c0d5e16"
   integrity sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==
 
-"@firebase/messaging@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.13.1.tgz#32beaa0d6967067ea589fc72f18a6156321ec5d9"
-  integrity sha512-kL8fdjbNBI7hprlXJrUjktDWosrpT4JtfwXtVVevImPF/rBRAsC+LS/jIs+kgQVuotnvMhaBCgAFipBoY9YU9g==
+"@firebase/messaging@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.13.0.tgz#40b0c9a564759c963527c8aef9038c438397c3c7"
+  integrity sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/messaging-interop-types" "0.2.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
-"@firebase/performance-compat@0.2.26":
-  version "0.2.26"
-  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.2.26.tgz#559a397ee5d0d0d50268d257198c8d2094cd5906"
-  integrity sha512-jgoocXLN6ao26xWQ8pzosmzQ33uLzGBJQPNK0NTbVy1XvIHr5pfgBf9hWLOxsWe+R7sJq5bjD+8ybXprmt61mA==
+"@firebase/performance-compat@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.2.25.tgz#2c23654e67d974b0679b39a18a7672bf886d0bb5"
+  integrity sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/performance" "0.7.13"
+    "@firebase/performance" "0.7.12"
     "@firebase/performance-types" "0.2.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/performance-types@0.2.4":
@@ -1027,28 +1027,28 @@
   resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.2.4.tgz#9aa9e531f974f4b5e5a09bffff12406e0dc11e1f"
   integrity sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==
 
-"@firebase/performance@0.7.13":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.7.13.tgz#59cd61dd9edcb61b241e353118acfabd007a7030"
-  integrity sha512-1u6fuXP9cj0s+lkTFAspr/ttfPebPbEdpx+5Wdr4mPZbp8qH2KCMxOddEAR1ZMRa5GI0E7hDYSnolEmbqOFOAg==
+"@firebase/performance@0.7.12":
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.7.12.tgz#7d46c91f4942df365669dbb32492c100d069bad6"
+  integrity sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
     web-vitals "^4.2.4"
 
-"@firebase/remote-config-compat@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.28.tgz#4d26f630b2462b09ee1bf0c57f2d254bbd58da8d"
-  integrity sha512-kEO9Gn6fbmVj7eNUtZ6d59mLgUDUD0qo7aCicGOWNfuRWTaUv3CF9DMYychO61zaEQ3cfA+CEny4V1E8A1gRGA==
+"@firebase/remote-config-compat@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz#19d05eb72deaf6f7205021c896f290c9426c13f1"
+  integrity sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/remote-config" "0.9.1"
+    "@firebase/remote-config" "0.9.0"
     "@firebase/remote-config-types" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/remote-config-types@0.5.1":
@@ -1056,26 +1056,26 @@
   resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz#2bc52831f8b52aff2b1b434158b4f7803e05f86e"
   integrity sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==
 
-"@firebase/remote-config@0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.9.1.tgz#62cf8c305b8cd94f07fda5c8d531204b7175dab8"
-  integrity sha512-nzQUSJnk1zAZEl2Q5O3I7Z61cYLK5JI4H6wyyOiHkVZ+bmgy1YXNNMptNbVjixMQ/eCzgA6nZRaC+1eBcJGUFA==
+"@firebase/remote-config@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.9.0.tgz#f3d2b1a86c56a6f9da17602e8f4f347b4edee297"
+  integrity sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/storage-compat@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.4.4.tgz#7ddc6769047fbc276cbf08ddd1fc24f533c391a1"
-  integrity sha512-qSRgCB9f2R/nCp8t/8OC101cIFBFeUazlRInOMdzbnLzvrQBzEfx19SrR4pvdj/0+M+P/y8AK/a2s+3EB+B1Pw==
+"@firebase/storage-compat@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.4.3.tgz#85a01de8fbd0ef4cad261d39beea5e6391e5a051"
+  integrity sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/storage" "0.14.4"
+    "@firebase/component" "0.7.3"
+    "@firebase/storage" "0.14.3"
     "@firebase/storage-types" "0.8.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/storage-types@0.8.4":
@@ -1083,19 +1083,19 @@
   resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.8.4.tgz#88d72c80eb9a1167da33e8c551fd3b703c2422ec"
   integrity sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==
 
-"@firebase/storage@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.14.4.tgz#110afe6d6256e2b339d690e36578abcc12ccc8ce"
-  integrity sha512-jfzEWZb3Fpsq3FwAB2ifoc8mcSh935qXdDou3TpyjDWa45hhNcZUv8/w28/10njByhfK7snbakKN30nwnzQ3/w==
+"@firebase/storage@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.14.3.tgz#df93f895ff6f296e9305933cfe6c387d19fa4f93"
+  integrity sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/util@1.15.2":
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.15.2.tgz#0650ace6fa8b98c772910e9fe50e20e61f4093f4"
-  integrity sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==
+"@firebase/util@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.15.1.tgz#7efaf8903f50b601c06afbaffbeb48ed2ba7aab8"
+  integrity sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==
   dependencies:
     tslib "^2.1.0"
 
@@ -5013,39 +5013,39 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-firebase@^12.17.1:
-  version "12.17.1"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-12.17.1.tgz#4d500cbd342b37de2275ef09d16a2e679e9ec03c"
-  integrity sha512-dhp41ye9jMQvhx5FwjMkf/hjDHJApl7gXmvzOZGvP0M7c/GZGUnQ4qvsvlOBkF0Pa7wAwHMdcpL0ON2pXCQ4Sw==
+firebase@12.16.0:
+  version "12.16.0"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-12.16.0.tgz#d94f3827626314e310c434c55a50542495b6151f"
+  integrity sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==
   dependencies:
-    "@firebase/ai" "2.14.0"
-    "@firebase/analytics" "0.10.23"
-    "@firebase/analytics-compat" "0.2.29"
-    "@firebase/app" "0.16.0"
-    "@firebase/app-check" "0.13.0"
-    "@firebase/app-check-compat" "0.4.6"
-    "@firebase/app-compat" "0.5.16"
+    "@firebase/ai" "2.13.1"
+    "@firebase/analytics" "0.10.22"
+    "@firebase/analytics-compat" "0.2.28"
+    "@firebase/app" "0.15.1"
+    "@firebase/app-check" "0.12.0"
+    "@firebase/app-check-compat" "0.4.5"
+    "@firebase/app-compat" "0.5.15"
     "@firebase/app-types" "0.9.5"
-    "@firebase/auth" "1.13.4"
-    "@firebase/auth-compat" "0.6.9"
-    "@firebase/data-connect" "0.7.3"
-    "@firebase/database" "1.1.4"
-    "@firebase/database-compat" "2.1.6"
-    "@firebase/firestore" "4.17.0"
-    "@firebase/firestore-compat" "0.4.12"
-    "@firebase/functions" "0.13.6"
-    "@firebase/functions-compat" "0.4.6"
-    "@firebase/installations" "0.6.23"
-    "@firebase/installations-compat" "0.2.23"
-    "@firebase/messaging" "0.13.1"
-    "@firebase/messaging-compat" "0.2.28"
-    "@firebase/performance" "0.7.13"
-    "@firebase/performance-compat" "0.2.26"
-    "@firebase/remote-config" "0.9.1"
-    "@firebase/remote-config-compat" "0.2.28"
-    "@firebase/storage" "0.14.4"
-    "@firebase/storage-compat" "0.4.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/auth" "1.13.3"
+    "@firebase/auth-compat" "0.6.8"
+    "@firebase/data-connect" "0.7.1"
+    "@firebase/database" "1.1.3"
+    "@firebase/database-compat" "2.1.4"
+    "@firebase/firestore" "4.16.0"
+    "@firebase/firestore-compat" "0.4.11"
+    "@firebase/functions" "0.13.5"
+    "@firebase/functions-compat" "0.4.5"
+    "@firebase/installations" "0.6.22"
+    "@firebase/installations-compat" "0.2.22"
+    "@firebase/messaging" "0.13.0"
+    "@firebase/messaging-compat" "0.2.27"
+    "@firebase/performance" "0.7.12"
+    "@firebase/performance-compat" "0.2.25"
+    "@firebase/remote-config" "0.9.0"
+    "@firebase/remote-config-compat" "0.2.27"
+    "@firebase/storage" "0.14.3"
+    "@firebase/storage-compat" "0.4.3"
+    "@firebase/util" "1.15.1"
 
 flat-cache@^4.0.0:
   version "4.0.1"
@@ -6891,10 +6891,10 @@ raw-body@^3.0.0, raw-body@^3.0.2:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
-re2js@^2.8.3:
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/re2js/-/re2js-2.8.6.tgz#acbd17a1ad0e98c1f2ee0a2adc17ba0903d9ca95"
-  integrity sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==
+re2js@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.4.3.tgz#1318cd0c12aa6ed3ba56d5e012311ffbfb2aef35"
+  integrity sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==
 
 readable-stream@>=4.0.0, readable-stream@^4.0.0:
   version "4.7.0"


### PR DESCRIPTION
## Summary

参照実装の mulmoclaude では **#2912 でピン留め済み**だった `@firebase/auth` のリグレッション回避が、**こちらに伝播していませんでした**。

| | firebase | `@firebase/auth` |
| --- | --- | --- |
| mulmoclaude main | `12.16.0`（キャレット無し） | 1.13.3 |
| **mulmoterminal main（この PR 前）** | **`^12.17.1`** | **1.13.4 — 回帰版** |

両者は同じ形で `signInWithPopup` を呼んでいます（`RemoteHostControl.vue:141` ↔ `useRemoteHost.ts:151`）。CLAUDE.md の「MulmoClaude is the reference host」に該当する状況です。

## 何が壊れるか

1.13.4 が `IndexedDBLocalPersistence` に `visibilitychange` リスナを足し、`document.visibilityState === 'hidden'` をページ teardown と同じ扱いにしました。サインインのポップアップが元ウィンドウを背面に回した状態で認証情報を永続化しようとすると `_openDb()` が throw します。

```
signInWithPopup → PopupOperation → _signIn → _signInWithCredential
  → auth._updateCurrentUser → directlySetCurrentUser
  → assertedPersistence.setCurrentUser → IndexedDBLocalPersistence._set
  → _withRetries → _openDb → throw new Error('Database is closing/hidden')
```

`_withRetries()` は `isHiding` のときリトライせず rethrow するので回復経路がありません。**読み取り（`_poll()`）は `isHiding` を見て `[]` を返して握りつぶすのに、書き込みだけ例外を上げる**という非対称が芯です。

上流 [firebase-js-sdk#10264](https://github.com/firebase/firebase-js-sdk/issues/10264)。修正 [#10300](https://github.com/firebase/firebase-js-sdk/pull/10300) は 2026-08-13 マージ済みですが **npm に出ていない**ので、上げても直りません。

## Items to Confirm / Review

1. **キャレットを付けていません。** `^12.16.0` だと 12.17.x に浮いて 1.13.4 に戻ります。12.16.0 は `@firebase/auth` 1.13.3 を同梱する最新の 12.x です。
2. **`firebase` は `dependencies`** にあり、ブラウザ束（`src/config/firebase.ts`）と server 実行時（`server/backends/remoteHost/*` が `firebase/firestore` / `firebase/storage` を import）の両方で使われるので、**npm 利用者にもそのまま届きます**。mulmoclaude は monorepo で 2 箇所必要でしたが、こちらは `package.json` 1 つだけです。
3. **#1661 とは別問題として扱っています。** あちらの `auth/popup-blocked` は `window.open()` が null を返した時点のエラー（`_assert(newWin, auth, "popup-blocked")`）で、永続化まで到達していません。ただし #1661 の「`signInWithIdp` 200 だが `firebaseLocalStorageDb` が空」は**このリグレッションの症状そのもの**なので、マージ後に報告者へ再確認したいです。
4. **戻すときは mulmoclaude と揃えてください。** 片方だけ動かすと、また今回のような伝播漏れになります。plans にもそう書きました。

## User Prompt

- mulmoterminal #1661 と mulmoclaude #2912 は同じ問題か（→ 別問題だが、こちらに回帰版が残っていた）。
- じゃあピン留めしよう。

## 検証

**依存を動かす変更なので、warm な `node_modules` では確かめていません**（そこは「ローカル緑・CI 赤」の温床なので）。

1. `rm -rf node_modules && yarn install --frozen-lockfile` → 成功。解決結果 **firebase 12.16.0 / `@firebase/auth` 1.13.3**
2. lint / typecheck / build / test すべて緑（**710 files, 10217 tests**）
3. lockfile 差分 224 行のうち、`@firebase` 系以外で動いたのは **`re2js` 1 件だけ**。削除ではなく `@firebase/firestore` 12.16.0 の要求範囲に合わせた `^2.8.3` → `^0.4.2`（0.4.3 が入る）
4. **出荷される束から回帰コードが消えたことを直接確認しました**

   | マーカー | `dist/assets/*.js` |
   | --- | --- |
   | `Database is closing/hidden` | **0** |
   | `isHiding` | **0** |
   | `signInWithPopup` / `popup-blocked` | 1（firebase auth 自体は入っている） |

   ビルドが通ること自体も検証の一部で、`firebase/app` `firebase/auth` `firebase/firestore` `firebase/storage` の subpath export がバージョン間で変わっていないことを示しています。

Closes #1731

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned Firebase to version 12.16.0 to prevent authentication persistence regressions.

* **Documentation**
  * Added documentation describing the Firebase regression, validation steps, and criteria for future version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->