### PR TITLE
test(windows): 実 PTY の spec に 60 秒の timeout を与える (#1740)

### DIFF
--- a/test/server/session/shell-spawn-win.spec.ts
+++ b/test/server/session/shell-spawn-win.spec.ts
@@ -40,7 +40,23 @@ const runShell = (command: string, cwd: string, replaceShell = false) => run(she
 /** The path a Shell cell actually takes: a LaunchTarget, resolved the way spawnLauncherPty does. */
 const runTarget = (target: LaunchTarget, cwd: string) => run(launchInvocation(target, "win32", undefined), cwd);
 
-describe.skipIf(!isWindows)("a shell terminal on Windows", () => {
+// Every test here starts a REAL PowerShell through a real PTY, which is not what the default
+// 15s `testTimeout` was sized for — that number is for unit tests. The first spawn in the process
+// is the expensive one (PowerShell loading .NET), and on the PR gate it is slower still because
+// that workflow deliberately does NOT disable Defender: `pull_request` runs code the PR supplied,
+// so turning the runner's protection off ahead of it is a trade this repo refused (#1723).
+//
+// Measured on the same spec, same command, same runner image:
+//
+//   Windows (daily), Defender off   2956ms
+//   Windows (PR),    Defender on    4272 / 4773 / 4896ms  — then 15007ms and a failure
+//
+// So the PR gate ran at 1.5-1.7x with less than half the headroom, and load finished the job
+// (#1740). The timeout is raised HERE rather than globally: 15s is right for the other 700 spec
+// files, and raising it for all of them would hide a real slowdown in any of them.
+const PTY_TIMEOUT_MS = 60_000;
+
+describe.skipIf(!isWindows)("a shell terminal on Windows", { timeout: PTY_TIMEOUT_MS }, () => {
   let dir = "";
   beforeAll(() => {
     dir = mkdtempSync(path.join(tmpdir(), "mt-shell-"));
@@ -136,7 +152,7 @@ describe.skipIf(!isWindows)("a shell terminal on Windows", () => {
 // The shell under test is one we WRITE, not one the runner image happens to ship: a `.cmd` inside
 // a directory whose name contains a space. That makes the repro deterministic, and it exits on its
 // own — pointing this at a real interactive shell would just hang the pty.
-describe.skipIf(!isWindows)("a shell path containing a space", () => {
+describe.skipIf(!isWindows)("a shell path containing a space", { timeout: PTY_TIMEOUT_MS }, () => {
   const TOKEN = "MTOK-spaced-shell";
   let root = "";
   let shellPath = "";


### PR DESCRIPTION
## Summary

`Windows (PR)` ゲートで `shell-spawn-win.spec.ts` の最初のテストが **15007ms でタイムアウト**しました。この spec は**実 PTY で PowerShell を起動**するので、既定の `testTimeout: 15_000` が想定しているユニットテストとは性質が違います。

### 原因は環境差で、実測値がそろっています

| workflow | Defender 無効化 | `runs a command` の所要 |
| --- | --- | --- |
| **Windows (daily)** | **あり** | **2956ms** |
| Windows (PR) | **なし** | 4272 / 4773 / 4896ms |
| Windows (PR)（失敗時） | なし | **15007ms** |

**PR ゲートは恒常的に 1.5〜1.7 倍遅く、15 秒に対する余裕が半分以下**でした。そこに負荷が乗って越えています。

差の理由は **#1723 で PR ゲートから Defender 無効化を意図的に外した**ことです。Codex のセキュリティ指摘によるもので、**その判断は正しいままで、この PR は覆しません**:

> `pull_request` は PR が持ち込んだコードを実行する。public リポジトリなので誰でも PR を開ける。ランナーの保護を先に切ってからそのコードを走らせるのは、install が時々コケることと引き換えにするには大きすぎる。

最初の 1 本だけ飛び抜けて重いのは PowerShell の初回起動（.NET のロード）で、それが Defender のリアルタイムスキャンを受けるためと考えられます。

## Items to Confirm / Review

1. **グローバルの `testTimeout` は上げていません。** 15 秒は他の 700 spec ファイルにとって正しい値で、全体を上げると**どれかの本当の遅さを隠す**ことになります。この spec だけが遅いのには理由がある（実プロセス起動）ので、そこに理由付きで長い時間を与えました。
2. **60 秒の根拠**は「観測された最悪 4896ms の 12 倍」です。実 PTY のテストが 60 秒かかるなら、それは遅さではなく別の不具合なので、そこで落ちてよいと考えました。
3. **`describe` の `timeout` オプションが本当に効くかを実測しました。** このリポジトリの設定下で 16 秒待つ捨て spec を一時的に置き、既定 15 秒を超えて pass することを確認しています（推測で出していません）。
4. **`decision-scan-fold.spec.ts` は直していません。** 同じ run の 2 回目で落ちましたが 1318ms なのでタイムアウトではなく、別件です。この PR の後に残るか確認が要ります（#1740 に記載）。

## User Prompt

- （`/gh-review-loop` を #1736 に対して実行中、CI 失敗の追跡として）

## 検証

- `yarn lint` / `yarn typecheck` / `yarn test` すべて緑（713 files, 10249 tests）
- **`describe` の `timeout` オプションの実効性を実測**（既定 15 秒 → 16 秒待って pass）
- **この spec 自体は macOS では skip される**ので、効果の確認は Windows CI が唯一の ground truth です。この PR の `Windows (PR)` ジョブがそれになります

Closes #1740

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for Windows terminal session tests to 60 seconds.
  * Applied the extended timeout to tests involving PowerShell startup and shell sessions launched through PTYs, improving reliability on slower systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->