### PR TITLE
fix(shared-app): headless preview が全ページを「応答なし」と報告していた

### DIFF
--- a/server/backends/sharedApp/headlessPreview.ts
+++ b/server/backends/sharedApp/headlessPreview.ts
@@ -334,6 +334,18 @@ interface Driver {
   stalled: () => boolean;
 }
 
+/** The deadline expiring, told apart from every answer a script can give.
+ *
+ *  It was `undefined`, and `undefined` is what a perfectly healthy script returns: `FILL_INPUTS`
+ *  is an IIFE with no `return` and `decline()` answers nothing, and both run on every page, on
+ *  every mount. So EVERY page was reported unresponsive — and that verdict is the first line of
+ *  the report, saying the page never got going and that nothing below it describes its behaviour,
+ *  directly above an accurate account of the page drawing and its button reaching the parent. A
+ *  false red costs more than the missing flag would: the author is told to go fix a page that
+ *  works, and the one real thing this flag catches — a script that keeps the frame's thread — is
+ *  now indistinguishable from every other run. */
+const TIMED_OUT = Symbol("the deadline expired");
+
 /** Wait for `work`, but not for ever.
  *
  *  Everything crossing into the browser is a question put to code the author wrote, and an author's
@@ -341,10 +353,10 @@ interface Driver {
  *  fires and an `evaluate` on it never settles. Unbounded, that is not a slow preview — it is a
  *  tool call that never answers, holding the per-repository lock behind it. On the deadline the
  *  answer is `undefined`, which every reader here already treats as "nothing observed". */
-async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T | undefined> {
+async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T | typeof TIMED_OUT> {
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<undefined>((resolve) => {
-    timer = setTimeout(() => resolve(undefined), ms);
+  const deadline = new Promise<typeof TIMED_OUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMED_OUT), ms);
   });
   try {
     return await Promise.race([work, deadline]);
@@ -394,11 +406,17 @@ async function openDriver(browser: Browser, origin: string): Promise<Driver> {
    *  declares no DOM (`types: ["node"]`), so a closure mentioning `window` would not compile. */
   let stalled = false;
   const evaluate = async (script: string, target?: Frame): Promise<unknown> => {
+    // A script that THREW is not a page that stopped answering: it answered, with a failure, and
+    // every reader here already treats `undefined` as "nothing observed". Only the deadline moves
+    // this flag.
     const answered = await withDeadline(
       (target ?? page).evaluate(script).catch(() => undefined),
       LIMITS.evaluateMs,
     );
-    if (answered === undefined) stalled = true;
+    if (answered === TIMED_OUT) {
+      stalled = true;
+      return undefined;
+    }
     return answered;
   };
   return {

--- a/server/backends/sharedApp/headlessPreview.ts
+++ b/server/backends/sharedApp/headlessPreview.ts
@@ -406,13 +406,21 @@ async function openDriver(browser: Browser, origin: string): Promise<Driver> {
    *  declares no DOM (`types: ["node"]`), so a closure mentioning `window` would not compile. */
   let stalled = false;
   const evaluate = async (script: string, target?: Frame): Promise<unknown> => {
-    // A script that THREW is not a page that stopped answering: it answered, with a failure, and
-    // every reader here already treats `undefined` as "nothing observed". Only the deadline moves
-    // this flag.
-    const answered = await withDeadline(
-      (target ?? page).evaluate(script).catch(() => undefined),
-      LIMITS.evaluateMs,
-    );
+    // A rejection is NOT a page that stopped answering, and it is not nothing either. It is a
+    // question that could not be put: a getter of the page's own that throws, or a frame that
+    // navigated itself out from under the handle we were holding. Every reader here treats
+    // `undefined` as "nothing observed", so left alone it becomes a page with no controls and no
+    // text — reported as calmly as an empty page, which is the shape of a false green.
+    //
+    // So it goes where the browser's own complaints already go, and travels the path they travel:
+    // per mount into `errors`, per press into that press's `errors`. Said as OUR question failing,
+    // because the reader of that list is the author and the list is otherwise their page's words.
+    const asked = (target ?? page).evaluate(script).catch((err: unknown) => {
+      noise.push(`the preview could not put a question to this page: ${messageOf(err)}`);
+      return undefined;
+    });
+    // Only the deadline moves this flag.
+    const answered = await withDeadline(asked, LIMITS.evaluateMs);
     if (answered === TIMED_OUT) {
       stalled = true;
       return undefined;

--- a/test/server/backends/headlessPreview.spec.ts
+++ b/test/server/backends/headlessPreview.spec.ts
@@ -154,6 +154,25 @@ const REVEALS = `
   });
 </script>`;
 
+/** A page that breaks the QUESTIONS this run puts to it, rather than breaking itself.
+ *
+ *  A getter of the page's own that throws is the reachable version of it; a frame that navigates
+ *  itself out from under the handle is the other, and neither can be arranged deterministically
+ *  except this way. Both make `evaluate` REJECT, and a rejection that is swallowed leaves a page
+ *  with a button in it reported as a page with no text and no controls — as calmly as an empty
+ *  page. */
+const POISONED = `
+<button type="button" id="go">Order</button>
+<script>
+  Object.defineProperty(HTMLElement.prototype, "innerText", {
+    get() {
+      throw new Error("innerText is poisoned");
+    },
+  });
+  window.__MC_APP_VIEW.onState(() => {});
+  window.__MC_APP_VIEW.ready();
+</script>`;
+
 const page = (id: string, html: string): HeadlessPageInput => ({ id, audience: "public", html, datasets, submit });
 
 describe.skipIf(!chromeReady)("a headless run, in a real browser", () => {
@@ -248,6 +267,26 @@ describe.skipIf(!chromeReady)("a headless run, in a real browser", () => {
     expect(unreachable?.presses[1]?.notClickable).toBe(true); // display:none — no box to aim at
     expect(unreachable?.presses[1]?.submitted).toBeNull();
   });
+});
+
+describe.skipIf(!chromeReady)("a document that breaks the questions put to it", () => {
+  // Its own run rather than a seventh page in the shared one: `LIMITS.pages` is 6, and a seventh
+  // is dropped — reported, but dropped, so the assertions below would have read `undefined`.
+  it("says a question could not be put, rather than reporting an empty page", async () => {
+    const run = await runPagesHeadless([page("poisoned", POISONED)]);
+    expect(run.ok).toBe(true);
+    if (!run.ok) return;
+    const poisoned = run.pages[0];
+    // The page is fine — it drew, and it answered the handshake. What it broke is our question,
+    // and `evaluate` rejects: the survey then finds no control and the screen reads as empty.
+    // Every one of those is an ordinary, calm-looking value, which is why the rejection has to be
+    // said out loud instead.
+    expect(poisoned?.readied).toBe(true);
+    expect(poisoned?.errors.some((line) => line.includes("could not put a question"))).toBe(true);
+    // And it is not called unresponsive: the page answered everything it could, and the flag above
+    // it says something else.
+    expect(poisoned?.unresponsive).toBe(false);
+  }, 240_000);
 });
 
 describe.skipIf(!chromeReady)("a document that stops answering", () => {

--- a/test/server/backends/headlessPreview.spec.ts
+++ b/test/server/backends/headlessPreview.spec.ts
@@ -182,6 +182,11 @@ describe.skipIf(!chromeReady)("a headless run, in a real browser", () => {
     const works = pages[0];
     expect(works?.readied).toBe(true);
     expect(works?.stateDelivered).toBe(true);
+    // AND it was not called unresponsive. The flag is what the report leads with, and it says
+    // nothing below it describes the page — so a flag stuck on true does not add a wrong line, it
+    // disowns every right one. It was stuck on true: the deadline answered `undefined`, which is
+    // also what a healthy `FILL_INPUTS` and a healthy `decline()` return, on every page.
+    expect(works?.unresponsive).toBe(false);
     expect(works?.text).toContain("Curry, Ramen");
     expect(works?.liveForms).toBe(0);
     // The press reached the parent as a submission for the declared collection — and was declined,
@@ -195,6 +200,9 @@ describe.skipIf(!chromeReady)("a headless run, in a real browser", () => {
     const shipped = pages[1];
     expect(shipped?.readied).toBe(false);
     expect(shipped?.stateDelivered).toBe(false);
+    // Deadlocked is not unresponsive. This page answers everything put to it; what it never does
+    // is send `ready`, and the report has a different sentence for that.
+    expect(shipped?.unresponsive).toBe(false);
     expect(shipped?.text).toContain("loading");
     // And the Submit button does nothing at all: the browser blocks the submission BEFORE the
     // `submit` event fires, so the handler that would have called `view.submit` never runs.


### PR DESCRIPTION
## 何が起きていたか

`manageSharedApp` の `action: "preview"` が、**どのページに対しても**こう報告していた:

> It STOPPED ANSWERING — it never finished loading, or a question put to it ran out of time. (...) Nothing below is a report about the page's behaviour; it is a report about a page that never got going.

そしてその直後に、ページが描画され、ボタンが親に届き、送信が正しく宣言どおりに組み立てられていた、という**正確な記録**が続く。

これは行が 1 本間違っているのではない。1 行目が以下の全部を無効だと宣言するので、**正しい観測が全部捨てられる**。実地のテストでは、エージェントがこの行を 2 回出されたうえで無視し、deploy と publish に進んだ。診断が信用されなくなるのはこの一撃で、偽の緑と同じだけ悪い。

## 原因

`headlessPreview.ts` の `evaluate` が、期限切れと「スクリプトが `undefined` を返した」を同じ `undefined` で受けていた:

```ts
const answered = await withDeadline(...evaluate(script).catch(() => undefined), LIMITS.evaluateMs);
if (answered === undefined) stalled = true;
```

`FILL_INPUTS` は `return` の無い IIFE、`decline()` は何も返さない。どちらも**全ページ・全マウントで走る**ので、`stalled` は常に立つ。タイミングの問題ではなく、常に true だった。

再現: 実アプリの公開ページをそのまま `runPagesHeadless` に渡すと、2.5 秒・タイムアウト 0 で `unresponsive: true` になる。

## 直しかた

期限切れだけを表す `TIMED_OUT` シンボルを `withDeadline` から返し、それだけで `stalled` を立てる。throw したスクリプトは「応答なし」ではない — 答えている、失敗として — ので、これも立てない（読み手はいずれにせよ `undefined` を「観測なし」として扱う）。

この旗が本当に捕まえるもの（フレームのスレッドを離さないスクリプト）は変わらず捕まる。

## テスト側の穴

ブラウザを起動する契約テストは、無限ループのページが `unresponsive === true` であることしか見ていなかった。**正常なページが false であること**を誰も見ていないので、常時 true が素通りする。

- `works` — 描画も送信も成功するページ
- `shipped` — `ready()` が `onState` の中にあるデッドロック。**応答はする**ので false であるべきで、これが「応答なし」と「握手しなかった」が別の文であることを固定する

## 検証

- `vue-tsc -b` / `yarn lint` / `yarn vitest run test/server/backends/headlessPreview.spec.ts test/server/backends/headlessReport.spec.ts` = 23 passed, 1 skipped
- 実アプリの公開ページ（ラジオ約 50 個）で `unresponsive: false`、送信は従来どおり親に到達

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview page status handling to distinguish actual timeouts from scripts that fail or return no result.
  * Prevented healthy preview pages from being incorrectly marked as unresponsive.
  * Ensured genuinely stalled pages continue to be identified correctly.

* **Tests**
  * Added coverage for healthy and stalled preview page scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->