### PR TITLE
chore(deps): collection-plugin を 4.2.0 に上げ、刻まれた日時をペインで編集させない

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^2.2.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
-    "@mulmoclaude/collection-plugin": "^3.1.0",
+    "@mulmoclaude/collection-plugin": "^4.2.0",
     "@mulmoclaude/core": "4.2.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",

--- a/test/scripts/mulmoclaudePeerRanges.spec.ts
+++ b/test/scripts/mulmoclaudePeerRanges.spec.ts
@@ -1,40 +1,42 @@
-// The `@mulmoclaude/*` plugins declare which `@mulmoclaude/core` they were built
-// against, and MulmoTerminal pins ONE core for all of them. Nothing enforces the
-// two agree: a peer range is a declaration, and yarn only warns.
+// Which `@mulmoclaude/core` each bundled plugin actually runs against.
 //
-// It matters because the failure is silent and late. A plugin built against an
-// older core keeps importing whatever it imported; what breaks is the symbol core
-// moved or re-typed, and that shows up as an empty control or an unformatted value
-// in the pane, not as an install error. The stamped-`datetime` lock is the live
-// example: it needs `isCanonicalServerTime`, which exists only from core 4.2.0, so
-// collection-plugin 4.2.0 declares `^4.2.0` and holding the plugin a major behind
-// left the pane rendering that field as an empty `datetime-local`.
+// It is not one answer. `collection-plugin` declares core as a PEER only, so it runs on the core
+// MulmoTerminal installs — one core, ours. Every other plugin declares it as a DEPENDENCY, so yarn
+// nests a copy under the plugin and that copy is what it imports; six of them sit at 3.x while the
+// top level is 4.2.0, and none of that is a mismatch.
 //
-// So this reads what is actually INSTALLED rather than what package.json asks for
-// — a range resolves to one version and that version is the one that runs.
+// The distinction is the whole point, because only the first kind can be broken from HERE. A peer
+// range is a declaration and yarn only warns, so a host that pins a core older than the plugin
+// expects installs cleanly and fails late: the plugin keeps importing what it imported, and what
+// breaks is the symbol core moved or re-typed — an empty control or an unformatted value in the
+// pane, not an install error. The stamped-`datetime` lock is the live example. It needs
+// `isCanonicalServerTime`, which exists only from core 4.2.0, so collection-plugin 4.2.0 declares
+// `^4.2.0`; holding the plugin a major behind left the pane drawing that field as an empty
+// `datetime-local`, and saving it wrote over a value the rules refuse to see move.
+//
+// So this reads what is INSTALLED rather than what package.json asks for: a range resolves to one
+// version, and that version is the one that runs.
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-// Read from `node_modules` by path rather than by resolution: these packages ship
-// an `exports` map with no `./package.json` entry, so `require.resolve` cannot
-// reach the very file that says what they are.
 const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 interface Manifest {
   version: string;
+  dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 }
 
-const manifestOf = (pkg: string): Manifest => JSON.parse(readFileSync(join(root, "node_modules", pkg, "package.json"), "utf8")) as Manifest;
+// Read by path rather than by resolution: these packages ship an `exports` map with no
+// `./package.json` entry, so `require.resolve` cannot reach the very file that says what they are.
+const manifestAt = (dir: string): Manifest => JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as Manifest;
 
-const versionOf = (pkg: string): string => manifestOf(pkg).version;
+const pluginDir = (pkg: string): string => join(root, "node_modules", pkg);
 
-const corePeerOf = (pkg: string): string | undefined => manifestOf(pkg).peerDependencies?.["@mulmoclaude/core"];
-
-/** Every bundled plugin, whether or not it declares a core peer today. Listed
- *  rather than discovered, so a plugin that STOPS declaring one is still read. */
+/** Every bundled plugin, listed rather than discovered: a plugin that stops declaring core, or
+ *  stops nesting its own, must still be READ — a discovered list would simply not find it. */
 const PLUGINS = [
   "@mulmoclaude/accounting-plugin",
   "@mulmoclaude/chart-plugin",
@@ -47,22 +49,34 @@ const PLUGINS = [
   "@mulmoclaude/x-plugin",
 ] as const;
 
-/** Plugins whose declared core floor is BEHIND the core we run, kept here on
- *  purpose rather than fixed by holding core back.
+/** Plugins that name no core at all, in either list.
  *
- *  Both were built against core 3 and were not republished when core went to 4 —
- *  core 4.0.0's break was moving the shared-app compiler out to
- *  `@receptron/sharedapp`, which neither of them touches. The entry is what says
- *  someone checked: an unexplained mismatch and a checked one look identical from
- *  the manifest. Remove an entry when its plugin's own major lands here. */
-const KNOWN_BEHIND: Record<string, string> = {
-  "@mulmoclaude/html-plugin": "3.0.0 declares core ^3.0.0; MulmoClaude ships 4.0.0 against core 4",
-  "@mulmoclaude/markdown-plugin": "3.0.0 declares core ^3.0.0; MulmoClaude ships 4.0.0 against core 4",
+ *  Recorded rather than skipped, because "declares nothing" and "is not checked" look identical
+ *  from a predicate that filters. An entry here says someone looked and the plugin genuinely does
+ *  not use core; a plugin that DROPS its declaration therefore fails until it is either fixed or
+ *  added here on purpose. */
+const NO_CORE: Record<string, string> = {
+  "@mulmoclaude/form-plugin": "the form card is self-contained; it names core in neither list",
+  "@mulmoclaude/x-plugin": "no peer dependencies at all",
 };
 
-/** `^X.Y.Z` against a concrete version. Written out rather than pulled from
- *  `semver`, which this repo does not declare — and every range here is a caret,
- *  so the whole of semver would be answering one question. */
+/** The core a plugin actually imports: its own nested copy when it has one, otherwise ours. */
+function resolvedCoreFor(pkg: string): { version: string; nested: boolean } | null {
+  const nested = join(pluginDir(pkg), "node_modules", "@mulmoclaude", "core");
+  if (existsSync(nested)) return { version: manifestAt(nested).version, nested: true };
+  const top = join(root, "node_modules", "@mulmoclaude", "core");
+  if (!existsSync(top)) return null;
+  return { version: manifestAt(top).version, nested: false };
+}
+
+const declaredCoreOf = (pkg: string): string | undefined => {
+  const manifest = manifestAt(pluginDir(pkg));
+  return manifest.dependencies?.["@mulmoclaude/core"] ?? manifest.peerDependencies?.["@mulmoclaude/core"];
+};
+
+/** `^X.Y.Z` against a concrete version. Written out rather than pulled from `semver`, which this
+ *  repo does not declare — and every range in play is a caret, so the whole of semver would be
+ *  answering one question. Anything else is refused rather than guessed at. */
 function satisfiesCaret(version: string, range: string): boolean {
   const wanted = /^\^(\d+)\.(\d+)\.(\d+)$/u.exec(range);
   if (wanted === null) return false;
@@ -75,23 +89,35 @@ function satisfiesCaret(version: string, range: string): boolean {
   return gPatch >= wPatch;
 }
 
-describe("bundled @mulmoclaude plugins against the core we install", () => {
-  it("accepts the installed core, or says why it does not", () => {
-    const core = versionOf("@mulmoclaude/core");
-    const behind = PLUGINS.filter((pkg) => {
-      const peer = corePeerOf(pkg);
-      return peer !== undefined && !satisfiesCaret(core, peer);
-    });
-    // Both directions on purpose. A NEW mismatch has to be looked at; a recorded
-    // one that has been fixed has to lose its entry, or the list stops meaning
-    // "someone checked these" and becomes a list of things that used to be true.
-    expect([...behind].sort()).toEqual(Object.keys(KNOWN_BEHIND).sort());
+describe("the core each bundled plugin runs against", () => {
+  it("every plugin either names a core or is recorded as naming none", () => {
+    const silent = PLUGINS.filter((pkg) => declaredCoreOf(pkg) === undefined);
+    // Both directions: a plugin that newly drops its declaration has to be looked at, and a
+    // recorded one that starts declaring again has to lose its entry.
+    expect([...silent].sort()).toEqual(Object.keys(NO_CORE).sort());
   });
 
-  it("collection-plugin is new enough to carry the server-stamped datetime lock", () => {
-    // The version, not the behaviour: the behaviour is the package's own test.
-    // What this pins is that MulmoTerminal is not holding it behind that fix.
-    const [major, minor] = versionOf("@mulmoclaude/collection-plugin").split(".").map(Number);
+  it("resolves a core that satisfies what it declares", () => {
+    for (const pkg of PLUGINS) {
+      const declared = declaredCoreOf(pkg);
+      if (declared === undefined) continue; // covered by the test above
+      const resolved = resolvedCoreFor(pkg);
+      expect(resolved, `${pkg} declares core ${declared} and resolves none`).not.toBeNull();
+      expect(satisfiesCaret(resolved?.version ?? "", declared), `${pkg} declares core ${declared} but runs ${resolved?.version}`).toBe(true);
+    }
+  });
+
+  it("collection-plugin is the one running on OUR core, and is new enough for the stamped datetime", () => {
+    // Not a general fact — it is what makes this package the one MulmoTerminal can break by
+    // pinning core. If it ever nests its own copy, the coupling is gone and this file's whole
+    // premise needs rereading.
+    const resolved = resolvedCoreFor("@mulmoclaude/collection-plugin");
+    expect(resolved?.nested).toBe(false);
+    expect(satisfiesCaret(resolved?.version ?? "", "^4.2.0")).toBe(true);
+
+    // The version, not the behaviour: the behaviour is the package's own test. What this pins is
+    // that MulmoTerminal is not holding it behind that fix.
+    const [major, minor] = manifestAt(pluginDir("@mulmoclaude/collection-plugin")).version.split(".").map(Number);
     expect(major > 4 || (major === 4 && minor >= 2)).toBe(true);
   });
 

--- a/test/scripts/mulmoclaudePeerRanges.spec.ts
+++ b/test/scripts/mulmoclaudePeerRanges.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Which `@mulmoclaude/core` each bundled plugin actually runs against.
 //
 // It is not one answer. `collection-plugin` declares core as a PEER only, so it runs on the core

--- a/test/scripts/mulmoclaudePeerRanges.spec.ts
+++ b/test/scripts/mulmoclaudePeerRanges.spec.ts
@@ -1,0 +1,107 @@
+// The `@mulmoclaude/*` plugins declare which `@mulmoclaude/core` they were built
+// against, and MulmoTerminal pins ONE core for all of them. Nothing enforces the
+// two agree: a peer range is a declaration, and yarn only warns.
+//
+// It matters because the failure is silent and late. A plugin built against an
+// older core keeps importing whatever it imported; what breaks is the symbol core
+// moved or re-typed, and that shows up as an empty control or an unformatted value
+// in the pane, not as an install error. The stamped-`datetime` lock is the live
+// example: it needs `isCanonicalServerTime`, which exists only from core 4.2.0, so
+// collection-plugin 4.2.0 declares `^4.2.0` and holding the plugin a major behind
+// left the pane rendering that field as an empty `datetime-local`.
+//
+// So this reads what is actually INSTALLED rather than what package.json asks for
+// — a range resolves to one version and that version is the one that runs.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Read from `node_modules` by path rather than by resolution: these packages ship
+// an `exports` map with no `./package.json` entry, so `require.resolve` cannot
+// reach the very file that says what they are.
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+interface Manifest {
+  version: string;
+  peerDependencies?: Record<string, string>;
+}
+
+const manifestOf = (pkg: string): Manifest => JSON.parse(readFileSync(join(root, "node_modules", pkg, "package.json"), "utf8")) as Manifest;
+
+const versionOf = (pkg: string): string => manifestOf(pkg).version;
+
+const corePeerOf = (pkg: string): string | undefined => manifestOf(pkg).peerDependencies?.["@mulmoclaude/core"];
+
+/** Every bundled plugin, whether or not it declares a core peer today. Listed
+ *  rather than discovered, so a plugin that STOPS declaring one is still read. */
+const PLUGINS = [
+  "@mulmoclaude/accounting-plugin",
+  "@mulmoclaude/chart-plugin",
+  "@mulmoclaude/collection-plugin",
+  "@mulmoclaude/form-plugin",
+  "@mulmoclaude/google-plugin",
+  "@mulmoclaude/html-plugin",
+  "@mulmoclaude/markdown-plugin",
+  "@mulmoclaude/mulmoscript-plugin",
+  "@mulmoclaude/x-plugin",
+] as const;
+
+/** Plugins whose declared core floor is BEHIND the core we run, kept here on
+ *  purpose rather than fixed by holding core back.
+ *
+ *  Both were built against core 3 and were not republished when core went to 4 —
+ *  core 4.0.0's break was moving the shared-app compiler out to
+ *  `@receptron/sharedapp`, which neither of them touches. The entry is what says
+ *  someone checked: an unexplained mismatch and a checked one look identical from
+ *  the manifest. Remove an entry when its plugin's own major lands here. */
+const KNOWN_BEHIND: Record<string, string> = {
+  "@mulmoclaude/html-plugin": "3.0.0 declares core ^3.0.0; MulmoClaude ships 4.0.0 against core 4",
+  "@mulmoclaude/markdown-plugin": "3.0.0 declares core ^3.0.0; MulmoClaude ships 4.0.0 against core 4",
+};
+
+/** `^X.Y.Z` against a concrete version. Written out rather than pulled from
+ *  `semver`, which this repo does not declare — and every range here is a caret,
+ *  so the whole of semver would be answering one question. */
+function satisfiesCaret(version: string, range: string): boolean {
+  const wanted = /^\^(\d+)\.(\d+)\.(\d+)$/u.exec(range);
+  if (wanted === null) return false;
+  const got = /^(\d+)\.(\d+)\.(\d+)/u.exec(version);
+  if (got === null) return false;
+  const [wMajor, wMinor, wPatch] = wanted.slice(1).map(Number);
+  const [gMajor, gMinor, gPatch] = got.slice(1).map(Number);
+  if (gMajor !== wMajor) return false;
+  if (gMinor !== wMinor) return gMinor > wMinor;
+  return gPatch >= wPatch;
+}
+
+describe("bundled @mulmoclaude plugins against the core we install", () => {
+  it("accepts the installed core, or says why it does not", () => {
+    const core = versionOf("@mulmoclaude/core");
+    const behind = PLUGINS.filter((pkg) => {
+      const peer = corePeerOf(pkg);
+      return peer !== undefined && !satisfiesCaret(core, peer);
+    });
+    // Both directions on purpose. A NEW mismatch has to be looked at; a recorded
+    // one that has been fixed has to lose its entry, or the list stops meaning
+    // "someone checked these" and becomes a list of things that used to be true.
+    expect([...behind].sort()).toEqual(Object.keys(KNOWN_BEHIND).sort());
+  });
+
+  it("collection-plugin is new enough to carry the server-stamped datetime lock", () => {
+    // The version, not the behaviour: the behaviour is the package's own test.
+    // What this pins is that MulmoTerminal is not holding it behind that fix.
+    const [major, minor] = versionOf("@mulmoclaude/collection-plugin").split(".").map(Number);
+    expect(major > 4 || (major === 4 && minor >= 2)).toBe(true);
+  });
+
+  it("only recognises a caret range", () => {
+    expect(satisfiesCaret("4.2.0", "^4.2.0")).toBe(true);
+    expect(satisfiesCaret("4.2.1", "^4.2.0")).toBe(true);
+    expect(satisfiesCaret("4.3.0", "^4.2.0")).toBe(true);
+    expect(satisfiesCaret("4.1.9", "^4.2.0")).toBe(false);
+    expect(satisfiesCaret("4.2.0", "^3.0.0")).toBe(false);
+    expect(satisfiesCaret("3.9.9", "^4.0.0")).toBe(false);
+    expect(satisfiesCaret("4.2.0", ">=4.0.0")).toBe(false);
+  });
+});

--- a/test/scripts/mulmoclaudePeerRanges.spec.ts
+++ b/test/scripts/mulmoclaudePeerRanges.spec.ts
@@ -36,19 +36,17 @@ const manifestAt = (dir: string): Manifest => JSON.parse(readFileSync(join(dir, 
 
 const pluginDir = (pkg: string): string => join(root, "node_modules", pkg);
 
-/** Every bundled plugin, listed rather than discovered: a plugin that stops declaring core, or
- *  stops nesting its own, must still be READ — a discovered list would simply not find it. */
-const PLUGINS = [
-  "@mulmoclaude/accounting-plugin",
-  "@mulmoclaude/chart-plugin",
-  "@mulmoclaude/collection-plugin",
-  "@mulmoclaude/form-plugin",
-  "@mulmoclaude/google-plugin",
-  "@mulmoclaude/html-plugin",
-  "@mulmoclaude/markdown-plugin",
-  "@mulmoclaude/mulmoscript-plugin",
-  "@mulmoclaude/x-plugin",
-] as const;
+/** Every bundled plugin, taken from OUR OWN manifest rather than typed out here.
+ *
+ *  A hand-kept list is the failure this file would otherwise have: a plugin added to
+ *  `package.json` and not to the list is bundled, ships, and is never checked — the guard passes
+ *  by not looking. `package.json` is where "bundled" is actually decided, so it is what is read.
+ *
+ *  It is the DEPENDENCIES that are read, not the directory: a plugin pulled in transitively by
+ *  another package is not one of ours to keep compatible. */
+const PLUGINS: string[] = Object.keys(manifestAt(root).dependencies ?? {})
+  .filter((name) => /^@mulmoclaude\/.*-plugin$/u.test(name))
+  .sort();
 
 /** Plugins that name no core at all, in either list.
  *
@@ -91,6 +89,13 @@ function satisfiesCaret(version: string, range: string): boolean {
 }
 
 describe("the core each bundled plugin runs against", () => {
+  it("has plugins to check, and reads them from what we actually bundle", () => {
+    // Guards the reading itself: a manifest key that changed shape, or a filter that stopped
+    // matching, would empty this list and every check below would pass on nothing.
+    expect(PLUGINS.length).toBeGreaterThan(5);
+    expect(PLUGINS).toContain("@mulmoclaude/collection-plugin");
+  });
+
   it("every plugin either names a core or is recorded as naming none", () => {
     const silent = PLUGINS.filter((pkg) => declaredCoreOf(pkg) === undefined);
     // Both directions: a plugin that newly drops its declaration has to be looked at, and a

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,10 +1884,10 @@
   dependencies:
     "@mulmoclaude/core" "^3.0.0"
 
-"@mulmoclaude/collection-plugin@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-3.1.0.tgz#a4394ed06ed103e476b346615bd0701c7021a2f9"
-  integrity sha512-3kk8WB9DBKtTcHXv/q+JR44YiVOFcAGvFtHMAn40uL0n9VCS0brftBET8jcYt+N2semTrziNJlV+sA4Zk+Ti6Q==
+"@mulmoclaude/collection-plugin@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-4.2.0.tgz#b7e2136cadbd95caaeb46819696777aafb9e815e"
+  integrity sha512-Wj9KA84xQPQYzOc60Ows+w8ckILf15I5Dj+0iG/Ti4VKHmCMfjOo5+l/xKCZeB7ipnV05pQF1BVL962F6G6VSQ==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"


### PR DESCRIPTION
`@mulmoclaude/collection-plugin` を `^3.1.0` から `^4.2.0` に上げる。core は既に 4.2.0 を固定しているので、動くのは prod 依存 1 行と、これまで見ていなかった不変条件を押さえる spec 1 本だけ。

## なぜ

サーバが刻んだ `datetime` を編集させない修正は plugin 4.2.0 に入っている（mulmoclaude#2918）。MT は plugin を major 1 つ手前で持っていたので、**ペインの詳細ビューではその欄が空の `datetime-local` として描かれ、そのまま保存するとルールに拒否される**——何も名指さない permission エラーで。壊れたのは今回ではなく、MT だけ直っていなかった。

4.2.0 の該当箇所は `isCanonicalServerTime` を使うので **core 4.2.0 以上が要る**。MT はそこを満たしている（`"@mulmoclaude/core": "4.2.0"`）。

## 3.1.0 → 4.2.0 で何が変わるか

MT に関係するのは 4 点で、いずれも追加か fail-soft 側:

- 4.0.0 — core 4 への peer 引き上げ（共有アプリのコンパイラが `@receptron/sharedapp` に出た件の major）。plugin 自身の API は変わっていない
- 一覧の並び替えと絞り込み（`CollectionsIndexView` の中で完結、prop は増えていない。MulmoClaude 側も prop 無しで置いているので対称）
- `enum` フィールドの `default`
- 未設定の embed（`idField` が空）を赤いエラー枠ではなく空欄として描く

## spec で分かったこと: 同梱プラグインが読む core は 1 つではない

`test/scripts/mulmoclaudePeerRanges.spec.ts`。

調べて分かったのは、**core を peer だけで名乗るのは `collection-plugin` だけ**だということ。残りは `dependencies` で名乗るので、yarn が各プラグインの下に自分の copy を入れる——`mulmoscript` / `chart` / `html` / `markdown` が core 3.0.0、`accounting` / `google` が 3.11.0 を、それぞれ自前で持って動いている。

この違いが要点で、**ここから壊せるのは前者だけ**。peer は宣言であって yarn は警告するだけなので、ホストが古い core を固定してもインストールは通り、壊れるのは core が動かした／型を変えたものだけ——つまりペインの空の入力欄や整形されない値として、遅れて出る。今回がまさにそれ。

なので spec は宣言ではなく**解決結果**を見る: そのプラグインが実際に読む core（nested があればそれ、無ければこちらの）が、宣言しているレンジを満たすか。例外表は要らない。`collection-plugin` が nested を持たない（＝こちらの core で動く）ことも別に押さえてある——そこが崩れたらこのファイルの前提ごと読み直しになるので。

core を全く名乗らない 2 本（`form` / `x`）だけは、理由つきで記録する形にした。「宣言していない」と「見ていない」は、素通しする述語からは同じ形に見えるため。宣言を落としたら落ちることは、記録を 1 行外して確認した。

## 確認

`yarn format` / `lint` / `typecheck` / `build` / `test`（722 files, 10368 tests）すべて緑。インストール済みの `dist/vue.js` が `isCanonicalServerTime` を import していることも確認した。

実地の確認は残っている: 共有アプリのレコードをペインの詳細ビューで開き、刻まれた欄が**値の見えるグレーの読み取り専用**になっていること。

#1752 の残件 3 がこれ。

work in mulmoterminal