### PR TITLE
fix(shared-app): ペインが名簿向けページに viewer を渡していなかった

### DIFF
--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -6,6 +6,7 @@
 // exists to remove. The server's own result type extends this with what only it uses.
 //
 // Design: `plans/feat-shared-app-preview.md`.
+import type { Viewer } from "@receptron/sharedapp/view";
 
 /** Who a page was written for. Three audiences, three DOCUMENTS with three sets of rules — never
  *  one page shown three ways. Reading them as interchangeable is how a page written for the front
@@ -17,6 +18,19 @@ export interface PreviewPage {
   id: string;
   html: string;
   audience: PreviewAudience;
+  /** WHO the author is to this page, and what they may change — the same
+   *  `{ me, can }` mulmoserver posts to the live `/m/` and `/p/`, computed from
+   *  the same projection by the same function.
+   *
+   *  Absent on a public page, which has no reader and no roles: `public.submit`
+   *  is judged from the declaration alone, and a `viewer` there would be an
+   *  answer to a question that page never asks.
+   *
+   *  It comes from the SERVER because the client has neither the projection nor
+   *  the author's verified address. Sending the projection instead and letting
+   *  the pane resolve it would be the second implementation this whole change
+   *  exists to remove. */
+  viewer?: Viewer;
 }
 
 export type PreviewDataset = Record<string, unknown>[];

--- a/common/sharedAppViewVocabulary.ts
+++ b/common/sharedAppViewVocabulary.ts
@@ -30,18 +30,22 @@ export const REFUSALS: Record<string, string> = {
   cancelled: "the confirmation was declined",
 };
 
-/** The same refusal, read on a page whose actions are not submissions.
+/** What a member or participant page is told when it asks for a write.
  *
- *  `transition`, `assign` and `withdraw` are what a member or participant page sends, and the
- *  parent that runs in a preview judges submissions only — so it answers them `not-a-submission`,
- *  and the ordinary translation above would blame the page for something it did correctly. */
-export const NOT_A_SUBMISSION_ON_A_MEMBER_PAGE =
-  "the message was not a submission. On this page that is expected for `transition`, `assign` and `withdraw`: the parent that answers those is not the one running here " +
-  "(see the note above). It is a real fault only if the page called `submit`.";
+ *  `transition`, `assign` and `withdraw` reach the member parent, which judges them and would
+ *  perform them on the live page — here it has nowhere to write, so it answers `read-only`. That
+ *  is a GOOD outcome and has to read like one: the ask arrived, in the right shape, and was
+ *  declined for the reason every preview declines a write.
+ *
+ *  It replaced a longer note saying the parent answering intents "is not the one running here",
+ *  which was true while the preview had only the public bridge and is not any more. */
+export const READ_ONLY_ON_A_MEMBER_PAGE =
+  "the preview does not write, so it declined. The ask itself was well formed and reached the parent — this line means the control is wired, not that anything is wrong. " +
+  "Whether the deployed rules would accept the write is a different question and is not answered here.";
 
 /** One refusal, in the words that fit the page it happened on. */
 export const explainRefusal = (reason: string, audience: PreviewAudience): string => {
-  if (reason === "not-a-submission" && audience !== "public") return NOT_A_SUBMISSION_ON_A_MEMBER_PAGE;
+  if (reason === "read-only" && audience !== "public") return READ_ONLY_ON_A_MEMBER_PAGE;
   return REFUSALS[reason] ?? reason;
 };
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^3.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^2.1.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.7.0",
+    "@receptron/sharedapp": "^0.7.1",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^3.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^2.1.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.6.0",
+    "@receptron/sharedapp": "^0.7.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^3.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^2.1.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.7.1",
+    "@receptron/sharedapp": "^0.7.2",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/plans/feat-shared-app-member-parent.md
+++ b/plans/feat-shared-app-member-parent.md
@@ -1,0 +1,112 @@
+# 名簿向けページの親を、両方のホストで同じものにする（P7）
+
+**状態**: 実装済み（2026-08-16）。**sharedapp 0.7.0 の npm 公開待ち**
+**日付**: 2026-08-16
+**前提**: [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)、
+[`plans/feat-shared-app-preview.md`](./feat-shared-app-preview.md)（手元のプレビューは本番と同じ親を動かす）、
+[`plans/feat-shared-app-member-write.md`](./feat-shared-app-member-write.md)（intent の語彙）
+
+## 1. 出た形
+
+エアロビクスジムの予約アプリを作っていた別のセッションが、こう報告した:
+
+> クラス 224 / 申込み 1 / **viewer keys=[]** {} / bridge keys=[onState,ready,submit,transition,assign,withdraw]
+
+そして「プラットフォームが `/p/` で `viewer` を空のまま渡している」と診断し、メールアドレスを
+打たせて自分の申込みを絞り込む回避策を入れて公開した。
+
+**診断は場所を間違えていた。** mulmoserver の `/p/` は `useAppIntent` が `{ me, can }` を作って
+`AppViewFrame.vue` が state に載せる。空になる経路は無い。空だったのは **MulmoTerminal の
+Collections ペインで見たとき**で、理由は 1 つ:
+
+- ペインは `@receptron/sharedapp/view` の **`viewBridge`（公開ページ用）** を使っていた
+- その state は `{ type, collections }` で、**`viewer` のキーが無い**（`bridge.ts`）
+- 注入される runtime は `onState(data.collections || {}, data.viewer || {})`（`srcdoc.ts`）
+
+つまり**プレビューで開いた名簿向けページは、例外なく空の `viewer` を受け取っていた**。ページは
+ボタンを 1 つも描けず、その状態は「著者が capability の名前を間違えた」のと**画面上まったく
+区別が付かない**。実際そう診断された。
+
+## 2. これは既知の穴だった
+
+`headlessReport.ts` が毎回のレポートにこう書いていた:
+
+> The parent carrying `viewer` capabilities and answering the three intents lives in mulmoserver
+> (`AppViewFrame.vue`) and is **NOT shared code yet** … Until that is lifted, the limit belongs to
+> the Collections pane too, which is why it is **STATED** rather than worked around: a second
+> parent written here would make the preview disagree with production, which is the one thing it
+> must never do.
+
+**言うだけでは足りなかった。** レポートを読むのは著者と、著者が使う LLM で、どちらも
+「ここでは試されない」より先に「ボタンが出ない」を見る。書いてあることは、見えている症状に
+負ける。
+
+## 3. やったこと
+
+3 リポジトリ、上流から順に。
+
+### sharedapp 0.7.0
+
+| | |
+| --- | --- |
+| `src/view/capability.ts` | `capabilityOf` / `capabilitiesFor` / `mayTransition` / **`viewerFor`**。mulmoserver から移設 |
+| `src/view/intent.ts` | intent の読みと判断。同じく移設 |
+| `src/view/intentMail.ts` | 遷移に乗る通知。同じく移設 |
+| `src/view/memberBridge.ts` | **名簿・参加者向けページの親**（新規） |
+
+**`viewBridge` にフラグを足すのではなく 2 本目の親にした。** 依頼の意味が違うため:
+公開ページの submit は他人が新しいレコードを提案するもので、だから確認を挟んで訪問者が押す。
+名簿の人の ask は既にあるレコードを動かすもので、射影に照らして判断し実行する。1 つにまとめると、
+会員のボタンの前に押し直しの確認が挟まるか、`pending` が 2 つの意味を持つ。
+
+**共有されるのはハンドシェイクで、呼び出しではなく同一であることによって共有する。**
+ready への返事はチャネルだけ、データはポートに答えた文書を待つ — 理由は `bridge.ts` に全部ある。
+
+**`viewerFor` を足したのは形の合意のため。** capability は既に共有されていたのに**包み**は
+されておらず、それが `viewer.can.transitionAny`（`can` はコレクション id で引くので、どのアプリ
+でも undefined）というページ側の不具合を生んだ。
+
+### mulmoserver
+
+`AppViewFrame.vue` から会話そのものが出ていき、DOM が要る部分だけ残った（iframe、sandbox、
+メッセージが自分の frame から来たかの判定）。697 行削除。`ViewWrite` / `ViewMail` は package の
+型の別名になり、**読み戻しの parse だけ残る** — 信用できない document を Firestore から読むのは
+このホストの仕事で、コンパイラは壊れたものを見ない。
+
+`perform` は **getter** で渡す。route が変わると prop が差し替わるので、値で掴むとアプリ B の
+intent をアプリ A のハンドラで判断することになる。
+
+### MulmoTerminal
+
+- **サーバが `viewer` を解決する。** `preview.ts` が tier の射影と `handle.email` から
+  `viewerFor` を呼び、ページごとに載せる。クライアントは射影も著者のアドレスも持たないので、
+  射影を送って向こうで解決させるのは「2 つ目の実装」そのものになる
+- `PreviewPage.viewer?: Viewer` を `common/` に足す（両端が決める wire shape なので）
+- ペインは audience で親を選ぶ — 本番でアドレスが選ぶのと同じ判断
+- **headless harness も同じ**。両方が「プレビュー」なので、片方だけ直すと次に同じ話になる
+- `MEMBER_PAGE_LIMIT` を実態まで縮める
+
+## 4. 残っている限界（意図的）
+
+**プレビューは intent を実行しない。** ペインにも headless にも会員の書き込み用の経路が無いので、
+`transition` / `assign` / `withdraw` は **`read-only` として名指しで拒否**される。
+
+これは沈黙ではないことが要点で、語彙も直した: `READ_ONLY_ON_A_MEMBER_PAGE` は「**その控えは
+配線されている**、おかしいことは何も起きていない」と読ませる。以前の
+`NOT_A_SUBMISSION_ON_A_MEMBER_PAGE`（公開の親が intent を `not-a-submission` と答えていた頃の
+文言）は、もう起きないので消した。
+
+ペインに書き込みまでやらせるかは別の判断で、この計画には入っていない。ペインの Preview ボタンは
+**公開フォームの submit** については実際に書くので、非対称ではある。
+
+## 5. 順序
+
+sharedapp → mulmoserver → MulmoTerminal。**途中でやめると本番とプレビューが食い違う**ので、
+3 本通しで 1 つの作業として扱う。sharedapp 0.7.0 が npm に出るまで、下 2 つの CI は赤い。
+
+## 6. 採らなかったもの
+
+- **MT 側で `viewer` を組み立てる。** `headlessReport.ts` が明示的に禁じている通り、
+  プレビューが本番と食い違うのは、このペインが最も避けるべきこと
+- **`viewBridge` にフラグ。** 3 節に理由
+- **mulmoserver の親をそのまま MT にコピー。** それが「2 つ目の実装」

--- a/server/backends/sharedApp/headlessHarness.ts
+++ b/server/backends/sharedApp/headlessHarness.ts
@@ -52,12 +52,16 @@ export const HARNESS_HTML = `<!doctype html>
 <body>
 <div id="host"></div>
 <script type="module">
-import { portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE } from "${VIEW_MOUNT}/index.js";
+import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE } from "${VIEW_MOUNT}/index.js";
 
 const host = document.getElementById("host");
 let frame = null;
 let datasets = {};
 let config = null;
+// The \`{ me, can }\` this page's audience resolves to, or null for a public one. A member page run
+// without it is the bug this harness reported for months as an author's mistake: the page is handed
+// \`{}\`, draws none of its buttons, and the report says the controls were not there.
+let viewer = null;
 let nonce = viewNonce();
 let outbound = [];
 let submitted = [];
@@ -80,22 +84,36 @@ const cells = {
   readied: { value: false },
 };
 
+const recording = (make) => () => {
+  const channel = make();
+  return {
+    post: (message) => {
+      outbound.push(message);
+      channel.post(message);
+    },
+    onMessage: channel.onMessage,
+    close: channel.close,
+  };
+};
+
+/** The member's parent, for a roster or participant page. It performs nothing — a headless run
+ *  never writes — so every intent is refused BY NAME on the channel, which the report reads back
+ *  out of \`outbound\`. */
+const member = memberBridge(
+  {
+    channel: recording(() => portChannel(frame)),
+    state: () => datasets,
+    viewer: () => viewer ?? { me: null, can: {} },
+  },
+  () => nonce,
+);
+
 const bridge = viewBridge(
   {
-    // Wrapped so every message the parent sends is recorded on its way out. The refusals are only
-    // visible here: they are answered on the port and never drawn, which is exactly why an author
-    // watching the screen cannot see them.
-    channel: () => {
-      const channel = portChannel(frame);
-      return {
-        post: (message) => {
-          outbound.push(message);
-          channel.post(message);
-        },
-        onMessage: channel.onMessage,
-        close: channel.close,
-      };
-    },
+    // Recorded on its way out, like the member parent's above. The refusals are only visible here:
+    // they are answered on the port and never drawn, which is exactly why an author watching the
+    // screen cannot see them.
+    channel: recording(() => portChannel(frame)),
     // Never reached: every confirmation is declined. Here so that a change which starts accepting
     // has to delete this sentence first.
     submit: async () => ({ ok: false, error: "a headless preview never writes" }),
@@ -108,7 +126,13 @@ const bridge = viewBridge(
 
 // Only our frame. The sandbox's origin is opaque, so \`event.origin\` cannot draw this line.
 window.addEventListener("message", (event) => {
-  if (frame !== null && event.source === frame.contentWindow) bridge.receive(event.data);
+  if (frame === null || event.source !== frame.contentWindow) return;
+  // The audience decides which parent answers, exactly as the address does in production.
+  if (viewer !== null) {
+    member.receive(event.data);
+    return;
+  }
+  bridge.receive(event.data);
 });
 
 const refusals = () => outbound.filter((message) => message.type === VIEW_MESSAGE.result && message.ok === false).map((message) => String(message.error));
@@ -118,9 +142,11 @@ window.__preview = {
    *  page in its starting state rather than against whatever the previous press left behind. */
   render(page) {
     bridge.restart();
+    member.forget();
     outbound = [];
     submitted = [];
     datasets = page.datasets;
+    viewer = page.viewer ?? null;
     config = page.submit === null ? null : { submit: page.submit };
     nonce = viewNonce();
     if (frame !== null) frame.remove();

--- a/server/backends/sharedApp/headlessHarness.ts
+++ b/server/backends/sharedApp/headlessHarness.ts
@@ -104,6 +104,11 @@ const member = memberBridge(
     channel: recording(() => portChannel(frame)),
     state: () => datasets,
     viewer: () => viewer ?? { me: null, can: {} },
+    // THE SAME CELL the public parent writes, because \`observe()\` reads one and the report puts
+    // "It NEVER answered the handshake" at the top of a page whose value is false — over a
+    // paragraph saying nothing below describes the page's behaviour. Wired to the public bridge
+    // alone, every healthy member page was reported that way.
+    readied: cells.readied,
   },
   () => nonce,
 );

--- a/server/backends/sharedApp/headlessPreview.ts
+++ b/server/backends/sharedApp/headlessPreview.ts
@@ -29,6 +29,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isRecord } from "../../../common/isRecord.js";
 import type { PreviewAudience, PreviewDataset } from "../../../common/sharedAppPreview.js";
+import type { Viewer } from "@receptron/sharedapp/view";
 import { previewPageKey } from "../../../common/sharedAppPreview.js";
 import { previewSharedApp } from "./preview.js";
 import { VIEW_MOUNT, HARNESS_HTML, type HarnessObservation } from "./headlessHarness.js";
@@ -46,6 +47,13 @@ export interface HeadlessPageInput {
    *  which does not switch the parent's check off but makes it refuse everything with
    *  `unknown-collection`, blaming a declaration that is correct. */
   submit: Record<string, { createFields: string[] }> | null;
+  /** WHO the author is to this page and what they may change, for a member or participant page.
+   *
+   *  `undefined` for a public one, and that is what SELECTS the parent in the harness — the same
+   *  decision the address makes in production. A member page run without it gets the public parent,
+   *  which sends no `viewer` at all: the page draws none of its buttons and the report says its
+   *  controls were not there, which is a false account of a page that is fine. */
+  viewer?: Viewer | undefined;
 }
 
 /** What one press produced. */
@@ -462,7 +470,9 @@ async function openDriver(browser: Browser, origin: string): Promise<Driver> {
       stalled = false;
       // The render is awaited on ITS OWN deadline (`evaluate`'s), because what it waits for is the
       // frame's `load` — which a script that never returns never reaches.
-      await evaluate(`window.__preview.render(${JSON.stringify({ html: input.html, datasets: input.datasets, submit: input.submit })})`);
+      await evaluate(
+        `window.__preview.render(${JSON.stringify({ html: input.html, datasets: input.datasets, submit: input.submit, viewer: input.viewer ?? null })})`,
+      );
       await page.waitForFunction("window.__preview.observe().readied", { timeout: LIMITS.readyMs }).catch(() => undefined);
       await new Promise((resolve) => setTimeout(resolve, LIMITS.settleMs));
     },
@@ -663,6 +673,7 @@ export async function headlessPreview(root: string): Promise<HeadlessRun> {
     audience: page.audience,
     html: page.html,
     datasets: preview.datasets[previewPageKey(page.audience, page.id)] ?? {},
+    ...(page.viewer === undefined ? {} : { viewer: page.viewer }),
     submit: Object.keys(preview.submit).length > 0 ? preview.submit : null,
   }));
   return runPagesHeadless(inputs);

--- a/server/backends/sharedApp/headlessReport.ts
+++ b/server/backends/sharedApp/headlessReport.ts
@@ -18,15 +18,19 @@ import type { HeadlessPageReport, HeadlessPress, HeadlessRun } from "./headlessP
 /** What this run does NOT do to a page written for the roster.
  *
  *  Said on every such page, because the omission is invisible: the page loads, draws and looks
- *  exercised. The parent carrying `viewer` capabilities and answering the three intents lives in
- *  mulmoserver (`AppViewFrame.vue`) and is NOT shared code yet — `@receptron/sharedapp/view`'s
- *  bridge is the public one. Until that is lifted, the limit belongs to the Collections pane too,
- *  which is why it is STATED rather than worked around: a second parent written here would make
- *  the preview disagree with production, which is the one thing it must never do. */
+ *  exercised. It used to be far larger — the parent was the PUBLIC one, so the page got no
+ *  `viewer` at all and drew none of its buttons. That parent now comes from
+ *  `@receptron/sharedapp/view`, the same one mulmoserver puts in front of `/m/` and `/p/`, and it
+ *  carries the capabilities this author resolves to.
+ *
+ *  What is left is the writes. An intent is REFUSED here by name rather than performed, because a
+ *  headless run never writes — so a button is proven to exist, to be reachable and to ask for the
+ *  right thing, and not to succeed. The refusal is reported like any other, which is the
+ *  difference from before: an untested control now says so in its own line. */
 const MEMBER_PAGE_LIMIT =
-  "This page is written for the roster, and only PART of it is exercised here. It loads, it answers the handshake and it gets its records — but the parent running it " +
-  "is the public one, so it carries no `viewer` capabilities and it does not answer `transition`, `assign` or `withdraw`. Controls that depend on those are untested, " +
-  "here and in the Collections pane alike.";
+  "This page is written for the roster. It gets the same `viewer` capabilities the live page would, from the same parent — but a headless run never writes, so " +
+  "`transition`, `assign` and `withdraw` are REFUSED rather than performed. A control that asks for one is reported below as refused, which says it is wired; whether " +
+  "the rules would accept the write is not tested here.";
 
 const quoted = quoteForReport;
 

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -42,7 +42,7 @@ import { publicFormOf, type PublicForm } from "./publicForm.js";
 import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
 import { viewerFor, writableFields } from "@receptron/sharedapp/view";
-import type { ProjectedViewWrite } from "@receptron/sharedapp";
+import { projectedWritesOf } from "@receptron/sharedapp";
 import {
   previewPageKey,
   type PreviewDataset,
@@ -140,19 +140,6 @@ async function readDatasets(
   // ids in, so a projection sorted one way against a listing sorted another does not read as a
   // change.
   return { datasets, unreadable: [...unreadable].sort((left, right) => (left < right ? -1 : 1)) };
-}
-
-/** The `write` half of a tier's projection, narrowed rather than asserted.
- *
- *  The document is built by the compiler in this same process, so this is not
- *  defence against a stranger — it is the floor that keeps a shape change in
- *  `@receptron/sharedapp` from reaching the pane as a page that draws nothing.
- *  An entry that is not a record with a `cid` is dropped, exactly as
- *  mulmoserver's `writeOf` drops one it reads back off Firestore. */
-function projectedWrites(config: Record<string, unknown> | null): ProjectedViewWrite[] {
-  const write: unknown = config?.write;
-  if (!Array.isArray(write)) return [];
-  return write.filter((entry): entry is ProjectedViewWrite => isRecord(entry) && typeof entry.cid === "string" && entry.cid !== "");
 }
 
 /** What one tier's projection says each of its pages may query for. */
@@ -262,7 +249,10 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     // package's, and mulmoserver calls the same one with the same projection —
     // which is the whole point: while the pane had only the PUBLIC bridge, every
     // roster page previewed here was handed `{}` and drew no buttons at all.
-    const viewer = viewerFor(projectedWrites(plan.config), handle.email, plan.tier);
+    // Read back through the PACKAGE's reader, which is the one mulmoserver uses on the document it
+    // gets off Firestore. A looser read here would let the preview draw a control production drops
+    // — the preview being looser than production, the one thing it must never be.
+    const viewer = viewerFor(projectedWritesOf(plan.config), handle.email, plan.tier);
     return plan.pages.map((tierPage): PreviewPage => ({ id: tierPage.id, html: tierPage.html, audience: plan.tier, viewer }));
   });
   const pages = [...publicPages, ...tierPages];

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -41,7 +41,8 @@ import { planAppViewTiers, type TierPlan } from "./appViews.js";
 import { publicFormOf, type PublicForm } from "./publicForm.js";
 import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
-import { writableFields } from "@receptron/sharedapp/view";
+import { viewerFor, writableFields } from "@receptron/sharedapp/view";
+import type { ProjectedViewWrite } from "@receptron/sharedapp";
 import {
   previewPageKey,
   type PreviewDataset,
@@ -139,6 +140,19 @@ async function readDatasets(
   // ids in, so a projection sorted one way against a listing sorted another does not read as a
   // change.
   return { datasets, unreadable: [...unreadable].sort((left, right) => (left < right ? -1 : 1)) };
+}
+
+/** The `write` half of a tier's projection, narrowed rather than asserted.
+ *
+ *  The document is built by the compiler in this same process, so this is not
+ *  defence against a stranger — it is the floor that keeps a shape change in
+ *  `@receptron/sharedapp` from reaching the pane as a page that draws nothing.
+ *  An entry that is not a record with a `cid` is dropped, exactly as
+ *  mulmoserver's `writeOf` drops one it reads back off Firestore. */
+function projectedWrites(config: Record<string, unknown> | null): ProjectedViewWrite[] {
+  const write: unknown = config?.write;
+  if (!Array.isArray(write)) return [];
+  return write.filter((entry): entry is ProjectedViewWrite => isRecord(entry) && typeof entry.cid === "string" && entry.cid !== "");
 }
 
 /** What one tier's projection says each of its pages may query for. */
@@ -243,9 +257,14 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
 
   const publicHtml = page !== null && page.ok ? page.view.html : null;
   const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public" }];
-  const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) =>
-    plan.pages.map((tierPage): PreviewPage => ({ id: tierPage.id, html: tierPage.html, audience: plan.tier })),
-  );
+  const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) => {
+    // The author, as this tier's projection resolves them. `viewerFor` is the
+    // package's, and mulmoserver calls the same one with the same projection —
+    // which is the whole point: while the pane had only the PUBLIC bridge, every
+    // roster page previewed here was handed `{}` and drew no buttons at all.
+    const viewer = viewerFor(projectedWrites(plan.config), handle.email, plan.tier);
+    return plan.pages.map((tierPage): PreviewPage => ({ id: tierPage.id, html: tierPage.html, audience: plan.tier, viewer }));
+  });
   const pages = [...publicPages, ...tierPages];
 
   // WHICH collections, asked of each page's own PROJECTION rather than of the declaration —

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -41,8 +41,9 @@ import { planAppViewTiers, type TierPlan } from "./appViews.js";
 import { publicFormOf, type PublicForm } from "./publicForm.js";
 import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
-import { viewerFor, writableFields } from "@receptron/sharedapp/view";
-import { projectedWritesOf } from "@receptron/sharedapp";
+// Both from `/view`, which is where the PARENT's vocabulary lives — and where the read-back has to
+// be: the root entry reaches the compiler, and the compiler imports core's server half at runtime.
+import { projectedWritesOf, viewerFor, writableFields } from "@receptron/sharedapp/view";
 import {
   previewPageKey,
   type PreviewDataset,

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -20,7 +20,7 @@
 // a role may WRITE is not tested; nobody else exists, so nothing here is concurrent; and it cannot
 // tell whether the Firestore rules a new declaration needs have been deployed at all.
 import { computed, onBeforeUnmount, ref, shallowRef, toRaw, watch } from "vue";
-import { portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE, type PendingSubmit } from "@receptron/sharedapp/view";
+import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE, type PendingSubmit } from "@receptron/sharedapp/view";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
 import { isRecord } from "../../common/isRecord";
 import { createPreviewLog, renderPreviewLog, type PreviewLogEvent } from "../utils/sharedAppPreviewLog";
@@ -28,9 +28,7 @@ import { useUpdateStatus } from "../composables/useUpdateStatus";
 import {
   previewPageKey,
   type PreviewAudience,
-  type PreviewDataset,
   type PreviewForm,
-  type PreviewFormField,
   type PreviewPage,
   type PreviewUncertainWrite,
   type PreviewWrittenRecord,
@@ -39,76 +37,7 @@ import {
 
 const props = defineProps<{ cwd: string | null }>();
 
-/** The payload, narrowed rather than asserted. Every field has a floor, because a pane that threw
- *  on an unexpected shape would report a server it could not read as an app that will not publish —
- *  two very different things to be told while you are trying to fix a page. */
-function asPayload(value: unknown): SharedAppPreview | null {
-  if (!isRecord(value)) return null;
-  return {
-    aid: typeof value.aid === "string" ? value.aid : "",
-    submit: asSubmit(value.submit),
-    pages: Array.isArray(value.pages) ? value.pages.flatMap(asPage) : [],
-    publicOpen: value.publicOpen === true,
-    fromLiveApp: value.fromLiveApp === true,
-    generatedForm: value.generatedForm === true,
-    formInputs: asFormInputs(value.formInputs),
-    datasets: isRecord(value.datasets) ? Object.fromEntries(Object.entries(value.datasets).map(([key, rows]) => [key, asDatasets(rows)])) : {},
-    unreadable: strings(value.unreadable),
-    warnings: strings(value.warnings),
-  };
-}
-
-/** What a public create may carry, per collection. Narrowed with a floor of `[]` rather than
- *  dropped: an unreadable declaration must make the parent refuse a FIELD, not refuse the whole
- *  collection — the two refusals name different repositories to whoever reads them. */
-const asSubmit = (value: unknown): Record<string, { createFields: string[] }> => {
-  if (!isRecord(value)) return {};
-  return Object.fromEntries(Object.entries(value).map(([cid, spec]) => [cid, { createFields: isRecord(spec) ? strings(spec.createFields) : [] }]));
-};
-
-/** The generated form's inputs. A collection whose inputs cannot be read is DROPPED rather than
- *  drawn empty: an empty form is a Send button that submits nothing, and the author would read the
- *  refusal that follows as a fault in their declaration. */
-const asFormInputs = (value: unknown): PreviewForm => {
-  if (!isRecord(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).flatMap(([cid, fields]) => {
-      const drawn = Array.isArray(fields) ? fields.flatMap(asFormField) : [];
-      return drawn.length === 0 ? [] : [[cid, drawn] as const];
-    }),
-  );
-};
-
-const asFormField = (value: unknown): PreviewFormField[] => {
-  if (!isRecord(value) || typeof value.name !== "string" || value.name === "") return [];
-  const values = strings(value.values);
-  return [
-    {
-      name: value.name,
-      label: typeof value.label === "string" && value.label !== "" ? value.label : value.name,
-      required: value.required === true,
-      type: typeof value.type === "string" ? value.type : "string",
-      ...(values.length === 0 ? {} : { values }),
-    },
-  ];
-};
-
-const strings = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
-
-const AUDIENCES: PreviewAudience[] = ["public", "member", "roster"];
-
-const asPage = (value: unknown): PreviewPage[] => {
-  if (!isRecord(value) || typeof value.id !== "string" || typeof value.html !== "string") return [];
-  const audience = AUDIENCES.find((candidate) => candidate === value.audience);
-  return audience === undefined ? [] : [{ id: value.id, html: value.html, audience }];
-};
-
-const asDatasets = (value: unknown): Record<string, PreviewDataset> => {
-  if (!isRecord(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).map(([cid, rows]) => [cid, Array.isArray(rows) ? rows.filter((row): row is Record<string, unknown> => isRecord(row)) : []]),
-  );
-};
+import { asPayload } from "../utils/sharedAppPreviewPayload";
 
 const loading = ref(true);
 const declared = ref(false);
@@ -295,15 +224,59 @@ const unwrap = (value: unknown): unknown => {
   return raw;
 };
 
+/** The parent a MEMBER's page gets: the roster and participant pages, which is what `/m/` and
+ *  `/p/` put in front of the same HTML.
+ *
+ *  A second bridge rather than a flag, because a member's ask is not a submission — see
+ *  `memberBridge` in the package. What matters here is that it is the package's and not this
+ *  pane's: while there was only the public one to reach for, a member page previewed here was sent
+ *  a state message with no `viewer` key at all, the injected runtime read `data.viewer || {}`, and
+ *  the page drew none of its buttons. That is indistinguishable from an author who got the
+ *  capability names wrong, and it was diagnosed as exactly that.
+ *
+ *  It performs NOTHING. A transition, an assignment or a withdrawal is a real write against the
+ *  live rules and the pane has no route for one, so every intent is refused — by name, on the
+ *  channel, which the strip below reports. That is the honest answer and it is not silence. */
+const member = memberBridge(
+  {
+    channel: () => {
+      const channel = portChannel(frame.value, (message) => structuredCloneable(message));
+      return {
+        post: (message) => {
+          noteOutbound(message);
+          channel.post(message);
+        },
+        onMessage: channel.onMessage,
+        close: channel.close,
+      };
+    },
+    state: () => datasets.value,
+    // Never a floor. A page whose payload carried no viewer is a page this pane could not resolve
+    // one for, and inventing an empty one here is the bug being fixed.
+    viewer: () => page.value?.viewer ?? { me: null, can: {} },
+  },
+  () => nonce.value,
+);
+
+/** Which parent is talking to the document on screen. The audience decides, exactly as the address
+ *  decides it in production: `/a/` is the public one, `/m/` and `/p/` are the member's. */
+const memberPage = computed(() => page.value !== null && page.value.audience !== "public");
+
 /** Only messages from OUR frame. The sandbox's origin is opaque, so `event.origin` cannot draw
  *  this boundary and `event.source` is what does. */
 const onMessage = (event: MessageEvent) => {
-  if (frame.value !== null && event.source === frame.value.contentWindow) bridge.receive(event.data);
+  if (frame.value === null || event.source !== frame.value.contentWindow) return;
+  if (memberPage.value) {
+    member.receive(event.data);
+    return;
+  }
+  bridge.receive(event.data);
 };
 window.addEventListener("message", onMessage);
 onBeforeUnmount(() => {
   window.removeEventListener("message", onMessage);
   bridge.restart();
+  member.forget();
 });
 
 // A new document means a new conversation: the old channel belongs to a document we are no longer
@@ -331,7 +304,10 @@ watch(
   // for the same reason the datasets are.
   () => (page.value === null ? null : keyOf(page.value)),
   () => {
+    // BOTH, always. The page that is going may have been the other audience's, and a channel left
+    // open belongs to a document nobody is looking at any more.
     bridge.restart();
+    member.forget();
     nonce.value = viewNonce();
     // NOT a reset of the log. Switching pages is part of what the author was doing, and the page
     // they came from is often where the fault is — a member page that never readied looks identical
@@ -340,8 +316,16 @@ watch(
   },
 );
 
-// New data, same document — the view asked once and cannot ask again.
-watch(datasets, () => bridge.sendState(), { deep: true });
+// New data, same document — the view asked once and cannot ask again. Sent to whichever parent
+// holds the conversation; the other one has no open channel and its call is a no-op.
+watch(
+  datasets,
+  () => {
+    bridge.sendState();
+    member.sendState();
+  },
+  { deep: true },
+);
 
 /** Every record this preview session wrote, newest first.
  *

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -254,6 +254,10 @@ const member = memberBridge(
     // Never a floor. A page whose payload carried no viewer is a page this pane could not resolve
     // one for, and inventing an empty one here is the bug being fixed.
     viewer: () => page.value?.viewer ?? { me: null, can: {} },
+    // The same log the public parent writes to. A member page can throw before it ever readies —
+    // the page that sits on its loading state — and without this the pane would report that page
+    // as silent, which is the one thing it exists not to do.
+    notice: (report) => remember({ kind: "notice", code: report.code, detail: report.detail }),
   },
   () => nonce.value,
 );

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -20,7 +20,7 @@
 // a role may WRITE is not tested; nobody else exists, so nothing here is concurrent; and it cannot
 // tell whether the Firestore rules a new declaration needs have been deployed at all.
 import { computed, onBeforeUnmount, ref, shallowRef, toRaw, watch } from "vue";
-import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE, type PendingSubmit } from "@receptron/sharedapp/view";
+import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE, type PendingSubmit, type Viewer } from "@receptron/sharedapp/view";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
 import { isRecord } from "../../common/isRecord";
 import { createPreviewLog, renderPreviewLog, type PreviewLogEvent } from "../utils/sharedAppPreviewLog";
@@ -251,9 +251,14 @@ const member = memberBridge(
       };
     },
     state: () => datasets.value,
-    // Never a floor. A page whose payload carried no viewer is a page this pane could not resolve
-    // one for, and inventing an empty one here is the bug being fixed.
-    viewer: () => page.value?.viewer ?? { me: null, can: {} },
+    // NO FLOOR. This parent is chosen only for a page that HAS a viewer (see `memberPage`), so
+    // there is nothing to fall back to — and inventing `{ me: null, can: {} }` here is the exact
+    // bug this whole change removes: a page drawing no controls, with nothing anywhere saying why.
+    viewer: () => page.value?.viewer ?? UNRESOLVED_VIEWER,
+    // The SAME cell the public parent writes, so the handshake is logged whichever parent answered
+    // it. Watched below rather than recorded here: the cell is what the bridge actually writes, so
+    // nothing can move without the log seeing it.
+    readied: cells.readied,
     // The same log the public parent writes to. A member page can throw before it ever readies —
     // the page that sits on its loading state — and without this the pane would report that page
     // as silent, which is the one thing it exists not to do.
@@ -262,9 +267,24 @@ const member = memberBridge(
   () => nonce.value,
 );
 
-/** Which parent is talking to the document on screen. The audience decides, exactly as the address
- *  decides it in production: `/a/` is the public one, `/m/` and `/p/` are the member's. */
-const memberPage = computed(() => page.value !== null && page.value.audience !== "public");
+/** Answering a `viewer` question for a page that has none. Unreachable — `memberPage` is what
+ *  selects this parent and it requires one — and here so that a future change which loses that
+ *  guarantee produces an empty-capability page WITH a line in the log above, rather than the silent
+ *  no-controls page this whole change removes. */
+const UNRESOLVED_VIEWER: Viewer = { me: null, can: {} };
+
+/** Which parent is talking to the document on screen.
+ *
+ *  The audience decides WHICH parent a page should have — `/a/` is the public one, `/m/` and `/p/`
+ *  are the member's, exactly as the address decides it in production. But the member parent needs
+ *  capabilities to be worth choosing, so the test is that the payload actually carried them: a
+ *  member page without a `viewer` would otherwise be handed an empty one and draw no controls,
+ *  which is the failure being fixed rather than a smaller version of the fix.
+ *
+ *  That case is REPORTED. Falling back to the public parent quietly would put an author back in
+ *  front of the same blank page with nothing to read — and the cause is not in their page at all,
+ *  it is a host too old to resolve capabilities, or a payload this pane could not narrow. */
+const memberPage = computed(() => page.value !== null && page.value.audience !== "public" && page.value.viewer !== undefined);
 
 /** Only messages from OUR frame. The sandbox's origin is opaque, so `event.origin` cannot draw
  *  this boundary and `event.source` is what does. */
@@ -317,6 +337,14 @@ watch(
     // they came from is often where the fault is — a member page that never readied looks identical
     // to one nobody opened.
     if (page.value !== null) remember({ kind: "page", id: page.value.id, audience: page.value.audience });
+    // Said once per page, and counted as a problem: everything below it is a report about a page
+    // running under the wrong parent.
+    if (page.value !== null && page.value.audience !== "public" && page.value.viewer === undefined) {
+      remember({
+        kind: "host",
+        note: "this page is written for the roster but arrived with no capabilities, so it is being run under the PUBLIC parent — it will be sent no `viewer` and its member controls cannot work. The page is not at fault: either this server could not resolve them, or its answer was in a shape this pane could not read.",
+      });
+    }
   },
 );
 

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -1,0 +1,116 @@
+// The preview payload, narrowed rather than asserted.
+//
+// Its own module because narrowing an untrusted-shaped payload is a different job from drawing it:
+// everything here is a pure function of the JSON and is testable without a browser or a server —
+// and because the pane it serves is at its line limit, which is what forced the split.
+//
+// The wire shape itself lives in `common/sharedAppPreview.ts`, decided by both ends.
+import type { Viewer, ViewCapability } from "@receptron/sharedapp/view";
+import { isRecord } from "../../common/isRecord";
+import type { PreviewAudience, PreviewDataset, PreviewForm, PreviewFormField, PreviewPage, SharedAppPreview } from "../../common/sharedAppPreview";
+
+/** The payload, narrowed rather than asserted. Every field has a floor, because a pane that threw
+ *  on an unexpected shape would report a server it could not read as an app that will not publish —
+ *  two very different things to be told while you are trying to fix a page. */
+export function asPayload(value: unknown): SharedAppPreview | null {
+  if (!isRecord(value)) return null;
+  return {
+    aid: typeof value.aid === "string" ? value.aid : "",
+    submit: asSubmit(value.submit),
+    pages: Array.isArray(value.pages) ? value.pages.flatMap(asPage) : [],
+    publicOpen: value.publicOpen === true,
+    fromLiveApp: value.fromLiveApp === true,
+    generatedForm: value.generatedForm === true,
+    formInputs: asFormInputs(value.formInputs),
+    datasets: isRecord(value.datasets) ? Object.fromEntries(Object.entries(value.datasets).map(([key, rows]) => [key, asDatasets(rows)])) : {},
+    unreadable: strings(value.unreadable),
+    warnings: strings(value.warnings),
+  };
+}
+
+/** What a public create may carry, per collection. Narrowed with a floor of `[]` rather than
+ *  dropped: an unreadable declaration must make the parent refuse a FIELD, not refuse the whole
+ *  collection — the two refusals name different repositories to whoever reads them. */
+const asSubmit = (value: unknown): Record<string, { createFields: string[] }> => {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(Object.entries(value).map(([cid, spec]) => [cid, { createFields: isRecord(spec) ? strings(spec.createFields) : [] }]));
+};
+
+/** The generated form's inputs. A collection whose inputs cannot be read is DROPPED rather than
+ *  drawn empty: an empty form is a Send button that submits nothing, and the author would read the
+ *  refusal that follows as a fault in their declaration. */
+const asFormInputs = (value: unknown): PreviewForm => {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([cid, fields]) => {
+      const drawn = Array.isArray(fields) ? fields.flatMap(asFormField) : [];
+      return drawn.length === 0 ? [] : [[cid, drawn] as const];
+    }),
+  );
+};
+
+const asFormField = (value: unknown): PreviewFormField[] => {
+  if (!isRecord(value) || typeof value.name !== "string" || value.name === "") return [];
+  const values = strings(value.values);
+  return [
+    {
+      name: value.name,
+      label: typeof value.label === "string" && value.label !== "" ? value.label : value.name,
+      required: value.required === true,
+      type: typeof value.type === "string" ? value.type : "string",
+      ...(values.length === 0 ? {} : { values }),
+    },
+  ];
+};
+
+const strings = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
+
+const AUDIENCES: PreviewAudience[] = ["public", "member", "roster"];
+
+const asPage = (value: unknown): PreviewPage[] => {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.html !== "string") return [];
+  const audience = AUDIENCES.find((candidate) => candidate === value.audience);
+  if (audience === undefined) return [];
+  return [{ id: value.id, html: value.html, audience, ...asViewer(value.viewer) }];
+};
+
+/** One collection's capability, field by field.
+ *
+ *  Rebuilt rather than passed through, and NOT asserted into shape: what arrives is JSON from this
+ *  host's own server, but the SHAPE is decided in another repository (`@receptron/sharedapp`), and
+ *  an assertion here would turn a rename there into a page drawing a control it may not use. Every
+ *  flag floors to false, which is the direction that refuses. */
+const asCapability = (cid: string, value: unknown): ViewCapability => {
+  const from = isRecord(value) ? value : {};
+  return {
+    cid,
+    transitionAny: from.transitionAny === true,
+    transitionOwn: from.transitionOwn === true,
+    assign: from.assign === true,
+    assignees: strings(from.assignees),
+    ...(typeof from.assigneeField === "string" ? { assigneeField: from.assigneeField } : {}),
+    withdrawFrom: strings(from.withdrawFrom),
+  };
+};
+
+/** The `{ me, can }` the server resolved for this page, or nothing.
+ *
+ *  A FLOOR IS NOT WANTED HERE, and that is the decision rather than an omission: inventing
+ *  `{ me: null, can: {} }` for a payload that carried none is the empty viewer this whole change
+ *  exists to remove — it draws a page with no buttons and says nothing about why. Absent, the pane
+ *  uses the public parent, which is right for a public page and reported for any other.
+ *
+ *  `me` floors to null rather than to "": null is "no verified address", a member of nothing, while
+ *  "" is an address that could accidentally equal an empty `assigneeField` on a record. */
+const asViewer = (value: unknown): { viewer?: Viewer } => {
+  if (!isRecord(value) || !isRecord(value.can)) return {};
+  const me = typeof value.me === "string" && value.me !== "" ? value.me : null;
+  return { viewer: { me, can: Object.fromEntries(Object.entries(value.can).map(([cid, entry]) => [cid, asCapability(cid, entry)])) } };
+};
+
+const asDatasets = (value: unknown): Record<string, PreviewDataset> => {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).map(([cid, rows]) => [cid, Array.isArray(rows) ? rows.filter((row): row is Record<string, unknown> => isRecord(row)) : []]),
+  );
+};

--- a/test/server/backends/headlessReport.spec.ts
+++ b/test/server/backends/headlessReport.spec.ts
@@ -102,17 +102,19 @@ describe("narrateHeadlessRun", () => {
     expect(said).toContain("confirmation was already open");
   });
 
-  it("says what a member page's run did NOT cover, and does not blame the page for an intent", () => {
-    // `transition` / `assign` / `withdraw` are answered by a parent that is not shared code yet
-    // (mulmoserver's `AppViewFrame.vue`), so the public parent judging them `not-a-submission` is
-    // expected — reading it back as "you sent a value that is not a string" would send an author
-    // to rewrite a page that is correct.
-    const said = narrate({ audience: "member", presses: [press({ refused: ["not-a-submission"] })] });
-    expect(said).toContain("only PART of it is exercised here");
-    expect(said).toContain("no `viewer` capabilities");
-    expect(said).toContain("expected for `transition`");
+  it("reads a member page's declined write as the control WORKING, not as a fault", () => {
+    // The member parent judges `transition` / `assign` / `withdraw` and would perform them on the
+    // live page; here it has nowhere to write, so it answers `read-only`. Said as a fault, this
+    // would send an author to rewrite a page that is correct — and it is the shape the old report
+    // had, back when the public parent judged an intent `not-a-submission`.
+    const said = narrate({ audience: "member", presses: [press({ refused: ["read-only"] })] });
+    expect(said).toContain("the control is wired, not that anything is wrong");
     expect(said).not.toContain("most often a value that is not a string");
-    // And a PUBLIC page still gets the ordinary translation.
+    // The remaining limit is the WRITE, and it is still stated on every member page.
+    expect(said).toContain("REFUSED rather than performed");
+    // What is no longer claimed: the page DOES get its capabilities now.
+    expect(said).not.toContain("no `viewer` capabilities");
+    // And a PUBLIC page still gets the ordinary translation of a real refusal.
     expect(narrate({ presses: [press({ refused: ["not-a-submission"] })] })).toContain("most often a value that is not a string");
   });
 

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -21,6 +21,18 @@ const PAGE = "<h1>Book</h1>";
 
 const FORM_FIELD = { name: "name", label: "お名前", required: true, type: "string" };
 
+/** One collection's capability, as the server resolves it for the author. Written out rather than
+ *  built, so the SHAPE a page reads is pinned here too: `can` is keyed by collection, and a page
+ *  reaching for `viewer.can.transitionAny` gets undefined for every app that has ever existed. */
+const MEMBER_CAPABILITY = { cid: "bookings", transitionAny: true, transitionOwn: false, assign: false, assignees: [], withdrawFrom: [] };
+
+/** An app whose only page is written for the front desk, so it is the one selected on mount. */
+const memberPayload = () =>
+  payload({
+    pages: [{ id: "desk", html: PAGE, audience: "member", viewer: { me: "owner@gym.jp", can: { bookings: MEMBER_CAPABILITY } } }],
+    datasets: { "member:desk": { bookings: [] } },
+  });
+
 const payload = (over: Record<string, unknown> = {}) => ({
   declared: true,
   ok: true,
@@ -259,6 +271,52 @@ describe("SharedAppPreview", () => {
     await settle();
 
     expect(await copyBlock(wrapper)).toContain("could not reach this host's own server");
+  });
+
+  // WHO the author is to a member page, and what they may change.
+  //
+  // The pane had one parent — the PUBLIC one — whose state message has no `viewer` key at all. The
+  // injected runtime reads `data.viewer || {}`, so every roster page ever previewed here was handed
+  // an empty object and drew none of its buttons. That is indistinguishable from an author who got
+  // the capability names wrong, and it was diagnosed as exactly that before this was fixed.
+  it("hands a member page the capabilities the live page would get", async () => {
+    vi.stubGlobal("fetch", answering(memberPayload()));
+    const wrapper = await mountPreview();
+    const { answers } = await connect(wrapper);
+    const state = answers.find((message) => message.type === "mc-public-view:state");
+    expect(state).toBeDefined();
+    expect(state?.viewer).toEqual({ me: "owner@gym.jp", can: { bookings: MEMBER_CAPABILITY } });
+    wrapper.unmount();
+  });
+
+  // A public page must NOT get one. It has no reader and no roles, and a `viewer` there would be an
+  // answer to a question that page never asks — the pane sending one anyway is how a public page
+  // starts branching on something only a member has.
+  it("sends no viewer to a public page", async () => {
+    const wrapper = await mountPreview();
+    const { answers } = await connect(wrapper);
+    const state = answers.find((message) => message.type === "mc-public-view:state");
+    expect(state).toBeDefined();
+    expect(state).not.toHaveProperty("viewer");
+    wrapper.unmount();
+  });
+
+  // The member parent performs nothing — the pane has no route for a member's write — so an intent
+  // is answered BY NAME rather than dropped. A view left on a promise is, to the person holding the
+  // phone, a button that does nothing, which is the symptom this whole pane exists to explain.
+  it("answers a member page's intent instead of leaving it waiting", async () => {
+    vi.stubGlobal("fetch", answering(memberPayload()));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+    port.postMessage({ type: "mc-public-view:intent", requestId: "r1", kind: "transition", cid: "bookings", itemId: "b1", to: "approved" });
+    await settle();
+    // `submitResult`, not `result`: one name answers a submission and an intent alike, because the
+    // view awaits one promise either way.
+    const result = answers.find((message) => message.type === "mc-public-view:submitResult" && message.requestId === "r1");
+    expect(result).toBeDefined();
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toBe("read-only");
+    wrapper.unmount();
   });
 
   it("renders the page in a frame no looser than the published one", async () => {

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -283,6 +283,11 @@ describe("SharedAppPreview", () => {
     vi.stubGlobal("fetch", answering(memberPayload()));
     const wrapper = await mountPreview();
     const { answers } = await connect(wrapper);
+    // A port's delivery is a MACROTASK, so `flushPromises` alone does not guarantee it has
+    // arrived. It happened to on Linux and macOS and did not on Windows — a test that passes by
+    // being fast enough is a test that reports a working feature as broken on somebody else's
+    // machine.
+    await settle();
     const state = answers.find((message) => message.type === "mc-public-view:state");
     expect(state).toBeDefined();
     expect(state?.viewer).toEqual({ me: "owner@gym.jp", can: { bookings: MEMBER_CAPABILITY } });
@@ -295,6 +300,11 @@ describe("SharedAppPreview", () => {
   it("sends no viewer to a public page", async () => {
     const wrapper = await mountPreview();
     const { answers } = await connect(wrapper);
+    // A port's delivery is a MACROTASK, so `flushPromises` alone does not guarantee it has
+    // arrived. It happened to on Linux and macOS and did not on Windows — a test that passes by
+    // being fast enough is a test that reports a working feature as broken on somebody else's
+    // machine.
+    await settle();
     const state = answers.find((message) => message.type === "mc-public-view:state");
     expect(state).toBeDefined();
     expect(state).not.toHaveProperty("viewer");
@@ -328,6 +338,35 @@ describe("SharedAppPreview", () => {
     const wrapper = await mountPreview();
     await speakFromFrame(wrapper, { type: "mc-public-view:notice", nonce: nonceOf(wrapper), code: "error", detail: "boom" });
     expect(await copyBlock(wrapper)).toContain("the page raised an error nothing caught");
+    wrapper.unmount();
+  });
+
+  // A member page that arrives WITHOUT capabilities. The pane must not hand it an invented empty
+  // viewer — that is the no-controls page this whole change removes — and it must not fall back to
+  // the public parent quietly either, which puts the author in front of the same blank page with
+  // nothing to read. The cause is not in their page: it is a host too old to resolve them, or an
+  // answer in a shape this pane could not narrow.
+  it("says so when a member page arrives with no capabilities, rather than drawing a blank one", async () => {
+    vi.stubGlobal("fetch", answering(payload({ pages: [{ id: "desk", html: PAGE, audience: "member" }], datasets: { "member:desk": { bookings: [] } } })));
+    const wrapper = await mountPreview();
+    const block = await copyBlock(wrapper);
+    expect(block).toContain("arrived with no capabilities");
+    expect(block).toContain("The page is not at fault");
+    // And it is COUNTED, so the pane's own indicator lights: a line nobody is pointed at is a line
+    // nobody reads.
+    expect(block).toContain("1 problem");
+    wrapper.unmount();
+  });
+
+  // Whichever parent answered it. The handshake is the line above which nothing else can be
+  // trusted, and the pane watches ONE cell for it — wired to the public parent alone, a member page
+  // that readied perfectly showed no handshake at all.
+  it("logs the handshake for a member page too", async () => {
+    vi.stubGlobal("fetch", answering(memberPayload()));
+    const wrapper = await mountPreview();
+    await connect(wrapper);
+    await settle();
+    expect(await copyBlock(wrapper)).toContain("the page answered the handshake");
     wrapper.unmount();
   });
 

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -319,6 +319,18 @@ describe("SharedAppPreview", () => {
     wrapper.unmount();
   });
 
+  // A member page that throws while its script is being parsed never reaches `ready()`. It sits on
+  // its loading state with the reason sealed inside the frame, and it is the page an author cannot
+  // otherwise diagnose — so the pane must hear it through the member parent too, not only the
+  // public one.
+  it("hears a member page report itself before the handshake", async () => {
+    vi.stubGlobal("fetch", answering(memberPayload()));
+    const wrapper = await mountPreview();
+    await speakFromFrame(wrapper, { type: "mc-public-view:notice", nonce: nonceOf(wrapper), code: "error", detail: "boom" });
+    expect(await copyBlock(wrapper)).toContain("the page raised an error nothing caught");
+    wrapper.unmount();
+  });
+
   it("renders the page in a frame no looser than the published one", async () => {
     const wrapper = await mountPreview();
     const frame = wrapper.find("iframe");

--- a/test/src/utils/sharedAppPreviewLog.spec.ts
+++ b/test/src/utils/sharedAppPreviewLog.spec.ts
@@ -56,12 +56,12 @@ describe("the pane's log", () => {
     expect(block).toContain("`createFields`");
   });
 
-  it("does not blame a roster page for an intent the preview's parent cannot answer", () => {
-    // `transition`, `assign` and `withdraw` come back `not-a-submission` here because the parent
-    // that answers them is mulmoserver's, and the public translation would read as a fault in a
-    // page that did the right thing.
-    const block = render((log) => log.add({ kind: "refused", reason: "not-a-submission", audience: "member" }));
-    expect(block).toContain("expected for `transition`");
+  it("reads a roster page's declined write as the control working, not as a fault", () => {
+    // The member parent judges `transition`, `assign` and `withdraw` and would perform them on the
+    // live page. Here it has nowhere to write, so it answers `read-only` — and the public
+    // translation of a refusal would read as a fault in a page that did the right thing.
+    const block = render((log) => log.add({ kind: "refused", reason: "read-only", audience: "member" }));
+    expect(block).toContain("the control is wired, not that anything is wrong");
   });
 
   it("keeps the deployed rules' refusal, which the screen keeps only until the next attempt", () => {

--- a/test/src/utils/sharedAppPreviewPayload.spec.ts
+++ b/test/src/utils/sharedAppPreviewPayload.spec.ts
@@ -1,0 +1,77 @@
+// The preview payload, as the pane reads it back.
+//
+// Narrowing is what stands between a shape decided in `@receptron/sharedapp` and a pane that draws
+// the wrong thing without failing. The capability half is the one with teeth: every flag floors to
+// FALSE, so a renamed or missing field takes a control away rather than offering one the rules will
+// refuse — and a control drawn on a permission nobody holds is the exact mismatch the whole viewer
+// mechanism exists to prevent.
+import { describe, it, expect } from "vitest";
+import { asPayload } from "../../../src/utils/sharedAppPreviewPayload";
+
+const page = (over: Record<string, unknown> = {}) => ({ id: "desk", html: "<h1>Desk</h1>", audience: "member", ...over });
+
+describe("the preview payload", () => {
+  it("carries a member page's viewer through, rebuilt field by field", () => {
+    const viewer = {
+      me: "desk@gym.jp",
+      can: { bookings: { transitionAny: true, assignees: ["a@x.jp"], assigneeField: "coach", withdrawFrom: ["requested"] } },
+    };
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer })] });
+    expect(parsed?.pages[0]?.viewer).toEqual({
+      me: "desk@gym.jp",
+      can: {
+        bookings: {
+          cid: "bookings",
+          transitionAny: true,
+          transitionOwn: false,
+          assign: false,
+          assignees: ["a@x.jp"],
+          assigneeField: "coach",
+          withdrawFrom: ["requested"],
+        },
+      },
+    });
+  });
+
+  it("floors every permission to false, so a renamed field removes a control rather than inventing one", () => {
+    // The direction matters. A page handed `transitionAny: true` for a permission the reader does
+    // not hold draws a button the rules refuse — a refusal that names nothing, to somebody who did
+    // what the page told them to.
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer: { me: "x@y.jp", can: { bookings: { transitionAnyy: true, assign: "yes" } } } })] });
+    const can = parsed?.pages[0]?.viewer?.can.bookings;
+    expect(can?.transitionAny).toBe(false);
+    expect(can?.assign).toBe(false);
+    expect(can?.assignees).toEqual([]);
+    expect(can?.assigneeField).toBeUndefined();
+  });
+
+  it("keeps the cid from the KEY, so an entry cannot claim to be another collection", () => {
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer: { me: "x@y.jp", can: { bookings: { cid: "payments", transitionAny: true } } } })] });
+    expect(parsed?.pages[0]?.viewer?.can.bookings?.cid).toBe("bookings");
+  });
+
+  it("leaves a page with no viewer WITHOUT one, rather than inventing an empty answer", () => {
+    // An invented `{ me: null, can: {} }` is precisely the bug this change removes: it draws a page
+    // with no buttons and says nothing about why. Absent, the pane uses the public parent.
+    const parsed = asPayload({ aid: "a", pages: [page()] });
+    expect(parsed?.pages[0]).not.toHaveProperty("viewer");
+    // And a `viewer` with no `can` is not a viewer either.
+    expect(asPayload({ aid: "a", pages: [page({ viewer: { me: "x@y.jp" } })] })?.pages[0]).not.toHaveProperty("viewer");
+  });
+
+  it("reads no address as null, never as an empty string", () => {
+    // `""` would equal an empty `assigneeField` on a record, which is how a reader with no address
+    // ends up holding somebody's row.
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer: { me: "", can: {} } })] });
+    expect(parsed?.pages[0]?.viewer?.me).toBeNull();
+  });
+
+  it("drops a page whose audience is not one of the three", () => {
+    expect(asPayload({ aid: "a", pages: [page({ audience: "staff" })] })?.pages).toEqual([]);
+  });
+
+  it("answers a payload it cannot read at all with null, rather than throwing", () => {
+    expect(asPayload("nope")).toBeNull();
+    expect(asPayload({})?.pages).toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.6.0.tgz#dcb9f1013448307616b347635abe7535bd8ec705"
-  integrity sha512-PYoMrXBjYI5OhkNEDYOaMYprafyRz95lfYNTthY/qjJmBKG2C2Qm5EosMPxbvsMXzcyS0rL9/fGHrXWJc4oAwQ==
+"@receptron/sharedapp@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.7.0.tgz#55c0c6e8676ce35da83c38b5c06992c2260e201a"
+  integrity sha512-8shNli5AN7ssS7s+aC2GPvU9ABZeRSCMASwiqzbulEj+z2p0HZVUcEC7mDDpVZVCsYwfvm4X4p8NfovxcKucMQ==
   dependencies:
     zod "^4.1.13"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.7.0.tgz#55c0c6e8676ce35da83c38b5c06992c2260e201a"
-  integrity sha512-8shNli5AN7ssS7s+aC2GPvU9ABZeRSCMASwiqzbulEj+z2p0HZVUcEC7mDDpVZVCsYwfvm4X4p8NfovxcKucMQ==
+"@receptron/sharedapp@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.7.2.tgz#6a0fef957f70a4a2b905120852c7dde5f5861334"
+  integrity sha512-b5ss3WVXwRgpIKQ1OhQKiGLtTUiFCYaYGMHQoFdZXItJOE/ggCofQpov0jx0i06+zcp136aIdRW7YrcXk96XWQ==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
Collections ペインで名簿・参加者向けページをプレビューすると、ページが**ボタンを 1 つも描かない**。

## 何が起きていたか

ペインは公開ページ用の `viewBridge` を使っていた。その state は `{ type, collections }` で **`viewer` のキーが無い**（`bridge.ts`）。注入される runtime は `onState(data.collections || {}, data.viewer || {})`（`srcdoc.ts`）。

つまり**プレビューで開いた名簿向けページは、例外なく空の `viewer` を受け取っていた**。そしてその状態は「著者が capability の名前を間違えた」のと画面上まったく区別が付かない — 実際、別セッションがこれを `/p/` のプラットフォーム不具合と診断し、メールアドレスを打たせて自分の申込みを絞り込む回避策を公開した。本番の `/p/` は正常です。

## 言うだけでは足りなかった

`headlessReport.ts` はこれを毎回のレポートに書いていた:

> The parent carrying `viewer` capabilities … lives in mulmoserver (`AppViewFrame.vue`) and is **NOT shared code yet** … the limit belongs to the Collections pane too, which is why it is **STATED** rather than worked around.

レポートを読むのは著者と、著者が使う LLM です。どちらも「ここでは試されない」より先に**「ボタンが出ない」**を見る。書いてあることは、見えている症状に負けました。

## 直し方

親は `@receptron/sharedapp/view` の **`memberBridge`** から取る（receptron/sharedapp#8）。mulmoserver が `/m/` と `/p/` に出しているのと同じもので、そうでなければ「2 つ目の実装」になる — 同ファイルが明示的に禁じているとおりです。

- **`viewer` はサーバが解決する。** `preview.ts` が tier の射影と `handle.email` から `viewerFor` を呼び、ページごとに載せる。クライアントは射影も著者のアドレスも持たないので、射影を送って向こうで解決させるのが、まさにその 2 つ目の実装にあたる
- `PreviewPage.viewer?: Viewer` を `common/` に（両端が決める wire shape なので）
- **ペインは audience で親を選ぶ** — 本番でアドレスが選ぶのと同じ判断
- **headless harness も同じ**。両方が「プレビュー」なので、片方だけ直すと次に同じ話になる
- `MEMBER_PAGE_LIMIT` を実態まで縮める

## 残る限界（意図的）

**プレビューは intent を実行しません。** ペインにも headless にも会員の書き込み用の経路が無いので、`transition` / `assign` / `withdraw` は **`read-only` として名指しで拒否**されます。

沈黙ではないことが要点なので、語彙も直しました。`READ_ONLY_ON_A_MEMBER_PAGE` は「**その控えは配線されている**、おかしいことは何も起きていない」と読ませます。以前の `NOT_A_SUBMISSION_ON_A_MEMBER_PAGE`（公開の親が intent を `not-a-submission` と答えていた頃の文言）は、もう起きないので削除しました。

## 副産物

`SharedAppPreview.vue` が 600 行の上限に当たったので、payload の narrowing を `src/utils/sharedAppPreviewPayload.ts` に出しました。ついでに `can` の型アサーションを**フィールドごとの組み立て**に置き換えています — 形を決めているのは別リポジトリなので、アサーションだと向こうの rename が「使えない控えを描くページ」になって現れる。**すべて false に floor する**ので、名前が変われば控えが消える方向に倒れます。

## 確認

`format` / `lint` / `typecheck` / `build` / `test`（**10,383 tests**、うち新規 10）すべて緑。

## 順序

**receptron/sharedapp#8 → receptron/mulmoserver#189 → これ。** sharedapp 0.7.0 が npm に出るまで CI は赤い（`^0.7.0` を宣言済み）。

計画: `plans/feat-shared-app-member-parent.md`

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Member-page previews now include viewer identity and capabilities.
  - Headless previews support member-page viewer context.
  - Preview data is safely validated and normalized, including malformed or incomplete inputs.

- **Bug Fixes**
  - Improved routing and state handling when switching between public and member pages.
  - Correctly refused member-page actions are now clearly identified as read-only rather than errors.

- **Tests**
  - Added coverage for viewer permissions, payload validation, member-page behavior, and refusal messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->