### PR TITLE
docs: staging を消したあとに残っていた過去形でない注釈を直す

### DIFF
--- a/server/backends/sharedApp/appViews.ts
+++ b/server/backends/sharedApp/appViews.ts
@@ -21,13 +21,12 @@
 //
 //   A WITHDRAWN PAGE IS DELETED, not merely stopped being written. The tier is
 //   readable by everyone it admits, forever: drop a view from `views[]` and the
-//   old page stays fetchable until something removes it. Deploy withdraws its
-//   `staged:`, publish withdraws its `live:`.
+//   old page stays fetchable until something removes it, so publish withdraws
+//   the `live:` documents its own declaration no longer names.
 //
-//   DEPLOY AND PUBLISH WRITE THE SAME SHAPE at two prefixes. That is what makes
-//   "try the staff page before the customers see it" possible at all, and it is
-//   the same road the schemas already travel (`staging/{cid}` then
-//   `collections/{cid}`).
+//   `live:` IS A PREFIX WITH NOTHING TO CONTRAST WITH, and it is kept anyway —
+//   it is how that sweep tells a page THIS code wrote from any other document in
+//   the tier. See `staleViewDocs` below.
 import {
   appViewTierPath,
   participantScope,
@@ -124,11 +123,12 @@ const wantedDocIds = (plan: TierPlan): Set<string> => {
   return new Set([viewConfigDocId(), ...plan.pages.map((page) => viewDocId(page.id))]);
 };
 
-/** Documents at this stage that the declaration no longer names.
+/** Documents in this tier that the declaration no longer names.
  *
- *  Listed rather than inferred, for the reason `staleStaged` gives about the
- *  schemas: a page withdrawn from `views[]` leaves a document nothing would
- *  otherwise touch, the entrance goes on offering it.
+ *  Listed rather than inferred, for the reason the schemas' own sweep had: the
+ *  declaration says what SHOULD be there and nothing says what is, so a page
+ *  withdrawn from `views[]` leaves a document nothing would otherwise touch —
+ *  and the entrance goes on offering it.
  *
  *  `live:` is the only prefix there is. There was a `staged:` set beside it, written by a deploy
  *  for the roster to try; both are gone (`plans/feat-shared-app-no-staging.md`). */

--- a/server/backends/sharedApp/appViews.ts
+++ b/server/backends/sharedApp/appViews.ts
@@ -1,7 +1,7 @@
 // The app's own pages, written to the tier each audience may read.
 //
-// The public page keeps `config/*` — world-readable, one view, already
-// deployed. What is new here is the other two audiences, and the reason they
+// The public page keeps `config/*` — world-readable, one view, already in
+// place. What is new here is the other two audiences, and the reason they
 // cannot share that document is the rules: `config/{docId}` is
 // `allow read: if true`, so a page written for the front desk would publish the
 // app's internal vocabulary — status names, review-note headings, how work is
@@ -91,8 +91,8 @@ function unreachableProblems(
  *  The same reader the public page uses, and the same refusals: a path to
  *  nothing, a page over the document limit, a page written against the host's
  *  bridge. It runs BEFORE anything is written, because a page that cannot be
- *  read must stop the operation rather than land after the schemas have been
- *  promoted.
+ *  read must stop the operation rather than land after the schemas have gone
+ *  out.
  *
  *  The `participantRead` in force is the manifest's, because that is what publish writes beside
  *  these pages. Getting it wrong publishes `scope: "all"` for a collection the rules then deny. */
@@ -168,10 +168,10 @@ export function tierWrites(handle: SharedAppHandle, aid: string, plan: TierPlan,
     // The PAGES first, then the settings that name them.
     //
     // `runWrites` can stop after any successful write, so the order decides
-    // what a half-finished deploy leaves. Settings-first leaves a document
+    // what a half-finished publish leaves. Settings-first leaves a document
     // naming a page that is not there — the entrance offers it and it cannot be
     // drawn. Pages-first leaves a page nobody has been told about, which is
-    // invisible and harmless, and the next deploy completes it.
+    // invisible and harmless, and the next publish completes it.
     ...plan.pages.map((page) => ({
       what: `the ${plan.tier} page '${page.id}' (${at}/${viewDocId(page.id)})`,
       run: () => handle.docs.set(at, viewDocId(page.id), { html: page.html, publishedAt: stamp.publishedAt }),
@@ -203,13 +203,12 @@ export interface PlannedTier {
   stale: string[];
 }
 
-/** Everything both operations need before they write a single document: the
- *  pages read off disk, and the documents at this stage the declaration no
- *  longer names.
+/** Everything publish needs before it writes a single document: the pages read
+ *  off disk, and the documents in this tier the declaration no longer names.
  *
- *  Read off disk BEFORE either operation writes anything: a page that is
- *  missing, oversized, or written against the host's bridge has to stop the run
- *  rather than land after the schemas have been promoted.
+ *  Read off disk BEFORE anything is written: a page that is missing, oversized,
+ *  or written against the host's bridge has to stop the run rather than land
+ *  after the schemas have gone out.
  *
  *  ONE function, and it used to be shared by deploy and publish so the two could not disagree
  *  about what a tier contains. Publish is the only writer now. */

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -116,8 +116,8 @@ function ownerFromRoster(app: AuthoredApp): string | undefined {
  *
  *  Shared by the gate that runs before a publish and by `check`, which exists to answer "would a
  *  publish be refused?" — two implementations of that question is two answers, and the one `check`
- *  gave was the optimistic one (it missed the `owner` uid mismatch, and said deployable about a
- *  declaration the next deploy refused). */
+ *  gave was the optimistic one (it missed the `owner` uid mismatch, and said publishable about a
+ *  declaration the next publish refused). */
 export function declarationProblems(app: AuthoredApp, collections: readonly LoadedCollection[], handle: { email: string; uid: string } | null): string[] {
   const problems = publishProblems(
     app,
@@ -137,7 +137,7 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
     // misunderstanding of what the key is.
     problems.push(
       `app.json declares owner "${app.owner}", which is not your uid (${handle.uid}). ` +
-        "`owner` is stamped by deploy and carried forward unchanged afterwards — remove it from app.json rather than maintaining it by hand.",
+        "`owner` is stamped by the operation that creates the app and carried forward unchanged afterwards — remove it from app.json rather than maintaining it by hand.",
     );
   }
   return problems;
@@ -147,7 +147,7 @@ export function declarationProblems(app: AuthoredApp, collections: readonly Load
  *
  *  `email() in a.members` is an exact string comparison and rules have no `lower()`. Firebase puts
  *  a lower-cased address in the token, so `Foo@Example.com` on the roster grants nothing — and the
- *  deploy succeeds, the file reads correctly to a human, and the person invited is refused
+ *  publish succeeds, the file reads correctly to a human, and the person invited is refused
  *  everything with no error anywhere that names them. Said here rather than repaired, because the
  *  roster is a committed file people edit by hand and rewriting somebody's key is not ours to do.
  *
@@ -171,7 +171,7 @@ export interface SharedAppContext {
 }
 
 /** Load and vet everything the three operations share, in one place so they cannot disagree about
- *  what a valid declaration is — the gate that runs before deploy has to be the same one that runs
+ *  what a valid declaration is — the gate that runs before publish has to be the same one that runs
  *  before publish, or `confirm` on the cheap operation becomes a way past the expensive one. */
 export async function sharedAppContext(root: string): Promise<SharedAppContext | SharedAppFailure> {
   const handle = firestoreHandle();
@@ -194,7 +194,7 @@ export async function sharedAppContext(root: string): Promise<SharedAppContext |
   return { ok: true, authored: authored.app, collections, handle };
 }
 
-/** The app document as it stands, or the refusal — shared by deploy and publish, which read it
+/** The app document as it stands, or the refusal — shared by every operation that reads it
  *  for the same two reasons and must report a failed read the same way.
  *
  *  The read decides what the rules care about: whether `owner` is stamped or carried forward, and
@@ -244,7 +244,7 @@ export async function readCurrentApp(
  *  missing index, a stale transaction, a client the backend wants restarted. Reading it as a
  *  refusal is dangerous in both places this predicate is used, and in the same direction:
  *
- *  - the app document would look ABSENT, so a deploy would rebuild it from the declaration alone
+ *  - the app document would look ABSENT, so a publish would rebuild it from the declaration alone
  *    and drop the `public` block and the held slug — silently unpublishing a live app and
  *    stranding its URL name;
  *  - a slug would look like SOMEBODY ELSE'S, so a numbered alternative would be taken while the
@@ -262,7 +262,7 @@ export function isRefusal(err: unknown): boolean {
  *  Sharing the builder is what keeps the two from drifting into stamping different clocks, or
  *  dropping `dirty` on one side: a commit that does not describe what was written is worse than
  *  no commit, because it looks auditable. (The KEY is `publishedAt` whichever operation stamps
- *  it; the deploy projection re-reads it as `deployedAt`.) */
+ *  it; the publish projection re-reads it as `publishedAt`.) */
 export async function stampFor(handle: SharedAppHandle, root: string, opts: SharedAppOptions): Promise<{ stamp: PublishStamp; dirty: boolean }> {
   const source = await (opts.resolveCommit ?? gitStamp)(root);
   return {

--- a/server/backends/sharedApp/declare.ts
+++ b/server/backends/sharedApp/declare.ts
@@ -2,8 +2,8 @@
 //
 // `app.json` is a small file, and every one of its failures found in testing came from the same
 // place: the agent had to write it from memory, before anything could check it. It guessed the
-// owner's address (the tool knows it), it wrote a `public` block that deploy refused for three
-// separate reasons, and when a deploy failed it edited the file by hand — deleting the `aid` and
+// owner's address (the tool knows it), it wrote a `public` block that publish refused for three
+// separate reasons, and when a publish failed it edited the file by hand — deleting the `aid` and
 // creating a second, orphaned app.
 //
 // So the things a person actually asks for become operations: start an app, take over a clone of
@@ -47,7 +47,7 @@ export type DeclareResult = DeclareSuccess | SharedAppFailure;
  *
  *  The address is the whole reason this is an operation rather than a paragraph of instructions.
  *  It has to match what the rules see (`request.auth.token.email`), the agent cannot read it, and
- *  asking the user invites the one answer that fails at deploy — the address they think they are
+ *  asking the user invites the one answer that fails at publish — the address they think they are
  *  using. */
 export async function initSharedApp(root: string, name: string | undefined, slug: string | undefined): Promise<DeclareResult> {
   // The file first, because "you already have one" is the more useful answer and it does not
@@ -71,7 +71,7 @@ export async function initSharedApp(root: string, name: string | undefined, slug
       partial: false,
       problems: [
         "starting an app needs a signed-in session: connect remote-host first.",
-        "The declaration names its owner by EMAIL, and it has to be the address this machine is signed in with — guessing it produces an app nobody can deploy.",
+        "The declaration names its owner by EMAIL, and it has to be the address this machine is signed in with — guessing it produces an app nobody can publish.",
       ],
     };
   }
@@ -84,14 +84,14 @@ export async function initSharedApp(root: string, name: string | undefined, slug
   // `apps/{aid}` is a shelf every user of the deployment shares, and its `allow create` asks only
   // that you name yourself owner. The aid used to be minted into `app.json` — a file meant to be
   // committed and read in a pull request — while the document stayed absent until the first
-  // deploy. Anyone who read the file in that window could create the document as themselves, and
+  // publish. Anyone who read the file in that window could create the document as themselves, and
   // then it is theirs: the real owner's write becomes an update they are not allowed to make, and
   // nothing can free the id, because a client may never delete an app document. A UUID stops the
   // aid being GUESSED; it was never going to stop it being read.
   //
   // The reservation carries the roster and nothing else — no `public`, no `collections` — so it
-  // grants exactly one thing: this address is the owner. Deploy's `set` then lands as an update by
-  // the same owner, which is what it always was for an app deployed twice.
+  // grants exactly one thing: this address is the owner. Publish's `set` then lands as an update by
+  // the same owner, which is what it always was for an app published twice.
   const reserved = await reserveApp(handle, aid, reservation, "init");
   if (reserved) return reserved;
 
@@ -223,7 +223,7 @@ export async function forkSharedApp(root: string, name: string | undefined, slug
       partial: false,
       problems: [
         "forking an app needs a signed-in session: connect remote-host first.",
-        "The new declaration names its owner by EMAIL, and it has to be the address this machine is signed in with — guessing it produces an app nobody can deploy.",
+        "The new declaration names its owner by EMAIL, and it has to be the address this machine is signed in with — guessing it produces an app nobody can publish.",
       ],
     };
   }
@@ -389,7 +389,7 @@ export interface CheckReport {
   /** The address the declaration names as app-wide owner, when it names one. */
   declaredOwner: string | undefined;
   problems: string[];
-  /** What the pages it names will probably get wrong, without stopping a deploy. See
+  /** What the pages it names will probably get wrong, without stopping a publish. See
    *  `viewWarnings`. */
   warnings: string[];
 }
@@ -398,7 +398,7 @@ export interface CheckReport {
  *  anything or touching the app.
  *
  *  The gate that used to run only at deploy. An agent that has just written a declaration cannot
- *  otherwise find out whether it is deployable — and in testing it did not: the invalid `public`
+ *  otherwise find out whether it is publishable — and in testing it did not: the invalid `public`
  *  block travelled all the way to a live refusal, and by then the agent was editing files to
  *  recover. */
 export async function checkSharedApp(root: string): Promise<CheckReport | SharedAppFailure> {
@@ -409,13 +409,13 @@ export async function checkSharedApp(root: string): Promise<CheckReport | Shared
 
   const collections = await sharedCollections(root);
   const handle = firestoreHandle();
-  // The SAME gate a deploy runs, not a second opinion. `check` exists to answer "would a deploy be
+  // The SAME gate a publish runs, not a second opinion. `check` exists to answer "would a publish be
   // refused?", and a separate implementation of that question answers it differently — this one
-  // used to miss the `owner` uid mismatch and call a declaration deployable that deploy then
+  // used to miss the `owner` uid mismatch and call a declaration publishable that publish then
   // refused.
   const problems = declarationProblems(parsed.app, collections, handle);
   // The PAGES too, read from disk. A `path` naming nothing, a page too large, a page written
-  // against the host's bridge: each of those refuses a deploy, and answering "deployable" without
+  // against the host's bridge: each of those refuses a publish, and answering "publishable" without
   // having opened them is the answer this action exists not to give.
   const pages = await viewFilesReport(root, parsed.app);
   return {
@@ -450,7 +450,7 @@ export interface InviteSuccess {
  *  would be a worse version of editing it by hand. `role: null` removes. */
 export async function inviteToSharedApp(root: string, rawEmail: string, role: AppRoleName | null, cid: string): Promise<InviteSuccess | SharedAppFailure> {
   // `assignee` is not an app-wide role, and it is refused HERE rather than left
-  // to the deploy for the same reason every other refusal in this file is: the
+  // to the publish for the same reason every other refusal in this file is: the
   // write would otherwise succeed, the tool would report the invitation as done,
   // and the author would open `app.json`, find exactly what they asked for, and
   // have nothing to work back from. Which rows are yours is a per-collection
@@ -467,10 +467,10 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
   }
   // Lower-cased, because the roster key is compared to `request.auth.token.email` by a rule that
   // has no `lower()`. Firebase hands the token a lower-cased address, so an entry typed
-  // `Foo@Example.com` matches nobody — and once deployed the failure is silent in the worst way:
+  // `Foo@Example.com` matches nobody — and once published the failure is silent in the worst way:
   // the roster reads correctly to a human, and the person invited is refused everything with no
   // error naming them. Written correctly here; a hand-edited one is stopped by
-  // `rosterCaseProblems` before a deploy can carry it.
+  // `rosterCaseProblems` before a publish can carry it.
   const email = rawEmail.toLowerCase();
   let written = email;
   let ambiguous: string[] = [];
@@ -492,7 +492,7 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
     written = matches[0] ?? email;
     const next = nextMembers(manifest, written, role, cid);
     if (next === null) return null;
-    // An app with no app-wide owner has no publisher: every deploy is refused, INCLUDING the one
+    // An app with no app-wide owner has no publisher: every publish is refused, INCLUDING the one
     // that would put an owner back. The file can still be edited by hand, but this tool must not
     // be the way somebody locks themselves out — removing or demoting an owner is fine once
     // another one exists.
@@ -519,7 +519,7 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
       partial: false,
       problems: [
         `that would leave the app with no owner: ${written} is the only address holding \`"*": "owner"\`.`,
-        "An app with no owner cannot be deployed at all — not even to put an owner back. Add another owner first, then remove this one.",
+        "An app with no owner cannot be published at all — not even to put an owner back. Add another owner first, then remove this one.",
       ],
     };
   }
@@ -538,7 +538,7 @@ export async function inviteToSharedApp(root: string, rawEmail: string, role: Ap
  *  file belongs to the author and this tool only ever changes the key it is asked about, and an
  *  upper-case key can be CORRECT — it is what the rules compare against when the provider hands
  *  over that address, which is exactly the case `rosterCaseProblems` exempts. Silently lower-casing
- *  it while changing somebody's role would revoke everything that person has. The deploy-time check
+ *  it while changing somebody's role would revoke everything that person has. The publish-time check
  *  is where a wrong spelling is reported, and a hand edit is how it gets fixed. */
 /** The keys as they will be shown back to the author: quoted, in the order the file has them. */
 function quoted(keys: readonly string[]): string {
@@ -554,7 +554,7 @@ function rosterMatches(manifest: Record<string, unknown>, email: string): string
  *
  *  Built by filtering rather than by deleting keys: the roster is the permission list, and an
  *  entry that half-survives a removal is the failure mode the rules cannot save us from —
- *  `membersConsistent()` would reject the deploy, which is the good case, but only after the
+ *  `membersConsistent()` would reject the publish, which is the good case, but only after the
  *  operator believed somebody had been removed. */
 function nextMembers(manifest: Record<string, unknown>, email: string, role: AppRoleName | null, cid: string): Record<string, unknown> | null {
   const members = isRecord(manifest.members) ? manifest.members : {};

--- a/server/backends/sharedApp/exclusivity.ts
+++ b/server/backends/sharedApp/exclusivity.ts
@@ -144,13 +144,14 @@ const liveMirrorOf = (live: Record<string, unknown> | null, cid: string): string
  *  reads only happen for collections that changed. */
 export async function frozenKeyProblems(
   authored: AuthoredApp,
-  promoted: Record<string, { mirrorOf?: string | undefined }>,
+  declared: Record<string, { mirrorOf?: string | undefined }>,
   live: Record<string, unknown> | null,
   handle: SharedAppHandle,
 ): Promise<string[]> {
   const problems: string[] = [];
-  // The submission side is published from the MANIFEST, so that is what this
-  // compares. The collection side below is not.
+  // Both halves are published from the MANIFEST, so that is what this compares.
+  // The collection side below used to read what a DEPLOY had staged, because
+  // that was the version publish promoted; there is one version now.
   for (const [cid, submit] of Object.entries(authored.public?.submit ?? {})) {
     problems.push(
       ...(await movedUnderRecords(
@@ -162,18 +163,13 @@ export async function frozenKeyProblems(
       )),
     );
   }
-  // From what DEPLOY staged, because that is what publish promotes. Reading
-  // `app.json` here would let an author deploy a changed mirror, revert the
-  // key locally, and publish a promotion this gate never saw.
-  //
-  // The UNION with what is live, not just what is promoted: deploy withdraws
-  // the staging document of a collection the repository no longer has, so a
-  // mirror REMOVED that way is absent from `promoted` entirely — and a loop
-  // over `promoted` alone would never compare it against the live half it is
-  // about to drop.
-  for (const cid of new Set([...Object.keys(promoted), ...liveCollectionCids(live)])) {
+  // The UNION with what is live, not just what the manifest declares: a
+  // collection the repository no longer has is absent from `declared`
+  // entirely, and a loop over `declared` alone would never compare it against
+  // the live half it is about to drop.
+  for (const cid of new Set([...Object.keys(declared), ...liveCollectionCids(live)])) {
     const was = liveMirrorOf(live, cid);
-    const now = text(promoted[cid]?.mirrorOf);
+    const now = text(declared[cid]?.mirrorOf);
     if (was === now) continue;
     problems.push(
       ...(await movedUnderRecords(handle, authored.aid, cid, [{ key: "mirrorOf", was, now }], "the projection those records are the public face of")),

--- a/server/backends/sharedApp/headlessPreview.ts
+++ b/server/backends/sharedApp/headlessPreview.ts
@@ -4,7 +4,7 @@
 // else built for this problem stops short of the same line: `viewDefects.ts` READS a page and
 // catches the two failures we have already met, and the Collections pane RUNS one but needs a
 // person in front of it. What shipped broken (a lunch sign-up, published twice with a dead Submit
-// button, 2026-08-14) was written, checked, deployed and published without the document ever being
+// button, 2026-08-14) was written, checked and published without the document ever being
 // loaded once. This is the door that closes that: `manageSharedApp` with `action: "preview"`.
 //
 // WHAT IT PROVES, AND WHAT IT DOES NOT. It proves the document loads, the handshake completes, the

--- a/server/backends/sharedApp/manifestWrite.ts
+++ b/server/backends/sharedApp/manifestWrite.ts
@@ -35,7 +35,7 @@ export type ManifestUpdate = { ok: true; manifest: Record<string, unknown>; writ
 
 /** The key two callers must AGREE on to be serialized against each other: one file, one key.
  *
- *  Exported because a whole shared-app OPERATION serializes on the same repository — one deploy
+ *  Exported because a whole shared-app OPERATION serializes on the same repository — one publish
  *  landing inside a publish is the same class of interleaving as two writes to `app.json`, and
  *  keying them differently would leave each holding a lock the other does not.
  *

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -69,7 +69,7 @@ interface RequestedCollection {
 /** One collection's records, read with the author's own credentials.
  *
  *  A refusal is carried back rather than thrown. The most common one is the ordinary state of an
- *  app that has never been deployed — `apps/{aid}` does not exist, so the rules cannot resolve an
+ *  app that has never been published — `apps/{aid}` does not exist, so the rules cannot resolve an
  *  owner for anything beneath it — and refusing to preview at all because there are no records yet
  *  would make the feature useless exactly when it is most wanted.
  *

--- a/server/backends/sharedApp/publicForm.ts
+++ b/server/backends/sharedApp/publicForm.ts
@@ -81,9 +81,9 @@ export type PublicForm = Record<string, PublicCollectionForm>;
 
 /** The form spec for every collection the declaration opens for public submission.
  *
- *  Read from the STAGED schemas — the version publish is promoting — for the same reason the
- *  promotion itself is: what ships is what the roster reviewed, not what the working tree says
- *  now. */
+ *  Read from the schemas publish is about to write — the same objects the gates were given —
+ *  rather than re-read off disk here. One run, one version: a form drawn from a second read could
+ *  describe fields the schemas beside it do not have. */
 export function publicFormOf(authored: AuthoredApp, schemas: readonly { cid: string; schema: CollectionSchema }[]): PublicForm {
   const submit = authored.public?.submit ?? {};
   const byCid = new Map(schemas.map((entry) => [entry.cid, entry.schema]));
@@ -203,8 +203,8 @@ function fieldsOf(
 /** How much of the world-readable config document the projection may take up.
  *
  *  Firestore refuses a document over 1 MiB, and `config/public` carries core's settings projection
- *  as well as this form. A refusal from the database arrives mid-publish — after schemas have
- *  already been promoted — and says only that a document was too large; this says which app is too
+ *  as well as this form. A refusal from the database arrives mid-publish — after the schemas have
+ *  already gone out — and says only that a document was too large; this says which app is too
  *  big to draw and stops before the first write. The margin is for the settings beside it. */
 const PUBLIC_CONFIG_BUDGET = 700_000;
 

--- a/server/backends/sharedApp/publicView.ts
+++ b/server/backends/sharedApp/publicView.ts
@@ -343,12 +343,12 @@ function contentProblems(html: string, bytes: number, declared: string, where: s
   return null;
 }
 
-/** Every page the declaration names, read the way deploy will read it — for `check`, which writes
+/** Every page the declaration names, read the way publish will read it — for `check`, which writes
  *  nothing and needs no connection.
  *
- *  `check` answers "would a deploy be refused?", and until this existed it answered that from the
+ *  `check` answers "would a publish be refused?", and until this existed it answered that from the
  *  declaration alone: a `path` naming a file that is not there, a page over the document limit, or
- *  a page written against the host's bridge all passed `check` and were refused by the deploy
+ *  a page written against the host's bridge all passed `check` and were refused by the publish
  *  afterwards — which is exactly the point in the flow this action exists to move earlier. The
  *  warnings come with it for the same reason: they are what the author still has time to act on.
  *

--- a/server/backends/sharedApp/publish.ts
+++ b/server/backends/sharedApp/publish.ts
@@ -211,7 +211,7 @@ async function publishGate(
 
 /** The two questions that are asked of the PAGE and of the live records before
  *  anything is written — both of them things a run cannot take back once the
- *  schemas have been promoted.
+ *  schemas have gone out.
  *
  *  Together because they share that timing, not because they are alike: one
  *  reads a file off disk, the other reads what the app already holds. */

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -60,8 +60,11 @@ export async function scanRecords(collections: readonly LoadedCollection[], work
 
 /** The scan as a refusal, or null when the operation may proceed.
  *
- *  `what` names the boundary in both messages, because the two differ in what confirming COSTS:
- *  a confirmed deploy is visible to the roster, a confirmed publish to everyone. */
+ *  Every message names publish, and does so literally rather than through a
+ *  boundary argument. It used to take one, because there were two boundaries
+ *  and they differed in what confirming COST: a confirmed deploy was visible
+ *  to the roster, a confirmed publish to everyone. There is one boundary now,
+ *  so there is one cost to state — everyone. */
 export function recordRefusal(scan: RecordScan, confirm: boolean | undefined): string[] | null {
   if (scan.unreadable.length > 0) {
     return [

--- a/server/backends/sharedApp/records.ts
+++ b/server/backends/sharedApp/records.ts
@@ -5,10 +5,12 @@
 // operator can override, because a breaking change is sometimes exactly what is intended; the
 // point is that it is a decision rather than a discovery.
 //
-// It runs at BOTH boundaries (design D10). Deploy's `confirm` lets a draft into staging on
-// purpose — mid-migration, that is the useful thing — so publish re-runs the scan against the
-// version it is about to promote rather than trusting that deploy was clean. A confirm spent on
-// staging must not buy the public.
+// It runs at ONE boundary now. It used to run at two (design D10): deploy's `confirm` let a draft
+// into staging on purpose — mid-migration, that is the useful thing — so publish re-ran the scan
+// against the version it was about to promote rather than trusting that deploy had been clean.
+// There is no staged version to disagree with the working tree any more
+// (`plans/feat-shared-app-no-staging.md`), so the scan and the `confirm` that overrides it both
+// belong to publish, and a confirm buys exactly the publish it was spent on.
 import { MAX_RECORD_ISSUES, STORE_UNREADABLE, validateCollectionRecords, type LoadedCollection } from "@mulmoclaude/core/collection/server";
 
 /** How many broken records to name before summarising. A write that would break a thousand rows

--- a/server/backends/sharedApp/serialize.ts
+++ b/server/backends/sharedApp/serialize.ts
@@ -1,7 +1,7 @@
 // One at a time, per thing.
 //
 // Two chains are kept with this: `app.json` writes (so a read-modify-write cannot lose the other
-// half) and whole shared-app OPERATIONS (so a deploy cannot land in the middle of a publish).
+// half) and whole shared-app OPERATIONS (so one operation cannot land in the middle of another).
 // They are the same mechanism because they are the same problem — a sequence of reads and writes
 // that is only correct if nothing interleaves with it — and having one implementation is what
 // keeps a second one from being written with the subtle parts left out.
@@ -23,7 +23,7 @@ export function serializeBy<T>(key: string, run: () => Promise<T>): Promise<T> {
   const next = previous.catch(() => {}).then(run);
   chains.set(key, next);
   // Dropped when the last waiter settles, so the map does not grow with every project ever
-  // deployed.
+  // published.
   void next
     .catch(() => {})
     .finally(() => {

--- a/server/backends/sharedApp/unpublish.ts
+++ b/server/backends/sharedApp/unpublish.ts
@@ -5,9 +5,12 @@
 // projection behind it, which is a tidiness problem; the other order would leave it open with the
 // projection gone, which is the failure this ordering exists to make impossible.
 //
-// The schemas under `collections/{cid}` are deliberately LEFT: nobody can read them while the
-// app is closed, so they cost nothing, and publishing again then rewrites them in place rather
-// than rebuilding the collection from nothing.
+// The schemas under `collections/{cid}` are deliberately LEFT. `schemaRead` is
+// `readerOf || publicRead || partRead`, so closing the app takes the middle clause away and a
+// STRANGER can no longer reach them — while the roster still can, which is right: the members'
+// and participants' pages stay standing (below), and a page that could not read its own schema
+// would draw nothing. Publishing again then rewrites them where they stand rather than rebuilding
+// the collection from nothing.
 //
 // It deliberately does NOT run the declaration gate that `check` and publish share, and it does
 // not mint an `aid` the way they do. Those steps decide whether something may go OUT; taking it

--- a/server/backends/sharedApp/unpublish.ts
+++ b/server/backends/sharedApp/unpublish.ts
@@ -5,11 +5,11 @@
 // projection behind it, which is a tidiness problem; the other order would leave it open with the
 // projection gone, which is the failure this ordering exists to make impossible.
 //
-// The promoted schemas under `collections/{cid}` are deliberately LEFT: nobody can read them
-// while the app is closed, so they cost nothing, and re-publishing is then a promotion rather
-// than a rebuild.
+// The schemas under `collections/{cid}` are deliberately LEFT: nobody can read them while the
+// app is closed, so they cost nothing, and publishing again then rewrites them in place rather
+// than rebuilding the collection from nothing.
 //
-// It deliberately does NOT run the declaration gate that deploy and publish share, and it does
+// It deliberately does NOT run the declaration gate that `check` and publish share, and it does
 // not mint an `aid` the way they do. Those steps decide whether something may go OUT; taking it
 // down has to work when the declaration is broken, which is one of the times an operator most
 // wants it. And a take-down must not AUTHOR: minting an aid here would write a fresh id into

--- a/server/infra/shared-app-tool.ts
+++ b/server/infra/shared-app-tool.ts
@@ -10,7 +10,7 @@
 // There is exactly ONE write path to a shared app, and this is it. Core's whole-app `publishApp`
 // was deleted rather than left unused (mulmoclaude #2871) because MulmoTerminal declares the
 // shared-collections capability and binds the Firestore accessor — an action left in core would
-// simply work here, and it wrote `public` without ever passing through staging.
+// simply work here, and it wrote `public` without ever passing through the gates in this file.
 import type { ToolDefinition } from "gui-chat-protocol";
 import { headlessPreview } from "../backends/sharedApp/headlessPreview.js";
 import { narrateHeadlessRun } from "../backends/sharedApp/headlessReport.js";
@@ -172,7 +172,7 @@ async function narrateUnpublish(root: string): Promise<string> {
   if (!result.ok) return result.problems.join("\n");
   return result.wasOpen
     ? `Unpublished apps/${result.aid}: the public block is gone, so anonymous access is closed${noLonger(result.slug)}, and the public config document was deleted. ` +
-        "The promoted schemas were left in place, so publishing again is a promotion."
+        "The schemas under collections/ were left in place, so publishing again rewrites them where they stand."
     : `apps/${result.aid} was already closed to the public — nothing was open to take down. The public config document was deleted if it was still there.`;
 }
 


### PR DESCRIPTION
#1760 で `deploy` / `staging` は無くなったが、それを**現在形で**説明している注釈が 3 か所残っていた。「昔はこうだった」と過去形で書いてある歴史（`preview.ts`, `unpublish.ts`, `publish.ts` など）は設計の理由なので触っていない。

| ファイル | 何が嘘になっていたか |
|---|---|
| `records.ts` | 「It runs at BOTH boundaries」— 呼び出しは `publish.ts` 一本だけ。`confirm` は staging を買うのではなく、それを使った publish だけを買う |
| `exclusivity.ts` | 引数名 `promoted` が「deploy が staging に置いた版」を指していた。今は submit 側も collection 側も manifest から来る → `declared` に改名。live と UNION を取る理由も、今の理由（宣言から消えた collection は `declared` に居ない）に書き直し |
| `appViews.ts` | 「DEPLOY AND PUBLISH WRITE THE SAME SHAPE at two prefixes」— 片方が存在しない。`live:` を残している理由（`staleViewDocs` の掃除が「自分が書いた文書」を見分ける手段）に置き換え。ついでに存在しない `staleStaged` への参照も外した |

コメントと引数名 1 つだけで、振る舞いの変更はない。

## 確認
- `yarn format` / `yarn lint` / `yarn typecheck` 通過
- `test/server/backends/sharedApp.spec.ts` 34 passed

work in mulmoterminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shared-app guidance to consistently describe the publish-only workflow.
  * Clarified that publishing validates and plans changes before writing schemas, while withdrawn pages are removed.
  * Documented publish-time migration checks and confirmation behavior.
  * Updated preview, unpublish, and validation guidance to reflect current terminology and workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->