### PR TITLE
fix: retry /api/config so a restarting backend stops emptying the launcher

### DIFF
--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -53,6 +53,10 @@ const props = defineProps<{
   choice: LaunchChoice | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
+  // The saved directories could not be READ — /api/config failed and the retries gave up. The
+  // chip row is empty for a reason the user cannot otherwise see, so it says so instead of
+  // looking like a user who has opened nothing.
+  configUnavailable?: boolean | undefined;
   // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
   launchers?: Launcher[] | undefined;
   // Session ids open in other grid cells. Resuming one of them would detach that cell, so those
@@ -81,7 +85,9 @@ const emit = defineEmits<{
   (e: "resume", value: { id: string; cwd: string | null; agent?: TerminalAgent }): void;
   (e: "run", value: RunCommand): void;
   (e: "launch", value: LaunchPick): void;
-  (e: "close"): void;
+  // `retry-config`: read the config again after it could not be read at all — the button on the
+  // notice below. The shell owns the read; this only asks for another one.
+  (e: "close" | "retry-config"): void;
 }>();
 
 // An empty field means the server's workspace default — the placeholder is a hint, not a value.
@@ -599,6 +605,13 @@ async function requestRemove(repoDir: string | null, w: Worktree): Promise<void>
     >
       <span class="material-symbols-outlined" aria-hidden="true">close</span>
     </button>
+    <!-- Not a chip: a chip launches somewhere, and there is nowhere to launch here. It sits where
+       the chips would be because that is the emptiness it explains. -->
+    <p v-if="configUnavailable" data-testid="cell-config-unavailable" class="flex w-full items-center justify-center gap-1.5 text-[11px] opacity-70">
+      <span class="material-symbols-outlined text-[13px]" aria-hidden="true">cloud_off</span>
+      Couldn't reach the server, so your saved directories aren't listed.
+      <button type="button" class="underline underline-offset-2 hover:opacity-100" @click="emit('retry-config')">Try again</button>
+    </p>
     <div v-if="chips.length" class="flex w-full flex-wrap justify-center gap-1.5">
       <span
         v-for="p in chips"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -467,7 +467,7 @@ onMounted(() => (offNewTerminal = registerNewTerminalHandler(openNewTerminal)));
 onBeforeUnmount(detachNewTerminal);
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
-const { defaultCwd, home, presets, launchers, customAgents, loadConfig, recordPreset, removePreset } = useAppConfig();
+const { defaultCwd, home, presets, configUnavailable, launchers, customAgents, loadConfig, recordPreset, removePreset } = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -809,6 +809,7 @@ onBeforeUnmount(detachSpawnedChat);
       :cancel-uid="cancelUid"
       :default-cwd="defaultCwd"
       :presets="presets"
+      :config-unavailable="configUnavailable"
       :launchers="launchers"
       :custom-agents="customAgents"
       :home="home"
@@ -822,6 +823,7 @@ onBeforeUnmount(detachSpawnedChat);
       @cwd="onCwd"
       @record-cwd="recordPreset"
       @remove-preset="removePreset"
+      @retry-config="loadConfig"
       @close="onClose"
       @toggle-expand="onToggleExpand"
       @focus-cell="focusedCellUid = $event"

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -108,6 +108,9 @@ const props = defineProps<
     autoStart?: boolean;
     defaultCwd: string | null;
     presets: CwdPreset[];
+    // The saved directories could not be read at all — passed straight to the launch form, which
+    // says so where the chips would be.
+    configUnavailable?: boolean;
     // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
     launchers?: Launcher[];
     // The user's own ways of starting Claude Code, offered in this cell's Agent Picker (#1414).
@@ -140,6 +143,9 @@ const emit = defineEmits<
     (e: "agent", value: TerminalAgent): void;
     // Set this cell aside, or bring it back. The grid owns the flag; this only asks.
     (e: "park", value: boolean): void;
+    // The launch form's "try again" on a config that could not be read. Value-less: the shell owns
+    // the read, this only asks for another one.
+    (e: "retry-config"): void;
   }
 >();
 
@@ -1744,6 +1750,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :choice="launchChoice"
         :default-cwd="defaultCwd"
         :presets="presets"
+        :config-unavailable="configUnavailable === true"
         :launchers="launchers"
         :custom-agents="customAgents ?? []"
         :open-session-ids="openSessionIds"
@@ -1757,6 +1764,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         @run="(cmd) => emit('run', cmd)"
         @launch="(pick) => emit('launch', pick)"
         @remove-preset="(path) => emit('remove-preset', path)"
+        @retry-config="emit('retry-config')"
         @close="emit('close')"
       />
     </div>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -94,6 +94,8 @@ const props = defineProps<{
   cancelUid: number | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
+  // The saved directories could not be read — handed down so the launch form can say so.
+  configUnavailable?: boolean;
   launchers: Launcher[];
   // The user's own ways of starting Claude Code, for the Agent Picker in an empty cell (#1414).
   // Optional, unlike `launchers`: an install with none configured is the normal case, and the
@@ -119,6 +121,8 @@ const emit = defineEmits<{
   (e: "park", uid: number, value: boolean): void;
   // Shared preset list events — uid-less since they mutate the one config list.
   (e: "record-cwd" | "remove-preset", value: string): void;
+  // Read the config again, after it could not be read at all — uid-less for the same reason.
+  (e: "retry-config"): void;
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length)));
@@ -1415,6 +1419,7 @@ watch(
           :initial-agent="cell.agent"
           :auto-start="cell.autoStart === true"
           :presets="presets"
+          :config-unavailable="configUnavailable === true"
           :launchers="launchers"
           :custom-agents="customAgents ?? []"
           :open-session-ids="openSessionIds"
@@ -1428,6 +1433,7 @@ watch(
           @cwd="(c) => emit('cwd', cell.uid, c)"
           @record-cwd="(c) => emit('record-cwd', c)"
           @remove-preset="(path) => emit('remove-preset', path)"
+          @retry-config="emit('retry-config')"
           @run="(cmd) => emit('run', cell.uid, cmd)"
           @run-spare="(cmd) => emit('runSpare', cell.uid, cmd)"
           @launch="(pick) => emit('launch', cell.uid, pick)"

--- a/src/composables/configRetryPolicy.ts
+++ b/src/composables/configRetryPolicy.ts
@@ -1,0 +1,31 @@
+// How long to wait before trying `/api/config` again, and when to stop trying.
+//
+// A separate module for the same reason as `reconnectPolicy`: the numbers are a decision with
+// consequences the composable's own tests can't reach — too few attempts and the launcher stays
+// empty, an unbounded loop polls a server that is genuinely gone for the life of the tab.
+//
+// WHAT IS BEING WAITED OUT is a backend that is restarting while the page keeps working. In
+// development that is not an edge case: Vite serves the page on its own port and proxies `/api`
+// to Express, so every save under `server/` (which `scripts/dev-server.mjs` answers with a full
+// backend restart) leaves a window of seconds where the page is fine and `/api/config` is a 502
+// from the proxy. Without a retry the tab that loaded in that window shows no saved directories
+// at all, for as long as it stays open, with nothing on screen saying why.
+//
+// The schedule is 500ms doubling to a 5s ceiling, over 9 attempts — about 32 seconds of trying.
+// The shape matches `reconnectDelayMs` (the terminal sockets are waiting out the same restart,
+// and two different rhythms for one event would be noise); the ATTEMPT CAP is this module's own,
+// because a terminal socket reconnects forever by design while a config read is a one-shot the
+// user can always redo by reloading. 32s covers a `tsx` boot and the supervisor's 4s crash
+// backoff with room to spare; past that the server is down rather than restarting.
+const RETRY_BASE_MS = 500;
+const RETRY_MAX_MS = 5000;
+const MAX_ATTEMPTS = 9;
+
+/**
+ * How long to wait before retry number `attempt` (0 = the first retry after the initial failure),
+ * or `null` when the config load should be given up on.
+ */
+export function configRetryDelayMs(attempt: number): number | null {
+  if (attempt < 0 || attempt >= MAX_ATTEMPTS) return null;
+  return Math.min(RETRY_BASE_MS * 2 ** attempt, RETRY_MAX_MS);
+}

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -1,4 +1,4 @@
-import { ref, type Ref } from "vue";
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
 import { presetLabel, type CwdPreset } from "../components/presets";
 import { isManagedWorktreePath, worktreeLabel } from "../../common/worktreePath";
 import type { Launcher } from "../components/launchers";
@@ -30,6 +30,12 @@ import { setSessionIdleReapDays } from "./sessionReap";
 import { setHeaderConfigSummary } from "./headerConfigSummary";
 import { postConfigField } from "./postConfigField";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
+import { configRetryDelayMs } from "./configRetryPolicy";
+
+// Waiting between retry attempts. `setTimeout` rather than anything cancellable: a chain that
+// has been superseded checks its generation after the sleep, so an abandoned one costs a timer
+// that fires into a `return` and nothing else.
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // The custom attention-sound file is a SINGLETON ref shared across every
 // useAppConfig() caller — the beep player lives in the single view while the
@@ -84,15 +90,19 @@ const worktreesRoot = ref<string | null>(null);
 // the root rather than decide without it (Codex on #1543). Null when nothing is loading — then
 // there is nothing to wait for. It never rejects and `fetchWithTimeout` bounds it, so a dead
 // server delays one chip instead of stalling the queue.
-let configLoadInFlight: Promise<void> | null = null;
+let configLoadInFlight: Promise<unknown> | null = null;
 
 /** Run a config load, publishing it as the in-flight one for the duration — what a preset record
- *  waits on when it needs the worktree root before it can decide. */
-async function trackConfigLoad(load: () => Promise<void>): Promise<void> {
+ *  waits on when it needs the worktree root before it can decide.
+ *
+ *  ONE ATTEMPT, never the retry chain that may follow it (see `loadConfig`). The waiter above is
+ *  bounded by `fetchWithTimeout`; publishing a chain that sleeps between attempts would make a
+ *  restarting backend hold a chip's recording for half a minute instead of one request. */
+async function trackConfigLoad<T>(load: () => Promise<T>): Promise<T> {
   const run = load();
   configLoadInFlight = run;
   try {
-    await run;
+    return await run;
   } finally {
     // Only when a LATER load has not already taken the slot: clearing another's would tell a
     // waiter that nothing is coming.
@@ -518,6 +528,96 @@ async function saveUserMcpServers(next: UserMcpServer[]): Promise<boolean> {
 // line budget without saying anything a reader needed.
 const soundSettings = { soundFile, soundKinds, sounds, saveSound, saveSoundKinds, saveSounds };
 
+/** What one config read has to reach that is not module-level state: the per-call refs and the
+ *  preset manager's version coordination. Passed in rather than closed over so the read itself can
+ *  live out here beside the retry that drives it. */
+interface ConfigReaderDeps {
+  defaultCwd: Ref<string | null>;
+  snapshotVersion: () => number;
+  adoptServerPresets: (list: unknown, capturedVersion: number) => void;
+  migrateLegacyRecents: () => Promise<void>;
+}
+
+/** One attempt at reading the config. `true` when the server ANSWERED, adopted or not; `false`
+ *  only when the REQUEST failed (a restarting backend, the dev proxy's 502, a timeout) — the one
+ *  kind of failure a retry can fix, so the only one that arms one. A 200 whose body we cannot read
+ *  is the server's real answer, and asking nine more times returns the same thing. */
+function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }: ConfigReaderDeps): () => Promise<boolean> {
+  return async function readConfig(): Promise<boolean> {
+    const version = snapshotVersion();
+    try {
+      const res = await fetchWithTimeout("/api/config");
+      if (!res.ok) return false;
+      const body: unknown = await res.json();
+      if (!isRecord(body)) return true;
+      const c = body;
+      defaultCwd.value = typeof c.cwd === "string" ? c.cwd : null;
+      home.value = typeof c.home === "string" ? c.home : null;
+      worktreesRoot.value = typeof c.worktreesRoot === "string" ? c.worktreesRoot : null;
+      adoptServerPresets(c.cwdPresets, version);
+      adoptSoundConfig(c);
+      pushEnabled.value = c.pushEnabled === true;
+      pushKinds.value = listOf(c.pushKinds, isPushKind);
+      adoptRepoConfig(c);
+      adoptListConfig(c);
+      applyGlobalSettings(c);
+      adoptServerSideSettings(c);
+      await migrateLegacyRecents();
+      return true;
+    } catch {
+      // Not fatal and not final: the retry above is what turns a restarting backend back into a
+      // populated launcher, so this only has to say that this attempt got nothing.
+      return false;
+    }
+  };
+}
+
+/**
+ * The config read, WITH the retry that makes a failed one temporary.
+ *
+ * Nothing else re-reads `/api/config`: it runs once, from the shell's `onMounted`, and every saved
+ * directory, the workspace chip and a dozen global settings come out of it. So one failed request
+ * used to leave the launcher showing no saved directories for as long as the tab stayed open —
+ * indistinguishable from a user who has opened none, with nothing on screen saying otherwise. A
+ * backend that is merely RESTARTING is what produces it, and in this repo's own dev loop that is
+ * routine: Vite keeps serving the page from its own port and answers the proxied `/api` with a 502
+ * for the seconds the backend takes to come back (`scripts/dev-server.mjs` restarts it on every
+ * save under `server/`).
+ *
+ * Module-level, like `createPresetManager` — it owns state (which chain is current, whether the
+ * scope is gone) that has no business being read from anywhere else.
+ */
+function createConfigLoader(loadOnce: () => Promise<boolean>): () => Promise<void> {
+  // Which chain is the current one. A second `load()` — a remount, an HMR update — supersedes the
+  // chain the previous one left running, so two of them never race to write the same refs.
+  let generation = 0;
+  // Set when the scope that started a chain goes away: a grid that unmounted has nothing to fill
+  // in, and a chain outliving it would sleep on and write into refs nobody reads.
+  let disposed = false;
+  if (getCurrentScope()) onScopeDispose(() => (disposed = true));
+
+  async function retry(mine: number): Promise<void> {
+    for (let attempt = 0; ; attempt++) {
+      const delay_ms = configRetryDelayMs(attempt);
+      // The server is down rather than restarting. Reloading the page is the user's move, and
+      // polling it for the life of the tab would not have made it answer.
+      if (delay_ms === null) return;
+      await sleep(delay_ms);
+      if (mine !== generation || disposed) return; // superseded, or the caller is gone
+      if (await trackConfigLoad(loadOnce)) return;
+    }
+  }
+
+  /** The FIRST attempt is awaited, so `onMounted(loadConfig)` still means "the config is here" on
+   *  a healthy server. The retries are deliberately not: they are a background repair, and a mount
+   *  must not block on a server that may never answer. */
+  return async function load(): Promise<void> {
+    const mine = ++generation;
+    if (await trackConfigLoad(loadOnce)) return;
+    void retry(mine);
+  };
+}
+
 // Server config (default workspace dir, home, directory presets, custom sound)
 // shared by both the single view and the grid view so each can open the settings
 // modal without duplicating the fetch/save logic.
@@ -536,32 +636,7 @@ export function useAppConfig() {
 
   const { savePresets, recordPreset, removePreset, migrateLegacyRecents, snapshotVersion, adoptServerPresets } = createPresetManager(presets, saving, error);
 
-  const loadConfig = (): Promise<void> => trackConfigLoad(loadConfigOnce);
-
-  async function loadConfigOnce() {
-    const version = snapshotVersion();
-    try {
-      const res = await fetchWithTimeout("/api/config");
-      if (!res.ok) return;
-      const body: unknown = await res.json();
-      if (!isRecord(body)) return;
-      const c = body;
-      defaultCwd.value = typeof c.cwd === "string" ? c.cwd : null;
-      home.value = typeof c.home === "string" ? c.home : null;
-      worktreesRoot.value = typeof c.worktreesRoot === "string" ? c.worktreesRoot : null;
-      adoptServerPresets(c.cwdPresets, version);
-      adoptSoundConfig(c);
-      pushEnabled.value = c.pushEnabled === true;
-      pushKinds.value = listOf(c.pushKinds, isPushKind);
-      adoptRepoConfig(c);
-      adoptListConfig(c);
-      applyGlobalSettings(c);
-      adoptServerSideSettings(c);
-      await migrateLegacyRecents();
-    } catch {
-      // the app still works; presets are just unavailable
-    }
-  }
+  const loadConfig = createConfigLoader(createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }));
 
   return {
     defaultCwd,

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -538,17 +538,41 @@ interface ConfigReaderDeps {
   migrateLegacyRecents: () => Promise<void>;
 }
 
+/** What one attempt is given: the signal that cancels it when it is no longer wanted, and the
+ *  test for whether its answer is still the one to adopt. */
+interface ReadAttempt {
+  signal: AbortSignal;
+  stale: () => boolean;
+}
+
+type ConfigRead = (attempt: ReadAttempt) => Promise<boolean>;
+
 /** One attempt at reading the config. `true` when the server ANSWERED, adopted or not; `false`
  *  only when the REQUEST failed (a restarting backend, the dev proxy's 502, a timeout) — the one
- *  kind of failure a retry can fix, so the only one that arms one. A 200 whose body we cannot read
- *  is the server's real answer, and asking nine more times returns the same thing. */
-function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }: ConfigReaderDeps): () => Promise<boolean> {
-  return async function readConfig(): Promise<boolean> {
+ *  kind of failure a retry can fix, so the only one that arms one.
+ *
+ *  THE SPLIT IS AT THE RESPONSE HEAD, not at the end of the function: everything after a 200 has
+ *  arrived is the server's real answer, whether we can parse it, recognise its shape, or finish
+ *  adopting it. Asking such a server nine more times returns the same body, so the reload is the
+ *  user's move. Keeping one `try` around both halves quietly made a malformed body retryable —
+ *  Codex caught exactly that on #1771. */
+function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }: ConfigReaderDeps): ConfigRead {
+  return async function readConfig({ signal, stale }: ReadAttempt): Promise<boolean> {
     const version = snapshotVersion();
+    let res: Response;
     try {
-      const res = await fetchWithTimeout("/api/config");
-      if (!res.ok) return false;
+      res = await fetchWithTimeout("/api/config", { signal });
+    } catch {
+      return false; // the request never landed — this is what a retry is for
+    }
+    if (!res.ok) return false;
+    try {
       const body: unknown = await res.json();
+      // Asked AFTER the body, because that is the await this attempt can lose the race on: a
+      // newer load's answer may already have been adopted while ours was still arriving, and
+      // adopting now would put the older config back (Codex on #1771). The abort covers the
+      // request itself; this covers a response that had already landed when it fired.
+      if (stale()) return true;
       if (!isRecord(body)) return true;
       const c = body;
       defaultCwd.value = typeof c.cwd === "string" ? c.cwd : null;
@@ -563,12 +587,11 @@ function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, m
       applyGlobalSettings(c);
       adoptServerSideSettings(c);
       await migrateLegacyRecents();
-      return true;
     } catch {
-      // Not fatal and not final: the retry above is what turns a restarting backend back into a
-      // populated launcher, so this only has to say that this attempt got nothing.
-      return false;
+      // Unreadable, or an adoption step that failed. The screen keeps whatever it already had —
+      // and this still counts as answered, so no retry is armed.
     }
+    return true;
   };
 }
 
@@ -587,24 +610,54 @@ function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, m
  * Module-level, like `createPresetManager` — it owns state (which chain is current, whether the
  * scope is gone) that has no business being read from anywhere else.
  */
-function createConfigLoader(loadOnce: () => Promise<boolean>): () => Promise<void> {
+function createConfigLoader(loadOnce: ConfigRead): () => Promise<void> {
   // Which chain is the current one. A second `load()` — a remount, an HMR update — supersedes the
   // chain the previous one left running, so two of them never race to write the same refs.
   let generation = 0;
   // Set when the scope that started a chain goes away: a grid that unmounted has nothing to fill
   // in, and a chain outliving it would sleep on and write into refs nobody reads.
   let disposed = false;
-  if (getCurrentScope()) onScopeDispose(() => (disposed = true));
+  // The attempt currently in flight, so being superseded (or disposed) CANCELS it rather than
+  // waiting for it to land and be discarded.
+  let inFlight: AbortController | null = null;
+  const abandonInFlight = () => {
+    inFlight?.abort();
+    inFlight = null;
+  };
+  if (getCurrentScope())
+    onScopeDispose(() => {
+      disposed = true;
+      abandonInFlight();
+    });
+
+  /** Arm the next attempt, or `null` when this chain is no longer the one to make it. The check
+   *  and the assignment are one synchronous step on purpose: with an await between them a chain
+   *  that had just been superseded could publish its controller over the current one, and the
+   *  next supersede would then cancel the wrong request. */
+  function arm(mine: number): ReadAttempt | null {
+    if (mine !== generation || disposed) return null;
+    const controller = new AbortController();
+    inFlight = controller;
+    return { signal: controller.signal, stale: () => mine !== generation || disposed };
+  }
+
+  async function attempt(mine: number): Promise<boolean | null> {
+    const armed = arm(mine);
+    if (!armed) return null; // superseded, or the caller is gone
+    const answered = await trackConfigLoad(() => loadOnce(armed));
+    if (inFlight?.signal === armed.signal) inFlight = null;
+    return armed.stale() ? null : answered;
+  }
 
   async function retry(mine: number): Promise<void> {
-    for (let attempt = 0; ; attempt++) {
-      const delay_ms = configRetryDelayMs(attempt);
+    for (let round = 0; ; round++) {
+      const delay_ms = configRetryDelayMs(round);
       // The server is down rather than restarting. Reloading the page is the user's move, and
       // polling it for the life of the tab would not have made it answer.
       if (delay_ms === null) return;
       await sleep(delay_ms);
-      if (mine !== generation || disposed) return; // superseded, or the caller is gone
-      if (await trackConfigLoad(loadOnce)) return;
+      const answered = await attempt(mine);
+      if (answered !== false) return; // answered, or this chain is no longer the current one
     }
   }
 
@@ -612,8 +665,9 @@ function createConfigLoader(loadOnce: () => Promise<boolean>): () => Promise<voi
    *  a healthy server. The retries are deliberately not: they are a background repair, and a mount
    *  must not block on a server that may never answer. */
   return async function load(): Promise<void> {
+    abandonInFlight(); // an earlier chain's request must not land on top of this one
     const mine = ++generation;
-    if (await trackConfigLoad(loadOnce)) return;
+    if ((await attempt(mine)) !== false) return;
     void retry(mine);
   };
 }

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -616,7 +616,7 @@ function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, m
  * answer of the other, since the module-level singletons have no version guard of their own.
  * (CodeRabbit on #1771 read the old wording here as claiming module-level state.)
  */
-function createConfigLoader(loadOnce: ConfigRead): () => Promise<void> {
+function createConfigLoader(loadOnce: ConfigRead, unavailable: Ref<boolean>): () => Promise<void> {
   // Which chain is the current one. A second `load()` — a remount, an HMR update — supersedes the
   // chain the previous one left running, so two of them never race to write the same refs.
   let generation = 0;
@@ -652,15 +652,21 @@ function createConfigLoader(loadOnce: ConfigRead): () => Promise<void> {
     if (!armed) return null; // superseded, or the caller is gone
     const answered = await trackConfigLoad(() => loadOnce(armed));
     if (inFlight?.signal === armed.signal) inFlight = null;
-    return armed.stale() ? null : answered;
+    if (armed.stale()) return null;
+    if (answered) unavailable.value = false;
+    return answered;
   }
 
   async function retry(mine: number): Promise<void> {
     for (let round = 0; ; round++) {
       const delay_ms = configRetryDelayMs(round);
-      // The server is down rather than restarting. Reloading the page is the user's move, and
-      // polling it for the life of the tab would not have made it answer.
-      if (delay_ms === null) return;
+      // The server is down rather than restarting. Say so — half a minute of silent retrying ends
+      // in the same empty launcher this whole change exists to explain, and the user is the only
+      // one left who can do anything about it (CodeRabbit on #1771).
+      if (delay_ms === null) {
+        unavailable.value = true;
+        return;
+      }
       await sleep(delay_ms);
       const answered = await attempt(mine);
       if (answered !== false) return; // answered, or this chain is no longer the current one
@@ -696,12 +702,17 @@ export function useAppConfig() {
 
   const { savePresets, recordPreset, removePreset, migrateLegacyRecents, snapshotVersion, adoptServerPresets } = createPresetManager(presets, saving, error);
 
-  const loadConfig = createConfigLoader(createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }));
+  // Whether the config could not be read at all, after the retries gave up — what the launcher
+  // shows instead of pretending the user has no saved directories. Per-call like `presets`, and
+  // filled in for the caller that loads.
+  const configUnavailable = ref(false);
+  const loadConfig = createConfigLoader(createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, migrateLegacyRecents }), configUnavailable);
 
   return {
     defaultCwd,
     home,
     presets,
+    configUnavailable,
     prRepos,
     gitlabHosts,
     saveGitlabHosts,

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -607,8 +607,14 @@ function createConfigReader({ defaultCwd, snapshotVersion, adoptServerPresets, m
  * for the seconds the backend takes to come back (`scripts/dev-server.mjs` restarts it on every
  * save under `server/`).
  *
- * Module-level, like `createPresetManager` — it owns state (which chain is current, whether the
- * scope is gone) that has no business being read from anywhere else.
+ * ONE LOADER PER `useAppConfig()` CALL, like the preset manager beside it: the chain state (which
+ * generation is current, whether the scope is gone) belongs to the caller that loads, and `stale()`
+ * therefore compares against that caller's own generation only. Two live callers do not supersede
+ * each other — which is safe for the reason the caution above `useAppConfig` gives: the shell that
+ * mounts is the one that loads, and everything else takes the values from it. Give a second caller
+ * a `loadConfig` and that stops being true, and a slow attempt of one could adopt over a newer
+ * answer of the other, since the module-level singletons have no version guard of their own.
+ * (CodeRabbit on #1771 read the old wording here as claiming module-level state.)
  */
 function createConfigLoader(loadOnce: ConfigRead): () => Promise<void> {
   // Which chain is the current one. A second `load()` — a remount, an HMR update — supersedes the

--- a/test/src/components/CellLaunchForm.spec.ts
+++ b/test/src/components/CellLaunchForm.spec.ts
@@ -25,7 +25,14 @@ function mockFetch(worktrees: WorktreeRow[] = [], sessions: SessionRow[] = []) {
 
 const mountForm = (
   openSessionIds: string[] = [],
-  over: { dir?: string; presets?: { label: string; path: string }[]; agent?: AgentPick; defaultCwd?: string | null; customAgents?: CustomAgent[] } = {},
+  over: {
+    dir?: string;
+    presets?: { label: string; path: string }[];
+    agent?: AgentPick;
+    defaultCwd?: string | null;
+    customAgents?: CustomAgent[];
+    configUnavailable?: boolean;
+  } = {},
 ) =>
   mount(CellLaunchForm, {
     // defaultCwd is deliberately NOT "/repo": the launcher treats the workspace differently — it
@@ -1186,5 +1193,28 @@ describe("removing a worktree", () => {
     finish();
     await flushPromises();
     expect(w.find('[data-testid="wt-error"]').text()).toContain("uncommitted changes");
+  });
+});
+
+// An empty chip row has two very different causes, and they used to look identical: a user who has
+// opened no directories, and a config that could not be read at all. The second one now says so —
+// and offers the only move left, since nothing else re-reads the config once the retries give up.
+describe("CellLaunchForm — the config could not be read", () => {
+  it("says nothing while the config is merely empty", async () => {
+    const w = mountForm([], { presets: [] });
+    await flushPromises();
+
+    expect(w.find('[data-testid="cell-config-unavailable"]').exists()).toBe(false);
+  });
+
+  it("explains the empty chip row and offers another read", async () => {
+    const w = mountForm([], { presets: [], configUnavailable: true });
+    await flushPromises();
+
+    const notice = w.find('[data-testid="cell-config-unavailable"]');
+    expect(notice.exists()).toBe(true);
+
+    await notice.find("button").trigger("click");
+    expect(w.emitted("retry-config")).toHaveLength(1);
   });
 });

--- a/test/src/composables/configRetryPolicy.spec.ts
+++ b/test/src/composables/configRetryPolicy.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { configRetryDelayMs } from "../../../src/composables/configRetryPolicy";
+
+// The schedule is the whole module, so it is pinned here rather than implied by a composable test
+// that would go green with one attempt or a hundred.
+describe("configRetryDelayMs", () => {
+  it("doubles from 500ms and settles at the 5s ceiling", () => {
+    expect([0, 1, 2, 3, 4, 5].map(configRetryDelayMs)).toEqual([500, 1000, 2000, 4000, 5000, 5000]);
+  });
+
+  it("gives up rather than retrying forever", () => {
+    expect(configRetryDelayMs(8)).not.toBeNull();
+    expect(configRetryDelayMs(9)).toBeNull();
+    expect(configRetryDelayMs(99)).toBeNull();
+  });
+
+  // The window being waited out is a backend restart: `scripts/dev-server.mjs` kills the child,
+  // waits out its backoff (up to 4s) and boots tsx again. A schedule that expired inside that
+  // window would leave the launcher empty exactly when it is most likely to be.
+  it("keeps trying for long enough to outlast a backend restart", () => {
+    let total = 0;
+    for (let attempt = 0; ; attempt++) {
+      const delay = configRetryDelayMs(attempt);
+      if (delay === null) break;
+      total += delay;
+    }
+    expect(total).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it("has no delay for a negative attempt", () => {
+    expect(configRetryDelayMs(-1)).toBeNull();
+  });
+});

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -489,7 +489,7 @@ describe("useAppConfig — loadConfig retries a request that failed", () => {
   // A 200 is the server's real answer even when the body is unusable. Retrying re-reads the same
   // body, and this spec is also what keeps the other loadConfig tests from leaving a chain running
   // into the next one.
-  it("does not retry a body it simply could not read", async () => {
+  it("does not retry a body of the wrong shape", async () => {
     const calls = mockAttempts(UP([]));
     const { loadConfig } = useAppConfig();
 
@@ -497,6 +497,45 @@ describe("useAppConfig — loadConfig retries a request that failed", () => {
     await vi.advanceTimersByTimeAsync(120_000);
 
     expect(calls).toHaveLength(1);
+  });
+
+  // The same rule one step earlier: a body that will not PARSE at all. The wrong-shape test above
+  // cannot see this — its `json()` resolves — and with one `try` around the whole read this case
+  // came out the far side as a failed request and armed the chain (Codex on #1771).
+  it("does not retry a body that will not parse", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        json: async () => {
+          throw new SyntaxError("Unexpected end of JSON input");
+        },
+      };
+    }) as unknown as typeof fetch;
+    const { loadConfig } = useAppConfig();
+
+    await expect(loadConfig()).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  // A non-2xx IS retryable, and it is the shape the dev proxy answers with while the backend is
+  // restarting (502, with a text/plain body that never reaches `json()`).
+  it("retries a 502 from the dev proxy", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string) => {
+      calls.push(String(url));
+      return calls.length === 1 ? { ok: false, status: 502 } : { ok: true, json: async () => ({ cwdPresets: [{ label: "proj", path: "/p" }] }) };
+    }) as unknown as typeof fetch;
+    const { loadConfig, presets } = useAppConfig();
+
+    await loadConfig();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(presets.value).toEqual([{ label: "proj", path: "/p" }]);
+    expect(calls).toHaveLength(2);
   });
 
   it("abandons the chain when the scope that started it goes away", async () => {
@@ -511,6 +550,35 @@ describe("useAppConfig — loadConfig retries a request that failed", () => {
     await vi.advanceTimersByTimeAsync(120_000);
 
     expect(calls).toHaveLength(1);
+  });
+
+  // The same hazard one step in: an attempt that is ALREADY IN FLIGHT when a newer load answers.
+  // It is aborted, but a response that had landed before the abort would otherwise be adopted on
+  // top of the fresh one — and the module-level singletons (launchers, quick commands, the global
+  // settings) have no version guard of their own to catch it (Codex on #1771).
+  it("does not adopt an answer that arrived after a newer load overtook it", async () => {
+    let releaseStale: () => void = () => {};
+    const stalled = new Promise<void>((resolve) => (releaseStale = resolve));
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        await stalled;
+        return { ok: true, json: async () => ({ launchers: [{ label: "stale", command: "old" }] }) };
+      }
+      return { ok: true, json: async () => ({ launchers: [{ label: "fresh", command: "new" }] }) };
+    }) as unknown as typeof fetch;
+
+    const { loadConfig, launchers } = useAppConfig();
+    const first = loadConfig();
+    await loadConfig();
+    expect(launchers.value).toEqual([{ label: "fresh", command: "new" }]);
+
+    releaseStale();
+    await first;
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(launchers.value).toEqual([{ label: "fresh", command: "new" }]);
   });
 
   // Two chains writing the same refs is how a stale answer lands on top of a fresh one. A remount

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -538,6 +538,32 @@ describe("useAppConfig — loadConfig retries a request that failed", () => {
     expect(calls).toHaveLength(2);
   });
 
+  // Silence for half a minute and then silence forever is the same empty launcher this whole
+  // change exists to explain. When the retries give up, the shell gets something to render.
+  it("reports the config as unavailable only once the retries give up", async () => {
+    mockAttempts(DOWN);
+    const { loadConfig, configUnavailable } = useAppConfig();
+
+    await loadConfig();
+    expect(configUnavailable.value).toBe(false); // still trying — nothing to tell the user yet
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(configUnavailable.value).toBe(true);
+  });
+
+  it("takes the notice back when a later read succeeds", async () => {
+    mockAttempts(DOWN);
+    const { loadConfig, configUnavailable } = useAppConfig();
+    await loadConfig();
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(configUnavailable.value).toBe(true);
+
+    mockAttempts(UP({ cwdPresets: [{ label: "proj", path: "/p" }] }));
+    await loadConfig();
+
+    expect(configUnavailable.value).toBe(false);
+  });
+
   it("abandons the chain when the scope that started it goes away", async () => {
     const calls = mockAttempts(DOWN);
     const scope = effectScope();

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { effectScope } from "vue";
 import { currentGitlabHosts, useAppConfig } from "../../../src/composables/useAppConfig";
 import { globalHeaderStatusColors, globalHeaderStatusTint } from "../../../src/composables/headerStatusColors";
 import { DEFAULT_HEADER_STATUS_TINT } from "../../../common/headerStatusColors";
@@ -424,5 +425,106 @@ describe("useAppConfig — loadConfig validates what the server sends", () => {
     await expect(loadConfig()).resolves.toBeUndefined();
 
     expect(launchers.value).toEqual(before);
+  });
+});
+
+// A page that loads while the backend is restarting gets NOTHING from /api/config — and nothing
+// re-read it, so the launcher showed no saved directories for as long as that tab stayed open. In
+// this repo's own dev loop that is the common case rather than the rare one: Vite keeps serving
+// the page from its own port and answers the proxied /api with a 502 for the seconds the backend
+// takes to come back.
+describe("useAppConfig — loadConfig retries a request that failed", () => {
+  // The fetches a run made, so a test can say how many attempts happened rather than only what
+  // landed. `answers` is consumed one per call; the last one repeats.
+  function mockAttempts(...answers: Array<{ ok: boolean; body?: unknown }>) {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string) => {
+      calls.push(String(url));
+      const answer = answers[Math.min(calls.length - 1, answers.length - 1)];
+      if (!answer.ok) throw new Error("ECONNREFUSED");
+      return { ok: true, json: async () => answer.body ?? {} };
+    }) as unknown as typeof fetch;
+    return calls;
+  }
+
+  const DOWN = { ok: false };
+  const UP = (body: unknown) => ({ ok: true, body });
+
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("fills the launcher in once the backend comes back", async () => {
+    const calls = mockAttempts(DOWN, DOWN, UP({ cwdPresets: [{ label: "proj", path: "/p" }] }));
+    const { loadConfig, presets } = useAppConfig();
+
+    await loadConfig();
+    expect(presets.value).toEqual([]); // the state the bug left behind — now temporary
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(presets.value).toEqual([{ label: "proj", path: "/p" }]);
+    expect(calls).toHaveLength(3);
+  });
+
+  // A retry that the caller had to await would make `onMounted(loadConfig)` block a mount on a
+  // server that may never answer.
+  it("returns from the first attempt instead of awaiting the chain", async () => {
+    mockAttempts(DOWN, UP({ cwdPresets: [{ label: "proj", path: "/p" }] }));
+    const { loadConfig, presets } = useAppConfig();
+
+    await expect(loadConfig()).resolves.toBeUndefined();
+    expect(presets.value).toEqual([]);
+  });
+
+  it("stops rather than polling a server that is down for good", async () => {
+    const calls = mockAttempts(DOWN);
+    const { loadConfig } = useAppConfig();
+
+    await loadConfig();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(calls).toHaveLength(10); // the initial attempt plus the nine retries
+  });
+
+  // A 200 is the server's real answer even when the body is unusable. Retrying re-reads the same
+  // body, and this spec is also what keeps the other loadConfig tests from leaving a chain running
+  // into the next one.
+  it("does not retry a body it simply could not read", async () => {
+    const calls = mockAttempts(UP([]));
+    const { loadConfig } = useAppConfig();
+
+    await loadConfig();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("abandons the chain when the scope that started it goes away", async () => {
+    const calls = mockAttempts(DOWN);
+    const scope = effectScope();
+    await scope.run(async () => {
+      const { loadConfig } = useAppConfig();
+      await loadConfig();
+    });
+
+    scope.stop();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  // Two chains writing the same refs is how a stale answer lands on top of a fresh one. A remount
+  // (or an HMR update, which re-runs the shell's setup) is the case that produces it.
+  it("lets a later load supersede the chain an earlier one left running", async () => {
+    const calls = mockAttempts(DOWN);
+    const { loadConfig, presets } = useAppConfig();
+    await loadConfig();
+
+    mockAttempts(UP({ cwdPresets: [{ label: "fresh", path: "/fresh" }] }));
+    await loadConfig();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(presets.value).toEqual([{ label: "fresh", path: "/fresh" }]);
+    expect(calls).toHaveLength(1); // the abandoned chain never fired again
   });
 });


### PR DESCRIPTION
## The bug

The launcher's saved-directory chips sometimes come up completely empty, then come back on the next reload.

Everything that row shows — the saved directories, the WORKSPACE chip, plus a dozen global settings — comes from a single `GET /api/config` issued once from `GridView`'s `onMounted`. `loadConfigOnce` swallowed every failure (`if (!res.ok) return;` and a bare `catch`), and **nothing re-read it**. So one failed request left the tab showing no saved directories for as long as it stayed open, indistinguishable from a user who has opened none, with nothing on screen saying otherwise.

The failure that produces it is a backend that is merely **restarting**, and in this repo's own dev loop that is routine rather than rare: Vite serves the page from its own port and proxies `/api` to Express, while `scripts/dev-server.mjs` does a full backend restart on every save under `server/`, `common/` or `bin/`. Measured against a real Vite proxy with a dead target:

```
--- page:  200
--- api:   HTTP/1.1 502 Bad Gateway
[vite] http proxy error: /api/config
AggregateError [ECONNREFUSED]
```

The 8s `fetchWithTimeout` never comes into it — ECONNREFUSED is immediate. An HMR update makes it worse: it re-runs the shell's setup, so `presets` is rebuilt as an empty per-instance ref and the list you already had disappears without a page reload.

## The fix

`createConfigLoader` wraps the read in a retry chain.

- The **first attempt is still awaited**, so `onMounted(loadConfig)` means what it always did on a healthy server. Retries are explicitly not awaited — a mount must not block on a server that may never answer.
- The schedule (`configRetryPolicy.ts`) is 500ms doubling to a 5s ceiling over nine attempts, ~32s. Shape matches `reconnectDelayMs` because the terminal sockets are waiting out the same restart; the attempt cap is this module's own, since a config read is a one-shot the user can redo by reloading.
- A chain stops on the first answer, when a later `loadConfig()` supersedes it (remount, HMR), and when the scope is disposed.
- **Only a failed REQUEST retries.** A 200 whose body we cannot read is the server's real answer — asking nine more times returns the same body.
- `trackConfigLoad` still publishes ONE ATTEMPT, never the chain: `recordPreset` waits on it for the worktree root, and a chain that sleeps between attempts would hold a chip's recording for half a minute instead of one bounded request.

`loadConfigOnce` moved out to a module-level `createConfigReader` (like the neighbouring `createPresetManager`) to keep `useAppConfig` inside its line budget.

## Not in this PR

A related way the row can stay empty, worth its own change: `mutateOneOnServer` bumps `version` before its write, so a preset write that FAILS during the initial load makes `adoptServerPresets` reject the in-flight GET's (successful) answer, and the list stays empty with no failed request to retry.

## Tests

`yarn test` (10456 passed), `yarn lint`, `yarn typecheck` all green. New specs cover the schedule itself and, with fake timers: fills in once the backend returns, does not await the chain, gives up instead of polling forever, does not retry an unreadable body, abandons on scope stop, and lets a later load supersede an earlier chain.

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retries when configuration requests fail, with increasing delays and a maximum retry limit.
  * New configuration loads cancel earlier requests and ignore outdated responses.
  * Configuration loading stops safely when the relevant application scope is disposed.

* **Bug Fixes**
  * Prevented malformed or unusable configuration responses from triggering unnecessary retries.
  * Improved handling of failed and non-successful configuration requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->