### PR TITLE
collections ペイン: ツールバーを 1 本にまとめ、expand / close とプレビュー既定を入れる

### DIFF
--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -229,34 +229,26 @@ useCollectionTeleportTarget(probe);
          only for a directory declaring a shared app, which meant the bar itself came and went as
          you moved between cells and there was nowhere to put a control that is not about apps.
 
-         The controls on the LEFT are about what the pane is showing, so they do come and go:
-         "Back to collections" while the preview is up, and otherwise "Preview the shared app" —
-         a shared app is declared by an `app.json` in the cell's directory, and a button that
-         answers "there is no app here" on every other directory is a button nobody reads. It is
-         here rather than in the collection strip at the bottom because the question is about the
-         APP, every collection it publishes and the pages built over them, not about the one
-         collection on screen. -->
+         The control on the LEFT switches what fills the pane: "Previews" ON is the app's pages,
+         OFF is the collections underneath them. A checkbox rather than a button because it is a
+         state you can see the value of without pressing it. It appears only where an `app.json`
+         declares a shared app — everywhere else there are no pages and nothing to switch — and it
+         sits here rather than in the collection strip at the bottom because it is about the APP,
+         every collection it publishes and the pages built over them, not about the one collection
+         on screen. It starts ON: in a directory that IS a shared app, the pages are the thing
+         being worked on and the collections are their storage. -->
     <div class="flex-none border-b border-border bg-panel px-4 py-2 font-sans text-[14px] text-fg">
       <div class="flex items-center justify-between gap-2">
         <div class="flex items-center gap-2">
           <span class="font-semibold">Collections</span>
-          <button
-            v-if="previewing"
-            type="button"
-            class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
-            @click="previewing = false"
-          >
-            Back to collections
-          </button>
-          <button
-            v-else-if="declaresApp"
-            type="button"
-            class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
+          <label
+            v-if="declaresApp"
+            class="flex cursor-pointer items-center gap-1.5 text-[11px] text-dim"
             title="Draw the pages publishing this app would put on screen. Nothing is written."
-            @click="previewing = true"
           >
-            Preview the shared app
-          </button>
+            <input v-model="previewing" data-testid="collections-preview-toggle" type="checkbox" class="h-3.5 w-3.5 cursor-pointer accent-accent" />
+            Previews
+          </label>
         </div>
         <!-- Expand then close, in that order and with the same icons and classes as the Tools and
              Canvas headers: the panes share one slot, so the same control must be in the same

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -207,7 +207,13 @@ useCollectionTeleportTarget(probe);
 
 <template>
   <div class="flex h-full min-h-0 flex-col bg-panel" role="region" aria-label="Collections">
-    <!-- The pane's TOOLBAR, and it is ALWAYS here — outside every state below it, because the
+    <!-- The header recipe is the shared one — `bg-panel px-4 py-2 text-[14px]` with a bold title at
+         the left, exactly as Tools, Prompts, Question and Canvas have it. The panes take turns in
+         one slot, so a header of its own height or padding makes the whole pane jump as you switch
+         between them. The `border-b` is this pane's only addition: the others separate header from
+         body by background (bg-panel over bg-deep) and this one's body is bg-panel too.
+
+         The TOOLBAR is ALWAYS here — outside every state below it, because the
          controls on its right are how the pane is resized and closed and those must not depend on
          whether a directory resolved, declares an app, or is showing the preview. It used to render
          only for a directory declaring a shared app, which meant the bar itself came and went as
@@ -220,9 +226,10 @@ useCollectionTeleportTarget(probe);
          here rather than in the collection strip at the bottom because the question is about the
          APP, every collection it publishes and the pages built over them, not about the one
          collection on screen. -->
-    <div class="flex-none border-b border-border px-2.5 py-1.5 font-sans">
-      <div class="flex min-h-[21px] items-center justify-between gap-2">
+    <div class="flex-none border-b border-border bg-panel px-4 py-2 font-sans text-[14px] text-fg">
+      <div class="flex items-center justify-between gap-2">
         <div class="flex items-center gap-2">
+          <span class="font-semibold">Collections</span>
           <button
             v-if="previewing"
             type="button"
@@ -269,10 +276,10 @@ useCollectionTeleportTarget(probe);
         </div>
       </div>
     </div>
-    <div v-if="resolving" class="p-3 font-sans text-[12px] text-dim">Loading collections…</div>
+    <div v-if="resolving" class="px-4 py-3 font-sans text-[12px] text-dim">Loading collections…</div>
     <!-- Not an error, and deliberately not the workspace's collections under this cell's name:
          a directory the server does not know has no collections of its own to show. -->
-    <div v-else-if="unknownDirectory" class="p-3 font-sans text-[12px] text-dim">
+    <div v-else-if="unknownDirectory" class="px-4 py-3 font-sans text-[12px] text-dim">
       This directory has no collections yet. Collections live in <code>.claude/skills</code> under the folder the cell is open in.
     </div>
     <div v-else-if="previewing" class="min-h-0 flex-1">
@@ -291,7 +298,7 @@ useCollectionTeleportTarget(probe);
       <!-- The portability check, on a strip of its own below the plugin's own surface: it is the
            HOST's question about the collection (does it survive a clone), not part of the
            collection's data, and it must not be inside the shadow root the package styles. -->
-      <div v-if="openSlug" class="flex-none border-t border-border px-2.5 py-1.5 font-sans">
+      <div v-if="openSlug" class="flex-none border-t border-border px-4 py-2 font-sans">
         <div class="flex items-center gap-2">
           <button
             type="button"

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -20,7 +20,11 @@ import type { ShortcutKind } from "../../common/shortcuts";
 import SharedAppPreview from "./SharedAppPreview.vue";
 import { isRecord } from "../../common/isRecord";
 
-const props = defineProps<{ cwd: string | null }>();
+const props = defineProps<{ cwd: string | null; expanded?: boolean }>();
+
+// The pane-slot contract, the same one Tools / Canvas / Prompts / GitHub answer: the grid owns
+// the width and which pane is open, so both controls report rather than act.
+const emit = defineEmits<{ close: []; toggleExpand: [] }>();
 
 // ── this pane's own view state (the router's job, done locally) ──
 type PaneView = { mode: "index"; kind: ShortcutKind } | { mode: "detail"; kind: ShortcutKind; slug: string };
@@ -203,42 +207,78 @@ useCollectionTeleportTarget(probe);
 
 <template>
   <div class="flex h-full min-h-0 flex-col bg-panel" role="region" aria-label="Collections">
+    <!-- The pane's TOOLBAR, and it is ALWAYS here — outside every state below it, because the
+         controls on its right are how the pane is resized and closed and those must not depend on
+         whether a directory resolved, declares an app, or is showing the preview. It used to render
+         only for a directory declaring a shared app, which meant the bar itself came and went as
+         you moved between cells and there was nowhere to put a control that is not about apps.
+
+         The controls on the LEFT are about what the pane is showing, so they do come and go:
+         "Back to collections" while the preview is up, and otherwise "Preview the shared app" —
+         a shared app is declared by an `app.json` in the cell's directory, and a button that
+         answers "there is no app here" on every other directory is a button nobody reads. It is
+         here rather than in the collection strip at the bottom because the question is about the
+         APP, every collection it publishes and the pages built over them, not about the one
+         collection on screen. -->
+    <div class="flex-none border-b border-border px-2.5 py-1.5 font-sans">
+      <div class="flex min-h-[21px] items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <button
+            v-if="previewing"
+            type="button"
+            class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
+            @click="previewing = false"
+          >
+            Back to collections
+          </button>
+          <button
+            v-else-if="declaresApp"
+            type="button"
+            class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
+            title="Draw the pages publishing this app would put on screen. Nothing is written."
+            @click="previewing = true"
+          >
+            Preview the shared app
+          </button>
+        </div>
+        <!-- Expand then close, in that order and with the same icons and classes as the Tools and
+             Canvas headers: the panes share one slot, so the same control must be in the same
+             place in each of them. -->
+        <div class="flex items-center gap-1">
+          <button
+            type="button"
+            data-testid="collections-expand-btn"
+            class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
+            :title="expanded ? 'Restore the terminal beside the collections' : 'Expand the collections over the terminal'"
+            :aria-label="expanded ? 'Restore collections pane width' : 'Expand collections pane'"
+            :aria-pressed="expanded === true"
+            @click="emit('toggleExpand')"
+          >
+            <span class="material-symbols-outlined" aria-hidden="true">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
+          </button>
+          <button
+            type="button"
+            data-testid="collections-close-btn"
+            class="cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-dim hover:text-fg"
+            title="Close collections pane"
+            aria-label="Close collections pane"
+            @click="emit('close')"
+          >
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
+          </button>
+        </div>
+      </div>
+    </div>
     <div v-if="resolving" class="p-3 font-sans text-[12px] text-dim">Loading collections…</div>
     <!-- Not an error, and deliberately not the workspace's collections under this cell's name:
          a directory the server does not know has no collections of its own to show. -->
     <div v-else-if="unknownDirectory" class="p-3 font-sans text-[12px] text-dim">
       This directory has no collections yet. Collections live in <code>.claude/skills</code> under the folder the cell is open in.
     </div>
-    <template v-else-if="previewing">
-      <div class="flex-none border-b border-border px-2.5 py-1.5 font-sans">
-        <button
-          type="button"
-          class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
-          @click="previewing = false"
-        >
-          Back to collections
-        </button>
-      </div>
-      <div class="min-h-0 flex-1">
-        <SharedAppPreview :cwd="cwd" />
-      </div>
-    </template>
+    <div v-else-if="previewing" class="min-h-0 flex-1">
+      <SharedAppPreview :cwd="cwd" />
+    </div>
     <template v-else>
-      <!-- The shared app this directory declares, if it declares one. ABOVE the collections rather
-           than below them: the pane's own surface fills the height, so a strip under it sat past
-           the fold and was not found at all. Its own control rather than part of the collection
-           strip at the bottom — the question is about the APP, every collection it publishes and
-           the pages built over them, not about the one collection on screen. -->
-      <div v-if="declaresApp" class="flex-none border-b border-border px-2.5 py-1.5 font-sans">
-        <button
-          type="button"
-          class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent"
-          title="Draw the pages publishing this app would put on screen. Nothing is written."
-          @click="previewing = true"
-        >
-          Preview the shared app
-        </button>
-      </div>
       <div class="min-h-0 flex-1">
         <PluginFrame :css="collectionShadowCss" height="100%">
           <div ref="probe" style="height: 100%">
@@ -255,6 +295,7 @@ useCollectionTeleportTarget(probe);
         <div class="flex items-center gap-2">
           <button
             type="button"
+            data-testid="collections-portability-btn"
             class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent disabled:cursor-default disabled:opacity-60"
             :disabled="checking"
             :aria-busy="checking"

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -114,7 +114,17 @@ async function probeForApp(cwd: string | null): Promise<void> {
   try {
     const res = await fetchWithTimeout(`/api/shared-app/declared?cwd=${encodeURIComponent(cwd)}`);
     const body: unknown = await res.json();
-    if (mine === probeGeneration) declaresApp.value = isRecord(body) && body.declared === true;
+    if (mine !== probeGeneration) return;
+    declaresApp.value = isRecord(body) && body.declared === true;
+    // In a directory that IS a shared app, the app is what the pane is for: the pages are the
+    // thing being worked on and the collections underneath them are its storage. So the preview
+    // is the DEFAULT view here, not a control you have to find — the collections stay one click
+    // away on the toolbar.
+    //
+    // Only while the pane is still on its own index, though. The probe is async, and a user who
+    // has already opened a collection in the meantime has said what they want to look at; taking
+    // the screen off them after the fact is worse than not defaulting at all.
+    if (declaresApp.value && view.value.mode === "index") previewing.value = true;
   } catch {
     // A directory whose app-ness could not be established simply shows no preview control. There
     // is nothing to tell the user here: they did not ask a question.

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -31,6 +31,29 @@ type PaneView = { mode: "index"; kind: ShortcutKind } | { mode: "detail"; kind: 
 const view = ref<PaneView>({ mode: "index", kind: "collection" });
 const selectedId = ref<string | null>(null);
 
+// Which of the pane's two faces is up: the app's pages, or the collections under them. Declared
+// with the view state rather than beside its probe below, because `navigated` clears it — a
+// navigation is a request for a COLLECTION, and it must not run before this exists.
+const declaresApp = ref(false);
+const previewing = ref(false);
+
+// Whether anything has NAVIGATED since this directory was opened. The shared-app default below
+// only applies to a pane nobody has steered yet, and "still on the index" is not that test:
+// `gotoIndex("feed")` and a deliberate return to the collections index both leave `mode ===
+// "index"`, so a probe still in flight would land on top of the view the user just chose.
+let viewTouched = false;
+
+/** Every navigation the plugin's views drive. It goes through here so that the two things a
+ *  navigation implies are said once: the pane is no longer showing the app's pages (the request
+ *  is FOR a collection, and leaving the preview up makes the click look like it did nothing),
+ *  and the pane has been steered, so the default must not fire over it. */
+function navigated(next: PaneView, itemId: string | null): void {
+  viewTouched = true;
+  previewing.value = false;
+  selectedId.value = itemId;
+  view.value = next;
+}
+
 const nav: CollectionNavSurface = {
   routeSlug: () => (view.value.mode === "detail" ? view.value.slug : undefined),
   routeSelectedId: () => selectedId.value ?? undefined,
@@ -39,18 +62,15 @@ const nav: CollectionNavSurface = {
     selectedId.value = itemId;
   },
   gotoIndex: (kind) => {
-    selectedId.value = null;
-    view.value = { mode: "index", kind };
+    navigated({ mode: "index", kind }, null);
   },
   gotoDetail: (kind, slug) => {
-    selectedId.value = null;
-    view.value = { mode: "detail", kind, slug };
+    navigated({ mode: "detail", kind, slug }, null);
   },
   // A ref hop from one record to another: same pane, the target collection open with that record
   // selected. `recordId` is optional because a hop may target the collection itself.
   navigateToRecord: (targetSlug, recordId) => {
-    view.value = { mode: "detail", kind: "collection", slug: targetSlug };
-    selectedId.value = recordId ?? null;
+    navigated({ mode: "detail", kind: "collection", slug: targetSlug }, recordId ?? null);
   },
 };
 
@@ -86,8 +106,12 @@ watch(
     invalidateCheck();
     // The app is the DIRECTORY's, so a cwd change is a different app or none.
     void probeForApp(cwd ?? null);
-    // Reset the view: a slug open in one directory need not exist in the next.
-    nav.gotoIndex("collection");
+    // Reset the view: a slug open in one directory need not exist in the next. NOT through `nav`:
+    // this is the new directory's starting point, not a navigation within it, and routing it
+    // through there would mark the pane as steered and cancel its own default.
+    selectedId.value = null;
+    view.value = { mode: "index", kind: "collection" };
+    viewTouched = false;
   },
   { immediate: true },
 );
@@ -102,8 +126,6 @@ const unknownDirectory = computed(() => !resolving.value && projectId.value === 
 //
 // The probe is a separate, cheap route (one `stat`). Asking the preview route would compute a
 // whole publish projection, and open a Firestore session, to decide whether to draw a button.
-const declaresApp = ref(false);
-const previewing = ref(false);
 
 let probeGeneration = 0;
 async function probeForApp(cwd: string | null): Promise<void> {
@@ -121,10 +143,11 @@ async function probeForApp(cwd: string | null): Promise<void> {
     // is the DEFAULT view here, not a control you have to find — the collections stay one click
     // away on the toolbar.
     //
-    // Only while the pane is still on its own index, though. The probe is async, and a user who
-    // has already opened a collection in the meantime has said what they want to look at; taking
-    // the screen off them after the fact is worse than not defaulting at all.
-    if (declaresApp.value && view.value.mode === "index") previewing.value = true;
+    // Only for a pane nobody has steered yet, though. The probe is async, and a user who has
+    // navigated in the meantime — into a collection, to the feeds index, back to the collections
+    // index — has said what they want to look at; taking the screen off them after the fact is
+    // worse than not defaulting at all.
+    if (declaresApp.value && !viewTouched) previewing.value = true;
   } catch {
     // A directory whose app-ness could not be established simply shows no preview control. There
     // is nothing to tell the user here: they did not ask a question.
@@ -242,11 +265,15 @@ useCollectionTeleportTarget(probe);
          being worked on and the collections are their storage. -->
     <div class="flex-none border-b border-border bg-panel px-4 py-2 font-sans text-[14px] text-fg">
       <div class="flex items-center justify-between gap-2">
-        <div class="flex items-center gap-2">
+        <!-- `min-w-0` on the left group and `shrink-0` on the right: the preview teleports a page
+             picker in here, and a select is as wide as its longest option. Without these the pane's
+             own expand and close are pushed off its right edge by a descriptive page id — controls
+             that are meant to be reachable in every state. -->
+        <div class="flex min-w-0 items-center gap-2">
           <span class="font-semibold">Collections</span>
           <label
             v-if="declaresApp"
-            class="flex cursor-pointer items-center gap-1.5 text-[11px] text-dim"
+            class="flex shrink-0 cursor-pointer items-center gap-1.5 text-[11px] text-dim"
             title="Draw the pages publishing this app would put on screen. Nothing is written."
           >
             <input v-model="previewing" data-testid="collections-preview-toggle" type="checkbox" class="h-3.5 w-3.5 cursor-pointer accent-accent" />
@@ -256,12 +283,12 @@ useCollectionTeleportTarget(probe);
                lives there, so it is teleported in rather than lifted — but it belongs on this bar:
                a second strip of chrome directly beneath this one was two toolbars saying different
                halves of one thing. Empty, and so invisible, whenever the preview is not up. -->
-          <div ref="pickerSlot" class="flex items-center gap-2"></div>
+          <div ref="pickerSlot" class="flex min-w-0 items-center gap-2"></div>
         </div>
         <!-- Expand then close, in that order and with the same icons and classes as the Tools and
              Canvas headers: the panes share one slot, so the same control must be in the same
              place in each of them. -->
-        <div class="flex items-center gap-1">
+        <div class="flex shrink-0 items-center gap-1">
           <button
             type="button"
             data-testid="collections-expand-btn"

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -211,6 +211,9 @@ const SEVERITY_CLASS: Record<SelfContainmentSeverity, string> = {
 
 // The probe sits inside the PluginFrame shadow, which is what lets the composable resolve
 // this pane's shadow root as the record modal's teleport target.
+// The toolbar element the preview teleports its page picker into (see the toolbar template).
+const pickerSlot = ref<HTMLElement | null>(null);
+
 const probe = ref<HTMLElement>();
 useCollectionTeleportTarget(probe);
 </script>
@@ -249,6 +252,11 @@ useCollectionTeleportTarget(probe);
             <input v-model="previewing" data-testid="collections-preview-toggle" type="checkbox" class="h-3.5 w-3.5 cursor-pointer accent-accent" />
             Previews
           </label>
+          <!-- Where the preview's PAGE PICKER lands. It is the preview's control and its state
+               lives there, so it is teleported in rather than lifted — but it belongs on this bar:
+               a second strip of chrome directly beneath this one was two toolbars saying different
+               halves of one thing. Empty, and so invisible, whenever the preview is not up. -->
+          <div ref="pickerSlot" class="flex items-center gap-2"></div>
         </div>
         <!-- Expand then close, in that order and with the same icons and classes as the Tools and
              Canvas headers: the panes share one slot, so the same control must be in the same
@@ -285,7 +293,7 @@ useCollectionTeleportTarget(probe);
       This directory has no collections yet. Collections live in <code>.claude/skills</code> under the folder the cell is open in.
     </div>
     <div v-else-if="previewing" class="min-h-0 flex-1">
-      <SharedAppPreview :cwd="cwd" />
+      <SharedAppPreview :cwd="cwd" :picker-target="pickerSlot" />
     </div>
     <template v-else>
       <div class="min-h-0 flex-1">

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -738,7 +738,7 @@ watch(
       <!-- `to` is only read while enabled; the body fallback keeps Vue from warning about a null
            target on the in-place path, where nothing is teleported at all. -->
       <Teleport :to="pickerTarget ?? 'body'" :disabled="!pickerTarget">
-        <div :class="pickerTarget ? 'flex flex-wrap items-center gap-2' : 'flex flex-none flex-wrap items-center gap-2 border-b border-border px-2.5 py-1.5'">
+        <div :class="pickerTarget ? 'flex min-w-0 items-center gap-2' : 'flex flex-none flex-wrap items-center gap-2 border-b border-border px-2.5 py-1.5'">
           <!-- No visible label: on the host's toolbar the dropdown sits among controls that name
                themselves, and every option already reads "<id> — <audience>". The name a screen
                reader needs is still here. -->
@@ -746,7 +746,13 @@ watch(
             id="mt-preview-page"
             v-model="selectedId"
             aria-label="Which page of this app to draw"
-            class="rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg"
+            :class="[
+              'rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg',
+              // On a host toolbar the pane is 360-480px and shares the row with the pane's own
+              // controls, so the select must be allowed to shrink below its longest option rather
+              // than pushing them off the edge. Standing alone it keeps its intrinsic width.
+              pickerTarget ? 'min-w-0 max-w-[16rem] shrink truncate' : '',
+            ]"
           >
             <option v-for="candidate in pages" :key="keyOf(candidate)" :value="keyOf(candidate)">
               {{ candidate.id }} — {{ AUDIENCE_LABEL[candidate.audience] }}

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -35,7 +35,11 @@ import {
   type SharedAppPreview,
 } from "../../common/sharedAppPreview";
 
-const props = defineProps<{ cwd: string | null }>();
+// `pickerTarget` is where the PAGE PICKER goes. The pane that hosts this preview has a toolbar of
+// its own, and a strip of chrome directly under it was two toolbars saying different halves of one
+// thing — so the host hands us an element in its toolbar and the picker is teleported into it.
+// Left unset (a standalone mount, and the specs) the picker renders in place, as it used to.
+const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
 
@@ -731,19 +735,25 @@ watch(
     <div v-else-if="pages.length === 0" class="p-3 text-[12px] text-dim">This app publishes no pages — only its schemas. There is nothing to draw.</div>
 
     <template v-else>
-      <div class="flex flex-none flex-wrap items-center gap-2 border-b border-border px-2.5 py-1.5">
-        <label class="text-[11px] text-dim" for="mt-preview-page">Page</label>
-        <select id="mt-preview-page" v-model="selectedId" class="rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg">
-          <option v-for="candidate in pages" :key="keyOf(candidate)" :value="keyOf(candidate)">
-            {{ candidate.id }} — {{ AUDIENCE_LABEL[candidate.audience] }}
-          </option>
-        </select>
-        <!-- Which face this is, said in the pane rather than only in the picker: the three tiers
-             are separate documents with separate rules, and reading the wrong one as "the app" is
-             how a page written for the front desk gets published to the world. -->
-        <span v-if="page" class="text-[11px] text-dim">{{ AUDIENCE_LABEL[page.audience] }}</span>
-        <span v-if="payload && !payload.publicOpen" class="text-[11px] text-dim">· Roster only</span>
-      </div>
+      <!-- `to` is only read while enabled; the body fallback keeps Vue from warning about a null
+           target on the in-place path, where nothing is teleported at all. -->
+      <Teleport :to="pickerTarget ?? 'body'" :disabled="!pickerTarget">
+        <div :class="pickerTarget ? 'flex flex-wrap items-center gap-2' : 'flex flex-none flex-wrap items-center gap-2 border-b border-border px-2.5 py-1.5'">
+          <!-- No visible label: on the host's toolbar the dropdown sits among controls that name
+               themselves, and every option already reads "<id> — <audience>". The name a screen
+               reader needs is still here. -->
+          <select
+            id="mt-preview-page"
+            v-model="selectedId"
+            aria-label="Which page of this app to draw"
+            class="rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg"
+          >
+            <option v-for="candidate in pages" :key="keyOf(candidate)" :value="keyOf(candidate)">
+              {{ candidate.id }} — {{ AUDIENCE_LABEL[candidate.audience] }}
+            </option>
+          </select>
+        </div>
+      </Teleport>
 
       <div class="min-h-0 flex-1">
         <!-- Byte for byte the document a visitor is served. No `allow-modals`, so `alert` /

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1345,8 +1345,11 @@ watch(
         <CollectionsPane
           v-else-if="rightPane === 'collections'"
           :cwd="expandedCwd"
+          :expanded="paneFull"
           :style="paneFull ? { flex: '1 1 0%', width: 'auto' } : { flex: `0 0 ${paneWidth}px` }"
           class="border-l border-border"
+          @toggle-expand="togglePaneExpanded"
+          @close="setRightPane(null, paneUid)"
         />
         <!-- Every configured repo, whatever the cell is: what the cell's directory decides is
              which repo's section LEADS (common/githubPaneOrder.ts). A directory that names no

--- a/test/src/components/CollectionsPanePortability.spec.ts
+++ b/test/src/components/CollectionsPanePortability.spec.ts
@@ -27,6 +27,10 @@ vi.mock("../../../src/composables/collectionProject", () => ({
 const CollectionsPane = (await import("../../../src/components/CollectionsPane.vue")).default;
 const { activeCollectionNavSurface } = await import("../../../src/composables/collectionSurface");
 
+/** The portability strip's own button. The toolbar above it carries the pane-slot expand and
+ *  close controls, so "the first button in the pane" stopped being this one. */
+const PORTABILITY = '[data-testid="collections-portability-btn"]';
+
 const REPORT = {
   slug: "newsletters",
   portable: false,
@@ -67,19 +71,22 @@ describe("CollectionsPane portability strip", () => {
   it("offers nothing while the pane is on the index — the question is per collection", async () => {
     const w = mount(CollectionsPane, { props: { cwd: "/srv/mag2" } });
     await flushPromises();
-    expect(w.find("button").exists()).toBe(false);
+    expect(w.find(PORTABILITY).exists()).toBe(false);
+    // The toolbar is not part of that: it is the pane's own chrome and is there in every state.
+    expect(w.find('[data-testid="collections-close-btn"]').exists()).toBe(true);
   });
 
   it("says so when the directory is not a project the server knows", async () => {
     const w = mount(CollectionsPane, { props: { cwd: "/srv/unknown" } });
     await flushPromises();
     expect(w.text()).toContain("This directory has no collections yet");
-    expect(w.find("button").exists()).toBe(false);
+    expect(w.find(PORTABILITY).exists()).toBe(false);
+    expect(w.find('[data-testid="collections-close-btn"]').exists()).toBe(true);
   });
 
   it("asks the server for THIS pane's project, and renders what breaks on the other machine", async () => {
     const { wrapper: w } = await mountOnCollection();
-    const button = w.find("button");
+    const button = w.find(PORTABILITY);
     expect(button.exists()).toBe(true);
     await button.trigger("click");
     await flushPromises();
@@ -94,7 +101,7 @@ describe("CollectionsPane portability strip", () => {
   it("reports a clean collection without inventing a finding row", async () => {
     mockFetch({ slug: "newsletters", portable: true, findings: [] });
     const { wrapper: w } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Nothing to fix");
     expect(w.findAll("li")).toHaveLength(0);
@@ -106,7 +113,7 @@ describe("CollectionsPane portability strip", () => {
   it("never says 'nothing to fix' about a report whose verdict is not portable", async () => {
     mockFetch({ slug: "newsletters", portable: false, findings: [] });
     const { wrapper: w } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Would not survive a clone");
     expect(w.text()).not.toContain("Nothing to fix");
@@ -122,7 +129,7 @@ describe("CollectionsPane portability strip", () => {
       findings: [{ code: "sqlite-store", severity: "blocker", message: "Records are one SQLite file; git cannot merge it." }],
     });
     const { wrapper: w } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Would not survive a clone");
     expect(w.text()).not.toContain("Travels, with caveats");
@@ -137,7 +144,7 @@ describe("CollectionsPane portability strip", () => {
       findings: [{ code: "no-primary-key", severity: "warning", message: "No primaryKey is declared." }],
     });
     const { wrapper: w } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Travels, with caveats");
     expect(w.text()).not.toContain("Would not survive");
@@ -153,7 +160,7 @@ describe("CollectionsPane portability strip", () => {
     expect(region.attributes("aria-live")).toBe("polite");
     expect(region.text()).toBe("");
 
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     // The findings are inside it too: the list IS the answer, not a decoration on it.
     expect(w.find('[role="status"]').text()).toContain("Would not survive a clone");
@@ -163,7 +170,7 @@ describe("CollectionsPane portability strip", () => {
   it("says the check failed rather than showing a verdict it does not have", async () => {
     mockFetch({}, false);
     const { wrapper: w } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Could not run the check");
     expect(w.text()).not.toContain("survive");
@@ -186,7 +193,7 @@ describe("CollectionsPane portability strip", () => {
     const navA = activeCollectionNavSurface();
     navA?.gotoDetail("collection", "notes");
     await flushPromises();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
 
     // The cell walks to another project, and the user opens ITS collection of the same name.
     await w.setProps({ cwd: "/srv/other" });
@@ -201,13 +208,13 @@ describe("CollectionsPane portability strip", () => {
     expect(w.text()).not.toContain("A's problem");
     expect(w.text()).not.toContain("Would not survive a clone");
     // And the superseded request must not have left the button spinning.
-    expect(w.find("button").text()).toBe("Survives a clone?");
+    expect(w.find(PORTABILITY).text()).toBe("Survives a clone?");
   });
 
   // A verdict that outlived the collection it was about would read as the new one's.
   it("drops the report when the pane moves to another collection", async () => {
     const { wrapper: w, nav } = await mountOnCollection();
-    await w.find("button").trigger("click");
+    await w.find(PORTABILITY).trigger("click");
     await flushPromises();
     expect(w.text()).toContain("Would not survive a clone");
 

--- a/test/src/components/CollectionsPaneSharedApp.spec.ts
+++ b/test/src/components/CollectionsPaneSharedApp.spec.ts
@@ -14,7 +14,7 @@ vi.mock("../../../src/components/PluginFrame.vue", () => ({
   default: { name: "PluginFrame", template: "<div><slot /></div>" },
 }));
 vi.mock("../../../src/components/SharedAppPreview.vue", () => ({
-  default: { name: "SharedAppPreview", template: "<div>the preview</div>" },
+  default: { name: "SharedAppPreview", props: ["cwd", "pickerTarget"], template: "<div>the preview</div>" },
 }));
 
 const PROJECT_OF: Record<string, string> = { "/srv/app": "p1", "/srv/plain": "p2" };
@@ -66,6 +66,19 @@ describe("CollectionsPane default view", () => {
     await flushPromises();
     expect(w.text()).not.toContain("the preview");
     expect(w.text()).toContain("index");
+  });
+
+  // The preview's page picker is teleported into the pane's toolbar, so the element the pane hands
+  // it has to BE in that toolbar by the time the preview is mounted — a template ref is set after
+  // its own render, which is exactly the kind of ordering that silently leaves a picker nowhere.
+  it("hands the preview a picker slot that is inside the toolbar", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" }, attachTo: document.body });
+    await flushPromises();
+    const slot = w.findComponent({ name: "SharedAppPreview" }).props("pickerTarget") as HTMLElement | null;
+    expect(slot).toBeInstanceOf(HTMLElement);
+    expect(w.find("header, div.border-b").element.contains(slot)).toBe(true);
+    w.unmount();
   });
 
   // The probe is async. Someone who opened a collection while it was in flight has said what they

--- a/test/src/components/CollectionsPaneSharedApp.spec.ts
+++ b/test/src/components/CollectionsPaneSharedApp.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// The plugin's Vue surfaces and the preview both pull large module graphs and render inside a
+// shadow root; neither is what this spec is about (which VIEW the pane opens in is). Stubbed at
+// the module boundary so the pane mounts as itself.
+vi.mock("@mulmoclaude/collection-plugin/vue", () => ({
+  CollectionsIndexView: { name: "CollectionsIndexView", template: "<div>index</div>" },
+  CollectionView: { name: "CollectionView", template: "<div>collection</div>" },
+  FeedsView: { name: "FeedsView", template: "<div>feeds</div>" },
+  configureCollectionUi: () => {},
+}));
+vi.mock("../../../src/components/PluginFrame.vue", () => ({
+  default: { name: "PluginFrame", template: "<div><slot /></div>" },
+}));
+vi.mock("../../../src/components/SharedAppPreview.vue", () => ({
+  default: { name: "SharedAppPreview", template: "<div>the preview</div>" },
+}));
+
+const PROJECT_OF: Record<string, string> = { "/srv/app": "p1", "/srv/plain": "p2" };
+vi.mock("../../../src/composables/collectionProject", () => ({
+  projectIdForCwd: async (cwd: string | null) => (cwd === null ? null : (PROJECT_OF[cwd] ?? null)),
+}));
+
+// Imported at module scope on purpose — an `await import` inside a test bills the whole module
+// graph against that test's timeout (CLAUDE.md).
+const CollectionsPane = (await import("../../../src/components/CollectionsPane.vue")).default;
+const { activeCollectionNavSurface } = await import("../../../src/composables/collectionSurface");
+
+/** Answer the declared-app probe, and nothing else: no other route is reached in these tests. */
+function mockDeclared(declared: boolean, hold?: Promise<void>) {
+  globalThis.fetch = vi.fn(async () => {
+    if (hold) await hold;
+    return { ok: true, status: 200, json: async () => ({ declared }) } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("CollectionsPane default view", () => {
+  it("opens on the preview in a directory that declares a shared app", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("the preview");
+    // And the way back is on the toolbar, not lost.
+    expect(w.text()).toContain("Back to collections");
+  });
+
+  it("opens on the collections everywhere else", async () => {
+    mockDeclared(false);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/plain" } });
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+    expect(w.text()).toContain("index");
+  });
+
+  it("leaves the preview once the user goes back, and does not re-open it", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    await w.find("button").trigger("click"); // Back to collections
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+    expect(w.text()).toContain("Preview the shared app");
+  });
+
+  // The probe is async. Someone who opened a collection while it was in flight has said what they
+  // want on screen; taking it off them after the fact is worse than not defaulting at all.
+  it("does not steal the screen from a collection opened while the probe was in flight", async () => {
+    let release!: () => void;
+    mockDeclared(true, new Promise<void>((resolve) => (release = resolve)));
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    activeCollectionNavSurface()?.gotoDetail("collection", "notes");
+    await flushPromises();
+
+    release();
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+    expect(w.text()).toContain("collection");
+  });
+});

--- a/test/src/components/CollectionsPaneSharedApp.spec.ts
+++ b/test/src/components/CollectionsPaneSharedApp.spec.ts
@@ -35,14 +35,17 @@ function mockDeclared(declared: boolean, hold?: Promise<void>) {
   }) as unknown as typeof fetch;
 }
 
+/** The toolbar's "Previews" checkbox: ON is the app's pages, OFF the collections under them. */
+const PREVIEWS = '[data-testid="collections-preview-toggle"]';
+
 describe("CollectionsPane default view", () => {
   it("opens on the preview in a directory that declares a shared app", async () => {
     mockDeclared(true);
     const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
     await flushPromises();
     expect(w.text()).toContain("the preview");
-    // And the way back is on the toolbar, not lost.
-    expect(w.text()).toContain("Back to collections");
+    // And the checkbox shows that state rather than merely offering it.
+    expect((w.find(PREVIEWS).element as HTMLInputElement).checked).toBe(true);
   });
 
   it("opens on the collections everywhere else", async () => {
@@ -51,16 +54,18 @@ describe("CollectionsPane default view", () => {
     await flushPromises();
     expect(w.text()).not.toContain("the preview");
     expect(w.text()).toContain("index");
+    // No app here: no pages, so nothing to switch to.
+    expect(w.find(PREVIEWS).exists()).toBe(false);
   });
 
-  it("leaves the preview once the user goes back, and does not re-open it", async () => {
+  it("shows the collections once the box is cleared, and does not re-check itself", async () => {
     mockDeclared(true);
     const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
     await flushPromises();
-    await w.find("button").trigger("click"); // Back to collections
+    await w.find(PREVIEWS).setValue(false);
     await flushPromises();
     expect(w.text()).not.toContain("the preview");
-    expect(w.text()).toContain("Preview the shared app");
+    expect(w.text()).toContain("index");
   });
 
   // The probe is async. Someone who opened a collection while it was in flight has said what they

--- a/test/src/components/CollectionsPaneSharedApp.spec.ts
+++ b/test/src/components/CollectionsPaneSharedApp.spec.ts
@@ -17,7 +17,7 @@ vi.mock("../../../src/components/SharedAppPreview.vue", () => ({
   default: { name: "SharedAppPreview", props: ["cwd", "pickerTarget"], template: "<div>the preview</div>" },
 }));
 
-const PROJECT_OF: Record<string, string> = { "/srv/app": "p1", "/srv/plain": "p2" };
+const PROJECT_OF: Record<string, string> = { "/srv/app": "p1", "/srv/app2": "p3", "/srv/plain": "p2" };
 vi.mock("../../../src/composables/collectionProject", () => ({
   projectIdForCwd: async (cwd: string | null) => (cwd === null ? null : (PROJECT_OF[cwd] ?? null)),
 }));
@@ -79,6 +79,54 @@ describe("CollectionsPane default view", () => {
     expect(slot).toBeInstanceOf(HTMLElement);
     expect(w.find("header, div.border-b").element.contains(slot)).toBe(true);
     w.unmount();
+  });
+
+  // Two reviewers landed on the same seam from different sides (#1784): "still on the index" is
+  // not the same question as "nobody has steered this pane". Both of these leave `mode ===
+  // "index"`, and both are a choice the arriving probe must not overrule.
+  it("does not overrule a feeds-index navigation made while the probe was in flight", async () => {
+    let release!: () => void;
+    mockDeclared(true, new Promise<void>((resolve) => (release = resolve)));
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    activeCollectionNavSurface()?.gotoIndex("feed");
+    await flushPromises();
+
+    release();
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+    expect(w.text()).toContain("feeds");
+  });
+
+  // A collection link activated from another mounted card is routed to this surface. With the
+  // preview up and nothing clearing it, the request would be honoured behind the preview and the
+  // click would look like it did nothing.
+  it("leaves the preview when a navigation asks for a collection", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("the preview");
+
+    activeCollectionNavSurface()?.navigateToRecord("notes", "r1");
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+    expect(w.text()).toContain("collection");
+    expect((w.find(PREVIEWS).element as HTMLInputElement).checked).toBe(false);
+  });
+
+  // The default is per DIRECTORY: walking the cell to another shared app is a fresh start, not a
+  // pane the user has steered.
+  it("defaults again when the cell moves to another directory", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    await w.find(PREVIEWS).setValue(false);
+    await flushPromises();
+    expect(w.text()).not.toContain("the preview");
+
+    await w.setProps({ cwd: "/srv/app2" });
+    await flushPromises();
+    expect(w.text()).toContain("the preview");
   });
 
   // The probe is async. Someone who opened a collection while it was in flight has said what they

--- a/test/src/components/CollectionsPaneSharedApp.spec.ts
+++ b/test/src/components/CollectionsPaneSharedApp.spec.ts
@@ -107,11 +107,16 @@ describe("CollectionsPane default view", () => {
     await flushPromises();
     expect(w.text()).toContain("the preview");
 
-    activeCollectionNavSurface()?.navigateToRecord("notes", "r1");
+    const nav = activeCollectionNavSurface();
+    nav?.navigateToRecord("notes", "r1");
     await flushPromises();
     expect(w.text()).not.toContain("the preview");
     expect(w.text()).toContain("collection");
     expect((w.find(PREVIEWS).element as HTMLInputElement).checked).toBe(false);
+    // BOTH identifiers the hop carried, read back off the surface the plugin's views read: the
+    // rendered text alone would pass with some other collection, or with no record selected.
+    expect(nav?.routeSlug()).toBe("notes");
+    expect(nav?.routeSelectedId()).toBe("r1");
   });
 
   // The default is per DIRECTORY: walking the cell to another shared app is a fresh start, not a

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -158,6 +158,29 @@ const mountPreview = async () => {
 };
 
 describe("SharedAppPreview", () => {
+  // The page picker is the HOST's chrome once a host offers a place for it: the collections pane
+  // has a toolbar of its own, and a strip directly under it was two toolbars saying different
+  // halves of one thing. Without a target it stays where it was, which is what a standalone mount
+  // (and every other test in this file) gets.
+  it("teleports the page picker into the host's toolbar when it is given one", async () => {
+    const slot = document.createElement("div");
+    document.body.appendChild(slot);
+    const wrapper = mount(SharedAppPreview, { props: { cwd: "/repo", pickerTarget: slot } });
+    await flushPromises();
+
+    expect(slot.querySelector("#mt-preview-page")).not.toBeNull();
+    expect(wrapper.element.querySelector("#mt-preview-page")).toBeNull();
+    wrapper.unmount();
+    // And it leaves nothing of its own behind in the host's toolbar.
+    expect(slot.querySelector("#mt-preview-page")).toBeNull();
+    slot.remove();
+  });
+
+  it("keeps the page picker in place when no target is given", async () => {
+    const wrapper = await mountPreview();
+    expect(wrapper.element.querySelector("#mt-preview-page")).not.toBeNull();
+  });
+
   // WHAT HAPPENED, carried out of the pane in one press.
   //
   // Every fact below already passed through this component and was then thrown away, and each was


### PR DESCRIPTION
collections ペインの見た目と操作を、他のペインに揃えるところまで小さく積んだ 5 コミット。

## 変更

1. **ツールバーを常設にした** — 帯は共有アプリを宣言したディレクトリでしか描かれておらず、セルを移ると帯そのものが現れたり消えたりし、アプリ以外の操作を置く場所が無かった。帯は常に出し、その中の個々の操作だけを出し入れする。
2. **expand / close を付けた** — このペインだけがペインスロットの約束（`expanded` prop と `close` / `toggleExpand` emit）に答えていなかった。Tools と同じアイコン・順序・クラスで右端に置き、`TerminalGrid` 側も Tools と同じ形で結線した。帯を状態分岐の外に出したのはそのため — 解決中でも、未知のディレクトリでも、プレビュー中でも閉じられなければならない。
3. **ヘッダの寸法を他のペインに揃えた** — Tools / Prompts / Question / Canvas は `bg-panel px-4 py-2 text-[14px]` に太字タイトルという同じ作り。高さを決めているのはタイトルの行ボックスなので、余白だけでは低いままになる。`border-b` はこのペインだけの追加で、他は背景で本体と分けているのに対しここは本体も `bg-panel` のため。
4. **共有アプリならプレビューが既定** — そのディレクトリが共有アプリなら作業の対象はページで、下のコレクションはその保存場所。切り替えは "Previews" のチェックボックス（既定 ON、共有アプリのディレクトリにだけ出る）。ただし既定が効くのはペインが自分の index にいる間だけ — probe は非同期で、その間にコレクションを開いた人から後で画面を奪うのは、既定を出さないことより悪い。
5. **ツールバーを 1 本にした** — プレビューは自分のすぐ下にもう 1 本帯を持っていた。ページ選択の状態はプレビュー側にあるので持ち上げず、ホストがツールバー内の要素を渡してそこへ teleport する。渡されなければ従来どおりその場に描く（単体マウントと spec）。ツールバーでは "Page" ラベルと選択の後ろの説明を落とした（選択肢自体が "<id> — <対象読者>" と読める）。

## 注意

- 5 で落とした説明のうち **「· Roster only」だけは選択肢に含まれない情報**（`publicOpen` が false であること）で、ツールバーからは読めなくなった。戻すなら別の置き場所が要る。
- spec が「ペインの最初のボタン」を portability ボタンの代わりに使っていたのが成り立たなくなったので testid で名指しにした。

## 確認

`yarn lint` / `yarn typecheck` / `yarn test`（component 1985 件）通過。teleport は両方向（渡した場合／渡さない場合、および unmount 後にホスト側へ残らないこと）と、ペインが渡す要素が実際にツールバー内にあることを spec で押さえた。**実画面での確認はまだ**（`yarn build` 未実行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preview, expand, and close controls to the collections pane.
  * Collections can now be viewed in preview mode, expanded to full width, or closed.
  * Page selection is integrated into the pane toolbar when previewing shared apps.
  * Preview mode adapts based on the current project view.

* **Bug Fixes**
  * Improved loading, unknown-project, and portability indicator spacing.
  * Prevented delayed loading results from overriding navigation or selection changes.
  * Improved collection selection and preview behavior when changing directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->