### PR TITLE
共有アプリ: ライブ投票のテンプレートを anonymous にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.12.0",
+    "@receptron/sharedapp": "^0.13.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -502,10 +502,17 @@ you publish. This is a survey anyone may answer once they sign in:
 
 Every line of that is load-bearing, and publish refuses the declaration without them:
 
-- **`auth` must be `verifiedEmail`.** `none` and `anonymous` exist in the rules and are REFUSED
-  here — a product decision, not an oversight. So "anyone with the link, no sign-in" is not
-  something you can offer today: a respondent signs in with an email address. Say that to the user
-  rather than promising anonymity and discovering it at publish.
+- **`auth` is `verifiedEmail` or `anonymous`; `none` is REFUSED.** Ask which one the app wants
+  before writing it, because it decides whether people answer at all:
+  - **`verifiedEmail`** — a Google sign-in, address confirmed. Required whenever the app needs an
+    address (`emailField`), sends mail, or admits people from its roster (`audience: "participant"`);
+    publish refuses `anonymous` with any of those, because an anonymous session has no address.
+  - **`anonymous`** — the browser opens a session by itself, no sign-in screen. The uid is real, so
+    `idFrom: "auth.uid"` / `"auth.uid+field"` still enforces one row per person. This is the mode for
+    an audience that must answer in the next ten seconds. What it is not is an identity: a phone and
+    a laptop are two people, an incognito window is a third, and nobody's address is recorded.
+  - **`none`** is refused: with no session there is no uid, so `idFrom` can only be `auto` and the
+    same person can submit as often as they can press the button.
 - **`emailField` names the field their address lands in**, and it must be in `createFields`.
 - **`submitOnly: true` is required** whenever the submission binds a record to its submitter. The
   record means "this person said this", and without it an owner or editor could write rows that

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -508,9 +508,10 @@ Every line of that is load-bearing, and publish refuses the declaration without 
     address (`emailField`), sends mail, or admits people from its roster (`audience: "participant"`);
     publish refuses `anonymous` with any of those, because an anonymous session has no address.
   - **`anonymous`** — the browser opens a session by itself, no sign-in screen. The uid is real, so
-    `idFrom: "auth.uid"` / `"auth.uid+field"` still enforces one row per person. This is the mode for
-    an audience that must answer in the next ten seconds. What it is not is an identity: a phone and
-    a laptop are two people, an incognito window is a third, and nobody's address is recorded.
+    `idFrom: "auth.uid"` / `"auth.uid+field"` enforces one row **per anonymous uid — which is a
+    browser profile, not a person**. This is the mode for an audience that must answer in the next
+    ten seconds. Say the limit in those words when you offer it: the same person answers again from
+    their phone, and again in an incognito window, and no address is recorded anywhere.
   - **`none`** is refused: with no session there is no uid, so `idFrom` can only be `auto` and the
     same person can submit as often as they can press the button.
 - **`emailField` names the field their address lands in**, and it must be in `createFields`.
@@ -844,8 +845,12 @@ Three things are worth asking and the rest are not:
 
 - **their email address**, if you do not have it — nothing works without it in `members`;
 - **whether people outside the roster should be able to answer** — it decides whether there is a
-  `public` block at all. Ask it in those words: everyone who answers signs in with an email
-  address either way, so "public" here means "anyone who signs in", not "anonymous";
+  `public` block at all. If yes, ask the second half too, because it is the one that decides whether
+  they actually answer: **are they asked to sign in?** `verifiedEmail` means a Google sign-in and a
+  recorded address — the app can write to them, and one row per account. `anonymous` means no screen
+  at all and no address, at the price of one row per browser rather than per person (see the `auth`
+  list above). Put it to the user as what the moment is: a form somebody fills in over a week, or an
+  audience answering in ten seconds;
 - **whether the people who answer need to see their own answer later** (step 2c) — it decides what
   the PUBLIC page may be, which is not a thing to discover after writing one. Answering yes does
   not make the app invite-only: leaving the public page generated serves a respondent who is on no

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -59,7 +59,7 @@ that side is N→1 by definition however popular the stream gets.
     "read": ["questions"],
     "submit": {
       "votes": {
-        "auth": "verifiedEmail",
+        "auth": "anonymous",
         "idFrom": "auth.uid+field",
         "idField": "questionId",
         "stampField": "votedAt",
@@ -96,10 +96,12 @@ that side is N→1 by definition however popular the stream gets.
   that quietly do not keep the promise. An app declaring nothing is `1.0.0`, which is what every app
   published before this key existed is.
 
-- **`auth: "verifiedEmail"`** — what publish accepts today, and the cost to be aware of: **a viewer
-  has to sign in with Google before they can vote**. In a stream that loses people. See "the sign-in
-  question" below — the rules already implement the mode that avoids it, and publish does not yet
-  allow it, which is one line in `@receptron/sharedapp`.
+- **`auth: "anonymous"`** — **no sign-in screen.** The visitor's browser opens a session by itself,
+  and the uid it gets is real enough for the rules to build a document id out of, so one-vote-per-
+  question is still ENFORCED. This is the whole reason a stream can use this: a Google sign-in
+  between the question and the answer loses most of the room. It requires **the Anonymous provider
+  enabled in the Firebase console** — once per project, and nothing in the repository can do it for
+  you. See "the sign-in question" below for what `anonymous` is not.
 - **`idFrom: "auth.uid+field"` + `idField: "questionId"`** — the document id becomes
   `uid + "_" + questionId`, so a second vote on the same question is a create where a document
   already exists. Firestore refuses it. **This is what "one vote per person per question" IS** — not
@@ -124,7 +126,7 @@ Say this out loud before using the shape, because the pages above make it look o
 
 | | enforced by | so |
 |---|---|---|
-| one vote per person per question | the RULES (`idFrom: "auth.uid+field"` — the id is `uid + "_" + questionId`) | a second vote is a create over an existing document, and Firestore refuses it |
+| one vote per BROWSER per question | the RULES (`idFrom: "auth.uid+field"` — the id is `uid + "_" + questionId`) | a second vote is a create over an existing document, and Firestore refuses it. Per browser, not per person, because this app is `anonymous` — see below |
 | `choice` is one of the five option keys | the RULES (`validate.keyFields`) | a fabricated option is REFUSED, not merely hidden from the tally |
 | `votedAt` is the server's clock | the RULES (`stampField`) | a page cannot backdate a vote |
 | only the fields declared | the RULES (`createFields` is their `hasOnly` list) | nothing else can be written |
@@ -154,19 +156,24 @@ collection the audience can read) and read the votes as records behind the `memb
 | mode | what it asks of a viewer | in a live stream |
 |---|---|---|
 | `verifiedEmail` | Google sign-in, address confirmed | **most viewers stop here** |
-| `none` | nothing | **one vote per person is unenforceable** — press it forty times |
+| `none` | nothing | **refused by publish** — with no uid, one vote per anybody is unenforceable |
 | `anonymous` | that a session exists (the browser makes one silently) | one vote per BROWSER per question, **with no sign-in screen** |
 
-`anonymous` is the mode this shape wants, and the front-end already does its half: it opens the
-session by itself, shows no sign-in screen, and says plainly that such an answer belongs to the
-browser rather than to an account (mulmoserver #202). What is missing is one line in
-`@receptron/sharedapp` — `authProblems` refuses to PUBLISH anything but `verifiedEmail`, deliberately
-and as a product decision, not a rules limitation. Until that is lifted this template declares
-`verifiedEmail`, which publishes; when it is lifted, change the one key and enable the Anonymous
-provider in the Firebase console once.
+`anonymous` is what this template declares, and every part of it is in place: the rules have always
+implemented the mode, the public page opens the session by itself and says plainly that such an answer
+belongs to the browser rather than to an account (mulmoserver #202), and publish accepts it
+(`@receptron/sharedapp` 0.13.0 — before that it refused everything but `verifiedEmail`).
 
-What `anonymous` is not: an identity. One vote per browser means a phone and a laptop vote twice, and
-an incognito window is a new browser.
+**One thing is not in the repository: the Anonymous provider has to be enabled in the Firebase
+console.** Once per project. Without it the sign-in fails at runtime with `auth/operation-not-allowed`
+and the page can only say that voting is unavailable — publish will not warn you, because nothing in
+a declaration can see a console setting.
+
+What `anonymous` is NOT: an identity. One vote per browser means a phone and a laptop vote twice, an
+incognito window is a third, and nobody's address is recorded. If the poll needs to know WHO answered
+— a graded quiz, a vote with a quorum, anything contested — that is a `verifiedEmail` app, and
+publish will make you say so: `anonymous` is refused alongside `emailField`, `audience: "participant"`
+and a `mail` queue, because an anonymous session has no address to put in any of them.
 
 ## .claude/skills/questions/schema.json
 
@@ -502,8 +509,8 @@ counts document — and nothing needs to, because the roster is the only audienc
 
 1. **`init`** — mints the `aid` and reserves the `slug`. **The reservation cannot be taken back**, so
    decide the slug first.
-2. **Tell the audience they will be asked to sign in** (or lift the gate and use `anonymous`, above —
-   in which case enable the Anonymous provider in the Firebase console before the stream, not during).
+2. **Enable the Anonymous provider in the Firebase console** — before the stream, not during. It is
+   the one step no file here can do, and without it every vote fails at sign-in.
 3. **Write the questions** into `questions` with `state: "draft"` — from the collection pane, or with
    `manageCollection`. Give them `order` in the sequence you will ask them.
 4. **`publish`** — the public page and the desk both appear.
@@ -514,9 +521,10 @@ counts document — and nothing needs to, because the roster is the only audienc
 
 - **No tally on the audience's page.** Not a limitation of the pages: it is the N→N fan-out, and
   publish refuses to declare it. Put the desk on the stream.
-- **One vote per ACCOUNT per question, while this declares `verifiedEmail`** — and every viewer has
-  to sign in first. On `anonymous` (see above) it becomes one vote per browser and no sign-in screen,
-  which is a different trade and the one a stream usually wants.
+- **One vote per BROWSER per question, not per person.** `anonymous` buys the missing sign-in screen
+  by giving up identity: a phone and a laptop are two votes, and an incognito window is a third. For a
+  stream that is the right trade; for anything contested, declare `verifiedEmail` and accept that most
+  of the room will not sign in.
 - **Nothing stops a vote on a question that is not open, or a `choice` nobody offered.** See "what
   the rules do and do not enforce" above — the declaration cannot express either, the desk ignores
   unknown choices, and a reopened question counts what arrived while it was shut.

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -104,8 +104,10 @@ that side is N→1 by definition however popular the stream gets.
   you. See "the sign-in question" below for what `anonymous` is not.
 - **`idFrom: "auth.uid+field"` + `idField: "questionId"`** — the document id becomes
   `uid + "_" + questionId`, so a second vote on the same question is a create where a document
-  already exists. Firestore refuses it. **This is what "one vote per person per question" IS** — not
-  a check in the page, which anybody can skip.
+  already exists. Firestore refuses it. **This is what the once-per-question guarantee IS** — not a
+  check in the page, which anybody can skip. Under `anonymous` the uid belongs to a BROWSER, so what
+  is enforced is once per browser; under `verifiedEmail` the same declaration means once per account.
+  The mechanism does not change with the mode, only what the uid stands for.
 - **`validate.keyFields` on `choice`** — the rules refuse any value outside that list. So a vote
   carries an OPTION KEY (`"a"`…`"e"`), not the text of the option: the text is per question, and a rule
   can compare a field to a fixed set but not to a list living in another document. The question's

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,10 +2264,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.12.0.tgz#9cd69778d97ca4bb1ad7caee1e3bfa271f03312b"
-  integrity sha512-o/wWKBIXCZ6n+KpceVn+yl9JCpHWou93BbmReqqkVQojhUhzSds3qiktnjR6k2lD7dpI1SMLZq5jYU8iMpr4Kg==
+"@receptron/sharedapp@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.13.0.tgz#e13e37acd2da5971c994b04b86f3b41f2bd6c57a"
+  integrity sha512-WC+hKY4PefxrtATtl4IPnjJVRDjNocH3rPRoM0u5OPHeFvWIO8GW3HWpTpcDcoXRBTdbRAnJkaiUwsbuHD1DIQ==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
receptron/sharedapp#24 が入って **0.13.0 が npm に出るまでマージできません**（`package.json` は `^0.13.0` を指していますが、`yarn.lock` はまだ更新できないので CI は通りません）。draft なのはそのためです。

設計: #1785。テンプレートは #1792 で入ったもの。

## なぜ

テンプレートが `verifiedEmail` だったのは **publish が拒否していたから**で、設計上の選択ではありませんでした。設問と回答のあいだに Google サインインを挟むと、配信の会場はほとんど落ちます。sharedapp#24 がそこを開けるので、テンプレートが最初から欲しかった側を選びます。

## 変わるところ

`app.json` は 1 キーですが、まわりの言い方が 4 か所:

- **「1 人 1 票」→「1 ブラウザ 1 票」**。強制されていること自体は変わりません（id は `uid + "_" + questionId`）が、**何が**強制されているかが変わります — スマホと PC で 2 票、シークレットウィンドウで 3 票目
- **「サインインすると伝えろ」→「Firebase コンソールで Anonymous provider を有効にしろ」**。リポジトリの中の何を直してもできない唯一の手順で、忘れると本番の投票が全部 `auth/operation-not-allowed` で落ちます。**publish は警告できません**（宣言からコンソールの設定は見えない）
- **`none` の行を「publish が拒否する」に**。あの表は「ルールにあるモードの一覧」ではなく「書ける宣言の一覧」として読まれるので
- **本人を知る必要がある投票は `verifiedEmail`** だと言い切る。`anonymous` は `emailField` / `audience: "participant"` / `mail` と一緒に宣言すると拒否されます（匿名のセッションには住所が無い）

`SKILL.md` の「`auth` は `verifiedEmail` でなければならない」も 3 モードの選び分けに書き直しました。ここは**全アプリが読む場所**なので、ライブ投票だけの話にはしていません。

## マージまでの順番

1. receptron/sharedapp#24 をマージ
2. **0.13.0 を npm に publish**
3. このブランチで `yarn add @receptron/sharedapp@^0.13.0`（lock を更新）→ draft を外す
4. マージ後、**動かしているインスタンスを rebuild + 再起動**（dist を配っているので、これが無いと publish 経路は古いまま）
5. **Firebase コンソールで Anonymous provider を有効化**（1 プロジェクト 1 回）

mulmoserver 側は**変更不要**です（`publicSignIn.ts` が 3 モードとも実装済み、#202）。ルールの deploy も不要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live polls now support anonymous voting, allowing participants to vote without providing an email address.
  * Voting is limited to one vote per question per browser session.

* **Documentation**
  * Clarified anonymous-session behavior, identity limitations, setup requirements, and expected runtime behavior.
  * Documented when verified email authentication is still required for submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->