### PR TITLE
ライブ投票のテンプレート: 押す前に親へ訊き、それでも来た拒否は受け止める

### DIFF
--- a/docs/shared-app-principles.md
+++ b/docs/shared-app-principles.md
@@ -71,6 +71,10 @@ MulmoTerminal の検査（`records.ts` の移行ゲート、`scopedFields.ts` �
   **1 回だけ**である。2 回目の state で描き直せるか（行が入れ替わらず増えないか、
   リスナーが state ごとに増えないか）、購読が更新を運んだときに**選択中の入力や打ちかけの文字が
   消えないか**は、どちらの preview でも**未検証**である
+- **`view.mine(cid, key)` の答えは常に「分からない」。** preview は親ではないので lookup を渡さず、
+  すべての問いに `known: false`（誰も見ていない）が返る。ページは必ず**分からない側の枝**を通る —
+  そこは設計上いちばん安全な枝なので、`found: true` のときにだけ現れる振る舞い（回答を出し戻す、
+  もう使った操作を隠す）は**一度も走らないまま緑になる**
 
 一次資料は `server/infra/shared-app-tool.ts` の `manageSharedApp` prompt（ここは要約である）。
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.13.0",
+    "@receptron/sharedapp": "^0.15.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/backends/sharedApp/headlessReport.ts
+++ b/server/backends/sharedApp/headlessReport.ts
@@ -327,6 +327,20 @@ const LIVE_UNVERIFIED =
   "delivers state once. Whether such a page redraws correctly on a second state, and whether an update landing mid-edit wipes a selection or a half-typed field, " +
   "is NOT tested here.";
 
+/** The other fixed sentence, and the same kind of blindness from the opposite side.
+ *
+ *  `view.mine(cid, key)` asks the PARENT whether this visitor already has one particular row. This
+ *  run is not that parent: it offers no lookup, so every ask is answered `known: false` — "nobody
+ *  looked" — and a page takes its unknown branch every time. That branch is the safe one by design,
+ *  so a page whose real behaviour lives in `found: true` (drawing an answer back, hiding a control
+ *  somebody has already used) is never exercised, and looks completely fine here.
+ *
+ *  Unconditional for the reason above it: the sentence is about what this run does, and a report
+ *  that goes quiet when the app happens not to ask teaches a reader that silence means covered. */
+const LOOKUP_UNVERIFIED =
+  "`view.mine(cid, key)` — 'have I already got this row?' — is answered `known: false` here, because this run does not read records back. A page that asks is " +
+  "therefore always on its unknown branch: what it draws when the answer is `found: true` (an answer shown back, a control it hides) is NOT tested here.";
+
 function closing(run: { wrote: boolean; writesSkipped: number; screenshotDir: string | null; pages: readonly HeadlessPageReport[] }): string[] {
   const skipped =
     run.writesSkipped === 0
@@ -345,10 +359,11 @@ function closing(run: { wrote: boolean; writesSkipped: number; screenshotDir: st
       "This does NOT prove the app is ready to publish. It says nothing about whether the deployed rules would accept a write, about other people's devices, " +
         "about two people submitting at once, or about whether the rules are deployed at all.",
       LIVE_UNVERIFIED,
+      LOOKUP_UNVERIFIED,
     ];
   }
   const wroteAnything = run.pages.some((page) => page.presses.some((press) => press.write !== null));
-  return ["", ...whatWasWritten(run.pages), ...skipped, ...pictures, stillUnknown(wroteAnything), LIVE_UNVERIFIED];
+  return ["", ...whatWasWritten(run.pages), ...skipped, ...pictures, stillUnknown(wroteAnything), LIVE_UNVERIFIED, LOOKUP_UNVERIFIED];
 }
 
 export function narrateHeadlessRun(run: HeadlessRun): string {

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -188,11 +188,16 @@ Reading `known: false` as "you have not answered" is the one mistake that matter
 away from somebody entitled to it. Leaving it on offer costs at most one refused press, and the page
 handles that below.
 
-**Which is why the refusal handling stays.** The ask can be unavailable (an older host), and a vote
-can still be refused for a reason nobody predicted. When that happens the page turns it into a
-sentence and stops asking — and it separates the refusals that are not refusals at all: a visitor who
-CANCELLED the confirmation (`cancelled`), or pressed while one was open (`busy`), has not been refused
-anything. Count those as a refusal and somebody who changed their mind can never vote.
+**A refusal is not proof of a duplicate, so the page asks again rather than concluding.** `{ ok:
+false }` is what the bridge reports for everything: a rules denial, a network failure, a disabled
+Anonymous provider, a validation refusal — and the only field is an untyped string. So when a vote
+comes back refused, the page asks about the same key: a row means their vote is in (show it), no row
+or no answer means it is not (leave the vote on offer and say what happened). Folding the vote away on
+any `{ ok: false }` would leave somebody whose connection blinked unable to vote for the rest of the
+poll.
+
+Two of those failures are not refusals at all and never reach that question: a visitor who CANCELLED
+the confirmation (`cancelled`), or pressed while one was open (`busy`).
 
 ### The sign-in question, which decides whether an audience actually votes
 
@@ -283,11 +288,11 @@ of them is something a page that reads once never has to think about:
 3. **Show that a vote landed even though the page will keep receiving updates.** The visitor's own
    vote is not in what they can read (`votes` is not public), so the page remembers it — in a
    variable, because there is nowhere else (see rule 4).
-4. **Ask before offering, because a reload wipes everything the page knows.** `view.mine("votes",
-   question.id)` is how it finds out, and the answer has three states rather than two — see "what a
-   reload costs" above. Handle the refusal as well: the ask can be unavailable, and a vote can be
-   refused for a reason nobody predicted. What the visitor reads at that moment is the whole
-   difference between a working poll and a broken one.
+4. **Ask rather than assume — before offering the vote, and again if one is refused.**
+   `view.mine("votes", question.id)` is how the page finds out, and its answer has three states
+   rather than two (see "what a reload costs" above). A refused submission is not proof of anything
+   either: the same shape carries a network failure. What the visitor reads at that moment is the
+   whole difference between a working poll and a broken one.
 
 ```html
 <h1>Live poll</h1>
@@ -313,10 +318,9 @@ of them is something a page that reads once never has to think about:
   // The questions this browser has already answered. NOT what stops a second vote — the rules do
   // that, because the document id is uid + questionId — this only decides what the page shows.
   const voted = new Map();
-  // Questions the rules refused. Not the same as "could not send": a visitor who cancelled the
-  // confirmation has not been refused anything, and counting that here would leave somebody who
-  // changed their mind unable to vote at all.
-  const refused = new Set();
+  // The two failures that are not refusals at all: the visitor cancelled the confirmation, or
+  // pressed while one was open. Counting either as "already answered" leaves somebody who changed
+  // their mind unable to vote.
   const RETRYABLE = new Set(["cancelled", "busy"]);
   // Questions already put to the parent. A mark that the ASK happened, not a memory of the answer:
   // the answer lands in `voted`, or nowhere at all when nobody knows.
@@ -389,16 +393,6 @@ of them is something a page that reads once never has to think about:
     show("voted");
   };
 
-  // The refusal, in the same place as the thank-you: there is nothing else this person can do about
-  // this question, and waiting for the next one is the honest next state. The reason is shown small
-  // — meaningless to a visitor, and the only thread an author has to pull on, since a published page
-  // has no diagnostics of its own.
-  const drawRefused = (why) => {
-    document.getElementById("votedMark").textContent = "That vote was not accepted.";
-    document.getElementById("votedChoice").textContent = `It looks like you have already answered this one.${why ? ` (${why})` : ""}`;
-    show("voted");
-  };
-
   // Rule 4: ask the parent about THIS question, once. The answer arrives a turn later and switches
   // the page if it says so; nothing waits for it, because a page that blocks on a read shows an
   // audience a spinner where the question should be.
@@ -407,7 +401,7 @@ of them is something a page that reads once never has to think about:
   // refused — and treating that as "you have not answered" is the one mistake that takes the vote
   // away from somebody entitled to it.
   const askIfAnswered = (question) => {
-    if (asked.has(question.id) || voted.has(question.id) || refused.has(question.id)) {
+    if (asked.has(question.id) || voted.has(question.id)) {
       return;
     }
     if (typeof view.mine !== "function") {
@@ -441,15 +435,11 @@ of them is something a page that reads once never has to think about:
       return;
     }
     askIfAnswered(question);
-    if (voted.has(question.id) || refused.has(question.id)) {
+    if (voted.has(question.id)) {
       if (shownId !== question.id) {
         shownId = question.id;
         shownSignature = null;
-        if (voted.has(question.id)) {
-          drawVoted(question.id);
-        } else {
-          drawRefused("");
-        }
+        drawVoted(question.id);
       }
       return;
     }
@@ -500,12 +490,26 @@ of them is something a page that reads once never has to think about:
       notice(why === "busy" ? "Still sending. Try again in a moment." : "");
       return;
     }
-    // Rule 4: the rules said no. Do not offer the same write again — it will be refused the same
-    // way — and say what it most likely means.
-    refused.add(questionId);
-    if (shownId === questionId) {
-      drawRefused(why);
+    // A refusal is NOT proof of a duplicate. `{ ok: false }` is also what a network failure looks
+    // like, and a disabled Anonymous provider, and a validation refusal — the only field here is an
+    // untyped string. Folding the vote away on any of them means somebody whose connection blinked
+    // can never vote again.
+    //
+    // So ask what actually happened. It is the same read as rule 4, for the same key.
+    const after = typeof view.mine === "function" ? await view.mine("votes", questionId).catch(() => null) : null;
+    if (after?.known && after.found) {
+      // A row IS there: either they answered before, or this write landed and something after it
+      // failed. Either way their vote counts, and this is their answer.
+      const option = optionsOf(question).find((one) => one.key === after.record?.choice);
+      voted.set(questionId, option?.label ?? after.record?.choice ?? "");
+      if (shownId === questionId) {
+        drawVoted(questionId);
+      }
+      return;
     }
+    // Nothing was written, or nobody can say. Leave the vote on offer and show what happened.
+    document.getElementById("send").disabled = false;
+    notice(`Could not vote: ${why || "unknown error"}`);
   });
 
   view.ready();
@@ -647,8 +651,8 @@ counts document — and nothing needs to, because the roster is the only audienc
   of the room will not sign in.
 - **A reload is answered by asking, not by remembering.** The page cannot remember anything (no
   storage in the sandbox), so it asks the parent about the question on screen — see "what a reload
-  costs". On an older host that ask is unavailable and the reload costs one refused press, which the
-  page turns into a sentence rather than a permission error.
+  costs". On an older host the ask is unavailable: the vote is offered again, refused, and the page
+  says so and lets them try rather than deciding for them.
 - **Nothing stops a vote on a question that is not open, or a `choice` nobody offered.** See "what
   the rules do and do not enforce" above — the declaration cannot express either, the desk ignores
   unknown choices, and a reopened question counts what arrived while it was shut.

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -151,6 +151,39 @@ So: fine for a stream, a class, a retro. **Not** for anything whose outcome some
 There, do not publish the state as the gate — publish the RESULT when a question is done (a row in a
 collection the audience can read) and read the votes as records behind the `member` page.
 
+### What a reload costs, and why the page cannot fix it
+
+**A published page cannot remember anything by itself.** The sandbox gives it an opaque origin, so
+`localStorage`, `sessionStorage` and `document.cookie` all raise `SecurityError` — measured, not
+assumed. Reload and the page is new-born.
+
+The only memory it has is the parent's. The public page hands a view `viewer.mine` — the rows this
+visitor has already submitted, projected to the fields the page could have sent (mulmoserver #207) —
+and for `idFrom: "auth.uid"` that answers "have I answered?" exactly.
+
+**For `auth.uid+field` it cannot answer, and the reason is permanent.** The ids are
+`uid + "_" + <field>`, so finding them means asking for a RANGE of document ids — and rules cannot
+authorize a list that way: for a list the `{itemId}` wildcard is never bound, so every branch of
+`ownRow` that names it is false however the query is written. A read-only prefix branch was added to
+the rules and tried against the emulator; it made no difference. An anonymous session has no address
+to query by either. The limit is pinned in mulmoserver's `test/rules/rules_ownReadback.ts`.
+
+So on this shape, after a reload:
+
+1. the page shows the vote again (it has no way to know)
+2. the visitor votes, and the rules refuse it — correctly, because they are what enforces one per
+   question
+3. **the page must turn that refusal into a sentence, and stop asking.** Not a raw permission error,
+   and not a button they can press again to be refused again
+
+`views/poll.html` below does that. The distinction it makes is the one that matters: a visitor who
+CANCELLED the confirmation (`cancelled`), or pressed while one was open (`busy`), has not been
+refused anything — count those as a refusal and somebody who changed their mind can never vote.
+
+Closing the gap for good needs the declaration to say where the field's values come from, so the
+parent can `get` `uid_q1`, `uid_q2`… one at a time — a document get IS granted (the same emulator
+run shows it). That key does not exist yet.
+
 ### The sign-in question, which decides whether an audience actually votes
 
 `firestore.rules` implements three modes, and the difference matters more here than anywhere else:
@@ -238,7 +271,12 @@ of them is something a page that reads once never has to think about:
 2. **When the question changes, drop everything about the previous one** — the selection, the error,
    the "thank you".
 3. **Show that a vote landed even though the page will keep receiving updates.** The visitor's own
-   vote is not in what they can read (`votes` is not public), so the page remembers it.
+   vote is not in what they can read (`votes` is not public), so the page remembers it — in a
+   variable, because there is nowhere else (see rule 4).
+4. **Handle the refusal, because a reload will produce one.** Everything the page remembers is gone
+   on reload, and this shape cannot get it back: see "what a reload costs" below. So the page offers
+   the vote again, the rules refuse it, and what the visitor reads at that moment is the whole
+   difference between a working poll and a broken one.
 
 ```html
 <h1>Live poll</h1>
@@ -264,6 +302,11 @@ of them is something a page that reads once never has to think about:
   // The questions this browser has already answered. NOT what stops a second vote — the rules do
   // that, because the document id is uid + questionId — this only decides what the page shows.
   const voted = new Map();
+  // Questions the rules refused. Not the same as "could not send": a visitor who cancelled the
+  // confirmation has not been refused anything, and counting that here would leave somebody who
+  // changed their mind unable to vote at all.
+  const refused = new Set();
+  const RETRYABLE = new Set(["cancelled", "busy"]);
   let shownId = null;
   let shownSignature = null;
   let sending = false;
@@ -327,7 +370,18 @@ of them is something a page that reads once never has to think about:
 
   const drawVoted = (questionId) => {
     const choice = voted.get(questionId);
+    document.getElementById("votedMark").textContent = "Your vote was recorded.";
     document.getElementById("votedChoice").textContent = choice ? `You answered: ${choice}` : "";
+    show("voted");
+  };
+
+  // The refusal, in the same place as the thank-you: there is nothing else this person can do about
+  // this question, and waiting for the next one is the honest next state. The reason is shown small
+  // — meaningless to a visitor, and the only thread an author has to pull on, since a published page
+  // has no diagnostics of its own.
+  const drawRefused = (why) => {
+    document.getElementById("votedMark").textContent = "That vote was not accepted.";
+    document.getElementById("votedChoice").textContent = `It looks like you have already answered this one.${why ? ` (${why})` : ""}`;
     show("voted");
   };
 
@@ -339,11 +393,15 @@ of them is something a page that reads once never has to think about:
       show("waiting");
       return;
     }
-    if (voted.has(question.id)) {
+    if (voted.has(question.id) || refused.has(question.id)) {
       if (shownId !== question.id) {
         shownId = question.id;
         shownSignature = null;
-        drawVoted(question.id);
+        if (voted.has(question.id)) {
+          drawVoted(question.id);
+        } else {
+          drawRefused("");
+        }
       }
       return;
     }
@@ -386,8 +444,20 @@ of them is something a page that reads once never has to think about:
       }
       return;
     }
-    document.getElementById("send").disabled = false;
-    notice(`Could not vote: ${answer?.error ?? "unknown error"}`);
+    const why = answer?.error ?? "";
+    if (RETRYABLE.has(why)) {
+      // They cancelled, or a confirmation was already open. Nothing was refused; let them press
+      // again.
+      document.getElementById("send").disabled = false;
+      notice(why === "busy" ? "Still sending. Try again in a moment." : "");
+      return;
+    }
+    // Rule 4: the rules said no. Do not offer the same write again — it will be refused the same
+    // way — and say what it most likely means.
+    refused.add(questionId);
+    if (shownId === questionId) {
+      drawRefused(why);
+    }
   });
 
   view.ready();
@@ -527,6 +597,9 @@ counts document — and nothing needs to, because the roster is the only audienc
   by giving up identity: a phone and a laptop are two votes, and an incognito window is a third. For a
   stream that is the right trade; for anything contested, declare `verifiedEmail` and accept that most
   of the room will not sign in.
+- **A reload costs one refused press.** The page cannot remember (no storage in the sandbox) and
+  cannot ask (a composite id has no read-back) — see "what a reload costs". It turns the refusal
+  into a sentence and stops; it cannot avoid it.
 - **Nothing stops a vote on a question that is not open, or a `choice` nobody offered.** See "what
   the rules do and do not enforce" above — the declaration cannot express either, the desk ignores
   unknown choices, and a reopened question counts what arrived while it was shut.

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -151,38 +151,48 @@ So: fine for a stream, a class, a retro. **Not** for anything whose outcome some
 There, do not publish the state as the gate — publish the RESULT when a question is done (a row in a
 collection the audience can read) and read the votes as records behind the `member` page.
 
-### What a reload costs, and why the page cannot fix it
+### What a reload costs, and the two things that answer it
 
 **A published page cannot remember anything by itself.** The sandbox gives it an opaque origin, so
 `localStorage`, `sessionStorage` and `document.cookie` all raise `SecurityError` — measured, not
-assumed. Reload and the page is new-born.
+assumed. Reload and the page is new-born. Everything it knows about "have I answered?" comes from the
+parent, and there are two ways to get it.
 
-The only memory it has is the parent's. The public page hands a view `viewer.mine` — the rows this
-visitor has already submitted, projected to the fields the page could have sent (mulmoserver #207) —
-and for `idFrom: "auth.uid"` that answers "have I answered?" exactly.
+**`viewer.mine`, with the state.** The rows this visitor has already submitted, projected to the
+fields the page could have sent. It answers for `idFrom: "auth.uid"` exactly — and for
+`auth.uid+field` it cannot, because finding those rows means asking for a RANGE of document ids and
+rules cannot authorize a list that way: for a list the `{itemId}` wildcard is never bound, so every
+branch of `ownRow` that names it is false however the query is written. A read-only prefix branch was
+added to the rules and tried against the emulator; it made no difference. The limit is pinned in
+mulmoserver's `test/rules/rules_ownReadback.ts`.
 
-**For `auth.uid+field` it cannot answer, and the reason is permanent.** The ids are
-`uid + "_" + <field>`, so finding them means asking for a RANGE of document ids — and rules cannot
-authorize a list that way: for a list the `{itemId}` wildcard is never bound, so every branch of
-`ownRow` that names it is false however the query is written. A read-only prefix branch was added to
-the rules and tried against the emulator; it made no difference. An anonymous session has no address
-to query by either. The limit is pinned in mulmoserver's `test/rules/rules_ownReadback.ts`.
+**`view.mine(cid, key)`, on demand — which is what this shape uses.** A document GET is granted (the
+same emulator run shows it), and the only thing missing was the key: the parent cannot enumerate the
+question ids, and the page is looking at one. So the page asks about the question it is showing, the
+parent builds `uid + "_" + key` and reads that one document.
 
-So on this shape, after a reload:
+```js
+const answer = await view.mine("votes", question.id);
+// { known: true, found: true, record: { choice: "b" } }
+```
 
-1. the page shows the vote again (it has no way to know)
-2. the visitor votes, and the rules refuse it — correctly, because they are what enforces one per
-   question
-3. **the page must turn that refusal into a sentence, and stop asking.** Not a raw permission error,
-   and not a button they can press again to be refused again
+**Three answers, and only one of them is "no".**
 
-`views/poll.html` below does that. The distinction it makes is the one that matters: a visitor who
-CANCELLED the confirmation (`cancelled`), or pressed while one was open (`busy`), has not been
-refused anything — count those as a refusal and somebody who changed their mind can never vote.
+| | means | the page should |
+|---|---|---|
+| `known: false` | nobody looked — an older host, a read that failed | leave the vote on offer |
+| `known: true, found: false` | this visitor really has not answered | leave the vote on offer |
+| `known: true, found: true` | they have | show it back, before they press |
 
-Closing the gap for good needs the declaration to say where the field's values come from, so the
-parent can `get` `uid_q1`, `uid_q2`… one at a time — a document get IS granted (the same emulator
-run shows it). That key does not exist yet.
+Reading `known: false` as "you have not answered" is the one mistake that matters: it takes the vote
+away from somebody entitled to it. Leaving it on offer costs at most one refused press, and the page
+handles that below.
+
+**Which is why the refusal handling stays.** The ask can be unavailable (an older host), and a vote
+can still be refused for a reason nobody predicted. When that happens the page turns it into a
+sentence and stops asking — and it separates the refusals that are not refusals at all: a visitor who
+CANCELLED the confirmation (`cancelled`), or pressed while one was open (`busy`), has not been refused
+anything. Count those as a refusal and somebody who changed their mind can never vote.
 
 ### The sign-in question, which decides whether an audience actually votes
 
@@ -273,9 +283,10 @@ of them is something a page that reads once never has to think about:
 3. **Show that a vote landed even though the page will keep receiving updates.** The visitor's own
    vote is not in what they can read (`votes` is not public), so the page remembers it — in a
    variable, because there is nowhere else (see rule 4).
-4. **Handle the refusal, because a reload will produce one.** Everything the page remembers is gone
-   on reload, and this shape cannot get it back: see "what a reload costs" below. So the page offers
-   the vote again, the rules refuse it, and what the visitor reads at that moment is the whole
+4. **Ask before offering, because a reload wipes everything the page knows.** `view.mine("votes",
+   question.id)` is how it finds out, and the answer has three states rather than two — see "what a
+   reload costs" above. Handle the refusal as well: the ask can be unavailable, and a vote can be
+   refused for a reason nobody predicted. What the visitor reads at that moment is the whole
    difference between a working poll and a broken one.
 
 ```html
@@ -307,6 +318,9 @@ of them is something a page that reads once never has to think about:
   // changed their mind unable to vote at all.
   const refused = new Set();
   const RETRYABLE = new Set(["cancelled", "busy"]);
+  // Questions already put to the parent. A mark that the ASK happened, not a memory of the answer:
+  // the answer lands in `voted`, or nowhere at all when nobody knows.
+  const asked = new Set();
   let shownId = null;
   let shownSignature = null;
   let sending = false;
@@ -385,6 +399,39 @@ of them is something a page that reads once never has to think about:
     show("voted");
   };
 
+  // Rule 4: ask the parent about THIS question, once. The answer arrives a turn later and switches
+  // the page if it says so; nothing waits for it, because a page that blocks on a read shows an
+  // audience a spinner where the question should be.
+  //
+  // `known` is the field to read first. False means nobody looked — an older host, a read that was
+  // refused — and treating that as "you have not answered" is the one mistake that takes the vote
+  // away from somebody entitled to it.
+  const askIfAnswered = (question) => {
+    if (asked.has(question.id) || voted.has(question.id) || refused.has(question.id)) {
+      return;
+    }
+    if (typeof view.mine !== "function") {
+      return; // an older runtime; the refusal path below is what covers it
+    }
+    asked.add(question.id);
+    view
+      .mine("votes", question.id)
+      .then((answer) => {
+        if (!answer?.known || !answer.found) {
+          return;
+        }
+        // The record carries the KEY. The label for it is in the question on screen.
+        const option = optionsOf(question).find((one) => one.key === answer.record?.choice);
+        voted.set(question.id, option?.label ?? answer.record?.choice ?? "");
+        if (shownId === question.id) {
+          drawVoted(question.id);
+        }
+      })
+      .catch(() => {
+        // Could not ask. Leave it unknown: the vote stays on offer, and a refusal will say so.
+      });
+  };
+
   view.onState((state) => {
     const question = openQuestion(Array.isArray(state?.questions) ? state.questions : []);
     if (question === null) {
@@ -393,6 +440,7 @@ of them is something a page that reads once never has to think about:
       show("waiting");
       return;
     }
+    askIfAnswered(question);
     if (voted.has(question.id) || refused.has(question.id)) {
       if (shownId !== question.id) {
         shownId = question.id;
@@ -597,9 +645,10 @@ counts document — and nothing needs to, because the roster is the only audienc
   by giving up identity: a phone and a laptop are two votes, and an incognito window is a third. For a
   stream that is the right trade; for anything contested, declare `verifiedEmail` and accept that most
   of the room will not sign in.
-- **A reload costs one refused press.** The page cannot remember (no storage in the sandbox) and
-  cannot ask (a composite id has no read-back) — see "what a reload costs". It turns the refusal
-  into a sentence and stops; it cannot avoid it.
+- **A reload is answered by asking, not by remembering.** The page cannot remember anything (no
+  storage in the sandbox), so it asks the parent about the question on screen — see "what a reload
+  costs". On an older host that ask is unavailable and the reload costs one refused press, which the
+  page turns into a sentence rather than a permission error.
 - **Nothing stops a vote on a question that is not open, or a `choice` nobody offered.** See "what
   the rules do and do not enforce" above — the declaration cannot express either, the desk ignores
   unknown choices, and a reopened question counts what arrived while it was shut.

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -470,6 +470,10 @@ of them is something a page that reads once never has to think about:
       return;
     }
     const questionId = shownId;
+    // SNAPSHOT, taken before anything is awaited. The host can advance the poll while a write or a
+    // read-back is in flight, and `shownQuestion` is then the NEXT question — mapping a recovered
+    // key against it stores somebody's answer as a label they never saw.
+    const submitted = shownQuestion;
     sending = true;
     document.getElementById("send").disabled = true;
     notice("Sending…");
@@ -505,7 +509,7 @@ of them is something a page that reads once never has to think about:
     if (after?.known && after.found) {
       // A row IS there: either they answered before, or this write landed and something after it
       // failed. Either way their vote counts, and this is their answer.
-      const option = optionsOf(shownQuestion ?? {}).find((one) => one.key === after.record?.choice);
+      const option = optionsOf(submitted ?? {}).find((one) => one.key === after.record?.choice);
       voted.set(questionId, option?.label ?? after.record?.choice ?? "");
       if (shownId === questionId) {
         drawVoted(questionId);

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -326,6 +326,9 @@ of them is something a page that reads once never has to think about:
   // the answer lands in `voted`, or nowhere at all when nobody knows.
   const asked = new Set();
   let shownId = null;
+  // The question object itself, not just its id: an answer that arrives later has to be turned into
+  // a LABEL, and the labels live on the question. The click handler runs long after `onState`.
+  let shownQuestion = null;
   let shownSignature = null;
   let sending = false;
 
@@ -430,10 +433,12 @@ of them is something a page that reads once never has to think about:
     const question = openQuestion(Array.isArray(state?.questions) ? state.questions : []);
     if (question === null) {
       shownId = null;
+      shownQuestion = null;
       shownSignature = null;
       show("waiting");
       return;
     }
+    shownQuestion = question;
     askIfAnswered(question);
     if (voted.has(question.id)) {
       if (shownId !== question.id) {
@@ -500,7 +505,7 @@ of them is something a page that reads once never has to think about:
     if (after?.known && after.found) {
       // A row IS there: either they answered before, or this write landed and something after it
       // failed. Either way their vote counts, and this is their answer.
-      const option = optionsOf(question).find((one) => one.key === after.record?.choice);
+      const option = optionsOf(shownQuestion ?? {}).find((one) => one.key === after.record?.choice);
       voted.set(questionId, option?.label ?? after.record?.choice ?? "");
       if (shownId === questionId) {
         drawVoted(questionId);

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -176,6 +176,11 @@ const answer = await view.mine("votes", question.id);
 // { known: true, found: true, record: { choice: "b" } }
 ```
 
+A record whose `choice` is not one of the options on screen is still a vote — the choices were
+edited after somebody answered, or the row came from something other than this page. The page drops
+the CLAIM about which option it was and keeps the fact: the control goes, because the rules will
+refuse a second one either way, and a bare `d` on screen means nothing to the person reading it.
+
 **Three answers, and only one of them is "no".**
 
 | | means | the page should |
@@ -417,9 +422,13 @@ of them is something a page that reads once never has to think about:
         if (!answer?.known || !answer.found) {
           return;
         }
-        // The record carries the KEY. The label for it is in the question on screen.
+        // The record carries the KEY; the label for it is in the question. A key with no option —
+        // the choices were edited after they voted, or the row was written by something other than
+        // this page — is still a vote, and the control still has to go: the rules will refuse a
+        // second one. What is dropped is the CLAIM about which option it was. Showing the bare key
+        // would put a letter on screen that means nothing to the person reading it.
         const option = optionsOf(question).find((one) => one.key === answer.record?.choice);
-        voted.set(question.id, option?.label ?? answer.record?.choice ?? "");
+        voted.set(question.id, option?.label ?? "");
         if (shownId === question.id) {
           drawVoted(question.id);
         }
@@ -510,7 +519,7 @@ of them is something a page that reads once never has to think about:
       // A row IS there: either they answered before, or this write landed and something after it
       // failed. Either way their vote counts, and this is their answer.
       const option = optionsOf(submitted ?? {}).find((one) => one.key === after.record?.choice);
-      voted.set(questionId, option?.label ?? after.record?.choice ?? "");
+      voted.set(questionId, option?.label ?? "");
       if (shownId === questionId) {
         drawVoted(questionId);
       }

--- a/test/server/backends/headlessReport.spec.ts
+++ b/test/server/backends/headlessReport.spec.ts
@@ -415,3 +415,17 @@ describe("narrateHeadlessRun", () => {
     expect(narrateHeadlessRun({ ok: false, problems: ["no browser", "ask the user"] })).toBe("no browser\nask the user");
   });
 });
+
+describe("what a green run does not say about a read-back", () => {
+  it("says the lookup was never answered, whether or not anything was written", () => {
+    // `view.mine(cid, key)` is answered by the PARENT, and this run is not that parent: it offers no
+    // lookup, so every ask comes back `known: false` and the page takes its unknown branch. That
+    // branch is the safe one by design — which is exactly why a page whose real behaviour lives in
+    // `found: true` looks fine here.
+    for (const wrote of [true, false]) {
+      const said = narrate({}, 0, { wrote });
+      expect(said, `a run with wrote=${wrote} must still say it`).toContain("view.mine(cid, key)");
+      expect(said).toContain("known: false");
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,10 +2264,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.13.0.tgz#e13e37acd2da5971c994b04b86f3b41f2bd6c57a"
-  integrity sha512-WC+hKY4PefxrtATtl4IPnjJVRDjNocH3rPRoM0u5OPHeFvWIO8GW3HWpTpcDcoXRBTdbRAnJkaiUwsbuHD1DIQ==
+"@receptron/sharedapp@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.15.0.tgz#afb33f586fa4bbf54d13bb9052d9cbfaa27211be"
+  integrity sha512-43wu+GCe83UvYbkdpMAS1B7k3PnMh/iPgtEK5NByt7rvjteO7krJvUyxvxjUih2iVp3kqsu60jgAisaGc44GDg==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
実地で出ました: 匿名で 1 票入れる → リロード → また投票画面 → 押す → 権限エラー。

拒否は正しい（それが「1 設問 1 票」を守っている唯一のものです）。悪いのは **ページが差し出したこと**と、断られたことを **Firebase の生の文**でしか言えないことでした。

## なぜ避けられないか（テンプレートに新しい節を足しました）

**ページには覚える手段がありません。** sandbox は不透明オリジンなので、`localStorage` / `sessionStorage` / `document.cookie` はすべて `SecurityError` になります — 推測ではなく実測です。

思い出す道は親の **`viewer.mine`**（mulmoserver #207）だけで、それが**この形では答えられません**。票の id は `uid + "_" + questionId` で、合成 id の行は「id が uid で始まる範囲」でしか引けず、**list ではルールがそれを許可できない**（list では `{itemId}` が束縛されないため、`ownRow` の itemId を名指す枝はクエリの書き方に関わらず false）。読み取り専用の prefix 枝をルールに足して emulator で試し、**変わらないこと**も確認しました。限界は mulmoserver の `test/rules/rules_ownReadback.ts` に固定してあります。

## なので「避ける」ではなく「受け止める」

- 断られたら**文にして、そこで止まる**（押し直させない）。「すでに投票済みのようです」— 言い切らないのは、断られた理由がページからは見えないから
- 理由の文字列は小さく出します。訪問者には意味が無いけれど、**公開ページには他に診断の窓がありません**
- **取り消し（`cancelled`）と重複押し（`busy`）は拒否に数えません。** 混ぜると、確認で「やめる」を押しただけの人がその設問に永久に投票できなくなります

ページの「守る点」は 3 つから 4 つになりました。4 つ目が「**リロードは必ず来る**」です。

## 塞ぐには

宣言で「その field の値はどのコレクションの id から来るか」を言えるようにすれば、親が `uid_q1`, `uid_q2`… を **1 件ずつ get** できます（**doc の get はルールが通す** — 同じ emulator 実行で確認済み）。そのキーはまだありません。要ると判断されたら別 issue で。

## 確かめたこと

- テンプレートの 2 つの HTML ブロックの JS を `node --check`
- `yarn test` 10,691 本 pass（テンプレートは spec が**実際の publish ゲート**に通しています）、lint も通過
- 同じ変更をサンプルアプリ `~/git/ai/apps/live` にも入れ、puppeteer の検査 27 本で確認しました: **断られたら投票済みの場所に移る / すでに投票済みだと伝える / 押し直させない / 取り消しなら投票画面のまま・もう一度押せる**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-question vote read-back with pending, successful, and unavailable states.
  - Restored previously recorded votes after reloading the audience page.
  - Kept voting available when a vote cannot be confirmed.
  - Added retry support for cancelled or temporarily busy submissions.
  - Prevented duplicate vote prompts and displayed submission errors clearly.
- **Documentation**
  - Documented vote read-back behavior, preview limitations, and reload handling.
  - Clarified reporting when vote verification is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->