### PR TITLE
共有アプリ: sharedapp 0.16.0 への bump と、ID を作れない投稿の拒否

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.15.0",
+    "@receptron/sharedapp": "^0.16.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.16.0",
+    "@receptron/sharedapp": "^0.16.1",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -178,7 +178,13 @@ function formInputsOf(config: PublishedConfigDoc, form: PublicForm): PreviewForm
       if (!isRecord(spec)) return [];
       const createFields = Array.isArray(spec.createFields) ? spec.createFields.filter((field): field is string => typeof field === "string") : [];
       const emailField = typeof spec.emailField === "string" ? spec.emailField : undefined;
-      const fields = writableFields({ fields: collection.fields, statusField: collection.statusField }, createFields, emailField).map((field) => {
+      // The stamp is passed for the same reason the address is: it is a field the visitor does not
+      // choose. `recordOf` overwrites it with the server's clock on every create, so a box for it
+      // is one nothing can usefully be typed into — and where the schema marks it required, the
+      // empty box stopped the submission at `missingRequired` over a value the server was about to
+      // supply. Read off the SUBMIT block, which is where the rules read it from.
+      const stampField = typeof spec.stampField === "string" ? spec.stampField : undefined;
+      const fields = writableFields({ fields: collection.fields, statusField: collection.statusField }, createFields, emailField, stampField).map((field) => {
         const drawn = collection.fields[field.name];
         return {
           ...field,

--- a/server/backends/sharedApp/previewWrite.ts
+++ b/server/backends/sharedApp/previewWrite.ts
@@ -28,6 +28,7 @@ import { randomUUID } from "node:crypto";
 import { appSchemasPath, type PublishedConfigDoc } from "@receptron/sharedapp";
 import {
   MIRROR_OPEN,
+  missingIdField,
   missingRequired,
   plannedWrite,
   recordId,
@@ -203,7 +204,7 @@ export async function writePreviewSubmission(root: string, cid: string, values: 
   // `sharedAppContext` has answered, the author is signed in. The check belongs to a host whose
   // reader may be anonymous, which is mulmoserver's public page and not this one.
 
-  const fields = writableFields(spec.drawn, spec.submit.createFields, spec.submit.emailField);
+  const fields = writableFields(spec.drawn, spec.submit.createFields, spec.submit.emailField, spec.submit.stampField);
   const missing = missingRequired(fields, values);
   if (missing.length > 0) return { ok: false, reason: "host", error: `missing: ${missing.join(" / ")}` };
 
@@ -212,8 +213,16 @@ export async function writePreviewSubmission(root: string, cid: string, values: 
   // and it is handed over whether or not the app declares a `stampField`, because that is the
   // declaration's answer rather than this module's.
   const record = recordOf(fields, spec.drawn, spec.submit, values, { uid: handle.uid, email: handle.email }, serverTimestamp);
+
+  // ASKED BEFORE THE ID IS BUILT, because both ways an absent id field went wrong were silent.
+  // `idFrom: "field"` produced `""`, which is not a document id and fails at the SDK with a message
+  // about paths that names no field; `idFrom: "auth.uid+field"` produced `"<uid>_"`, which IS a
+  // valid id — one per person with the thing they were claiming missing, so a second claim lands on
+  // the first one's document. `recordId` refuses both now; this asks first so the author is told
+  // WHICH field, which is the only part of it they can act on.
+  const noId = missingIdField(spec.submit, record);
+  if (noId !== undefined) return { ok: false, reason: "host", error: `no-id: the submission has no value for "${noId}", which its id is built from` };
   const id = recordId(spec.submit, handle.uid, record, randomUUID());
-  if (id === "") return { ok: false, reason: "host", error: "no-id" };
 
   const plan = plannedWrite(cid, spec.submit, id, record);
   const failed = await commit(handle, preview.aid, plan);

--- a/test/server/backends/sharedAppPreviewWrite.spec.ts
+++ b/test/server/backends/sharedAppPreviewWrite.spec.ts
@@ -342,6 +342,14 @@ describe("shared app preview writes", () => {
     expect(result.ok === false && result.error).toContain("slot");
     expect(batched).toEqual([]);
     expect(docs.writes).toEqual([]);
+
+    // And a lone space is nothing too. `missingRequired` never sees this field — it is optional —
+    // so a blank value used to travel all the way to a document named " ", which no page can show
+    // and no author can find.
+    const blank = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "   " });
+    expect(blank.ok).toBe(false);
+    expect(blank.ok === false && blank.error).toContain("no-id");
+    expect(batched).toEqual([]);
   });
 
   it("refuses one-per-person-per-thing when the thing is missing, rather than colliding on one document", async () => {
@@ -365,6 +373,11 @@ describe("shared app preview writes", () => {
 
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.error).toContain("no-id");
+    expect(docs.writes.filter((op) => op.startsWith("create"))).toEqual([]);
+    // A blank one collides in exactly the same way — `"<uid>_ "` is one document per person — and
+    // is refused for the same reason.
+    const blank = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: " " });
+    expect(blank.ok === false && blank.error).toContain("no-id");
     expect(docs.writes.filter((op) => op.startsWith("create"))).toEqual([]);
     // And the id it DOES build from a value is unchanged — the acceptance half, since a refusal
     // this near the write is satisfied by refusing everything.

--- a/test/server/backends/sharedAppPreviewWrite.spec.ts
+++ b/test/server/backends/sharedAppPreviewWrite.spec.ts
@@ -349,7 +349,11 @@ describe("shared app preview writes", () => {
     const blank = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "   " });
     expect(blank.ok).toBe(false);
     expect(blank.ok === false && blank.error).toContain("no-id");
+    expect(blank.ok === false && blank.error).toContain("slot");
     expect(batched).toEqual([]);
+    // The WHOLE log, not the creates in it: a refusal that still managed a `set` or a `delete`
+    // would be a different bug wearing this one's clothes.
+    expect(docs.writes).toEqual([]);
   });
 
   it("refuses one-per-person-per-thing when the thing is missing, rather than colliding on one document", async () => {
@@ -373,16 +377,25 @@ describe("shared app preview writes", () => {
 
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.error).toContain("no-id");
-    expect(docs.writes.filter((op) => op.startsWith("create"))).toEqual([]);
+    expect(result.ok === false && result.error).toContain("slot");
+    // Every write surface, not the creates among them. The refusal has to leave the database
+    // exactly as it found it, and a stray `set` or `delete` is as wrong as a create.
+    expect(docs.writes).toEqual([]);
+    expect(batched).toEqual([]);
     // A blank one collides in exactly the same way — `"<uid>_ "` is one document per person — and
     // is refused for the same reason.
     const blank = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: " " });
     expect(blank.ok === false && blank.error).toContain("no-id");
-    expect(docs.writes.filter((op) => op.startsWith("create"))).toEqual([]);
+    expect(blank.ok === false && blank.error).toContain("slot");
+    expect(docs.writes).toEqual([]);
+    expect(batched).toEqual([]);
     // And the id it DOES build from a value is unchanged — the acceptance half, since a refusal
     // this near the write is satisfied by refusing everything.
     const made = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "roomA-1000" });
     expect(made.ok && made.written.id).toBe(`${OWNER.uid}_roomA-1000`);
+    expect(docs.writes).toEqual([
+      `create apps/${AID}/collections/bookings/items/${OWNER.uid}_roomA-1000 {"requesterName":"客","slot":"roomA-1000","requesterEmail":"${OWNER.email}","status":"booked"}`,
+    ]);
   });
 
   it("gives the slot back when the write is taken away", async () => {

--- a/test/server/backends/sharedAppPreviewWrite.spec.ts
+++ b/test/server/backends/sharedAppPreviewWrite.spec.ts
@@ -307,6 +307,71 @@ describe("shared app preview writes", () => {
     expect(batched).toEqual([]);
   });
 
+  it("names a whitespace-only answer as missing, rather than booking under a name of one space", async () => {
+    const result = await writePreviewSubmission(root, "bookings", { requesterName: "   ", slot: "roomA-1000" });
+
+    // A required answer of spaces is not an answer. Accepted, it becomes a booking whose name
+    // nobody can read — and where such a field is the id, a document id made of a space.
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("missing:");
+    expect(batched).toEqual([]);
+    // What is refused is the JUDGEMENT, not the value: spaces INSIDE an answer are part of it.
+    const kept = await writePreviewSubmission(root, "bookings", { requesterName: " 客 ", slot: "roomA-1000" });
+    expect(kept.ok).toBe(true);
+    expect(batched[0]).toContain('"requesterName":" 客 "');
+  });
+
+  it("refuses a claim whose id field carries nothing, instead of claiming an empty id", async () => {
+    // The id field is OPTIONAL here on purpose: a required one is stopped by `missingRequired`
+    // first, and the case being pinned is the one that got past every check. `idFrom: "field"`
+    // built `""` — not a document id at all — and the failure surfaced from the SDK as a complaint
+    // about a path, naming no field the author could fix.
+    writeCollection("bookings", {
+      requesterName: { type: "string", label: "Name", required: true },
+      requesterEmail: { type: "email", label: "Email", required: true },
+      slot: { type: "string", label: "Slot" },
+      status: { type: "enum", label: "Status", values: ["booked"] },
+    });
+
+    const result = await writePreviewSubmission(root, "bookings", { requesterName: "客" });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toBe("host");
+    expect(result.ok === false && result.error).toContain("no-id");
+    // The field is NAMED. It is the only part of this an author can act on.
+    expect(result.ok === false && result.error).toContain("slot");
+    expect(batched).toEqual([]);
+    expect(docs.writes).toEqual([]);
+  });
+
+  it("refuses one-per-person-per-thing when the thing is missing, rather than colliding on one document", async () => {
+    // The worse half of the same bug, because `"<uid>_"` IS a valid document id: every claim by one
+    // person landed on it, so a second one looked like it took something while taking nothing.
+    writeCollection("bookings", {
+      requesterName: { type: "string", label: "Name", required: true },
+      requesterEmail: { type: "email", label: "Email", required: true },
+      slot: { type: "string", label: "Slot" },
+      status: { type: "enum", label: "Status", values: ["booked"] },
+    });
+    // No `idIn` and no mirror: the rules read `idIn` only for `idFrom: "field"`, and a declared
+    // `mirrorOf` needs its half back — both are refused by the gates before any of this is reached.
+    const base = bookingApp({ submit: { idFrom: "auth.uid+field", idIn: undefined, mirror: undefined } });
+    writeApp({
+      ...base,
+      collections: { bookings: { submitOnly: true, statusField: "status", transitions: { initial: ["booked"] } }, slots: {} },
+    });
+
+    const result = await writePreviewSubmission(root, "bookings", { requesterName: "客" });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("no-id");
+    expect(docs.writes.filter((op) => op.startsWith("create"))).toEqual([]);
+    // And the id it DOES build from a value is unchanged — the acceptance half, since a refusal
+    // this near the write is satisfied by refusing everything.
+    const made = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "roomA-1000" });
+    expect(made.ok && made.written.id).toBe(`${OWNER.uid}_roomA-1000`);
+  });
+
   it("gives the slot back when the write is taken away", async () => {
     const made = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "roomA-1000" });
     expect(made.ok).toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,10 +2264,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.15.0.tgz#afb33f586fa4bbf54d13bb9052d9cbfaa27211be"
-  integrity sha512-43wu+GCe83UvYbkdpMAS1B7k3PnMh/iPgtEK5NByt7rvjteO7krJvUyxvxjUih2iVp3kqsu60jgAisaGc44GDg==
+"@receptron/sharedapp@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.16.0.tgz#e5dee2ba372beebda40afb8ccb6d28ffaa73e5e3"
+  integrity sha512-Fri2LGDL8U7xubnNGi5EYTc9imy1YuPZ+tIjYBsdE8ZZ8qt50qFLSzAFUwdu1UaqsGFohMAG2nRe4aNUB+Kj1A==
   dependencies:
     zod "^4.1.13"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,10 +2264,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.16.0.tgz#e5dee2ba372beebda40afb8ccb6d28ffaa73e5e3"
-  integrity sha512-Fri2LGDL8U7xubnNGi5EYTc9imy1YuPZ+tIjYBsdE8ZZ8qt50qFLSzAFUwdu1UaqsGFohMAG2nRe4aNUB+Kj1A==
+"@receptron/sharedapp@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.16.1.tgz#0aa94f8d17cc4d27b86f15b37aaaa08ec6ca2df8"
+  integrity sha512-2nvV/fckqMMXp/RWaN/j4Qtx6NE0CwbF79J9WIXBBpMPeD26EN0DNf5FQkAuKM1j3fPb1pTPT0ZtenOxtCN+wA==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
sharedapp 側 receptron/sharedapp#30 / receptron/sharedapp#33 の submission runtime 安全化を、host としてこちらで受け取る。

## 変更

### `@receptron/sharedapp` 0.15.0 → 0.16.0

これだけで挙動が変わるのは required field の判定。空白だけの入力が `missingRequired()` で missing になる（**保存する値は trim されない** — 前後空白が意味を持つ値はそのまま）。空白のみの答えは、通れば読めない名前の予約になるし、その field が ID の元なら空白でできた document ID になる。

### `writableFields()` に `submit.stampField` を渡す

- `server/backends/sharedApp/preview.ts` の `formInputsOf()`
- `server/backends/sharedApp/previewWrite.ts` の書き込み経路

**描画は変わらない。** こちらの `publicFormOf()`（`publicForm.ts` の `fieldsOf`）は既に stamp を入力欄から外しているので、渡しても出てくる field 一覧は同じ。それでも渡すのは、「visitor が選ばない field」を共有関数の側にも言わせておくため — form の出所が変わっても鍵が二つ掛かっている状態にする。

### ID を作れない投稿を、書き込み前に名前のある拒否にする

`missingIdField()` で `recordId()` の前に訊き、どの field が空なのかを author に返す。

従来の `if (id === "")` は `idFrom: "field"` しか捕まえられなかった。`auth.uid+field` は `"<uid>_"` を返し、これは**有効な document ID** なので、同じ人の別々の主張が一つの document に重なり、二件目が何かを取ったように見えていた。

## test

`test/server/backends/sharedAppPreviewWrite.spec.ts` に 3 件追加（いずれも拒否と受入を対に）:

- 空白だけの必須入力は missing、空白を**含む**実値は受け入れられ、打たれたとおり保存される。
- 空の idField（`idFrom: "field"`）は書き込み 0 件で拒否され、error が field 名を含む。id field を optional にした fixture を使う — required なら `missingRequired` が先に止めてしまい、実際にすり抜けていた経路を通らないため。
- `auth.uid+field` の欠落も拒否され、値がある場合の ID は従来どおり `<uid>_roomA-1000`。

`yarn typecheck` / `yarn lint` / `yarn test`（10695 passed, 50 skipped）すべて成功。

mulmoterminal 本体の version は上げていない（このリポジトリでは release commit が別に上げているため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in sharedapp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview forms now omit server-generated timestamp fields.
  * Submissions with missing values required to create a record ID are rejected with a clear error instead of creating invalid records.
  * Whitespace-only required values are handled correctly.
  * Failed submissions no longer write incomplete data.
  * Valid composite IDs and internal whitespace are preserved.
  * Error messages now identify the missing field preventing submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->