### PR TITLE
skill(shared-app): ライブ投票の司会卓が、次を出す前に今の設問を締める

### DIFF
--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -802,6 +802,14 @@ the cost in the text the reader can see.
   `transitions` (for a member) or `public.submit.<cid>.selfTransitions` (for a participant). Those
   are different tables, so a staff page and a participant page draw different buttons for the same
   collection. Ask for a move the record cannot make and the answer names it.
+- **`transitions` says nothing about the OTHER rows.** It judges one record's move, so "only one
+  question is open", "only one item is being served", "only one draft at a time" cannot be declared
+  — no rule keeps them and publish cannot refuse an app that breaks them. Where the app's meaning
+  depends on such a rule, the PAGE performs it: send the move that closes the current row, wait for
+  it to succeed, then send the one that opens the next, and disable the controls in between. A page
+  that only sends the second half is the worst kind of broken — every call succeeds, the rows say
+  what the operator expects, and the screen the audience is looking at does not move. (This is
+  exactly what the live-poll desk does; copy it rather than reinventing the pair.)
 - **`withdraw` takes the reader's own row away** and names no destination, because nothing moves.
   It exists only where `selfDelete` declares the statuses, it is offered on a participant's page
   and never on a staff one (owner and editor delete by role), and where the collection has a

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -262,6 +262,10 @@ ordering is the desk's to perform, not the rules' to keep — `transitions` judg
 and "at most one is open" is a statement about the other records, which no declaration here can
 make. `order` is what settles the moment between the two writes.
 
+If the second write is refused after the first landed, the desk puts the question it closed back —
+nothing open is the one state worse than not moving, because every audience page drops to "waiting"
+while the host is still talking.
+
 **A desk that only opened the next question would look broken.** The previous one stays open, the
 audience is on the lower `order`, and the screen everybody is watching does not move — while the
 button reports success and the row says "open". Whether pressing a button moved the audience would
@@ -665,10 +669,20 @@ counts document — and nothing needs to, because the roster is the only audienc
    *  the desk performs it, and the public page's lowest-`order` rule stays as the tiebreak for the
    *  moment between the two writes (and for a second desk, which nothing prevents).
    *
-   *  Two writes, IN ORDER, and not a batch: `view.transition` moves one record. The close is sent
-   *  first and the open only if it succeeded, so a failure leaves the audience on the question they
-   *  were already answering rather than on nothing at all. Delegated from the container because the
-   *  rows are redrawn under the pointer — a listener bound to a button would go with it. */
+   *  Two writes, IN ORDER, and not a batch: `view.transition` moves one record, and there is no
+   *  operation here that moves two. So the pair can half-happen, and each half is handled:
+   *
+   *    the CLOSE fails — the open is not attempted. Both halves undone is the audience still
+   *    answering the question they were on, which is the harmless end of this.
+   *
+   *    the OPEN fails after the close landed — NOTHING is open, and that is the state to avoid:
+   *    every audience page drops to "Waiting for a question…" while the host is still talking about
+   *    the one they just closed. So the close is put back, best effort, and what happened is said
+   *    either way. A rollback that is itself refused is reported rather than hidden — the list is
+   *    the truth, and the host can see two rows and press again.
+   *
+   *  Delegated from the container because the rows are redrawn under the pointer — a listener bound
+   *  to a button would go with it. */
   document.getElementById("list").addEventListener("click", async (event) => {
     const button = event.target.closest("button");
     if (button === null || busy) {
@@ -682,17 +696,25 @@ counts document — and nothing needs to, because the roster is the only audienc
     render();
     say("Working…");
     const current = openQuestion(latest.questions);
+    const move = (id, state) => view.transition("questions", id, state).catch((err) => ({ ok: false, error: String(err) }));
+    // The question being taken off the screen, if this press is a switch rather than a plain
+    // open or close. Held because it is what a failed open has to be given back.
+    const leaving = to === "open" && current !== null && current.id !== qid ? current : null;
     let problem = "";
-    if (to === "open" && current !== null && current.id !== qid) {
-      const closed = await view.transition("questions", current.id, "closed").catch((err) => ({ ok: false, error: String(err) }));
+    if (leaving !== null) {
+      const closed = await move(leaving.id, "closed");
       if (!closed?.ok) {
         problem = closed?.error ?? "unknown error";
       }
     }
     if (problem === "") {
-      const moved = await view.transition("questions", qid, to).catch((err) => ({ ok: false, error: String(err) }));
+      const moved = await move(qid, to);
       if (!moved?.ok) {
         problem = moved?.error ?? "unknown error";
+        if (leaving !== null) {
+          const back = await move(leaving.id, "open");
+          problem = back?.ok ? `${problem} — ${leaving.id} is open again` : `${problem}, and ${leaving.id} could not be reopened: ${back?.error ?? "unknown error"}`;
+        }
       }
     }
     // ALWAYS, and before the message. A refused call produces no state update, so `onState` never

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -262,9 +262,11 @@ ordering is the desk's to perform, not the rules' to keep — `transitions` judg
 and "at most one is open" is a statement about the other records, which no declaration here can
 make. `order` is what settles the moment between the two writes.
 
-If the second write is refused after the first landed, the desk puts the question it closed back —
-nothing open is the one state worse than not moving, because every audience page drops to "waiting"
-while the host is still talking.
+Asking a question closes EVERY open one, not only the one the audience is on: more than one can be
+open (a second desk, a press that half-happened), and leaving one below the target's `order` is the
+same stall. If a write is refused partway, the desk puts back what it closed — nothing open is the
+one state worse than not moving, because every audience page drops to "waiting" while the host is
+still talking.
 
 **A desk that only opened the next question would look broken.** The previous one stays open, the
 audience is on the lower `order`, and the screen everybody is watching does not move — while the
@@ -672,14 +674,14 @@ counts document — and nothing needs to, because the roster is the only audienc
    *  Two writes, IN ORDER, and not a batch: `view.transition` moves one record, and there is no
    *  operation here that moves two. So the pair can half-happen, and each half is handled:
    *
-   *    the CLOSE fails — the open is not attempted. Both halves undone is the audience still
-   *    answering the question they were on, which is the harmless end of this.
+   *    the CLOSE fails — the open is not attempted. Nothing moved is the audience still answering
+   *    the question they were on, which is the harmless end of this.
    *
-   *    the OPEN fails after the close landed — NOTHING is open, and that is the state to avoid:
+   *    the OPEN fails after a close landed — NOTHING is open, and that is the state to avoid:
    *    every audience page drops to "Waiting for a question…" while the host is still talking about
-   *    the one they just closed. So the close is put back, best effort, and what happened is said
-   *    either way. A rollback that is itself refused is reported rather than hidden — the list is
-   *    the truth, and the host can see two rows and press again.
+   *    the one they just closed. So everything closed on the way here is put back, best effort, and
+   *    what happened is said either way. A reopen that is itself refused is named rather than
+   *    hidden — the list is the truth, and the host can see it and press again.
    *
    *  Delegated from the container because the rows are redrawn under the pointer — a listener bound
    *  to a button would go with it. */
@@ -695,27 +697,41 @@ counts document — and nothing needs to, because the roster is the only audienc
     busy = true;
     render();
     say("Working…");
-    const current = openQuestion(latest.questions);
     const move = (id, state) => view.transition("questions", id, state).catch((err) => ({ ok: false, error: String(err) }));
-    // The question being taken off the screen, if this press is a switch rather than a plain
-    // open or close. Held because it is what a failed open has to be given back.
-    const leaving = to === "open" && current !== null && current.id !== qid ? current : null;
+    // EVERY open question that is not the target, not just the one the audience is on. More than
+    // one can be open — a second desk, or a press that half-happened — and closing only the lowest
+    // `order` would leave another one below the target, which is the stall this handler exists to
+    // prevent. Held because a failed open has to give them back.
+    const leaving = to === "open" ? byOrder(latest.questions).filter((question) => question.state === "open" && question.id !== qid) : [];
+    const closed = [];
     let problem = "";
-    if (leaving !== null) {
-      const closed = await move(leaving.id, "closed");
-      if (!closed?.ok) {
-        problem = closed?.error ?? "unknown error";
+    for (const question of leaving) {
+      const done = await move(question.id, "closed");
+      if (!done?.ok) {
+        problem = `${question.id}: ${done?.error ?? "unknown error"}`;
+        break;
       }
+      closed.push(question);
     }
     if (problem === "") {
       const moved = await move(qid, to);
       if (!moved?.ok) {
         problem = moved?.error ?? "unknown error";
-        if (leaving !== null) {
-          const back = await move(leaving.id, "open");
-          problem = back?.ok ? `${problem} — ${leaving.id} is open again` : `${problem}, and ${leaving.id} could not be reopened: ${back?.error ?? "unknown error"}`;
+      }
+    }
+    // Whatever was closed on the way here goes back, because the alternative is worse than not
+    // moving: with nothing open every audience page drops to "waiting" while the host is still
+    // talking about the question they just closed. Best effort, and a reopen that is refused too is
+    // NAMED rather than swallowed — the list is the truth and the host can press again.
+    if (problem !== "" && closed.length > 0) {
+      const stuck = [];
+      for (const question of closed) {
+        const back = await move(question.id, "open");
+        if (!back?.ok) {
+          stuck.push(`${question.id} (${back?.error ?? "unknown error"})`);
         }
       }
+      problem = stuck.length === 0 ? `${problem} — nothing was changed` : `${problem}, and could not be reopened: ${stuck.join(", ")}`;
     }
     // ALWAYS, and before the message. A refused call produces no state update, so `onState` never
     // redraws — the buttons would stay dead until the operator reloaded, mid-stream, on a page whose

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -120,7 +120,9 @@ that side is N→1 by definition however popular the stream gets.
 - **`votes` is `submitOnly`** — it is not in `public.read`, so nobody can list the votes from the
   public page. The tally exists only where the roster can read it.
 - **`transitions` on `questions`** — `draft → open → closed`, and `closed → open` because a host
-  reopens a question they closed too early. The desk moves it; the rules judge the move.
+  reopens a question they closed too early, and because going BACK to an earlier question is that
+  same move. The desk moves it; the rules judge the move. What the rules cannot judge is how many
+  questions are open at once — see the note under `order` below.
 
 ### What the rules DO and DO NOT enforce about a vote
 
@@ -254,8 +256,16 @@ option keys `a`…`e`, in order**, and a sixth line is not offered by the pages:
 refused by the rules (`validate.keyFields`), and drawing an option nobody can choose is worse than not
 drawing it.
 
-`order` decides which question the audience sees when more than one is `open`. "One at a time" is the
-desk's discipline, not something the rules keep.
+`order` decides which question the audience sees when more than one is `open`, and the desk keeps
+there from being more than one: pressing a question's button closes whichever is open first. That
+ordering is the desk's to perform, not the rules' to keep — `transitions` judges one record's move,
+and "at most one is open" is a statement about the other records, which no declaration here can
+make. `order` is what settles the moment between the two writes.
+
+**A desk that only opened the next question would look broken.** The previous one stays open, the
+audience is on the lower `order`, and the screen everybody is watching does not move — while the
+button reports success and the row says "open". Whether pressing a button moved the audience would
+depend on which way the `order`s compared rather than on what was pressed.
 
 ## .claude/skills/votes/schema.json
 
@@ -551,6 +561,14 @@ counts document — and nothing needs to, because the roster is the only audienc
     document.getElementById("say").textContent = message ?? "";
   };
 
+  // The last snapshot, KEPT — because this page redraws itself between snapshots. Moving the
+  // audience on takes two writes (see the handler), the buttons are dead while they go out, and
+  // that redraw has to describe the state the page is already holding.
+  let latest = { questions: [], votes: [], can: {} };
+  // One switch at a time. Two overlapping presses would interleave their closes and opens, and the
+  // audience would land on whichever won the race.
+  let busy = false;
+
   const KEYS = ["a", "b", "c", "d", "e"];
 
   const optionsOf = (question) =>
@@ -561,11 +579,12 @@ counts document — and nothing needs to, because the roster is the only audienc
       .slice(0, KEYS.length)
       .map((label, index) => ({ key: KEYS[index], label }));
 
-  const openQuestion = (questions) =>
-    questions
-      .filter((question) => question.state === "open")
-      .sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0))
-      .at(0) ?? null;
+  const byOrder = (questions) => questions.slice().sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0));
+
+  /** The question the AUDIENCE is on — the lowest `order` among the open ones, which is the rule
+   *  the public page applies too. Both pages have to agree about this or the desk shows a tally for
+   *  a question nobody is being asked. */
+  const openQuestion = (questions) => byOrder(questions).find((question) => question.state === "open") ?? null;
 
   /** The tally of the question on screen. Recomputed from the rows on every snapshot — the numbers
    *  ARE the rows, so there is nothing to keep in step. */
@@ -599,48 +618,98 @@ counts document — and nothing needs to, because the roster is the only audienc
     }
   };
 
-  /** Every question, with the one button its state allows. */
-  const drawList = (questions, votes, viewer) => {
+  /** Every question, with the one button its state allows.
+   *
+   *  The button says what the OPERATOR is doing — putting this question in front of the audience —
+   *  rather than which state it is about to be in. "Open" on a question while another one is open
+   *  reads as "switch to this", and that is what the handler performs. */
+  const drawList = () => {
     const host = document.getElementById("list");
     host.textContent = "";
-    for (const question of questions.slice().sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0))) {
+    for (const question of byOrder(latest.questions)) {
       const row = document.createElement("p");
       row.textContent = `${question.order ?? ""} ${question.text ?? question.id} [${question.state}] ${
-        votes.filter((vote) => vote.questionId === question.id).length
+        latest.votes.filter((vote) => vote.questionId === question.id).length
       } vote(s) `;
       // Drawn from what the viewer may actually do. The same answer is applied again to the intent,
       // so this decides what is OFFERED and never what is allowed.
-      const next = question.state === "open" ? "closed" : "open";
-      if (viewer?.can?.questions?.transitionAny) {
+      if (latest.can.transitionAny) {
         const button = document.createElement("button");
         button.type = "button";
-        button.textContent = next === "open" ? "Open" : "Close";
-        button.addEventListener("click", async () => {
-          button.disabled = true;
-          say("Working…");
-          try {
-            const done = await view.transition("questions", question.id, next);
-            say(done?.ok ? `${question.id} is now ${next}.` : `Not done: ${done?.error ?? "unknown error"}`);
-          } catch (err) {
-            say(`Not done: ${err instanceof Error ? err.message : String(err)}`);
-          } finally {
-            // ALWAYS. A rejected call produces no state update, so `onState` never redraws this row —
-            // the button would stay disabled until the operator reloaded, mid-stream, on a page whose
-            // whole job is to be usable in the next five seconds.
-            button.disabled = false;
-          }
-        });
+        button.dataset.qid = question.id;
+        button.dataset.to = question.state === "open" ? "closed" : "open";
+        button.textContent = question.state === "open" ? "Close" : question.state === "closed" ? "Reopen" : "Ask this";
+        // Every button, not the pressed one: while a switch is in flight the whole list is one
+        // operation, and a second press would race the first one's two writes.
+        button.disabled = busy;
         row.append(button);
       }
       host.append(row);
     }
   };
 
+  const render = () => {
+    drawTally(openQuestion(latest.questions), latest.votes);
+    drawList();
+  };
+
+  /** ONE QUESTION AT A TIME, PERFORMED HERE.
+   *
+   *  The audience sees the lowest `order` among the OPEN questions, so a desk that only opened the
+   *  next one would leave the previous one open and the audience on it — the button works, the row
+   *  says "open", and the screen everybody is looking at does not move. Whether it moved would
+   *  depend on which way the `order`s compared rather than on which button was pressed.
+   *
+   *  The rules cannot keep this. `transitions` judges one record's move, and "at most one question
+   *  is open" is a statement about the OTHER records — nothing in the declaration can say it. So
+   *  the desk performs it, and the public page's lowest-`order` rule stays as the tiebreak for the
+   *  moment between the two writes (and for a second desk, which nothing prevents).
+   *
+   *  Two writes, IN ORDER, and not a batch: `view.transition` moves one record. The close is sent
+   *  first and the open only if it succeeded, so a failure leaves the audience on the question they
+   *  were already answering rather than on nothing at all. Delegated from the container because the
+   *  rows are redrawn under the pointer — a listener bound to a button would go with it. */
+  document.getElementById("list").addEventListener("click", async (event) => {
+    const button = event.target.closest("button");
+    if (button === null || busy) {
+      return;
+    }
+    const { qid, to } = button.dataset;
+    if (!qid || !to) {
+      return;
+    }
+    busy = true;
+    render();
+    say("Working…");
+    const current = openQuestion(latest.questions);
+    let problem = "";
+    if (to === "open" && current !== null && current.id !== qid) {
+      const closed = await view.transition("questions", current.id, "closed").catch((err) => ({ ok: false, error: String(err) }));
+      if (!closed?.ok) {
+        problem = closed?.error ?? "unknown error";
+      }
+    }
+    if (problem === "") {
+      const moved = await view.transition("questions", qid, to).catch((err) => ({ ok: false, error: String(err) }));
+      if (!moved?.ok) {
+        problem = moved?.error ?? "unknown error";
+      }
+    }
+    // ALWAYS, and before the message. A refused call produces no state update, so `onState` never
+    // redraws — the buttons would stay dead until the operator reloaded, mid-stream, on a page whose
+    // whole job is to be usable in the next five seconds.
+    busy = false;
+    render();
+    say(problem === "" ? "" : `Not done: ${problem}`);
+  });
+
   view.onState((state, viewer) => {
-    const questions = Array.isArray(state?.questions) ? state.questions : [];
-    const votes = Array.isArray(state?.votes) ? state.votes : [];
-    drawTally(openQuestion(questions), votes);
-    drawList(questions, votes, viewer);
+    latest = {
+      questions: Array.isArray(state?.questions) ? state.questions : [],
+      votes: Array.isArray(state?.votes) ? state.votes : [],
+      can: viewer?.can?.questions ?? {},
+    };
+    render();
   });
 
   view.ready();
@@ -656,8 +725,11 @@ counts document — and nothing needs to, because the roster is the only audienc
 3. **Write the questions** into `questions` with `state: "draft"` — from the collection pane, or with
    `manageCollection`. Give them `order` in the sequence you will ask them.
 4. **`publish`** — the public page and the desk both appear.
-5. **During the stream** — open one question from the desk, close it, open the next. The audience's
-   page follows without reloading; the tally moves as votes land.
+5. **During the stream** — press a question's button on the desk. It closes whatever is open and
+   asks that one, so moving on is one press and going back to an earlier question is the same press
+   on its row. The audience's page follows without reloading; the tally moves as votes land.
+   Somebody who already answered the question you return to sees their own answer rather than the
+   choices — one vote per person per question is what `idFrom: "auth.uid+field"` means.
 
 ## What this shape does NOT do
 
@@ -677,5 +749,9 @@ counts document — and nothing needs to, because the roster is the only audienc
 - **No result after the fact for the audience.** They cannot read `votes` at all. If they should see
   the outcome, publish it as a row in a collection they CAN read — a `results` collection the desk
   writes — rather than opening the votes.
+- **Nothing STOPS a second desk from opening two questions.** The desk closes the current question
+  before asking the next, and that is a page behaving itself, not a rule. Two hosts pressing at the
+  same moment can leave two open; the audience then follows the lower `order` until somebody closes
+  one. It is self-correcting and it is not enforceable here.
 - **Nothing catches up a viewer who arrives mid-question.** They see the question that is open when
   they arrive, and can vote on it. A question closed before they arrived is simply not there.

--- a/test/src/skillTemplateLivePollDesk.spec.ts
+++ b/test/src/skillTemplateLivePollDesk.spec.ts
@@ -103,9 +103,11 @@ const question = (id: string, order: number, state: string): Question => ({
   state,
 });
 
-/** The handler awaits two writes; the clicks below are synchronous. */
+/** The clicks below are synchronous and the handler is not: it awaits a write per question it
+ *  closes, one for the target, and one per question it puts back. Generous on purpose — the count
+ *  is a property of the case being tested, and a loop too short reads as "the desk stopped early". */
 const settle = async (): Promise<void> => {
-  for (let turn = 0; turn < 8; turn += 1) {
+  for (let turn = 0; turn < 64; turn += 1) {
     await Promise.resolve();
   }
 };
@@ -188,7 +190,7 @@ describe("the live-poll desk template", () => {
     // just closed.
     expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> open", "questions/q1 -> open"]);
     expect(document.getElementById("say")?.textContent).toContain("permission-denied");
-    expect(document.getElementById("say")?.textContent).toContain("q1 is open again");
+    expect(document.getElementById("say")?.textContent).toContain("nothing was changed");
   });
 
   it("says so when the question cannot be put back either", async () => {
@@ -206,6 +208,45 @@ describe("the live-poll desk template", () => {
     const said = document.getElementById("say")?.textContent ?? "";
     expect(said).toContain("permission-denied");
     expect(said).toContain("still-denied");
+  });
+
+  it("closes EVERY open question, not only the one the audience is on", async () => {
+    const desk = loadDesk();
+    // Two open at once is reachable without anybody doing anything wrong: a second desk, or a press
+    // that half-happened. Closing only `q1` here would open `q3` under `q2`, and the audience — on
+    // the lowest `order` among the open ones — would sit on `q2`: the original stall, arrived at
+    // through the fix for it.
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "open"), question("q3", 3, "draft")], []);
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> closed", "questions/q3 -> open"]);
+  });
+
+  it("puts back everything it closed when the open is refused", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "open"), question("q3", 3, "draft")], []);
+    desk.refuse("questions/q3 -> open", "permission-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> closed", "questions/q3 -> open", "questions/q1 -> open", "questions/q2 -> open"]);
+    expect(document.getElementById("say")?.textContent).toContain("nothing was changed");
+  });
+
+  it("does not undo what it never did when the FIRST close is refused", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+    desk.refuse("questions/q1 -> closed", "permission-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // One move and no rollback: nothing was closed, so the audience is still on `q1` and a reopen
+    // would be a write with nothing to correct.
+    expect(desk.moves).toEqual(["questions/q1 -> closed"]);
   });
 
   it("gives the buttons back after a refusal, mid-stream", async () => {

--- a/test/src/skillTemplateLivePollDesk.spec.ts
+++ b/test/src/skillTemplateLivePollDesk.spec.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+//
+// The live-poll desk, RUN rather than read.
+//
+// `skillTemplates.spec.ts` holds the templates to the declaration gate and to the defects a sandbox
+// hides (a modal, a `<form>`, a missing `ready()`). This one exists because the failure that got
+// past all of it was none of those: the desk opened the next question and left the previous one
+// open, so the audience — which follows the lowest `order` among the OPEN questions — stayed on the
+// question they had already answered. Nothing was refused. The button reported success, the row
+// said "open", and the screen everybody was watching did not move.
+//
+// It cannot be caught by reading a declaration, because the declaration is not what is wrong:
+// "at most one question is open" is a statement about the OTHER records, and `transitions` judges
+// one record's move. The desk is the only place that can keep it, so the desk is what is run here.
+//
+// An app was shipped from this template with exactly that defect (`../apps/ai-live-poll`), which is
+// what a template costs when it is wrong: it is copied verbatim by an agent that cannot check it.
+import { describe, it, expect, beforeEach } from "vitest";
+
+// The template as text, through Vite rather than through `node:fs`: this spec belongs to the
+// DOM-typed project (it runs a page), and that program deliberately carries no node globals — see
+// the note in `tsconfig.test-server.json` about what mixing the two did to `window.setTimeout`.
+import template from "../../server/skills/mulmoterminal-shared-app/templates/live-poll.md?raw";
+
+/** The html block under one of the template's page headings — the same mapping
+ *  `skillTemplates.spec.ts` reads, so a renamed section fails here too rather than silently
+ *  testing nothing. */
+function pageOf(heading: string): string {
+  const lines = template.split("\n");
+  const start = lines.findIndex((line) => /^#{2,3} /.test(line) && line.replace(/^#{2,3} /, "").startsWith(heading));
+  expect(`${heading}: ${start === -1 ? "no section" : "has a section"}`).toBe(`${heading}: has a section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^#{2,3} /.test(line));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join("\n");
+  const [, html] = body.match(/```html\n([\s\S]*?)\n```/) ?? [];
+  expect(`${heading}: ${html === undefined ? "no html" : "has html"}`).toBe(`${heading}: has html`);
+  return html ?? "";
+}
+
+interface Question {
+  id: string;
+  order: number;
+  text: string;
+  choices: string;
+  state: string;
+}
+
+type Told = (questions: Question[], votes: Record<string, unknown>[]) => void;
+
+/** The desk, loaded into a document and holding a fake parent.
+ *
+ *  The script is run rather than inserted: markup assigned through `innerHTML` never executes its
+ *  scripts, and a test that only rendered the HTML would assert about buttons nothing had wired. */
+function loadDesk(): { moves: string[]; tell: Told; failNext: (error: string) => void } {
+  const html = pageOf("views/desk.html");
+  const [, script] = html.match(/<script>\n([\s\S]*?)\n<\/script>/) ?? [];
+  document.body.innerHTML = html.replace(/<script>[\s\S]*?<\/script>/, "");
+
+  const moves: string[] = [];
+  let refuse: string | null = null;
+  let onState: ((state: unknown, viewer: unknown) => void) | null = null;
+  (window as unknown as { __MC_APP_VIEW: unknown }).__MC_APP_VIEW = {
+    onState: (handler: (state: unknown, viewer: unknown) => void) => {
+      onState = handler;
+    },
+    transition: (cid: string, id: string, to: string) => {
+      moves.push(`${cid}/${id} -> ${to}`);
+      if (refuse !== null) {
+        const error = refuse;
+        refuse = null;
+        return Promise.resolve({ ok: false, error });
+      }
+      return Promise.resolve({ ok: true });
+    },
+    ready: () => {},
+  };
+
+  // Evaluated, because the page's own loader is not available here: this environment's jsdom does
+  // not run <script> elements, and markup assigned through `innerHTML` never runs them anywhere. A
+  // spec that only rendered the HTML would assert about buttons nothing had wired.
+  // eslint-disable-next-line sonarjs/code-eval -- the source is a file in this repository, read at test time
+  new Function(script ?? "")();
+
+  return {
+    moves,
+    tell: (questions, votes) => {
+      // `transitionAny` is what the desk draws its buttons from: the host is a member with the
+      // roster's own permission, and a viewer without it gets no buttons at all.
+      onState?.({ questions, votes }, { can: { questions: { transitionAny: true } } });
+    },
+    failNext: (error: string) => {
+      refuse = error;
+    },
+  };
+}
+
+const question = (id: string, order: number, state: string): Question => ({
+  id,
+  order,
+  text: `Question ${order}`,
+  choices: "Yes\nNo",
+  state,
+});
+
+/** The handler awaits two writes; the clicks below are synchronous. */
+const settle = async (): Promise<void> => {
+  for (let turn = 0; turn < 8; turn += 1) {
+    await Promise.resolve();
+  }
+};
+
+const buttonFor = (text: string): HTMLButtonElement => {
+  const found = [...document.querySelectorAll("button")].find((button) => button.textContent === text);
+  expect(`${text}: ${found === undefined ? "not offered" : "offered"}`).toBe(`${text}: offered`);
+  return found as HTMLButtonElement;
+};
+
+describe("the live-poll desk template", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("closes the question the audience is on before asking the next one", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // The order is the whole of it. Opening `q2` alone leaves `q1` open, and the audience follows
+    // the LOWEST `order` among the open ones — so the screen stays on `q1` while the desk says the
+    // move succeeded.
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> open"]);
+  });
+
+  it("goes BACK to an earlier question with the same one press", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "closed"), question("q2", 2, "open")], []);
+
+    buttonFor("Reopen").click();
+    await settle();
+
+    // Reopening `q1` while `q2` is open would move the audience anyway — `q1` has the lower order —
+    // and leave `q2` open behind it, so the next press would go nowhere. Going back is a switch.
+    expect(desk.moves).toEqual(["questions/q2 -> closed", "questions/q1 -> open"]);
+  });
+
+  it("closes the open question on its own, and does not close what is already shut", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "closed")], []);
+
+    buttonFor("Close").click();
+    await settle();
+    expect(desk.moves).toEqual(["questions/q1 -> closed"]);
+
+    // Nothing is open now, so asking a question is one move.
+    desk.tell([question("q1", 1, "closed"), question("q2", 2, "closed")], []);
+    buttonFor("Reopen").click();
+    await settle();
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q1 -> open"]);
+  });
+
+  it("leaves the audience on the question they were answering when the close is refused", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+    desk.failNext("permission-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // The open is NOT attempted. Sent anyway, both questions would be open and the audience would
+    // sit on `q1` — the same silent stall, arrived at from a failure instead of a design.
+    expect(desk.moves).toEqual(["questions/q1 -> closed"]);
+    expect(document.getElementById("say")?.textContent).toContain("permission-denied");
+  });
+
+  it("gives the buttons back after a refusal, mid-stream", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+    desk.failNext("permission-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // A refused call produces no state update, so nothing redraws this page. Buttons left disabled
+    // would stay disabled until the host reloaded — mid-stream, on the page running the show.
+    expect([...document.querySelectorAll("button")].every((button) => !(button as HTMLButtonElement).disabled)).toBe(true);
+  });
+});

--- a/test/src/skillTemplateLivePollDesk.spec.ts
+++ b/test/src/skillTemplateLivePollDesk.spec.ts
@@ -46,31 +46,32 @@ interface Question {
 }
 
 type Told = (questions: Question[], votes: Record<string, unknown>[]) => void;
+type Refuse = (move: string, error: string) => void;
 
 /** The desk, loaded into a document and holding a fake parent.
  *
  *  The script is run rather than inserted: markup assigned through `innerHTML` never executes its
  *  scripts, and a test that only rendered the HTML would assert about buttons nothing had wired. */
-function loadDesk(): { moves: string[]; tell: Told; failNext: (error: string) => void } {
+function loadDesk(): { moves: string[]; tell: Told; refuse: Refuse } {
   const html = pageOf("views/desk.html");
   const [, script] = html.match(/<script>\n([\s\S]*?)\n<\/script>/) ?? [];
   document.body.innerHTML = html.replace(/<script>[\s\S]*?<\/script>/, "");
 
   const moves: string[] = [];
-  let refuse: string | null = null;
+  // Refusals named by the MOVE rather than by call order: what is being pinned is which write the
+  // desk sends after a particular one was denied, and a counter would have to be rewritten every
+  // time the sequence changes.
+  const refusals = new Map<string, string>();
   let onState: ((state: unknown, viewer: unknown) => void) | null = null;
   (window as unknown as { __MC_APP_VIEW: unknown }).__MC_APP_VIEW = {
     onState: (handler: (state: unknown, viewer: unknown) => void) => {
       onState = handler;
     },
     transition: (cid: string, id: string, to: string) => {
-      moves.push(`${cid}/${id} -> ${to}`);
-      if (refuse !== null) {
-        const error = refuse;
-        refuse = null;
-        return Promise.resolve({ ok: false, error });
-      }
-      return Promise.resolve({ ok: true });
+      const move = `${cid}/${id} -> ${to}`;
+      moves.push(move);
+      const error = refusals.get(move);
+      return Promise.resolve(error === undefined ? { ok: true } : { ok: false, error });
     },
     ready: () => {},
   };
@@ -88,8 +89,8 @@ function loadDesk(): { moves: string[]; tell: Told; failNext: (error: string) =>
       // roster's own permission, and a viewer without it gets no buttons at all.
       onState?.({ questions, votes }, { can: { questions: { transitionAny: true } } });
     },
-    failNext: (error: string) => {
-      refuse = error;
+    refuse: (move: string, error: string) => {
+      refusals.set(move, error);
     },
   };
 }
@@ -163,7 +164,7 @@ describe("the live-poll desk template", () => {
   it("leaves the audience on the question they were answering when the close is refused", async () => {
     const desk = loadDesk();
     desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
-    desk.failNext("permission-denied");
+    desk.refuse("questions/q1 -> closed", "permission-denied");
 
     buttonFor("Ask this").click();
     await settle();
@@ -174,10 +175,43 @@ describe("the live-poll desk template", () => {
     expect(document.getElementById("say")?.textContent).toContain("permission-denied");
   });
 
+  it("puts the question back when the OPEN fails after the close landed", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+    desk.refuse("questions/q2 -> open", "permission-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // Left as it was, this is the one state worse than not moving: nothing is open, so every
+    // audience page drops to "waiting" while the host is still talking about the question they
+    // just closed.
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> open", "questions/q1 -> open"]);
+    expect(document.getElementById("say")?.textContent).toContain("permission-denied");
+    expect(document.getElementById("say")?.textContent).toContain("q1 is open again");
+  });
+
+  it("says so when the question cannot be put back either", async () => {
+    const desk = loadDesk();
+    desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
+    desk.refuse("questions/q2 -> open", "permission-denied");
+    desk.refuse("questions/q1 -> open", "still-denied");
+
+    buttonFor("Ask this").click();
+    await settle();
+
+    // Both refusals are reported. The rows are the truth and the host can press again — hiding the
+    // second one would leave them reading "could not open q2" on a screen showing no question.
+    expect(desk.moves).toEqual(["questions/q1 -> closed", "questions/q2 -> open", "questions/q1 -> open"]);
+    const said = document.getElementById("say")?.textContent ?? "";
+    expect(said).toContain("permission-denied");
+    expect(said).toContain("still-denied");
+  });
+
   it("gives the buttons back after a refusal, mid-stream", async () => {
     const desk = loadDesk();
     desk.tell([question("q1", 1, "open"), question("q2", 2, "draft")], []);
-    desk.failNext("permission-denied");
+    desk.refuse("questions/q1 -> closed", "permission-denied");
 
     buttonFor("Ask this").click();
     await settle();


### PR DESCRIPTION
`../apps/ai-live-poll` で「司会が次の設問にしても視聴者の画面が動かない、前の設問にも戻れない」という報告があり、原因を追ったところ**アプリではなくテンプレート側**でした。

## 何が起きていたか

視聴者のページは **「`state` が `open` のうち `order` が最小の設問」** を出します。一方テンプレートの司会卓が持っていたのは行ごとの Open / Close トグルだけで、**「次へ進む」という操作が存在しません**。

司会が次の設問の Open を押すと前の設問は `open` のまま残るので、視聴者は order の小さい前の設問を見続けます。しかも:

- `view.transition` は成功を返す
- 一覧の行は「open」と表示される
- 動かないのは、全員が見ている画面だけ

押したボタンではなく **order の大小**で動くかどうかが決まるため、前の設問に戻る操作も一貫しません（前の設問を開くと勝手に戻り、後の設問を開いても動かない）。

テンプレートは検算できない相手にそのまま写されるので、この弱点はそのままアプリの不具合になりました。散文には「"One at a time" is the desk's discipline」と書いてありましたが、**司会卓の UI がその規律を一切助けていなかった**のが実際のところです。

## 直したこと

### 1. 司会卓を `../apps/live`（実運用で問題なく動いている方）と同じ形に

- ボタンは「Ask this / Reopen / Close」。**出すときは今 `open` の設問を先に締め、それが通ってから開く**（`view.transition` は 1 レコードずつなので 2 手。close が拒否されたら open は送らず、視聴者は答えている途中の設問に留まる）。
- 書き込み中は一覧全体のボタンを無効化し、終わったら必ず戻す（拒否されると state 更新が来ないので、戻さないと配信中にリロードするまで押せなくなる）。
- 行はイベント委譲。再描画でボタンごと差し替わるため。

### 2. 散文を実態に合わせる

「1 問ずつは卓の規律」→「**卓が実行する。`order` は 2 つの書き込みの間を決着させるもの**」。あわせて「次だけ開く司会卓は壊れて見える」ことと、2 台目の卓が同時に押した場合は自己回復することを明記。

### 3. SKILL.md に一般形

`transitions` は 1 レコードの遷移しか判定できず、**他のレコードについては何も言えない** — 「open は同時に 1 つ」「今呼んでいる番号は 1 つ」といった不変条件は宣言できないので、必要ならページが順序付きの 2 手で実行する、という節を足しました。同じ形は投票以外でも出ます。

## test

`test/src/skillTemplateLivePollDesk.spec.ts`（新規）。テンプレートから司会卓の HTML を取り出し、**jsdom で実際に動かします**:

- 次の設問を出すとき、`close(現在) → open(対象)` がこの順で出る
- 前の設問に戻るときも同じ 1 押しで switch になる
- 締めるだけのときは 1 手。すでに閉じているものを閉じない
- close が拒否されたら open を送らない
- 拒否のあとボタンが戻る

**旧テンプレートに対しては 5 件すべて落ちます**（`git stash` して確認済み）。既存の `skillTemplates.spec.ts` は宣言ゲートとサンドボックス由来の欠陥を静的に見ますが、今回の欠陥はそのどちらでもない（宣言は正しい）ため、動かす方のテストを足しました。

`typecheck` / `lint` / `format:check` / `test`（10700 passed）成功。

> 補足: フルテストが 1 度だけ `test/server/routes/drop-route.spec.ts` で落ちましたが、この変更の前（別ブランチでの作業中）にも同じ形で 1 度発生しており、単体でも再現しません。その後のフル実行 2 回は exit 0 です。既存のフレークと見ています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in sharedapp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved live-poll question switching, including reopening previously closed questions.
  * Audience views now consistently display the selected open question based on its order.

* **Bug Fixes**
  * Prevented conflicting question transitions by completing one operation before starting another.
  * Controls are disabled during updates and restored after failures, with clear error feedback.

* **Documentation**
  * Added guidance on transition limitations and the required live-poll operating flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->