### PR TITLE
fix: fork every new worktree from the fresher of local/remote base

### DIFF
--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -302,18 +302,19 @@ async function adoptParentDirConfig(repo: string, worktreeDir: string): Promise<
 }
 
 // Create a fresh worktree + branch for `task`, forked from the repo's base branch. Pass `issue`
-// to anchor the branch to a GitHub issue (`issue/<N>-<slug>`), which also forks from the base as
-// the REMOTE has it. Returns the worktree path + branch, or null if `repoDir` isn't a git repo /
-// the worktree add fails.
+// to anchor the branch to a GitHub issue (`issue/<N>-<slug>`). Either way the fork point is the
+// base AS THE REMOTE HAS IT (see freshStartPoint): several clones of one repo sit side by side
+// here and only the one you happen to be in gets pulled, so forking from local main starts the
+// work on however old that clone is — and a PR opened from it conflicts with whatever landed on
+// the mainline since. `fetchOrigin` is a best-effort 30s-capped round trip, silent and harmless
+// offline or with no remote (baseStartPoint then falls back to the local branch). Returns the
+// worktree path + branch, or null if `repoDir` isn't a git repo / the worktree add fails.
 export async function createWorktree(repoDir: string, task: string, issue?: number | undefined): Promise<{ path: string; branch: string } | null> {
   const repo = await repoRoot(repoDir);
   if (!repo) return null;
   const stem = branchStem(task, issue);
   const root = worktreesRoot(repo);
-  // Only an issue-started worktree pays for a fresh base. Refreshing the remote is a network
-  // round trip on every create, and the launcher's type-a-task-name path keeps the local base it
-  // has always forked from — a deliberate asymmetry, pinned by a test.
-  const start = issue ? await freshStartPoint(repo) : await defaultBaseBranch(repo);
+  const start = await freshStartPoint(repo);
   return serializeCreate(async () => {
     const branch = await uniqueBranch(repo, stem, root);
     const dir = path.join(root, worktreeDirName(branch));

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -289,7 +289,12 @@ describe("git worktree lifecycle", () => {
   // The bug this closes: several clones of one repo sit side by side and only the one being
   // worked in gets pulled, so forking from LOCAL main starts the work on however old that clone
   // is. Here the remote-tracking ref is ahead of local main, and the new worktree must be at the
-  // remote's commit — the old code produced the local one and nothing said so.
+  // remote's commit — the old code produced the local one and nothing said so. This is asserted
+  // for BOTH an issue-anchored worktree and a plain type-a-task-name one: they used to differ
+  // here (only the issue-started path paid for a fresh base), which was its own source of the
+  // same bug — a plus-button worktree forking from a stale local main, and its eventual PR
+  // conflicting with whatever had already landed. Both now always fork from the fresher of the
+  // two, local or remote.
   it.skipIf(!hasGit)(
     "forks from origin/<base> rather than the local branch when the two differ",
     async () => {
@@ -314,13 +319,9 @@ describe("git worktree lifecycle", () => {
       expect(execFileSync("git", ["-C", wt.path, "rev-parse", "HEAD"], { encoding: "utf8" }).trim()).toBe(remote);
       expect(existsSync(path.join(wt.path, "remote-only.txt"))).toBe(true);
 
-      // The deliberate asymmetry: only an issue-started worktree pays for a fresh base. The
-      // launcher's type-a-task-name path keeps forking from the local branch it always has, so
-      // the same repo state gives the two paths DIFFERENT answers — which is the decision, not
-      // an oversight, and is why it is asserted rather than left implied.
       const unanchored = await createWorktree(repo, "unanchored");
       if (!unanchored) throw new Error("expected a worktree");
-      expect(existsSync(path.join(unanchored.path, "remote-only.txt"))).toBe(false);
+      expect(existsSync(path.join(unanchored.path, "remote-only.txt"))).toBe(true);
     },
     GIT_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary
- `createWorktree()` already had `freshStartPoint()` — fetch `origin`, then fork from whichever of the local branch / `origin/<base>` is not behind — but only issue-anchored worktrees used it. The plus-button's plain type-a-task-name path deliberately skipped the fetch and forked straight from the local base branch (a "deliberate asymmetry, pinned by a test").
- In practice: several worktrees/clones of one repo sit side by side, only the one you happen to be working in gets pulled, so a new worktree cut from the plus button silently starts from however stale that particular checkout's local base is. The PR opened from it then conflicts with whatever had already landed on the mainline in the meantime.
- Both paths now use `freshStartPoint()` unconditionally. `fetchOrigin` is best-effort with a 30s cap and fails silently offline / with no remote, and `baseStartPoint` only prefers `origin/<base>` when the local branch does **not** already contain it as an ancestor — so this never drops unpushed local work, it only adds a fetch to the path that used to skip it.

## Test plan
- [x] `yarn test test/server/git/` — 479/479 passing, including the updated "forks from origin/<base>" test, which now asserts fresh-base forking for both an issue-anchored and a plain unanchored worktree (previously it asserted they differed).
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format` — no diff

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worktrees now consistently start from the latest remote-tracking commit, including worktrees created without an issue.
  * Prevented stale local branches from causing newly created worktrees to miss recent remote changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->