### PR TITLE
docs(shared-app): 画面の切り替えはデータから決める

### DIFF
--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -908,11 +908,27 @@ because the visitor already knows what they did.
 record that may still land — there is no recalling a write — and makes the visitor wait for the real
 outcome. So the page is never told both.)
 
-**Deriving it at all needs the page to be handed the reader's own row, and that is settled before
-the page is written.** A public page is handed only the collections in `public.read`, and an
-`anonymous` visitor has no address to compare against — so "have I answered?" is not a question that
-page can ask, however it is coded. That is the trade in step 2c arriving in a different place: ask
-it while the shape is being chosen, not after writing a screen that cannot know when to appear.
+**"Have I already answered?" has THREE routes, and an anonymous visitor is not shut out of it.**
+The comparison above is only the first, and it is the one that needs an address:
+
+- **the reader's own row, in the data the page was handed** — `viewer.me` against `emailField`, as
+  above. It needs the collection to be readable by this audience (for a public page, named in
+  `public.read`) and it needs the reader to HAVE an address, so `auth: "anonymous"` cannot use it.
+- **`viewer.mine`, carried with the state.** The rows this visitor has already submitted, projected
+  beside the data — so a page reads it in `onState` with no call of its own. This is what an
+  `anonymous` + `idFrom: "auth.uid"` app derives from: nobody has an address, and the uid is the id.
+  **Absent is UNKNOWN, and unknown is not "no"** — a host that did not look sends nothing, and a page
+  reading that as "not yet" tells somebody who answered to answer again.
+- **`view.mine(cid, key)`, on demand** — a read the host performs with the visitor's own credentials
+  against an id it builds. It is the half that works where `viewer.mine` cannot: under
+  `idFrom: "auth.uid+field"` the id is `uid_<field>`, which the host cannot know before the page
+  names the key. It answers `{ known, found, record }`, and `known: false` means **nobody looked**.
+  Draw the action and let the refusal explain itself; never draw it as "no".
+
+So the question to settle before the page is written is not "is the visitor signed in" but **can
+this page learn the answer at all** — and only where all three are shut (`submitOnly` with the
+records outside `public.read`, so a submitter cannot read even their own row back) is the answer no.
+That is the trade in step 2c arriving in a different place.
 
 Where it genuinely cannot be derived, remembering is the fallback rather than the mistake — and it
 has to be written as one. [templates/live-poll.md](./templates/live-poll.md) is that case in full: an

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -886,14 +886,18 @@ view.onState((data, viewer) => { latest = { data, viewer }; render(); });   // t
 view.ready();
 
 const render = () => {
+  // `email` here is whatever THIS app declared as its `emailField`; the gym's is `memberEmail`.
+  // An app with no address to compare — `auth: "anonymous"` — derives it from `mine` instead
+  // (the three routes below).
   const mine = latest.data.responses.find((r) => r.email === latest.viewer.me);
   show(mine ? "answered" : "form");        // derived every time, remembered never
 };
 
 button.onclick = async () => {
   const res = await view.submit("responses", values);
-  if (res.ok) return;                       // onState is about to redraw
-  message.textContent = res.error === "cancelled" ? "" : `送信できませんでした: ${res.error}`;
+  // Clear it on EVERY outcome that is not a refusal. A page that returns early leaves the
+  // previous "送信できませんでした" on screen, and the visitor reads it as this press's answer.
+  message.textContent = res.ok || res.error === "cancelled" ? "" : `送信できませんでした: ${res.error}`;
 };
 ```
 
@@ -933,9 +937,13 @@ That is the trade in step 2c arriving in a different place.
 Where it genuinely cannot be derived, remembering is the fallback rather than the mistake — and it
 has to be written as one. [templates/live-poll.md](./templates/live-poll.md) is that case in full: an
 anonymous voter may not read the votes back, so the page keeps what it sent in a `Map`, remembers it
-only on `ok`, treats `cancelled` as "press again" rather than as a refusal, and knows that a reload
-loses the lot. Copy that shape rather than inventing it, and do not reach for it while the row is
-readable.
+only on `ok`, and treats `cancelled` as "press again" rather than as a refusal.
+
+**Copy it WITH its lookup.** That `Map` is a within-visit cache and not the answer to a reload — a
+reload empties it, and the page recovers by asking `view.mine("votes", question.id)` for the
+question it is showing, exactly as the third route above. A page copied without that call has the
+reload bug back, in the one shape where it is hardest to see: everything works until somebody
+refreshes.
 
 **`preview` does not catch either of these.** The run presses controls and accepts what it raises,
 and it loads each page once — so a page with both faults comes back clean. Until the harness presses

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -413,7 +413,13 @@ Ask them to confirm, in these terms:
   `transitions` table, `not-permitted` is the reader's role, `not-writable` is a missing
   `statusField` / `assigneeField` / `selfDelete`, and `not-in-view` is the page naming a row it was
   not handed (the preview writes as the OWNER, so it cannot let the rules decide whose row it is);
-- the **error paths** say something: an empty required field, an unchosen option.
+- the **error paths** say something: an empty required field, an unchosen option;
+- **cancelling the confirmation leaves the page where it was** — a page that shows the thank-you or
+  the results to somebody who pressed やめる read `submit` returning as sent (see "Which screen the
+  page shows"). This is a press the headless run never makes;
+- **reloading after answering shows the answered screen, not the empty form.** Same section, same
+  cause on the other side: it means the page remembered instead of deriving. The headless run loads
+  each page once, so this is the user's to press too.
 
 Do this **before publish** and again after any change to a page. If the user cannot look right now,
 say plainly what was and was not checked: a clean headless run means the page draws and the button
@@ -855,6 +861,70 @@ the cost in the text the reader can see.
   could name a template could mail "your booking is approved" about one it had just rejected.
 - **Nothing here grants anything.** The rules already decide what this member may write; these
   calls only let the page ask, and let the refusal say which assumption in the page was wrong.
+
+### Which screen the page shows
+
+A page that collects something has more than one screen — the form, and what somebody who has
+already answered sees instead. **Which one is drawn is a question about the DATA, not about what
+happened while this tab was open.** A page that answers it from an event is wrong in two ways, and
+both of them reached a published survey before anybody noticed:
+
+- the visitor **cancels** the confirmation and the page shows them the results anyway — it read
+  `await submit(...)` RETURNING as "sent", and never looked at the answer;
+- somebody who has already answered **reloads** and gets the empty form back — "I have answered"
+  was a variable in the page, and a reload throws it away.
+
+**Render only from `onState`. `submit`'s answer decides what to SAY, never what to show.** One rule,
+and it repairs both — because the parent re-sends the state once a confirmation is accepted, so the
+callback that draws the reload is the same callback that draws the moment the record lands. Written
+this way the page contains no line that switches screens at all, which is why neither bug can be
+written.
+
+```js
+let latest = null;
+view.onState((data, viewer) => { latest = { data, viewer }; render(); });   // the ONLY renderer
+view.ready();
+
+const render = () => {
+  const mine = latest.data.responses.find((r) => r.email === latest.viewer.me);
+  show(mine ? "answered" : "form");        // derived every time, remembered never
+};
+
+button.onclick = async () => {
+  const res = await view.submit("responses", values);
+  if (res.ok) return;                       // onState is about to redraw
+  message.textContent = res.error === "cancelled" ? "" : `送信できませんでした: ${res.error}`;
+};
+```
+
+**`cancelled` is a THIRD outcome and it is not an error.** Declining the parent's dialog answers the
+view `{ ok: false, error: "cancelled" }` — the same shape a refusal by the rules arrives in. So a
+page that prints `error` blindly tells somebody who deliberately pressed やめる that their
+submission failed, and a page that ignores `ok` thanks them for a record that does not exist. Read
+`ok` first, then separate `cancelled` from the rest: it is the one outcome with nothing to report,
+because the visitor already knows what they did.
+
+(Escape while a write is IN FLIGHT is not a cancel. The parent refuses to answer "cancelled" over a
+record that may still land — there is no recalling a write — and makes the visitor wait for the real
+outcome. So the page is never told both.)
+
+**Deriving it at all needs the page to be handed the reader's own row, and that is settled before
+the page is written.** A public page is handed only the collections in `public.read`, and an
+`anonymous` visitor has no address to compare against — so "have I answered?" is not a question that
+page can ask, however it is coded. That is the trade in step 2c arriving in a different place: ask
+it while the shape is being chosen, not after writing a screen that cannot know when to appear.
+
+Where it genuinely cannot be derived, remembering is the fallback rather than the mistake — and it
+has to be written as one. [templates/live-poll.md](./templates/live-poll.md) is that case in full: an
+anonymous voter may not read the votes back, so the page keeps what it sent in a `Map`, remembers it
+only on `ok`, treats `cancelled` as "press again" rather than as a refusal, and knows that a reload
+loses the lot. Copy that shape rather than inventing it, and do not reach for it while the row is
+readable.
+
+**`preview` does not catch either of these.** The run presses controls and accepts what it raises,
+and it loads each page once — so a page with both faults comes back clean. Until the harness presses
+cancel and re-loads, this section is the check: read the page back and ask, of each screen, where it
+learns that it is the one to draw.
 
 The simplest correct survey omits status entirely (`submitOnly` + `verifiedEmail` + `emailField`).
 Add a status only when somebody is going to work through the responses.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -929,21 +929,26 @@ The comparison above is only the first, and it is the one that needs an address:
   names the key. It answers `{ known, found, record }`, and `known: false` means **nobody looked**.
   Draw the action and let the refusal explain itself; never draw it as "no".
 
-So the question to settle before the page is written is not "is the visitor signed in" but **can
-this page learn the answer at all** — and only where all three are shut (`submitOnly` with the
-records outside `public.read`, so a submitter cannot read even their own row back) is the answer no.
-That is the trade in step 2c arriving in a different place.
+So the question to settle before the page is written is not "is the visitor signed in" but **which
+of the three this page will use** — and being unable to READ the collection does not settle it,
+because the last route is not a read of the collection: the rules grant a submitter the document
+they can name, which is why a `submitOnly` app whose records nobody may list can still tell one
+visitor about their own row. That is the trade in step 2c arriving in a different place.
 
-Where it genuinely cannot be derived, remembering is the fallback rather than the mistake — and it
-has to be written as one. [templates/live-poll.md](./templates/live-poll.md) is that case in full: an
-anonymous voter may not read the votes back, so the page keeps what it sent in a `Map`, remembers it
-only on `ok`, and treats `cancelled` as "press again" rather than as a refusal.
+**[templates/live-poll.md](./templates/live-poll.md) is the third route written out, and it is what
+to copy.** Anonymous voters, `idFrom: "auth.uid+field"` — so `viewer.mine` cannot carry the answer
+(the host has no key until the page says which question it is showing) and the page asks
+`view.mine("votes", question.id)` on load instead, treating `known: false` as unknown and offering
+the vote rather than refusing it.
 
-**Copy it WITH its lookup.** That `Map` is a within-visit cache and not the answer to a reload — a
-reload empties it, and the page recovers by asking `view.mine("votes", question.id)` for the
-question it is showing, exactly as the third route above. A page copied without that call has the
-reload bug back, in the one shape where it is hardest to see: everything works until somebody
-refreshes.
+**Its `Map` is not the fallback for that, and copying only the `Map` is how the reload bug comes
+back.** The map is the bridge WITHIN a visit — the answer to "what did I just send for the question
+still on screen", held while the lookup is in flight and for the questions already answered in this
+session. A reload empties it and the LOOKUP is what refills it. Remembering alone is all there is in
+exactly one place, and live-poll marks it: a runtime with no `view.mine` at all
+(`typeof view.mine !== "function"`). Even there the page does not claim the visitor has not
+answered — it offers the control and lets the refusal be the answer, which is the same rule as
+`known: false`.
 
 **`preview` does not catch either of these.** The run presses controls and accepts what it raises,
 and it loads each page once — so a page with both faults comes back clean. Until the harness presses

--- a/server/skills/mulmoterminal-shared-app/templates/gym.md
+++ b/server/skills/mulmoterminal-shared-app/templates/gym.md
@@ -275,8 +275,13 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
     // メッセージ全体が申込みでなくなり、not-a-submission として拒否されます。
     const result = await view.submit("bookings", { classId, memberName });
     // 失敗は「満席」ではありません — このアプリに満席という状態はない。解禁前
-    // （window）、サインインしていない、二重申込み（idFrom）のどれかです。
-    say.textContent = result.ok ? "受け付けました。順位は「自分の申込み」で見られます。" : `申し込めませんでした: ${result.error ?? "unknown"}`;
+    // （window）、サインインしていない、二重申込み（idFrom）のどれかです。そして
+    // "cancelled" はそのどれでもありません — 確認ダイアログで「やめる」を押しただけです。
+    if (result.ok) {
+      say.textContent = "受け付けました。順位は「自分の申込み」で見られます。";
+    } else {
+      say.textContent = result.error === "cancelled" ? "" : `申し込めませんでした: ${result.error ?? "unknown"}`;
+    }
   });
 
   view.ready();

--- a/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
+++ b/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
@@ -197,7 +197,12 @@
       return;
     }
     // 失敗を全部「取られました」と言わないこと。締切、サインイン、必須項目の
-    // どれでもここに来ます。理由は result.error にあります。
+    // どれでもここに来ます。理由は result.error にあります。そして "cancelled" は
+    // 失敗ですらありません — 確認ダイアログで「やめる」を押した人には何も出しません。
+    if (result.error === "cancelled") {
+      say.textContent = "";
+      return;
+    }
     say.textContent = result.error ? `予約できませんでした: ${result.error}` : "その枠は取られました。";
   });
   view.ready();

--- a/server/skills/mulmoterminal-shared-app/templates/salon.md
+++ b/server/skills/mulmoterminal-shared-app/templates/salon.md
@@ -191,8 +191,15 @@
       return;
     }
     const result = await view.submit("bookings", { slot, customerName, status: "pending" });
-    // 失敗の理由は二重予約とは限りません（締切、サインイン、必須項目）。
-    say.textContent = result.ok ? "受け付けました。" : result.error ? `予約できませんでした: ${result.error}` : "その枠は取られました。";
+    // 失敗の理由は二重予約とは限りません（締切、サインイン、必須項目）。そして
+    // "cancelled" は失敗ではありません — 確認ダイアログで「やめる」を押しただけです。
+    if (result.ok) {
+      say.textContent = "受け付けました。";
+    } else if (result.error === "cancelled") {
+      say.textContent = "";
+    } else {
+      say.textContent = result.error ? `予約できませんでした: ${result.error}` : "その枠は取られました。";
+    }
   });
   view.ready();
 </script>

--- a/server/skills/mulmoterminal-shared-app/templates/survey.md
+++ b/server/skills/mulmoterminal-shared-app/templates/survey.md
@@ -276,7 +276,13 @@ create** なので、上書きではなく拒否されます。「1 回だけ答
     });
     // 失敗は「壊れた」ではありません。サインインしていないか、この人が既に答えたか
     // （idFrom: "auth.uid"）のどちらかです。
-    say.textContent = result.ok ? "ありがとうございました。" : `送れませんでした: ${result.error ?? "unknown"}`;
+    // そして "cancelled" は失敗ですらありません — 確認ダイアログで「やめる」を押した人に
+    // 「送れませんでした」と出すのは嘘です。ok を先に読み、cancelled を残りと分けます。
+    if (result.ok) {
+      say.textContent = "ありがとうございました。";
+    } else {
+      say.textContent = result.error === "cancelled" ? "" : `送れませんでした: ${result.error ?? "unknown"}`;
+    }
   });
 
   view.ready();

--- a/test/src/skillTemplateSubmitCancel.spec.ts
+++ b/test/src/skillTemplateSubmitCancel.spec.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// What every template's public page SAYS when the visitor declines the confirmation.
+//
+// A submission is confirmed OUTSIDE the frame: the parent draws the values, and declining answers
+// the view `{ ok: false, error: "cancelled" }` — the same shape a refusal by the rules arrives in.
+// So a page that prints `error` without looking at it tells somebody who deliberately pressed
+// やめる that their booking failed, and a page that ignores `ok` thanks them for a record that does
+// not exist. Both were shipped from a published survey before this was written down.
+//
+// It is not a defect a declaration gate can see (`skillTemplates.spec.ts`) and not one the sandbox
+// checks look for: the page is well-formed, the button is wired, the write is correctly refused.
+// The only thing that is wrong is the sentence on the screen — so the pages are RUN, and what they
+// put in `#say` is the assertion.
+//
+// The cancel is pressed AFTER a real refusal on purpose. Clearing the message is the half a
+// refactor drops: a page that returns early on `cancelled` without touching `#say` leaves the
+// previous "予約できませんでした" standing, and the visitor reads it as the answer to the button
+// they just pressed.
+import { describe, it, expect, beforeEach } from "vitest";
+
+import gym from "../../server/skills/mulmoterminal-shared-app/templates/gym.md?raw";
+import meetingRoom from "../../server/skills/mulmoterminal-shared-app/templates/meeting-room.md?raw";
+import salon from "../../server/skills/mulmoterminal-shared-app/templates/salon.md?raw";
+import survey from "../../server/skills/mulmoterminal-shared-app/templates/survey.md?raw";
+
+/** The html block under one of a template's page headings — the same mapping the other template
+ *  specs read, so a renamed section fails here rather than silently testing nothing. */
+function pageOf(template: string, heading: string): string {
+  const lines = template.split("\n");
+  const start = lines.findIndex((line) => /^#{2,3} /.test(line) && line.replace(/^#{2,3} /, "").startsWith(heading));
+  expect(`${heading}: ${start === -1 ? "no section" : "has a section"}`).toBe(`${heading}: has a section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^#{2,3} /.test(line));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join("\n");
+  const [, html] = body.match(/```html\n([\s\S]*?)\n```/) ?? [];
+  expect(`${heading}: ${html === undefined ? "no html" : "has html"}`).toBe(`${heading}: has html`);
+  return html ?? "";
+}
+
+type Outcome = { ok: true } | { ok: false; error: string };
+
+interface Page {
+  /** What the parent will answer the NEXT submission with. */
+  answer: (outcome: Outcome) => void;
+  /** The data the page is handed, in the shape its own `onState` destructures. */
+  tell: (data: Record<string, unknown[]>) => void;
+  /** What the page is telling the visitor right now. */
+  said: () => string;
+}
+
+function load(template: string, heading: string): Page {
+  const html = pageOf(template, heading);
+  const [, script] = html.match(/<script>\n([\s\S]*?)\n<\/script>/) ?? [];
+  document.body.innerHTML = html.replace(/<script>[\s\S]*?<\/script>/, "");
+
+  let outcome: Outcome = { ok: true };
+  let onState: ((data: unknown, viewer: unknown) => void) | null = null;
+  (window as unknown as { __MC_APP_VIEW: unknown }).__MC_APP_VIEW = {
+    onState: (handler: (data: unknown, viewer: unknown) => void) => {
+      onState = handler;
+    },
+    submit: () => Promise.resolve(outcome),
+    ready: () => {},
+  };
+
+  // Run rather than insert: jsdom does not execute <script> elements, and markup assigned through
+  // `innerHTML` never runs them anywhere — a spec that only rendered the page would assert about
+  // buttons nothing had wired.
+  // eslint-disable-next-line sonarjs/code-eval -- the source is a file in this repository, read at test time
+  new Function(script ?? "")();
+
+  return {
+    answer: (next) => {
+      outcome = next;
+    },
+    tell: (data) => onState?.(data, { me: "visitor@example.com", can: {} }),
+    said: () => document.getElementById("say")?.textContent ?? "",
+  };
+}
+
+/** The click is synchronous and the handler is not — it awaits the write, and the parent's answer
+ *  arrives a microtask later. */
+const settle = async (): Promise<void> => {
+  for (let turn = 0; turn < 32; turn += 1) {
+    await Promise.resolve();
+  }
+};
+
+const type = (id: string, value: string): void => {
+  const field = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement | null;
+  expect(`${id}: ${field === null ? "missing" : "present"}`).toBe(`${id}: present`);
+  (field as HTMLInputElement).value = value;
+};
+
+/** One page per template that a VISITOR submits from, with whatever it needs before its submitting
+ *  control exists at all. */
+const PAGES: { name: string; open: () => Page; press: () => void }[] = [
+  {
+    name: "survey.md — views/survey.html",
+    open: () => {
+      const page = load(survey, "views/survey.html");
+      page.tell({ questions: [{ id: "q1", order: 1, text: "運動していますか", choices: "はい\nいいえ" }] });
+      type("who", "山田");
+      const radio = document.querySelector("input[type=radio]") as HTMLInputElement;
+      radio.checked = true;
+      return page;
+    },
+    press: () => (document.getElementById("send") as HTMLButtonElement).click(),
+  },
+  {
+    name: "salon.md — views/booking.html",
+    open: () => {
+      const page = load(salon, "views/booking.html");
+      page.tell({ stylists: [{ id: "a", name: "A" }], slots: [{ id: "s1", state: "open", startAt: "2026-09-01T10:00", stylist: "a" }] });
+      type("who", "山田");
+      return page;
+    },
+    press: () => (document.querySelector("#grid button") as HTMLButtonElement).click(),
+  },
+  {
+    name: "gym.md — views/signup.html",
+    open: () => {
+      const page = load(gym, "views/signup.html");
+      page.tell({ classes: [{ id: "c1", title: "ヨガ", startsAt: "2026-09-01T10:00" }] });
+      type("who", "山田");
+      return page;
+    },
+    press: () => (document.querySelector("#list button") as HTMLButtonElement).click(),
+  },
+  {
+    name: "meeting-room.md — views/grid.html",
+    open: () => {
+      const page = load(meetingRoom, "views/grid.html");
+      page.tell({ rooms: [{ id: "r1", title: "会議室" }], slots: [{ id: "s1", state: "open", room: "r1", startAt: "2026-09-01T10:00" }] });
+      type("who", "山田");
+      type("why", "打合せ");
+      return page;
+    },
+    press: () => (document.querySelector("#grid button") as HTMLButtonElement).click(),
+  },
+];
+
+describe("a visitor who declines the confirmation", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  for (const page of PAGES) {
+    it(`${page.name} says nothing about a failure`, async () => {
+      const view = page.open();
+
+      // A real refusal first, so there is a message on the screen to be left behind.
+      view.answer({ ok: false, error: "permission-denied" });
+      page.press();
+      await settle();
+      expect(`${page.name}: refusal ${view.said() === "" ? "silent" : "announced"}`).toBe(`${page.name}: refusal announced`);
+
+      view.answer({ ok: false, error: "cancelled" });
+      page.press();
+      await settle();
+      // Nothing at all: the visitor pressed やめる and already knows what they did. Anything here
+      // is either a failure they did not have, or the previous refusal read as this one's answer.
+      expect(`${page.name}: after cancel "${view.said()}"`).toBe(`${page.name}: after cancel ""`);
+    });
+
+    it(`${page.name} still says something when the write goes through`, async () => {
+      const view = page.open();
+      view.answer({ ok: true });
+      page.press();
+      await settle();
+      expect(`${page.name}: success ${view.said() === "" ? "silent" : "announced"}`).toBe(`${page.name}: success announced`);
+    });
+  }
+});


### PR DESCRIPTION
公開した survey で見つかった 2 つの不具合（どちらも修正済み）を、スキル側に持ち帰りました。

- 投稿をキャンセルすると、投稿していないのに結果が表示される
- 既に投稿した人がリロードすると、結果ではなく投票フォームが表示される

原因は 1 つです。ページが「今このタブで何が起きたか」から画面を決めていました。

## SKILL.md — 「Which screen the page shows」

- **描画は `onState` からだけ。`submit` の答えは何を言うかだけを決め、何を見せるかは決めない。**
  確認が accept されると親が `sendState()` を呼ぶので（`view/bridge.js` の `accept()`）、
  リロードを描くコールバックとレコードが入った瞬間を描くコールバックは同じものになります。
  こう書くと、画面を切り替える行がページから消えます。
- **`cancelled` は 3 つ目の結果であって失敗ではない。** `decline()` は
  `{ ok: false, error: "cancelled" }` を返します — ルールの拒否とまったく同じ形なので、
  `error` をそのまま出すページは「やめる」を押した人に「送れませんでした」と言います。
  書き込み中の Escape がキャンセルにならない理由も併記しました。
- **導出できない場合**（`public.read` の外、`anonymous` には比較する住所がない）は
  憶えるのが正解で、その形は `live-poll.md` にすでにあります。写す先として指しました。
- **`preview` はこのどちらも捕まえません。** accept しかせず、各ページを 1 回しか読み込まないので、
  両方壊れたページでもレポートは綺麗に返ります。そう書いた上で、step 3 のペインの確認項目に
  「キャンセルしても画面が動かないこと」「リロードで回答済みの画面が出ること」を足しました。

## テンプレート

`submit` を呼ぶ 4 箇所（survey / salon / gym / meeting-room）が `cancelled` を失敗として
報告していたので、`ok` を先に読む形に直しました。`live-poll` は元から正しいので触っていません。

## テスト

このスキルとテンプレートを見ている 4 ファイル 37 件は通っています
(`test/server/skills/sharedAppSkill.spec.ts`, `test/src/skillTemplateLivePollDesk.spec.ts`,
`test/server/backends/sharedAppPreviewIntent.spec.ts`, `test/server/backends/sharedAppServerTime.spec.ts`)。

## 残り

ここでは文章とテンプレートだけ直しました。まだ手をつけていないもの:

- `submit` の戻り値を捨てているページを `check` / `publish` が警告する
- `preview` がキャンセルを押し、書き込みのあと読み込み直す
- ページの雛形（loading / empty / error / answered を最初から持つ骨格）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-cancelled signups, bookings, and survey submissions no longer display misleading error messages.
  * Status messages are cleared when an action is cancelled, while genuine submission failures continue to show appropriate feedback.
  * Successful submissions retain their existing confirmation messages.

* **Documentation**
  * Added guidance for handling form states, submission outcomes, cancellation, reload behavior, and validation during preview testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->