### PR TITLE
fix(prompts): プロンプト一覧を範囲選択できるようにする

### DIFF
--- a/src/components/PromptsPane.vue
+++ b/src/components/PromptsPane.vue
@@ -135,6 +135,11 @@ function formatTime(at: number | null): string {
   return at >= startOfToday() ? time : `${d.toLocaleDateString([], { month: "numeric", day: "numeric" })} ${time}`;
 }
 
+// The time is INSIDE the toggle, so a label naming only the action would replace it in the
+// accessible name and cost a screen reader the one thing that places the prompt in time.
+const toggleLabel = (at: number | null, isOpen: boolean): string =>
+  [formatTime(at), isOpen ? "Collapse this prompt" : "Show the whole prompt"].filter(Boolean).join(" ");
+
 // Which rows are showing their full text. A long prompt is clamped so the list stays scannable,
 // and clicking one opens it in place — the pane reads, and this is still reading.
 const opened = ref(new Set<number>());
@@ -210,7 +215,7 @@ watch(prompts, () => {
             type="button"
             class="flex w-full cursor-pointer items-center justify-between gap-2 border-0 bg-transparent p-0 text-left text-inherit"
             :aria-expanded="opened.has(index)"
-            :aria-label="opened.has(index) ? 'Collapse this prompt' : 'Show the whole prompt'"
+            :aria-label="toggleLabel(prompt.at, opened.has(index))"
             :title="opened.has(index) ? 'Collapse' : 'Show the whole prompt'"
             @click="toggle(index)"
           >

--- a/src/components/PromptsPane.vue
+++ b/src/components/PromptsPane.vue
@@ -219,7 +219,7 @@ watch(prompts, () => {
           </button>
           <p
             data-testid="prompt-text"
-            class="m-0 mt-1 w-full select-text whitespace-pre-wrap break-words text-[12px] leading-[1.45]"
+            class="mt-1 w-full select-text whitespace-pre-wrap break-words text-[12px] leading-[1.45]"
             :class="opened.has(index) ? '' : 'line-clamp-3 overflow-hidden'"
             @click="toggleUnlessSelecting(index)"
           >

--- a/src/components/PromptsPane.vue
+++ b/src/components/PromptsPane.vue
@@ -14,6 +14,7 @@ import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 import type { TerminalAgent } from "../../common/sessionAgent";
 import type { PromptEntry } from "../../common/promptHistory";
 import { PROMPT_SUBMITTED_CHANNEL, isPromptSubmittedEvent } from "../../common/promptChannel";
+import { isTextSelected } from "./textSelected";
 
 const props = defineProps<{
   sessionId: string | null;
@@ -142,6 +143,13 @@ function toggle(index: number): void {
   if (!next.delete(index)) next.add(index);
   opened.value = next;
 }
+// Clicking the text opens it too, EXCEPT when that click is the end of a drag: the row would
+// collapse under the selection the reader just made, which is the whole reason the text is
+// outside the button.
+function toggleUnlessSelecting(index: number): void {
+  if (isTextSelected(window.getSelection())) return;
+  toggle(index);
+}
 // Keyed by index, so a reload that prepends rows must not leave an older row expanded by
 // coincidence.
 watch(prompts, () => {
@@ -188,22 +196,35 @@ watch(prompts, () => {
       <p v-else-if="!sessionId" data-testid="prompts-empty" class="px-4 py-6 text-center text-[12px] text-dim">This cell hasn't started a session yet.</p>
       <p v-else-if="prompts.length === 0" data-testid="prompts-empty" class="px-4 py-6 text-center text-[12px] text-dim">Nothing sent to this session yet.</p>
       <ol v-else class="m-0 list-none p-0">
-        <li v-for="(prompt, index) in newestFirst" :key="index" data-testid="prompt-row" class="border-b border-border last:border-b-0">
+        <!-- The prompt text sits OUTSIDE the button on purpose. A browser makes a button's own
+             content unselectable, so while the whole row was one button a reader could not drag
+             across their own prompt to copy it — only re-type it. Same shape as the tools pane:
+             the control is the header line, the prose is a sibling. -->
+        <li
+          v-for="(prompt, index) in newestFirst"
+          :key="index"
+          data-testid="prompt-row"
+          class="border-b border-border px-3 py-2 last:border-b-0 hover:bg-subtle"
+        >
           <button
             type="button"
-            class="flex w-full cursor-pointer flex-col items-start gap-1 border-0 bg-transparent px-3 py-2 text-left text-inherit hover:bg-subtle"
+            class="flex w-full cursor-pointer items-center justify-between gap-2 border-0 bg-transparent p-0 text-left text-inherit"
             :aria-expanded="opened.has(index)"
+            :aria-label="opened.has(index) ? 'Collapse this prompt' : 'Show the whole prompt'"
             :title="opened.has(index) ? 'Collapse' : 'Show the whole prompt'"
             @click="toggle(index)"
           >
             <span data-testid="prompt-time" class="text-[11px] tabular-nums text-dim">{{ formatTime(prompt.at) }}</span>
-            <span
-              data-testid="prompt-text"
-              class="w-full whitespace-pre-wrap break-words text-[12px] leading-[1.45]"
-              :class="opened.has(index) ? '' : 'line-clamp-3 overflow-hidden'"
-              >{{ prompt.text }}</span
-            >
+            <span class="material-symbols-outlined text-[16px] text-dim" aria-hidden="true">{{ opened.has(index) ? "expand_less" : "expand_more" }}</span>
           </button>
+          <p
+            data-testid="prompt-text"
+            class="m-0 mt-1 w-full select-text whitespace-pre-wrap break-words text-[12px] leading-[1.45]"
+            :class="opened.has(index) ? '' : 'line-clamp-3 overflow-hidden'"
+            @click="toggleUnlessSelecting(index)"
+          >
+            {{ prompt.text }}
+          </p>
         </li>
       </ol>
       <!-- Says which end was cut, because the answer is not obvious from a list that is newest

--- a/src/components/textSelected.ts
+++ b/src/components/textSelected.ts
@@ -1,0 +1,9 @@
+// A click that ENDS a drag-selection must not act on the row under it: the reader is copying the
+// text, and collapsing the row takes away what they just selected.
+//
+// Typed structurally rather than as a DOM `Selection` so it can be tested without one — the
+// browser's own object satisfies it.
+type SelectionLike = { isCollapsed: boolean; toString: () => string };
+
+export const isTextSelected = (selection: SelectionLike | null | undefined): boolean =>
+  !!selection && !selection.isCollapsed && selection.toString().trim().length > 0;

--- a/src/components/textSelected.ts
+++ b/src/components/textSelected.ts
@@ -1,9 +1,11 @@
 // A click that ENDS a drag-selection must not act on the row under it: the reader is copying the
 // text, and collapsing the row takes away what they just selected.
 //
+// Any live range counts, whitespace included — a prompt is rendered pre-wrap, so its indentation
+// and blank lines are content a reader can deliberately drag across (Codex, #1806).
+//
 // Typed structurally rather than as a DOM `Selection` so it can be tested without one — the
 // browser's own object satisfies it.
-type SelectionLike = { isCollapsed: boolean; toString: () => string };
+type SelectionLike = { isCollapsed: boolean };
 
-export const isTextSelected = (selection: SelectionLike | null | undefined): boolean =>
-  !!selection && !selection.isCollapsed && selection.toString().trim().length > 0;
+export const isTextSelected = (selection: SelectionLike | null | undefined): boolean => !!selection && !selection.isCollapsed;

--- a/test/src/components/PromptsPane.spec.ts
+++ b/test/src/components/PromptsPane.spec.ts
@@ -221,6 +221,28 @@ describe("PromptsPane", () => {
     expect(w.get('[data-testid="prompt-text"]').classes()).not.toContain("line-clamp-3"); // still open
   });
 
+  // An aria-label REPLACES the button's contents in the accessible name, and the time is one of
+  // them — a label naming only the action would take the timestamp away from a screen reader.
+  it("keeps the time in the toggle's accessible name", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        prompts: [
+          { at: Date.now(), text: "hi" },
+          { at: null, text: "no clock" },
+        ],
+        truncated: false,
+      }),
+    );
+    const w = mountPane();
+    await flushPromises();
+    const labels = w.findAll('[data-testid="prompt-row"] button').map((b) => b.attributes("aria-label") ?? "");
+    expect(labels[0]).toBe("Show the whole prompt"); // the row whose time is unreadable
+    const withTime = labels[1] ?? "";
+    expect(withTime.endsWith(" Show the whole prompt")).toBe(true);
+    expect(withTime.split(" ")[0]).toContain(":"); // the clock still leads the label
+  });
+
   it("emits close and toggleExpand from its header", async () => {
     vi.stubGlobal("fetch", mockFetch({ prompts, truncated: false }));
     const w = mountPane();

--- a/test/src/components/PromptsPane.spec.ts
+++ b/test/src/components/PromptsPane.spec.ts
@@ -193,6 +193,27 @@ describe("PromptsPane", () => {
     expect(w.get('[data-testid="prompt-text"]').classes()).toContain("line-clamp-3");
     await w.get('[data-testid="prompt-row"] button').trigger("click");
     expect(w.get('[data-testid="prompt-text"]').classes()).not.toContain("line-clamp-3");
+    await w.get('[data-testid="prompt-text"]').trigger("click"); // the text closes it again
+    expect(w.get('[data-testid="prompt-text"]').classes()).toContain("line-clamp-3");
+  });
+
+  // The row used to be one <button>, and a browser makes a button's own content unselectable —
+  // so the prompts you wrote could be read and not copied.
+  it("keeps the prompt text outside the button, so it can be selected", async () => {
+    vi.stubGlobal("fetch", mockFetch({ prompts, truncated: false }));
+    const w = mountPane();
+    await flushPromises();
+    expect(w.get('[data-testid="prompt-text"]').element.closest("button")).toBeNull();
+  });
+
+  it("does not collapse the row when the click is the end of a drag-selection", async () => {
+    vi.stubGlobal("fetch", mockFetch({ prompts: [{ at: 1, text: "x".repeat(500) }], truncated: false }));
+    const w = mountPane();
+    await flushPromises();
+    await w.get('[data-testid="prompt-row"] button').trigger("click"); // opened
+    vi.stubGlobal("getSelection", () => ({ isCollapsed: false, toString: () => "xxx" }));
+    await w.get('[data-testid="prompt-text"]').trigger("click");
+    expect(w.get('[data-testid="prompt-text"]').classes()).not.toContain("line-clamp-3"); // still open
   });
 
   it("emits close and toggleExpand from its header", async () => {

--- a/test/src/components/PromptsPane.spec.ts
+++ b/test/src/components/PromptsPane.spec.ts
@@ -206,12 +206,17 @@ describe("PromptsPane", () => {
     expect(w.get('[data-testid="prompt-text"]').element.closest("button")).toBeNull();
   });
 
-  it("does not collapse the row when the click is the end of a drag-selection", async () => {
+  // Whitespace counts: a prompt renders pre-wrap, so its indentation and blank lines are content a
+  // reader can drag across — and reclamping the row would hide what they just selected (Codex, #1806).
+  it.each([
+    ["text", "xxx"],
+    ["whitespace", "   \n  "],
+  ])("does not collapse the row when the click is the end of a drag-selection (%s)", async (_kind, selected) => {
     vi.stubGlobal("fetch", mockFetch({ prompts: [{ at: 1, text: "x".repeat(500) }], truncated: false }));
     const w = mountPane();
     await flushPromises();
     await w.get('[data-testid="prompt-row"] button').trigger("click"); // opened
-    vi.stubGlobal("getSelection", () => ({ isCollapsed: false, toString: () => "xxx" }));
+    vi.stubGlobal("getSelection", () => ({ isCollapsed: false, toString: () => selected }));
     await w.get('[data-testid="prompt-text"]').trigger("click");
     expect(w.get('[data-testid="prompt-text"]').classes()).not.toContain("line-clamp-3"); // still open
   });

--- a/test/src/components/textSelected.spec.ts
+++ b/test/src/components/textSelected.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { isTextSelected } from "../../../src/components/textSelected";
+
+const selection = (text: string, isCollapsed = false) => ({ isCollapsed, toString: () => text });
+
+describe("isTextSelected", () => {
+  it("is true only for a selection that actually holds text", () => {
+    expect(isTextSelected(selection("a prompt"))).toBe(true);
+    expect(isTextSelected(selection("a prompt", true))).toBe(false); // a caret, not a range
+    expect(isTextSelected(selection(""))).toBe(false);
+    expect(isTextSelected(selection("  \n "))).toBe(false); // whitespace is not worth suppressing a click for
+  });
+
+  it("treats no selection at all as no selection", () => {
+    expect(isTextSelected(null)).toBe(false);
+    expect(isTextSelected(undefined)).toBe(false);
+  });
+});

--- a/test/src/components/textSelected.spec.ts
+++ b/test/src/components/textSelected.spec.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { isTextSelected } from "../../../src/components/textSelected";
 
-const selection = (text: string, isCollapsed = false) => ({ isCollapsed, toString: () => text });
-
 describe("isTextSelected", () => {
-  it("is true only for a selection that actually holds text", () => {
-    expect(isTextSelected(selection("a prompt"))).toBe(true);
-    expect(isTextSelected(selection("a prompt", true))).toBe(false); // a caret, not a range
-    expect(isTextSelected(selection(""))).toBe(false);
-    expect(isTextSelected(selection("  \n "))).toBe(false); // whitespace is not worth suppressing a click for
+  // Codex, #1806: what the range CONTAINS is deliberately not part of the rule. A prompt renders
+  // pre-wrap, so indentation and blank lines are draggable content, and reading such a range as
+  // "no selection" reclamped the row over the selection just made.
+  it("is true for a live range and false for a caret", () => {
+    expect(isTextSelected({ isCollapsed: false })).toBe(true);
+    expect(isTextSelected({ isCollapsed: true })).toBe(false); // a plain click leaves this
   });
 
   it("treats no selection at all as no selection", () => {


### PR DESCRIPTION
## Summary

右パネルの Prompts ペインで、自分が送ったプロンプトを**マウスで範囲選択してコピーできなかった**のを直す。

原因はマークアップ。プロンプト1行が丸ごと `<button>` だった（`PromptsPane.vue`）。ブラウザは button の中身を選択不可にする（UA スタイルシートの `user-select: none`）ため、ドラッグしても選択が始まらず、読めるのに写せない状態だった。CSS でもペイン側でもない。

ToolsPane がすでに正しい形をしているので、それに合わせた:

- `<button>` は**見出し行（時刻＋開閉シェブロン）だけ**に縮小。キーボード操作と `aria-expanded` はそのまま維持
- プロンプト本文は button の外の `<p>`（`select-text`）へ。これで普通にドラッグ選択・コピーできる
- 本文クリックでの開閉は残しつつ、**ドラッグ選択を終えたクリックでは畳まない**ガードを追加。これが無いと、選択した直後に行が閉じて選択が消える
- 判定は純関数 `src/components/textSelected.ts`（`isTextSelected`）に切り出し、単体テスト付き

コピー用のボタン等の機能追加はしていない（依頼が「機能としてのコピーではなく通常の範囲選択」だったため）。

## Items to Confirm / Review

- **実ブラウザでの動作確認が未実施**。作業セッションに Playwright / ブラウザ MCP が無く、実際のドラッグ選択を再現できていない。検証はユニットテスト（本文が `<button>` の外にあること、選択中クリックで畳まないこと）＋ jsdom レベルまで。**マージ前に実機で「右パネル → Prompts → プロンプトをドラッグして選択 → コピー」を一度確認してほしい**
- **見た目が少し変わる**: 行の右端に開閉シェブロン（`expand_more` / `expand_less`）が出るようになった。以前は行全体がボタンで、開閉のアフォーダンスが無かった箇所。スクリーンショットは未添付
- **クランプ中の選択**: 折りたたみ時は `line-clamp-3` で3行に切られているが、ドラッグで選択すると DOM 上の全文がコピーされる。実害は無いと判断して手当てしていない
- `isTextSelected` は空白だけの選択を「選択なし」として扱う（誤爆でクリックが効かなくなるのを防ぐため）。この判断でよいか

## 検証

- `test/src/components/PromptsPane.spec.ts`（3件追加）+ `test/src/components/textSelected.spec.ts`（新規）→ 18 件パス
- `yarn format` / `eslint`（変更ファイル）/ `yarn typecheck` グリーン
- 全体テストは未実行（マシンの load average が 20 前後だったため）。CI を ground truth とする

## User Prompt

- 右パネルにユーザプロンプト（自分のプロンプト）の一覧を出せるけれど、普通にコピペしたいのにできない。機能としてのコピーではなく、通常のブラウザの範囲選択ができないので、まずはそれだけ直してほしい
- main からブランチを切って PR を作ってほしい

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt text can now be selected and copied directly.
  * Long prompts can still be expanded or collapsed by clicking the prompt text or header.
  * Active text selections remain intact instead of unintentionally collapsing the prompt.

* **Accessibility**
  * Updated prompt layout and controls to better support text selection and keyboard-friendly interaction.

* **Tests**
  * Added coverage for prompt expansion, text selection, and selection-preserving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->