### PR TITLE
fix: 画面外のセルをリサイズしない — ズーム時の実体のないスクロールバー (#1762)

### DIFF
--- a/plans/fix-1762-phantom-scrollbar.md
+++ b/plans/fix-1762-phantom-scrollbar.md
@@ -1,0 +1,141 @@
+# fix #1762 — ズーム表示のエージェントセルに、実体のないスクロールバーが残る
+
+## 症状（報告 #1762）
+
+ズーム表示（単一セッション表示）にすると、Claude セルの右端にスクロールバーが出る。
+
+1. つまみの高さがチャットの量とまったく連動せず、常に同じ大きさ
+2. ホイールを回すと、つまみがスクロール位置と無関係に飛ぶ
+3. つまみをドラッグしてもチャットは動かない（つまみだけが動く）
+
+報告者は Windows 11 / Chrome / tmux なし。「毎回必ず発生」。
+
+## 原因（確定済み）
+
+alternate screen にはスクロールバックが無いので、本来この位置にスクロールバーは出ない。
+出ているのは、**xterm の viewport がスクロール範囲を古い値と新しい値の混在で作ってしまう**ため。
+
+xterm は画面外に出たセルの描画を止める（`RenderService` の IntersectionObserver → `_isPaused`）。
+停止中に `terminal.resize()` が来ると:
+
+- `BufferService.resize()` は即座に走り、`buffer.lines.length` が新しい行数になる
+- `RenderService.handleResize()` は `_isPaused` を見て**レンダラのリサイズを `_pausedResizeTask` に先送り**する
+  ので、`renderService.dimensions.css.canvas.height` は古い高さのまま
+
+`Viewport._sync()` はこの2つから寸法を作る:
+
+```
+setScrollDimensions({
+  height:      dimensions.css.canvas.height,                    // 古い（ズーム前）
+  scrollHeight: dimensions.css.cell.height * buffer.lines.length // 新しい（ズーム後）
+})
+```
+
+結果、存在しないスクロール範囲ができる。そして `_sync` を呼ぶきっかけは
+`onResize` / `onBufferActivate` / `onScroll` の3つしかなく、alternate buffer では
+全画面 TUI がその場で描き直すだけなので `onScroll` は二度と起きない。
+**一度ずれると、次にリサイズが起きるまで直らない。**
+
+後から IntersectionObserver が「見えた」を配ると `_pausedResizeTask` が flush されて
+レンダラの寸法だけは正しくなるが、viewport を再計算するものは何も無い。
+
+### 3症状がすべてこれで説明できる
+
+1. つまみの比率 = 古い高さ ÷ 新しい高さ。ズーム倍率だけで決まるので、内容と無関係に一定
+2. ホイールは `guardMouseWheel` が正しくエージェントへ転送している。それとは別に
+   vscode 由来の `ScrollableElement` が**同じ wheel イベント**を拾い、実体のない範囲でつまみを動かす
+   （`term.parser` で mouse tracking の DECSET を握りつぶしているため、xterm の
+   `coreMouseService` は「アプリが wheel を欲しがっている」ことを知らず、`handleMouseWheel` を切らない）
+3. ドラッグは実体のない範囲の `scrollTop` を変えるだけ。`_handleScroll` → `scrollLines` は
+   alternate buffer では `ydisp === 0` で即 return するので、何も起きない
+
+### 再現と裏取り
+
+`@xterm/xterm@6.0.0` を本アプリと同じオプションで開き、alternate buffer に入れ、
+「一度 DOM から外して IntersectionObserver に非表示を配らせてから」大きなコンテナに戻して
+fit する、という手順で再現（Playwright / Chromium / macOS）。報告者の実測値と一致した:
+
+| | 報告者 | 再現 |
+|---|---|---|
+| `barClass` | `invisible scrollbar vertical fade` | `invisible scrollbar vertical fade` |
+| `barHeight` | 544 | 544 |
+| `sliderHeight` | 341px | 342px |
+| `screenHeight` | 867 | 864 |
+
+`fade` が付くのは `_isNeeded === true`、すなわち xterm 自身が
+「スクロールバーが必要」と判断しているとき**だけ**なので、これが決め手になった。
+症状2・3も同じ再現環境で確認済み（ホイール: エージェントに1バイト送られる一方でつまみが独立に動く。
+ドラッグ: エージェントへ0バイト、`viewportY` は 0 のまま）。
+
+DOM から外れている時間を 0ms にすると発生しない（IntersectionObserver が非表示を配れないため）。
+**Windows 固有ではなく、タイミングの問題。**
+
+## 本リポジトリ側の引き金
+
+このリポジトリの fit は複数の経路から走る:
+
+- `Terminal.vue` の `ResizeObserver` → `conn.fit`
+- `expanded` の watcher → `nextTick(() => conn.fit)` と `setTimeout(..., FLIP_MS + 30)`
+- `onActivated` → `conn.fit`
+- `attach()` の `fitAndSyncSize` と、その後の `requestAnimationFrame(() => fit(key))`
+
+ズーム時、list mode では `.stage.zoomed.listmode .grid` が `left: -99999px` に移り、
+拡大されるセルは `.zoom-main` へ Teleport される。ロースターから別セッションを拡大した場合、
+そのセルは**直前まで画面外**にあり、`_isPaused === true` のまま `nextTick` の fit が走る。
+IntersectionObserver の配信はフレーム末なので、`_sync` を実行する rAF のほうが先に来る。
+`attach()` 経由（タブ切り替え等で再マウント）でも同じ窓に入りうる。
+
+`FLIP_MS + 30` の遅い fit は、行数がすでに一致しているため `Terminal.resize()` の
+早期 return で no-op になり、修復にならない。
+
+## 直し方
+
+**画面外の間は fit を保留し、戻ってきたときに実行する。**
+
+- 判断のルールだけを純粋関数として `src/composables/terminalFitGate.ts` に置く
+- `useTerminalConnections` は接続ごとに `IntersectionObserver` を1つ持ち、
+  自分が所有する `c.host` を監視する。配信のたびに gate を更新し、
+  保留していた fit があればその場で実行する
+- gate は `fitAndSyncSize()` の中で1か所だけ効かせる。これで
+  `fit` / `attach` / `setFont` / `rebuildTerminal` の全経路が同じ規則に従う
+
+### なぜ「戻ってきたときに実行」で直るのか
+
+配信バッチの中で fit すると、xterm 自身の observer コールバックも同じバッチで走り、
+`_pausedResizeTask.flush()` でレンダラの寸法が追いつく。
+`Viewport` の `_sync` は `addRefreshCallback`（次のフレームの rAF）なので、
+**それが動く時点では寸法が新しくなっている**。observer の登録順に依存しない。
+再現環境でこの修正を入れ、ズームの往復を繰り返しても再発しないことを確認済み。
+
+### 保留して大丈夫な理由
+
+- 新規スロットの gate は `onScreen: true` で始まる（xterm の `_isPaused` も false で始まる）。
+  observer の初回配信より前に走る `attach()` の fit は素通りするので、
+  spawn 時のジオメトリを URL に載せる #1178 の経路は変わらない
+- 画面外のセルの fit を止めると、そのセルは前のサイズを保つ。見えていないので実害は無く、
+  戻ってきた時点で必ず fit される。ズーム時に画面外の 8 セルへ一斉に resize を送らなくなる分、
+  むしろ SIGWINCH の嵐が減る
+- `IntersectionObserver` が無い環境（jsdom）では gate を開けたままにするので、既存の挙動のまま
+
+## 変更するファイル
+
+- `src/composables/terminalFitGate.ts`（新規・純粋関数）
+- `src/composables/useTerminalConnections.ts`（observer と gate の配線）
+- `test/src/composables/terminalFitGate.spec.ts`（新規・ルールの網羅テスト）
+- `test/src/composables/terminalFitDeferred.spec.ts`（新規・実配線のテスト）
+- `plans/fix-1762-phantom-scrollbar.md`（本ファイル）
+
+## 検証
+
+1. `yarn format` → `yarn lint` → `yarn build` → `yarn typecheck` → `yarn test`
+2. 実機確認（負荷が落ちてから）: `yarn dev` を起動し、
+   - ロースターから別セッションを拡大 → スクロールバーが出ないこと
+   - ズームの往復を繰り返しても出ないこと
+   - 通常バッファ（shell セル）ではスクロールバーが従来どおり出て、ドラッグで動くこと
+   - ズーム後にエージェントへホイールが届くこと（従来どおり）
+   - スクリーンショットを証跡として残す
+
+## 上流
+
+xterm.js 側の欠陥でもある（停止中のリサイズを先送りしたあと、viewport を再同期しない）。
+本リポジトリの修正とは別に issue を立てる。

--- a/src/composables/terminalFitGate.ts
+++ b/src/composables/terminalFitGate.ts
@@ -1,0 +1,43 @@
+// When a terminal may be fitted to its host, and what to do with a fit that arrives while it
+// cannot be.
+//
+// xterm PAUSES its renderer while the terminal is off screen (an IntersectionObserver of its own).
+// A resize that lands while it is paused takes effect on the buffer immediately but DEFERS the
+// renderer's dimensions, and xterm's viewport then builds its scroll range out of one of each: the
+// canvas height it had before, over the line count it has now. In the alternate buffer nothing
+// re-syncs that — a full-screen TUI repaints in place and never scrolls, so the `onScroll` that
+// would recompute it never fires — which leaves an agent cell with a scrollbar for scrollback it
+// does not have, a slider that tracks nothing and a drag that moves nothing (#1762).
+//
+// So a fit waits for the terminal to be on screen. This file is the rule alone; the observer that
+// feeds it lives in useTerminalConnections.
+
+export interface FitGate {
+  /** The last on-screen state the observer DELIVERED. Starts true because xterm's own pause flag
+   *  starts false: before either observer has delivered anything the two agree, so the fit that
+   *  attach() does before connect() (#1178) still runs. */
+  readonly onScreen: boolean;
+  /** A fit was asked for while off screen and is owed. One flag rather than a count: a fit reads
+   *  the host's CURRENT size, so replaying two of them is replaying the same one twice. */
+  readonly owed: boolean;
+}
+
+export const initialFitGate: FitGate = { onScreen: true, owed: false };
+
+export interface FitGateStep {
+  readonly gate: FitGate;
+  /** Whether the caller should fit now. */
+  readonly fit: boolean;
+}
+
+/** Ask to fit. Off screen the request is remembered instead, for reportOnScreen to release. */
+export function requestFit(gate: FitGate): FitGateStep {
+  if (!gate.onScreen) return { gate: { onScreen: false, owed: true }, fit: false };
+  return { gate: { onScreen: true, owed: false }, fit: true };
+}
+
+/** Record what the observer delivered. `fit` is true when a held-back fit is now due. */
+export function reportOnScreen(gate: FitGate, onScreen: boolean): FitGateStep {
+  if (!onScreen) return { gate: { onScreen: false, owed: gate.owed }, fit: false };
+  return { gate: { onScreen: true, owed: false }, fit: gate.owed };
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -36,6 +36,7 @@ import { getTerminalScrollSpeed } from "./useTerminalScrollSpeed";
 import { scrollsToBottomOnSubmit } from "./useScrollToBottomOnSubmit";
 import { isTypedInput } from "./terminalUserInput";
 import { bufferIsShort, readBufferShape } from "./terminalBufferHealth";
+import { initialFitGate, reportOnScreen, requestFit, type FitGate } from "./terminalFitGate";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
 import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
@@ -170,6 +171,13 @@ interface Conn {
   // -Infinity rather than 0 so "never notified" outlasts any cooldown: a spec that stubs Date.now
   // to a small number would otherwise lose the FIRST banner and still read as passing.
   lastDroppedInputNoticeMs: number;
+  // Whether the terminal is on screen, and whether a fit is owed because it was not — see
+  // terminalFitGate for what a resize costs when xterm has the renderer paused (#1762).
+  fitGate: FitGate;
+  // What answers that question. Re-pointed whenever `host` is replaced, which is the rebuild
+  // (#846) — an observer left on the dead host would report the state of an element nothing
+  // renders into.
+  onScreenObserver: IntersectionObserver | null;
 }
 
 // The banner is re-armed on a timer rather than shown once per stretch, because a stretch has no
@@ -204,6 +212,13 @@ const conns = new Map<string, Conn>();
 // bottom. The fit() can throw when the host isn't laid out yet — the caller's
 // ResizeObserver fit() then follows — so it's swallowed.
 function fitAndSyncSize(c: Conn): void {
+  const step = requestFit(c.fitGate);
+  c.fitGate = step.gate;
+  // Off screen, xterm has its renderer paused: the new row count would reach the buffer while the
+  // renderer's dimensions stayed behind, and the scroll range built from one of each has nothing
+  // to correct it in the alternate buffer (#1762). watchOnScreen replays this when the cell is
+  // back — which is also when the size it should fit to is the one it will keep.
+  if (!step.fit) return;
   try {
     c.fitAddon.fit();
   } catch {
@@ -211,6 +226,35 @@ function fitAndSyncSize(c: Conn): void {
   }
   if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
   c.term.scrollToBottom();
+}
+
+// Feed the gate above. `host` rather than xterm's own `.xterm-screen`: it is the element this
+// module owns and it fills the cell, so the two observers answer to the same geometry without
+// this depending on xterm's DOM.
+//
+// Fitting from inside the delivery is what makes the repair work, and it does not depend on which
+// observer runs first: xterm's callback lands in the SAME batch, so `_pausedResizeTask` has
+// flushed by the time the viewport's own sync runs (it is scheduled a frame later, via
+// addRefreshCallback).
+function watchOnScreen(c: Conn): void {
+  c.onScreenObserver?.disconnect();
+  c.onScreenObserver = null;
+  // jsdom and older embedders have no IntersectionObserver; the gate then stays open and every
+  // fit runs exactly as it did before.
+  if (typeof IntersectionObserver === "undefined") return;
+  const observer = new IntersectionObserver(
+    (entries) => {
+      // The last entry is the current state; earlier ones are the transitions it coalesced.
+      const latest = entries.at(-1);
+      if (!latest) return;
+      const step = reportOnScreen(c.fitGate, latest.isIntersecting);
+      c.fitGate = step.gate;
+      if (step.fit) fit(c.key);
+    },
+    { threshold: 0 },
+  );
+  observer.observe(c.host);
+  c.onScreenObserver = observer;
 }
 
 // The reactive projection the view binds to (status pill, RunMenu cwd). Keyed by
@@ -508,10 +552,13 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     lastRebuildMs: 0,
     warnedDroppedInput: false,
     lastDroppedInputNoticeMs: Number.NEGATIVE_INFINITY,
+    fitGate: initialFitGate,
+    onScreenObserver: null,
   };
   conns.set(key, c);
   connView.set(key, { status: "connecting", serverCwd: target.cwd });
   wireTerminalToConn(term, c);
+  watchOnScreen(c);
   return c;
 }
 
@@ -532,6 +579,7 @@ function rebuildTerminal(c: Conn): void {
   c.wheel = wheel;
   c.lastRebuildMs = Date.now();
   wireTerminalToConn(term, c);
+  watchOnScreen(c);
   c.attachedEl?.appendChild(host);
   deadHost.remove();
   deadTerm.dispose();
@@ -707,8 +755,11 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   // before it, not after.
   if (!sameFont(c.font, font)) applyFont(c, font);
   // Fit BEFORE connecting, not after: connect() puts the terminal's geometry on the URL so the pty
-  // is spawned at it, and an unfitted terminal would send xterm's 80x24 default there (#1178). For
-  // an already-live slot this is the same sync it always was — the send is a no-op until OPEN.
+  // is spawned at it, and an unfitted terminal would send xterm's 80x24 default there (#1178). A
+  // slot created here has never been observed, so its gate is still open and this runs — what the
+  // gate holds back is the RE-PARENT of a live slot onto a host that is not on screen yet, which
+  // is the one that strands a scrollbar (#1762); the observer replays it. The send is a no-op
+  // until OPEN either way.
   fitAndSyncSize(c);
   if (created || inherited) connect(c);
   c.term.focus();
@@ -762,6 +813,8 @@ export function release(key: string) {
     // already closing
   }
   c.ws = null;
+  c.onScreenObserver?.disconnect();
+  c.onScreenObserver = null;
   try {
     c.host.remove();
   } catch {

--- a/test/src/composables/terminalFitDeferred.spec.ts
+++ b/test/src/composables/terminalFitDeferred.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Same doubles as the sibling connection specs (test/helpers/xtermDouble.ts); see the note there
+// about why the mock factories import themselves.
+const { termState: mockTermState, keyState: mockKeyState } = await vi.hoisted(async () => (await import("../../helpers/xtermDouble")).createXtermState());
+
+vi.mock("@xterm/xterm", async () => (await import("../../helpers/xtermDouble")).xtermModule(mockTermState, mockKeyState));
+vi.mock("@xterm/addon-fit", async () => (await import("../../helpers/xtermDouble")).fitAddonModule());
+vi.mock("@xterm/addon-web-links", async () => (await import("../../helpers/xtermDouble")).webLinksAddonModule());
+vi.mock("@xterm/addon-clipboard", async () => (await import("../../helpers/xtermDouble")).clipboardAddonModule());
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+import * as conn from "../../../src/composables/useTerminalConnections";
+import { FakeWebSocket } from "../../helpers/xtermDouble";
+
+// A fit that lands while the cell is off screen is what strands a scrollbar in an agent cell
+// (#1762): xterm has the renderer paused there, so the resize reaches the buffer while the
+// renderer's dimensions stay behind, and in the alternate buffer nothing recomputes the viewport
+// afterwards. The manager therefore holds the fit until the cell is back — the RULE is covered in
+// terminalFitGate.spec; what this file pins is that the manager is actually wired to it, since
+// jsdom has no IntersectionObserver of its own and a missing observer would look identical to a
+// working one on every other spec.
+
+const KEY = "cell-fit-gate";
+const target = { sessionId: null, cwd: "/w", devTerminal: false, command: null, launcher: null };
+const resizeFrames = (ws: FakeWebSocket) => ws.sent.map((s) => JSON.parse(s)).filter((m) => m.type === "resize");
+
+// What a browser would deliver, in the manager's own hands. Module state rather than instance
+// state because the manager builds the observer itself: a test never holds the instance.
+let deliverToManager: ((isIntersecting: boolean) => void) | null = null;
+let observedElements: Element[] = [];
+let stoppedWatching = false;
+
+class IntersectionObserverStub {
+  constructor(callback: (entries: { isIntersecting: boolean }[]) => void) {
+    deliverToManager = (isIntersecting) => callback([{ isIntersecting }]);
+    observedElements = [];
+    stoppedWatching = false;
+  }
+  observe(el: Element) {
+    observedElements.push(el);
+  }
+  disconnect() {
+    stoppedWatching = true;
+  }
+  unobserve() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+const deliver = (isIntersecting: boolean): void => {
+  if (!deliverToManager) throw new Error("the manager never observed the terminal");
+  deliverToManager(isIntersecting);
+};
+
+const socket = (): FakeWebSocket => {
+  const ws = FakeWebSocket.instances.at(-1);
+  if (!ws) throw new Error("no socket created");
+  return ws;
+};
+
+describe("fit while the terminal is off screen", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances.length = 0;
+    deliverToManager = null;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    globalThis.IntersectionObserver = IntersectionObserverStub as unknown as typeof IntersectionObserver;
+  });
+  afterEach(() => {
+    conn.release(KEY);
+    Reflect.deleteProperty(globalThis, "IntersectionObserver");
+  });
+
+  it("watches the host it owns", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    expect(observedElements).toEqual([el.firstElementChild]);
+  });
+
+  it("fits before the observer has reported anything", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    socket().sent.length = 0;
+
+    conn.fit(KEY);
+
+    // Only a delivery can close the gate. One that started closed would hold back the fit attach()
+    // does before connect(), and the pty would be spawned at xterm's 80x24 (#1178).
+    expect(resizeFrames(socket())).toHaveLength(1);
+  });
+
+  it("does not resize the pty while the cell is off screen", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    deliver(false);
+    socket().sent.length = 0;
+
+    conn.fit(KEY);
+    conn.fit(KEY);
+
+    expect(resizeFrames(socket())).toHaveLength(0);
+  });
+
+  it("runs the held-back fit once the cell is back on screen", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    deliver(false);
+    conn.fit(KEY);
+    conn.fit(KEY);
+    socket().sent.length = 0;
+
+    deliver(true);
+
+    expect(resizeFrames(socket())).toHaveLength(1);
+  });
+
+  it("does not fit on a return that nothing was waiting for", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    deliver(false);
+    deliver(true);
+    socket().sent.length = 0;
+
+    deliver(true);
+
+    expect(resizeFrames(socket())).toHaveLength(0);
+  });
+
+  it("fits normally again once the cell is back", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    deliver(false);
+    deliver(true);
+    socket().sent.length = 0;
+
+    conn.fit(KEY);
+
+    expect(resizeFrames(socket())).toHaveLength(1);
+  });
+
+  it("stops watching when the slot is torn down", () => {
+    const el = document.createElement("div");
+    conn.attach(KEY, target, {}, el);
+    conn.release(KEY);
+    expect(stoppedWatching).toBe(true);
+  });
+});

--- a/test/src/composables/terminalFitGate.spec.ts
+++ b/test/src/composables/terminalFitGate.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { initialFitGate, reportOnScreen, requestFit, type FitGate } from "../../../src/composables/terminalFitGate";
+
+// The rule behind #1762: a terminal xterm has paused (because it is off screen) must not be
+// resized, or its viewport keeps a scroll range built from the height it had and the line count it
+// has — which in the alternate buffer nothing ever recomputes.
+
+const offScreen: FitGate = { onScreen: false, owed: false };
+
+describe("terminal fit gate", () => {
+  it("starts open, so the fit attach() does before connect() still runs", () => {
+    expect(initialFitGate.onScreen).toBe(true);
+    expect(requestFit(initialFitGate).fit).toBe(true);
+  });
+
+  it("fits while on screen and owes nothing", () => {
+    const step = requestFit({ onScreen: true, owed: false });
+    expect(step).toEqual({ gate: { onScreen: true, owed: false }, fit: true });
+  });
+
+  it("holds a fit back while off screen and remembers it", () => {
+    const step = requestFit(offScreen);
+    expect(step).toEqual({ gate: { onScreen: false, owed: true }, fit: false });
+  });
+
+  it("collapses repeated off-screen requests into the one fit that is owed", () => {
+    const once = requestFit(offScreen);
+    const twice = requestFit(once.gate);
+    const thrice = requestFit(twice.gate);
+    expect(thrice.fit).toBe(false);
+    expect(thrice.gate).toEqual({ onScreen: false, owed: true });
+    // …and coming back pays it exactly once.
+    const back = reportOnScreen(thrice.gate, true);
+    expect(back.fit).toBe(true);
+    expect(reportOnScreen(back.gate, true).fit).toBe(false);
+  });
+
+  it("runs the held-back fit when the terminal comes back on screen", () => {
+    const held = requestFit(offScreen).gate;
+    expect(reportOnScreen(held, true)).toEqual({ gate: { onScreen: true, owed: false }, fit: true });
+  });
+
+  it("does not fit on a return that nothing was waiting for", () => {
+    expect(reportOnScreen(offScreen, true)).toEqual({ gate: { onScreen: true, owed: false }, fit: false });
+  });
+
+  it("never fits on the way off screen, and keeps a debt across the trip", () => {
+    const held = requestFit(offScreen).gate;
+    const away = reportOnScreen(held, false);
+    expect(away).toEqual({ gate: { onScreen: false, owed: true }, fit: false });
+    expect(reportOnScreen({ onScreen: true, owed: false }, false)).toEqual({ gate: { onScreen: false, owed: false }, fit: false });
+  });
+
+  it("clears a stale debt when a fit is admitted", () => {
+    // Not reachable through the two functions (a debt is only taken on while off screen), but the
+    // gate is a plain value a caller could hand back — an admitted fit settles whatever was owed.
+    expect(requestFit({ onScreen: true, owed: true })).toEqual({ gate: { onScreen: true, owed: false }, fit: true });
+  });
+
+  it("leaves the gate it was given untouched", () => {
+    const gate: FitGate = { onScreen: false, owed: false };
+    requestFit(gate);
+    reportOnScreen(gate, true);
+    expect(gate).toEqual({ onScreen: false, owed: false });
+  });
+
+  it("stays put under a repeated report of the same state", () => {
+    const on = reportOnScreen(initialFitGate, true);
+    expect(on).toEqual({ gate: { onScreen: true, owed: false }, fit: false });
+    const off = reportOnScreen(offScreen, false);
+    expect(off).toEqual({ gate: { onScreen: false, owed: false }, fit: false });
+  });
+});


### PR DESCRIPTION
## Summary

ズーム表示のエージェントセルに、**実体のないスクロールバー**が出て消えなくなる不具合を直します（#1762）。

xterm は画面外にあるセルの描画を停止します（`RenderService` の IntersectionObserver → `_isPaused`）。停止中にリサイズが届くと、**行数はその場で更新される一方、レンダラの寸法の更新は先送りされます**。`Viewport._sync()` はこの2つからスクロール範囲を作るため、

- 表示領域の高さ = **ズーム前**の canvas 高さ
- スクロール可能な全長 = `cell.height × 新しい行数`

という組み合わせになり、存在しないスクロール範囲ができます。`_sync` を呼ぶきっかけは `onResize` / `onBufferActivate` / `onScroll` の3つだけで、alternate buffer では全画面 TUI がその場で描き直すだけなので `onScroll` は二度と起きません。**一度ずれると、次のリサイズまで直りません。**

引き金は本リポジトリ側にあります。**ロースターから別セッションを拡大する**と必ず踏みます — そのセルは直前まで `left: -99999px` に置かれており、`expanded` watcher の `nextTick` fit が IntersectionObserver の配信（フレーム末）より先に走るためです。`FLIP_MS + 30` の遅い fit は行数が一致していて `Terminal.resize()` の早期 return に当たるので、修復になりません。

**直し方**: 画面外の間は fit を保留し、画面に戻った配信の中で実行します。判断ルールは純粋関数 `src/composables/terminalFitGate.ts` に切り出しました。配信の中で fit すれば xterm 自身のコールバックも同じバッチで走るため、`_pausedResizeTask` が flush され、viewport の同期（`addRefreshCallback` で次フレーム）までに寸法が追いつきます。**observer の登録順には依存しません。**

設計と再現の詳細は [`plans/fix-1762-phantom-scrollbar.md`](plans/fix-1762-phantom-scrollbar.md)。

## Items to Confirm / Review

1. **ゲートを `fitAndSyncSize()` の1か所に置いた判断** — これで `fit` / `attach` / `setFont` / `rebuildTerminal` の全経路が同じ規則に従います。新規スロットの gate は `onScreen: true` で始まる（xterm の `_isPaused` も false で始まる）ので、`attach()` が `connect()` の前に行う fit は素通りし、spawn ジオメトリを URL に載せる #1178 の経路は変わりません。ここが崩れると #1178 の再発です。
2. **監視対象を `c.host` にした点** — xterm は `.xterm-screen` を見ていますが、host はこのモジュールが所有する要素でセルを埋めるので、同じジオメトリに答えます。xterm の DOM 構造に依存しないための選択です。
3. **`typeof IntersectionObserver === "undefined"` のガード** — jsdom には無いので、そこでは gate が開いたままとなり従来どおりの挙動になります（`useCanvasCardHeight` の ResizeObserver と同じ前例）。
4. **画面外のセルは fit を保留する**、という挙動変更そのもの。実測では差は出ませんでした（下記）が、意図的な変更なので目を通してください。
5. 上流（xterm.js）の欠陥でもあります: 停止中のリサイズを先送りしたあと、viewport を再同期しません。別途 issue を立てる予定です。

## 検証

### 最小再現（`@xterm/xterm@6.0.0`、本アプリと同じオプション）

報告者の実測値と一致しました。`fade` が付くのは xterm 自身が「スクロールバーが必要」と判断しているときだけなので、これが決め手でした。

| | 報告者 | 再現 |
|---|---|---|
| `barClass` | `invisible scrollbar vertical fade` | `invisible scrollbar vertical fade` |
| `barHeight` | 544 | 544 |
| `sliderHeight` | 341px | 342px |
| `screenHeight` | 867 | 864 |

3症状すべて再現: ホイールはエージェントに届く（1バイト送信）一方でつまみが独立に動く／ドラッグではエージェントへ0バイト、`viewportY` は 0 のまま。

### 実機（`yarn dev` + Playwright、alternate screen の `vim` を入れたセル）

| 状態 | 修正なし | 修正あり |
|---|---|---|
| ロースターからセル2を拡大 | **bar=510 slider=300px screen=867**（`fade` 付き） | 867 / 867 / 867 |
| セル1へ戻す | **同じまま残る** | 867 / 867 / 867 |

tmux あり・なしの両方で確認（報告者は tmux 未使用）。

### 副作用の確認

200文字の行を出力し、xterm がリサイズのたびに折り返す幅＝**PTY に伝わったサイズ**を全状態で比較しました。**修正あり／なしで完全に一致**します。

| | 修正なし | 修正あり |
|---|---|---|
| タイル表示 | 92 / 92 | 92 / 92 |
| セル1をズーム（セル2は待避） | 150 / 109 | 150 / 109 |
| ロースターからセル2を拡大 | 41 / 150 | 41 / 150 |
| タイル表示に戻す | 92 / 58 | 92 / 58 |

理由: この gate と xterm の停止フラグは同じ要素の同じ配信で動くため、常に一致します。画面外へ**出ていく**ときの fit は（配信前なので）従来どおり走り、xterm 側も停止前なのでレンダラを即座にリサイズします。保留がかかるのは画面外**から戻る**ケースだけです。

スクロールバックが実在する通常バッファの挙動も、修正あり／なしで一致（bar 544/slider 61px → bar 864/slider 155px、いずれも比率どおり）。

### テスト

- `test/src/composables/terminalFitGate.spec.ts` — ルールの網羅（10件）
- `test/src/composables/terminalFitDeferred.spec.ts` — 実配線（7件）。jsdom には IntersectionObserver が無く、observer の付け忘れが他のテストと見分けられないため、スタブを注入して実際の配線を駆動しています
- **ゲートを外すと配線テスト2件が落ちる**ことを確認済み（テストが素通りしないことの確認）

`yarn format` / `lint` / `build` / `typecheck` / `test`（10788 passed）すべて green。

## User Prompt

- ユーザからフィードバックがあった: https://github.com/receptron/mulmoterminal/issues/1762
- 修正できるの？副作用ない？ないならすすめたい

Closes #1762

work in mulmoterminal5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed phantom scrollbars that could appear in zoomed terminal cells.
  * Terminal resizing now waits until the terminal is visible, then automatically applies the deferred resize.
  * Improved terminal behavior when moving cells off-screen and back into view.
  * Prevented unnecessary repeated resizing and ensured proper cleanup when terminals are released.

* **Tests**
  * Added coverage for off-screen resizing, viewport visibility changes, deferred updates, and observer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->