### PR TITLE
fix(shared app): uidField に版を割り当てない（sharedapp 0.18.0）

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.17.0",
+    "@receptron/sharedapp": "^0.18.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/plans/feat-shared-app-uid-identity.md
+++ b/plans/feat-shared-app-uid-identity.md
@@ -229,7 +229,7 @@ uid の箱を描いて全部拒否される」というのが根拠だったが�
 実測した。todo-board テンプレートを実際に投影し（sharedapp 0.17.0 + MT の `publicFormOf`）、
 `protocol` を `"1.0.0"` に書き換えて mulmoserver #216 **以前**の `publicConfigFrom` に食わせた:
 
-```
+```text
 OLD READER REFUSED: UnsupportedProjection - this app was published in a shape this release does not read
 CONTROL（createFields から uid を抜いたもの）: drawn
 ```
@@ -260,7 +260,7 @@ CONTROL（createFields から uid を抜いたもの）: drawn
 黙って落として、uid が誰にも束縛されていない板を公開してしまうのを floor が止める）」と書いた。
 **これも間違いだった。** キー導入前のビルド（`cd37037^`）に uid の `app.json` を食わせて実測した:
 
-```
+```text
 --- floor 宣言なし:   REFUSED   public.submit.claims: Unrecognized key: "uidField"
 --- floor 1.1.0 あり: REFUSED   public.submit.claims: Unrecognized key: "uidField"
 ```
@@ -282,8 +282,13 @@ floor は何も買っていなかった。
 文書の中にある。** 導出元の隣に導出結果を書いても、情報は 1 ビットも増えない。
 
 **決定: `uidField` に版を割り当てない。** `APP_PROTOCOL = "1.0.0"` の 1 定数に戻し、
-`UID_FIELD_PROTOCOL` / `protocolFor` / `protocolFloorProblems` を削除する。著者に
-`protocol` を書かせるのもやめる（払い損の摩擦）。
+`UID_FIELD_PROTOCOL` / `protocolFor` / `protocolFloorProblems` を削除する。
+
+消えるのは **uid 専用の floor 要求**（`uidField` を使うなら `protocol` を上げて宣言しろ）
+だけである。**`app.json` の `protocol` そのものは残る** —— 全テンプレートが宣言している
+`"1.0.0"` は据え置きで、todo-board もそれに揃える（`skillTemplates.spec.ts` が全テンプレートを
+`APP_PROTOCOL` と突き合わせて固定する）。宣言をやめるのではなく、**機能ごとに違う番号を
+書かせるのをやめる**、が正確な言い方である。
 
 **版の仕組み自体は残す。** キーの**追加**は strict なスキーマが fail-closed にするが、
 **既存キーの意味が動く**変更は未知のキーが無いので、スキーマには見えない。そのときだけ

--- a/plans/feat-shared-app-uid-identity.md
+++ b/plans/feat-shared-app-uid-identity.md
@@ -174,6 +174,10 @@ deploy したらこの節に日付を書き足すこと。
 
 ## U8 — reader が知らないキーである、という別種の非互換（版は**アプリごと**に決まる）
 
+> **この節の結論（MAJOR = 2.0.0）は U10 で覆した。** 2.0.0 → 1.1.0 → **版を割り当てない**、
+> と 2 段階で降りている。宣言ごとに刻印を決める仕組み（`protocolFor`）も一緒に消えた。
+> ここは経緯として残す。結論は U10。
+
 sharedapp を書いていて出てきた、rules だけ見ていたときには無かった話。
 
 公開ページは `emailField` の欄を**セッションから埋め、フォームには描かない**。`uidField` も同じ
@@ -214,6 +218,84 @@ rules → sharedapp → **mulmoserver client** → MT になる理由でもあ�
   伸びていて、新しい引数は任意 = **更新していないホストは黙って箱を描き続ける**。
   更新していないホストは**コンパイルで落ちるべき**である。MT の 2 箇所（`previewWrite.ts` と
   `preview.ts`）はこの変更で直す必要がある。
+
+## U10 — 版そのものが要らなかった（`1.0.0` のまま）
+
+4 本すべてマージしたあとに出た問い —— この段階で major を使うのは重すぎないか。調べ直したら、
+**U8 の前提そのものが間違っていた**。「minor はどの reader も反応しない番号だから、古いタブは
+uid の箱を描いて全部拒否される」というのが根拠だったが、**古いタブはそもそもこのアプリを
+描かない**。
+
+実測した。todo-board テンプレートを実際に投影し（sharedapp 0.17.0 + MT の `publicFormOf`）、
+`protocol` を `"1.0.0"` に書き換えて mulmoserver #216 **以前**の `publicConfigFrom` に食わせた:
+
+```
+OLD READER REFUSED: UnsupportedProjection - this app was published in a shape this release does not read
+CONTROL（createFields から uid を抜いたもの）: drawn
+```
+
+偶然ではなく構造的で、三つが同時に成り立つから起きる:
+
+- ルールは `request.resource.data.keys().hasOnly(createFields)` しか受け付けない
+  → uid は **`createFields` に必ず入る**（入っていない宣言は publish が拒否する）
+- 描かないことが機能そのもの → uid は **`form.fields` に絶対に入らない**
+- `publicFormOf` は描く欄がゼロでもコレクションの form エントリを残す
+  → `consistent` の「form に無い cid は素通し」に**逃げない**
+
+古い `agrees` が「ホストが埋めるから描かれなくてよい」と数えるのは email / status / stamp の
+**3 つだけ**なので、`uid` が残って整合検査に落ちる。**major が買う画面を、major より 1 世代前の
+検査が既に出していた。**
+
+**major が余分に覆う面が 1 つだけある。** member / participant のティア設定は `submit` を運ぶが
+`form` を運ばないので、突き合わせる相手がいない（`memberViewChoice` は `protocolDrawable` でしか
+拒否しない）。古いビルドは uid アプリの `/m/{slug}` を描いてしまう。ただし書き込みは `uidOk` /
+`uidHeld` が拒否し、own スコープの読みは `where(uidField, "==", uid)` を付けられないので
+ルールが拒否する —— **押しても効かないボタンが名簿の人に見えるだけ**で、uid の偽装も漏れもない。
+見るのは owner が入れた既知の人だけで、見知らぬ人が来る公開ページは構造的に拒否される。
+全 uid アプリを全ての古いリーダーで永久に拒否させる対価としては高い、と判断した。
+
+### では minor は要るのか —— 要らなかった
+
+ここで一度 `1.1.0` に落とし、「番号が効いているのは**書く側**（古い publisher が `uidField` を
+黙って落として、uid が誰にも束縛されていない板を公開してしまうのを floor が止める）」と書いた。
+**これも間違いだった。** キー導入前のビルド（`cd37037^`）に uid の `app.json` を食わせて実測した:
+
+```
+--- floor 宣言なし:   REFUSED   public.submit.claims: Unrecognized key: "uidField"
+--- floor 1.1.0 あり: REFUSED   public.submit.claims: Unrecognized key: "uidField"
+```
+
+`SubmitZ` は `.strict()` である。**知らないキーはスキーマで落ちる**し、その検査は
+`protocolProblems` より**先**に走るので、floor を宣言してもしなくても結果もメッセージも同じ。
+floor は何も買っていなかった。
+
+版を読む相手を数え直すと、4 系統すべてが 1.0.0 と 1.1.0 を区別しない:
+
+| 見る相手 | 差 |
+|---|---|
+| 読む側の門 `protocolDrawable` | major しか見ない → 同じ |
+| 読む側の分岐 `protocolAtLeast` | 分岐が 1 つも無い → 同じ |
+| 著者の floor `protocolProblems` | 知らないキーには走らない（上） → 同じ |
+| 人・診断 | `submit.<cid>.uidField` が刻印の 3 行隣に載っている → 同じ |
+
+最後の 1 行が、この件のいちばん効く指摘だと思う。**刻印は宣言から導かれる値で、その宣言は同じ
+文書の中にある。** 導出元の隣に導出結果を書いても、情報は 1 ビットも増えない。
+
+**決定: `uidField` に版を割り当てない。** `APP_PROTOCOL = "1.0.0"` の 1 定数に戻し、
+`UID_FIELD_PROTOCOL` / `protocolFor` / `protocolFloorProblems` を削除する。著者に
+`protocol` を書かせるのもやめる（払い損の摩擦）。
+
+**版の仕組み自体は残す。** キーの**追加**は strict なスキーマが fail-closed にするが、
+**既存キーの意味が動く**変更は未知のキーが無いので、スキーマには見えない。そのときだけ
+`protocolProblems`（ceiling を超える floor の拒否）と major が要る。
+
+**出す順は U8 と逆**（リーダーが**最後**）: sharedapp 0.18.0 の publish → MulmoTerminal →
+mulmoserver。`2.0.0` で publish されたアプリは存在しない（uid アプリはまだ作られておらず、
+ホストも再ビルド前）ので、無傷で回収できた。
+
+**この判断が乗っている不変条件はテストで固定した**（`test/server/backends/publicForm.spec.ts`）。
+uid が `createFields` にあって投影フォームに無いことが崩れると、古いリーダーは黙って描き始める
+—— 番号は何も守っていないので、崩れたことに気づく手段が他に無い。
 
 ## やり残し
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -553,10 +553,9 @@ Every line of that is load-bearing, and publish refuses the declaration without 
 - **`uidField` is the same binding without an address** — the field the rules compare with the
   submitter's own uid. Reach for it when the DOCUMENT ID is already spent on exclusivity (a claim
   whose id is the task's) AND the rows are shown to people: publishing a row publishes every field
-  in it, so an `emailField` board hands out addresses and a `uidField` board does not. It costs two
-  things — an app declaring it needs `"protocol": "2.0.0"` at the top of `app.json` (older readers
-  refuse to draw the app rather than drawing a form nobody can submit), and the uid is FROZEN after
-  create, so a row is given back and retaken rather than reassigned. Like the address, it goes in
+  in it, so an `emailField` board hands out addresses and a `uidField` board does not. It costs one
+  thing: the uid is FROZEN after create, so a row is given back and retaken rather than reassigned
+  (nobody, the owner included, can type somebody else's uid into it). Like the address, it goes in
   `createFields` and is never drawn: the page fills it from the session. See
   [templates/todo-board.md](./templates/todo-board.md).
 - **`submitOnly: true` is required** whenever the submission binds a record to its submitter. The

--- a/server/skills/mulmoterminal-shared-app/templates/todo-board.md
+++ b/server/skills/mulmoterminal-shared-app/templates/todo-board.md
@@ -46,7 +46,7 @@
   "aid": "(init が書きます。手で触らないこと)",
   "name": "今週の作業",
   "slug": "team-todo",
-  "protocol": "2.0.0",
+  "protocol": "1.0.0",
   "members": {
     "owner@example.com": { "*": "owner" }
   },
@@ -84,10 +84,12 @@
 }
 ```
 
-**`protocol: "2.0.0"` は省略できません。** `uidField` はページ側が理解していないと動かない
-キーで（uid はセッションから埋め、フォームには描かない）、宣言が無いと publish が拒否します。
-古いブラウザのタブは、このアプリを**描かずに「読めません」と言います** — それが正しい壊れ方で、
-「uid を入力してください」という箱を描いて全部拒否されるよりずっとよい。
+**`protocol` は他のテンプレートと同じ `"1.0.0"` のままです。** `uidField` に専用の版は
+ありません。古いビルドは、このキーを知らなければ宣言の検査で `Unrecognized key: "uidField"` と
+言って止まりますし、古いブラウザのタブは `submit` と `form` の整合検査で落ちて、このアプリを
+**描かずに「読めません」と言います**（uid は `createFields` にあってフォームには無いので、
+その組み合わせが拒否されます）。それが正しい壊れ方で、「uid を入力してください」という箱を
+描いて全部拒否されるよりずっとよい。
 
 **`uid` は `createFields` に入り、しかしフォームには絶対に描かれません。** 入っているのは
 ルールが「createFields の外のキーは拒否」するからで、埋めるのはページです。あなたが書く
@@ -318,9 +320,9 @@
 1. `manageSharedApp` の `init`（名前と slug）。
 2. `.claude/skills/tasks/` と `.claude/skills/claims/` に `SKILL.md` と `schema.json` を書く
    （`storage: {"type":"firestore"}`）。
-3. `app.json` に上の宣言を書く。**`protocol: "2.0.0"` を忘れないこと。**
+3. `app.json` に上の宣言を書く。
 4. `check` — `uidField` がスキーマに実在するか、`createFields` に入っているか、`selfUpdate` に
-   入っていないか、`protocol` の floor が足りているかを、ここが全部見ます。
+   入っていないかを、ここが全部見ます。
 5. `preview` — 実ブラウザでページを走らせる。既定では**何も書かない**ので、押下が
    ルールに通るかは `confirm: true` を渡したときだけ分かります（実レコードを書きます）。
 6. `publish`。板の URL は `/a/{slug}`、受付は `/m/{slug}`。

--- a/test/server/backends/publicForm.spec.ts
+++ b/test/server/backends/publicForm.spec.ts
@@ -187,6 +187,30 @@ describe("the field the page takes from the session rather than asks", () => {
     expect(Object.keys(publicFormOf(claimed, withUid).responses?.fields ?? {})).toEqual(["name"]);
   });
 
+  it("stays a shape a reader that never learnt uidField refuses outright", () => {
+    // THIS IS WHAT THE VERSION NUMBER IS NOT DOING. `uidField` ships under no version of its own —
+    // the contract stays 1.0.0 — so nothing in the document tells an older build to stand back. It
+    // stands back anyway, on the shape: since 1.0.0 the reader has refused a projection
+    // whose `createFields` names something the form does not draw and it cannot identify as
+    // host-filled (it knows three — the address, the status, the stamp). A uid is a fourth, so the
+    // whole projection is refused as "a shape this release does not read" rather than drawn with a
+    // box asking a visitor to type their uid.
+    //
+    // Which makes the two facts below load-bearing, and this test the only thing holding them
+    // together: the uid is IN createFields (the rules take no key outside it) and NEVER in the
+    // drawn fields (not drawing it is the feature). Break either and old builds start drawing uid
+    // apps, silently, with no version left to stop them. See U10 in
+    // `plans/feat-shared-app-uid-identity.md`.
+    const spec = claimed.public?.submit?.responses;
+    const drawn = publicFormOf(claimed, withUid).responses;
+    expect(spec?.createFields).toContain("uid");
+    expect(Object.keys(drawn?.fields ?? {})).not.toContain("uid");
+    // The reader's own judgement, as it stood before it learnt the key (mulmoserver's `agrees`).
+    const hostFilled = [spec?.emailField, drawn?.statusField, spec?.stampField];
+    const undrawn = (spec?.createFields ?? []).filter((name) => !hostFilled.includes(name)).filter((name) => !Object.hasOwn(drawn?.fields ?? {}, name));
+    expect(undrawn).toEqual(["uid"]);
+  });
+
   it("keeps a form whose only create field is the uid", () => {
     // The same "count me in" as the stamp's, for an app whose document id is spent on the thing
     // being claimed: the whole submission is who pressed the button.

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -328,7 +328,6 @@ describe("shared app preview", () => {
     writeApp(
       root,
       declaration({
-        protocol: "2.0.0",
         collections: { claims: { submitOnly: true } },
         public: { submit: { claims: { auth: "verifiedEmail", uidField: "uid", createFields: ["taskId", "who", "uid"] } } },
       }),
@@ -370,7 +369,6 @@ describe("shared app preview", () => {
     writeApp(
       root,
       declaration({
-        protocol: "2.0.0",
         collections: { claims: { submitOnly: true } },
         views: [{ id: "mine", path: "views/mine.html", audience: "participant", collections: ["claims"] }],
         public: { submit: { claims: { auth: "verifiedEmail", uidField: "uid", createFields: ["taskId", "uid"] } } },
@@ -414,7 +412,6 @@ describe("shared app preview", () => {
     writeApp(
       root,
       declaration({
-        protocol: "2.0.0",
         collections: { claims: { submitOnly: true } },
         public: { submit: { claims: { auth: "verifiedEmail", uidField: "uid", createFields: ["uid"] } } },
       }),

--- a/test/server/backends/sharedAppPreviewWrite.spec.ts
+++ b/test/server/backends/sharedAppPreviewWrite.spec.ts
@@ -256,7 +256,6 @@ describe("shared app preview writes", () => {
           createFields: ["requesterName", "requesterEmail", "slot", "status", "uid"],
         },
       }),
-      protocol: "2.0.0",
     });
 
     const result = await writePreviewSubmission(root, "bookings", { requesterName: "客", slot: "roomA-1000", uid: "somebody-else" });

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -13,7 +13,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
 import { declarationProblems } from "../../../server/backends/sharedApp/context.js";
-import { parseAuthoredApp, protocolFor } from "@receptron/sharedapp";
+import { APP_PROTOCOL, parseAuthoredApp } from "@receptron/sharedapp";
 import { modalCallIn } from "../../../server/backends/sharedApp/modalCall.js";
 import { formElementIn, readyNeverCalled } from "../../../server/backends/sharedApp/viewDefects.js";
 import { readdirSync } from "node:fs";
@@ -134,20 +134,20 @@ describe("the shared-app templates", () => {
     }
   });
 
-  it("each template states the publish contract its own declaration needs", () => {
-    // A template is copied VERBATIM, so the key is either in every one of them or it teaches that
-    // declaring it is optional decoration. It is a FLOOR: an app relying on a newer publisher is
-    // refused instead of published as documents that do not keep the promise.
+  it("every template states the same publish contract, because no feature has one of its own", () => {
+    // `protocol` is a FLOOR, and a template is copied VERBATIM — so the key is either in every one
+    // of them or it teaches that declaring it is optional decoration.
     //
-    // Asked as `protocolFor(declaration)` rather than as one constant, because the answer is per
-    // APP now — a declaration using nothing new is stamped the first contract (which is what the
-    // apps published before the key existed are), and the board sample uses `uidField`, whose
-    // reader has to have learnt it. Pinned to a literal, this test would have been "fixed" by
-    // pasting the new number into the five samples that must NOT carry it: a template asking for a
-    // contract it does not use would teach every app to refuse older readers for nothing.
+    // Asserted against the constant rather than a literal, so that the day a feature DOES move the
+    // contract, this fails and says which samples were left behind. What it must not become is a
+    // per-template number: `uidField` briefly had one (2.0.0, then 1.1.0), and pasting it into the
+    // board sample alone was how that looked from here. It bought nothing — an older build refuses
+    // an unknown key at its own manifest schema, before any version is compared — and a floor a
+    // sample declares for a feature is a floor every author then copies. See U10 in
+    // `plans/feat-shared-app-uid-identity.md`.
     for (const file of readdirSync(TEMPLATES).filter((name) => name.endsWith(".md"))) {
       const manifest = blocksOf(file).get("app.json") as Record<string, unknown> | undefined;
-      expect(`${file}: ${String(manifest?.protocol)}`).toBe(`${file}: ${protocolFor(manifest as never)}`);
+      expect(`${file}: ${String(manifest?.protocol)}`).toBe(`${file}: ${APP_PROTOCOL}`);
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.17.0.tgz#70222e9db4ec4d7986641b073ee122c77bc220cc"
-  integrity sha512-ilDgWhVbM3DgfevmuQHzsbW3gjRQQtIYIx7Dgxz8ZKt3TkqKLJyQJ5ipMhgGat69++VGgCHzYnBTnE+qreJKuw==
+"@receptron/sharedapp@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.18.0.tgz#32bd652fd7527ae1cea5c82bc64a55f46e9737ef"
+  integrity sha512-AFq4iJzUdkej83EWZoS3YljcsqlbI06NnMKZHBA6rHXej2NjbRETHhL/3Zz04mhj93fgj8yQ4PC/byCDZdyw5A==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
#1805 で `uidField` を `protocol: "2.0.0"` として出しましたが、**major も minor も要りませんでした**。receptron/sharedapp#37（0.18.0）に追従して、テンプレートと説明を戻します。

## major が要らない: 古いリーダーは既にこの投影を拒否している

todo-board を実際に投影し、`protocol` を `"1.0.0"` に書き換えて mulmoserver #216 **以前**の `publicConfigFrom` に食わせました:

```
OLD READER REFUSED: UnsupportedProjection - this app was published in a shape this release does not read
CONTROL（createFields から uid を抜いたもの）: drawn
```

構造的にそうなります:

- ルールは `keys().hasOnly(createFields)` しか受け付けない → uid は **createFields に必ず入る**
- 描かないことが機能そのもの → uid は **form.fields に絶対に入らない**
- `publicFormOf` は描く欄がゼロでも form エントリを残す → 「form に無い cid は素通し」に逃げない

古い `agrees` が host-filled として除外するのは email / status / stamp の 3 つだけなので、`uid` が残って整合検査に落ちます。

## minor も要らない: 誰も差を読んでいない

| 見る相手 | 1.0.0 と 1.1.0 の差 |
|---|---|
| 読む側の門 `protocolDrawable` | major しか見ない → 同じ |
| 読む側の分岐 `protocolAtLeast` | 分岐が 1 つも無い → 同じ |
| 著者の floor `protocolProblems` | `SubmitZ` が `.strict()` で、知らないキーは**スキーマで先に**落ちる → 同じ |
| 人・診断 | `submit.<cid>.uidField` が刻印の隣に載っている → 同じ |

3 番目はキー導入前のビルドで実測しました。floor を宣言してもしなくても `Unrecognized key: "uidField"` で同じです。

## 変更

- テンプレートの `protocol` は**他の 5 本と同じ `"1.0.0"`**。これは元から全テンプレート共通の慣習で、uid のために上げていたのを戻しただけです
- テストは `APP_PROTOCOL` と突き合わせる形に。リテラル固定だと、次に版が動いたとき「サンプルに新しい番号を貼る」方向で直ってしまいます（それは全アプリに古いリーダーを拒否させる宣言を教えることになる）
- `SKILL.md` の `uidField` の代償は 1 つ（uid の凍結）に
- **この判断が乗っている不変条件を `publicForm.spec.ts` に固定**。uid が `createFields` にあってフォームに無いことと、古いリーダーの `agrees` をその場で再現して「描かれない欄は uid ちょうど 1 つ」を主張します。`publicForm.ts` から `spec.uidField` を外すと赤くなることを確認済み。ここが崩れると古いリーダーが黙って描き始めるのに、**もう番号は何も守っていない**ので気づく手段が他にありません
- plan に **U10**（2.0.0 → 1.1.0 → 版なし、と 2 段階で降りた経緯と実測）
- `@receptron/sharedapp` 0.18.0

テスト 10772 本 green、typecheck / lint / format 済み。

## マージ順

このあとに mulmoserver#220（`SUPPORTED_PROTOCOL_MAJOR` を 1 に戻す）。`2.0.0` で publish されたアプリは存在しません。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated shared app compatibility to use the standard protocol version.
  * Simplified UID field configuration without requiring a separate protocol declaration.
  * UID fields remain assigned after creation and cannot be changed to another person’s identifier.
  * Older readers safely reject unsupported UID field projections instead of requesting manual UID entry.
* **Documentation**
  * Updated publishing guidance and templates to reflect the simplified UID field behavior.
  * Standardized protocol declarations across app templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->