### PR TITLE
One parent in the preview: the pane stops differing from the live page

### DIFF
--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -22,9 +22,13 @@ export interface PreviewPage {
    *  `{ me, can }` mulmoserver posts to the live `/m/` and `/p/`, computed from
    *  the same projection by the same function.
    *
-   *  Absent on a public page, which has no reader and no roles: `public.submit`
-   *  is judged from the declaration alone, and a `viewer` there would be an
-   *  answer to a question that page never asks.
+   *  ON THE PUBLIC PAGE TOO, and that is a correction rather than an addition.
+   *  It was left off because "a public page has no reader and no roles" — but
+   *  the rules disagree: `ownRow` asks for `authed()` and nothing else, and
+   *  `selfTransitions` / `selfDelete` are declared inside `public.submit[cid]`.
+   *  So the visitor who booked a slot may cancel it, and a page with no
+   *  `viewer` draws no button for that. It is the participant's own answer,
+   *  computed at the same tier (`PUBLIC_WRITE_TIER`).
    *
    *  It comes from the SERVER because the client has neither the projection nor
    *  the author's verified address. Sending the projection instead and letting
@@ -101,6 +105,22 @@ export interface SharedAppPreview {
    *  different things than the published site does — a preview of nothing real. */
   formInputs: PreviewForm;
   datasets: PreviewDatasets;
+  /** WHAT THE AUTHOR HAS ALREADY SUBMITTED to this app, projected to the fields a page could have
+   *  SENT — the `viewer.mine` every published page is handed.
+   *
+   *  Per APP rather than per page, because that is what the question is about: it asks after the
+   *  READER, and the reader is the same person whichever page they are looking at.
+   *
+   *  ABSENCE IS THE ANSWER TO A DIFFERENT QUESTION, at two levels, and both matter. A cid missing
+   *  from the map is "nothing could be read" — the app has never been published, the read was
+   *  refused — which a page must draw as UNKNOWN. A cid present with an empty array is "you have
+   *  not submitted anything here". Getting that backwards tells somebody they have already answered
+   *  when they have not, and takes a one-time action away from them.
+   *
+   *  It exists because the pane had NO ANSWER AT ALL: the public parent here was wired without the
+   *  port, so `view.mine()` was `known: false` for ever and a page asking "have I registered?" drew
+   *  its registration form on top of a registration. The author then debugged the page. */
+  own: Record<string, PreviewDataset>;
   /** Collections a page names but whose records could not be read. Reported rather than silently
    *  empty: "no bookings yet" and "the read was refused" put identical pixels on the screen. */
   unreadable: string[];
@@ -145,6 +165,15 @@ export interface PreviewWrittenRecord {
    *  neither survives a restart, and a preview's writes become ordinary records when it ends. */
   token: string;
 }
+
+/** WHAT THE PANE ANSWERS A `view.mine(cid, key)` WITH.
+ *
+ *  `ok: false` is "nobody looked" — no session, an id strategy with nothing to build from, a read
+ *  that was refused — and the parent turns it into `known: false`. It is NOT "you have not
+ *  answered", which is `{ ok: true, found: false }`: a page told the second stops offering an
+ *  action to somebody entitled to it, and a page told the first keeps offering it and lets the
+ *  refusal explain itself. */
+export type PreviewLookupResult = { ok: false } | { ok: true; found: boolean; record?: Record<string, unknown> };
 
 /** A write whose outcome is unknown: the request threw after the server may already have written.
  *

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.18.0",
+    "@receptron/sharedapp": "^0.19.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/plans/feat-one-view-parent.md
+++ b/plans/feat-one-view-parent.md
@@ -74,9 +74,14 @@
 
 - `public` audience → `WriteTier` は **`roster`**。同型だからである — `roster` 層の
   意味は「ロールは無い、ルールが**記録から**答える」で、`ownRow` はまさにそれ。
-- `viewer.me` は公開層では **`null`**（匿名 auth に住所は無い）。`roster` 層の
-  `capabilityOf` は `me` を読まないので、これで整合する。**自分の行かどうかは
-  `viewer.mine` と `view.mine()` が答える** — 住所の比較ではなく。
+- `viewer.me` は**他のページと同じ規則** — サインイン済みの住所、無ければ空。匿名セッションには
+  住所が無いので「無い」は普通の答えであり、`roster` 層の `capabilityOf` は `me` を読まないので
+  どちらでも整合する。**自分の行かどうかは `viewer.mine` と `view.mine()` が答える** — 住所の
+  比較ではなく。ルールは記録の上の uid か検証済み住所で自分の行を判定するので、そのどちらも
+  ページが持っているとは限らないからである。
+  （当初は公開層だけ `me: null` に固定する案だったが、専用のヘルパを 1 本増やすことになり、
+  それは「2 つのホストが食い違える場所を 1 つ増やす」ことなので、`viewerFor(writes, address,
+  PUBLIC_WRITE_TIER)` という**全ページ共通の 1 本**に寄せた。）
 - `withdrawFrom` は `selfDelete`、`transitionAny` は `selfTransitions` から。
   どちらも既にある宣言で、**ルールの変更は要らない**。
 

--- a/plans/feat-one-view-parent.md
+++ b/plans/feat-one-view-parent.md
@@ -1,0 +1,148 @@
+# 親を 1 つにする — preview と本番、`/a` と `/m` と `/p` の差をなくす
+
+**状態**: 実装済み（3 リポジトリとも PR 提出、`@receptron/sharedapp` の npm 公開待ち）
+**日付**: 2026-08-19
+**前提**: [`docs/shared-app-principles.md`](../docs/shared-app-principles.md)（不変条件）、
+[`plans/feat-shared-app-preview.md`](./feat-shared-app-preview.md)（プレビューは親を共有する、という決定）、
+[`plans/feat-shared-app-member-write.md`](./feat-shared-app-member-write.md)（`/m` と `/p` の書き込み）
+
+この計画が答える問いは 1 つ:
+
+> **同じ HTML が、`/a` と `/m` と `/p` とプレビューで違う動きをする。
+> どれが「してはいけないこと」で、どれが「配線されていないだけ」なのか。**
+
+答えは **ほとんど全部が後者**である。禁止は Firestore のルールが既に持っていて、
+今そこにあるのは**ポートの形をした禁止** — 親が答えないから、ページの promise が
+永久に解決しない、という形の「禁止」だった。
+
+## 1. 実測した差分
+
+`@receptron/sharedapp` の bootstrap（`src/view/srcdoc.ts`）は**1 つ**で、
+`/a` も `/m` も `/p` もプレビューも同じものを注入される。ページが呼べる語彙は
+どこでも同じ 5 つ — `submit` / `transition` / `assign` / `withdraw` / `mine`。
+
+違うのは**親が何に答えるか**だけである。
+
+| ページが呼ぶ | `/a` 公開（`viewBridge`） | `/m` `/p`（`memberBridge`） | MT ペイン公開 | MT ペイン会員 |
+| --- | --- | --- | --- | --- |
+| `submit` | 確認 → 書く | **`unsupported-request`** | 確認 → 書く | 同左 |
+| `transition` / `assign` / `withdraw` | **黙って落ちる（永久に待つ）** | 判定 → 書く | 黙って落ちる | 判定 → 書く（#1802） |
+| `mine(cid, key)`（lookup） | 読む | **常に `known:false`** | **ポート無し → `known:false`** | 常に `known:false` |
+| `viewer.mine`（state に同梱） | 付く | **付かない** | **付かない** | 付かない |
+| `viewer.me` / `viewer.can` | **付かない** | 付く | 付かない | 付く |
+
+太字が「してはいけないこと」ではなく「配線されていないだけ」のもの。
+
+**最悪の 1 マスは `/a` の intent** である。`readSubmitMessage` は intent を
+`{ ok:false, reason:"not-a-submission", requestId:"" }` として返し、`offer` は
+`requestId === ""` を「誰も待っていない」と読んで答えない（`bridge.ts` の `offer`）。
+だが**待っている**。ページの `transition()` は settle しない promise を握ったままになる。
+両方の bridge のヘッダが「view を待たせたままにするのは死んだボタンだ」と書いている、
+まさにその失敗が公開ページに残っていた。
+
+## 2. ルールは既に許している
+
+差分表の禁止のうち、**ルールが本当に禁じているものは 1 つも無い**。
+`mulmoserver/firestore.rules` の該当行:
+
+- `ownRow(a, s, cid, itemId)`（304 行）が要求するのは **`authed()` と `subOpen` だけ**。
+  ロールもテナントも要らない。匿名セッションの uid でも通る（コメントがそう明言している）。
+- 更新 (765–772 行): `isWriter(r)` **または** `ownRow(...) && !finalize && inWindow && selfWriteOk(c, s)`。
+  `selfWriteOk` は `public.submit[cid].selfUpdate` / `selfTransitions` を現在ステータスごとに読む。
+- 削除 (244 行): `isWriter(r)` / 担当者 / **`selfDelete(...)`** — これも `ownRow` ベース。
+- 読み (285 行 `readWith`): 最後の枝が `ownRow`。**自分の行は誰でも読める。**
+
+つまり **`/a` の訪問者と `/p` の参加者は、自分の行に関してルール上まったく同じ権限を持つ**。
+`selfTransitions` と `selfDelete` は `public.submit[cid]` に書く宣言であって、
+参加者層だけのものではない — なのに投影は participant 層にしか出していない
+（`appViews.ts` の `transitionPart` / `withdrawPart` が `Exclude<ViewAudience,"public">` を取る）。
+
+**だから公開ページは、ルールが許している「自分の予約を取り下げる」を宣言できず、
+親も答えず、ページは永久に待つ。** これが今回直すものの中心である。
+
+## 3. 設計
+
+原則を 3 つに畳む。
+
+**P-1. 語彙は 1 つ、親も 1 つ。** `viewBridge` と `memberBridge` を 1 つの親
+（`viewParent`）に統合する。どの audience でも 5 つの ask すべてに**答える** —
+実行するか、理由を付けて断るか。**黙って落とす枝を 1 つも残さない。**
+
+**P-2. audience が決めるのは「答え」であって「語彙」ではない。**
+何ができるかは投影とルールが決める。親の形は決めない。
+具体的には、公開層にも `write` 投影を出す:
+
+- `public` audience → `WriteTier` は **`roster`**。同型だからである — `roster` 層の
+  意味は「ロールは無い、ルールが**記録から**答える」で、`ownRow` はまさにそれ。
+- `viewer.me` は公開層では **`null`**（匿名 auth に住所は無い）。`roster` 層の
+  `capabilityOf` は `me` を読まないので、これで整合する。**自分の行かどうかは
+  `viewer.mine` と `view.mine()` が答える** — 住所の比較ではなく。
+- `withdrawFrom` は `selfDelete`、`transitionAny` は `selfTransitions` から。
+  どちらも既にある宣言で、**ルールの変更は要らない**。
+
+**P-3. 確認ダイアログは ask の種類が決める。audience は決めない。**
+`submit`（見知らぬ人が新しい記録を提案する）は全 audience で確認を出す。
+intent（既にある自分の行を動かす）は全 audience で出さない。
+今の「公開だけ確認、会員は確認なし」は audience 依存に見えて、実は
+**ask 依存**でよく、そう言い直すと `/a` と `/m` の差が 1 つ消える。
+
+## 4. 意図的に残る非対称
+
+**ヘッドレスは書かない。** `manageSharedApp` の `action: "preview"` は実ブラウザで
+ページを走らせるが書き込みは行わない。これは親ではなく lint であり、
+「本番と同じ」を要求する対象ではない。ただし**語彙には答える** — 断り方は
+`read-only` で、黙って落とさない。
+
+**プレビューの読みは著者の資格で行われる。** ペインは著者の Mac で動くので、
+`scope: "own"` の絞り込みは**ホスト側で**行う（`preview.ts` に既にある）。
+ルールが訪問者に対して行う絞り込みを、著者の資格のまま模す — これは
+「プレビューが本番より緩くならない」ための既存の決定であって、
+差分ではなく差分を消すための仕掛けである（`previewIntent.ts` の `NOT_IN_VIEW` と同じ理屈）。
+
+## 5. 手順
+
+順送りで 4 本。`@receptron/sharedapp` は npm 経由なので、公開が両ホストの前提になる。
+
+1. **sharedapp** — 親の統合（P-1）、公開層の `write` 投影と `viewerFor` の公開対応（P-2）、
+   自分の行の射影（今 mulmoserver の `publicOwnView.ts` にあるもの）をパッケージへ移す。
+   `viewBridge` / `memberBridge` は 1 リリースのあいだ薄い包みとして残す。
+2. **mulmoserver** — `PublicViewFrame` に `perform` を、`AppViewFrame` に `mine` / `lookup` /
+   `submit` を配線。`useAppIntent` は既に tier 引数を取るので `roster` を渡すだけ。
+   ルール変更は無い見込み — emulator (`yarn test:rules`) で「公開の訪問者が自分の行を
+   selfTransition / selfDelete できる」を固定する。
+3. **mulmoterminal** — ペインの 2 つの親を統合後の 1 つにし、公開側に `mine` / `lookup` /
+   `perform` を配線。`preview.ts` は公開ページの submit 先を `scope: "own"` でも読む。
+   ヘッドレスも同じ語彙に答える。
+4. **ドキュメント** — `mulmoterminal-shared-app` の SKILL とテンプレート。
+   「`/a` では `mine` が来ない」という現状の前提で書かれた記述を消す。
+
+## 6. 実装の結果
+
+3 本とも上の手順どおりに入った。予定と変わった点だけ書く。
+
+**会員ページの submit は、宣言をどこから読むかで解けた。** 層 config には `form`（描画される
+フィールド）が無いので不可能に見えたが、**`config/public` は `allow read: if true`** で、id 戦略も
+描画フィールドもそこにある。`/m` `/p` はそれを読み、`/a` と**同じ配線**（`ownSubmissionPorts.ts`）を
+共有する。publish の投影は変えていない。
+
+**公開ページの intent は「自分の行がデータセットに無い」で 1 回落ちた。** 人が submit する
+コレクションは `public.read` が開けない唯一のもの — 開けば訪問者が互いの回答を読める — なので、
+公開ページが動かす行は**データセットには絶対に無い**。`viewer.mine` として届く。判定は
+「ページのデータセット **∪** 読み手自身の行」に対して行う（`previewIntent.ts`）。
+
+**ルックアップの「読めなかった」と「無かった」を 1 度取り違えた。** 実装は `.catch(() => null)` で
+両方を "not found" に潰していて、テストが落として直した — このモジュール自身のヘッダが警告している
+まさにその誤りだった。
+
+**ルールは 1 行も変えていない。** mulmoserver の emulator は 182 pass。主張（公開の訪問者が自分の
+行を動かして取り下げられる）は `rules_selfDelete` / `rules_uidField` が既に固定していた。
+
+## 7. 検査
+
+- **rules emulator** — 公開の訪問者（ロール無し・匿名可）が自分の行を読み・
+  selfTransition し・selfDelete できること、他人の行はできないこと。
+- **パッケージ** — 5 つの ask × 4 audience の表を 1 本のテストで固定する
+  （「黙って落ちる枠が無い」ことを含む）。
+- **ホスト** — `/a` と `/m` と MT ペインが**同じポート集合**を渡していることを、
+  ポート名の集合を突き合わせる形で固定する。名前の集合なら、片方に足して
+  片方に足し忘れたときに落ちる。

--- a/server/backends/sharedApp/headlessHarness.ts
+++ b/server/backends/sharedApp/headlessHarness.ts
@@ -127,7 +127,7 @@ export const HARNESS_HTML = `<!doctype html>
 <body>
 <div id="host"></div>
 <script type="module">
-import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE } from "${VIEW_MOUNT}/index.js";
+import { portChannel, publicViewSrcdoc, viewNonce, viewParent, VIEW_MESSAGE } from "${VIEW_MOUNT}/index.js";
 
 const host = document.getElementById("host");
 let frame = null;
@@ -137,6 +137,9 @@ let config = null;
 // without it is the bug this harness reported for months as an author's mistake: the page is handed
 // \`{}\`, draws none of its buttons, and the report says the controls were not there.
 let viewer = null;
+// What the reader has already submitted, projected as the live page receives it. Null is "nobody
+// looked", which is not the same statement as an empty map.
+let own = null;
 let nonce = viewNonce();
 let outbound = [];
 let submitted = [];
@@ -189,34 +192,23 @@ const recording = (make) => () => {
   };
 };
 
-/** The member's parent, for a roster or participant page. It performs nothing — a transition, an
- *  assignment or a withdrawal is a real write against the live rules and neither this harness nor
- *  the PANE has a route for one — so every intent is refused BY NAME on the channel, which the
- *  report reads back out of \`outbound\`. That refusal is parity, not a shortfall: the pane refuses
- *  them too, for the same reason and in the same words. */
-const member = memberBridge(
+/** ONE PARENT, for whichever page is being run — the same one the pane wires and the same one
+ *  mulmoserver puts in front of the live pages.
+ *
+ *  There were two here, chosen per page, and each answered half the vocabulary the injected
+ *  bootstrap gives every document. A public page's intent was DROPPED (read as "not a submission",
+ *  found to carry no request id) and a member page's \`view.mine()\` was answered "nobody looked"
+ *  whatever the app declared — so a run could report a page as silent when the harness was the
+ *  thing that had not answered.
+ *
+ *  IT STILL PERFORMS NOTHING, and that is deliberate rather than a shortfall: a transition, an
+ *  assignment or a withdrawal is a real write against the live rules, and a headless run writes
+ *  nothing. With no \`perform\` port every intent is refused BY NAME on the channel — \`read-only\`,
+ *  which the report reads back out of \`outbound\` — rather than left unanswered. */
+const parent = viewParent(
   {
-    channel: recording(() => portChannel(frame)),
-    state: () => datasets,
-    viewer: () => viewer ?? { me: null, can: {} },
-    // The page's own account of itself, which the pane has always taken and this harness dropped.
-    // A page that crashes reports it HERE and nowhere else the run can see — dropped, it read as a
-    // page that simply drew nothing.
-    notice: (report) => notices.push({ code: String(report.code), detail: String(report.detail) }),
-    // THE SAME CELL the public parent writes, because \`observe()\` reads one and the report puts
-    // "It NEVER answered the handshake" at the top of a page whose value is false — over a
-    // paragraph saying nothing below describes the page's behaviour. Wired to the public bridge
-    // alone, every healthy member page was reported that way.
-    readied: cells.readied,
-  },
-  () => nonce,
-);
-
-const bridge = viewBridge(
-  {
-    // Recorded on its way out, like the member parent's above. The refusals are only visible here:
-    // they are answered on the port and never drawn, which is exactly why an author watching the
-    // screen cannot see them.
+    // Recorded on its way out. The refusals are only visible here: they are answered on the port
+    // and never drawn, which is exactly why an author watching the screen cannot see them.
     channel: recording(() => portChannel(frame)),
     // THE ANSWER NODE ALREADY DECIDED, or a refusal when it decided nothing.
     //
@@ -226,7 +218,18 @@ const bridge = viewBridge(
     // this document never held anything that could reach a database.
     submit: async () => answer ?? { ok: false, error: "a headless preview never writes" },
     state: () => datasets,
+    // WHO the reader is to this page, on every audience. Undefined rather than \`{ me: null, can: {} }\`
+    // where the payload resolved none: an empty \`can\` is a claim ("you may do nothing"), and the
+    // page must be able to tell it from silence.
+    viewer: () => viewer ?? undefined,
+    // What the reader has already submitted. Same rule: undefined is "nobody looked".
+    mine: () => own ?? undefined,
+    // The page's own account of itself. A page that crashes reports it HERE and nowhere else the
+    // run can see — dropped, it read as a page that simply drew nothing.
     notice: (report) => notices.push({ code: String(report.code), detail: String(report.detail) }),
+    // Nothing here can break in a way the page has not already been told about, and this document
+    // has no console worth writing to. Said rather than forgotten, which is what the port is for.
+    defect: () => {},
   },
   () => config,
   () => nonce,
@@ -236,12 +239,7 @@ const bridge = viewBridge(
 // Only our frame. The sandbox's origin is opaque, so \`event.origin\` cannot draw this line.
 window.addEventListener("message", (event) => {
   if (frame === null || event.source !== frame.contentWindow) return;
-  // The audience decides which parent answers, exactly as the address does in production.
-  if (viewer !== null) {
-    member.receive(event.data);
-    return;
-  }
-  bridge.receive(event.data);
+  parent.receive(event.data);
 });
 
 const refusals = () => outbound.filter((message) => message.type === VIEW_MESSAGE.result && message.ok === false).map((message) => String(message.error));
@@ -250,8 +248,7 @@ window.__preview = {
   /** Mount one document. Called again for every button pressed, so each press is judged against a
    *  page in its starting state rather than against whatever the previous press left behind. */
   render(page) {
-    bridge.restart();
-    member.forget();
+    parent.restart();
     outbound = [];
     submitted = [];
     notices = [];
@@ -259,6 +256,7 @@ window.__preview = {
     answer = null;
     datasets = page.datasets;
     viewer = page.viewer ?? null;
+    own = page.own ?? null;
     config = page.submit === null ? null : { submit: page.submit };
     nonce = viewNonce();
     if (frame !== null) frame.remove();
@@ -290,7 +288,7 @@ window.__preview = {
   },
   /** Answer the confirmation the way a visitor who changed their mind would. */
   decline() {
-    bridge.decline();
+    parent.decline();
   },
   /** Answer it the way somebody who meant it would, with the verdict Node already has.
    *
@@ -299,7 +297,7 @@ window.__preview = {
    *  real answer, which is the whole reason to accept rather than to decline. */
   async accept(given) {
     answer = given;
-    await bridge.accept();
+    await parent.accept();
     answer = null;
   },
 };

--- a/server/backends/sharedApp/headlessPreview.ts
+++ b/server/backends/sharedApp/headlessPreview.ts
@@ -49,13 +49,22 @@ export interface HeadlessPageInput {
    *  which does not switch the parent's check off but makes it refuse everything with
    *  `unknown-collection`, blaming a declaration that is correct. */
   submit: Record<string, { createFields: string[] }> | null;
-  /** WHO the author is to this page and what they may change, for a member or participant page.
+  /** WHO the author is to this page and what they may change.
    *
-   *  `undefined` for a public one, and that is what SELECTS the parent in the harness — the same
-   *  decision the address makes in production. A member page run without it gets the public parent,
-   *  which sends no `viewer` at all: the page draws none of its buttons and the report says its
-   *  controls were not there, which is a false account of a page that is fine. */
+   *  On EVERY audience: the public page has one too, because the rules let the person who submitted
+   *  a row move it and take it away with no role at all. It no longer selects a parent — there is
+   *  one — but it is still the difference between a page that draws its controls and a page that
+   *  draws none and is reported as having none.
+   *
+   *  `undefined` where the projection resolved nothing, and never `{ me: null, can: {} }`: an empty
+   *  `can` is a claim, and the page must be able to tell it from silence. */
   viewer?: Viewer | undefined;
+  /** What the author has ALREADY SUBMITTED to this app, projected as the live page receives it.
+   *
+   *  Per app rather than per page — it asks after the reader, and the reader is the same person on
+   *  every page. `undefined` is "nobody looked", which a page must not draw as "you have not
+   *  answered": that is how a run reports a page as broken for correctly refusing to guess. */
+  own?: Record<string, PreviewDataset> | undefined;
 }
 
 /** What the host does when a confirmation is accepted, and how it takes the write back.
@@ -656,7 +665,13 @@ async function openDriver(browser: Browser, origin: string): Promise<Driver> {
       // The render is awaited on ITS OWN deadline (`evaluate`'s), because what it waits for is the
       // frame's `load` — which a script that never returns never reaches.
       await evaluate(
-        `window.__preview.render(${JSON.stringify({ html: input.html, datasets: input.datasets, submit: input.submit, viewer: input.viewer ?? null })})`,
+        `window.__preview.render(${JSON.stringify({
+          html: input.html,
+          datasets: input.datasets,
+          submit: input.submit,
+          viewer: input.viewer ?? null,
+          own: input.own ?? null,
+        })})`,
       );
       await page.waitForFunction("window.__preview.observe().readied", { timeout: LIMITS.readyMs }).catch(() => undefined);
       await new Promise((resolve) => setTimeout(resolve, LIMITS.settleMs));
@@ -1104,6 +1119,10 @@ export async function headlessPreview(root: string, opts: { write?: boolean } = 
     html: page.html,
     datasets: preview.datasets[previewPageKey(page.audience, page.id)] ?? {},
     ...(page.viewer === undefined ? {} : { viewer: page.viewer }),
+    // The same rows the pane sends, so a page asking "have I registered?" gets the same answer in
+    // both — an author whose page behaves differently under the two is looking at a difference this
+    // repository invented.
+    own: preview.own,
     submit: Object.keys(preview.submit).length > 0 ? preview.submit : null,
   }));
   return runPagesHeadless(inputs, opts.write === true ? repositoryWriter(root) : null);

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -71,7 +71,7 @@ export type PreviewResult = PreviewSuccess | SharedAppFailure;
  *
  *  The narrow shape of `ProjectedViewCollection`, restated rather than imported, because only these
  *  three fields decide what to read and the rest of that type is about how a tier is projected. */
-interface RequestedCollection {
+export interface RequestedCollection {
   cid: string;
   scope: "all" | "own";
   emailField?: string | undefined;
@@ -120,7 +120,7 @@ async function readCollection(handle: SharedAppHandle, aid: string, want: Reques
  *  and the intent path, which has to decide about a row that no list ever returned — a composite id
  *  (`auth.uid+field`) is granted by NAME and cannot be listed at all, so the page finds it through
  *  `view.mine(cid, key)` and nothing else here has seen it. */
-function ownsRow(want: RequestedCollection, row: Record<string, unknown>, who: { uid: string; email: string }): boolean {
+export function ownsRow(want: RequestedCollection, row: Record<string, unknown>, who: { uid: string; email: string }): boolean {
   if (want.ownDocId === "auth.uid") return row.id === who.uid;
   // REBUILT FROM THE STORED VALUE, never a prefix match on the id. That is the rules' own shape
   // (`ownRow`'s `auth.uid+field` branch) and its comment says why: an unconditional prefix match
@@ -131,6 +131,17 @@ function ownsRow(want: RequestedCollection, row: Record<string, unknown>, who: {
   const field = want.emailField;
   if (field === undefined) return false;
   return row[field] === who.email;
+}
+
+/** The selector each collection's own rows are found by, per cid — see {@link ownRequests}.
+ *
+ *  Exported for the INTENT path, which has to decide about a row no list returned: the list can
+ *  fail while the document itself is readable (a refused read on an app that has just been
+ *  published, an offline moment, a transient), and the page will have found that row through
+ *  `view.mine(cid, key)`, which is a `get` and not a list. Both paths then ask the same predicate,
+ *  which is the point of exporting it rather than writing a second one. */
+export function ownSelectors(config: PublishedConfigDoc): Record<string, RequestedCollection> {
+  return Object.fromEntries(ownRequests(config).map((want) => [want.cid, want]));
 }
 
 /** Every page's records, each page asking only for what its own projection names.

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -77,6 +77,16 @@ interface RequestedCollection {
   emailField?: string | undefined;
   uidField?: string | undefined;
   ownDocId?: "auth.uid" | undefined;
+  /** The id is `uid + "_" + <this field>` (`idFrom: "auth.uid+field"`).
+   *
+   *  The FOURTH way a row says whose it is, and the one that was missing. It is not in
+   *  `ProjectedViewCollection` — a tier's read scope never needs it, because a tier lists — and it
+   *  is needed here: for that strategy the identity is in the document NAME, so a collection
+   *  declaring neither `uidField` nor `emailField` (`auth: "anonymous"` + `auth.uid+field`, which is
+   *  live-poll's whole shape) matched nothing at all. The author's own votes were absent from
+   *  `viewer.mine`, and an intent about one came back `not-in-view` about a row the page had
+   *  legitimately been handed. */
+  ownIdField?: string | undefined;
 }
 
 /** One collection's records, read with the author's own credentials.
@@ -96,14 +106,31 @@ async function readCollection(handle: SharedAppHandle, aid: string, want: Reques
   // (a booking's id IS its slot), and a page that renders a list needs it as a field.
   const rows: PreviewDataset = docs.map((doc) => ({ ...(isRecord(doc.data) ? doc.data : {}), id: doc.id }));
   if (want.scope === "all") return rows;
-  if (want.ownDocId === "auth.uid") return rows.filter((row) => row.id === handle.uid);
-  // The uid before the address, matching the reader (`ownLookup` in mulmoserver): a projection
-  // carries exactly one selector, and asking in a fixed order keeps the answer from depending on
-  // which branch happens to be written first.
-  if (want.uidField !== undefined) return rows.filter((row) => row[want.uidField ?? ""] === handle.uid);
+  return rows.filter((row) => ownsRow(want, row, handle));
+}
+
+/** IS THIS ROW THE READER'S OWN? — the question `ownRow` asks in the rules, asked here in the only
+ *  terms this host has.
+ *
+ *  The uid before the address, matching the reader (`ownLookup` in mulmoserver): a projection
+ *  carries exactly one selector, and asking in a fixed order keeps the answer from depending on
+ *  which branch happens to be written first.
+ *
+ *  Its own function because two callers need it and they must not drift: the dataset read above,
+ *  and the intent path, which has to decide about a row that no list ever returned — a composite id
+ *  (`auth.uid+field`) is granted by NAME and cannot be listed at all, so the page finds it through
+ *  `view.mine(cid, key)` and nothing else here has seen it. */
+function ownsRow(want: RequestedCollection, row: Record<string, unknown>, who: { uid: string; email: string }): boolean {
+  if (want.ownDocId === "auth.uid") return row.id === who.uid;
+  // REBUILT FROM THE STORED VALUE, never a prefix match on the id. That is the rules' own shape
+  // (`ownRow`'s `auth.uid+field` branch) and its comment says why: an unconditional prefix match
+  // would let somebody create `<victim uid>_x` in a collection with a different strategy and grow
+  // self-edit rights over it.
+  if (want.ownIdField !== undefined) return typeof row[want.ownIdField] === "string" && row.id === `${who.uid}_${String(row[want.ownIdField])}`;
+  if (want.uidField !== undefined) return row[want.uidField] === who.uid;
   const field = want.emailField;
-  if (field === undefined) return [];
-  return rows.filter((row) => row[field] === handle.email);
+  if (field === undefined) return false;
+  return row[field] === who.email;
 }
 
 /** Every page's records, each page asking only for what its own projection names.
@@ -220,17 +247,20 @@ function formInputsOf(config: PublishedConfigDoc, form: PublicForm): PreviewForm
 
 /** WHERE THE AUTHOR'S OWN ROWS ARE READ FROM, per collection the app opens for submission.
  *
- *  The same three selectors the rules identify an own row by, in the order `readCollection` applies
- *  them: the document id when it IS the uid, then the uid field, then the verified address. Read as
+ *  The same FOUR selectors the rules identify an own row by, in the order `ownsRow` applies them:
+ *  the document id when it IS the uid, the id rebuilt as `uid + "_" + <idField>`, the uid field,
+ *  then the verified address. Read as
  *  the author (this runs on their machine) and then FILTERED to their own rows, because the reader
  *  a published page has is a visitor and the preview must never show more than production. */
 const ownRequests = (config: PublishedConfigDoc): RequestedCollection[] =>
   Object.entries(config.submit ?? {}).map(([cid, spec]) => {
     const text = (key: string): string | undefined => (typeof spec[key] === "string" ? spec[key] : undefined);
+    const composite = spec.idFrom === "auth.uid+field" ? text("idField") : undefined;
     return {
       cid,
       scope: "own" as const,
       ...(spec.idFrom === "auth.uid" ? { ownDocId: "auth.uid" as const } : {}),
+      ...(composite === undefined ? {} : { ownIdField: composite }),
       ...(text("uidField") === undefined ? {} : { uidField: text("uidField") }),
       ...(text("emailField") === undefined ? {} : { emailField: text("emailField") }),
     };

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -284,7 +284,15 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
   // cancellation the rules were waiting to allow drew no button, and the intent behind it reached a
   // parent that dropped it.
   writes.public = projectedWritesOf(face.config);
-  const publicViewer = viewerFor(writes.public, handle.email, PUBLIC_WRITE_TIER);
+  // `me` IS NULL, and it matches what mulmoserver posts to the live `/a/{slug}` — see
+  // `publicSelfWrites.ts` there for the reasoning, which is worth repeating in one line: nothing on
+  // this tier reads it, and a published page that held the visitor's address could carry it off by
+  // navigating its own context once.
+  //
+  // The author's address is NOT substituted here either, and that is the point of the whole file: a
+  // preview that handed the page one more thing than production hands it is a preview of a page
+  // that does not exist. The author IS a reader here, and this is what a reader gets.
+  const publicViewer = viewerFor(writes.public, null, PUBLIC_WRITE_TIER);
   const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public", viewer: publicViewer }];
   const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) => {
     // The author, as this tier's projection resolves them. `viewerFor` is the

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -37,12 +37,13 @@ import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
 // Both from `/view`, which is where the PARENT's vocabulary lives — and where the read-back has to
 // be: the root entry reaches the compiler, and the compiler imports core's server half at runtime.
-import { projectedWritesOf, viewerFor, writableFields } from "@receptron/sharedapp/view";
+import { ownRowsFor, projectedWritesOf, PUBLIC_WRITE_TIER, viewerFor, writableFields } from "@receptron/sharedapp/view";
 import {
   previewPageKey,
   type PreviewDataset,
   type PreviewDatasets,
   type PreviewForm,
+  type PreviewAudience,
   type PreviewPage,
   type SharedAppPreview,
 } from "../../../common/sharedAppPreview.js";
@@ -61,7 +62,7 @@ export interface PreviewSuccess extends SharedAppPreview {
    *  `viewer` and never the projection it came from. Sending this to the browser would put a second
    *  judge there — one that could disagree with the one that performs the write — which is the
    *  divergence `PreviewPage.viewer` was introduced to remove. */
-  writes: Partial<Record<TierPlan["tier"], ProjectedViewWrite[]>>;
+  writes: Partial<Record<PreviewAudience, ProjectedViewWrite[]>>;
 }
 
 export type PreviewResult = PreviewSuccess | SharedAppFailure;
@@ -217,6 +218,28 @@ function formInputsOf(config: PublishedConfigDoc, form: PublicForm): PreviewForm
   );
 }
 
+/** WHERE THE AUTHOR'S OWN ROWS ARE READ FROM, per collection the app opens for submission.
+ *
+ *  The same three selectors the rules identify an own row by, in the order `readCollection` applies
+ *  them: the document id when it IS the uid, then the uid field, then the verified address. Read as
+ *  the author (this runs on their machine) and then FILTERED to their own rows, because the reader
+ *  a published page has is a visitor and the preview must never show more than production. */
+const ownRequests = (config: PublishedConfigDoc): RequestedCollection[] =>
+  Object.entries(config.submit ?? {}).map(([cid, spec]) => {
+    const text = (key: string): string | undefined => (typeof spec[key] === "string" ? spec[key] : undefined);
+    return {
+      cid,
+      scope: "own" as const,
+      ...(spec.idFrom === "auth.uid" ? { ownDocId: "auth.uid" as const } : {}),
+      ...(text("uidField") === undefined ? {} : { uidField: text("uidField") }),
+      ...(text("emailField") === undefined ? {} : { emailField: text("emailField") }),
+    };
+  });
+
+/** The key the own-rows read is cached under. Never a page's: no page is handed these as datasets —
+ *  they travel as `viewer.mine`, which is a different message with a different meaning. */
+const OWN_KEY = "own:reader";
+
 /** The public page has no view id of its own — it is the app's one anonymous face, and the
  *  projection names it nowhere. */
 const PUBLIC_PAGE_ID = "public";
@@ -251,11 +274,18 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
   if (!tiers.ok) return { ok: false, partial: false, problems: tiers.problems };
 
   const publicHtml = page !== null && page.ok ? page.view.html : null;
-  const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public" }];
-  // The projection each tier writes, kept BESIDE the viewer it resolves to rather than recomputed
+  // The projection each page writes, kept BESIDE the viewer it resolves to rather than recomputed
   // later: an intent is judged against the same `write` list this `viewer` was built from, so the
   // buttons a page draws and the moves this host will perform cannot come from two readings.
-  const writes: Partial<Record<TierPlan["tier"], ProjectedViewWrite[]>> = {};
+  const writes: Partial<Record<PreviewAudience, ProjectedViewWrite[]>> = {};
+  // THE PUBLIC PAGE HAS ONE TOO. Read off the same document the anonymous page reads, at the
+  // PARTICIPANT's tier — because the rules make those two readers the same one over their own row
+  // (`ownRow` asks for `authed()` and nothing else). It used to have none, so a page offering the
+  // cancellation the rules were waiting to allow drew no button, and the intent behind it reached a
+  // parent that dropped it.
+  writes.public = projectedWritesOf(face.config);
+  const publicViewer = viewerFor(writes.public, handle.email, PUBLIC_WRITE_TIER);
+  const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public", viewer: publicViewer }];
   const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) => {
     // The author, as this tier's projection resolves them. `viewerFor` is the
     // package's, and mulmoserver calls the same one with the same projection —
@@ -280,7 +310,17 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     ...tiers.plans.flatMap(tierRequests),
   ]);
 
+  // THE AUTHOR'S OWN ROWS, read separately from the pages and never as a page's datasets: they
+  // travel as `viewer.mine`, which is a different message saying a different thing. A cid that
+  // could not be read is left OUT by `readDatasets`, which is exactly the shape the port wants —
+  // absent means "nobody looked", present-and-empty means "you have submitted nothing".
+  const ownRead = await readDatasets(handle, aid, [{ key: OWN_KEY, collections: ownRequests(face.config) }]);
+
   const form = publicFormOf(authored, schemasOf(collections));
+  // THE ONE LIST OF "what a page could have sent", used for the boxes the pane draws AND for the
+  // projection of the author's own rows. Two computations of it is one more place for the preview
+  // to hand a page a field production would have dropped.
+  const formInputs = formInputsOf(face.config, form);
 
   return {
     ok: true,
@@ -293,8 +333,16 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     publicOpen: face.public !== undefined,
     fromLiveApp: existingApp !== null,
     generatedForm: publicHtml === null && Object.keys(form).length > 0,
-    formInputs: formInputsOf(face.config, form),
+    formInputs,
     datasets,
+    // Projected to the fields a page in this position could have SENT — the package's rule, so the
+    // preview hands a page exactly what mulmoserver hands the live one. A page given one more field
+    // here than production gives it is a preview of a page that does not exist.
+    own: ownRowsFor(
+      Object.entries(formInputs).map(([cid, fields]) => ({ cid, fields })),
+      ownRead.datasets[OWN_KEY] ?? {},
+      Object.keys(ownRead.datasets[OWN_KEY] ?? {}),
+    ),
     unreadable,
     warnings: [...(page !== null && page.ok ? page.view.warnings : []), ...tiers.warnings],
   };

--- a/server/backends/sharedApp/previewIntent.ts
+++ b/server/backends/sharedApp/previewIntent.ts
@@ -27,7 +27,7 @@
 import { doc, collection, writeBatch } from "firebase/firestore";
 import { APPS_COLLECTION, appSchemasPath } from "@receptron/sharedapp";
 import { MIRROR_OPEN, readIntentMessage, VIEW_MESSAGE, type JudgedIntent, type WriteTier } from "@receptron/sharedapp/view";
-import { previewPageKey, type PreviewIntent, type PreviewIntentResult } from "../../../common/sharedAppPreview.js";
+import { previewPageKey, type PreviewAudience, type PreviewIntent, type PreviewIntentResult } from "../../../common/sharedAppPreview.js";
 import { currentFirestore } from "../remoteHost/session.js";
 import { previewSharedApp } from "./preview.js";
 import { sharedAppContext } from "./context.js";
@@ -43,15 +43,16 @@ const itemsPath = (aid: string, cid: string): string => `${appSchemasPath(aid)}/
 const mailPath = (aid: string): string => `${APPS_COLLECTION}/${aid}/mail`;
 const mailDocId = (cid: string, itemId: string, template: string): string => `${cid}_${itemId}_${template}`;
 
-/** The audiences that have intents at all.
+/** WHAT REPLACED `NOT_A_MEMBER_PAGE`.
  *
- *  A public page has no reader, no roles and no tier — `readIntentMessage` cannot judge for one,
- *  and there is nothing sensible to judge it AS. Refused by name rather than squeezed into one of
- *  the package's refusals: the package's names are about a declaration, and this one is about the
- *  page having been the wrong kind of page, which no declaration can fix. Unreachable from the pane
- *  (the public parent never routes an intent here) and stated anyway, because the alternative to an
- *  unreachable branch is an unnoticed one. */
-export const NOT_A_MEMBER_PAGE = "not-a-member-page";
+ *  There used to be a refusal here for "the page was the wrong kind of page" — a public page asking
+ *  to move a record. It is gone because it was wrong: the rules let the person who submitted a row
+ *  move it and take it away wherever they are standing, and the constant existed only because the
+ *  public parent had no `perform` port to reach this with. Both halves are now wired, and an ask
+ *  from a public page is judged exactly as a participant's is.
+ *
+ *  Kept as a note rather than as a dead export: nothing compares the string, and a refusal name
+ *  that no longer refuses anything is the kind of thing that gets re-added by pattern-matching. */
 
 /** The preview has no page under that id — the author renamed or removed a view and a document from
  *  the previous render is still on screen asking about it. */
@@ -78,7 +79,23 @@ export const NOT_IN_VIEW = "not-in-view";
 
 const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
-const isTier = (audience: string): audience is WriteTier => audience === "member" || audience === "roster";
+/** WHICH TIER JUDGES THIS PAGE'S ASK.
+ *
+ *  The public page is judged as a PARTICIPANT, and that is a statement about the rules rather than
+ *  a convenience: `ownRow` in `firestore.rules` asks for `authed()` and nothing else — no role, no
+ *  membership, an anonymous uid will do — and the moves it allows come from `public.submit[cid]`
+ *  (`selfTransitions`, `selfDelete`), which is the public page's own declaration. So a visitor who
+ *  booked a slot and a participant who booked the same slot may do exactly the same things to it.
+ *
+ *  It used to be refused here by name, on the reasoning that "a public page has no reader, no roles
+ *  and no tier". Two of those are true and the conclusion was not: what it has instead is the
+ *  roster tier's answer, which is "there are no roles; the rules answer from the record". */
+const tierOf = (audience: PreviewAudience): WriteTier => {
+  if (audience === "member") {
+    return "member";
+  }
+  return "roster";
+};
 
 /** The batch, and every intent goes through one.
  *
@@ -153,8 +170,8 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
   if (!context.ok) return { ok: false, error: context.problems.join(" ") };
   const { handle } = context;
 
-  if (!isTier(asked.page.audience)) return { ok: false, error: NOT_A_MEMBER_PAGE };
-  const tier = asked.page.audience;
+  const audience = asked.page.audience;
+  const tier = tierOf(audience);
 
   const preview = await previewSharedApp(root);
   if (!preview.ok) return { ok: false, error: preview.problems.join(" ") };
@@ -162,15 +179,26 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
   // The page has to still be there. A document from the previous render can outlive the view that
   // produced it — the author edits `app.json` while the frame is up — and judging its ask against
   // whatever page happens to be first would perform a move on a projection nobody is looking at.
-  const page = preview.pages.find((candidate) => candidate.id === asked.page.id && candidate.audience === tier);
+  const page = preview.pages.find((candidate) => candidate.id === asked.page.id && candidate.audience === audience);
   if (page === undefined) return { ok: false, error: NO_SUCH_PAGE };
 
-  const write = preview.writes[tier] ?? [];
+  const write = preview.writes[audience] ?? [];
   // THE RECORDS THIS PAGE WAS HANDED, and not the collection at large. The judgement asks what
   // status a row is in, and asking it of a row the page may not even read would decide a member's
   // move from data their projection excludes.
-  const held = preview.datasets[previewPageKey(tier, page.id)] ?? {};
-  const record = (cid: string, itemId: string): Record<string, unknown> | null => (held[cid] ?? []).find((row) => row.id === itemId) ?? null;
+  const held = preview.datasets[previewPageKey(audience, page.id)] ?? {};
+  // THE PAGE'S DATASETS **AND** THE READER'S OWN ROWS, because those are the two things a live page
+  // is handed and they are not the same list. A collection people submit to is exactly the one
+  // `public.read` cannot open — one visitor would be reading every other visitor's answer — so the
+  // row a public page moves is never in its datasets. It arrives as `viewer.mine`, which is the
+  // whole reason that message exists, and an intent judged against the datasets alone answered
+  // `not-in-view` about a row the page was legitimately showing.
+  //
+  // It does not widen anything: `own` is filtered to the author's own rows by the same three
+  // selectors the rules identify one by (`readCollection`), so a row somebody else submitted is in
+  // neither list.
+  const record = (cid: string, itemId: string): Record<string, unknown> | null =>
+    (held[cid] ?? []).find((row) => row.id === itemId) ?? (preview.own[cid] ?? []).find((row) => row.id === itemId) ?? null;
 
   // Rebuilt into the message shape the package reads, rather than the package being given a second
   // entry point for a pre-parsed ask: `readIntentMessage` is what mulmoserver judges with, and a

--- a/server/backends/sharedApp/previewIntent.ts
+++ b/server/backends/sharedApp/previewIntent.ts
@@ -27,9 +27,10 @@
 import { doc, collection, writeBatch } from "firebase/firestore";
 import { APPS_COLLECTION, appSchemasPath } from "@receptron/sharedapp";
 import { MIRROR_OPEN, readIntentMessage, VIEW_MESSAGE, type JudgedIntent, type WriteTier } from "@receptron/sharedapp/view";
+import { isRecord } from "../../../common/isRecord.js";
 import { previewPageKey, type PreviewAudience, type PreviewIntent, type PreviewIntentResult } from "../../../common/sharedAppPreview.js";
 import { currentFirestore } from "../remoteHost/session.js";
-import { previewSharedApp } from "./preview.js";
+import { ownSelectors, ownsRow, previewSharedApp } from "./preview.js";
 import { sharedAppContext } from "./context.js";
 
 /** Where a shared collection's records live. Spelled as `previewWrite.ts` spells it. */
@@ -200,13 +201,36 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
   const record = (cid: string, itemId: string): Record<string, unknown> | null =>
     (held[cid] ?? []).find((row) => row.id === itemId) ?? (preview.own[cid] ?? []).find((row) => row.id === itemId) ?? null;
 
-  // NOTHING IS READ ON DEMAND HERE, and the reason is worth stating because it looks like a gap.
-  // A row the page found through `view.mine(cid, key)` is in `own` too: that map is built by the
-  // same four selectors the rules identify an own row by, INCLUDING the one whose identity is the
-  // document name (`idFrom: "auth.uid+field"` — see `ownsRow`). It was missing that one, so
-  // live-poll's rows were absent from `viewer.mine` and an intent about one came back
-  // `not-in-view`; the fix belongs there rather than in a second read here, or the two would answer
-  // the same question differently.
+  /** THE ROW THE PAGE FOUND WHEN NO LIST COULD.
+   *
+   *  `viewer.mine` is built from a LIST, and `view.mine(cid, key)` is a `get` — so the two do not
+   *  fail together. A list refused on an app published a moment ago, an offline blink, any
+   *  transient: `own` loses the collection for that render, the page's keyed lookup still answers,
+   *  and the control it draws would then fail `not-in-view`. Rendered and refused is precisely the
+   *  shape this whole change removes.
+   *
+   *  IT CANNOT BE LOOSER THAN THE LIST, because it asks the SAME question: `ownsRow`, the predicate
+   *  `readCollection` filters with, which is `ownRow` in the rules said in the terms this host has.
+   *  A staff page asking after somebody else's row still gets `not-in-view` — nothing here widens
+   *  what a page may name, it only stops the host refusing a row the reader owns.
+   *
+   *  Not reached for a row already held: the ordinary intent costs no read. */
+  const ownRecord = async (cid: string, itemId: string): Promise<Record<string, unknown> | null> => {
+    const want = ownSelectors(preview.config)[cid];
+    if (want === undefined) return null;
+    const found = await handle.docs.get(itemsPath(preview.aid, cid), itemId).catch(() => null);
+    if (!isRecord(found)) return null;
+    const row = { ...found, id: itemId };
+    return ownsRow(want, row, handle) ? row : null;
+  };
+
+  // RESOLVED BEFORE THE JUDGEMENT, so the package sees the row's real status rather than nothing —
+  // and so that what is judged and what is checked below cannot be two different answers.
+  const asking = record(asked.cid, asked.itemId) ?? (await ownRecord(asked.cid, asked.itemId));
+  const holding = (cid: string, itemId: string): Record<string, unknown> | null => {
+    if (cid === asked.cid && itemId === asked.itemId) return asking;
+    return record(cid, itemId);
+  };
 
   // Rebuilt into the message shape the package reads, rather than the package being given a second
   // entry point for a pre-parsed ask: `readIntentMessage` is what mulmoserver judges with, and a
@@ -222,7 +246,7 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
       ...(asked.to === undefined ? {} : { to: asked.to }),
     },
     write,
-    record,
+    holding,
     { address: handle.email, tier },
   );
   if (!read.ok) return { ok: false, error: read.reason };
@@ -230,7 +254,7 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
   // AFTER the package's judgement, not before, so its own refusals keep their names: a cid this
   // view never declared is `unknown-collection`, which says which declaration to change, and it
   // would otherwise be reported as a missing row.
-  if (record(read.intent.cid, read.intent.itemId) === null) return { ok: false, error: NOT_IN_VIEW };
+  if (holding(read.intent.cid, read.intent.itemId) === null) return { ok: false, error: NOT_IN_VIEW };
 
   const failed = await commit(preview.aid, read.intent);
   if (failed !== null) return { ok: false, error: failed };

--- a/server/backends/sharedApp/previewIntent.ts
+++ b/server/backends/sharedApp/previewIntent.ts
@@ -200,6 +200,14 @@ export async function performPreviewIntent(root: string, asked: PreviewIntent): 
   const record = (cid: string, itemId: string): Record<string, unknown> | null =>
     (held[cid] ?? []).find((row) => row.id === itemId) ?? (preview.own[cid] ?? []).find((row) => row.id === itemId) ?? null;
 
+  // NOTHING IS READ ON DEMAND HERE, and the reason is worth stating because it looks like a gap.
+  // A row the page found through `view.mine(cid, key)` is in `own` too: that map is built by the
+  // same four selectors the rules identify an own row by, INCLUDING the one whose identity is the
+  // document name (`idFrom: "auth.uid+field"` — see `ownsRow`). It was missing that one, so
+  // live-poll's rows were absent from `viewer.mine` and an intent about one came back
+  // `not-in-view`; the fix belongs there rather than in a second read here, or the two would answer
+  // the same question differently.
+
   // Rebuilt into the message shape the package reads, rather than the package being given a second
   // entry point for a pre-parsed ask: `readIntentMessage` is what mulmoserver judges with, and a
   // shortcut past its own narrowing is a second reading of what an intent IS. The request id is

--- a/server/backends/sharedApp/previewLookup.ts
+++ b/server/backends/sharedApp/previewLookup.ts
@@ -1,0 +1,107 @@
+// "HAVE I ALREADY GOT THIS ROW?", answered in the preview — for the one key the page names.
+//
+// `viewer.mine` carries the answer for every id strategy that can be LISTED, and for one it never
+// can: `auth.uid+field` builds ids as `uid + "_" + <field>`, and the rules grant a submitter the
+// document they can NAME rather than a range of them. The key is exactly what this side lacks and
+// the page has — it is showing that question — so the answer is a read on demand.
+//
+// IT IS mulmoserver's `publicOwnLookup.ts`, PERFORMED AS THE AUTHOR. The id rule is the package's
+// `recordId`, called with the same arguments in the same order, because the id a lookup asks about
+// must be the one a submission would write: a second copy of that rule tells the page "no row"
+// about a row it is about to be refused for.
+//
+// The uid half is NOT the page's to choose. It comes from the author's session here, so a page
+// asking about a made-up key learns only that a row of its own does not exist.
+//
+// NOT KNOWING IS AN ANSWER, and it is a different one from "no". A collection whose ids cannot be
+// built from a key, a read that was refused, an app that has never been published: all of those are
+// `known: false` — nobody looked — and the parent must not turn them into "you have not answered",
+// which takes a one-time action away from somebody entitled to it.
+import { appSchemasPath } from "@receptron/sharedapp";
+import { missingIdField, ownRow, recordId, type SubmitSpec } from "@receptron/sharedapp/view";
+
+import type { PreviewLookupResult } from "../../../common/sharedAppPreview.js";
+import { previewSharedApp } from "./preview.js";
+import { sharedAppContext } from "./context.js";
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+
+/** The id half of a submit declaration, lifted out field by field.
+ *
+ *  The projection types `submit` loosely — the rules read those keys by the author's own names — and
+ *  only these three decide an id. Read here rather than asserted into shape, so a declaration
+ *  missing one becomes "nothing to look up" instead of a crash on the route. `createFields` rides
+ *  along because `SubmitSpec` requires it and `recordId` never reads it. */
+const idPartOf = (submit: Record<string, unknown>): SubmitSpec => ({
+  createFields: [],
+  ...(typeof submit.idFrom === "string" ? { idFrom: submit.idFrom } : {}),
+  ...(typeof submit.idField === "string" ? { idField: submit.idField } : {}),
+});
+
+/** The strategies whose id this side can build from a key.
+ *
+ *  `auto` has none — the id was random and the record is unfindable by anything the page knows —
+ *  and `field` names a record the page did not create, which is a different question from "mine". */
+const buildsFromUid = (submit: SubmitSpec): boolean => submit.idFrom === "auth.uid" || submit.idFrom === "auth.uid+field";
+
+/** The key, in the shape the id builder reads it from: a record with just that field. */
+const carrying = (submit: SubmitSpec, key: string): Record<string, unknown> => {
+  const field = submit.idField;
+  if (typeof field !== "string") {
+    return {};
+  }
+  return { [field]: key };
+};
+
+/** The document id this ask resolves to, or null for "nothing here can be looked up". */
+const idFor = (submit: SubmitSpec, uid: string, key: string): string | null => {
+  if (!buildsFromUid(submit) || uid === "") {
+    return null;
+  }
+  const record = carrying(submit, key);
+  // ASKED BEFORE THE ID IS BUILT, because `recordId` refuses a composite id whose field carries
+  // nothing — it would otherwise answer `"<uid>_"`, which is a valid document id and the wrong row.
+  if (missingIdField(submit, record) !== undefined) {
+    return null;
+  }
+  // The SHARED builder, and the empty `unique` is the tell that nothing here falls back to a random
+  // id: every strategy admitted above builds one from the uid.
+  const id = recordId(submit, uid, record, "");
+  if (id === "") {
+    return null;
+  }
+  return id;
+};
+
+/** One ask, answered against the live database with the author's own credentials. */
+export async function previewOwnLookup(root: string, ask: { cid: string; key: string }): Promise<PreviewLookupResult> {
+  const context = await sharedAppContext(root);
+  if (!context.ok) return { ok: false };
+  const { handle } = context;
+
+  const preview = await previewSharedApp(root);
+  if (!preview.ok) return { ok: false };
+
+  const declared = preview.config.submit?.[ask.cid];
+  if (!isRecord(declared)) return { ok: false };
+  const id = idFor(idPartOf(declared), handle.uid, ask.key);
+  if (id === null) return { ok: false };
+
+  // A THROWN read and an ABSENT document are the two answers this file exists to keep apart, and
+  // collapsing them is the easy mistake: `get` answers null for "there is no such document", and a
+  // refusal — the ordinary state of an app nobody has published — arrives as a rejection. Reading
+  // both as "not found" tells the author's page they have not answered, which is the one thing a
+  // lookup must never make up.
+  const read = await handle.docs
+    .get(`${appSchemasPath(preview.aid)}/${ask.cid}/items`, id)
+    .then((doc) => ({ read: true as const, doc }))
+    .catch(() => ({ read: false as const, doc: null }));
+  if (!read.read) return { ok: false };
+  const found = read.doc;
+  if (found === null) return { ok: true, found: false };
+  // PROJECTED, exactly as `viewer.mine` is: `ownRow` in the rules hands back the whole document,
+  // and the status the app moved it to or the note a reviewer left is not the page's business. The
+  // fields a page in this position could have SENT, plus the id.
+  const fields = preview.formInputs[ask.cid] ?? [];
+  return { ok: true, found: true, record: ownRow(fields, { ...(isRecord(found) ? found : {}), id }) };
+}

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -17,6 +17,7 @@ import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { previewSharedApp } from "./sharedApp/preview.js";
 import { undoPreviewSubmission, writePreviewSubmission } from "./sharedApp/previewWrite.js";
 import { performPreviewIntent } from "./sharedApp/previewIntent.js";
+import { previewOwnLookup } from "./sharedApp/previewLookup.js";
 import { requestBody } from "../routes/requestBody.js";
 import { isRecord } from "../../common/isRecord.js";
 import { workspaceForRoute } from "../routes/routeParams.js";
@@ -82,6 +83,7 @@ async function respondPreview(req: Request, res: Response): Promise<void> {
     generatedForm: result.generatedForm,
     formInputs: result.formInputs,
     datasets: result.datasets,
+    own: result.own,
     unreadable: result.unreadable,
     warnings: result.warnings,
   };
@@ -146,6 +148,24 @@ async function respondIntent(req: Request, res: Response): Promise<void> {
   res.json(await performPreviewIntent(cwd, asked));
 }
 
+/** One `view.mine(cid, key)`, answered. Out of the mount below for its line budget, and beside
+ *  `respondIntent` for the same reason: the narrowing is the part with a decision in it.
+ *
+ *  An unreadable ask is `{ ok: false }` — "nobody looked" — and never `{ found: false }`, which
+ *  would tell the page the author has not submitted. */
+async function respondLookup(req: Request, res: Response): Promise<void> {
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
+  const body = requestBody(req.body);
+  const cid = typeof body.cid === "string" ? body.cid : "";
+  const key = typeof body.key === "string" ? body.key : "";
+  if (cid === "" || key === "") {
+    res.json({ ok: false });
+    return;
+  }
+  res.json(await previewOwnLookup(cwd, { cid, key }));
+}
+
 export function mountSharedAppPreviewRoutes(app: Express): void {
   // The write the author accepted in the confirmation, performed as them.
   //
@@ -174,6 +194,14 @@ export function mountSharedAppPreviewRoutes(app: Express): void {
   // would mean one narrowing deciding which, over a body a sandboxed page's parent composed.
   app.post("/api/shared-app/preview/intent", (req, res) => {
     void respondIntent(req, res).catch((err: unknown) => fail(res, err));
+  });
+
+  // "Have I already got this row?" — a READ, for the one key the page names, performed with the
+  // author's own credentials against an id this host builds. Its own route because it answers in a
+  // different vocabulary from the two above: `{ known, found }` rather than `{ ok, error }`, and a
+  // page settling one as the other reads "not found" as "refused".
+  app.post("/api/shared-app/preview/lookup", (req, res) => {
+    void respondLookup(req, res).catch((err: unknown) => fail(res, err));
   });
 
   // Taking one back. Its own route rather than a flag on the one above, because the author presses

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -390,12 +390,18 @@ real answer in the app's data, not a rehearsal: tell the user that before they p
 and offer to remove it afterwards. Reaching the CONFIRMATION is what proves the page works;
 accepting is only needed when you want to see the record land.
 
-**A member's page is the one place the pane can prove more than the headless run.** A page written
-for the roster (`/m/`) or for the participant (`/p/`) asks for a `transition`, an `assign` or a
-`withdraw`, and the pane **performs it** — as the author, judged first against that page's own
-projection and then by the deployed rules. The headless run refuses all three (`read-only`), so it
-can only show that a control is wired; whether pressing it actually moves the record is a question
-only the pane answers.
+**Moving a record is the one thing the pane can prove and the headless run cannot.** A page asks for
+a `transition`, an `assign` or a `withdraw`, and the pane **performs it** — as the author, judged
+first against that page's own projection and then by the deployed rules. The headless run refuses
+all three (`read-only`), so it can only show that a control is wired; whether pressing it actually
+moves the record is a question only the pane answers.
+
+**On EVERY page, including the public one.** A visitor who submitted a row may move it along
+`selfTransitions` and take it away along `selfDelete` — both declared inside `public.submit[cid]` —
+with no role and no membership: `ownRow` in the rules asks that they are signed in and nothing more,
+and an anonymous session counts. The public page used to be unable to ask for any of it (the ask was
+dropped and the page waited for ever), which is worth knowing when reading an older page that works
+around it.
 
 **And it moves a REAL record, with no HOST confirmation and no undo.** A submission raises the
 parent's confirmation dialog and lands in the pane's Undo list; a member's move does neither — the
@@ -941,6 +947,14 @@ The comparison above is only the first, and it is the one that needs an address:
   `idFrom: "auth.uid+field"` the id is `uid_<field>`, which the host cannot know before the page
   names the key. It answers `{ known, found, record }`, and `known: false` means **nobody looked**.
   Draw the action and let the refusal explain itself; never draw it as "no".
+
+**All three work in the pane's preview, and the last two did not until 2026-08-19.** The pane
+answered `view.mine()` with `known: false` for ever and sent no `viewer.mine` at all, because the
+parent it wired had nowhere to route the read — so a page that correctly refused to guess drew its
+"please register" branch on top of a registration that existed, and the fault looked like the page's.
+If you are reading a page whose author added a "which one are you?" picker or a `?pretendRegistered`
+switch to get past that, **delete it**: the workaround runs in the preview and the real branch never
+does, which is the preview ceasing to preview anything.
 
 So the question to settle before the page is written is not "is the visitor signed in" but **which
 of the three this page will use** — and being unable to READ the collection does not settle it,

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -20,7 +20,7 @@
 // a role may WRITE is not tested; nobody else exists, so nothing here is concurrent; and it cannot
 // tell whether the Firestore rules a new declaration needs have been deployed at all.
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from "vue";
-import { memberBridge, portChannel, publicViewSrcdoc, viewBridge, viewNonce, VIEW_MESSAGE, type PendingSubmit, type Viewer } from "@receptron/sharedapp/view";
+import { portChannel, publicViewSrcdoc, viewNonce, viewParent, VIEW_MESSAGE, type LookupAsk, type PendingSubmit } from "@receptron/sharedapp/view";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
 import { isRecord } from "../../common/isRecord";
 import { createPreviewLog, renderPreviewLog, type PreviewLogEvent } from "../utils/sharedAppPreviewLog";
@@ -164,7 +164,54 @@ function noteOutbound(message: Record<string, unknown>): void {
   remember({ kind: "refused", reason, audience: audienceNow() });
 }
 
-const bridge = viewBridge(
+/** Take the stale page off the screen, DEFERRED — which is the whole of what this host adds to that
+ *  port's contract. `load()` blanks the payload on its way, which changes the page being drawn and
+ *  restarts the bridge: run synchronously it would close the channel before the answer to this very
+ *  intent had been posted, and the view would wait for ever on a request that actually succeeded. A
+ *  macrotask puts it after the post, which the bridge makes from the promise the sender returns. */
+const recover = () => window.setTimeout(() => void load(), 0);
+
+/** The member's writes — and the public page's, which is the change. It decides nothing (see its
+ *  header) and is given the four things it needs so that what a refusal does to the log can be
+ *  pinned without a frame. */
+const sendIntent = createIntentSender({ page: () => page.value, url: () => writeUrl("intent"), remember, refresh, recover });
+
+/** "Have I already got this row?", asked of the server for the one key the page names.
+ *
+ *  A REJECTION is the honest failure and `{ found: false }` is not: a refused read, an app that has
+ *  never been published and a collection whose ids cannot be built from a key are all "nobody
+ *  looked", and the parent turns a rejection into exactly that. Answering "no" instead would tell
+ *  the author's page that they have not submitted, and it would stop offering an action they are
+ *  entitled to. */
+async function lookupOwn(ask: LookupAsk): Promise<{ found: boolean; record?: Record<string, unknown> }> {
+  const res = await fetchWithTimeout(
+    writeUrl("lookup"),
+    { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ cid: ask.cid, key: ask.key }) },
+    SLOW_COMMAND_TIMEOUT_MS,
+  );
+  const body: unknown = await res.json();
+  if (!isRecord(body) || body.ok !== true) throw new Error("nothing could be looked up");
+  const record = isRecord(body.record) ? body.record : undefined;
+  return { found: body.found === true, ...(record === undefined ? {} : { record }) };
+}
+
+/** ONE PARENT, for whichever page is on screen.
+ *
+ *  There were two — the package's public bridge for `/a/`-style pages and its member bridge for the
+ *  roster and participant ones — and this pane chose between them per page. mulmoserver did the
+ *  same, and BOTH have stopped: the injected bootstrap is one document, so every page can call all
+ *  five asks, and a parent that answers half of them drops the rest. On the public page that meant
+ *  an intent was read as "not a submission", found to carry no request id, and dropped — the page's
+ *  promise never settled. On a member page it meant `view.mine()` was answered "nobody looked"
+ *  whatever the rules would have returned, so a page asking "have I registered?" drew its
+ *  registration form on top of a registration.
+ *
+ *  WHAT DIFFERS IS THE ANSWER, never the vocabulary. Every port below is offered on every page, and
+ *  what a reader may actually do is decided where it can be enforced: the projection the server
+ *  resolved (`viewer`), the judgement in `previewIntent.ts`, and then the deployed rules.
+ *
+ *  Design: `plans/feat-one-view-parent.md`. */
+const parent = viewParent(
   {
     channel: () => {
       // Wrapped rather than replaced: what may travel and when is the package's, and this only
@@ -192,6 +239,32 @@ const bridge = viewBridge(
     // `undeclared-field` are answered before it, which is what a preview is FOR.
     submit: (pending) => send(pending.cid, pending.values),
     state: () => datasets.value,
+    // WHAT THE AUTHOR HAS ALREADY SUBMITTED, as the published page will be told it. `undefined`
+    // until a payload has landed — which is "nobody has looked", not "you have submitted nothing",
+    // and the difference is what stops a page claiming somebody has answered when they have not.
+    mine: () => payload.value?.own,
+    // WHO the author is to THIS page and what they may change, resolved by the server against the
+    // page's own projection. Public pages carry one too now: the rules let the person who submitted
+    // a row move it and take it away with no role at all, so a public page with no `viewer` drew no
+    // button for a cancellation the rules were waiting to allow.
+    viewer: () => page.value?.viewer,
+    // A GETTER, as the port requires: the page on screen changes under this parent, and a handler
+    // captured once would send a later ask under the page that was there before.
+    perform: () => sendIntent,
+    // "Have I already got this row?", for the one key the page names — the half `mine` cannot
+    // cover, because a composite id has no range the rules will list. A REJECTION here is answered
+    // `known: false`, which is the honest "nobody looked".
+    lookup: (ask) => lookupOwn(ask),
+    // A DEFECT OF OURS — a port rejected, or threw before it could answer. The page has already
+    // been told `ok: false` with a fixed code and never sees this; what is left is whether the
+    // author does. It goes in the same log as everything else the pane collects, as a `host` line:
+    // the reader here is the author trying to fix the page, and a failure of the parent looks
+    // identical to a page that hung if nothing records it.
+    defect: (error, requestId) =>
+      remember({
+        kind: "host",
+        note: `the preview could not answer request ${requestId ?? "(none)"}: ${error instanceof Error ? error.message : String(error)}`,
+      }),
   },
   // The REAL declaration, never an empty map.
   //
@@ -204,112 +277,16 @@ const bridge = viewBridge(
   cells,
 );
 
-/** The member's writes, in their own module. It decides nothing — see its header — and is given
- *  the four things it needs so that what a refusal does to the log can be pinned without a frame. */
-/** Take the stale page off the screen, DEFERRED — which is the whole of what this host adds to that
- *  port's contract. `load()` blanks the payload on its way, which changes the page being drawn and
- *  restarts the bridge: run synchronously it would close the channel before the answer to this very
- *  intent had been posted, and the view would wait for ever on a request that actually succeeded. A
- *  macrotask puts it after the post, which the bridge makes from the promise the sender returns. */
-const recover = () => window.setTimeout(() => void load(), 0);
-
-const sendIntent = createIntentSender({ page: () => page.value, url: () => writeUrl("intent"), remember, refresh, recover });
-
-/** The parent a MEMBER's page gets: the roster and participant pages, which is what `/m/` and
- *  `/p/` put in front of the same HTML.
- *
- *  A second bridge rather than a flag, because a member's ask is not a submission — see
- *  `memberBridge` in the package. What matters here is that it is the package's and not this
- *  pane's: while there was only the public one to reach for, a member page previewed here was sent
- *  a state message with no `viewer` key at all, the injected runtime read `data.viewer || {}`, and
- *  the page drew none of its buttons. That is indistinguishable from an author who got the
- *  capability names wrong, and it was diagnosed as exactly that.
- *
- *  AND IT PERFORMS. A transition, an assignment or a withdrawal is a real write against the live
- *  rules, made as the author through `/preview/intent` — the same destination the submissions above
- *  go to, and for the same reason. It used to refuse all three in one word, so a desk drew its
- *  buttons and every one of them failed; why that is not a preview of a desk is in
- *  `server/backends/sharedApp/previewIntent.ts`, which also holds the judgement — none of it is
- *  here. */
-const member = memberBridge(
-  {
-    channel: () => {
-      const channel = portChannel(frame.value, (message) => structuredCloneable(message));
-      return {
-        post: (message) => {
-          noteOutbound(message);
-          channel.post(message);
-        },
-        onMessage: channel.onMessage,
-        close: channel.close,
-      };
-    },
-    state: () => datasets.value,
-    // NO FLOOR. This parent is chosen only for a page that HAS a viewer (see `memberPage`), so
-    // there is nothing to fall back to — and inventing `{ me: null, can: {} }` here is the exact
-    // bug this whole change removes: a page drawing no controls, with nothing anywhere saying why.
-    viewer: () => page.value?.viewer ?? UNRESOLVED_VIEWER,
-    // A GETTER, as the port requires: the page on screen changes under this bridge, and a handler
-    // captured once would send a later ask under the page that was there before.
-    perform: () => sendIntent,
-    // The SAME cell the public parent writes, so the handshake is logged whichever parent answered
-    // it. Watched below rather than recorded here: the cell is what the bridge actually writes, so
-    // nothing can move without the log seeing it.
-    readied: cells.readied,
-    // The same log the public parent writes to. A member page can throw before it ever readies —
-    // the page that sits on its loading state — and without this the pane would report that page
-    // as silent, which is the one thing it exists not to do.
-    notice: (report) => remember({ kind: "notice", code: report.code, detail: report.detail }),
-    // A DEFECT OF OURS — the preview's own `perform` rejected, or threw before it could answer.
-    // The page has already been told `ok: false` with a fixed code and never sees this; what is
-    // left is whether the author does. It goes in the same log as everything else the pane
-    // collects, as a `host` line: the reader here is the author trying to fix the page, and a
-    // failure of the parent looks identical to a page that hung if nothing records it. Required by
-    // `@receptron/sharedapp` 0.10.0 rather than optional, for exactly that reason — a place that
-    // can be forgotten is the same as swallowing it.
-    defect: (error, requestId) =>
-      remember({
-        kind: "host",
-        note: `the preview could not answer intent ${requestId ?? "(none)"}: ${error instanceof Error ? error.message : String(error)}`,
-      }),
-  },
-  () => nonce.value,
-);
-
-/** Answering a `viewer` question for a page that has none. Unreachable — `memberPage` is what
- *  selects this parent and it requires one — and here so that a future change which loses that
- *  guarantee produces an empty-capability page WITH a line in the log above, rather than the silent
- *  no-controls page this whole change removes. */
-const UNRESOLVED_VIEWER: Viewer = { me: null, can: {} };
-
-/** Which parent is talking to the document on screen.
- *
- *  The audience decides WHICH parent a page should have — `/a/` is the public one, `/m/` and `/p/`
- *  are the member's, exactly as the address decides it in production. But the member parent needs
- *  capabilities to be worth choosing, so the test is that the payload actually carried them: a
- *  member page without a `viewer` would otherwise be handed an empty one and draw no controls,
- *  which is the failure being fixed rather than a smaller version of the fix.
- *
- *  That case is REPORTED. Falling back to the public parent quietly would put an author back in
- *  front of the same blank page with nothing to read — and the cause is not in their page at all,
- *  it is a host too old to resolve capabilities, or a payload this pane could not narrow. */
-const memberPage = computed(() => page.value !== null && page.value.audience !== "public" && page.value.viewer !== undefined);
-
 /** Only messages from OUR frame. The sandbox's origin is opaque, so `event.origin` cannot draw
  *  this boundary and `event.source` is what does. */
 const onMessage = (event: MessageEvent) => {
   if (frame.value === null || event.source !== frame.value.contentWindow) return;
-  if (memberPage.value) {
-    member.receive(event.data);
-    return;
-  }
-  bridge.receive(event.data);
+  parent.receive(event.data);
 };
 window.addEventListener("message", onMessage);
 onBeforeUnmount(() => {
   window.removeEventListener("message", onMessage);
-  bridge.restart();
-  member.forget();
+  parent.restart();
 });
 
 // A new document means a new conversation: the old channel belongs to a document we are no longer
@@ -337,10 +314,9 @@ watch(
   // for the same reason the datasets are.
   () => (page.value === null ? null : keyOf(page.value)),
   () => {
-    // BOTH, always. The page that is going may have been the other audience's, and a channel left
-    // open belongs to a document nobody is looking at any more.
-    bridge.restart();
-    member.forget();
+    // A channel left open belongs to a document nobody is looking at any more — and a confirmation
+    // still open refers to a page the author can no longer see.
+    parent.restart();
     nonce.value = viewNonce();
     // NOT a reset of the log. Switching pages is part of what the author was doing, and the page
     // they came from is often where the fault is — a member page that never readied looks identical
@@ -357,16 +333,10 @@ watch(
   },
 );
 
-// New data, same document — the view asked once and cannot ask again. Sent to whichever parent
-// holds the conversation; the other one has no open channel and its call is a no-op.
-watch(
-  datasets,
-  () => {
-    bridge.sendState();
-    member.sendState();
-  },
-  { deep: true },
-);
+// New data, same document — the view asked once and cannot ask again. EVERY half of the state
+// message moves here: the datasets, what the author has submitted of their own (which moves on
+// their own send) and the viewer the server resolved.
+watch([datasets, () => payload.value?.own, () => page.value?.viewer], () => parent.sendState(), { deep: true });
 
 /** Every record this preview session wrote, newest first.
  *
@@ -842,7 +812,7 @@ watch(
             type="button"
             class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent disabled:cursor-default disabled:opacity-60"
             :disabled="cells.sending.value"
-            @click="bridge.accept()"
+            @click="parent.accept()"
           >
             Send it
           </button>
@@ -850,7 +820,7 @@ watch(
             type="button"
             class="cursor-pointer rounded-[5px] border border-border bg-input px-1.5 py-[3px] text-[11px] text-fg hover:border-accent disabled:cursor-default disabled:opacity-60"
             :disabled="cells.sending.value"
-            @click="bridge.decline()"
+            @click="parent.decline()"
           >
             Cancel
           </button>

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -23,6 +23,10 @@ export function asPayload(value: unknown): SharedAppPreview | null {
     generatedForm: value.generatedForm === true,
     formInputs: asFormInputs(value.formInputs),
     datasets: isRecord(value.datasets) ? Object.fromEntries(Object.entries(value.datasets).map(([key, rows]) => [key, asDatasets(rows)])) : {},
+    // The author's own rows. `{}` is the floor and it is the honest one: a cid ABSENT from this map
+    // is "nobody looked", so an unreadable payload says nothing about any collection rather than
+    // saying "you have submitted nothing" about all of them.
+    own: asDatasets(value.own),
     unreadable: strings(value.unreadable),
     warnings: strings(value.warnings),
   };

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -46,7 +46,16 @@ class RecordingDocs implements FirestoreDocs {
     return created;
   }
 
+  /** Refuse to LIST records, which is the ordinary state of an app nobody has published: the rules
+   *  cannot resolve an owner for anything under a document that does not exist. Separate from
+   *  `denyItemReads` because they are different operations — a lookup `get`s one document by name
+   *  and a dataset `list`s a collection — and a preview has to tell them apart. */
+  denyItemLists = false;
+
   list = (collectionPath: string): Promise<FirestoreDoc[]> => {
+    if (this.denyItemLists && collectionPath.includes("/collections/")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
     const docs = [...this.read(collectionPath)].sort(([left], [right]) => (left < right ? -1 : 1));
     return Promise.resolve(docs.map(([id, data]) => ({ id, data })));
   };
@@ -206,8 +215,74 @@ describe("shared app preview", () => {
     const result = await previewSharedApp(root, stamp);
 
     expect(result.ok === false ? result.problems : []).toEqual([]);
-    expect(result.ok && result.pages).toEqual([{ id: "public", html, audience: "public" }]);
+    // WITH A VIEWER, which the public page did not use to get. The rules let the person who
+    // submitted a row move it and take it away with no role at all (`ownRow` asks for `authed()`
+    // and nothing else), so a public page handed no capabilities drew no button for a cancellation
+    // the rules were waiting to allow. `can` is empty here because this app declares no
+    // `selfTransitions` and no `selfDelete` — an empty answer, not a missing one.
+    expect(result.ok && result.pages).toEqual([{ id: "public", html, audience: "public", viewer: { me: "owner@example.com", can: {} } }]);
     expect(docs.writes).toEqual([]);
+  });
+
+  it("hands back what the AUTHOR has already submitted, projected as the page will see it", async () => {
+    // The port that did not exist. A collection people submit to is exactly the one `public.read`
+    // cannot open — one visitor would be reading every other visitor's answer — so a page cannot
+    // find its own row for itself, and the pane answered "nobody looked" for ever. A page asking
+    // "have I registered?" then drew its registration form on top of a registration.
+    writeApp(
+      root,
+      declaration({
+        collections: { bookings: { submitOnly: true } },
+        public: {
+          enabled: true,
+          read: ["notes"],
+          submit: { bookings: { auth: "verifiedEmail", emailField: "note", createFields: ["note", "closesAt"] } },
+        },
+      }),
+    );
+    docs.store.set(
+      `apps/${AID}/collections/bookings/items`,
+      new Map([
+        ["mine", { note: OWNER.email, closesAt: 5, status: "approved", staffNote: "難しい客" }],
+        ["theirs", { note: "somebody@example.com", closesAt: 6 }],
+      ]),
+    );
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    // THEIRS IS NOT HERE. The read is made as the author (this is their machine) and then filtered
+    // to their own rows by the same selectors the rules identify one by — a preview that showed
+    // more than production is the one direction this must never fail in.
+    //
+    // AND NEITHER IS `status` OR `staffNote`. `ownRow` in the rules hands back the whole document;
+    // what a page in this position could have SENT is narrower, and handing over the rest would
+    // widen what a published page knows about the app in order to tell it something it already
+    // knew. `closesAt` survives because the form draws it; `note` is the address field the host
+    // fills in, so it does not.
+    expect(result.ok && result.own).toEqual({ bookings: [{ id: "mine", closesAt: 5 }] });
+  });
+
+  it("says nothing about a collection whose rows could not be read", async () => {
+    // ABSENT is "nobody looked" and an empty array is "you have submitted nothing". A page told the
+    // second when the first is true stops offering an action to somebody entitled to it, which is
+    // the bug this whole port exists to prevent — arriving from the other direction.
+    writeApp(
+      root,
+      declaration({
+        collections: { bookings: { submitOnly: true } },
+        public: {
+          enabled: true,
+          read: ["notes"],
+          submit: { bookings: { auth: "verifiedEmail", emailField: "note", createFields: ["note", "closesAt"] } },
+        },
+      }),
+    );
+    docs.denyItemLists = true;
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok && result.own).toEqual({});
   });
 
   it("refuses a page it cannot read, rather than previewing an app without it", async () => {

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -268,6 +268,43 @@ describe("shared app preview", () => {
     expect(result.ok && result.own).toEqual({ bookings: [{ id: "mine", closesAt: 5 }] });
   });
 
+  it("finds an own row whose identity is the document NAME, not a field", async () => {
+    // The FOURTH id shape, and the one that was missing: `idFrom: "auth.uid+field"` puts the uid in
+    // the document name, and an `anonymous` app has no address and no uid FIELD to find it by. That
+    // is live-poll's whole shape — so its author's votes were absent from `viewer.mine`, the page
+    // asked `view.mine()` about them and could not act on them.
+    //
+    // Rebuilt from the STORED value rather than matched as a prefix, which is the rules' own shape:
+    // an unconditional prefix match would let somebody create `<victim uid>_x` in a collection with
+    // a different strategy and grow rights over it.
+    writeApp(
+      root,
+      declaration({
+        collections: { bookings: { submitOnly: true } },
+        public: {
+          enabled: true,
+          read: ["notes"],
+          submit: { bookings: { auth: "anonymous", createFields: ["note"], idFrom: "auth.uid+field", idField: "note" } },
+        },
+      }),
+    );
+    docs.store.set(
+      `apps/${AID}/collections/bookings/items`,
+      new Map([
+        [`${OWNER.uid}_q1`, { note: "q1" }],
+        // Somebody else's, under the same strategy: the name does not rebuild from THIS reader's uid.
+        ["uid-someone_q1", { note: "q1" }],
+        // And a name that does not rebuild from its own stored value, which is what the prefix match
+        // this deliberately is not would have accepted.
+        [`${OWNER.uid}_q9`, { note: "q1" }],
+      ]),
+    );
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok && result.own).toEqual({ bookings: [{ id: `${OWNER.uid}_q1`, note: "q1" }] });
+  });
+
   it("says nothing about a collection whose rows could not be read", async () => {
     // ABSENT is "nobody looked" and an empty array is "you have submitted nothing". A page told the
     // second when the first is true stops offering an action to somebody entitled to it, which is

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -220,7 +220,12 @@ describe("shared app preview", () => {
     // and nothing else), so a public page handed no capabilities drew no button for a cancellation
     // the rules were waiting to allow. `can` is empty here because this app declares no
     // `selfTransitions` and no `selfDelete` — an empty answer, not a missing one.
-    expect(result.ok && result.pages).toEqual([{ id: "public", html, audience: "public", viewer: { me: "owner@example.com", can: {} } }]);
+    //
+    // AND `me` IS NULL, exactly as mulmoserver posts it to the live page. Nothing on this tier
+    // reads it, and a published page holding the reader's address could carry it off by navigating
+    // its own context once. Putting the AUTHOR's address here instead would be the preview handing
+    // a page something production never gives it.
+    expect(result.ok && result.pages).toEqual([{ id: "public", html, audience: "public", viewer: { me: null, can: {} } }]);
     expect(docs.writes).toEqual([]);
   });
 

--- a/test/server/backends/sharedAppPreviewIntent.spec.ts
+++ b/test/server/backends/sharedAppPreviewIntent.spec.ts
@@ -56,8 +56,17 @@ class Docs implements FirestoreDocs {
     return this.store.get(collectionPath) ?? new Map();
   }
 
-  list = (collectionPath: string): Promise<FirestoreDoc[]> =>
-    Promise.resolve([...this.read(collectionPath)].sort(([l], [r]) => (l < r ? -1 : 1)).map(([id, data]) => ({ id, data })));
+  /** Refuse to LIST records while leaving a `get` working — which is not a contrived pair. A list
+   *  refused on an app published a moment ago, an offline blink, a transient: the page's keyed
+   *  `view.mine(cid, key)` is a `get` and answers anyway. */
+  denyItemLists = false;
+
+  list = (collectionPath: string): Promise<FirestoreDoc[]> => {
+    if (this.denyItemLists && collectionPath.includes("/collections/")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    return Promise.resolve([...this.read(collectionPath)].sort(([l], [r]) => (l < r ? -1 : 1)).map(([id, data]) => ({ id, data })));
+  };
 
   get = (collectionPath: string, docId: string): Promise<unknown | null> => {
     const existing = this.read(collectionPath).get(docId);
@@ -393,6 +402,47 @@ describe("a member's intent, performed from the preview", () => {
 
       expect(result).toEqual({ ok: true, mailed: false });
       expect(batched).toEqual([`update apps/${AID}/collections/votes/items/${OWNER.uid}_q1 {"state":"withdrawn"}`]);
+    });
+
+    it("acts on a row the page could only LOOK UP, when the list was refused", async () => {
+      // `viewer.mine` is built from a LIST and `view.mine(cid, key)` is a `get`, so the two do not
+      // fail together: the collection can be unlistable for a render while the document itself
+      // reads back. The page then draws a control from an answer it really got, and the host
+      // refusing it as `not-in-view` is the rendered-and-refused shape this change exists to
+      // remove — the live page allows the move, because there the rules answer ownership.
+      docs.store.set(bookingsPath, new Map([["roomA-1000", { requesterEmail: OWNER.email, slot: "roomA-1000", status: "booked" }]]));
+      docs.denyItemLists = true;
+
+      const result = await performPreviewIntent(root, {
+        page: { id: "public", audience: "public" },
+        kind: "transition",
+        cid: "bookings",
+        itemId: "roomA-1000",
+        to: "cancelled",
+      });
+
+      expect(result).toEqual({ ok: true, mailed: false });
+      expect(batched).toEqual([`update ${bookingsPath}/roomA-1000 {"status":"cancelled"}`]);
+    });
+
+    it("still refuses a row that is NOT the author's, when only a lookup could reach it", async () => {
+      // The same conditions and the other answer. The read on demand asks `ownsRow` — the predicate
+      // the dataset read filters with, which is `ownRow` in the rules said in this host's terms — so
+      // it cannot be looser than the list it stands in for. It matters here more than anywhere: this
+      // write goes out as the app's OWNER, who may touch anything.
+      docs.store.set(bookingsPath, new Map([["roomA-1000", { requesterEmail: "someone@else.example", slot: "roomA-1000", status: "booked" }]]));
+      docs.denyItemLists = true;
+
+      const result = await performPreviewIntent(root, {
+        page: { id: "public", audience: "public" },
+        kind: "transition",
+        cid: "bookings",
+        itemId: "roomA-1000",
+        to: "cancelled",
+      });
+
+      expect(result).toEqual({ ok: false, error: "not-in-view" });
+      expect(batched).toEqual([]);
     });
 
     it("still refuses a row that is NOT the author's, however it was named", async () => {

--- a/test/server/backends/sharedAppPreviewIntent.spec.ts
+++ b/test/server/backends/sharedAppPreviewIntent.spec.ts
@@ -143,6 +143,9 @@ const bookingApp = () => ({
   views: [
     { id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] },
     { id: "mine", audience: "participant", path: "views/desk.html", collections: ["bookings"] },
+    // The page the booking was made on. It draws `slots`, which is all `public.read` opens — the
+    // bookings themselves are the one thing a public page must never list.
+    { id: "public", audience: "public", path: "views/desk.html", collections: ["slots"] },
   ],
   public: {
     enabled: true,
@@ -228,12 +231,19 @@ describe("a member's intent, performed from the preview", () => {
     expect(batched).toEqual([]);
   });
 
-  it("refuses an intent that arrives from a public page", async () => {
-    // A public page has no reader and no roles, so there is nothing to judge the move AS. Answered
-    // by name rather than performed as somebody.
+  it("judges an intent from a PUBLIC page as a participant's, rather than refusing it by kind", async () => {
+    // It used to be refused by name — "a public page has no reader, no roles and no tier". Two of
+    // those are true and the conclusion was not: `ownRow` in the rules asks for `authed()` and
+    // nothing else, and the moves it allows are declared in `public.submit[cid]`. So the visitor who
+    // submitted a row may move it exactly as a participant may, and the refusal was the host's
+    // shape rather than the app's rule.
+    //
+    // This app publishes no public page at all, so the answer is still no — but it is
+    // `no-such-page`, which says which page the ask named, rather than "wrong kind of page", which
+    // named nothing the author could act on. The app below has one, and performs.
     const result = await performPreviewIntent(root, asked({ page: { id: "public", audience: "public" } }));
 
-    expect(result).toEqual({ ok: false, error: "not-a-member-page" });
+    expect(result).toEqual({ ok: false, error: "no-such-page" });
     expect(batched).toEqual([]);
   });
 
@@ -326,6 +336,27 @@ describe("a member's intent, performed from the preview", () => {
       // reopen are both refused, and there is no commit in which the booking is gone and the grid
       // still says taken.
       expect(batched).toEqual([`delete ${bookingsPath}/roomA-1000`, `update apps/${AID}/collections/slots/items/roomA-1000 {"state":"open"}`]);
+    });
+
+    it("cancels the author's OWN booking from the public page, as a participant would", async () => {
+      // THE ONE THIS CHANGE EXISTS FOR. `selfTransitions` is declared inside `public.submit`, which
+      // is the public page's own declaration, and `ownRow` in the rules asks for `authed()` and
+      // nothing else — no role, no membership, an anonymous uid will do. So the visitor who booked
+      // the slot may cancel it, and the page that took the booking is where they would press it.
+      //
+      // It was refused here by kind ("not a member page") because the public parent had no
+      // `perform` port to reach this with, and on the live page the intent was dropped without an
+      // answer at all. Both halves are wired now, and the ask is judged exactly as `/p/`'s is.
+      const result = await performPreviewIntent(root, {
+        page: { id: "public", audience: "public" },
+        kind: "transition",
+        cid: "bookings",
+        itemId: "roomA-1000",
+        to: "cancelled",
+      });
+
+      expect(result).toEqual({ ok: true, mailed: false });
+      expect(batched).toEqual([`update ${bookingsPath}/roomA-1000 {"status":"cancelled"}`]);
     });
 
     it("writes the assignee into the field the declaration names", async () => {

--- a/test/server/backends/sharedAppPreviewIntent.spec.ts
+++ b/test/server/backends/sharedAppPreviewIntent.spec.ts
@@ -338,6 +338,81 @@ describe("a member's intent, performed from the preview", () => {
       expect(batched).toEqual([`delete ${bookingsPath}/roomA-1000`, `update apps/${AID}/collections/slots/items/roomA-1000 {"state":"open"}`]);
     });
 
+    it("acts on a row whose identity is in the document NAME and nowhere else", async () => {
+      // `viewer.mine` is built from a LIST, and `idFrom: "auth.uid+field"` has none: the rules grant
+      // a submitter the document they can NAME rather than a range of them. So a page finds that row
+      // through `view.mine(cid, key)` — live-poll's whole shape — and it is in neither the page's
+      // datasets nor `own`. The ask came back `not-in-view` about a row the page had legitimately
+      // been handed, and it was ALLOWED on the live page, where the rules answer ownership.
+      //
+      // The row is read on demand and accepted only if it is the author's own by the same selector
+      // the dataset read filters with — which is the question `ownRow` asks.
+      writeCollection("votes", {
+        questionId: { type: "string", label: "Q" },
+        choice: { type: "string", label: "Choice" },
+        state: { type: "enum", label: "State", values: ["cast", "withdrawn"] },
+      });
+      writeApp({
+        aid: AID,
+        name: "Poll",
+        members: { [OWNER.email]: { "*": "owner" } },
+        collections: { votes: { submitOnly: true, statusField: "state", transitions: { initial: ["cast"] } }, questions: {} },
+        views: [
+          { id: "desk", audience: "member", path: "views/desk.html", collections: ["questions"] },
+          // The public page draws the QUESTIONS, which is all `public.read` opens — the votes
+          // themselves are the one thing it must never list, which is why the row it acts on can
+          // only have come from a lookup.
+          { id: "public", audience: "public", path: "views/desk.html", collections: ["questions"] },
+        ],
+        public: {
+          enabled: true,
+          read: ["questions"],
+          submit: {
+            votes: {
+              // live-poll's shape, exactly: anonymous, and the uid appears NOWHERE in the record —
+              // the document NAME is the only place it lives.
+              auth: "anonymous",
+              createFields: ["questionId", "choice", "state"],
+              initialStatus: "cast",
+              idFrom: "auth.uid+field",
+              idField: "questionId",
+              selfTransitions: { cast: ["withdrawn"] },
+            },
+          },
+        },
+      });
+      docs.store.set(`apps/${AID}/collections/votes/items`, new Map([[`${OWNER.uid}_q1`, { questionId: "q1", choice: "b", state: "cast" }]]));
+
+      const result = await performPreviewIntent(root, {
+        page: { id: "public", audience: "public" },
+        kind: "transition",
+        cid: "votes",
+        itemId: `${OWNER.uid}_q1`,
+        to: "withdrawn",
+      });
+
+      expect(result).toEqual({ ok: true, mailed: false });
+      expect(batched).toEqual([`update apps/${AID}/collections/votes/items/${OWNER.uid}_q1 {"state":"withdrawn"}`]);
+    });
+
+    it("still refuses a row that is NOT the author's, however it was named", async () => {
+      // The other half, and the reason the fallback is a predicate rather than a read: `NOT_IN_VIEW`
+      // stands in for the ownership check the rules would have made, because this write goes out as
+      // the app's OWNER — who may touch anything. A row belonging to somebody else stays refused.
+      docs.store.set(bookingsPath, new Map([["roomA-1000", { requesterEmail: "someone@else.example", slot: "roomA-1000", status: "booked" }]]));
+
+      const result = await performPreviewIntent(root, {
+        page: { id: "public", audience: "public" },
+        kind: "transition",
+        cid: "bookings",
+        itemId: "roomA-1000",
+        to: "cancelled",
+      });
+
+      expect(result).toEqual({ ok: false, error: "not-in-view" });
+      expect(batched).toEqual([]);
+    });
+
     it("cancels the author's OWN booking from the public page, as a participant would", async () => {
       // THE ONE THIS CHANGE EXISTS FOR. `selfTransitions` is declared inside `public.submit`, which
       // is the public page's own declaration, and `ownRow` in the rules asks for `authed()` and

--- a/test/server/backends/sharedAppPreviewLookup.spec.ts
+++ b/test/server/backends/sharedAppPreviewLookup.spec.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+//
+// "Have I already got this row?", answered in the preview — the half `viewer.mine` cannot cover.
+//
+// `mine` rides with the state and can only carry what can be LISTED. For `idFrom: "auth.uid+field"`
+// the ids are `uid + "_" + <field>` and the rules grant a submitter the document they can NAME
+// rather than a range of them, so nothing can be listed ahead of time: the page holds the key and
+// asks.
+//
+// What is pinned here is the shape of the answers, because two of them look alike and mean opposite
+// things. `{ ok: false }` is "nobody looked" — the parent turns it into `known: false`, and the page
+// keeps offering the action. `{ ok: true, found: false }` is "you have not answered". A host that
+// collapses the first into the second takes a one-time action away from somebody entitled to it.
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs, type FirestoreDoc } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { previewOwnLookup } from "../../../server/backends/sharedApp/previewLookup.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const AID = "app-under-lookup";
+const OWNER = { uid: "uid-owner", email: "owner@example.com" };
+
+class Docs implements FirestoreDocs {
+  readonly store = new Map<string, Map<string, Record<string, unknown>>>();
+  /** Refuse the read, as the rules do for an app nobody has published. */
+  denyItemReads = false;
+
+  private read(collectionPath: string): Map<string, Record<string, unknown>> {
+    return this.store.get(collectionPath) ?? new Map();
+  }
+
+  list = (collectionPath: string): Promise<FirestoreDoc[]> =>
+    Promise.resolve([...this.read(collectionPath)].sort(([l], [r]) => (l < r ? -1 : 1)).map(([id, data]) => ({ id, data })));
+
+  get = (collectionPath: string, docId: string): Promise<unknown | null> => {
+    if (this.denyItemReads && collectionPath.includes("/collections/")) {
+      return Promise.reject(Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" }));
+    }
+    const existing = this.read(collectionPath).get(docId);
+    // The rules' shape: a missing app document is REFUSED, not absent.
+    if (collectionPath === "apps" && !existing) return Promise.reject(Object.assign(new Error("refused"), { code: "permission-denied" }));
+    return Promise.resolve(existing ?? null);
+  };
+
+  create = (): Promise<boolean> => Promise.resolve(true);
+  set = (): Promise<void> => Promise.resolve();
+  delete = (): Promise<boolean> => Promise.resolve(true);
+  watch = (): (() => void) => () => {};
+}
+
+let docs = new Docs();
+let root = "";
+
+const schemaFor = (slug: string, fields: Record<string, unknown>) => ({
+  title: slug,
+  icon: "star",
+  primaryKey: "id",
+  storage: { type: "firestore" },
+  fields: { id: { type: "string", label: "ID", primary: true, required: true }, ...fields },
+});
+
+function writeCollection(slug: string, fields: Record<string, unknown>): void {
+  mkdirSync(path.join(root, ".claude", "skills", slug), { recursive: true });
+  writeFileSync(path.join(root, ".claude", "skills", slug, "schema.json"), JSON.stringify(schemaFor(slug, fields)));
+}
+
+/** A poll: one answer per person per question, which is the id strategy `mine` cannot list. */
+const pollApp = (over: Record<string, unknown> = {}) => ({
+  aid: AID,
+  name: "Poll",
+  members: { [OWNER.email]: { "*": "owner" } },
+  collections: { votes: { submitOnly: true } },
+  public: {
+    enabled: true,
+    read: [],
+    submit: {
+      votes: {
+        auth: "anonymous",
+        uidField: "uid",
+        createFields: ["uid", "questionId", "choice"],
+        idFrom: "auth.uid+field",
+        idField: "questionId",
+      },
+    },
+    ...over,
+  },
+});
+
+const votesPath = `apps/${AID}/collections/votes/items`;
+
+describe("looking up one of the author's own rows", () => {
+  beforeAll(() => {
+    initCollectionsBackend({ workspace: makeTempDir("mt-lookup-ws-") });
+    setSharedCollectionsSupport(true);
+    setFirestoreAccessor(() => ({ docs, email: OWNER.email, uid: OWNER.uid }));
+  });
+
+  beforeEach(() => {
+    docs = new Docs();
+    root = makeTempDir("mt-lookup-");
+    writeCollection("votes", {
+      uid: { type: "string", label: "Uid" },
+      questionId: { type: "string", label: "Question" },
+      choice: { type: "string", label: "Choice" },
+    });
+    writeFileSync(path.join(root, "app.json"), JSON.stringify(pollApp()));
+    docs.store.set("apps", new Map([[AID, { owner: OWNER.uid, members: { [OWNER.email]: { "*": "owner" } }, memberEmails: [OWNER.email] }]]));
+  });
+
+  it("builds the id the SUBMISSION would have written, and projects what it finds", async () => {
+    docs.store.set(votesPath, new Map([[`${OWNER.uid}_q1`, { uid: OWNER.uid, questionId: "q1", choice: "b", countedAt: "2026-08-19" }]]));
+
+    const answer = await previewOwnLookup(root, { cid: "votes", key: "q1" });
+
+    // The id is `recordId`'s, not a second copy of the rule: a lookup that named a different
+    // document would tell the page "no row" about a row it is about to be refused for.
+    //
+    // `countedAt` is the app's and does not cross into the sandbox; `uid` is host-filled and does
+    // not either. What is left is the id and what the page could have sent.
+    expect(answer).toEqual({ ok: true, found: true, record: { id: `${OWNER.uid}_q1`, questionId: "q1", choice: "b" } });
+  });
+
+  it("says 'you have not answered' when the row is genuinely not there", async () => {
+    const answer = await previewOwnLookup(root, { cid: "votes", key: "q2" });
+
+    expect(answer).toEqual({ ok: true, found: false });
+  });
+
+  it("says NOBODY LOOKED when the read was refused", async () => {
+    // Not `found: false`. A refused read is the ordinary state of an app that has never been
+    // published, and a page told "no" there stops offering an action to somebody entitled to it.
+    docs.denyItemReads = true;
+
+    expect(await previewOwnLookup(root, { cid: "votes", key: "q1" })).toEqual({ ok: false });
+  });
+
+  it("says nobody looked for a collection whose id cannot be built from a key", async () => {
+    // `auto` has no id anything can name, and `field` names a record the page did not create —
+    // which is a different question from "mine".
+    writeFileSync(
+      path.join(root, "app.json"),
+      JSON.stringify(pollApp({ submit: { votes: { auth: "anonymous", uidField: "uid", createFields: ["uid", "questionId", "choice"] } } })),
+    );
+
+    expect(await previewOwnLookup(root, { cid: "votes", key: "q1" })).toEqual({ ok: false });
+  });
+
+  it("says nobody looked for a collection the app never opened", async () => {
+    expect(await previewOwnLookup(root, { cid: "nothing-here", key: "q1" })).toEqual({ ok: false });
+  });
+});

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -366,14 +366,20 @@ describe("SharedAppPreview", () => {
     // being fast enough is a test that reports a working feature as broken on somebody else's
     // machine.
     const state = await answerFor(answers, (message) => message.type === "mc-public-view:state", "the page's state");
-    expect(state?.viewer).toEqual({ me: "owner@gym.jp", can: { bookings: MEMBER_CAPABILITY } });
+    // `mine` rides in the same envelope now — the two used to belong to different parents, so a
+    // page could have one or the other and a member page always had neither.
+    expect(state?.viewer).toEqual({ me: "owner@gym.jp", can: { bookings: MEMBER_CAPABILITY }, mine: {} });
     wrapper.unmount();
   });
 
-  // A public page must NOT get one. It has no reader and no roles, and a `viewer` there would be an
-  // answer to a question that page never asks — the pane sending one anyway is how a public page
-  // starts branching on something only a member has.
-  it("sends no viewer to a public page", async () => {
+  // A PUBLIC PAGE GETS ONE TOO, and that is the correction. It was withheld because "a public page
+  // has no reader and no roles" — but the rules disagree: `ownRow` asks for `authed()` and nothing
+  // else, and `selfTransitions` / `selfDelete` are declared inside `public.submit`. So the visitor
+  // who submitted a row may move it, and a page with no `viewer` draws no button for that.
+  //
+  // What it carries here is `mine` and nothing else: this payload resolves no capabilities, and an
+  // absent `can` is "this host does not say" rather than "you may do nothing".
+  it("tells a public page what it has already submitted", async () => {
     const wrapper = await mountPreview();
     const { answers } = await connect(wrapper);
     // A port's delivery is a MACROTASK, so `flushPromises` alone does not guarantee it has
@@ -381,7 +387,7 @@ describe("SharedAppPreview", () => {
     // being fast enough is a test that reports a working feature as broken on somebody else's
     // machine.
     const state = await answerFor(answers, (message) => message.type === "mc-public-view:state", "the page's state");
-    expect(state).not.toHaveProperty("viewer");
+    expect(state?.viewer).toEqual({ mine: {} });
     wrapper.unmount();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.18.0.tgz#32bd652fd7527ae1cea5c82bc64a55f46e9737ef"
-  integrity sha512-AFq4iJzUdkej83EWZoS3YljcsqlbI06NnMKZHBA6rHXej2NjbRETHhL/3Zz04mhj93fgj8yQ4PC/byCDZdyw5A==
+"@receptron/sharedapp@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.19.0.tgz#809ebe3f0cc237752c354a6ff68e7db4aa20f53d"
+  integrity sha512-ABwH5jsG9X+Ts8j/j738uGR0dVXNkXO05vljli7WrZa/7M4SjPQlbAf8iYclOTL7La1XLn7ig5Feph4Fi6USPg==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
> **依存**: `@receptron/sharedapp` **0.19.0**（receptron/sharedapp#38）と receptron/mulmoserver#223。npm 公開前は CI の install が落ちます。

## なぜ

別セッションが報告してくれた「名前を登録したのに登録 UI が出たまま」の根本原因です。**ページは正しく、ペインが答えていませんでした。**

ペインは親を 2 つ配線してページごとに選んでいて（mulmoserver も同じでした）、それぞれが bootstrap の語彙の半分しか答えていませんでした:

- **`view.mine()` はペインでは永久に `known: false`** — 公開ページ用の親に `lookup` も `mine` も渡していなかったから。パッケージの契約では `known:false` は「不明」なので、ページは正しく登録フォームを描き続けます。そして著者はページを疑います。
- **公開ページからの intent は答えずに落ちる**（サーバまで届いても `not-a-member-page` で拒否）。

どちらもルールの禁止ではありません。`ownRow` は `authed()` だけを要求し、`readWith` の最後の枝がそれ、`selfTransitions` / `selfDelete` は `public.submit[cid]` — 公開ページ自身の宣言です。

## 何をしたか

- **`SharedAppPreview.vue` は `viewParent` 1 本**、ポート全部。ヘッドレスのハーネスも同じ 1 本にしました（**書き込みは今も行いません** — ただし黙って落とすのではなく `read-only` と名前で断ります）。
- **`preview.ts` が著者自身の行を読む** — ルールが自分の行を判定するのと同じ 3 つのセレクタで絞り、パッケージの `ownRowsFor` で射影。mulmoserver と**同じ規則**なので、プレビューのページと本番のページが受け取るフィールドは一致します。
- **公開ページに `viewer`** を（参加者と同じ層で）。
- **`previewIntent.ts` は公開ページの ask を参加者のものとして判定**し、行は「ページのデータセット **∪** 読み手自身の行」から探します。後者は必須でした: 人が submit するコレクションは `public.read` が開けない唯一のものなので、**公開ページが動かす行はデータセットには絶対に無い**（`viewer.mine` として届く）。
- **`/api/shared-app/preview/lookup`** が `view.mine(cid, key)` に答えます — `idFrom: "auth.uid+field"`（live-poll の形）で `mine` が答えられない側。

## テストが自分の実装を落とした 1 件

ルックアップの初版は `.catch(() => null)` で「**読めなかった**」と「**無かった**」を両方 "not found" に潰していました。モジュール自身のヘッダが警告しているまさにその誤りです。refused は `{ ok: false }`（誰も見ていない）で、ページは操作を出し続けます。

## 著者へのお願い（`../apps/todos` の件）

**「これが自分です」のようなプレビュー用の回避 UI は消してください。** それが残ると**プレビューでは偽の枝だけが動き、本番だけが通る本物の枝は一度も踏まれません** — プレビューがプレビューでなくなります。SKILL にもその一節を足しました。

## 検査

- 10803 テスト green、`lint` / `typecheck` 通過。
- `test/server/backends/sharedAppPreviewLookup.spec.ts`（新規）— 「読めなかった」「無かった」「id が作れない」「宣言が無い」の 4 つの断り分け。
- `sharedAppPreview.spec.ts` — 自分の行の射影（他人の行が来ない・`status` や社内メモが来ない）と、読めなかったコレクションが**キーごと落ちる**こと。
- `sharedAppPreviewIntent.spec.ts` — 公開ページから自分の予約を cancel できること。

設計: `plans/feat-one-view-parent.md`

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public-page previews now support viewing and managing visitors’ own submitted records.
  * Added checks for whether a personal submission exists, with clear handling for unavailable data.
  * Unified preview behavior across public, member, and other page types.
* **Bug Fixes**
  * Improved public-page actions, including cancellation of personal records.
  * Viewer information and visible personal records are now provided consistently.
* **Documentation**
  * Updated guidance for record transitions and self-management on public pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->