### PR TITLE
Take sharedapp 0.20.0, and give the staff page its delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.19.0",
+    "@receptron/sharedapp": "^0.20.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -422,7 +422,7 @@ Ask them to confirm, in these terms:
 - on a member's page, pressing a **control actually moves the row** — the list redraws with the new
   status. If it does not, the log below names the refusal: `illegal-transition` is the declared
   `transitions` table, `not-permitted` is the reader's role, `not-writable` is a missing
-  `statusField` / `assigneeField` / `selfDelete`, and `not-in-view` is the page naming a row it was
+  `statusField` / `assigneeField` / `selfDelete` / `writerDelete`, and `not-in-view` is the page naming a row it was
   not handed (the preview writes as the OWNER, so it cannot let the rules decide whose row it is);
 - the **error paths** say something: an empty required field, an unchosen option;
 - **cancelling the confirmation leaves the page where it was** — a page that shows the thank-you or
@@ -787,13 +787,15 @@ Four calls, and a page cannot name a field in any of them:
 await window.__MC_APP_VIEW.submit(cid, values);          // a new record
 await window.__MC_APP_VIEW.transition(cid, itemId, to);  // approve, reject, cancel
 await window.__MC_APP_VIEW.assign(cid, itemId, address); // hand a row to a colleague
-await window.__MC_APP_VIEW.withdraw(cid, itemId);        // take the reader's OWN row away
+await window.__MC_APP_VIEW.withdraw(cid, itemId);        // take a row away (see the two halves below)
 ```
 
 `withdraw` names no destination because nothing moves — the row is deleted, and where the
-collection has a `mirror` the parent reopens it in the same batch. It works only where
-`selfDelete` names the row's current status, only on a participant's page, and (like the two
-above) only on a runtime that has it.
+collection has a `mirror` the parent reopens it in the same batch. **Two permissions answer it**
+and the page asks the capability, never the audience: `can.<cid>.withdrawFrom` is the reader's own
+row from the statuses `selfDelete` names, and `can.<cid>.withdrawAny` is any row at all, for an
+`owner` or `editor` where the collection declares `writerDelete`. Like the two above, it also needs
+a runtime that has it.
 
 **Call `ready()` once, after registering `onState` — nothing arrives until you do.** The parent
 holds the app's data until the view answers the handshake, so a page that listens and never says
@@ -815,6 +817,8 @@ window.__MC_APP_VIEW.onState((data, viewer) => {
   // can.transitionAny  — may approve any row  (owner / editor)
   // can.transitionOwn  — may approve the rows assigned to them  (assignee)
   // can.withdrawFrom   — the statuses this reader may take their OWN row away from
+  // can.withdrawAny    — may take ANY row here away  (owner / editor, where the
+  //                      collection declares `writerDelete`)
   // can.assigneeField  — the field a row carries its owner's address in
   // can.assign         — may hand a row to somebody else
   // can.assignees      — who may be named
@@ -859,11 +863,22 @@ the cost in the text the reader can see.
   that only sends the second half is the worst kind of broken — every call succeeds, the rows say
   what the operator expects, and the screen the audience is looking at does not move. (This is
   exactly what the live-poll desk does; copy it rather than reinventing the pair.)
-- **`withdraw` takes the reader's own row away** and names no destination, because nothing moves.
-  It exists only where `selfDelete` declares the statuses, it is offered on a participant's page
-  and never on a staff one (owner and editor delete by role), and where the collection has a
-  `mirror` the parent reopens it in the same batch. `viewer.can.<cid>.withdrawFrom` is the list of
-  statuses, not a boolean: draw the control on the rows that are actually in one of them.
+- **`withdraw` takes a row away** and names no destination, because nothing moves. Where the
+  collection has a `mirror`, the parent reopens it in the same batch. **Two different permissions
+  answer it, and a page asks whichever one it was handed:**
+  - `viewer.can.<cid>.withdrawFrom` — the reader's OWN row, from the statuses `selfDelete` declares
+    (`public.submit[cid]`). A LIST, not a boolean: draw the control on the rows actually in one of
+    them. This is the participant's and the public visitor's half.
+  - `viewer.can.<cid>.withdrawAny` — ANY row, in any status, for an `owner` or `editor`, where the
+    collection declares `writerDelete: true`. A boolean, because the rules ask no status of a
+    writer (`deleteWith` opens with `isWriter`). This is the staff half, and it is the one to give
+    an owner who needs to remove a task somebody abandoned or a name registered by mistake.
+
+  The staff half did not exist before `@receptron/sharedapp` 0.20.0, and its absence used to be
+  worked around by publishing the OWNER's page as `audience: "participant"` — which costs
+  assignment, the staff transitions and the roster's answer about who is who, and draws the delete
+  control for every participant. If you meet an app shaped that way, that is why; move the page
+  back to `member` and declare `writerDelete`.
 - **`assign` moves `assigneeField`**, and only to an address holding `owner`, `editor` or
   `assignee` on that collection (`assignees` in the capability above). Anything else would write a
   row NOBODY could touch afterwards. An `assignee` cannot hand a row on at all, their own

--- a/server/skills/mulmoterminal-shared-app/templates/todo-board.md
+++ b/server/skills/mulmoterminal-shared-app/templates/todo-board.md
@@ -55,7 +55,8 @@
     "claims": {
       "submitOnly": true,
       "statusField": "status",
-      "transitions": { "initial": ["doing"], "doing": ["done"], "done": ["doing"] }
+      "transitions": { "initial": ["doing"], "doing": ["done"], "done": ["doing"] },
+      "writerDelete": true
     }
   },
   "views": [
@@ -173,7 +174,7 @@
 | 名前を直す | 取った本人 | `selfUpdate: { "doing": ["name"] }` |
 | 完了にする | 取った本人 | `selfTransitions: { "doing": ["done"] }` |
 | 作業中を解除して降りる | 取った本人 | `selfDelete: ["doing"]` |
-| 他人の担当を消す | owner のみ | writer の delete |
+| 他人の担当を消す | owner のみ | `collections.claims.writerDelete: true` |
 | 作業を足す・消す | owner のみ | `tasks` は公開の submit を持たない |
 
 **`done` は取り下げられません**（`selfDelete` は `doing` のみ）。終わった記録を残すためで、
@@ -273,7 +274,11 @@
   const view = window.__MC_APP_VIEW;
   const rows = document.getElementById("rows");
   const note = document.getElementById("note");
-  view.onState(({ tasks = [], claims = [] }) => {
+  // 誰の担当でも消してよいか。owner / editor だけ true になります（`writerDelete` +
+  // 名簿）。false のまま描くと、押した人全員がルールに拒否されます。
+  let mayRemove = false;
+  view.onState(({ tasks = [], claims = [] }, viewer) => {
+    mayRemove = viewer?.can?.claims?.withdrawAny === true;
     const title = Object.fromEntries(tasks.map((task) => [task.id, task.title ?? task.id]));
     rows.replaceChildren(
       ...claims.map((claim) => {
@@ -281,18 +286,51 @@
         const label = document.createElement("span");
         label.textContent = `${title[claim.taskId] ?? claim.taskId} — ${claim.name}（${claim.status}）`;
         row.append(label);
+        if (mayRemove) row.append(removeButton(claim));
         return row;
       }),
     );
     note.textContent = claims.length === 0 ? "まだ誰も取っていません。" : "";
   });
+
+  // 2 度押しで訊きます。`confirm()` はサンドボックスが無視して false を返すので、
+  // ガードに使うとボタンが黙って効かなくなります。
+  function removeButton(claim) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "担当を外す";
+    let armed = false;
+    button.addEventListener("click", async () => {
+      if (!armed) {
+        armed = true;
+        button.textContent = "本当に外す？";
+        return;
+      }
+      button.disabled = true;
+      const result = await view.withdraw("claims", claim.id);
+      // 行は消えて状態が届き直します。失敗したときだけ、ここに残る文言が要ります。
+      if (!result.ok) {
+        button.disabled = false;
+        armed = false;
+        button.textContent = "担当を外す";
+        note.textContent = `外せませんでした: ${result.error ?? "理由なし"}`;
+      }
+    });
+    return button;
+  }
   view.ready();
 </script>
 ```
 
-**受付が担当を消すのは、この画面ではなくコレクションペインです。** ビューから他人の行を
-消す経路は宣言にありません（`selfDelete` は本人のもの）。owner はペインで claim の行を
-削除し、それで作業が空きに戻ります。
+**行は消えます。** `withdraw` は削除で、`done → 空き` に戻す遷移ではありません。誰が取って
+いたかの記録は残らず、`mail` も紐づけられません（キューのルールは書き込み後の文書を読むので、
+無い文書には反応できません）。記録を残したいなら、消さずに `done` のまま置いて別の状態を
+足す設計にしてください — どちらにするかはユーザーに訊いて決めます。
+
+**`writerDelete` は `@receptron/sharedapp` 0.20.0 から**で、それ以前はビューから他人の行を
+消す経路が本当にありませんでした。owner のページを `audience: "participant"` にして回避した
+アプリが実在しますが、それは担当の付け替え（assign）と受付側の遷移表を失う書き方なので、
+真似しないでください。宣言しない場合に残る道はコレクションペインからの削除です。
 
 ---
 

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -140,7 +140,9 @@ let lastPending = "";
  *  about anything. A submission is confirmed and can be taken back; a transition, an assignment and
  *  a withdrawal are none of those, on any audience. */
 const movesRecords = computed(() =>
-  Object.values(page.value?.viewer?.can ?? {}).some((can) => can.transitionAny || can.transitionOwn || can.assign || can.withdrawFrom.length > 0),
+  Object.values(page.value?.viewer?.can ?? {}).some(
+    (can) => can.transitionAny || can.transitionOwn || can.assign || can.withdrawAny || can.withdrawFrom.length > 0,
+  ),
 );
 
 /** Every message the parent sends, on its way out.

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -94,6 +94,14 @@ const asCapability = (cid: string, value: unknown): ViewCapability => {
     assignees: strings(from.assignees),
     ...(typeof from.assigneeField === "string" ? { assigneeField: from.assigneeField } : {}),
     withdrawFrom: strings(from.withdrawFrom),
+    // The STAFF half of a withdrawal, and a different permission from the list above rather than a
+    // wider setting of it: that one is the statuses a submitter may take their OWN row away from,
+    // and this is the role (`writerDelete` + `writers`, resolved by the package).
+    //
+    // Rebuilt by name like everything else here, and the field that proves why: the package made it
+    // REQUIRED, so leaving it out was a compile error rather than a staff page previewing without
+    // the delete control that the published page draws.
+    withdrawAny: from.withdrawAny === true,
   };
 };
 

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -25,7 +25,7 @@ const FORM_FIELD = { name: "name", label: "お名前", required: true, type: "st
 /** One collection's capability, as the server resolves it for the author. Written out rather than
  *  built, so the SHAPE a page reads is pinned here too: `can` is keyed by collection, and a page
  *  reaching for `viewer.can.transitionAny` gets undefined for every app that has ever existed. */
-const MEMBER_CAPABILITY = { cid: "bookings", transitionAny: true, transitionOwn: false, assign: false, assignees: [], withdrawFrom: [] };
+const MEMBER_CAPABILITY = { cid: "bookings", transitionAny: true, transitionOwn: false, assign: false, assignees: [], withdrawFrom: [], withdrawAny: false };
 
 /** And one as it resolves for a PUBLIC page, which carries a viewer too: the rules let whoever
  *  submitted a row move it and take it away, so `selfTransitions` and `selfDelete` resolve to
@@ -404,6 +404,16 @@ describe("SharedAppPreview", () => {
     const wrapper = await mountPreview();
     expect(wrapper.text()).toContain("There is no confirmation and no undo");
     wrapper.unmount();
+
+    // A page whose ONLY control is the writer's delete is warned too — the sharpest case there is,
+    // since a delete takes the row away and `withdrawFrom` (the submitter's half) is empty on a
+    // staff page. Asking only the halves that existed before `writerDelete` left this page silent
+    // about the one control that empties a collection.
+    const deletes = { me: "owner@gym.jp", can: { names: { ...MEMBER_CAPABILITY, cid: "names", transitionAny: false, withdrawAny: true } } };
+    vi.stubGlobal("fetch", answering(payload({ pages: [{ id: "desk", html: PAGE, audience: "member", viewer: deletes }] })));
+    const deleting = await mountPreview();
+    expect(deleting.text()).toContain("There is no confirmation and no undo");
+    deleting.unmount();
 
     // And it asks the CAPABILITIES rather than the audience: a page that can move nothing is not
     // warned about a control it does not have.

--- a/test/src/utils/sharedAppPreviewPayload.spec.ts
+++ b/test/src/utils/sharedAppPreviewPayload.spec.ts
@@ -28,8 +28,27 @@ describe("the preview payload", () => {
           assignees: ["a@x.jp"],
           assigneeField: "coach",
           withdrawFrom: ["requested"],
+          withdrawAny: false,
         },
       },
+    });
+  });
+
+  it("carries the WRITER's delete, which is the staff half of a withdrawal", () => {
+    // A different permission from `withdrawFrom` rather than a wider setting of it: that one is the
+    // statuses a submitter may take their OWN row away from, and this is the role. Left out of this
+    // rebuild, a staff page previewed without the delete control the published page draws — which
+    // is the preview/production divergence the one-parent change removed.
+    const viewer = { me: "desk@gym.jp", can: { names: { withdrawAny: true } } };
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer })] });
+    expect(parsed?.pages[0]?.viewer?.can.names).toEqual({
+      cid: "names",
+      transitionAny: false,
+      transitionOwn: false,
+      assign: false,
+      assignees: [],
+      withdrawFrom: [],
+      withdrawAny: true,
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.19.0.tgz#809ebe3f0cc237752c354a6ff68e7db4aa20f53d"
-  integrity sha512-ABwH5jsG9X+Ts8j/j738uGR0dVXNkXO05vljli7WrZa/7M4SjPQlbAf8iYclOTL7La1XLn7ig5Feph4Fi6USPg==
+"@receptron/sharedapp@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.20.0.tgz#fe066cdca6e45b8918e5e4a71f36fc4574cb91ff"
+  integrity sha512-jzcT1xJhPdJqNjb6fnV+6kboNNcmUzYAfG/LtuOhUqCcQ76AfSA6DECNt0Ts87WwiylaUUnZYStj+alr06IlgQ==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
Follows [sharedapp #39](https://github.com/receptron/sharedapp/pull/39) (published as 0.20.0). `writerDelete` exposes a permission the deployed rules always had — `deleteWith` opens with `isWriter(r)`, no status condition — and it reaches a page as `viewer.can.<cid>.withdrawAny`.

## The three sites that decide what a preview shows

- **`src/utils/sharedAppPreviewPayload.ts`** — `asCapability` rebuilds the wire payload field by name, deliberately: the shape is decided in the package, so an assertion here would turn a rename there into a page drawing a control it may not use. With no line for `withdrawAny`, a staff page previewed **without** the delete control the published page draws — the preview/production divergence #1810 existed to remove. Codex flagged exactly this as a P1 on #39, and because the package made the field **required**, the bump did not typecheck until it was added. Both halves of that are the mechanism working as intended.
- **`src/components/SharedAppPreview.vue`** — `movesRecords` decides whether the pane warns "a control on this page moves a real record the moment you press it — no confirmation and no undo". It asked the three capabilities that existed before, so the page that just got a **delete** was the one it stayed quiet about.
- **the capability fixtures**, which are literals rather than `viewerFor` output.

## And the skill, which had documented the gap as a rule

`server/skills/mulmoterminal-shared-app/SKILL.md` said `withdraw` is "offered on a participant's page and never on a staff one (owner and editor delete by role)" — true until 0.20.0, and now the opposite of what an agent should write. Every mention names both halves now: `withdrawFrom` (own row, the statuses `selfDelete` declares) and `withdrawAny` (any row, for an owner or editor, where `writerDelete` is declared).

`templates/todo-board.md` gets the real change, because its desk page was precisely the page that could not delete: it declares `writerDelete: true` and its `views/desk.html` draws the control from `withdrawAny`, two-press (the sandbox ignores `confirm()`, which returns `false` — a guard that silently disables the button). It also says outright that publishing the owner's page as `audience: "participant"` to reach the permission is not the way: that workaround exists in a real app and costs assignment and the staff transition table.

## Checks

`yarn test` 10813 passed / 50 skipped, `typecheck`, `lint`, `format`, `knip` clean. Both new tests were checked against their own revert:

- dropping `withdrawAny` from `asCapability` fails "carries the WRITER's delete…"
- dropping it from `movesRecords` fails the irreversible-write warning test

mulmoserver needs the bump alone — it reads capabilities out of `viewerFor` and rebuilds none.

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authorized owners and editors can delete claims from the todo board.
  - Deletion controls appear only for users with the appropriate permission.
  - Added two-step deletion confirmation and recovery when deletion fails.
  - Shared-app previews now recognize staff withdrawal permissions and display relevant warnings.

- **Documentation**
  - Updated withdrawal guidance, permission rules, API examples, and migration instructions.
  - Clarified deletion behavior and required permissions for staff and participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->