### PR TITLE
テンプレート 7 本が、自分の紙の色を宣言する

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.20.0",
+    "@receptron/sharedapp": "^0.21.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -731,6 +731,17 @@ entry per page, each naming **who it is for**:
   the values in a dialog of its own and writes only when the visitor accepts — so between the
   click and the answer, nothing has been sent and the promise is simply waiting for a person. A
   page that says 送信中… there is describing a step that has not happened, and reads as stuck.
+- **Paint the page's own background, or the thing it is embedded in paints it for you.** A view is a
+  document inside somebody else's frame: the public site is light, MulmoTerminal's pane is nearly
+  black, and a page that sets `color` and no background is transparent — so the same HTML read
+  black-on-white in one and black-on-black in the other, unreadable, with nothing wrong in it.
+  The runtime now lays white paper under every view (`html { color-scheme: light; background:
+  #ffffff; color: #1c1c20 }`, `@receptron/sharedapp` 0.21.0), which is a FLOOR and not a style —
+  any plain rule of yours beats it. Two things follow, and every template shows both: **say it on
+  `html`**, because a background on the root is what stops the body's from reaching the canvas (a
+  page that paints only `body` gets its colour on the body box and the runtime's white around it);
+  and if the page is to be dark, **say both halves** — a `background` with no `color` leaves dark
+  text on it.
 - **`alert`, `confirm` and `prompt` DO NOTHING.** (`check` and `publish` warn when a page looks
   like it calls one, and go through anyway — the check reads the page without parsing it, so it
   is a hint, not a verdict. A page it stays quiet about can still be wrong.) Every view — public, staff, participant — is

--- a/server/skills/mulmoterminal-shared-app/templates/gym.md
+++ b/server/skills/mulmoterminal-shared-app/templates/gym.md
@@ -232,6 +232,9 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
 読めるのは `classes` だけ。`memberEmail` と `status` は親が入れるので送りません。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <label>お名前 <input id="who" maxlength="40" /></label>
 <p id="say" role="status"></p>
 <div id="list"></div>
@@ -293,6 +296,9 @@ opensAt = (クラスの開始日の 3 日前の 08:00 現地時間).getTime()
 `audience: "participant"`、入口は `/p/{slug}`。順位はここでしか出せません。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <div id="mine"></div>
 <p id="say" role="status"></p>
 <script>
@@ -385,6 +391,9 @@ publish されます。オーナーの Mac が閉じていても、受付がス�
 2 枚が違う数え方をすれば、受付とお客さんが違う番号を見ることになります。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <div id="classes"></div>
 <p id="say" role="status"></p>
 <script>

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -316,6 +316,9 @@ of them is something a page that reads once never has to think about:
    whole difference between a working poll and a broken one.
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <h1>Live poll</h1>
 <p id="lede">The question changes as the host moves on. No need to reload.</p>
 
@@ -556,6 +559,9 @@ Watches both collections. Counts on the client: there is no server code here, so
 counts document — and nothing needs to, because the roster is the only audience for this page.
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <h1>Poll desk</h1>
 <div id="tally"></div>
 <div id="list"></div>

--- a/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
+++ b/server/skills/mulmoterminal-shared-app/templates/meeting-room.md
@@ -151,6 +151,9 @@
 `type="button"` のボタンにして、**click** で送信し、入力チェックは自分で書きます。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <label>お名前 <input id="who" maxlength="40" /></label>
 <label>用件 <input id="why" maxlength="60" /></label>
 <p id="say" role="status"></p>
@@ -242,6 +245,9 @@
 その状態にある行にだけボタンを出します。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <ul id="mine"></ul>
 <p id="say" role="status"></p>
 <script>
@@ -303,6 +309,9 @@ publish されます。総務の Mac が閉じたままでも、受付が自分�
 だけ — つまり受付が押すボタンはありません（枠を空けるのは本人の取り下げ、下記）。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <label>日付 <input id="day" type="date" /></label>
 <p id="count" role="status"></p>
 <div id="rows"></div>

--- a/server/skills/mulmoterminal-shared-app/templates/project-board.md
+++ b/server/skills/mulmoterminal-shared-app/templates/project-board.md
@@ -228,6 +228,7 @@ uid も**書きません**。uid は id として既に在るので、フィー�
 
 ```html
 <style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
   body { margin: 0; padding: 20px 16px 48px; font: 15px/1.6 system-ui, "Hiragino Sans", sans-serif; }
   section { border: 1px solid #d7d7dc; border-radius: 10px; padding: 14px 16px; margin: 0 0 18px; }
   h2 { font-size: 13px; color: #6b6b74; margin: 0 0 10px; }
@@ -430,6 +431,7 @@ uid も**書きません**。uid は id として既に在るので、フィー�
 
 ```html
 <style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
   body { margin: 0; padding: 20px 16px 48px; font: 15px/1.6 system-ui, "Hiragino Sans", sans-serif; }
   section { border: 1px solid #d7d7dc; border-radius: 10px; padding: 14px 16px; margin: 0 0 18px; }
   h2 { font-size: 13px; color: #6b6b74; margin: 0 0 10px; }

--- a/server/skills/mulmoterminal-shared-app/templates/salon.md
+++ b/server/skills/mulmoterminal-shared-app/templates/salon.md
@@ -156,6 +156,9 @@
 `type="button"` のボタンにして、**click** で送信し、入力チェックは自分で書きます。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <label>お名前 <input id="who" maxlength="40" /></label>
 <p id="say" role="status"></p>
 <div id="grid"></div>
@@ -235,6 +238,9 @@
 渡されるものだけで、`collections` に書いたものが**その人の資格情報で**読まれます。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <ul id="today"></ul>
 <script>
   const view = window.__MC_APP_VIEW;
@@ -321,6 +327,9 @@ view.onState((data, viewer) => {
 `public.submit.bookings.selfTransitions`、スタッフのそれは `collections.bookings.transitions`）。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <div id="rows"></div>
 <p id="say" role="status"></p>
 <script>

--- a/server/skills/mulmoterminal-shared-app/templates/survey.md
+++ b/server/skills/mulmoterminal-shared-app/templates/survey.md
@@ -206,6 +206,9 @@ create** なので、上書きではなく拒否されます。「1 回だけ答
 読めるのは `questions` だけ。`email` と `status` と `answeredAt` は親が入れるので送りません。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <h1>講演アンケート</h1>
 <div id="list"></div>
 <label>お名前 <input id="who" maxlength="40" /></label>
@@ -312,6 +315,9 @@ publish なしでできるので、集計を「いま宣言されているもの
 なった設問は、文言を書き換えるのではなく新しい `id` で足すほうが安全です。**
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <p id="count" role="status"></p>
 <div id="tally"></div>
 <h2>自由記述</h2>

--- a/server/skills/mulmoterminal-shared-app/templates/todo-board.md
+++ b/server/skills/mulmoterminal-shared-app/templates/todo-board.md
@@ -192,6 +192,9 @@
 `<div>` と `type="button"` にして、訊くのも報せるのもページの中の要素で。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <label>お名前 <input id="who" maxlength="40" /></label>
 <p id="say" role="status"></p>
 <div id="list"></div>
@@ -268,6 +271,9 @@
 ことになります — 名前は自己申告だと承知しておいてください。
 
 ```html
+<style>
+  html { background: #ffffff; color: #1c1c20; color-scheme: light; }
+</style>
 <p id="note" role="status"></p>
 <div id="rows"></div>
 <script>

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -145,6 +145,12 @@ describe("the shared-app templates", () => {
         expect(`${file}: paints its root = ${declares("background", "background-color")}`).toBe(`${file}: paints its root = true`);
         // And the other half of it, since a canvas with no foreground is only half a decision.
         expect(`${file}: states its foreground = ${declares("color")}`).toBe(`${file}: states its foreground = true`);
+        // The third, which is the one people leave out: `color-scheme` is what the UA reads for
+        // form controls, scrollbars and its own defaults, so without it a reader whose OS is dark
+        // gets dark widgets on this light paper. DECLARED, not `light` — a template that chooses
+        // dark paper says `dark` here, and a test demanding the value would be the thing standing
+        // in its way.
+        expect(`${file}: states its scheme = ${declares("color-scheme")}`).toBe(`${file}: states its scheme = true`);
       }
     }
   });

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -110,6 +110,34 @@ describe("the shared-app templates", () => {
     }
   });
 
+  it("gives every page a canvas of its own, on the root", () => {
+    // A view is a document inside somebody else's frame, and the frames differ: the public site is
+    // light, MulmoTerminal's pane is nearly black. A page that sets `color` and no background is
+    // transparent, so the SAME HTML was black-on-white in one and black-on-black in the other —
+    // unreadable, with nothing wrong in it. Every template was that page.
+    //
+    // The runtime lays white paper under all of them now (`publicViewSrcdoc`), which is why this
+    // asserts the TEMPLATES rather than trusting it: a template is copied verbatim, so it is the
+    // thing that teaches an author to state their own ground instead of inheriting one. It is also
+    // what lets a page choose to be dark.
+    //
+    // ON THE ROOT, not on `body`: a background on the root element is what stops the first body's
+    // from propagating to the canvas, so a page painting only `body` gets its colour on the body
+    // box and the runtime's white around it.
+    for (const file of readdirSync(TEMPLATES).filter((name) => name.endsWith(".md"))) {
+      for (const [, block] of readFileSync(path.join(TEMPLATES, file), "utf8").matchAll(/^```html\n([\s\S]*?)\n```/gm)) {
+        const sheet = /<style>([\s\S]*?)<\/style>/.exec(block ?? "")?.[1] ?? "";
+        // Line by line rather than by one regex over the sheet: the rule is written on its own
+        // line in every template, and a pattern spanning `{ … }` across newlines is the kind that
+        // backtracks.
+        const rule = sheet.split("\n").find((line) => line.trim().startsWith("html {")) ?? "";
+        expect(`${file}: paints its root = ${rule.includes("background:")}`).toBe(`${file}: paints its root = true`);
+        // And the other half of it, since a canvas with no foreground is only half a decision.
+        expect(`${file}: states its foreground = ${rule.includes("color:")}`).toBe(`${file}: states its foreground = true`);
+      }
+    }
+  });
+
   it("ships an HTML block for every page its app.json declares", () => {
     // A declared `path` is READ at deploy: `planAppViewTiers` opens each one and refuses the whole
     // operation when a file is missing. So a template that names two pages and shows neither does

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -131,9 +131,20 @@ describe("the shared-app templates", () => {
         // line in every template, and a pattern spanning `{ … }` across newlines is the kind that
         // backtracks.
         const rule = sheet.split("\n").find((line) => line.trim().startsWith("html {")) ?? "";
-        expect(`${file}: paints its root = ${rule.includes("background:")}`).toBe(`${file}: paints its root = true`);
+        // Split into declarations rather than searched as text: `border-color:` ENDS with the
+        // string `color:`, and `background-color:` ends with it too — so a page declaring
+        // `html { background: #111; border-color: #333 }` would have passed the foreground half
+        // below while rendering dark on dark, which is the exact failure both halves are here to
+        // stop.
+        const declared = rule
+          .replace(/^[^{]*\{/, "")
+          .split(";")
+          .map((part) => part.trim().split(":")[0]?.trim() ?? "");
+        const declares = (...properties: string[]): boolean => properties.some((property) => declared.includes(property));
+        // Either spelling of the canvas, because both are the same decision.
+        expect(`${file}: paints its root = ${declares("background", "background-color")}`).toBe(`${file}: paints its root = true`);
         // And the other half of it, since a canvas with no foreground is only half a decision.
-        expect(`${file}: states its foreground = ${rule.includes("color:")}`).toBe(`${file}: states its foreground = true`);
+        expect(`${file}: states its foreground = ${declares("color")}`).toBe(`${file}: states its foreground = true`);
       }
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.20.0.tgz#fe066cdca6e45b8918e5e4a71f36fc4574cb91ff"
-  integrity sha512-jzcT1xJhPdJqNjb6fnV+6kboNNcmUzYAfG/LtuOhUqCcQ76AfSA6DECNt0Ts87WwiylaUUnZYStj+alr06IlgQ==
+"@receptron/sharedapp@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.21.0.tgz#62af0105a2149a3e89bec728af56d57f309cd0bd"
+  integrity sha512-H+1/uPmmOlsH32RDNaMqezBR82fnl9wulo6hjmhaEg64gBNquzEYcjSne4voea51HDSIZBanfLl7bwIdFE5FAw==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
ビューは**他人の枠の中の文書**で、枠は場所ごとに違う — 公開サイトは明るく、MulmoTerminal のペインは `#11111f`。同梱テンプレート 7 本は**どれもキャンバスを塗っていなかった**（`color` は大量にあり、`background` は 1 つも無い）ので、同じ HTML が片方では黒地に白、もう片方では**ほぼ黒地に黒**になる。ページ自体はどこも間違っていない。

`@receptron/sharedapp` 0.21.0（receptron/sharedapp#40）が全ビューの下に白い紙を敷く — **公開済みのアプリはそれで直る**。これはもう半分で、**テンプレートは丸ごとコピーされる**ので、著者に「地の色は自分で言うもの」と教えるのはこちら。暗くしたければそう書ける、と分かるのもこちら。

各ページに 1 行:

```css
html { background: #ffffff; color: #1c1c20; color-scheme: light; }
```

**`body` ではなく `html`。** ルート要素に背景があると、最初の `<body>` の背景がキャンバスへ伝播しなくなる。`body` だけ塗ったページは、body ボックスにその色・周りにランタイムの白、になる。

`SKILL.md` にも、サンドボックスがページについて決めてしまう他の項目（モーダル・`<form>`・`ready()`）と並べて 1 項目。逆向きの間違い — **暗くしたいなら `background` と `color` の両方を言う**、片方だけだと暗い紙に暗い文字 — もそこに書いた。

テンプレート内の全 fenced ページに対するテストで固定（将来のテンプレートが忘れると赤くなることを、実際に外して確認済み）。`yarn test` 10831 pass / lint / typecheck clean。

順番: sharedapp#40 マージ → npm 公開 → MulmoTerminal と mulmoserver の bump。**この PR は bump を含まない**（テンプレートは独立して正しい）。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display consistency across app views by explicitly applying light-theme colors, including white backgrounds and dark text.
  * Prevented browser or runtime theme settings from causing unexpected colors on supported pages.

* **Documentation**
  * Added guidance for defining background and text colors in each view, including dark-theme requirements.

* **Tests**
  * Added coverage to verify that HTML views explicitly define both background and text colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->