### PR TITLE
feat: プロセスに mulmoterminal と名乗らせる (#1820)

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -31,6 +31,7 @@ import {
   serverSpawnEnv,
 } from "./cli-args.js";
 import { liveInstances } from "./instances.js";
+import { setProcessTitle } from "./process-title.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
@@ -475,6 +476,10 @@ async function main() {
   await confirmNoRunningInstance();
 
   const port = await choosePort(requestedPort, portExplicit);
+  // Named only now, because the port is half the name — and named at all so that the user who
+  // loses this terminal has something to search for (#1820). The server child names itself the
+  // same, so `pkill mulmoterminal` reaches whichever half is found first.
+  setProcessTitle(port);
   await runServer(port, noOpen, cwd, (c) => {
     child = c;
   });

--- a/bin/process-title.d.ts
+++ b/bin/process-title.d.ts
@@ -1,0 +1,2 @@
+export declare function processTitle(port: string | number | null | undefined): string;
+export declare function setProcessTitle(port: string | number | null | undefined): void;

--- a/bin/process-title.js
+++ b/bin/process-title.js
@@ -1,0 +1,47 @@
+// What this process is CALLED — in `ps`, and on Windows in the terminal tab (#1820).
+//
+// Without it every part of MulmoTerminal is a `node` among the user's other `node`s, because the
+// launcher is a `#!/usr/bin/env node` script: npx and a global install look identical, and
+// searching Activity Monitor for "mulmoterminal" finds nothing. The user who has lost the terminal
+// they started it from has no name to search for.
+//
+// `process.title` is three different features wearing one name, and the differences decide what
+// this file may promise:
+//
+//   Linux   — prctl(PR_SET_NAME) (the first 15 characters, so the base name must fit inside that)
+//             plus an argv overwrite. `ps` and `pkill` both see it.
+//   macOS   — the argv overwrite alone, as far as anything observable goes. `ps` and `pkill` see
+//             it; `top` does not, so Activity Monitor is expected not to either.
+//   Windows — SetConsoleTitleW and NOTHING else. The image name stays `node.exe`, so Task Manager,
+//             `Get-Process` and `taskkill /IM` are untouched. What it does rename is the console —
+//             i.e. the Windows Terminal tab, which is the thing the reporter lost. Worth doing for
+//             that alone, but it is why `mulmoterminal stop` exists rather than being optional.
+//
+// Node ignores the failure: the setter discards uv_set_process_title's return value, so this can
+// never throw, and a Windows process with no console attached simply keeps its old name.
+//
+// Assign ONCE. On macOS every assignment dlopens ApplicationServices and CoreFoundation to reach
+// LaunchServices — measured at 14.6ms for the first and ~7ms for each one after it.
+const BASE = "mulmoterminal";
+
+/**
+ * The title for a server (or launcher) serving `port`.
+ *
+ * The port is in the string to pay back what naming the process costs: the same argv overwrite
+ * that puts `mulmoterminal` in `ps` erases the `--port` and the install path that were, until
+ * now, the documented way to find this process. Appending it keeps `pkill mulmoterminal` working
+ * — both platforms match unanchored, and `mulmoterminal` fits Linux's 15-character `comm` with
+ * room to spare — while letting `pkill -f 'mulmoterminal :34567'` pick one worktree out of
+ * several.
+ *
+ * An unknown port gives the bare name rather than a title claiming a port nobody is serving.
+ */
+export function processTitle(port) {
+  const n = Number(port);
+  return Number.isInteger(n) && n > 0 ? `${BASE} :${n}` : BASE;
+}
+
+/** Name this process. Best-effort by construction — see above, it cannot throw. */
+export function setProcessTitle(port) {
+  process.title = processTitle(port);
+}

--- a/bin/process-title.js
+++ b/bin/process-title.js
@@ -34,11 +34,15 @@ const BASE = "mulmoterminal";
  * room to spare — while letting `pkill -f 'mulmoterminal :34567'` pick one worktree out of
  * several.
  *
- * An unknown port gives the bare name rather than a title claiming a port nobody is serving.
+ * Anything that is not a port gives the bare name rather than a title claiming one nobody is
+ * serving. The range is the one `parsePortArg` already enforces on `--port` — the two describe the
+ * same thing, and a title is no place to introduce a second opinion about what a port is.
  */
+const MAX_PORT = 65535;
+
 export function processTitle(port) {
   const n = Number(port);
-  return Number.isInteger(n) && n > 0 ? `${BASE} :${n}` : BASE;
+  return Number.isInteger(n) && n > 0 && n <= MAX_PORT ? `${BASE} :${n}` : BASE;
 }
 
 /** Name this process. Best-effort by construction — see above, it cannot throw. */

--- a/plans/feat-1820-stopping-the-server.md
+++ b/plans/feat-1820-stopping-the-server.md
@@ -1,0 +1,65 @@
+# Stopping MulmoTerminal — three independent routes (#1820)
+
+The only way a user can stop the server today is Ctrl+C in the terminal that started it. That
+terminal is exactly what gets lost: `npx mulmoterminal@latest` opens a browser, so attention moves
+there, and the reported case is a Windows user whose starting tab was buried among many others —
+they ended up hunting the process and killing it by hand.
+
+Three routes, deliberately independent. Each is revertible on its own, so each is its own PR.
+
+## What the audit found before any of this was designed
+
+Two findings changed the shape of the answer, and both are cheap to lose again:
+
+**`process.title` is not one feature on three platforms.** libuv implements it three ways.
+On Linux it is `prctl(PR_SET_NAME)` plus an argv overwrite; on macOS the argv overwrite plus a
+LaunchServices check-in; on Windows it is `SetConsoleTitleW` and *nothing else* — the image name
+stays `node.exe`, so Task Manager, `Get-Process` and `taskkill /IM` are all untouched. The
+platform where the report came from is the one where naming the process does not help.
+
+**The instance registry already exists.** `bin/instances.js` writes
+`~/.mulmoterminal/instances/<pid>.json` holding `{pid, port, startedAt}` (#1061), and the launcher
+already reads it to ask "MulmoTerminal is already running — start another one anyway? [y/N]".
+So in the reported scenario the user has *already been told* a server is running. The missing
+half is only how to stop it — and the registry hands over the pid to do it with, on every
+platform including the one `process.title` cannot serve.
+
+## PR 1 — `process.title` (this PR)
+
+Set the title on both the launcher and the server, once each, to `mulmoterminal :<port>`.
+
+- **The port is in the string on purpose.** Overwriting argv is what makes `ps` say
+  `mulmoterminal`, and the same overwrite erases `--port` and the install path that were the
+  documented way to find the process. Putting the port back keeps `pkill mulmoterminal` working
+  (both platforms match unanchored) while restoring what `ps` used to tell you, and it makes
+  `pkill -f "mulmoterminal :34567"` able to pick one of several worktrees.
+- **Both processes, not just the server.** A `node` with no name sitting next to a named one in
+  `ps` is the confusion this removes, and killing either collapses both anyway — the launcher
+  exits from its child's `close`.
+- **Windows too, accepting that the console title is not restored on exit.** It does not name the
+  process there, but it *does* name the Windows Terminal tab, which is the reported symptom.
+
+Set once: on macOS each assignment costs ~7ms (libuv dlopens ApplicationServices and CoreFoundation
+every call), measured at 14.6ms for the first.
+
+## PR 2 — `mulmoterminal stop`
+
+Read the registry, signal each live pid, report what was stopped. This is the route that works on
+all three platforms, and the one Windows actually needs.
+
+Also add a line to the launcher's "already running" prompt naming the command, because that prompt
+is the exact moment the question gets asked.
+
+## PR 3 — a Quit button in the browser
+
+`POST /api/app/quit` running the same path as SIGINT (`stopWhisperSidecar()` then `exit(0)`,
+`server/index.ts`), behind a confirmation dialog, surfaced in Settings under the `sessions` group.
+
+No extra CSRF defence is needed and none should be added: `sameOriginGuard` is mounted before
+every route in `app-routes.ts` and covers all state-changing methods by default, which is the
+whole point of it being central. The confirmation text has to say what happens to sessions,
+because that answer differs — with tmux the agent sessions survive and reappear under Surviving
+sessions, without it they end.
+
+Exposure is unchanged by this: with a non-loopback `BIND_HOST` anyone who can reach the server can
+already spawn an agent, so a quit route adds no new class of privilege.

--- a/plans/feat-1820-stopping-the-server.md
+++ b/plans/feat-1820-stopping-the-server.md
@@ -44,11 +44,20 @@ every call), measured at 14.6ms for the first.
 
 ## PR 2 — `mulmoterminal stop`
 
-Read the registry, signal each live pid, report what was stopped. This is the route that works on
-all three platforms, and the one Windows actually needs.
+Read the registry, signal each pid it can identify, report what was stopped. This is the route that
+works on all three platforms, and the one Windows actually needs.
+
+**A LIVE PID IS NOT AN IDENTITY**, and this is the part worth carrying forward. A server that was
+killed outright leaves its file behind, and the OS may hand that pid to something else — so
+signalling on the file alone SIGTERMs a stranger's process. Corroborating it by "does the recorded
+port answer" is not enough either: a server that crashed and was restarted on the SAME port answers
+happily while the old pid belongs to something unrelated. Only the process can settle it, so
+`GET /api/instance` has it report its own pid, and an entry is trusted exactly when the two match.
+`--force` skips the check, which is the way out for a server that has stopped answering.
 
 Also add a line to the launcher's "already running" prompt naming the command, because that prompt
-is the exact moment the question gets asked.
+is the exact moment the question gets asked — printed in the form the user can actually run, which
+is not the same for an npx user as for a global install.
 
 ## PR 3 — a Quit button in the browser
 

--- a/plans/feat-1820-stopping-the-server.md
+++ b/plans/feat-1820-stopping-the-server.md
@@ -52,8 +52,12 @@ is the exact moment the question gets asked.
 
 ## PR 3 — a Quit button in the browser
 
-`POST /api/app/quit` running the same path as SIGINT (`stopWhisperSidecar()` then `exit(0)`,
-`server/index.ts`), behind a confirmation dialog, surfaced in Settings under the `sessions` group.
+`POST /api/shutdown` — the path MulmoClaude already answers this need at (#2616), so both hosts
+stop the same way — behind a confirmation, surfaced in Settings under the `sessions` group.
+
+It runs the same path as Ctrl+C by SIGNALLING ITSELF rather than by calling the cleanup directly:
+`process.kill(process.pid, "SIGTERM")` lands on the handler this PR extracted into
+`server/infra/shutdown.ts`, so there is one shutdown implementation and not two that drift.
 
 No extra CSRF defence is needed and none should be added: `sameOriginGuard` is mounted before
 every route in `app-routes.ts` and covers all state-changing methods by default, which is the

--- a/server/index.ts
+++ b/server/index.ts
@@ -129,7 +129,7 @@ import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { installBundledSkills } from "./infra/install-bundled-skills.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initNotifier } from "./backends/notifier.js";
-import { stopWhisperSidecar } from "./backends/whisper.js";
+import { installShutdownHandlers } from "./infra/shutdown.js";
 import { startCollectionCompletionWatchers } from "./backends/collectionWatchers.js";
 import { initUserTaskScheduler } from "./backends/scheduler.js";
 import { buildSystemTasks } from "./backends/system-tasks.js";
@@ -148,6 +148,7 @@ import { reapSweepLines, survivingAfterSweep, sweepIdleSessions } from "./sessio
 import { installProcessGuards } from "./infra/process-guards.js";
 import { pruneOrphanSettings } from "./session/session-settings.js";
 import { earliestStartedAt, liveInstances, registerInstance } from "../bin/instances.js";
+import { setProcessTitle } from "../bin/process-title.js";
 import { pruneOrphanDrops } from "./session/session-drops.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
@@ -156,6 +157,11 @@ import { pruneOrphanDrops } from "./session/session-drops.js";
 // work runs, so a single unhandled error can't silently kill the backend and disconnect
 // every terminal at once (see infra/process-guards.ts).
 installProcessGuards();
+
+// Before the boot rather than after it: a server that is slow to start, or that dies during it, is
+// exactly the one the user goes looking for in `ps` (#1820). Assigned once — on macOS each
+// assignment costs several milliseconds inside libuv.
+setProcessTitle(PORT);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1013,13 +1019,4 @@ server.listen(Number(PORT), BIND_HOST, () => {
   void refreshUpdateStatus();
 });
 
-// The whisper sidecar is a spawned child that won't die with the parent on a
-// signal. Adding a signal listener suppresses Node's default termination, so we
-// kill the sidecar and exit explicitly. `exit` covers the normal-return path.
-process.once("exit", stopWhisperSidecar);
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.once(signal, () => {
-    stopWhisperSidecar();
-    process.exit(0);
-  });
-}
+installShutdownHandlers();

--- a/server/infra/shutdown.ts
+++ b/server/infra/shutdown.ts
@@ -1,0 +1,22 @@
+// How this process ends, in one place.
+//
+// The whisper sidecar is a spawned child that won't die with the parent on a signal, and adding a
+// signal listener suppresses Node's default termination — so the sidecar has to be killed and the
+// exit made explicit. `exit` covers the normal-return path, where no signal is involved.
+//
+// It lives here rather than at the foot of index.ts because it is about to have a second caller:
+// stopping MulmoTerminal from the browser (#1820) has to run THIS path and not a second one that
+// drifts from it — the guarantee a user is owed is that the button does what Ctrl+C does.
+import { stopWhisperSidecar } from "../backends/whisper.js";
+
+const SIGNALS = ["SIGINT", "SIGTERM"] as const;
+
+export function installShutdownHandlers(): void {
+  process.once("exit", stopWhisperSidecar);
+  for (const signal of SIGNALS) {
+    process.once(signal, () => {
+      stopWhisperSidecar();
+      process.exit(0);
+    });
+  }
+}

--- a/test/bin/process-title.spec.ts
+++ b/test/bin/process-title.spec.ts
@@ -19,12 +19,17 @@ describe("processTitle", () => {
     expect(processTitle("34567")).toBe(processTitle(34567));
   });
 
-  it.each([null, undefined, "", "abc", 0, -1, 1.5, NaN, Infinity])("falls back to the bare name rather than claiming port %p", (port) => {
+  it.each([null, undefined, "", "abc", 0, -1, 1.5, NaN, Infinity, 65536, 70000])("falls back to the bare name rather than claiming port %p", (port) => {
     expect(processTitle(port)).toBe("mulmoterminal");
   });
 
-  it("stays matchable by `pkill mulmoterminal` on every port", () => {
+  it("stays matchable by `pkill mulmoterminal` across the whole port range", () => {
     for (const port of [1, 80, 34567, 65535]) expect(processTitle(port)).toContain("mulmoterminal");
+  });
+
+  it("names the same range parsePortArg accepts, so the two cannot disagree about what a port is", () => {
+    expect(processTitle(65535)).toBe("mulmoterminal :65535");
+    expect(processTitle(65536)).toBe("mulmoterminal");
   });
 
   it("keeps the base name inside the length Linux preserves", () => {

--- a/test/bin/process-title.spec.ts
+++ b/test/bin/process-title.spec.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { processTitle } from "../../bin/process-title.js";
+
+// The base name has to stay findable by the two things a user reaches for, and both of them
+// constrain it: `pkill mulmoterminal` matches unanchored, and Linux only keeps the first 15
+// characters of the name in `comm` — so the base must fit inside that on its own, whatever gets
+// appended after it.
+const LINUX_COMM_MAX = 15;
+
+describe("processTitle", () => {
+  it("names the process and says which port it serves", () => {
+    expect(processTitle(34567)).toBe("mulmoterminal :34567");
+  });
+
+  it("accepts the port as the string the environment supplies", () => {
+    // PORT comes from `process.env.PORT || 34567`, so both types reach this in normal use.
+    expect(processTitle("34567")).toBe(processTitle(34567));
+  });
+
+  it.each([null, undefined, "", "abc", 0, -1, 1.5, NaN, Infinity])("falls back to the bare name rather than claiming port %p", (port) => {
+    expect(processTitle(port)).toBe("mulmoterminal");
+  });
+
+  it("stays matchable by `pkill mulmoterminal` on every port", () => {
+    for (const port of [1, 80, 34567, 65535]) expect(processTitle(port)).toContain("mulmoterminal");
+  });
+
+  it("keeps the base name inside the length Linux preserves", () => {
+    expect(processTitle(null).length).toBeLessThanOrEqual(LINUX_COMM_MAX);
+    // The truncated form is what `pkill mulmoterminal` matches against on Linux, so it must still
+    // contain the base — which it does only because the port is appended, never prepended.
+    expect(processTitle(34567).slice(0, LINUX_COMM_MAX)).toContain("mulmoterminal");
+  });
+});

--- a/test/server/infra/shutdown.spec.ts
+++ b/test/server/infra/shutdown.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// vi.mock is hoisted above every const in the file, so the spy has to be hoisted with it.
+const { stopWhisperSidecar } = vi.hoisted(() => ({ stopWhisperSidecar: vi.fn() }));
+vi.mock("../../../server/backends/whisper.js", () => ({ stopWhisperSidecar }));
+
+import { installShutdownHandlers } from "../../../server/infra/shutdown.js";
+
+// Registering a signal listener is what SUPPRESSES Node's own termination, so a signal this
+// module forgets is a MulmoTerminal that no longer dies from Ctrl+C. That failure is invisible to
+// every other test — nothing else sends the process a signal — which is the reason for this file.
+const SIGNALS = ["SIGINT", "SIGTERM"] as const;
+
+type Listener = (...args: never[]) => void;
+const listenersOf = (event: "exit" | (typeof SIGNALS)[number]): Listener[] => [...process.listeners(event)] as Listener[];
+
+describe("installShutdownHandlers", () => {
+  let added: { event: "exit" | (typeof SIGNALS)[number]; fn: Listener }[] = [];
+
+  beforeEach(() => {
+    stopWhisperSidecar.mockClear();
+    const before = new Map((["exit", ...SIGNALS] as const).map((e) => [e, listenersOf(e)]));
+    installShutdownHandlers();
+    added = (["exit", ...SIGNALS] as const).flatMap((event) =>
+      listenersOf(event)
+        .filter((fn) => !before.get(event)?.includes(fn))
+        .map((fn) => ({ event, fn })),
+    );
+  });
+
+  // The handlers are real and would end the test run; take them back off whatever the assertions did.
+  afterEach(() => added.forEach(({ event, fn }) => process.removeListener(event, fn)));
+
+  it.each(SIGNALS)("takes over termination for %s", (signal) => {
+    expect(added.filter((a) => a.event === signal)).toHaveLength(1);
+  });
+
+  it("stops the sidecar on a normal return, where no signal is involved", () => {
+    const onExit = added.find((a) => a.event === "exit");
+    expect(onExit).toBeDefined();
+    onExit?.fn();
+    expect(stopWhisperSidecar).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(SIGNALS)("kills the sidecar and exits 0 on %s, because the default exit is suppressed", (signal) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    added.find((a) => a.event === signal)?.fn();
+    expect(stopWhisperSidecar).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+    exit.mockRestore();
+  });
+});

--- a/test/server/infra/shutdown.spec.ts
+++ b/test/server/infra/shutdown.spec.ts
@@ -7,47 +7,52 @@ vi.mock("../../../server/backends/whisper.js", () => ({ stopWhisperSidecar }));
 
 import { installShutdownHandlers } from "../../../server/infra/shutdown.js";
 
-// Registering a signal listener is what SUPPRESSES Node's own termination, so a signal this
-// module forgets is a MulmoTerminal that no longer dies from Ctrl+C. That failure is invisible to
-// every other test — nothing else sends the process a signal — which is the reason for this file.
+// Registering a signal listener is what SUPPRESSES Node's own termination, so a signal this module
+// forgets is a MulmoTerminal that no longer dies from Ctrl+C. That failure is invisible to every
+// other test — nothing else sends the process a signal — which is the reason for this file.
+//
+// `process.once` is spied rather than the real listeners diffed: the handlers call process.exit, so
+// leaving one attached would end the test run, and the registration is the thing being asserted.
+type OnceArgs = Parameters<typeof process.once>;
+
 const SIGNALS = ["SIGINT", "SIGTERM"] as const;
 
-type Listener = (...args: never[]) => void;
-const listenersOf = (event: "exit" | (typeof SIGNALS)[number]): Listener[] => [...process.listeners(event)] as Listener[];
-
 describe("installShutdownHandlers", () => {
-  let added: { event: "exit" | (typeof SIGNALS)[number]; fn: Listener }[] = [];
+  let registered: OnceArgs[] = [];
 
   beforeEach(() => {
+    registered = [];
     stopWhisperSidecar.mockClear();
-    const before = new Map((["exit", ...SIGNALS] as const).map((e) => [e, listenersOf(e)]));
+    vi.spyOn(process, "once").mockImplementation((...args: OnceArgs) => {
+      registered.push(args);
+      return process;
+    });
     installShutdownHandlers();
-    added = (["exit", ...SIGNALS] as const).flatMap((event) =>
-      listenersOf(event)
-        .filter((fn) => !before.get(event)?.includes(fn))
-        .map((fn) => ({ event, fn })),
-    );
   });
 
-  // The handlers are real and would end the test run; take them back off whatever the assertions did.
-  afterEach(() => added.forEach(({ event, fn }) => process.removeListener(event, fn)));
+  afterEach(() => vi.restoreAllMocks());
+
+  const listenerFor = (event: string): OnceArgs[1] | undefined => registered.find(([e]) => e === event)?.[1];
 
   it.each(SIGNALS)("takes over termination for %s", (signal) => {
-    expect(added.filter((a) => a.event === signal)).toHaveLength(1);
+    expect(registered.filter(([e]) => e === signal)).toHaveLength(1);
   });
 
   it("stops the sidecar on a normal return, where no signal is involved", () => {
-    const onExit = added.find((a) => a.event === "exit");
+    const onExit = listenerFor("exit");
     expect(onExit).toBeDefined();
-    onExit?.fn();
+    onExit?.(0);
     expect(stopWhisperSidecar).toHaveBeenCalledTimes(1);
   });
 
   it.each(SIGNALS)("kills the sidecar and exits 0 on %s, because the default exit is suppressed", (signal) => {
     const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-    added.find((a) => a.event === signal)?.fn();
+    listenerFor(signal)?.(signal);
     expect(stopWhisperSidecar).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(0);
-    exit.mockRestore();
+  });
+
+  it("registers each of the three exactly once, so a second call cannot stack listeners", () => {
+    expect(registered.map(([e]) => e)).toEqual(["exit", ...SIGNALS]);
   });
 });


### PR DESCRIPTION
## Summary

`process.title` を launcher とサーバの両方に `mulmoterminal :<port>` として設定します。#1820 の (2)「プロセスに名前を付ける」に当たる部分です。

これまで MulmoTerminal はどの経路で起動しても `node` としか名乗りませんでした（launcher が `#!/usr/bin/env node` スクリプトなので npx でもグローバルインストールでも同じ）。起動したターミナルを見失ったユーザーには、探すための名前がありません。

- **`mulmoterminal :34567` という形にした理由**: `ps` に名前を出しているのは argv 領域の上書きで、その上書きは `--port` とインストールパスを同時に消します。それは今まで「このプロセスを見つける唯一の手段」として issue にも書かれていた情報なので、ポートを名前に含めて返しています。`pkill mulmoterminal` は前方一致でないので効いたまま、かつ `pkill -f 'mulmoterminal :34567'` で複数 worktree のうち 1 つを選べます。
- **launcher とサーバの両方**に付けます。名前の付いたプロセスの隣に無名の `node` が並ぶのが、まさに解消したい混乱なので。どちらを kill しても launcher は子の `close` で畳まれます。
- **Windows でも設定します**（下記「Items to Confirm」参照）。

`server/index.ts` が `max-lines` の上限ちょうど (600) だったため、終了処理を `server/infra/shutdown.ts` に切り出して場所を作りました。これは (1) のブラウザからの終了が同じ経路を通る必要があるので、いずれにせよ要る抽出です。

## Items to Confirm / Review

1. **Windows では「プロセス名」になりません。** libuv の `uv_set_process_title` は OS ごとに別実装で、Windows は `SetConsoleTitleW` を呼ぶ**だけ**です（[`src/win/util.c`](https://github.com/libuv/libuv/blob/v1.x/src/win/util.c#L344)）。イメージ名は `node.exe` のままなので、Task Manager / `Get-Process` / `taskkill /IM` には一切効きません。**代わりにコンソール窓＝Windows Terminal のタブ名が変わります。** 報告された症状（多数のタブの中で起動タブを見失う）にはこちらが直接効くと判断して全 OS で設定していますが、**終了後もタイトルは復元されません**。ここは意見が分かれ得るので確認してください。Windows 実機は未検証です。
2. **`ps` の情報が減ること**を、ポートを名前に含めることで相殺できているか。実行パスは戻していません（長すぎるため）。
3. **`shutdown.ts` の抽出**を、この PR に同梱してよいか。単独では revert できない（`max-lines` が通らなくなる）ので分けませんでした。
4. macOS の Activity Monitor は**変わらない見込み**です。`top -stats command` で確認したところ `node` のままでした（GUI 自体は未検証）。issue で「未確認」とされていた点への回答です。

## 動作確認

`yarn typecheck` / `yarn lint` / `yarn test`（10850 passed）に加えて、**実際にアプリを起動して確認**しました（server の boot 経路に触るため）:

```
$ node bin/mulmoterminal.js --port 34599 --no-open   # HOME を隔離して実行
$ ps ax -o pid=,ppid=,command= | grep "mulmoterminal :"
51424 51421 mulmoterminal :34599     <- launcher
51435 51424 mulmoterminal :34599     <- server
$ pgrep mulmoterminal
51424
51435
$ curl -o /dev/null -w "%{http_code}" http://localhost:34599/
200                                  <- 改名しても boot している
$ pkill mulmoterminal                <- この変更の目的そのもの
$ pgrep mulmoterminal ; echo $?
1                                    <- 残骸なし。ポートも解放
```

**`shutdown.ts` の抽出は「同じ挙動」を主張する変更なので、新旧の両方を実際に走らせて比較しました。** 実アプリを起動して server に SIGINT / SIGTERM を送り、4 観測（launcher の exit code / launcher の生死 / server の生死 / ポートの解放）を新旧で突き合わせて全て一致:

| | launcher_exit | launcher_alive | server_alive | port |
|---|---|---|---|---|
| 新 (SIGINT) | 0 | no | no | 解放 |
| 旧 (SIGINT) | 0 | no | no | 解放 |
| 新 (SIGTERM) | 0 | no | no | 解放 |
| 旧 (SIGTERM) | 0 | no | no | 解放 |

新しい `test/server/infra/shutdown.spec.ts` には、4 通りの mutation（SIGTERM を落とす / `exit` を落とす / exit code を 1 に / sidecar 停止を落とす）を入れて**全部 red になること**を確認済みです。シグナルハンドラの登録漏れは「Ctrl+C で止まらない」になるのに他のテストからは完全に見えないので、そこを見張るためのファイルです。

計測: macOS で `process.title` の代入は初回 14.6ms、2 回目以降も約 7ms（libuv が毎回 ApplicationServices と CoreFoundation を dlopen するため）。**一度しか代入しない**理由です。

## 残りの作業（この PR には含みません）

#1820 は 3 つの独立した経路に分けて、それぞれ別 PR にします。設計は [`plans/feat-1820-stopping-the-server.md`](plans/feat-1820-stopping-the-server.md) に置きました。

- **`mulmoterminal stop`** — `~/.mulmoterminal/instances/<pid>.json`（#1061 で入ったレジストリ）を読んで止める。**3 OS すべてで効く唯一の経路**で、Windows で本当に効く保険はこちらです。ドキュメント（「止め方」の節）もこの PR で入れます
- **ブラウザの Quit ボタン** — `POST /api/app/quit`。#1820 の本体

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1820 について、止めるボタンはあっても良いかもしれない。`process` 名ってどの OS でも付けられるのか？
- 副作用がないなら入れる。シャットダウンも検討を。
- （確認の結果）3 つとも実装する。`process.title` は全 OS で設定する。

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal and server processes now display the application name and active port, making them easier to identify.
* **Bug Fixes**
  * Improved server shutdown handling to reliably stop the Whisper sidecar during normal exits and termination signals.
  * Ensured shutdown completes cleanly before the process exits.
* **Documentation**
  * Added a plan covering future server-stop options, including command-line and browser-based shutdown flows.
* **Tests**
  * Added coverage for process titles and shutdown behavior across supported exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->