### PR TITLE
feat: ブラウザから MulmoTerminal を止められるようにする (#1820)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ npm install -g mulmoterminal
 mulmoterminal
 ```
 
+**Stopping it.** `Ctrl+C` in the terminal that started it, or — if you can no longer find that
+terminal — **Settings → Quit MulmoTerminal** in the browser. Both run the same shutdown: with `tmux`
+installed the agent sessions survive and come back under **Settings → Sessions that survived a
+restart**; without it they end with the server.
+
 **First-run setup (optional).** `npx mulmoterminal@latest init` checks your environment (Node ≥ 22.9
 and every CLI in the table above), seeds the launcher's **directory
 presets** from the projects in your Claude Code history, and writes `~/.mulmoterminal/config.json`.

--- a/docs/guide/en/getting-started.md
+++ b/docs/guide/en/getting-started.md
@@ -245,6 +245,7 @@ npx mulmoterminal@latest
 - It prints `✓ MulmoTerminal is ready` and opens your browser
 - If nothing opens, go to `http://localhost:34567` yourself
 - **Stop it with Ctrl + C** — closing the browser tab does not stop the server
+- **Lost that terminal?** Stop it from the browser instead: **Settings → Quit MulmoTerminal**
 
 Options worth knowing:
 

--- a/docs/guide/ja/getting-started.md
+++ b/docs/guide/ja/getting-started.md
@@ -249,6 +249,7 @@ npx mulmoterminal@latest
 - `✓ MulmoTerminal is ready` と出て、ブラウザが自動で開きます
 - 開かなければ、自分で `http://localhost:34567` を開いてください
 - **止めるときは Ctrl + C**（ブラウザを閉じただけでは止まりません）
+- **そのターミナルを見失ったら**、ブラウザから止められます：**設定 → MulmoTerminal を終了**
 
 よく使うオプション：
 

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -36,6 +36,7 @@ import { mountWorktreeRoutes } from "../git/worktree-routes.js";
 import { mountPickFileRoute } from "../files/pick-file.js";
 import { mountCommandSummaryRoute } from "../session/command-summary.js";
 import { mountCostRoute } from "../session/cost.js";
+import { mountShutdownRoute } from "./shutdown-routes.js";
 import { mountCollectionRoutes } from "../backends/collections.js";
 // "Would this collection survive a clone?" — mounts itself beside the collection routes.
 import { mountSelfContainmentRoutes } from "../backends/collectionSelfContainment.js";
@@ -400,6 +401,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   // GET /api/cost — estimated $ cost (session + today/month roll-up) for a project's
   // sessions, from public per-model pricing. Read-only; shown in the Settings modal (#245).
   mountCostRoute(app, { resolveCwd: workspaceForRoute });
+  mountShutdownRoute(app);
 
   // POST /api/remote-host/connect|disconnect + GET /status — start/stop the
   // Firestore host loop from the toolbar Connect control. Same-origin guarded like

--- a/server/routes/shutdown-routes.ts
+++ b/server/routes/shutdown-routes.ts
@@ -1,0 +1,51 @@
+// `POST /api/shutdown` — stop the server from the browser (#1820).
+//
+// Until now the only way to stop MulmoTerminal was Ctrl+C in the terminal that started it, and
+// `npx mulmoterminal@latest` opens a browser — so the user's attention is here, and the terminal
+// is what gets lost. Closing the tab does nothing; the server keeps running.
+//
+// MulmoClaude answers the same need at the same path with the same body, and this is a copy of
+// that decision rather than a second opinion: someone running both hosts must not find two
+// different ways to stop them (../mulmoclaude/server/api/routes/shutdown.ts, #2616).
+//
+// ONE DELIBERATE DIVERGENCE from it: MulmoClaude's note says the route is reachable from the local
+// machine only because its server binds 127.0.0.1. That is not true here — BIND_HOST can be a real
+// interface, and `bindSecurityWarning` exists for exactly that. It adds no new class of privilege,
+// because whoever can reach an exposed server can already spawn an agent on it, but the reason is
+// different and should not be copied over as if it were the same.
+//
+// No origin check of its own: `sameOriginGuard` is mounted before every route in app-routes.ts and
+// covers every state-changing method, which is the whole point of it being central — a route added
+// today is covered by default rather than by memory.
+import type { Express } from "express";
+
+// Zero would race the response: the socket can close before the browser has read it, and the user
+// sees a failed request from a button that in fact worked. Same value as MulmoClaude's
+// SHUTDOWN_RESPONSE_GRACE_MS, for the same reason.
+const SHUTDOWN_RESPONSE_GRACE_MS = 250;
+
+export interface ShutdownRouteDeps {
+  /** Injected so the request can be observed in a test without the test process dying. */
+  stop: () => void;
+  delayMs: number;
+}
+
+// SIGTERM to ourselves rather than a second shutdown implementation: infra/shutdown.ts already
+// handles it — it stops the whisper sidecar and exits 0 — so the button provably does what Ctrl+C
+// does. Duplicating any of that here is how the two copies start to disagree.
+const defaultDeps: ShutdownRouteDeps = {
+  stop: () => process.kill(process.pid, "SIGTERM"),
+  delayMs: SHUTDOWN_RESPONSE_GRACE_MS,
+};
+
+/** Answer first, stop second — the browser needs the reply to put its "stopped" screen up, and
+ *  stopping inside the handler closes the socket first, which makes a click that worked look like
+ *  a failure. */
+export function mountShutdownRoute(app: Express, deps: ShutdownRouteDeps = defaultDeps): void {
+  app.post("/api/shutdown", (_req, res) => {
+    console.log("[shutdown] stop requested from the browser");
+    res.json({ stopping: true });
+    // unref so a pending stop is not itself the reason the process stays alive.
+    setTimeout(deps.stop, deps.delayMs).unref();
+  });
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ import GithubOverlay from "./components/GithubOverlay.vue";
 import RoomsOverlay from "./components/RoomsOverlay.vue";
 import FilesOverlay from "./components/FilesOverlay.vue";
 import HoverTip from "./components/HoverTip.vue";
+import ServerStoppedOverlay from "./components/ServerStoppedOverlay.vue";
 import GridView from "./components/GridView.vue";
 import { useSessions } from "./composables/useSessions";
 import { useAppConfig } from "./composables/useAppConfig";
@@ -96,4 +97,7 @@ useFaviconState(sessions);
        document can never hold two — it teleports to <body> and positions itself against whichever
        chip the pointer is on. -->
   <HoverTip />
+  <!-- Over everything, including the settings modal it was pressed in: once the server is gone
+       nothing behind it works, and a live-looking pane underneath would say otherwise (#1820). -->
+  <ServerStoppedOverlay />
 </template>

--- a/src/components/ServerStoppedOverlay.vue
+++ b/src/components/ServerStoppedOverlay.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import { serverStopped } from "../composables/useServerStopped";
+
+// Rendered the moment POST /api/shutdown is answered — i.e. while the server is still there to
+// answer (#1820). It has to be up FIRST: once the process is gone this page can no longer load
+// anything, so a screen fetched afterwards would never arrive.
+const { t } = useI18n();
+</script>
+
+<template>
+  <!-- `role="alert"` rather than a dialog: there is nothing here to focus or dismiss, and this is
+       the one state a screen-reader user most needs told — the app is gone and no further
+       interaction will do anything. -->
+  <div v-if="serverStopped" data-testid="server-stopped-overlay" class="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 p-6">
+    <div role="alert" aria-live="assertive" class="max-w-md rounded-[10px] border border-border bg-panel p-6 text-center font-sans text-fg shadow-xl">
+      <p class="text-[14px] font-semibold">{{ t("settings.quit.stoppedTitle") }}</p>
+      <p class="mt-2 text-[12px] text-dim">{{ t("settings.quit.stoppedBody") }}</p>
+    </div>
+  </div>
+</template>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -37,6 +37,7 @@ import CostSection from "./settings/CostSection.vue";
 import GitHubSection from "./settings/GitHubSection.vue";
 import SessionSection from "./settings/SessionSection.vue";
 import SurvivingSessionsSection from "./settings/SurvivingSessionsSection.vue";
+import QuitSection from "./settings/QuitSection.vue";
 import HeaderChromeSection from "./settings/HeaderChromeSection.vue";
 import ModelsSection from "./settings/ModelsSection.vue";
 import TerminalKeysSection from "./settings/TerminalKeysSection.vue";
@@ -371,6 +372,9 @@ useModalKeyboard({
           </div>
           <div v-if="visitedTabs.has('cost')" v-show="activeTab === 'cost'" data-testid="settings-pane-cost">
             <CostSection :cwd="cwd" :session-id="sessionId" />
+          </div>
+          <div v-if="visitedTabs.has('quit')" v-show="activeTab === 'quit'" data-testid="settings-pane-quit">
+            <QuitSection />
           </div>
           <div v-if="visitedTabs.has('help')" v-show="activeTab === 'help'" data-testid="settings-pane-help">
             <HelpSection />

--- a/src/components/settings/QuitSection.vue
+++ b/src/components/settings/QuitSection.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { markServerStopped } from "../../composables/useServerStopped";
+import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../../utils/fetchWithTimeout";
+
+// Stopping MulmoTerminal from the browser (#1820) — the counterpart of MulmoClaude's Quit tab, at
+// the same route and with the same two-step shape, so someone running both hosts stops them the
+// same way (../mulmoclaude/src/components/SettingsQuitTab.vue).
+//
+// The confirmation is INLINE rather than window.confirm, which is what the rest of this app uses
+// for a destructive click. The difference is that this one has to explain an outcome — what
+// happens to the running sessions — and a browser confirm gives no room to say it, being one line
+// of text the browser styles itself.
+const { t } = useI18n();
+
+const confirming = ref(false);
+const stopping = ref(false);
+const failed = ref(false);
+
+async function quit(): Promise<void> {
+  if (stopping.value) return;
+  stopping.value = true;
+  failed.value = false;
+  try {
+    // The server answers BEFORE it stops (server/routes/shutdown-routes.ts), so this response is
+    // the signal to put the stopped screen up. Waiting for the socket to die instead would leave
+    // the user looking at a live-seeming app that is about to stop answering.
+    const res = await fetchWithTimeout("/api/shutdown", { method: "POST" }, SLOW_COMMAND_TIMEOUT_MS);
+    if (!res.ok) throw new Error(`POST /api/shutdown -> ${res.status}`);
+    markServerStopped();
+  } catch (err) {
+    console.warn("[shutdown] request failed:", err);
+    stopping.value = false;
+    confirming.value = false;
+    failed.value = true;
+  }
+}
+</script>
+
+<template>
+  <p class="mb-2 text-[12px]">{{ t("settings.quit.description") }}</p>
+  <p class="mb-3 text-[12px] text-dim">{{ t("settings.quit.restartHint") }}</p>
+
+  <button
+    v-if="!confirming"
+    type="button"
+    data-testid="quit-server"
+    class="cursor-pointer rounded-md border border-[var(--err-strong)] bg-transparent px-3 py-1.5 text-[13px] text-[var(--err-text)] hover:bg-[var(--err-hover-bg)]"
+    @click="confirming = true"
+  >
+    {{ t("settings.quit.button") }}
+  </button>
+
+  <div v-else data-testid="quit-confirm" class="rounded-md border border-[var(--err-strong)] bg-[var(--err-hover-bg)] p-3">
+    <p class="mb-1 text-[12px]">{{ t("settings.quit.confirmBody") }}</p>
+    <p class="mb-2.5 text-[12px] text-dim">{{ t("settings.quit.sessionsNote") }}</p>
+    <div class="flex gap-2">
+      <button
+        type="button"
+        data-testid="quit-confirm-yes"
+        class="cursor-pointer rounded-md border-none bg-[var(--err-strong)] px-3 py-1.5 text-[13px] text-white disabled:cursor-progress disabled:opacity-60"
+        :disabled="stopping"
+        @click="quit"
+      >
+        {{ stopping ? t("settings.quit.stopping") : t("settings.quit.confirmButton") }}
+      </button>
+      <button
+        type="button"
+        data-testid="quit-cancel"
+        class="cursor-pointer rounded-md border border-border bg-transparent px-3 py-1.5 text-[13px] hover:bg-hover disabled:cursor-progress"
+        :disabled="stopping"
+        @click="confirming = false"
+      >
+        {{ t("settings.quit.cancel") }}
+      </button>
+    </div>
+  </div>
+
+  <p v-if="failed" role="alert" class="mt-2 text-[12px] text-[var(--err-text)]" data-testid="quit-failed">{{ t("settings.quit.failed") }}</p>
+</template>

--- a/src/components/settings/QuitSection.vue
+++ b/src/components/settings/QuitSection.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { markServerStopped } from "../../composables/useServerStopped";
-import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../../utils/fetchWithTimeout";
+import { fetchWithTimeout, DEFAULT_REQUEST_TIMEOUT_MS } from "../../utils/fetchWithTimeout";
 
 // Stopping MulmoTerminal from the browser (#1820) — the counterpart of MulmoClaude's Quit tab, at
 // the same route and with the same two-step shape, so someone running both hosts stops them the
@@ -18,6 +18,22 @@ const confirming = ref(false);
 const stopping = ref(false);
 const failed = ref(false);
 
+// Both buttons are replaced by the other's panel when clicked, so without moving focus it lands on
+// <body> and a keyboard user is dropped out of the modal they were part way through — the same
+// defect #1568 fixed in the skill-launch confirmation, in the same modal.
+const confirmEl = ref<HTMLElement>();
+const quitButtonEl = ref<HTMLElement>();
+
+function arm(): void {
+  confirming.value = true;
+  void nextTick(() => confirmEl.value?.querySelector<HTMLElement>("button")?.focus());
+}
+
+function cancel(): void {
+  confirming.value = false;
+  void nextTick(() => quitButtonEl.value?.focus());
+}
+
 async function quit(): Promise<void> {
   if (stopping.value) return;
   stopping.value = true;
@@ -26,7 +42,10 @@ async function quit(): Promise<void> {
     // The server answers BEFORE it stops (server/routes/shutdown-routes.ts), so this response is
     // the signal to put the stopped screen up. Waiting for the socket to die instead would leave
     // the user looking at a live-seeming app that is about to stop answering.
-    const res = await fetchWithTimeout("/api/shutdown", { method: "POST" }, SLOW_COMMAND_TIMEOUT_MS);
+    //
+    // The ordinary deadline, not the slow one: this route shells out to nothing and answers in the
+    // same tick. A minute of "Stopping…" would be a minute of the user not knowing it had failed.
+    const res = await fetchWithTimeout("/api/shutdown", { method: "POST" }, DEFAULT_REQUEST_TIMEOUT_MS);
     if (!res.ok) throw new Error(`POST /api/shutdown -> ${res.status}`);
     markServerStopped();
   } catch (err) {
@@ -44,15 +63,16 @@ async function quit(): Promise<void> {
 
   <button
     v-if="!confirming"
+    ref="quitButtonEl"
     type="button"
     data-testid="quit-server"
     class="cursor-pointer rounded-md border border-[var(--err-strong)] bg-transparent px-3 py-1.5 text-[13px] text-[var(--err-text)] hover:bg-[var(--err-hover-bg)]"
-    @click="confirming = true"
+    @click="arm"
   >
     {{ t("settings.quit.button") }}
   </button>
 
-  <div v-else data-testid="quit-confirm" class="rounded-md border border-[var(--err-strong)] bg-[var(--err-hover-bg)] p-3">
+  <div v-else ref="confirmEl" data-testid="quit-confirm" class="rounded-md border border-[var(--err-strong)] bg-[var(--err-hover-bg)] p-3">
     <p class="mb-1 text-[12px]">{{ t("settings.quit.confirmBody") }}</p>
     <p class="mb-2.5 text-[12px] text-dim">{{ t("settings.quit.sessionsNote") }}</p>
     <div class="flex gap-2">
@@ -70,7 +90,7 @@ async function quit(): Promise<void> {
         data-testid="quit-cancel"
         class="cursor-pointer rounded-md border border-border bg-transparent px-3 py-1.5 text-[13px] hover:bg-hover disabled:cursor-progress"
         :disabled="stopping"
-        @click="confirming = false"
+        @click="cancel"
       >
         {{ t("settings.quit.cancel") }}
       </button>

--- a/src/components/settings/settingsTabs.ts
+++ b/src/components/settings/settingsTabs.ts
@@ -34,6 +34,7 @@ export type SettingsTabId =
   | "sessions"
   | "surviving"
   | "cost"
+  | "quit"
   | "help";
 
 export interface SettingsGroup {
@@ -51,7 +52,7 @@ export const SETTINGS_GROUPS: readonly SettingsGroup[] = [
   { key: "models", tabs: ["models", "mcp"] },
   { key: "notifications", tabs: ["sounds", "push", "quickCommands"] },
   { key: "integrations", tabs: ["github", "prRepos", "google"] },
-  { key: "sessions", tabs: ["sessions", "surviving", "cost"] },
+  { key: "sessions", tabs: ["sessions", "surviving", "cost", "quit"] },
   { key: "help", tabs: ["help"] },
 ];
 

--- a/src/composables/useServerStopped.ts
+++ b/src/composables/useServerStopped.ts
@@ -1,0 +1,17 @@
+// Whether this page's server has been stopped from the browser (#1820).
+//
+// Module-level rather than an emit chain: the button lives four components deep
+// (App -> GridView -> AppSettingsModal -> SettingsModal -> QuitSection) and the two things that
+// have to react to it are the PAGE — the overlay at the app root, and the close guard. Threading
+// one boolean through four `defineEmits` would put the fact in four files that do not care about it.
+//
+// ONE-WAY on purpose: nothing clears it, because there is no server left to tell us otherwise.
+import { computed, ref, type ComputedRef } from "vue";
+
+const stopped = ref(false);
+
+export const serverStopped: ComputedRef<boolean> = computed(() => stopped.value);
+
+export const markServerStopped = (): void => {
+  stopped.value = true;
+};

--- a/src/composables/useUnloadGuard.ts
+++ b/src/composables/useUnloadGuard.ts
@@ -1,4 +1,5 @@
 import { onMounted, onUnmounted, ref } from "vue";
+import { serverStopped } from "./useServerStopped";
 
 // How many live terminals each view reports, keyed by source ("single", "grid").
 // Keyed — not a single shared counter — because persistent connections mean the
@@ -51,6 +52,10 @@ export function useUnloadGuard(): void {
       skipNextUnload = false; // one-shot: consume so it never silences a later close
       return; // a reload we initiated (e.g. Vite HMR) — see suppressNextUnloadGuard
     }
+    // The stopped screen says "you can close this tab" — so it must be true. The terminal counts
+    // still read as live because nothing told them otherwise, and there is nothing left to lose:
+    // the server they belonged to is gone (#1820).
+    if (serverStopped.value) return;
     if (totalActive() <= 0) return;
     e.preventDefault();
     e.returnValue = ""; // legacy Chrome/Edge still need returnValue assigned to prompt

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -54,6 +54,7 @@ export const en = {
       sessions: "Sessions and background tasks",
       surviving: "Sessions that survived a restart",
       cost: "Cost (estimated)",
+      quit: "Quit MulmoTerminal",
       help: "Help & user guide",
     },
 
@@ -407,6 +408,25 @@ export const en = {
       month: "Month",
       failed: "Couldn't load cost estimate.",
       unpriced: "Some turns used a model with no known price and are excluded from these estimates.",
+    },
+
+    quit: {
+      description:
+        "Stop the MulmoTerminal server running on this machine. Closing this tab does not stop it — the server keeps running, and this is how to stop it without going back to the terminal you started it in.",
+      // Message-function form, which skips vue-i18n's message compiler: the literal `@` in
+      // `mulmoterminal@latest` would otherwise be read as a linked-message reference, the compiler
+      // throws, and the whole section renders as nothing.
+      restartHint: () => "To start it again, run `npx mulmoterminal@latest` in a terminal.",
+      button: "Quit MulmoTerminal",
+      confirmBody: "The server stops and this page stops working. Every terminal on the grid disappears from the screen.",
+      sessionsNote:
+        'Same as pressing Ctrl+C: with tmux installed the agent sessions keep running and come back under "Sessions that survived a restart" next time; without it they end with the server.',
+      confirmButton: "Quit",
+      cancel: "Cancel",
+      stopping: "Stopping…",
+      failed: "Couldn't stop the server.",
+      stoppedTitle: "MulmoTerminal has stopped",
+      stoppedBody: "You can close this tab.",
     },
 
     language: {

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -51,6 +51,7 @@ export const ja: Messages = {
       sessions: "セッションとバックグラウンド処理",
       surviving: "再起動を生き延びたセッション",
       cost: "コスト（推定）",
+      quit: "MulmoTerminal を終了",
       help: "ヘルプとユーザーガイド",
     },
 
@@ -405,6 +406,25 @@ export const ja: Messages = {
       month: "今月",
       failed: "コストの推定を読み込めませんでした。",
       unpriced: "価格が分からないモデルを使ったターンがあり、この推定からは除外されています。",
+    },
+
+    quit: {
+      description:
+        "このマシンで動いている MulmoTerminal サーバを終了します。このタブを閉じてもサーバは止まりません。起動したターミナルに戻らずに止める手段がここです。",
+      // Message-function form, which skips vue-i18n's message compiler: the literal `@` in
+      // `mulmoterminal@latest` would otherwise be read as a linked-message reference, the compiler
+      // throws, and the whole section renders as nothing.
+      restartHint: () => "もう一度起動するには、ターミナルで `npx mulmoterminal@latest` を実行してください。",
+      button: "MulmoTerminal を終了",
+      confirmBody: "サーバが停止し、このページは動かなくなります。グリッド上のターミナルは画面から消えます。",
+      sessionsNote:
+        "Ctrl+C と同じです。tmux が入っていればエージェントのセッションは動き続け、次回起動時に「再起動を生き延びたセッション」に出ます。無ければサーバと一緒に終わります。",
+      confirmButton: "終了する",
+      cancel: "キャンセル",
+      stopping: "終了しています…",
+      failed: "サーバを停止できませんでした。",
+      stoppedTitle: "MulmoTerminal を終了しました",
+      stoppedBody: "このタブは閉じて構いません。",
     },
 
     language: {

--- a/test/server/routes/shutdown-route.spec.ts
+++ b/test/server/routes/shutdown-route.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+// The contract POST /api/shutdown owes the browser: the reply lands BEFORE the process goes.
+// Getting that backwards is not a crash — it is a button that works and looks like it failed,
+// because the socket closes before the response can be read.
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import { routeCall, jsonPost } from "../../helpers/routeCall";
+import { mountShutdownRoute } from "../../../server/routes/shutdown-routes";
+
+// A real (tiny) delay rather than fake timers: the request helper awaits a real IO chain, and
+// freezing the clock underneath it deadlocks the call. One app and one spy PER TEST, so a stop
+// still pending from an earlier test cannot be counted as this one's.
+const DELAY_MS = 20;
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function mounted() {
+  const stop = vi.fn();
+  const app = express();
+  app.use(express.json());
+  mountShutdownRoute(app, { stop, delayMs: DELAY_MS });
+  return { stop, call: routeCall(app) };
+}
+
+describe("POST /api/shutdown", () => {
+  it("answers 200 with the shape the browser switches its screen on", async () => {
+    const { call } = mounted();
+    const res = await call("/api/shutdown", jsonPost({}));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ stopping: true });
+  });
+
+  it("has NOT stopped by the time it answers", async () => {
+    const { stop, call } = mounted();
+    await call("/api/shutdown", jsonPost({}));
+    // The whole reason for the delay: stopping inside the handler closes the socket first.
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("stops once the grace period elapses", async () => {
+    const { stop, call } = mounted();
+    await call("/api/shutdown", jsonPost({}));
+    await settle(DELAY_MS * 3);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops once per request, not once per handler pass", async () => {
+    const { stop, call } = mounted();
+    await call("/api/shutdown", jsonPost({}));
+    await call("/api/shutdown", jsonPost({}));
+    await settle(DELAY_MS * 3);
+    expect(stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("is not reachable by GET — stopping the server is not a safe method", async () => {
+    // It matters beyond tidiness: the central same-origin gate exempts safe methods on purpose
+    // (a cross-site <img> sends no Origin), so a GET here would be the one shape it cannot guard.
+    const { call } = mounted();
+    const res = await call("/api/shutdown");
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/src/components/settings/quitSection.spec.ts
+++ b/test/src/components/settings/quitSection.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { nextTick } from "vue";
 import { mount, flushPromises } from "@vue/test-utils";
 
 import QuitSection from "../../../../src/components/settings/QuitSection.vue";
@@ -84,5 +85,34 @@ describe("the quit section", () => {
     await confirm.trigger("click");
     await flushPromises();
     expect(calls()).toHaveLength(1);
+  });
+});
+
+// Focus, because both buttons are REPLACED by the other's panel when clicked. Without moving it,
+// focus lands on <body> and a keyboard user is dropped out of the modal — the defect #1568 fixed
+// for the skill-launch confirmation in this same modal.
+describe("the quit section and the keyboard", () => {
+  it("moves focus into the confirmation it just opened", async () => {
+    const w = mount(QuitSection, { attachTo: document.body });
+    try {
+      await w.get('[data-testid="quit-server"]').trigger("click");
+      await nextTick();
+      expect(document.activeElement).toBe(w.get('[data-testid="quit-confirm-yes"]').element);
+    } finally {
+      w.unmount();
+    }
+  });
+
+  it("hands focus back to the button that opened it when cancelled", async () => {
+    const w = mount(QuitSection, { attachTo: document.body });
+    try {
+      await w.get('[data-testid="quit-server"]').trigger("click");
+      await nextTick();
+      await w.get('[data-testid="quit-cancel"]').trigger("click");
+      await nextTick();
+      expect(document.activeElement).toBe(w.get('[data-testid="quit-server"]').element);
+    } finally {
+      w.unmount();
+    }
   });
 });

--- a/test/src/components/settings/quitSection.spec.ts
+++ b/test/src/components/settings/quitSection.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+import QuitSection from "../../../../src/components/settings/QuitSection.vue";
+
+// Mocked rather than read back: the real one is a module-level, ONE-WAY flag (nothing can clear it,
+// because there is no server left to say otherwise), so a test that set it would decide the answer
+// for every test after it in this file.
+const { markServerStopped } = vi.hoisted(() => ({ markServerStopped: vi.fn() }));
+vi.mock("../../../../src/composables/useServerStopped", () => ({ markServerStopped }));
+
+// The one control in this app that takes everything else away (#1820), so what is pinned here is
+// that it CANNOT be reached in a single click, and that the page is only declared stopped when the
+// server actually said so.
+const respond = (ok: boolean) => {
+  globalThis.fetch = vi.fn(async () => ({ ok, status: ok ? 200 : 500, json: async () => ({ stopping: ok }) })) as unknown as typeof fetch;
+};
+
+const calls = (): { url: string; method: string | undefined }[] =>
+  (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.map((c) => ({
+    url: String(c[0]),
+    method: (c[1] as RequestInit | undefined)?.method,
+  }));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  markServerStopped.mockClear();
+  respond(true);
+});
+
+describe("the quit section", () => {
+  it("does not stop anything on the first click — it asks first", async () => {
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    await flushPromises();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(w.find('[data-testid="quit-confirm"]').exists()).toBe(true);
+  });
+
+  it("says what happens to the running sessions, which a browser confirm has no room for", async () => {
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    // Not the exact words — that they are SHOWN. The wording is i18n's to own; its absence is a
+    // user pressing a destructive button without being told the one thing they would ask.
+    expect(w.get('[data-testid="quit-confirm"]').text().length).toBeGreaterThan(0);
+    expect(w.findAll('[data-testid="quit-confirm"] p')).toHaveLength(2);
+  });
+
+  it("backs out without asking the server anything", async () => {
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    await w.get('[data-testid="quit-cancel"]').trigger("click");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(w.find('[data-testid="quit-server"]').exists()).toBe(true);
+  });
+
+  it("posts to the path MulmoClaude uses, so both hosts stop the same way", async () => {
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    await w.get('[data-testid="quit-confirm-yes"]').trigger("click");
+    await flushPromises();
+    expect(calls()).toEqual([{ url: "/api/shutdown", method: "POST" }]);
+    // Only now, on the server's own acknowledgement — the page is not declared dead on a click.
+    expect(markServerStopped).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the page usable when the server refused, rather than claiming it stopped", async () => {
+    respond(false);
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    await w.get('[data-testid="quit-confirm-yes"]').trigger("click");
+    await flushPromises();
+    expect(markServerStopped).not.toHaveBeenCalled();
+    expect(w.find('[data-testid="quit-failed"]').exists()).toBe(true);
+    // Back to the un-armed state: the next attempt has to pass the confirmation again.
+    expect(w.find('[data-testid="quit-server"]').exists()).toBe(true);
+  });
+
+  it("cannot fire twice from a double click", async () => {
+    const w = mount(QuitSection);
+    await w.get('[data-testid="quit-server"]').trigger("click");
+    const confirm = w.get('[data-testid="quit-confirm-yes"]');
+    await confirm.trigger("click");
+    await confirm.trigger("click");
+    await flushPromises();
+    expect(calls()).toHaveLength(1);
+  });
+});

--- a/test/src/composables/useUnloadGuard.spec.ts
+++ b/test/src/composables/useUnloadGuard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
 import { useUnloadGuard, reportActiveTerminals, suppressNextUnloadGuard } from "../../../src/composables/useUnloadGuard";
@@ -95,5 +95,34 @@ describe("useUnloadGuard", () => {
     wrapper.unmount();
     wrapper = null;
     expect(fireBeforeUnload()).toBe(false);
+  });
+});
+
+// Stopping the server from the browser (#1820) leaves the terminal counts reading as live, because
+// nothing tells them otherwise. The stopped screen says "you can close this tab" — so the guard
+// must not then argue with it. The flag is module-level and ONE-WAY, so this lives in its own
+// describe with its own module instance rather than being ordered around inside the file above.
+describe("useUnloadGuard once the server has been stopped", () => {
+  it("stops warning, because there is nothing left to lose", async () => {
+    vi.resetModules();
+    const guard = await import("../../../src/composables/useUnloadGuard");
+    const { markServerStopped } = await import("../../../src/composables/useServerStopped");
+
+    const StoppedHost = defineComponent({
+      setup() {
+        guard.useUnloadGuard();
+        return () => null;
+      },
+    });
+    const w = mount(StoppedHost);
+    try {
+      guard.reportActiveTerminals("grid", 3);
+      expect(fireBeforeUnload()).toBe(true);
+
+      markServerStopped();
+      expect(fireBeforeUnload()).toBe(false);
+    } finally {
+      w.unmount();
+    }
   });
 });


### PR DESCRIPTION
## Summary

ブラウザから MulmoTerminal を止められるようにします。#1820 の本体です。`npx mulmoterminal@latest` はブラウザを開くので、ユーザーの視線はブラウザにあります。タブを閉じてもサーバは動き続け、止める導線はブラウザ側にありませんでした。

**Settings → Quit MulmoTerminal**（`sessions` グループの末尾）と `POST /api/shutdown` を足します。

### MulmoClaude が同じ機能を持っていたので、それに合わせました

実装前に `../mulmoclaude` を確認したところ、**同じ必要に既に答えていました**（#2616、`src/config/apiRoutes.ts` の `shutdown: "/api/shutdown"`）。CLAUDE.md の規約どおり**あちらが命名の権威**なので、当初考えていた `/api/app/quit` ではなく `/api/shutdown` にし、ボディ（`{ stopping: true }`）も猶予時間（250ms）も UI の 2 段階確認も合わせています。両方を使う人が、2 通りの止め方を見つけないために。

**意図的に違えた点が 1 つ**、コメントに理由付きで書きました: MulmoClaude の「127.0.0.1 にバインドしているのでローカル限定」という注釈は**ここでは成り立ちません**（`BIND_HOST` で実インターフェースに晒せる）。権限クラスは増えません — 晒したサーバに届く相手は既にエージェントを spawn できるので — が、理由が違うものをそのまま写すべきではないと判断しました。

### 設計

- **先に answer、後で stop**（250ms の猶予）。ハンドラ内で止めるとレスポンスより先にソケットが閉じ、**成功したクリックが失敗に見えます**
- **停止は自分に SIGTERM を送るだけ。** 既存の `infra/shutdown.ts` のハンドラが受けるので、ボタンは Ctrl+C と**同じ経路**を通ります。終了処理の実装を 2 つ持ちません
- **確認はインライン 2 段階**（`window.confirm` ではなく）。ブラウザの confirm には「セッションがどうなるか」を書く場所が無く、それは押す前に必ず訊かれることだからです
- **停止後は全面オーバーレイ**に切り替え、同時に **unload guard を黙らせます**。「このタブは閉じて構いません」と言う以上、閉じるときに警告してはいけないので
- **CSRF 対策は足していません。** `sameOriginGuard` が `app-routes.ts:143` で全ルートの前に mount されており、POST は既定で覆われます（下で実測しました）

## Items to Confirm / Review

1. **置き場所** — Settings の `sessions` グループ末尾に独立タブとして置きました。ヘッダのツールバーは誤クリックの被害が大きいので避けています
2. **確認文の言い回し** — tmux の有無でセッションの扱いが変わる件を、実行時に tmux を検出せず**両方書く**形にしました。UI に tmux の可否を渡す API が今は無く、そのために API 面を増やすほどではないと判断しています。実行時に出し分けるべきなら教えてください
3. **`useServerStopped` がモジュールレベルの一方向フラグ**であること。ボタンは 4 階層下（App → GridView → AppSettingsModal → SettingsModal → QuitSection）にあり、emit で通すと関心の無い 4 ファイルに boolean が増えます
4. **README / getting-started ガイドの「止め方」に追記しています。#1824 が同じ箇所に触るので、後にマージする方で軽い conflict が出ます**（どちらも 1 段落の追加）

## 動作確認

`yarn typecheck` / `yarn lint` / `yarn test`（10843 passed）に加えて、**実際にビルドして実ブラウザで通しました**（Playwright、コンソールエラー 0 件）:

| 段階 | 観測 |
|---|---|
| Quit タブ | 表示され、`npx mulmoterminal@latest` の `@` を含む文が正しく描画される |
| 1 回目のクリック | fetch は飛ばず、確認パネルだけが出る |
| 確認 → Quit | 停止オーバーレイ「MulmoTerminal has stopped / You can close this tab.」 |
| その後 | `curl` は connection refused。プロセスも残らない |

`@` の件は MulmoClaude が残してくれた罠でした。vue-i18n のメッセージコンパイラは `@` を linked message として解釈して**throw し、セクション全体が何も描画されなくなります**。message-function 形式で回避しています（コメントに理由付き）。

**same-origin gate が本当に守っているかも実測しました**（コメントで主張している以上、確かめるべきなので）:

```
evil origin  -> 403     ; still alive? -> 200     <- 落ちない
same origin  -> 200     ; now gone?    -> refused <- 落ちる
```

ルートの spec には 4 通りの mutation（ハンドラ内で即 stop / ボディを空に / stop しない / GET にする）を入れて**全部 red になること**を確認済みです。`stop-inline` が red になることが、この PR で一番壊れやすい所（answer-before-stop）を見張っています。

## 関連

#1820 の 3 経路の 3 本目（最後）です。設計は `plans/feat-1820-stopping-the-server.md`（#1823）にあります。

- #1823 — `process.title`（`ps` と Windows のタブから見つかるようにする）
- #1824 — `mulmoterminal stop`（3 OS すべてで効く経路）

3 本とも独立していて、この PR も単独でマージできます。3 本入った時点で #1820 は閉じられます。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1820 について、止めるボタンはあっても良いかもしれない。`process` 名ってどの OS でも付けられるのか？
- 副作用がないなら入れる。シャットダウンも検討を。
- （確認の結果）3 つとも実装する。`process.title` は全 OS で設定する。

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Settings → Quit MulmoTerminal**, allowing shutdown directly from the browser with confirmation and progress feedback.
  * Added a shutdown status screen with restart guidance after the server stops.
  * Added English and Japanese translations for the new controls and messages.

* **Documentation**
  * Documented shutdown via **Ctrl+C** or browser settings, including tmux-dependent session persistence behavior.

* **Bug Fixes**
  * Prevented unnecessary unload warnings after MulmoTerminal has been stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->