### PR TITLE
sharedapp 0.22.0 — メンバー自身の取り下げ

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.21.0",
+    "@receptron/sharedapp": "^0.22.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.21.0.tgz#62af0105a2149a3e89bec728af56d57f309cd0bd"
-  integrity sha512-H+1/uPmmOlsH32RDNaMqezBR82fnl9wulo6hjmhaEg64gBNquzEYcjSne4voea51HDSIZBanfLl7bwIdFE5FAw==
+"@receptron/sharedapp@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.22.0.tgz#95590bb399143ee0f0ec1d88fb27941ed1083f79"
+  integrity sha512-MLB3uHbA/ilVwUQGhCM3M/a2Malq/asjf7eRhIF+i6oSWerey+jLp3371Wfi1Gkon9nwQXMMCxRz6nKf+xZmYg==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
`@receptron/sharedapp` を `^0.21.0` → `^0.22.0` に。**このリポジトリのコードは変更なし。**

receptron/sharedapp#41 の中身: メンバーが**自分で出した行**を取り下げられるようになります。ルール（`deleteWith` → `selfDelete` → `ownRow`）は最初から許していて、射影と読み戻しがそれを誤って伝えていました。

このリポジトリは publish の射影も、作者向けプレビューの親も、パッケージ側の実装をそのまま呼んでいるので、上げるだけで両方に届きます。

## 確認したこと

- `yarn test` — **10940 pass** / 50 skipped
- `yarn typecheck`（`vue-tsc -b`）
- `yarn format:check`

## マージ後に必要なこと

**各アプリを publish し直すまで、そのアプリは変わりません。** パッケージを上げただけでは、既に publish 済みの member 文書は古い形のままです。新しい形になるのは次の publish から。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the shared application package to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->