### PR TITLE
Bump @receptron/sharedapp to 0.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.22.0",
+    "@receptron/sharedapp": "^0.23.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.22.0.tgz#95590bb399143ee0f0ec1d88fb27941ed1083f79"
-  integrity sha512-MLB3uHbA/ilVwUQGhCM3M/a2Malq/asjf7eRhIF+i6oSWerey+jLp3371Wfi1Gkon9nwQXMMCxRz6nKf+xZmYg==
+"@receptron/sharedapp@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.23.0.tgz#67b250e1d05476d1082e88c582dadb8387dc80b5"
+  integrity sha512-8vAWDqUMXg7EP1XWZDqTP69a72l9snYwHWSW5uKaRGioQdA8Soz5ateakza7/A+1GooA9Pi+pDwsqz5ZEpQsfg==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
Keeps this pane on the same parent as the live page. 0.23.0 ([sharedapp#43](https://github.com/receptron/sharedapp/pull/43)) adds a second argument to the `submit` port — `written`, which closes the confirmation when the record lands rather than when the port's promise settles.

**Nothing here needs to change.** A host that ignores the argument behaves exactly as before, and this pane already refreshes without awaiting — `send` in `SharedAppPreview.vue` found the same hazard from the other end and says so in a comment:

> NOT awaited, and NOT `load()`. The bridge answers the page immediately after this resolves, and `load()` blanks the payload on its way…

So this is the version bump alone.

**Why it matters that it happens.** The pane and the live page must run the same parent; a skew is exactly how the two stopped agreeing about what a page may draw during the 0.22.0 round.

Checks: `vue-tsc -b` clean, eslint clean, 10940 tests passing (755 files, 3 skipped).

Companion: [mulmoserver#235](https://github.com/receptron/mulmoserver/pull/235), which uses the new argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared application dependency to version 0.23.0 for improved compatibility and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->