### PR TITLE
Keep a watching page current in the preview pane

### DIFF
--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -35,6 +35,14 @@ export interface PreviewPage {
    *  the pane resolve it would be the second implementation this whole change
    *  exists to remove. */
   viewer?: Viewer;
+  /** The collections this page WATCHES, off the same projection the published site reads.
+   *
+   *  A page that declares `live` is written for `onState` to arrive more than once — production
+   *  subscribes to those collections and re-delivers on every change. This pane read the records
+   *  once, so a page previewed here sat still while the live one moved: somebody else's message
+   *  never appeared, which reads as a broken page rather than as a preview that does not watch.
+   *  The pane re-reads while the page on screen names any, and this is how it knows to. */
+  live?: string[];
 }
 
 export type PreviewDataset = Record<string, unknown>[];

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -37,7 +37,7 @@ import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
 // Both from `/view`, which is where the PARENT's vocabulary lives — and where the read-back has to
 // be: the root entry reaches the compiler, and the compiler imports core's server half at runtime.
-import { ownRowsFor, projectedWritesOf, PUBLIC_WRITE_TIER, viewerFor, writableFields } from "@receptron/sharedapp/view";
+import { ownRowsFor, projectedWritesOf, PUBLIC_WRITE_TIER, viewerFor, writableFields, type Viewer } from "@receptron/sharedapp/view";
 import {
   previewPageKey,
   type PreviewDataset,
@@ -176,6 +176,35 @@ async function readDatasets(
   // change.
   return { datasets, unreadable: [...unreadable].sort((left, right) => (left < right ? -1 : 1)) };
 }
+
+/** The collections a page WATCHES, read off the projection rather than off the declaration —
+ *  `withLive` in the package drops names the tier may not read, and a pane that polled for one of
+ *  those would be watching something production does not.
+ *
+ *  A tier document lists its pages under `views`; the public one has a single `view`. */
+/** ABSENT rather than empty when a page watches nothing, which is how the projection itself writes
+ *  it: `live: []` on the wire would say the author declared an empty watch list. */
+const watching = (live: string[]): { live?: string[] } => {
+  if (live.length === 0) return {};
+  return { live };
+};
+
+const liveOf = (value: unknown): string[] => {
+  if (!isRecord(value) || !Array.isArray(value.live)) return [];
+  return value.live.filter((cid): cid is string => typeof cid === "string");
+};
+
+const tierLive = (config: unknown, viewId: string): string[] => {
+  if (!isRecord(config) || !Array.isArray(config.views)) return [];
+  return liveOf(config.views.find((view) => isRecord(view) && view.id === viewId));
+};
+
+/** The anonymous page, or none. Its own function so the run above stays a list of steps: what it
+ *  needs is the HTML, the viewer already resolved, and the public document's own watch list. */
+const publicPageOf = (html: string | null, viewer: Viewer, config: unknown): PreviewPage[] => {
+  if (html === null) return [];
+  return [{ id: PUBLIC_PAGE_ID, html, audience: "public", viewer, ...watching(liveOf(isRecord(config) ? config.view : null)) }];
+};
 
 /** What one tier's projection says each of its pages may query for. */
 function tierRequests(plan: TierPlan): { key: string; collections: RequestedCollection[] }[] {
@@ -333,8 +362,7 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
   // The author's address is NOT substituted here either, and that is the point of the whole file: a
   // preview that handed the page one more thing than production hands it is a preview of a page
   // that does not exist. The author IS a reader here, and this is what a reader gets.
-  const publicViewer = viewerFor(writes.public, null, PUBLIC_WRITE_TIER);
-  const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public", viewer: publicViewer }];
+  const publicPages = publicPageOf(publicHtml, viewerFor(writes.public, null, PUBLIC_WRITE_TIER), face.config);
   const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) => {
     // The author, as this tier's projection resolves them. `viewerFor` is the
     // package's, and mulmoserver calls the same one with the same projection —
@@ -346,7 +374,13 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     const projected = projectedWritesOf(plan.config);
     writes[plan.tier] = projected;
     const viewer = viewerFor(projected, handle.email, plan.tier);
-    return plan.pages.map((tierPage): PreviewPage => ({ id: tierPage.id, html: tierPage.html, audience: plan.tier, viewer }));
+    return plan.pages.map((tierPage): PreviewPage => ({
+      id: tierPage.id,
+      html: tierPage.html,
+      audience: plan.tier,
+      viewer,
+      ...watching(tierLive(plan.config, tierPage.id)),
+    }));
   });
   const pages = [...publicPages, ...tierPages];
 

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -41,6 +41,7 @@ import {
 const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
+import { keepWatchedPageCurrent } from "../composables/sharedAppLiveWatch";
 import { createIntentSender } from "../utils/sharedAppPreviewIntent";
 import { structuredCloneable } from "../utils/structuredCloneable";
 
@@ -635,6 +636,16 @@ async function copyLog(): Promise<void> {
 }
 
 onBeforeUnmount(() => window.clearTimeout(copiedTimer));
+
+// A PAGE THAT WATCHES ITS RECORDS is re-read while it is the one on screen — see
+// `sharedAppLiveWatch` for why this is a poll rather than a listener, and for what it costs. Before
+// it, the pane was the only place a `live` page stood still: the author's own writes refreshed it
+// and nobody else's did, so a chat room previewed here looked broken in a way the published one was
+// not.
+keepWatchedPageCurrent(
+  () => page.value,
+  () => void refresh(),
+);
 
 // The DIRECTORY is the other half of the app's identity, and it changes without a payload landing
 // — a cell moved to a repository whose server cannot be reached keeps the old entries under the new

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -1,0 +1,57 @@
+// Keeping a WATCHING page current in the preview pane.
+//
+// A page that declares `live` is written for `onState` to arrive more than once: production
+// subscribes to those collections and posts a new state on every change. This pane read the records
+// once and refreshed only after the author's OWN write — so a chat room previewed here sat still
+// while somebody else posted, which reads as a broken page rather than as a preview that does not
+// watch.
+//
+// WHY A POLL. mulmoserver holds a Firestore listener per watched collection, in the browser, with
+// the reader's own credentials. The pane reads through this host's server over HTTP with the
+// author's handle; there is no socket here to hang a listener on, and opening one is a much larger
+// change than the gap it closes. So the pane asks again — and only while a page that declared
+// `live` is the one on screen, so an app that declares none is read exactly as often as before.
+import { onScopeDispose, watch } from "vue";
+
+import type { PreviewPage } from "../../common/sharedAppPreview";
+
+/** Chosen against what it is for: an author watching whether their page redraws when somebody else
+ *  writes. Fast enough to see it happen while looking at it, slow enough that a pane left open all
+ *  afternoon is not a bill. */
+export const LIVE_POLL_MS = 4000;
+
+/** Does the page on screen watch anything? Nothing shown yet is no. */
+export const watchesRecords = (page: PreviewPage | null): boolean => (page?.live ?? []).length > 0;
+
+/** Re-read while the shown page watches records, and stop when it does not.
+ *
+ *  HIDDEN WINDOWS ARE SKIPPED rather than stopped: the reason to re-read is that somebody is
+ *  looking, and a pane behind another window is a request every four seconds for nobody. The timer
+ *  stays so that coming back needs no new one.
+ *
+ *  `onScopeDispose` rather than `onBeforeUnmount` so this can be called from anywhere a scope
+ *  exists, and so a timer cannot outlive the pane that started it. */
+export const keepWatchedPageCurrent = (page: () => PreviewPage | null, reread: () => void): void => {
+  let timer: number | undefined;
+  const stop = () => {
+    window.clearInterval(timer);
+    timer = undefined;
+  };
+  watch(
+    () => watchesRecords(page()),
+    (watching) => {
+      stop();
+      if (!watching) {
+        return;
+      }
+      timer = window.setInterval(() => {
+        if (document.visibilityState === "hidden") {
+          return;
+        }
+        reread();
+      }, LIVE_POLL_MS);
+    },
+    { immediate: true },
+  );
+  onScopeDispose(stop);
+};

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -75,7 +75,12 @@ const asPage = (value: unknown): PreviewPage[] => {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.html !== "string") return [];
   const audience = AUDIENCES.find((candidate) => candidate === value.audience);
   if (audience === undefined) return [];
-  return [{ id: value.id, html: value.html, audience, ...asViewer(value.viewer) }];
+  // `live` floors to absent rather than to `[]`, which is the same distinction the projection
+  // makes: a page that watches nothing and a page whose watch list could not be read must not both
+  // read as "watches nothing" — but here they may, because the only thing the pane does with it is
+  // re-read, and re-reading a page that does not need it costs a poll rather than correctness.
+  const live = strings(value.live);
+  return [{ id: value.id, html: value.html, audience, ...asViewer(value.viewer), ...(live.length === 0 ? {} : { live }) }];
 };
 
 /** One collection's capability, field by field.

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -367,6 +367,40 @@ describe("shared app preview", () => {
     expect(docs.writes).toEqual([]);
   });
 
+  it("says which collections a page WATCHES, so the pane can keep it current", async () => {
+    // The pane reads once. A page that declared `live` is written for `onState` to arrive again —
+    // production subscribes and re-delivers — so previewed here it stood still while the published
+    // one moved, and somebody else's message never appeared. This is what tells the pane to re-read,
+    // and it must be per page: an app can watch on one page and not on another.
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    writeApp(
+      root,
+      declaration({
+        public: { read: ["bookings"] },
+        views: [
+          { id: "public", path: "views/front.html", audience: "public", collections: ["bookings"], live: ["bookings"] },
+          { id: "room", path: "views/room.html", audience: "member", collections: ["notes"], live: ["notes"] },
+          { id: "ledger", path: "views/ledger.html", audience: "member", collections: ["notes"] },
+        ],
+      }),
+    );
+    writeFileSync(path.join(root, "views", "front.html"), "<p>front</p>");
+    writeFileSync(path.join(root, "views", "room.html"), "<p>room</p>");
+    writeFileSync(path.join(root, "views", "ledger.html"), "<p>ledger</p>");
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    const live = result.ok ? Object.fromEntries(result.pages.map((page) => [`${page.audience}:${page.id}`, page.live])) : {};
+    expect(live["member:room"]).toEqual(["notes"]);
+    // Declared nothing, so there is nothing to poll for — absent rather than empty, and the pane
+    // reads that page exactly as often as it did before any of this.
+    expect(live["member:ledger"]).toBeUndefined();
+    // The anonymous page has its own watch list, in its own document.
+    expect(live["public:public"]).toEqual(["bookings"]);
+    expect(docs.writes).toEqual([]);
+  });
+
   it("carries what a public create may contain, so the parent can judge a submission", async () => {
     writeApp(root, declaration({ public: { read: ["bookings"], submit: { bookings: { auth: "verifiedEmail", createFields: ["note"] } } } }));
 

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -1,0 +1,117 @@
+// A previewed page that WATCHES its records, and the one place it used to stand still.
+//
+// The pane read the records once and refreshed after the author's own write, so a page declaring
+// `live` — a chat room, a live poll's audience screen — showed nothing when somebody ELSE wrote.
+// The published page moved and the preview of it did not, which reads as a broken page rather than
+// as a preview that does not watch.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { effectScope, ref } from "vue";
+
+import { LIVE_POLL_MS, keepWatchedPageCurrent, watchesRecords } from "../../../src/composables/sharedAppLiveWatch";
+import type { PreviewPage } from "../../../common/sharedAppPreview";
+
+const pageOf = (live?: string[]): PreviewPage => ({
+  id: "room",
+  html: "<h1>Room</h1>",
+  audience: "member",
+  ...(live === undefined ? {} : { live }),
+});
+
+/** Run `body` inside a scope, then dispose it — which is what the pane going away does. */
+const inScope = (body: () => void): (() => void) => {
+  const scope = effectScope();
+  scope.run(body);
+  return () => scope.stop();
+};
+
+const hide = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  hide("visible");
+});
+
+describe("watchesRecords", () => {
+  it("is what the page DECLARED, and nothing shown yet is no", () => {
+    expect(watchesRecords(pageOf(["messages"]))).toBe(true);
+    expect(watchesRecords(pageOf([]))).toBe(false);
+    expect(watchesRecords(pageOf())).toBe(false);
+    expect(watchesRecords(null)).toBe(false);
+  });
+});
+
+describe("keepWatchedPageCurrent", () => {
+  it("re-reads a watching page, over and over", () => {
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    expect(reread).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 3);
+    expect(reread).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("leaves a page that watches nothing exactly as often read as before", () => {
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(), reread));
+
+    vi.advanceTimersByTime(LIVE_POLL_MS * 10);
+    expect(reread).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("starts and stops as the author walks between pages", async () => {
+    vi.useFakeTimers();
+    const shown = ref<PreviewPage | null>(pageOf());
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => shown.value, reread));
+
+    shown.value = pageOf(["messages"]);
+    await Promise.resolve();
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+
+    // Back to a page that watches nothing: the polling has to END, not merely be ignored.
+    shown.value = pageOf();
+    await Promise.resolve();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("skips a hidden window, and picks up again when it comes back", () => {
+    // The reason to re-read is that somebody is LOOKING. A pane behind another window is a request
+    // every few seconds for nobody — and the timer stays, so returning needs no new one.
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    hide("hidden");
+    vi.advanceTimersByTime(LIVE_POLL_MS * 4);
+    expect(reread).not.toHaveBeenCalled();
+
+    hide("visible");
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("stops when the pane goes away", () => {
+    // A timer that outlived the pane would go on asking this host's server about a directory
+    // nobody is looking at, for as long as the app is open.
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
+    expect(reread).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What you see today

Open a `live` page in the collection pane and it never moves. Your own writes refresh it; nobody else's do. The published page at `/m/{slug}` updates the moment somebody posts, so the preview of it looks broken in a way the real thing is not.

Reported while testing a group chat: *"It does not get updated when somebody else posts a new message, unlike the website."*

## Why

`views[].live` is honoured by mulmoserver — one Firestore listener per watched collection, re-delivering state on every change. This pane never implemented the other half: `load()` on a directory change, `refresh()` after the author's own submit or intent, and nothing else. A page written for `onState` to arrive more than once was previewed by a host that delivered it once.

## The change

**`live` rides on each previewed page**, read off the projection rather than the declaration — `withLive` has already dropped anything the tier may not read, so the pane cannot poll for something production does not watch. Per page, because an app can watch on one page and not on another, and **absent rather than empty**: `live: []` on the wire would claim the author declared an empty list.

**The pane re-reads while a page that names any is the one on screen.** `keepWatchedPageCurrent` in a new `sharedAppLiveWatch` composable.

### Why a poll and not a listener

mulmoserver holds its listeners in the browser, with the reader's own credentials. This pane reads through this host's server over HTTP with the author's handle — there is no socket here to hang a listener on, and opening one is a much larger change than the gap it closes. So it asks again:

- **4 seconds** — chosen against what it is for: an author watching whether their page redraws when somebody else writes. Fast enough to see it happen while looking, slow enough that a pane left open all afternoon is not a bill.
- **Skipped while the window is hidden.** The reason to re-read is that somebody is looking. The timer stays, so coming back needs no new one.
- **Stopped with the scope**, and when the author walks to a page that watches nothing.
- **An app that declares no `live` is read exactly as often as before.** Nothing else changes.

The frame is keyed on the page, not the payload, so a re-read never remounts the document — the new datasets go down the channel as a state message, which is exactly what production does.

## Tests

- `test/src/composables/sharedAppLiveWatch.spec.ts` (6): re-reads repeatedly; a non-watching page is never polled; starting and stopping as the author moves between pages; a hidden window is skipped and picks up again; the timer dies with the scope.
- `test/server/backends/sharedAppPreview.spec.ts`: `live` rides per page — the watching member page has it, the one beside it does not, and the anonymous page carries its own list from its own document.

`vue-tsc -b`, eslint, and 10947 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live previews now automatically refresh pages that display watched records.
  * Preview updates occur periodically while the page is visible and pause rereads when hidden.
  * Pages can identify the live collections that should trigger refreshes.

* **Bug Fixes**
  * Keeps displayed preview data current as watched records change.

* **Tests**
  * Added coverage for live collection metadata, refresh behavior, page transitions, visibility changes, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->