### PR TITLE
Stream a watching page's records into the preview pane

### DIFF
--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -35,6 +35,14 @@ export interface PreviewPage {
    *  the pane resolve it would be the second implementation this whole change
    *  exists to remove. */
   viewer?: Viewer;
+  /** The collections this page WATCHES, off the same projection the published site reads.
+   *
+   *  A page that declares `live` is written for `onState` to arrive more than once — production
+   *  subscribes to those collections and re-delivers on every change. This pane read the records
+   *  once, so a page previewed here sat still while the live one moved: somebody else's message
+   *  never appeared, which reads as a broken page rather than as a preview that does not watch.
+   *  The pane re-reads while the page on screen names any, and this is how it knows to. */
+  live?: string[];
 }
 
 export type PreviewDataset = Record<string, unknown>[];

--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -47,6 +47,18 @@ export interface PreviewPage {
 
 export type PreviewDataset = Record<string, unknown>[];
 
+/** One collection's rows, for one page, as they stand now — what the record stream sends when a
+ *  watched collection changes.
+ *
+ *  THE ROWS RATHER THAN A DIFF. The pane holds a map keyed by page and collection; replacing one
+ *  entry cannot be applied out of order, and a diff against a map the sender cannot see could be. */
+export interface PreviewRecordChange {
+  /** `previewPageKey(audience, id)` — the same key the page's datasets are filed under. */
+  key: string;
+  cid: string;
+  rows: PreviewDataset;
+}
+
 /** The records ONE page is handed, per collection.
  *
  *  Per page rather than one map for the app, and that is the point rather than tidiness: a member

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -37,7 +37,7 @@ import { declaredView, readAppViewFile } from "./publicView.js";
 import { isRecord } from "../../../common/isRecord.js";
 // Both from `/view`, which is where the PARENT's vocabulary lives — and where the read-back has to
 // be: the root entry reaches the compiler, and the compiler imports core's server half at runtime.
-import { ownRowsFor, projectedWritesOf, PUBLIC_WRITE_TIER, viewerFor, writableFields } from "@receptron/sharedapp/view";
+import { ownRowsFor, projectedWritesOf, PUBLIC_WRITE_TIER, viewerFor, writableFields, type Viewer } from "@receptron/sharedapp/view";
 import {
   previewPageKey,
   type PreviewDataset,
@@ -176,6 +176,35 @@ async function readDatasets(
   // change.
   return { datasets, unreadable: [...unreadable].sort((left, right) => (left < right ? -1 : 1)) };
 }
+
+/** The collections a page WATCHES, read off the projection rather than off the declaration —
+ *  `withLive` in the package drops names the tier may not read, and a pane that polled for one of
+ *  those would be watching something production does not.
+ *
+ *  A tier document lists its pages under `views`; the public one has a single `view`. */
+/** ABSENT rather than empty when a page watches nothing, which is how the projection itself writes
+ *  it: `live: []` on the wire would say the author declared an empty watch list. */
+const watching = (live: string[]): { live?: string[] } => {
+  if (live.length === 0) return {};
+  return { live };
+};
+
+const liveOf = (value: unknown): string[] => {
+  if (!isRecord(value) || !Array.isArray(value.live)) return [];
+  return value.live.filter((cid): cid is string => typeof cid === "string");
+};
+
+const tierLive = (config: unknown, viewId: string): string[] => {
+  if (!isRecord(config) || !Array.isArray(config.views)) return [];
+  return liveOf(config.views.find((view) => isRecord(view) && view.id === viewId));
+};
+
+/** The anonymous page, or none. Its own function so the run above stays a list of steps: what it
+ *  needs is the HTML, the viewer already resolved, and the public document's own watch list. */
+const publicPageOf = (html: string | null, viewer: Viewer, config: unknown): PreviewPage[] => {
+  if (html === null) return [];
+  return [{ id: PUBLIC_PAGE_ID, html, audience: "public", viewer, ...watching(liveOf(isRecord(config) ? config.view : null)) }];
+};
 
 /** What one tier's projection says each of its pages may query for. */
 function tierRequests(plan: TierPlan): { key: string; collections: RequestedCollection[] }[] {
@@ -333,8 +362,7 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
   // The author's address is NOT substituted here either, and that is the point of the whole file: a
   // preview that handed the page one more thing than production hands it is a preview of a page
   // that does not exist. The author IS a reader here, and this is what a reader gets.
-  const publicViewer = viewerFor(writes.public, null, PUBLIC_WRITE_TIER);
-  const publicPages: PreviewPage[] = publicHtml === null ? [] : [{ id: PUBLIC_PAGE_ID, html: publicHtml, audience: "public", viewer: publicViewer }];
+  const publicPages = publicPageOf(publicHtml, viewerFor(writes.public, null, PUBLIC_WRITE_TIER), face.config);
   const tierPages: PreviewPage[] = tiers.plans.flatMap((plan) => {
     // The author, as this tier's projection resolves them. `viewerFor` is the
     // package's, and mulmoserver calls the same one with the same projection —
@@ -346,7 +374,13 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     const projected = projectedWritesOf(plan.config);
     writes[plan.tier] = projected;
     const viewer = viewerFor(projected, handle.email, plan.tier);
-    return plan.pages.map((tierPage): PreviewPage => ({ id: tierPage.id, html: tierPage.html, audience: plan.tier, viewer }));
+    return plan.pages.map((tierPage): PreviewPage => ({
+      id: tierPage.id,
+      html: tierPage.html,
+      audience: plan.tier,
+      viewer,
+      ...watching(tierLive(plan.config, tierPage.id)),
+    }));
   });
   const pages = [...publicPages, ...tierPages];
 

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -63,6 +63,20 @@ export interface PreviewSuccess extends SharedAppPreview {
    *  judge there — one that could disagree with the one that performs the write — which is the
    *  divergence `PreviewPage.viewer` was introduced to remove. */
   writes: Partial<Record<PreviewAudience, ProjectedViewWrite[]>>;
+  /** What a LISTENER has to hold to keep this preview current: one entry per page that declared
+   *  `live`, carrying the request THAT page makes of that collection.
+   *
+   *  Server-only, and the request rather than the cid alone: the same collection is read `all` for
+   *  the desk and `own` for the participant, so one change has to become rows per page. See
+   *  `previewWatch.ts`, its only caller. */
+  watches: PreviewWatch[];
+}
+
+/** One collection, watched for one page. */
+export interface PreviewWatch {
+  /** `previewPageKey(audience, id)` — the key its rows are filed under. */
+  key: string;
+  want: RequestedCollection;
 }
 
 export type PreviewResult = PreviewSuccess | SharedAppFailure;
@@ -204,6 +218,30 @@ const tierLive = (config: unknown, viewId: string): string[] => {
 const publicPageOf = (html: string | null, viewer: Viewer, config: unknown): PreviewPage[] => {
   if (html === null) return [];
   return [{ id: PUBLIC_PAGE_ID, html, audience: "public", viewer, ...watching(liveOf(isRecord(config) ? config.view : null)) }];
+};
+
+/** What every page asks for, in one list. Its own function so the run above stays a list of steps
+ *  — and so the watch plan and the one-shot read cannot be built from two different readings. */
+const requestsOf = (publicHtml: string | null, config: PublishedConfigDoc, plans: TierPlan[]): { key: string; collections: RequestedCollection[] }[] => {
+  const anonymous = publicHtml === null ? [] : [{ key: previewPageKey("public", PUBLIC_PAGE_ID), collections: publicRequests(config) }];
+  return [...anonymous, ...plans.flatMap(tierRequests)];
+};
+
+/** WHICH READS A LISTENER REPEATS: the collections each page declared `live`, paired with the
+ *  request that page makes of them.
+ *
+ *  Intersected with what the page actually asks for rather than taken from `live` alone. `live` is
+ *  a subset of `collections` by construction, and this is where that stops being trusted: a watch
+ *  with no request behind it would be a listener on a collection the page never reads.
+ *
+ *  Pure, so the mapping is testable without a session. */
+export const watchesOf = (pages: PreviewPage[], requests: { key: string; collections: RequestedCollection[] }[]): PreviewWatch[] => {
+  const asked = new Map(requests.map((entry) => [entry.key, entry.collections]));
+  return pages.flatMap((page) => {
+    const key = previewPageKey(page.audience, page.id);
+    const live = new Set(page.live ?? []);
+    return (asked.get(key) ?? []).filter((want) => live.has(want.cid)).map((want) => ({ key, want }));
+  });
 };
 
 /** What one tier's projection says each of its pages may query for. */
@@ -388,10 +426,8 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
   // `public.read` is what a visitor may see, and reading everything on disk would draw a page the
   // author cannot ship. Per page rather than one list for the app, because a member page may name a
   // collection the public one must never receive.
-  const { datasets, unreadable } = await readDatasets(handle, aid, [
-    ...(publicHtml === null ? [] : [{ key: previewPageKey("public", PUBLIC_PAGE_ID), collections: publicRequests(face.config) }]),
-    ...tiers.plans.flatMap(tierRequests),
-  ]);
+  const requests = requestsOf(publicHtml, face.config, tiers.plans);
+  const { datasets, unreadable } = await readDatasets(handle, aid, requests);
 
   // THE AUTHOR'S OWN ROWS, read separately from the pages and never as a page's datasets: they
   // travel as `viewer.mine`, which is a different message saying a different thing. A cid that
@@ -418,6 +454,7 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     generatedForm: publicHtml === null && Object.keys(form).length > 0,
     formInputs,
     datasets,
+    watches: watchesOf(pages, requests),
     // Projected to the fields a page in this position could have SENT — the package's rule, so the
     // preview hands a page exactly what mulmoserver hands the live one. A page given one more field
     // here than production gives it is a preview of a page that does not exist.

--- a/server/backends/sharedApp/previewWatch.ts
+++ b/server/backends/sharedApp/previewWatch.ts
@@ -1,0 +1,89 @@
+// Keeping the pane's copy of a WATCHING page current, from the records rather than from a clock.
+//
+// A page that declares `live` is written for `onState` to arrive more than once: mulmoserver
+// subscribes to those collections and posts a new state on every change. The pane read once and
+// re-read after the AUTHOR's own write — so a chat room previewed here sat still while somebody
+// else posted, and the page looked broken in a way the published one is not.
+//
+// THE LISTENER LIVES HERE, not in the browser. mulmoserver's runs in the reader's own tab with the
+// reader's own credentials; the pane has no Firestore of its own and no credentials — it reads
+// through this host, which holds the session (`currentFirestore()`). So this module holds the
+// subscription and the route streams what it sees. Nothing is polled: `onSnapshot` fires when the
+// records change and at no other time.
+//
+// ONE LISTENER PER COLLECTION, fanned out to the pages that watch it. Two pages can name the same
+// collection and read it differently — `all` for the desk, `own` for the participant — so a change
+// is turned into rows per page, by the same `ownsRow` the one-shot read uses. Subscribing twice
+// would be two listeners billing for one collection and two chances for them to disagree.
+import { collection, onSnapshot, type Unsubscribe } from "firebase/firestore";
+
+import { appSchemasPath } from "@receptron/sharedapp";
+
+import { isRecord } from "../../../common/isRecord.js";
+import type { PreviewDataset, PreviewRecordChange } from "../../../common/sharedAppPreview.js";
+import { currentEmail, currentFirestore, currentUid } from "../remoteHost/session.js";
+import { ownsRow, previewSharedApp, type PreviewWatch } from "./preview.js";
+
+/** What the caller gets: a way to stop, or the reason there is nothing to watch.
+ *
+ *  A preview that will not compute is NOT an error here. The pane has already been told why by the
+ *  route that draws it; saying it twice would put a second copy of the same problem on screen. */
+export type PreviewWatchHandle = { ok: true; watching: string[]; stop: () => void } | { ok: false };
+
+/** The rows of one snapshot, as the page that asked for them sees it. */
+const fields = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) return {};
+  return value;
+};
+
+const rowsFor = (docs: { id: string; data: () => unknown }[], watch: PreviewWatch, who: { uid: string; email: string }): PreviewDataset => {
+  // The id goes ON the record, as the one-shot read does it: the rules use the document id as the
+  // record's identity, and a page rendering a list needs it as a field.
+  const rows = docs.map((entry) => ({ ...fields(entry.data()), id: entry.id }));
+  if (watch.want.scope === "all") return rows;
+  return rows.filter((row) => ownsRow(watch.want, row, who));
+};
+
+/** Watch every collection this app's pages declare `live`, and report each change once per page.
+ *
+ *  `emit` is called with the collection's CURRENT rows rather than with a diff: the pane holds a
+ *  map keyed by page and collection, and replacing one entry is both smaller to reason about and
+ *  impossible to apply out of order.
+ *
+ *  A REFUSED SUBSCRIPTION is silent. The one-shot read already reported the collection as
+ *  unreadable and the pane says so; a listener that cannot open adds nothing to that, and throwing
+ *  here would take down the watch on every other collection with it. */
+export async function watchPreviewRecords(cwd: string, emit: (change: PreviewRecordChange) => void): Promise<PreviewWatchHandle> {
+  const preview = await previewSharedApp(cwd);
+  if (!preview.ok || preview.watches.length === 0) return { ok: false };
+  const uid = currentUid();
+  const email = currentEmail();
+  if (uid === null || email === null) return { ok: false };
+
+  const who = { uid, email };
+  const byCid = new Map<string, PreviewWatch[]>();
+  for (const watch of preview.watches) {
+    byCid.set(watch.want.cid, [...(byCid.get(watch.want.cid) ?? []), watch]);
+  }
+
+  const stops: Unsubscribe[] = [];
+  for (const [cid, watches] of byCid) {
+    const path = `${appSchemasPath(preview.aid)}/${cid}/items`;
+    stops.push(
+      onSnapshot(
+        collection(currentFirestore(), path),
+        (snapshot) => {
+          for (const watch of watches) emit({ key: watch.key, cid, rows: rowsFor(snapshot.docs, watch, who) });
+        },
+        () => undefined,
+      ),
+    );
+  }
+  return {
+    ok: true,
+    watching: [...byCid.keys()],
+    stop: () => {
+      for (const off of stops) off();
+    },
+  };
+}

--- a/server/backends/sharedApp/previewWatch.ts
+++ b/server/backends/sharedApp/previewWatch.ts
@@ -87,3 +87,47 @@ export async function watchPreviewRecords(cwd: string, emit: (change: PreviewRec
     },
   };
 }
+
+/** Hold a stream open until the request closes — WITH THE CLEANUP REGISTERED FIRST.
+ *
+ *  Opening the watch is asynchronous (the preview has to be computed before there is anything to
+ *  subscribe to), and a pane that changes page or directory in the meantime closes the request
+ *  while that is still running. Registering the close handler afterwards means the event has
+ *  already fired by the time anything is listening: the subscriptions and the heartbeat are created
+ *  a moment later and nothing ever stops them — Firestore listeners billing for a reader who has
+ *  gone, until the server exits.
+ *
+ *  So the handler goes on FIRST and the watch is handed to it when it exists. A request that closed
+ *  during setup is not a special case to detect afterwards; it is the ordinary one, and the watch it
+ *  produced is stopped the moment it is returned.
+ *
+ *  Everything it touches is injected, so the ordering can be tested without express or a session. */
+export async function holdOpen(deps: {
+  onClose: (release: () => void) => void;
+  open: () => Promise<PreviewWatchHandle>;
+  /** Start the heartbeat; the returned function stops it. Not started at all for a stream that
+   *  ends, and never started for a request that has already gone. */
+  beat: () => () => void;
+  /** End the response: nothing to watch, so nothing to wait for. */
+  end: () => void;
+}): Promise<void> {
+  let stop: (() => void) | null = null;
+  let quiet: (() => void) | null = null;
+  let gone = false;
+  deps.onClose(() => {
+    gone = true;
+    quiet?.();
+    stop?.();
+  });
+  const watch = await deps.open();
+  if (!watch.ok) {
+    deps.end();
+    return;
+  }
+  if (gone) {
+    watch.stop();
+    return;
+  }
+  stop = watch.stop;
+  quiet = deps.beat();
+}

--- a/server/backends/sharedApp/previewWatch.ts
+++ b/server/backends/sharedApp/previewWatch.ts
@@ -88,28 +88,34 @@ export async function watchPreviewRecords(cwd: string, emit: (change: PreviewRec
   };
 }
 
-/** Hold a stream open until the request closes — WITH THE CLEANUP REGISTERED FIRST.
+/** Hold a stream open until the request closes — WITH THE CLEANUP REGISTERED FIRST, and with the
+ *  response begun only once there is something to send.
  *
- *  Opening the watch is asynchronous (the preview has to be computed before there is anything to
- *  subscribe to), and a pane that changes page or directory in the meantime closes the request
- *  while that is still running. Registering the close handler afterwards means the event has
- *  already fired by the time anything is listening: the subscriptions and the heartbeat are created
- *  a moment later and nothing ever stops them — Firestore listeners billing for a reader who has
- *  gone, until the server exits.
+ *  THE ORDER OF THE CLEANUP. Opening the watch is asynchronous (the preview has to be computed
+ *  before there is anything to subscribe to), and a pane that changes page or directory in the
+ *  meantime closes the request while that is still running. Registering the close handler
+ *  afterwards means the event has already fired by the time anything is listening: the
+ *  subscriptions and the heartbeat are created a moment later and nothing ever stops them —
+ *  Firestore listeners billing for a reader who has gone, until the server exits. So the handler
+ *  goes on FIRST and the watch is handed to it when it exists.
  *
- *  So the handler goes on FIRST and the watch is handed to it when it exists. A request that closed
- *  during setup is not a special case to detect afterwards; it is the ordinary one, and the watch it
- *  produced is stopped the moment it is returned.
+ *  AND NOTHING TO WATCH IS NOT AN EMPTY STREAM. An `EventSource` whose 200 stream ends reconnects,
+ *  by design and for ever — so answering "no app here, no `live`, no session" with an opened-then-
+ *  ended stream is a client reconnecting every few seconds and a server recomputing the whole
+ *  preview each time, which is the poll this feature exists to avoid, arriving through the error
+ *  path. `nothing` therefore answers TERMINALLY, before the stream has begun.
  *
  *  Everything it touches is injected, so the ordering can be tested without express or a session. */
 export async function holdOpen(deps: {
   onClose: (release: () => void) => void;
   open: () => Promise<PreviewWatchHandle>;
-  /** Start the heartbeat; the returned function stops it. Not started at all for a stream that
-   *  ends, and never started for a request that has already gone. */
+  /** Begin the SSE response. Called once, only when there IS a watch, and never for a request that
+   *  has already gone. */
+  begin: () => void;
+  /** Start the heartbeat; the returned function stops it. */
   beat: () => () => void;
-  /** End the response: nothing to watch, so nothing to wait for. */
-  end: () => void;
+  /** Answer terminally: there is nothing to watch, and the client must not come back for more. */
+  nothing: () => void;
 }): Promise<void> {
   let stop: (() => void) | null = null;
   let quiet: (() => void) | null = null;
@@ -121,7 +127,7 @@ export async function holdOpen(deps: {
   });
   const watch = await deps.open();
   if (!watch.ok) {
-    deps.end();
+    if (!gone) deps.nothing();
     return;
   }
   if (gone) {
@@ -129,5 +135,6 @@ export async function holdOpen(deps: {
     return;
   }
   stop = watch.stop;
+  deps.begin();
   quiet = deps.beat();
 }

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -15,6 +15,7 @@ import { access } from "node:fs/promises";
 import path from "node:path";
 import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { previewSharedApp } from "./sharedApp/preview.js";
+import { watchPreviewRecords } from "./sharedApp/previewWatch.js";
 import { undoPreviewSubmission, writePreviewSubmission } from "./sharedApp/previewWrite.js";
 import { performPreviewIntent } from "./sharedApp/previewIntent.js";
 import { previewOwnLookup } from "./sharedApp/previewLookup.js";
@@ -166,6 +167,59 @@ async function respondLookup(req: Request, res: Response): Promise<void> {
   res.json(await previewOwnLookup(cwd, { cid, key }));
 }
 
+/** THE RECORDS, STREAMED while a page that watches them is open.
+ *
+ *  Server-sent events rather than a socket: this is one-way, it is text, and it needs no handshake
+ *  — the pane opens an `EventSource` and the listener behind it is closed when the request is.
+ *  And rather than a poll, which is what the pane would otherwise have to do: a listener fires when
+ *  the records change and at no other time, which is what the published page gets.
+ *
+ *  A HEARTBEAT, as a comment line: an idle stream through a proxy is a stream that gets closed, and
+ *  a comment is the one thing an `EventSource` reads and does not deliver. It carries no records and
+ *  asks the database nothing — it is not the poll wearing a hat. */
+async function streamRecords(req: Request, res: Response): Promise<void> {
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+  });
+  const watch = await watchPreviewRecords(cwd, (change) => {
+    res.write(`data: ${JSON.stringify(change)}\n\n`);
+  });
+  if (!watch.ok) {
+    // Nothing to watch — no app here, no page that declared `live`, or no session. The stream is
+    // ENDED rather than held open: an `EventSource` on a closed stream reconnects on its own, and a
+    // pane holding one that will never speak looks exactly like one whose records stopped moving.
+    res.end();
+    return;
+  }
+  const beat = setInterval(() => res.write(": open\n\n"), HEARTBEAT_MS);
+  req.on("close", () => {
+    clearInterval(beat);
+    watch.stop();
+  });
+}
+
+/** Often enough that nothing between here and the pane calls the stream idle, rarely enough to be
+ *  invisible. Both ends are on this machine; this is about proxies, not about latency. */
+const HEARTBEAT_MS = 25_000;
+
+/** The records as they change. Its own mount because it is the one route here that does not end:
+ *  the others answer a question, this one stays open until the pane goes away. */
+function mountRecordStream(app: Express): void {
+  app.get("/api/shared-app/preview/watch", (req, res) => {
+    void (async () => {
+      try {
+        await streamRecords(req, res);
+      } catch (err) {
+        fail(res, err);
+      }
+    })();
+  });
+}
+
 export function mountSharedAppPreviewRoutes(app: Express): void {
   // The write the author accepted in the confirmation, performed as them.
   //
@@ -242,6 +296,8 @@ export function mountSharedAppPreviewRoutes(app: Express): void {
       }
     })();
   });
+
+  mountRecordStream(app);
 
   app.get("/api/shared-app/preview", (req, res) => {
     void (async () => {

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -15,7 +15,7 @@ import { access } from "node:fs/promises";
 import path from "node:path";
 import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { previewSharedApp } from "./sharedApp/preview.js";
-import { watchPreviewRecords } from "./sharedApp/previewWatch.js";
+import { holdOpen, watchPreviewRecords } from "./sharedApp/previewWatch.js";
 import { undoPreviewSubmission, writePreviewSubmission } from "./sharedApp/previewWrite.js";
 import { performPreviewIntent } from "./sharedApp/previewIntent.js";
 import { previewOwnLookup } from "./sharedApp/previewLookup.js";
@@ -185,20 +185,20 @@ async function streamRecords(req: Request, res: Response): Promise<void> {
     "Cache-Control": "no-cache, no-transform",
     Connection: "keep-alive",
   });
-  const watch = await watchPreviewRecords(cwd, (change) => {
-    res.write(`data: ${JSON.stringify(change)}\n\n`);
-  });
-  if (!watch.ok) {
-    // Nothing to watch — no app here, no page that declared `live`, or no session. The stream is
-    // ENDED rather than held open: an `EventSource` on a closed stream reconnects on its own, and a
-    // pane holding one that will never speak looks exactly like one whose records stopped moving.
-    res.end();
-    return;
-  }
-  const beat = setInterval(() => res.write(": open\n\n"), HEARTBEAT_MS);
-  req.on("close", () => {
-    clearInterval(beat);
-    watch.stop();
+  // The ORDER is `holdOpen`'s, and it is the point of that function: the cleanup is registered
+  // before the watch is opened, because opening it is asynchronous and a pane that changes page
+  // meanwhile closes this request while it runs.
+  await holdOpen({
+    onClose: (release) => req.on("close", release),
+    open: () => watchPreviewRecords(cwd, (change) => res.write(`data: ${JSON.stringify(change)}\n\n`)),
+    beat: () => {
+      const timer = setInterval(() => res.write(": open\n\n"), HEARTBEAT_MS);
+      return () => clearInterval(timer);
+    },
+    // Nothing to watch — no app here, no page that declared `live`, or no session. ENDED rather
+    // than held open: an `EventSource` on a closed stream reconnects on its own, and a pane holding
+    // one that will never speak looks exactly like one whose records stopped moving.
+    end: () => res.end(),
   });
 }
 

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -180,25 +180,39 @@ async function respondLookup(req: Request, res: Response): Promise<void> {
 async function streamRecords(req: Request, res: Response): Promise<void> {
   const cwd = workspaceForRoute(req.query.cwd, res);
   if (cwd === null) return;
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache, no-transform",
-    Connection: "keep-alive",
-  });
+  // WRITTEN ONLY ONCE THE STREAM HAS BEGUN. `onSnapshot` delivers what it already has as soon as it
+  // is subscribed, and that can be before this response has any headers on it — which would send
+  // the first change as an ordinary 200 body and leave the pane reading rows it cannot parse.
+  let sending = false;
+  const held: string[] = [];
+  const send = (line: string) => {
+    if (sending) res.write(line);
+    else held.push(line);
+  };
   // The ORDER is `holdOpen`'s, and it is the point of that function: the cleanup is registered
   // before the watch is opened, because opening it is asynchronous and a pane that changes page
   // meanwhile closes this request while it runs.
   await holdOpen({
     onClose: (release) => req.on("close", release),
-    open: () => watchPreviewRecords(cwd, (change) => res.write(`data: ${JSON.stringify(change)}\n\n`)),
+    open: () => watchPreviewRecords(cwd, (change) => send(`data: ${JSON.stringify(change)}\n\n`)),
+    begin: () => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      });
+      sending = true;
+      for (const line of held) res.write(line);
+      held.length = 0;
+    },
     beat: () => {
       const timer = setInterval(() => res.write(": open\n\n"), HEARTBEAT_MS);
       return () => clearInterval(timer);
     },
-    // Nothing to watch — no app here, no page that declared `live`, or no session. ENDED rather
-    // than held open: an `EventSource` on a closed stream reconnects on its own, and a pane holding
-    // one that will never speak looks exactly like one whose records stopped moving.
-    end: () => res.end(),
+    // NOTHING TO WATCH — no app here, no page that declared `live`, or no session. Answered 204,
+    // which is the one status an `EventSource` treats as "do not come back": an opened-then-ended
+    // 200 stream is reconnected for ever, and every reconnection recomputes the whole preview.
+    nothing: () => res.status(204).end(),
   });
 }
 

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -41,7 +41,7 @@ import {
 const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
-import { keepWatchedPageCurrent } from "../composables/sharedAppLiveWatch";
+import { keepWatchedPageCurrent, withChange } from "../composables/sharedAppLiveWatch";
 import { createIntentSender } from "../utils/sharedAppPreviewIntent";
 import { structuredCloneable } from "../utils/structuredCloneable";
 
@@ -637,14 +637,22 @@ async function copyLog(): Promise<void> {
 
 onBeforeUnmount(() => window.clearTimeout(copiedTimer));
 
-// A PAGE THAT WATCHES ITS RECORDS is re-read while it is the one on screen — see
-// `sharedAppLiveWatch` for why this is a poll rather than a listener, and for what it costs. Before
-// it, the pane was the only place a `live` page stood still: the author's own writes refreshed it
-// and nobody else's did, so a chat room previewed here looked broken in a way the published one was
-// not.
+// A PAGE THAT WATCHES ITS RECORDS is kept current from the records themselves — the server holds
+// the `onSnapshot` (it has the session; this pane has no Firestore of its own) and streams what it
+// sees. Before it, the pane was the only place a `live` page stood still: the author's own writes
+// refreshed it and nobody else's did, so a chat room previewed here looked broken in a way the
+// published one was not.
 keepWatchedPageCurrent(
   () => page.value,
-  () => void refresh(),
+  () => writeUrl("watch"),
+  (change) => {
+    const held = payload.value;
+    if (held === null) return;
+    // A NEW PAYLOAD, because what holds it is a `shallowRef`: writing into the map it points at
+    // would change the records and tell nobody. Replacing it runs the same watcher a re-read does,
+    // which is what puts the rows on the page.
+    payload.value = { ...held, datasets: withChange(held.datasets, change) };
+  },
 );
 
 // The DIRECTORY is the other half of the app's identity, and it changes without a payload landing

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -540,7 +540,10 @@ const caughtDuringRead = pendingChanges();
 
 async function refresh(): Promise<boolean> {
   const mine = ++refreshGeneration;
-  caughtDuringRead.open();
+  // THIS read's own buffer. Reads overlap — a write starts one, an intent starts one, and the pane
+  // starts one — so a shared buffer let whichever finished first close the one the landing read was
+  // about to use.
+  const caught = caughtDuringRead.begin();
   const load = generation;
   try {
     const res = await fetchWithTimeout(previewUrl());
@@ -555,7 +558,7 @@ async function refresh(): Promise<boolean> {
     const next = asPayload(body.preview);
     if (next === null) return false;
     // The stream is NEWER than this answer wherever the two disagree — see `pendingChanges`.
-    payload.value = { ...next, datasets: withChanges(next.datasets, caughtDuringRead.close()) };
+    payload.value = { ...next, datasets: withChanges(next.datasets, caught()) };
     scopeLog(next.aid);
     return true;
   } catch {
@@ -565,9 +568,9 @@ async function refresh(): Promise<boolean> {
     return false;
   } finally {
     // EVERY WAY OUT, not only the one that used the changes. A read that was superseded, refused or
-    // threw would otherwise leave the buffer open, and it goes on collecting until the next read
-    // happens to close it. Closing twice is closing once — the second returns nothing.
-    caughtDuringRead.close();
+    // threw would otherwise leave its buffer collecting for as long as the pane is open. Closing
+    // twice is closing once — the second returns nothing.
+    caught();
   }
 }
 

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -41,6 +41,7 @@ import {
 const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
+import { keepWatchedPageCurrent } from "../composables/sharedAppLiveWatch";
 import { createIntentSender } from "../utils/sharedAppPreviewIntent";
 import { structuredCloneable } from "../utils/structuredCloneable";
 
@@ -635,6 +636,16 @@ async function copyLog(): Promise<void> {
 }
 
 onBeforeUnmount(() => window.clearTimeout(copiedTimer));
+
+// A PAGE THAT WATCHES ITS RECORDS is re-read while it is the one on screen — see
+// `sharedAppLiveWatch` for why this is a poll rather than a listener, and for what it costs. Before
+// it, the pane was the only place a `live` page stood still: the author's own writes refreshed it
+// and nobody else's did, so a chat room previewed here looked broken in a way the published one was
+// not.
+keepWatchedPageCurrent(
+  () => page.value,
+  () => void refresh(),
+);
 
 // The DIRECTORY is the other half of the app's identity, and it changes without a payload landing
 // — a cell moved to a repository whose server cannot be reached keeps the old entries under the new

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -29,6 +29,7 @@ import {
   previewPageKey,
   type PreviewForm,
   type PreviewPage,
+  type PreviewRecordChange,
   type PreviewUncertainWrite,
   type PreviewWrittenRecord,
   type SharedAppPreview,
@@ -41,7 +42,7 @@ import {
 const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
-import { keepWatchedPageCurrent, withChange } from "../composables/sharedAppLiveWatch";
+import { keepWatchedPageCurrent, withChange, withChanges } from "../composables/sharedAppLiveWatch";
 import { createIntentSender } from "../utils/sharedAppPreviewIntent";
 import { structuredCloneable } from "../utils/structuredCloneable";
 
@@ -535,8 +536,13 @@ let refreshGeneration = 0;
  *  A write changes the records, so the frame has to be told — but the DOCUMENT has not changed, and
  *  tearing it down to say so would throw away the conversation it is having. Only the payload is
  *  swapped; the page, its nonce and its channel all stay. */
+/** Record changes that landed while a one-shot read was in flight, oldest first. Cleared when one
+ *  starts, applied on top of the answer it brings back. */
+let duringRefresh: PreviewRecordChange[] = [];
+
 async function refresh(): Promise<boolean> {
   const mine = ++refreshGeneration;
+  duringRefresh = [];
   const load = generation;
   try {
     const res = await fetchWithTimeout(previewUrl());
@@ -550,7 +556,8 @@ async function refresh(): Promise<boolean> {
     if (!isRecord(body) || body.ok !== true) return false;
     const next = asPayload(body.preview);
     if (next === null) return false;
-    payload.value = next;
+    // The stream is NEWER than this answer wherever the two disagree — see `duringRefresh`.
+    payload.value = { ...next, datasets: withChanges(next.datasets, duringRefresh) };
     scopeLog(next.aid);
     return true;
   } catch {
@@ -646,6 +653,10 @@ keepWatchedPageCurrent(
   () => page.value,
   () => writeUrl("watch"),
   (change) => {
+    // KEPT AS WELL AS APPLIED, until the next one-shot read lands. A re-read answers with the rows
+    // as they were when it STARTED, so assigning its answer would undo a change that arrived while
+    // it was in flight — and no second snapshot is coming, because nothing has changed since.
+    duringRefresh.push(change);
     const held = payload.value;
     if (held === null) return;
     // A NEW PAYLOAD, because what holds it is a `shallowRef`: writing into the map it points at

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -29,7 +29,6 @@ import {
   previewPageKey,
   type PreviewForm,
   type PreviewPage,
-  type PreviewRecordChange,
   type PreviewUncertainWrite,
   type PreviewWrittenRecord,
   type SharedAppPreview,
@@ -42,7 +41,7 @@ import {
 const props = defineProps<{ cwd: string | null; pickerTarget?: HTMLElement | null }>();
 
 import { asPayload } from "../utils/sharedAppPreviewPayload";
-import { keepWatchedPageCurrent, withChange, withChanges } from "../composables/sharedAppLiveWatch";
+import { keepWatchedPageCurrent, pendingChanges, withChange, withChanges } from "../composables/sharedAppLiveWatch";
 import { createIntentSender } from "../utils/sharedAppPreviewIntent";
 import { structuredCloneable } from "../utils/structuredCloneable";
 
@@ -536,13 +535,12 @@ let refreshGeneration = 0;
  *  A write changes the records, so the frame has to be told — but the DOCUMENT has not changed, and
  *  tearing it down to say so would throw away the conversation it is having. Only the payload is
  *  swapped; the page, its nonce and its channel all stay. */
-/** Record changes that landed while a one-shot read was in flight, oldest first. Cleared when one
- *  starts, applied on top of the answer it brings back. */
-let duringRefresh: PreviewRecordChange[] = [];
+/** What the stream said while a read was out, to be put back on top of that read's answer. */
+const caughtDuringRead = pendingChanges();
 
 async function refresh(): Promise<boolean> {
   const mine = ++refreshGeneration;
-  duringRefresh = [];
+  caughtDuringRead.open();
   const load = generation;
   try {
     const res = await fetchWithTimeout(previewUrl());
@@ -556,8 +554,8 @@ async function refresh(): Promise<boolean> {
     if (!isRecord(body) || body.ok !== true) return false;
     const next = asPayload(body.preview);
     if (next === null) return false;
-    // The stream is NEWER than this answer wherever the two disagree — see `duringRefresh`.
-    payload.value = { ...next, datasets: withChanges(next.datasets, duringRefresh) };
+    // The stream is NEWER than this answer wherever the two disagree — see `pendingChanges`.
+    payload.value = { ...next, datasets: withChanges(next.datasets, caughtDuringRead.close()) };
     scopeLog(next.aid);
     return true;
   } catch {
@@ -565,6 +563,11 @@ async function refresh(): Promise<boolean> {
     // the middle of something is still not the answer — but the CALLER may need to know, and until
     // this said so a member's move could be acknowledged over a screen that never moved.
     return false;
+  } finally {
+    // EVERY WAY OUT, not only the one that used the changes. A read that was superseded, refused or
+    // threw would otherwise leave the buffer open, and it goes on collecting until the next read
+    // happens to close it. Closing twice is closing once — the second returns nothing.
+    caughtDuringRead.close();
   }
 }
 
@@ -653,10 +656,11 @@ keepWatchedPageCurrent(
   () => page.value,
   () => writeUrl("watch"),
   (change) => {
-    // KEPT AS WELL AS APPLIED, until the next one-shot read lands. A re-read answers with the rows
-    // as they were when it STARTED, so assigning its answer would undo a change that arrived while
-    // it was in flight — and no second snapshot is coming, because nothing has changed since.
-    duringRefresh.push(change);
+    // KEPT AS WELL AS APPLIED while a one-shot read is out, and only then: a read answers with the
+    // rows as they were when it STARTED, so assigning its answer would undo a change that arrived
+    // while it was in flight, and no second snapshot is coming. See `pendingChanges` for why
+    // nothing is held the rest of the time.
+    caughtDuringRead.record(change);
     const held = payload.value;
     if (held === null) return;
     // A NEW PAYLOAD, because what holds it is a `shallowRef`: writing into the map it points at

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -1,0 +1,57 @@
+// Keeping a WATCHING page current in the preview pane.
+//
+// A page that declares `live` is written for `onState` to arrive more than once: production
+// subscribes to those collections and posts a new state on every change. This pane read the records
+// once and refreshed only after the author's OWN write — so a chat room previewed here sat still
+// while somebody else posted, which reads as a broken page rather than as a preview that does not
+// watch.
+//
+// WHY A POLL. mulmoserver holds a Firestore listener per watched collection, in the browser, with
+// the reader's own credentials. The pane reads through this host's server over HTTP with the
+// author's handle; there is no socket here to hang a listener on, and opening one is a much larger
+// change than the gap it closes. So the pane asks again — and only while a page that declared
+// `live` is the one on screen, so an app that declares none is read exactly as often as before.
+import { onScopeDispose, watch } from "vue";
+
+import type { PreviewPage } from "../../common/sharedAppPreview";
+
+/** Chosen against what it is for: an author watching whether their page redraws when somebody else
+ *  writes. Fast enough to see it happen while looking at it, slow enough that a pane left open all
+ *  afternoon is not a bill. */
+export const LIVE_POLL_MS = 4000;
+
+/** Does the page on screen watch anything? Nothing shown yet is no. */
+export const watchesRecords = (page: PreviewPage | null): boolean => (page?.live ?? []).length > 0;
+
+/** Re-read while the shown page watches records, and stop when it does not.
+ *
+ *  HIDDEN WINDOWS ARE SKIPPED rather than stopped: the reason to re-read is that somebody is
+ *  looking, and a pane behind another window is a request every four seconds for nobody. The timer
+ *  stays so that coming back needs no new one.
+ *
+ *  `onScopeDispose` rather than `onBeforeUnmount` so this can be called from anywhere a scope
+ *  exists, and so a timer cannot outlive the pane that started it. */
+export const keepWatchedPageCurrent = (page: () => PreviewPage | null, reread: () => void): void => {
+  let timer: number | undefined;
+  const stop = () => {
+    window.clearInterval(timer);
+    timer = undefined;
+  };
+  watch(
+    () => watchesRecords(page()),
+    (watching) => {
+      stop();
+      if (!watching) {
+        return;
+      }
+      timer = window.setInterval(() => {
+        if (document.visibilityState === "hidden") {
+          return;
+        }
+        reread();
+      }, LIVE_POLL_MS);
+    },
+    { immediate: true },
+  );
+  onScopeDispose(stop);
+};

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -2,56 +2,89 @@
 //
 // A page that declares `live` is written for `onState` to arrive more than once: production
 // subscribes to those collections and posts a new state on every change. This pane read the records
-// once and refreshed only after the author's OWN write — so a chat room previewed here sat still
+// once and re-read only after the author's OWN write — so a chat room previewed here sat still
 // while somebody else posted, which reads as a broken page rather than as a preview that does not
 // watch.
 //
-// WHY A POLL. mulmoserver holds a Firestore listener per watched collection, in the browser, with
-// the reader's own credentials. The pane reads through this host's server over HTTP with the
-// author's handle; there is no socket here to hang a listener on, and opening one is a much larger
-// change than the gap it closes. So the pane asks again — and only while a page that declared
-// `live` is the one on screen, so an app that declares none is read exactly as often as before.
+// PUSHED, NOT POLLED. The listener is a real `onSnapshot`, held by this host's server, which is
+// where the Firestore session lives (`previewWatch.ts`); what arrives here is one collection's rows
+// for one page, when they change and at no other time. A clock would have been fewer lines and the
+// wrong thing: reads nobody asked for while nothing happens, and a page that is wrong for as long
+// as the interval between them.
 import { onScopeDispose, watch } from "vue";
 
-import type { PreviewPage } from "../../common/sharedAppPreview";
-
-/** Chosen against what it is for: an author watching whether their page redraws when somebody else
- *  writes. Fast enough to see it happen while looking at it, slow enough that a pane left open all
- *  afternoon is not a bill. */
-export const LIVE_POLL_MS = 4000;
+import { isRecord } from "../../common/isRecord";
+import type { PreviewPage, PreviewRecordChange } from "../../common/sharedAppPreview";
 
 /** Does the page on screen watch anything? Nothing shown yet is no. */
 export const watchesRecords = (page: PreviewPage | null): boolean => (page?.live ?? []).length > 0;
 
-/** Re-read while the shown page watches records, and stop when it does not.
+/** One change, as the pane holds its records: the page's datasets with that collection replaced.
  *
- *  HIDDEN WINDOWS ARE SKIPPED rather than stopped: the reason to re-read is that somebody is
- *  looking, and a pane behind another window is a request every four seconds for nobody. The timer
- *  stays so that coming back needs no new one.
+ *  A NEW MAP rather than a mutation. What the pane holds is a `shallowRef`, so nothing inside it is
+ *  reactive — writing into the nested object would update the screen for nobody. Pure, and the only
+ *  part of this file a test can reach without a server.
  *
- *  `onScopeDispose` rather than `onBeforeUnmount` so this can be called from anywhere a scope
- *  exists, and so a timer cannot outlive the pane that started it. */
-export const keepWatchedPageCurrent = (page: () => PreviewPage | null, reread: () => void): void => {
-  let timer: number | undefined;
-  const stop = () => {
-    window.clearInterval(timer);
-    timer = undefined;
+ *  A change for a page the pane does not hold is ignored rather than filed: the datasets are keyed
+ *  by page, and inventing an entry would put rows under a page that is not there. */
+export const withChange = (
+  datasets: Record<string, Record<string, Record<string, unknown>[]>>,
+  change: PreviewRecordChange,
+): Record<string, Record<string, Record<string, unknown>[]>> => {
+  const page = datasets[change.key];
+  if (page === undefined) return datasets;
+  return { ...datasets, [change.key]: { ...page, [change.cid]: change.rows } };
+};
+
+/** Hold a stream open while the shown page watches records, and let go when it does not.
+ *
+ *  ONE STREAM FOR THE APP, not one per page: the server subscribes to every collection any page
+ *  declares `live` and says which page each change is for, so switching pages in the picker needs
+ *  no reconnection. What starts and stops it is whether the page on screen watches ANYTHING —
+ *  an app that declares no `live` opens nothing, exactly as before.
+ *
+ *  `onScopeDispose` so a stream cannot outlive the pane that opened it: an `EventSource` left open
+ *  holds a listener on this host and a Firestore subscription behind it.
+ */
+export const keepWatchedPageCurrent = (page: () => PreviewPage | null, url: () => string, apply: (change: PreviewRecordChange) => void): void => {
+  let stream: EventSource | null = null;
+  const close = () => {
+    stream?.close();
+    stream = null;
   };
   watch(
-    () => watchesRecords(page()),
-    (watching) => {
-      stop();
-      if (!watching) {
-        return;
-      }
-      timer = window.setInterval(() => {
-        if (document.visibilityState === "hidden") {
-          return;
-        }
-        reread();
-      }, LIVE_POLL_MS);
+    () => (watchesRecords(page()) ? url() : null),
+    (address) => {
+      close();
+      if (address === null) return;
+      stream = new EventSource(address);
+      stream.onmessage = (event: MessageEvent<string>) => {
+        // Whatever arrives is JSON from this host's own server, and it is narrowed rather than
+        // trusted: a shape this pane cannot read must leave the records as they are, not throw
+        // inside a handler nobody is awaiting.
+        const change = asChange(event.data);
+        if (change !== null) apply(change);
+      };
     },
     { immediate: true },
   );
-  onScopeDispose(stop);
+  onScopeDispose(close);
+};
+
+const asChange = (data: string): PreviewRecordChange | null => {
+  const parsed = parsed_(data);
+  if (!isRecord(parsed)) return null;
+  const { key, cid, rows } = parsed;
+  if (typeof key !== "string" || typeof cid !== "string" || !Array.isArray(rows)) return null;
+  return { key, cid, rows: rows.filter(isRecord) };
+};
+
+/** A heartbeat is a COMMENT and never reaches here; anything else that will not parse is a line
+ *  this pane cannot read, and the records stay as they are. */
+const parsed_ = (data: string): unknown => {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
 };

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -36,6 +36,15 @@ export const withChange = (
   return { ...datasets, [change.key]: { ...page, [change.cid]: change.rows } };
 };
 
+/** Several changes, oldest first. What it is FOR is the race with a one-shot read: a re-read
+ *  started at T0 answers with rows as they were at T0, so a change that arrived at T1 is undone by
+ *  assigning that answer — and Firestore will not send it again, because nothing has changed since.
+ *  The changes that landed while the read was in flight are therefore applied on top of it. */
+export const withChanges = (
+  datasets: Record<string, Record<string, Record<string, unknown>[]>>,
+  changes: PreviewRecordChange[],
+): Record<string, Record<string, Record<string, unknown>[]>> => changes.reduce(withChange, datasets);
+
 /** Hold a stream open while the shown page watches records, and let go when it does not.
  *
  *  ONE STREAM FOR THE APP, not one per page: the server subscribes to every collection any page

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -45,6 +45,40 @@ export const withChanges = (
   changes: PreviewRecordChange[],
 ): Record<string, Record<string, Record<string, unknown>[]>> => changes.reduce(withChange, datasets);
 
+/** The changes that landed while a one-shot read was in flight, and NOTHING at any other time.
+ *
+ *  Its own object because both halves of that sentence are load-bearing. A read answers with the
+ *  rows as they were when it STARTED, so a change that arrived at T1 is undone by assigning it —
+ *  and no second snapshot is coming, because nothing has changed since. That is what has to be kept.
+ *
+ *  What must NOT be kept is everything else. A previewed chat room left open for an afternoon
+ *  receives a change per message; holding them all against a read that may never come is a list
+ *  that only grows. So nothing is held unless a read is out (`open`), and while one is, a page's
+ *  collection holds only its LATEST rows — every change carries the whole collection, so an older
+ *  one for the same pair says nothing the newer one does not.
+ *
+ *  At most one entry per watched page-and-collection, for as long as one read takes. */
+export const pendingChanges = (): {
+  open: () => void;
+  record: (change: PreviewRecordChange) => void;
+  close: () => PreviewRecordChange[];
+} => {
+  let held: Map<string, PreviewRecordChange> | null = null;
+  return {
+    open: () => {
+      held = new Map();
+    },
+    record: (change) => {
+      held?.set(`${change.key}|${change.cid}`, change);
+    },
+    close: () => {
+      const caught = held === null ? [] : [...held.values()];
+      held = null;
+      return caught;
+    },
+  };
+};
+
 /** Hold a stream open while the shown page watches records, and let go when it does not.
  *
  *  ONE STREAM FOR THE APP, not one per page: the server subscribes to every collection any page

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -110,6 +110,10 @@ export const keepWatchedPageCurrent = (page: () => PreviewPage | null, url: () =
     (address) => {
       close();
       if (address === null) return;
+      // A stream that drops is REOPENED by the browser on its own, which is what should happen to a
+      // server restarted under an open pane. The one answer that must not be retried — there is no
+      // app here, no page that declared `live`, or no session — is a 204, which an `EventSource`
+      // treats as "do not come back". That is the route's half of this; see `holdOpen`.
       stream = new EventSource(address);
       stream.onmessage = (event: MessageEvent<string>) => {
         // Whatever arrives is JSON from this host's own server, and it is narrowed rather than

--- a/src/composables/sharedAppLiveWatch.ts
+++ b/src/composables/sharedAppLiveWatch.ts
@@ -45,36 +45,46 @@ export const withChanges = (
   changes: PreviewRecordChange[],
 ): Record<string, Record<string, Record<string, unknown>[]>> => changes.reduce(withChange, datasets);
 
-/** The changes that landed while a one-shot read was in flight, and NOTHING at any other time.
+/** The changes that landed while a one-shot read was in flight — PER READ, and nothing at any
+ *  other time.
  *
- *  Its own object because both halves of that sentence are load-bearing. A read answers with the
- *  rows as they were when it STARTED, so a change that arrived at T1 is undone by assigning it —
- *  and no second snapshot is coming, because nothing has changed since. That is what has to be kept.
+ *  A read answers with the rows as they were when it STARTED, so a change that arrived at T1 is
+ *  undone by assigning that answer, and no second snapshot is coming because nothing has changed
+ *  since. That is what has to be kept, and it has to be kept for the read that will use it.
+ *
+ *  ONE BUFFER PER READ, because reads overlap: they are started fire-and-forget by a write, by an
+ *  intent and by the pane, and `refresh` supersedes rather than serialises. A single buffer let a
+ *  superseded read close the live one's — so a change caught during the read that was about to land
+ *  went missing, which is the bug this whole object exists to prevent, arriving by another door.
  *
  *  What must NOT be kept is everything else. A previewed chat room left open for an afternoon
- *  receives a change per message; holding them all against a read that may never come is a list
- *  that only grows. So nothing is held unless a read is out (`open`), and while one is, a page's
- *  collection holds only its LATEST rows — every change carries the whole collection, so an older
- *  one for the same pair says nothing the newer one does not.
+ *  receives a change per message; holding them against a read that may never come is a list that
+ *  only grows. So a buffer exists only between `begin` and its own close, and while it does, a
+ *  page's collection holds only its LATEST rows — every change carries the whole collection, so an
+ *  older one for the same pair says nothing the newer one does not.
  *
- *  At most one entry per watched page-and-collection, for as long as one read takes. */
+ *  Bounded by the reads actually in flight times what they watch. */
 export const pendingChanges = (): {
-  open: () => void;
+  begin: () => () => PreviewRecordChange[];
   record: (change: PreviewRecordChange) => void;
-  close: () => PreviewRecordChange[];
 } => {
-  let held: Map<string, PreviewRecordChange> | null = null;
+  const reading = new Set<Map<string, PreviewRecordChange>>();
   return {
-    open: () => {
-      held = new Map();
+    begin: () => {
+      const held = new Map<string, PreviewRecordChange>();
+      reading.add(held);
+      let closed = false;
+      // IDEMPOTENT: every way out of a read closes it — superseded, refused, threw — so the second
+      // call has to be nothing rather than a way to replay these onto another read's answer.
+      return () => {
+        if (closed) return [];
+        closed = true;
+        reading.delete(held);
+        return [...held.values()];
+      };
     },
     record: (change) => {
-      held?.set(`${change.key}|${change.cid}`, change);
-    },
-    close: () => {
-      const caught = held === null ? [] : [...held.values()];
-      held = null;
-      return caught;
+      for (const held of reading) held.set(`${change.key}|${change.cid}`, change);
     },
   };
 };

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -75,7 +75,12 @@ const asPage = (value: unknown): PreviewPage[] => {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.html !== "string") return [];
   const audience = AUDIENCES.find((candidate) => candidate === value.audience);
   if (audience === undefined) return [];
-  return [{ id: value.id, html: value.html, audience, ...asViewer(value.viewer) }];
+  // `live` floors to absent rather than to `[]`, which is the same distinction the projection
+  // makes: a page that watches nothing and a page whose watch list could not be read must not both
+  // read as "watches nothing" — but here they may, because the only thing the pane does with it is
+  // re-read, and re-reading a page that does not need it costs a poll rather than correctness.
+  const live = strings(value.live);
+  return [{ id: value.id, html: value.html, audience, ...asViewer(value.viewer), ...(live.length === 0 ? {} : { live }) }];
 };
 
 /** One collection's capability, field by field.

--- a/test/server/backends/previewWatchHold.spec.ts
+++ b/test/server/backends/previewWatchHold.spec.ts
@@ -30,9 +30,17 @@ describe("holdOpen", () => {
     const stop = vi.fn();
     const quiet = vi.fn();
     const beat = vi.fn(() => quiet);
+    const begin = vi.fn();
 
-    await holdOpen({ onClose: req.onClose, open: () => Promise.resolve({ ok: true, watching: ["messages"], stop }), beat, end: vi.fn() });
+    await holdOpen({
+      onClose: req.onClose,
+      open: () => Promise.resolve({ ok: true, watching: ["messages"], stop }),
+      begin,
+      beat,
+      nothing: vi.fn(),
+    });
 
+    expect(begin).toHaveBeenCalledTimes(1);
     expect(beat).toHaveBeenCalledTimes(1);
     expect(stop).not.toHaveBeenCalled();
 
@@ -52,25 +60,47 @@ describe("holdOpen", () => {
     const answer: ((handle: { ok: true; watching: string[]; stop: () => void }) => void)[] = [];
     const opening = new Promise<{ ok: true; watching: string[]; stop: () => void }>((resolve) => answer.push(resolve));
 
-    const held = holdOpen({ onClose: req.onClose, open: () => opening, beat, end: vi.fn() });
+    const begin = vi.fn();
+    const held = holdOpen({ onClose: req.onClose, open: () => opening, begin, beat, nothing: vi.fn() });
     req.close();
     answer[0]?.({ ok: true, watching: ["messages"], stop });
     await held;
 
     expect(stop).toHaveBeenCalledTimes(1);
-    // And no heartbeat was ever started, so there is no timer to leak either.
+    // And nothing was started for it: no heartbeat to leak, and no response begun for a request
+    // that has already gone.
+    expect(beat).not.toHaveBeenCalled();
+    expect(begin).not.toHaveBeenCalled();
+  });
+
+  it("answers terminally when there is nothing to watch, without beginning a stream", async () => {
+    // No app here, no page that declared `live`, or no session. Beginning a stream and ending it is
+    // what an `EventSource` reconnects to — for ever, recomputing the whole preview each time,
+    // which is the poll this feature exists to avoid arriving through the error path.
+    const nothing = vi.fn();
+    const begin = vi.fn();
+    const beat = vi.fn(() => vi.fn());
+
+    await holdOpen({ onClose: request().onClose, open: () => Promise.resolve({ ok: false }), begin, beat, nothing });
+
+    expect(nothing).toHaveBeenCalledTimes(1);
+    expect(begin).not.toHaveBeenCalled();
     expect(beat).not.toHaveBeenCalled();
   });
 
-  it("ends the response when there is nothing to watch, and starts no heartbeat", async () => {
-    // No app here, no page that declared `live`, or no session. A stream held open that will never
-    // speak looks exactly like one whose records stopped moving.
-    const end = vi.fn();
-    const beat = vi.fn(() => vi.fn());
+  it("says nothing at all to a request that closed before the answer came", async () => {
+    // Writing a status onto a response whose request has gone is an error on some servers and a
+    // no-op on others; either way there is nobody to read it.
+    const req = request();
+    const nothing = vi.fn();
+    const answer: ((handle: { ok: false }) => void)[] = [];
+    const opening = new Promise<{ ok: false }>((resolve) => answer.push(resolve));
 
-    await holdOpen({ onClose: request().onClose, open: () => Promise.resolve({ ok: false }), beat, end });
+    const held = holdOpen({ onClose: req.onClose, open: () => opening, begin: vi.fn(), beat: vi.fn(() => vi.fn()), nothing });
+    req.close();
+    answer[0]?.({ ok: false });
+    await held;
 
-    expect(end).toHaveBeenCalledTimes(1);
-    expect(beat).not.toHaveBeenCalled();
+    expect(nothing).not.toHaveBeenCalled();
   });
 });

--- a/test/server/backends/previewWatchHold.spec.ts
+++ b/test/server/backends/previewWatchHold.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+//
+// WHEN THE CLEANUP IS REGISTERED, which is the whole of this file.
+//
+// Opening the watch is asynchronous — the preview has to be computed before there is anything to
+// subscribe to — and a pane that changes page or directory meanwhile closes the request while that
+// is still running. With the close handler registered afterwards, the event has already fired by
+// the time anything is listening: the Firestore subscriptions and the heartbeat are created a
+// moment later and nothing ever stops them. Billed listeners for a reader who has gone, until the
+// server exits.
+
+import { describe, it, expect, vi } from "vitest";
+
+import { holdOpen } from "../../../server/backends/sharedApp/previewWatch";
+
+/** A request whose `close` we can fire whenever the test wants to. */
+const request = () => {
+  let release: (() => void) | null = null;
+  return {
+    onClose: (fn: () => void) => {
+      release = fn;
+    },
+    close: () => release?.(),
+  };
+};
+
+describe("holdOpen", () => {
+  it("holds the watch and the heartbeat until the request closes", async () => {
+    const req = request();
+    const stop = vi.fn();
+    const quiet = vi.fn();
+    const beat = vi.fn(() => quiet);
+
+    await holdOpen({ onClose: req.onClose, open: () => Promise.resolve({ ok: true, watching: ["messages"], stop }), beat, end: vi.fn() });
+
+    expect(beat).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+
+    req.close();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(quiet).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops a watch that arrives after the request has already closed", async () => {
+    // The leak. The pane went while the preview was still being computed, so the subscriptions were
+    // created for nobody — and the handler that would have stopped them was registered after them.
+    const req = request();
+    const stop = vi.fn();
+    const beat = vi.fn(() => vi.fn());
+    // Assigned inside the executor, so a nullable would narrow to `null` at the call below.
+    let arrive: (handle: { ok: true; watching: string[]; stop: () => void }) => void = () => {
+      throw new Error("the watch was answered before it was opened");
+    };
+    const opening = new Promise<{ ok: true; watching: string[]; stop: () => void }>((resolve) => {
+      arrive = resolve;
+    });
+
+    const held = holdOpen({ onClose: req.onClose, open: () => opening, beat, end: vi.fn() });
+    req.close();
+    arrive({ ok: true, watching: ["messages"], stop });
+    await held;
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    // And no heartbeat was ever started, so there is no timer to leak either.
+    expect(beat).not.toHaveBeenCalled();
+  });
+
+  it("ends the response when there is nothing to watch, and starts no heartbeat", async () => {
+    // No app here, no page that declared `live`, or no session. A stream held open that will never
+    // speak looks exactly like one whose records stopped moving.
+    const end = vi.fn();
+    const beat = vi.fn(() => vi.fn());
+
+    await holdOpen({ onClose: request().onClose, open: () => Promise.resolve({ ok: false }), beat, end });
+
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(beat).not.toHaveBeenCalled();
+  });
+});

--- a/test/server/backends/previewWatchHold.spec.ts
+++ b/test/server/backends/previewWatchHold.spec.ts
@@ -47,17 +47,14 @@ describe("holdOpen", () => {
     const req = request();
     const stop = vi.fn();
     const beat = vi.fn(() => vi.fn());
-    // Assigned inside the executor, so a nullable would narrow to `null` at the call below.
-    let arrive: (handle: { ok: true; watching: string[]; stop: () => void }) => void = () => {
-      throw new Error("the watch was answered before it was opened");
-    };
-    const opening = new Promise<{ ok: true; watching: string[]; stop: () => void }>((resolve) => {
-      arrive = resolve;
-    });
+    // The resolver, held in a list rather than in a `let`: assigned inside the executor, a nullable
+    // narrows to `null` at the call below and a placeholder function lies about its arity.
+    const answer: ((handle: { ok: true; watching: string[]; stop: () => void }) => void)[] = [];
+    const opening = new Promise<{ ok: true; watching: string[]; stop: () => void }>((resolve) => answer.push(resolve));
 
     const held = holdOpen({ onClose: req.onClose, open: () => opening, beat, end: vi.fn() });
     req.close();
-    arrive({ ok: true, watching: ["messages"], stop });
+    answer[0]?.({ ok: true, watching: ["messages"], stop });
     await held;
 
     expect(stop).toHaveBeenCalledTimes(1);

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -401,6 +401,33 @@ describe("shared app preview", () => {
     expect(docs.writes).toEqual([]);
   });
 
+  it("says what a LISTENER would have to hold, and holds nothing for a page that watches nothing", async () => {
+    // The plan the record stream subscribes from. Per PAGE rather than per collection: two pages
+    // can name the same collection and read it differently — `all` for the desk, `own` for a
+    // participant — so one change has to become rows per page, with that page's own scope.
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    writeApp(
+      root,
+      declaration({
+        public: { read: [] },
+        views: [
+          { id: "desk", path: "views/desk.html", audience: "member", collections: ["bookings"], live: ["bookings"] },
+          { id: "quiet", path: "views/quiet.html", audience: "member", collections: ["notes"] },
+        ],
+      }),
+    );
+    for (const page of ["desk", "quiet"]) writeFileSync(path.join(root, "views", `${page}.html`), `<p>${page}</p>`);
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    const watches = (result.ok ? result.watches : []).map((entry) => ({ key: entry.key, cid: entry.want.cid, scope: entry.want.scope }));
+    expect(watches).toEqual([{ key: "member:desk", cid: "bookings", scope: "all" }]);
+    // `quiet` declared no `live`, so nothing is subscribed for it — a listener on a page nobody
+    // asked to watch is a bill with no reader.
+    expect(docs.writes).toEqual([]);
+  });
+
   it("carries what a public create may contain, so the parent can judge a submission", async () => {
     writeApp(root, declaration({ public: { read: ["bookings"], submit: { bookings: { auth: "verifiedEmail", createFields: ["note"] } } } }));
 

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -367,6 +367,40 @@ describe("shared app preview", () => {
     expect(docs.writes).toEqual([]);
   });
 
+  it("says which collections a page WATCHES, so the pane can keep it current", async () => {
+    // The pane reads once. A page that declared `live` is written for `onState` to arrive again —
+    // production subscribes and re-delivers — so previewed here it stood still while the published
+    // one moved, and somebody else's message never appeared. This is what tells the pane to re-read,
+    // and it must be per page: an app can watch on one page and not on another.
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    writeApp(
+      root,
+      declaration({
+        public: { read: ["bookings"] },
+        views: [
+          { id: "public", path: "views/front.html", audience: "public", collections: ["bookings"], live: ["bookings"] },
+          { id: "room", path: "views/room.html", audience: "member", collections: ["notes"], live: ["notes"] },
+          { id: "ledger", path: "views/ledger.html", audience: "member", collections: ["notes"] },
+        ],
+      }),
+    );
+    writeFileSync(path.join(root, "views", "front.html"), "<p>front</p>");
+    writeFileSync(path.join(root, "views", "room.html"), "<p>room</p>");
+    writeFileSync(path.join(root, "views", "ledger.html"), "<p>ledger</p>");
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    const live = result.ok ? Object.fromEntries(result.pages.map((page) => [`${page.audience}:${page.id}`, page.live])) : {};
+    expect(live["member:room"]).toEqual(["notes"]);
+    // Declared nothing, so there is nothing to poll for — absent rather than empty, and the pane
+    // reads that page exactly as often as it did before any of this.
+    expect(live["member:ledger"]).toBeUndefined();
+    // The anonymous page has its own watch list, in its own document.
+    expect(live["public:public"]).toEqual(["bookings"]);
+    expect(docs.writes).toEqual([]);
+  });
+
   it("carries what a public create may contain, so the parent can judge a submission", async () => {
     writeApp(root, declaration({ public: { read: ["bookings"], submit: { bookings: { auth: "verifiedEmail", createFields: ["note"] } } } }));
 

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -1,15 +1,17 @@
 // A previewed page that WATCHES its records, and the one place it used to stand still.
 //
-// The pane read the records once and refreshed after the author's own write, so a page declaring
+// The pane read the records once and re-read after the author's own write, so a page declaring
 // `live` — a chat room, a live poll's audience screen — showed nothing when somebody ELSE wrote.
-// The published page moved and the preview of it did not, which reads as a broken page rather than
-// as a preview that does not watch.
+// The published page moved and the preview of it did not.
+//
+// What closed it is a stream, not a clock: the server holds the `onSnapshot` (it has the session)
+// and sends one collection's rows for one page when they change. These tests drive that end.
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { effectScope, ref } from "vue";
 
-import { LIVE_POLL_MS, keepWatchedPageCurrent, watchesRecords } from "../../../src/composables/sharedAppLiveWatch";
-import type { PreviewPage } from "../../../common/sharedAppPreview";
+import { keepWatchedPageCurrent, watchesRecords, withChange } from "../../../src/composables/sharedAppLiveWatch";
+import type { PreviewPage, PreviewRecordChange } from "../../../common/sharedAppPreview";
 
 const pageOf = (live?: string[]): PreviewPage => ({
   id: "room",
@@ -18,20 +20,36 @@ const pageOf = (live?: string[]): PreviewPage => ({
   ...(live === undefined ? {} : { live }),
 });
 
-/** Run `body` inside a scope, then dispose it — which is what the pane going away does. */
+/** Every stream this file opened, so a test can speak on it and assert it was closed. */
+const opened: { url: string; closed: boolean; send: (data: string) => void }[] = [];
+
+class FakeStream {
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public constructor(url: string) {
+    opened.push({
+      url,
+      closed: false,
+      send: (data: string) => this.onmessage?.({ data } as MessageEvent<string>),
+    });
+    this.index = opened.length - 1;
+  }
+  private readonly index: number;
+  public close(): void {
+    const entry = opened[this.index];
+    if (entry !== undefined) entry.closed = true;
+  }
+}
+
+vi.stubGlobal("EventSource", FakeStream);
+
 const inScope = (body: () => void): (() => void) => {
   const scope = effectScope();
   scope.run(body);
   return () => scope.stop();
 };
 
-const hide = (state: "visible" | "hidden") => {
-  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
-};
-
 afterEach(() => {
-  vi.useRealTimers();
-  hide("visible");
+  opened.length = 0;
 });
 
 describe("watchesRecords", () => {
@@ -43,75 +61,83 @@ describe("watchesRecords", () => {
   });
 });
 
+describe("withChange", () => {
+  const held = { "member:room": { messages: [{ id: "m1" }] }, "member:ledger": { notes: [] } };
+
+  it("replaces one collection on one page and leaves the rest alone", () => {
+    const next = withChange(held, { key: "member:room", cid: "messages", rows: [{ id: "m1" }, { id: "m2" }] });
+    expect(next["member:room"]?.messages).toHaveLength(2);
+    expect(next["member:ledger"]).toBe(held["member:ledger"]);
+    // A NEW MAP: what holds this is a `shallowRef`, so a mutation would change the records and
+    // tell nobody.
+    expect(next).not.toBe(held);
+    expect(held["member:room"]?.messages).toHaveLength(1);
+  });
+
+  it("ignores a page the pane is not holding rather than inventing one", () => {
+    const next = withChange(held, { key: "public:public", cid: "messages", rows: [{ id: "x" }] });
+    expect(next).toBe(held);
+  });
+});
+
 describe("keepWatchedPageCurrent", () => {
-  it("re-reads a watching page, over and over", () => {
-    vi.useFakeTimers();
-    const reread = vi.fn();
-    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+  const streamFor = (page: PreviewPage | null, apply = vi.fn()) => {
+    const shown = ref<PreviewPage | null>(page);
+    const stop = inScope(() =>
+      keepWatchedPageCurrent(
+        () => shown.value,
+        () => "/api/shared-app/preview/watch?cwd=/repo",
+        apply,
+      ),
+    );
+    return { shown, apply, stop };
+  };
 
-    expect(reread).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(LIVE_POLL_MS * 3);
-    expect(reread).toHaveBeenCalledTimes(3);
+  it("opens one stream for a watching page and files what arrives", () => {
+    const { apply, stop } = streamFor(pageOf(["messages"]));
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]?.url).toBe("/api/shared-app/preview/watch?cwd=/repo");
+
+    const change: PreviewRecordChange = { key: "member:room", cid: "messages", rows: [{ id: "m2" }] };
+    opened[0]?.send(JSON.stringify(change));
+    expect(apply).toHaveBeenCalledWith(change);
     stop();
   });
 
-  it("leaves a page that watches nothing exactly as often read as before", () => {
-    vi.useFakeTimers();
-    const reread = vi.fn();
-    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(), reread));
-
-    vi.advanceTimersByTime(LIVE_POLL_MS * 10);
-    expect(reread).not.toHaveBeenCalled();
+  it("opens nothing for a page that watches nothing", () => {
+    const { stop } = streamFor(pageOf());
+    expect(opened).toHaveLength(0);
     stop();
   });
 
-  it("starts and stops as the author walks between pages", async () => {
-    vi.useFakeTimers();
-    const shown = ref<PreviewPage | null>(pageOf());
-    const reread = vi.fn();
-    const stop = inScope(() => keepWatchedPageCurrent(() => shown.value, reread));
+  it("survives a line it cannot read, and leaves the records alone", () => {
+    // Whatever arrives is JSON from this host's own server — and a shape this pane cannot read must
+    // leave the records as they are rather than throw inside a handler nobody is awaiting.
+    const { apply, stop } = streamFor(pageOf(["messages"]));
+    for (const line of ["not json", "null", '{"key":"member:room"}', '{"key":1,"cid":"messages","rows":[]}']) {
+      opened[0]?.send(line);
+    }
+    expect(apply).not.toHaveBeenCalled();
+    stop();
+  });
 
-    shown.value = pageOf(["messages"]);
-    await Promise.resolve();
-    vi.advanceTimersByTime(LIVE_POLL_MS);
-    expect(reread).toHaveBeenCalledTimes(1);
-
-    // Back to a page that watches nothing: the polling has to END, not merely be ignored.
+  it("closes the stream when the author walks to a page that watches nothing", async () => {
+    const { shown, stop } = streamFor(pageOf(["messages"]));
     shown.value = pageOf();
     await Promise.resolve();
-    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
-    expect(reread).toHaveBeenCalledTimes(1);
+
+    expect(opened[0]?.closed).toBe(true);
+    expect(opened).toHaveLength(1);
     stop();
   });
 
-  it("skips a hidden window, and picks up again when it comes back", () => {
-    // The reason to re-read is that somebody is LOOKING. A pane behind another window is a request
-    // every few seconds for nobody — and the timer stays, so returning needs no new one.
-    vi.useFakeTimers();
-    const reread = vi.fn();
-    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
-
-    hide("hidden");
-    vi.advanceTimersByTime(LIVE_POLL_MS * 4);
-    expect(reread).not.toHaveBeenCalled();
-
-    hide("visible");
-    vi.advanceTimersByTime(LIVE_POLL_MS);
-    expect(reread).toHaveBeenCalledTimes(1);
+  it("closes the stream when the pane goes away", () => {
+    // Left open it holds a listener on this host, and a Firestore subscription behind that, for as
+    // long as the app is running.
+    const { stop } = streamFor(pageOf(["messages"]));
+    expect(opened[0]?.closed).toBe(false);
     stop();
-  });
-
-  it("stops when the pane goes away", () => {
-    // A timer that outlived the pane would go on asking this host's server about a directory
-    // nobody is looking at, for as long as the app is open.
-    vi.useFakeTimers();
-    const reread = vi.fn();
-    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
-
-    vi.advanceTimersByTime(LIVE_POLL_MS);
-    expect(reread).toHaveBeenCalledTimes(1);
-    stop();
-    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
-    expect(reread).toHaveBeenCalledTimes(1);
+    expect(opened[0]?.closed).toBe(true);
   });
 });

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { effectScope, ref } from "vue";
 
-import { keepWatchedPageCurrent, watchesRecords, withChange, withChanges } from "../../../src/composables/sharedAppLiveWatch";
+import { keepWatchedPageCurrent, pendingChanges, watchesRecords, withChange, withChanges } from "../../../src/composables/sharedAppLiveWatch";
 import type { PreviewPage, PreviewRecordChange } from "../../../common/sharedAppPreview";
 
 const pageOf = (live?: string[]): PreviewPage => ({
@@ -94,6 +94,44 @@ describe("withChanges", () => {
     // Oldest first, so the last one wins — which is the one the records are actually in.
     expect(withChanges(readAtT0, arrivedDuring)["member:room"]?.messages).toHaveLength(3);
     expect(withChanges(readAtT0, [])).toBe(readAtT0);
+  });
+});
+
+describe("pendingChanges", () => {
+  const change = (cid: string, ids: string[]) => ({ key: "member:room", cid, rows: ids.map((id) => ({ id })) });
+
+  it("holds nothing while no read is out", () => {
+    // The whole reason this is not a list the stream appends to. A previewed chat room left open
+    // for an afternoon receives a change per message; keeping them against a read that may never
+    // come is memory that only grows.
+    const caught = pendingChanges();
+    caught.record(change("messages", ["m1"]));
+    caught.record(change("messages", ["m1", "m2"]));
+    expect(caught.close()).toEqual([]);
+  });
+
+  it("keeps only the latest rows per page and collection while one is", () => {
+    // Every change carries the WHOLE collection, so an older one for the same pair says nothing the
+    // newer one does not — and the buffer is bounded by what is watched rather than by traffic.
+    const caught = pendingChanges();
+    caught.open();
+    caught.record(change("messages", ["m1"]));
+    caught.record(change("notes", ["n1"]));
+    caught.record(change("messages", ["m1", "m2"]));
+
+    const held = caught.close();
+    expect(held).toHaveLength(2);
+    expect(held.find((entry) => entry.cid === "messages")?.rows).toHaveLength(2);
+  });
+
+  it("closes once, and closing again is closing nothing", () => {
+    // Every way out of a read closes it — superseded, refused, threw — so the second call has to be
+    // harmless rather than a way to replay the last one's changes onto the next one's answer.
+    const caught = pendingChanges();
+    caught.open();
+    caught.record(change("messages", ["m1"]));
+    expect(caught.close()).toHaveLength(1);
+    expect(caught.close()).toEqual([]);
   });
 });
 

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { effectScope, ref } from "vue";
 
-import { keepWatchedPageCurrent, watchesRecords, withChange } from "../../../src/composables/sharedAppLiveWatch";
+import { keepWatchedPageCurrent, watchesRecords, withChange, withChanges } from "../../../src/composables/sharedAppLiveWatch";
 import type { PreviewPage, PreviewRecordChange } from "../../../common/sharedAppPreview";
 
 const pageOf = (live?: string[]): PreviewPage => ({
@@ -77,6 +77,23 @@ describe("withChange", () => {
   it("ignores a page the pane is not holding rather than inventing one", () => {
     const next = withChange(held, { key: "public:public", cid: "messages", rows: [{ id: "x" }] });
     expect(next).toBe(held);
+  });
+});
+
+describe("withChanges", () => {
+  it("puts the stream on top of an answer that was read before it", () => {
+    // The race: a re-read started at T0 answers with the rows as they were at T0, so assigning that
+    // answer would undo a change that arrived at T1 — and no second snapshot is coming, because
+    // nothing has changed since. The preview would sit on the older rows for good.
+    const readAtT0 = { "member:room": { messages: [{ id: "m1" }] } };
+    const arrivedDuring = [
+      { key: "member:room", cid: "messages", rows: [{ id: "m1" }, { id: "m2" }] },
+      { key: "member:room", cid: "messages", rows: [{ id: "m1" }, { id: "m2" }, { id: "m3" }] },
+    ];
+
+    // Oldest first, so the last one wins — which is the one the records are actually in.
+    expect(withChanges(readAtT0, arrivedDuring)["member:room"]?.messages).toHaveLength(3);
+    expect(withChanges(readAtT0, [])).toBe(readAtT0);
   });
 });
 

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -1,0 +1,117 @@
+// A previewed page that WATCHES its records, and the one place it used to stand still.
+//
+// The pane read the records once and refreshed after the author's own write, so a page declaring
+// `live` — a chat room, a live poll's audience screen — showed nothing when somebody ELSE wrote.
+// The published page moved and the preview of it did not, which reads as a broken page rather than
+// as a preview that does not watch.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { effectScope, ref } from "vue";
+
+import { LIVE_POLL_MS, keepWatchedPageCurrent, watchesRecords } from "../../../src/composables/sharedAppLiveWatch";
+import type { PreviewPage } from "../../../common/sharedAppPreview";
+
+const pageOf = (live?: string[]): PreviewPage => ({
+  id: "room",
+  html: "<h1>Room</h1>",
+  audience: "member",
+  ...(live === undefined ? {} : { live }),
+});
+
+/** Run `body` inside a scope, then dispose it — which is what the pane going away does. */
+const inScope = (body: () => void): (() => void) => {
+  const scope = effectScope();
+  scope.run(body);
+  return () => scope.stop();
+};
+
+const hide = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  hide("visible");
+});
+
+describe("watchesRecords", () => {
+  it("is what the page DECLARED, and nothing shown yet is no", () => {
+    expect(watchesRecords(pageOf(["messages"]))).toBe(true);
+    expect(watchesRecords(pageOf([]))).toBe(false);
+    expect(watchesRecords(pageOf())).toBe(false);
+    expect(watchesRecords(null)).toBe(false);
+  });
+});
+
+describe("keepWatchedPageCurrent", () => {
+  it("re-reads a watching page, over and over", () => {
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    expect(reread).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 3);
+    expect(reread).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("leaves a page that watches nothing exactly as often read as before", () => {
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(), reread));
+
+    vi.advanceTimersByTime(LIVE_POLL_MS * 10);
+    expect(reread).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("starts and stops as the author walks between pages", async () => {
+    vi.useFakeTimers();
+    const shown = ref<PreviewPage | null>(pageOf());
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => shown.value, reread));
+
+    shown.value = pageOf(["messages"]);
+    await Promise.resolve();
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+
+    // Back to a page that watches nothing: the polling has to END, not merely be ignored.
+    shown.value = pageOf();
+    await Promise.resolve();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("skips a hidden window, and picks up again when it comes back", () => {
+    // The reason to re-read is that somebody is LOOKING. A pane behind another window is a request
+    // every few seconds for nobody — and the timer stays, so returning needs no new one.
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    hide("hidden");
+    vi.advanceTimersByTime(LIVE_POLL_MS * 4);
+    expect(reread).not.toHaveBeenCalled();
+
+    hide("visible");
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("stops when the pane goes away", () => {
+    // A timer that outlived the pane would go on asking this host's server about a directory
+    // nobody is looking at, for as long as the app is open.
+    vi.useFakeTimers();
+    const reread = vi.fn();
+    const stop = inScope(() => keepWatchedPageCurrent(() => pageOf(["messages"]), reread));
+
+    vi.advanceTimersByTime(LIVE_POLL_MS);
+    expect(reread).toHaveBeenCalledTimes(1);
+    stop();
+    vi.advanceTimersByTime(LIVE_POLL_MS * 5);
+    expect(reread).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/src/composables/sharedAppLiveWatch.spec.ts
+++ b/test/src/composables/sharedAppLiveWatch.spec.ts
@@ -107,31 +107,53 @@ describe("pendingChanges", () => {
     const caught = pendingChanges();
     caught.record(change("messages", ["m1"]));
     caught.record(change("messages", ["m1", "m2"]));
-    expect(caught.close()).toEqual([]);
+    expect(caught.begin()()).toEqual([]);
   });
 
   it("keeps only the latest rows per page and collection while one is", () => {
     // Every change carries the WHOLE collection, so an older one for the same pair says nothing the
     // newer one does not — and the buffer is bounded by what is watched rather than by traffic.
     const caught = pendingChanges();
-    caught.open();
+    const close = caught.begin();
     caught.record(change("messages", ["m1"]));
     caught.record(change("notes", ["n1"]));
     caught.record(change("messages", ["m1", "m2"]));
 
-    const held = caught.close();
+    const held = close();
     expect(held).toHaveLength(2);
     expect(held.find((entry) => entry.cid === "messages")?.rows).toHaveLength(2);
   });
 
+  it("gives every read its own buffer, so a finished one cannot empty a running one", () => {
+    // Reads overlap: a write starts one, an intent starts one, the pane starts one, and `refresh`
+    // supersedes rather than serialises. With one buffer between them, whichever finished first
+    // closed the one the LANDING read was about to use — and the change it had caught was assigned
+    // away by an answer read before it. No second snapshot is coming, so the preview stays wrong.
+    const caught = pendingChanges();
+    const first = caught.begin();
+    const second = caught.begin();
+    caught.record(change("messages", ["m1", "m2"]));
+
+    expect(first()).toHaveLength(1);
+    expect(second()).toHaveLength(1);
+  });
+
   it("closes once, and closing again is closing nothing", () => {
     // Every way out of a read closes it — superseded, refused, threw — so the second call has to be
-    // harmless rather than a way to replay the last one's changes onto the next one's answer.
+    // harmless rather than a way to replay one read's changes onto another read's answer.
     const caught = pendingChanges();
-    caught.open();
+    const close = caught.begin();
     caught.record(change("messages", ["m1"]));
-    expect(caught.close()).toHaveLength(1);
-    expect(caught.close()).toEqual([]);
+    expect(close()).toHaveLength(1);
+    expect(close()).toEqual([]);
+  });
+
+  it("stops collecting for a read that has closed", () => {
+    const caught = pendingChanges();
+    const close = caught.begin();
+    close();
+    caught.record(change("messages", ["m1"]));
+    expect(caught.begin()()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Replaces #1832, which polled. This holds a real listener instead.

## The gap

Open a `live` page in the collection pane and it never moves. Your own writes refresh it; nobody else's do. The published page at `/m/{slug}` updates the moment somebody posts, so the preview looks broken in a way the real thing is not.

`views[].live` was only ever implemented by mulmoserver — one Firestore listener per watched collection, re-delivering state on every change. The pane had `load()` on a directory change, `refresh()` after the author's own submit or intent, and nothing else.

## The listener lives on the server

The pane has no Firestore and no credentials; this host holds the session (`currentFirestore()`), and the backend already reads records through the same Firebase JS SDK — which means `onSnapshot` works here. So `previewWatch.ts` holds the subscriptions and streams what they see.

**Server-sent events** to carry it: one way, text, no handshake, and the subscription is closed when the request is (`req.on("close")`). A heartbeat comment every 25s keeps an idle stream from being closed underneath us — it carries no records and asks the database nothing.

**Nothing is polled.** A listener fires when the records change and at no other time, which is exactly what the published page gets.

## Shape

- **`live` rides on each previewed page**, read off the projection rather than the declaration — `withLive` has already dropped anything the tier may not read.
- **The watch plan is built from the same request list the one-shot read uses.** A watch with no request behind it would be a listener on a collection the page never reads.
- **One listener per collection, fanned out to the pages that watch it.** Two pages can name the same collection and read it differently — `all` for the desk, `own` for the participant — so a change becomes rows per page, through the same `ownsRow` the one-shot read uses. Subscribing twice would be two listeners billing for one collection and two chances to disagree.
- **One stream for the app**, not one per page: the server says which page each change is for, so switching pages in the picker needs no reconnection.
- **An app that declares no `live` opens no stream at all.**
- The change carries the collection's **current rows**, not a diff: the pane holds a map keyed by page and collection, so replacing one entry cannot be applied out of order.
- The frame is keyed on the page, not the payload, so an update never remounts the document — the rows go down the channel as a state message, which is what production does.

## Tests

- `test/src/composables/sharedAppLiveWatch.spec.ts` (8): one stream opened for a watching page and what arrives is filed; nothing opened for a page that watches nothing; a line the pane cannot read leaves the records alone; the stream closes when the author walks to a non-watching page and when the pane goes away; `withChange` replaces one collection on one page, returns a new map (the payload is a `shallowRef`), and ignores a page the pane is not holding.
- `test/server/backends/sharedAppPreview.spec.ts` (2): `live` rides per page — the watching page has it, the one beside it does not, the anonymous page carries its own; and the watch plan names the page, the collection and that page's own scope, with nothing for a page that declared no `live`.

`vue-tsc -b`, eslint, and 10950 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared app previews now stay synchronized with live record changes.
  * Pages can watch selected collections and receive scoped updates automatically.
  * Added a live update stream with connection cleanup and periodic heartbeats.
  * Updates remain consistent while preview data is refreshing.
  * Invalid or unavailable updates are safely ignored without opening an unusable stream.

* **Tests**
  * Added coverage for live collection configuration, record updates, malformed messages, reconnection, refresh consistency, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->