### PR TITLE
feat: プレビューもビューが宣言した件数上限に従う

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.23.0",
+    "@receptron/sharedapp": "^0.24.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -101,6 +101,14 @@ export interface RequestedCollection {
    *  `viewer.mine`, and an intent about one came back `not-in-view` about a row the page had
    *  legitimately been handed. */
   ownIdField?: string | undefined;
+  /** Read only the LATEST `rows` records, ordered by `field` — the cap the page's own projection
+   *  declared (`views[].limit`).
+   *
+   *  HERE FOR PARITY, not for cost. Production issues this as `orderBy(field, "desc") + limit(rows)`
+   *  and is handed that many rows; the pane reads the collection whole either way, on the author's
+   *  own machine. What it must not do is show MORE than the published page will — the one direction
+   *  this whole file is not allowed to be wrong in — so the same window is taken after the read. */
+  limit?: { rows: number; field: string } | undefined;
 }
 
 /** One collection's records, read with the author's own credentials.
@@ -119,8 +127,11 @@ async function readCollection(handle: SharedAppHandle, aid: string, want: Reques
   // The id is put ON the record. The rules use the document id as the record's identity
   // (a booking's id IS its slot), and a page that renders a list needs it as a field.
   const rows: PreviewDataset = docs.map((doc) => ({ ...(isRecord(doc.data) ? doc.data : {}), id: doc.id }));
-  if (want.scope === "all") return rows;
-  return rows.filter((row) => ownsRow(want, row, handle));
+  if (want.scope === "all") return capped(want, rows);
+  return capped(
+    want,
+    rows.filter((row) => ownsRow(want, row, handle)),
+  );
 }
 
 /** IS THIS ROW THE READER'S OWN? — the question `ownRow` asks in the rules, asked here in the only
@@ -145,6 +156,41 @@ export function ownsRow(want: RequestedCollection, row: Record<string, unknown>,
   const field = want.emailField;
   if (field === undefined) return false;
   return row[field] === who.email;
+}
+
+/** One record's place in the order a cap is taken along, or null when it has none.
+ *
+ *  A `stampField` is written by the RULES (`request.time`), and what the host hands back for it is
+ *  either the ISO text or the seconds/nanos pair, depending on which reader converted it. Both are
+ *  ordered here, and anything else is treated as absent.
+ *
+ *  ABSENT IS EXCLUDED, not sorted last, and that is Firestore's behaviour rather than a choice: a
+ *  document missing the ordered field is not returned by an ordered query at all. A preview that
+ *  kept those rows would show records the published page never receives. */
+function orderKey(value: unknown): number | string | null {
+  if (typeof value === "number" || typeof value === "string") return value;
+  if (!isRecord(value) || typeof value.seconds !== "number") return null;
+  return value.seconds + (typeof value.nanoseconds === "number" ? value.nanoseconds / 1e9 : 0);
+}
+
+/** The LATEST `rows` records, as the published page would be handed them.
+ *
+ *  Shared by the one-shot read and the LISTENER (`previewWatch.ts`) for the same reason `ownsRow`
+ *  is: two copies of "which rows does this page see" are two chances for the pane and the page to
+ *  disagree, and the disagreement is invisible until somebody counts.
+ *
+ *  Descending, so N means the newest N — the same direction the query carries. */
+export function capped(want: RequestedCollection, rows: PreviewDataset): PreviewDataset {
+  const cap = want.limit;
+  if (cap === undefined) return rows;
+  const ordered = rows
+    .map((row) => ({ row, key: orderKey(row[cap.field]) }))
+    .filter((entry): entry is { row: Record<string, unknown>; key: number | string } => entry.key !== null);
+  ordered.sort((left, right) => {
+    if (left.key === right.key) return 0;
+    return left.key < right.key ? 1 : -1;
+  });
+  return ordered.slice(0, cap.rows).map((entry) => entry.row);
 }
 
 /** The selector each collection's own rows are found by, per cid — see {@link ownRequests}.
@@ -175,7 +221,7 @@ async function readDatasets(
     for (const want of page.collections) {
       // Keyed on the SCOPE too: the same collection read `all` for the front desk and `own` for the
       // participant is two different answers, and sharing one would hand a page rows it may not see.
-      const key = `${want.cid}:${want.scope}:${want.emailField ?? ""}:${want.uidField ?? ""}:${want.ownDocId ?? ""}`;
+      const key = `${want.cid}:${want.scope}:${want.emailField ?? ""}:${want.uidField ?? ""}:${want.ownDocId ?? ""}:${want.limit?.rows ?? ""}:${want.limit?.field ?? ""}`;
       if (!cache.has(key)) {
         cache.set(key, await readCollection(handle, aid, want).catch(() => null));
       }
@@ -256,6 +302,18 @@ function tierRequests(plan: TierPlan): { key: string; collections: RequestedColl
   return plan.pages.map((page) => ({ key: previewPageKey(plan.tier, page.id), collections: byId.get(page.id) ?? [] }));
 }
 
+/** The cap a projection carries, or nothing — BOTH halves, and only on a scope that can be
+ *  ordered. Read the way the published runtime reads it (mulmoserver `appViewShape.ts`), so the
+ *  pane cannot honour a shape production drops: a count with no field would take an arbitrary N
+ *  here and the newest N there, which is a preview that disagrees with the page it is previewing. */
+const askedCap = (value: unknown, scope: "all" | "own"): { limit?: { rows: number; field: string } } => {
+  if (scope !== "all" || !isRecord(value)) return {};
+  const { rows, field } = value;
+  if (typeof rows !== "number" || !Number.isInteger(rows) || rows < 1) return {};
+  if (typeof field !== "string" || field === "") return {};
+  return { limit: { rows, field } };
+};
+
 const asRequested = (value: unknown): RequestedCollection[] => {
   if (!isRecord(value) || typeof value.cid !== "string") return [];
   const scope = value.scope === "own" ? "own" : "all";
@@ -266,6 +324,7 @@ const asRequested = (value: unknown): RequestedCollection[] => {
       ...(typeof value.emailField === "string" ? { emailField: value.emailField } : {}),
       ...(typeof value.uidField === "string" ? { uidField: value.uidField } : {}),
       ...(value.ownDocId === "auth.uid" ? { ownDocId: "auth.uid" as const } : {}),
+      ...askedCap(value.limit, scope),
     },
   ];
 };
@@ -354,8 +413,18 @@ const PUBLIC_PAGE_ID = "public";
 
 /** What the anonymous page may query for. Everything at `scope: "all"`: a visitor holds no identity
  *  the rules could narrow a read by, which is why `public.read` is a list of whole collections. */
-const publicRequests = (config: PublishedConfigDoc): RequestedCollection[] =>
-  (config.view?.collections ?? config.read).map((cid) => ({ cid, scope: "all" as const }));
+const publicRequests = (config: PublishedConfigDoc): RequestedCollection[] => {
+  // Keyed by cid on the public document rather than riding on each entry: `view.collections` there
+  // is a list of NAMES with nowhere to hang a value. `Object.hasOwn` before the lookup, because
+  // `constructor` and `toString` are valid collection names and would otherwise reach a prototype
+  // member.
+  const caps = config.view?.limit;
+  return (config.view?.collections ?? config.read).map((cid) => ({
+    cid,
+    scope: "all" as const,
+    ...askedCap(caps !== undefined && Object.hasOwn(caps, cid) ? caps[cid] : undefined, "all"),
+  }));
+};
 
 export async function previewSharedApp(root: string, opts: SharedAppOptions = {}): Promise<PreviewResult> {
   const context = await sharedAppContext(root);

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -166,11 +166,49 @@ export function ownsRow(want: RequestedCollection, row: Record<string, unknown>,
  *
  *  ABSENT IS EXCLUDED, not sorted last, and that is Firestore's behaviour rather than a choice: a
  *  document missing the ordered field is not returned by an ordered query at all. A preview that
- *  kept those rows would show records the published page never receives. */
-function orderKey(value: unknown): number | string | null {
-  if (typeof value === "number" || typeof value === "string") return value;
+ *  kept those rows would show records the published page never receives.
+ *
+ *  A TUPLE, not a number, and the seconds and the nanos stay APART. `seconds + nanos / 1e9` looks
+ *  equivalent and is not: at epoch scale a double cannot resolve anything finer than about 240ns,
+ *  so two instants inside the same second collapse to one value — and where the cap boundary falls
+ *  between them, the preview would keep whichever the input order happened to put first while the
+ *  published query keeps the later one. The leading rank is Firestore's own type order (number
+ *  before timestamp before string), so a collection whose stamp changed shape mid-life is at least
+ *  ordered the way the query would order it. */
+type OrderKey = [number, number, number, string];
+
+interface Ordered {
+  row: Record<string, unknown>;
+  id: string;
+  key: OrderKey;
+}
+
+function orderKey(value: unknown): OrderKey | null {
+  if (typeof value === "number") return [0, value, 0, ""];
+  if (typeof value === "string") return [2, 0, 0, value];
   if (!isRecord(value) || typeof value.seconds !== "number") return null;
-  return value.seconds + (typeof value.nanoseconds === "number" ? value.nanoseconds / 1e9 : 0);
+  return [1, value.seconds, typeof value.nanoseconds === "number" ? value.nanoseconds : 0, ""];
+}
+
+/** Later first — and, where two records carry the SAME stamp, the higher document id first.
+ *
+ *  The tie-break is not arbitrary: an ordered Firestore query carries an implicit `__name__` in the
+ *  same direction, so a descending read breaks equal stamps by name descending. Returning 0 here
+ *  would leave the pair in the input order instead, which is name ASCENDING — and at the cap
+ *  boundary that is the opposite row from the one the published page is handed. */
+function laterFirst(left: Ordered, right: Ordered): number {
+  const pairs: [number | string, number | string][] = [
+    [left.key[0], right.key[0]],
+    [left.key[1], right.key[1]],
+    [left.key[2], right.key[2]],
+    [left.key[3], right.key[3]],
+    [left.id, right.id],
+  ];
+  for (const [mine, theirs] of pairs) {
+    if (mine === theirs) continue;
+    return mine < theirs ? 1 : -1;
+  }
+  return 0;
 }
 
 /** The LATEST `rows` records, as the published page would be handed them.
@@ -183,13 +221,11 @@ function orderKey(value: unknown): number | string | null {
 export function capped(want: RequestedCollection, rows: PreviewDataset): PreviewDataset {
   const cap = want.limit;
   if (cap === undefined) return rows;
-  const ordered = rows
-    .map((row) => ({ row, key: orderKey(row[cap.field]) }))
-    .filter((entry): entry is { row: Record<string, unknown>; key: number | string } => entry.key !== null);
-  ordered.sort((left, right) => {
-    if (left.key === right.key) return 0;
-    return left.key < right.key ? 1 : -1;
-  });
+  // The id is always a string here — the read puts the document id on the record — and it is read
+  // back defensively anyway: this is also handed rows from a listener's snapshot.
+  const named = rows.map((row) => ({ row, id: typeof row.id === "string" ? row.id : "", key: orderKey(row[cap.field]) }));
+  const ordered = named.filter((entry): entry is Ordered => entry.key !== null);
+  ordered.sort(laterFirst);
   return ordered.slice(0, cap.rows).map((entry) => entry.row);
 }
 

--- a/server/backends/sharedApp/previewWatch.ts
+++ b/server/backends/sharedApp/previewWatch.ts
@@ -13,7 +13,7 @@
 //
 // ONE LISTENER PER COLLECTION, fanned out to the pages that watch it. Two pages can name the same
 // collection and read it differently — `all` for the desk, `own` for the participant — so a change
-// is turned into rows per page, by the same `ownsRow` the one-shot read uses. Subscribing twice
+// is turned into rows per page, by the same `ownsRow` and `capped` the one-shot read uses. Subscribing twice
 // would be two listeners billing for one collection and two chances for them to disagree.
 import { collection, onSnapshot, type Unsubscribe } from "firebase/firestore";
 
@@ -22,7 +22,7 @@ import { appSchemasPath } from "@receptron/sharedapp";
 import { isRecord } from "../../../common/isRecord.js";
 import type { PreviewDataset, PreviewRecordChange } from "../../../common/sharedAppPreview.js";
 import { currentEmail, currentFirestore, currentUid } from "../remoteHost/session.js";
-import { ownsRow, previewSharedApp, type PreviewWatch } from "./preview.js";
+import { capped, ownsRow, previewSharedApp, type PreviewWatch } from "./preview.js";
 
 /** What the caller gets: a way to stop, or the reason there is nothing to watch.
  *
@@ -40,8 +40,13 @@ const rowsFor = (docs: { id: string; data: () => unknown }[], watch: PreviewWatc
   // The id goes ON the record, as the one-shot read does it: the rules use the document id as the
   // record's identity, and a page rendering a list needs it as a field.
   const rows = docs.map((entry) => ({ ...fields(entry.data()), id: entry.id }));
-  if (watch.want.scope === "all") return rows;
-  return rows.filter((row) => ownsRow(watch.want, row, who));
+  // The same window the one-shot read takes, through the same function: a listener that delivered
+  // the whole collection would quietly UNDO the cap on the first change after the page opened.
+  if (watch.want.scope === "all") return capped(watch.want, rows);
+  return capped(
+    watch.want,
+    rows.filter((row) => ownsRow(watch.want, row, who)),
+  );
 };
 
 /** Watch every collection this app's pages declare `live`, and report each change once per page.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -718,6 +718,26 @@ entry per page, each naming **who it is for**:
   draws an empty page, which is the one failure nothing reports. Publish refuses a `public` page
   fed a collection outside `public.read`, and a `participant` page fed one a participant cannot
   reach at all (neither in `participantRead` nor their own row through `public.submit`).
+- **A collection that grows forever needs `limit`, or every reader pays for its whole history.**
+  A view is handed its datasets WHOLE, so a chat room's page fetches every message ever posted to
+  draw the last twenty — a bill and a payload that grow with the app's age, paid by everyone who
+  opens the page. Drawing fewer does not help: the read already happened. Cap the READ instead,
+  per page, over a subset of `collections`:
+
+  ```json
+  { "id": "room", "audience": "member", "path": "views/room.html",
+    "collections": ["messages"], "live": ["messages"], "limit": { "messages": 200 } }
+  ```
+
+  It is the **latest** N, never the first N, and that is what makes the key usable: the cap is
+  ordered by the collection's own `public.submit[cid].stampField`, so **a collection without one is
+  refused the cap** rather than ordered by something a submitter can write. (Unordered, a limit
+  falls back to Firestore's document-id order — an arbitrary N, and a new record never arrives.
+  Nothing errors, and the page looks like it is working.) Two more things to know: the rows arrive
+  **newest first**, so sort them if the page draws oldest-at-the-top; and the older records are
+  still there — this is a window, not a deletion, and nothing pages back to them. A participant's
+  OWN-ROW page cannot be capped (that query is already narrowed by the submitter's address, and
+  ordering it too needs an index no deployment has) — publish says so.
 - **`submit` carries STRINGS and nothing else.** A number, a boolean or a nested object in
   `values` is not read as a partial submission — the whole message stops being one, and the view
   is answered `not-a-submission`, which names no field. `attendees: 3` breaks a booking; `"3"`

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -20,7 +20,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { setFirestoreAccessor, setSharedCollectionsSupport, type FirestoreDocs, type FirestoreDoc } from "@mulmoclaude/core/collection/server";
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
-import { previewSharedApp } from "../../../server/backends/sharedApp/preview.js";
+import { capped, previewSharedApp } from "../../../server/backends/sharedApp/preview.js";
 import { makeTempDir } from "../../support/tempDir";
 
 const AID = "app-under-preview";
@@ -143,6 +143,44 @@ function writeApp(root: string, app: Record<string, unknown>): void {
 const stamp = { now: () => 1_700_000_000_000, resolveCommit: () => Promise.resolve({ commit: "c0ffee", dirty: false }) };
 
 let root = "";
+
+describe("the window a capped page is handed", () => {
+  // `capped` is what stands between the pane and "the preview showed a row the page never gets".
+  // Exercised directly as well as through a preview, because the interesting cases are BOUNDARIES —
+  // which of two rows the cap keeps — and they are unreachable through a fixture that has to
+  // publish an app first.
+  const want = { cid: "messages", scope: "all" as const, limit: { rows: 2, field: "at" } };
+
+  it("keeps the newest, and drops a row with no stamp at all", () => {
+    // Firestore does not sort an unstamped document last — it does not RETURN it.
+    const rows = [{ id: "a", at: "2026-08-22T09:00:00Z" }, { id: "b", at: "2026-08-22T11:00:00Z" }, { id: "c" }, { id: "d", at: "2026-08-22T10:00:00Z" }];
+    expect(capped(want, rows).map((row) => row.id)).toEqual(["b", "d"]);
+    // And with no cap declared, the rows are handed over untouched — unstamped ones included.
+    expect(capped({ cid: "messages", scope: "all" }, rows).map((row) => row.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("separates two Timestamps inside the same second", () => {
+    // `seconds + nanoseconds / 1e9` cannot: at epoch scale a double resolves no finer than ~240ns,
+    // so these two would collapse to one value and the boundary would fall by input order.
+    const rows = [
+      { id: "a", at: { seconds: 1_800_000_000, nanoseconds: 1 } },
+      { id: "b", at: { seconds: 1_800_000_000, nanoseconds: 2 } },
+      { id: "c", at: { seconds: 1_799_999_999, nanoseconds: 999_999_999 } },
+    ];
+    expect(capped(want, rows).map((row) => row.id)).toEqual(["b", "a"]);
+  });
+
+  it("breaks an exact tie by document name DESCENDING, as the query's implicit __name__ does", () => {
+    // Input order is name ascending. Left alone, the boundary would keep the opposite row from the
+    // one the published page is handed.
+    const rows = [
+      { id: "a", at: "2026-08-22T09:00:00Z" },
+      { id: "b", at: "2026-08-22T09:00:00Z" },
+      { id: "c", at: "2026-08-22T09:00:00Z" },
+    ];
+    expect(capped(want, rows).map((row) => row.id)).toEqual(["c", "b"]);
+  });
+});
 
 describe("shared app preview", () => {
   beforeAll(() => {

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -118,6 +118,9 @@ const schemaFor = (slug: string) => ({
     // A window bound the declaration below points at. The publish gate checks that the field it
     // names EXISTS, so a fixture without it now fails before the case it is testing.
     closesAt: { type: "number", label: "Closes" },
+    // What a `stampField` has to be declared as: the rules write `request.time` there, and a
+    // number would make every comparison a type error (publish refuses that pair).
+    stampedAt: { type: "datetime", label: "Stamped" },
   },
 });
 
@@ -425,6 +428,45 @@ describe("shared app preview", () => {
     expect(watches).toEqual([{ key: "member:desk", cid: "bookings", scope: "all" }]);
     // `quiet` declared no `live`, so nothing is subscribed for it — a listener on a page nobody
     // asked to watch is a bill with no reader.
+    expect(docs.writes).toEqual([]);
+  });
+
+  it("hands a capped page the NEWEST rows only — never more than the published page will get", async () => {
+    // `views[].limit` exists so a collection that grows forever is not read whole on every open.
+    // Production issues it as an ordered query; the pane reads the collection whole either way, on
+    // the author's own machine. What it must not do is DRAW more than the published page will.
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    writeApp(
+      root,
+      declaration({
+        collections: { bookings: { submitOnly: true } },
+        public: {
+          read: [],
+          submit: { bookings: { auth: "verifiedEmail", emailField: "note", createFields: ["note", "stampedAt"], stampField: "stampedAt" } },
+        },
+        views: [{ id: "desk", path: "views/desk.html", audience: "member", collections: ["bookings"], live: ["bookings"], limit: { bookings: 2 } }],
+      }),
+    );
+    writeFileSync(path.join(root, "views", "desk.html"), "<p>desk</p>");
+    docs.store.set(
+      `apps/${AID}/collections/bookings/items`,
+      new Map([
+        ["b1", { note: "oldest", stampedAt: "2026-08-22T09:00:00.000000001Z" }],
+        ["b2", { note: "middle", stampedAt: "2026-08-22T10:00:00.000000002Z" }],
+        ["b3", { note: "newest", stampedAt: "2026-08-22T11:00:00.000000003Z" }],
+        // No stamp at all. Firestore does not sort such a row last — it does not RETURN it — so a
+        // preview that kept it would show a record the published page never receives.
+        ["b4", { note: "unstamped" }],
+      ]),
+    );
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    expect(result.ok && (result.datasets["member:desk"]?.bookings ?? []).map((row) => row.note)).toEqual(["newest", "middle"]);
+    // And the LISTENER is told the same cap, or the first change after the page opened would
+    // silently deliver the whole collection back.
+    expect(result.ok && result.watches.map((entry) => entry.want.limit)).toEqual([{ rows: 2, field: "stampedAt" }]);
     expect(docs.writes).toEqual([]);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.23.0.tgz#67b250e1d05476d1082e88c582dadb8387dc80b5"
-  integrity sha512-8vAWDqUMXg7EP1XWZDqTP69a72l9snYwHWSW5uKaRGioQdA8Soz5ateakza7/A+1GooA9Pi+pDwsqz5ZEpQsfg==
+"@receptron/sharedapp@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.24.0.tgz#23a0342d498feb595371ace26b6679b4be2e5794"
+  integrity sha512-iltViTOdWfqKiWhjdYR3Drnw+gK9Tz7bxu8WYm18NIvCF8jYf/fGCEMLmS9giY1Rsg9CBVq6KkLKx+RG6N0z3A==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
sharedapp [#44](https://github.com/receptron/sharedapp/pull/44)（`views[].limit`、0.24.0 として publish 済み）と mulmoserver [#238](https://github.com/receptron/mulmoserver/pull/238)（実際のクエリに反映）の三つ目。**プレビューが公開ページより多く見せない**ようにする。

## 何をしているか

- `@receptron/sharedapp` を `^0.24.0` へ
- 投影が `limit: { rows, field }` を持つデータセットは、読んだあと**同じ窓**（`field` の降順で `rows` 件）を取る
- 一発読み (`readCollection`) とレコードストリーム (`previewWatch` の `rowsFor`) が**同じ `capped()`** を通る
- 公開ページの cap は `config.view.limit` から cid で引く（`Object.hasOwn` 経由）
- SKILL.md に `limit` の項を追加

## コストではなく忠実性

ペインは著者のマシンで、著者の資格情報でどのみち全件読む。ここで上限を掛ける理由は料金ではなく、**プレビューが本番より多く見せてはいけない**という、このファイルが唯一間違えてはいけない方向を守るため（`scope: "own"` を適用しているのと同じ理由）。

**並び順のフィールドを持たない行は「最後に回す」のではなく「落とす」。** Firestore の順序付きクエリはその文書を返さないので、残すと公開ページには決して届かないレコードをプレビューが見せることになる。テストでスタンプの無い行を一つ混ぜてあるのはこのため。

## リスナーも同じ窓

`rowsFor` が全件配ると、**ページを開いた後の最初の変更で上限が静かに解除される**。一発読みと共有の `capped()` を通すのは `ownsRow` と同じ理由で、「このページはどの行を見るか」の実装が二つあると食い違いは誰かが数えるまで見えない。

## 検証

- `sharedAppPreview.spec.ts` に統合テスト1件: 4行（うち1行はスタンプ無し）を置いた `limit: { bookings: 2 }` のページが `["newest","middle"]` だけを受け取り、watch plan の `want.limit` に `{ rows: 2, field: "stampedAt" }` が載ることを確認。`capped` を無効化する変異と、並び順を昇順にする変異の両方で落ちる
- 全体 10961件 pass / 50 skipped、typecheck、lint、format:check 通過

## この後

chat.room の `app.json` に `"limit": { "messages": 200 }` を足せば、宣言から実際の読み取りまで一本で通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for limiting preview collections to the newest records using configurable ordering fields.
  * Applied collection limits consistently to live updates and filtered views.
  * Added support for numeric, text, and timestamp-based ordering.

* **Documentation**
  * Documented collection limit behavior, ordering requirements, and usage restrictions.

* **Bug Fixes**
  * Excluded records without valid ordering values from capped results.
  * Preserved sub-second timestamp precision and applied consistent tie-breaking.
  * Improved cache handling when collection limits change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->