### PR TITLE
fix: bind を広げても自分のセッションが届くよう loopback でも listen する (#1834)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,6 +143,13 @@ export default [
     // long because they explain themselves, not because they do too much.
     rules: {
       "max-lines": ["error", { max: 600, skipBlankLines: true, skipComments: true }],
+      // Both of these read a FIXTURE as if it were a deployment detail. `no-hardcoded-ip` exists
+      // to catch a real endpoint baked into shipped code instead of configuration; in a spec the
+      // address IS the input under test, and the alternative — assembling `192.168.64.1` from
+      // pieces to get past the rule — hides what the case is about. `publicly-writable-directories`
+      // reads a `/tmp/...` string the same way, and a spec's is a string nothing opens.
+      "sonarjs/no-hardcoded-ip": "off",
+      "sonarjs/publicly-writable-directories": "off",
       "max-lines-per-function": ["error", { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true }],
       complexity: ["error", 20],
       "max-depth": ["error", 4],

--- a/plans/fix-1834-loopback-listener.md
+++ b/plans/fix-1834-loopback-listener.md
@@ -1,0 +1,71 @@
+# Serving loopback again when the operator widens the bind (#1834)
+
+`MULMOTERMINAL_HOST=<a specific address>` is the documented opt-in for reaching this server from
+another machine. Setting it makes every claude session's hooks fail on every tool call and leaves
+the GUI MCP stuck on "still connecting", because binding ONE address stops serving loopback — and
+everything this server spawns reaches back to it over loopback.
+
+## Why not point the sessions at the bound address
+
+That is the obvious fix and it does not work. Measured, on a server bound to `192.168.64.1`:
+
+```
+curl -X POST http://192.168.64.1:34710/api/hook   ->  403 {"error":"forbidden origin"}
+```
+
+A hook is `curl`, which sends no Origin, and `isAllowedOrigin` trusts an Origin-less request only
+when the PEER is loopback. A local process reaching us on `192.168.64.1` has peer `192.168.64.1`
+(measured), so it is refused. The fix would therefore have to widen the one predicate standing
+between a visited web page and the user's terminal — and it still would not be enough, because two
+of the eight callers cannot be reached from here at all:
+
+| | who dials loopback | reachable from a code change? |
+|---|---|---|
+| `spawn-claude.ts:220-221` | claude hooks + GUI MCP | yes |
+| `mcp-config.ts` `DEFAULT_HOST` | codex cells | yes |
+| `index.ts` rate-limit probe | yes |
+| `gui-mcp-registration.ts` | grid cells | **no — the url is already written into the user's `.mcp.json`** |
+| `mcp/bridge.mjs` | muse bridge | **no — argv from a machine-wide plugin manifest** |
+| `mcp-routes.ts`, `plugin-routes.ts` | this server calling itself | yes |
+
+## What this does instead
+
+Restore the assumption. When the primary bind does not serve `127.0.0.1`, listen on it as well.
+
+All eight callers keep working unchanged, the origin predicate is untouched, and no migration is
+needed for the urls already on users' disks. Exposure does not grow: loopback is reachable only
+from this machine, and it is what an untouched install already serves — the operator asked to ADD
+an interface, not to remove that one.
+
+## The rule is about the v4 loopback specifically
+
+Not "is the bind loopback". `MULMOTERMINAL_HOST=localhost` resolves to `::1` on a dual-stack
+machine, and a server there REFUSES a client dialing `127.0.0.1` (both measured) — so the GUI MCP
+url, which says `127.0.0.1` literally, is unreachable today. That is a second, unreported bug the
+same rule closes. Six of the eight callers write `127.0.0.1` and none writes `::1`, so the second
+listener always takes the v4 loopback.
+
+The decision reads `server.address()` rather than `MULMOTERMINAL_HOST`, for the reason
+`infra/loopback.ts` already gives: `localhost`, `127.1` and `127.000.000.001` all mean loopback and
+a hosts file can point `localhost` elsewhere, so only the resolved answer covers every spelling.
+
+## Verified
+
+Every bind, on the real app: hooks POST, the GUI MCP url, and a PTY over the terminal WebSocket.
+
+| `MULMOTERMINAL_HOST` | 2nd listener | hook | GUI MCP | PTY |
+|---|---|---|---|---|
+| unset | no | 200 | reachable | ok |
+| `0.0.0.0` | no | 200 | reachable | ok |
+| `localhost` | **yes** | 200 | **reachable (was refused)** | ok |
+| `192.168.64.1` | **yes** | **200 (was refused)** | **reachable (was refused)** | ok |
+
+Plus a real browser against both listeners — the grid loads and a shell cell reaches a prompt, with
+no console errors — because the change puts a second server in front of every request and every
+WebSocket, which a green suite does not exercise.
+
+## Known gap
+
+A Linux kernel with `net.ipv6.bindv6only=1` makes `::` v6-only, and the wildcard check assumes it
+covers v4. Attempting the bind instead would warn on the EADDRINUSE that a correct dual-stack setup
+produces every time, which trains the operator to ignore the warning that means something.

--- a/plans/fix-1834-loopback-listener.md
+++ b/plans/fix-1834-loopback-listener.md
@@ -57,6 +57,7 @@ Every bind, on the real app: hooks POST, the GUI MCP url, and a PTY over the ter
 |---|---|---|---|---|
 | unset | no | 200 | reachable | ok |
 | `0.0.0.0` | no | 200 | reachable | ok |
+| `::` | attempted | 200 | reachable | ok |
 | `localhost` | **yes** | 200 | **reachable (was refused)** | ok |
 | `192.168.64.1` | **yes** | **200 (was refused)** | **reachable (was refused)** | ok |
 
@@ -64,8 +65,14 @@ Plus a real browser against both listeners — the grid loads and a shell cell r
 no console errors — because the change puts a second server in front of every request and every
 WebSocket, which a green suite does not exercise.
 
-## Known gap
+## The two wildcards are not the same question
 
-A Linux kernel with `net.ipv6.bindv6only=1` makes `::` v6-only, and the wildcard check assumes it
-covers v4. Attempting the bind instead would warn on the EADDRINUSE that a correct dual-stack setup
-produces every time, which trains the operator to ignore the warning that means something.
+`0.0.0.0` IS the v4 wildcard, so it serves the v4 loopback by definition and needs nothing.
+
+`::` is the ambiguous one: it usually accepts v4 as well, but a Linux kernel with
+`net.ipv6.bindv6only=1` makes it v6-only, and there the fixed `127.0.0.1` urls stay unreachable
+(raised by Codex on the PR). Rather than guess which kernel this is, the bind is ATTEMPTED and the
+answer read: holding `[::]:P` dual-stack is what makes `127.0.0.1:P` unavailable, so EADDRINUSE
+proves loopback is already covered and is not warned about — and if it binds instead, that kernel
+did not cover it and the gap just closed. Measured across all five binds: no configuration produces
+a warning.

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } fr
 import { serverErrorExit } from "./infra/server-exit.js";
 import { PORT, BIND_HOST, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { isLoopbackBinding } from "./infra/loopback.js";
+import { startLoopbackListener } from "./infra/loopback-listener.js";
 import { messageOf } from "./errors.js";
 import { hookSettingsJson } from "./session/hook-settings.js";
 import { mcpConfigJson } from "./session/mcp-config.js";
@@ -530,7 +531,15 @@ mountAppRoutes(app, {
 });
 
 const server = http.createServer(app);
-pubsub = createPubSub(server, isAllowedOrigin);
+// The second listener, for the case where the operator bound a specific non-loopback address and
+// everything this server spawns can therefore no longer reach it (#1834). Built unconditionally
+// and wired into the same app, sockets and upgrade routing as the primary, because that wiring
+// happens well before `listen()` tells us which address the OS actually chose; whether it ever
+// serves anything is decided down at the bind, and an http server that never listens costs
+// nothing.
+const loopbackServer = http.createServer(app);
+const listeners: readonly [http.Server, http.Server] = [server, loopbackServer];
+pubsub = createPubSub(listeners, isAllowedOrigin);
 
 // Wire the shared file-change publisher (markdown + html live-refresh) against
 // pubsub + the workspace. Must run before any write route fires (publishFileChange
@@ -921,7 +930,7 @@ try {
 
 // The terminal WebSocket endpoints (routes/ws-routes.ts).
 mountTerminalWebSockets({
-  server,
+  servers: listeners,
   isAllowedOrigin,
   claudeBin: CLAUDE_BIN,
   setWaiting: (id, waiting) => setWaiting(id, waiting),
@@ -969,6 +978,12 @@ server.listen(Number(PORT), BIND_HOST, () => {
   if (!isLoopbackBinding(server.address())) {
     console.warn(bindSecurityWarning(BIND_HOST, PORT, browserHostnames));
   }
+  // Unconditional, and NOT folded into the branch above: the two ask different questions. That
+  // one is "is this exposed?" — true for a specific LAN address, false for `::1`. This one is
+  // "can our own sessions still reach us?" — false for BOTH, because a server on `::1` refuses a
+  // client dialing 127.0.0.1. Gating this on the warning left `MULMOTERMINAL_HOST=localhost`
+  // broken, which is how that wiring mistake showed up here.
+  startLoopbackListener(server, loopbackServer, PORT);
   const surviving = tmuxAvailable() ? tmuxListSessionIds() : [];
   const reaped: string[] = [];
   if (tmuxAvailable()) {

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -37,43 +37,49 @@ export type BoundAddress = string | { address: string } | null;
 // answer a question nobody asks.
 const V4_LOOPBACK = "127.0.0.1";
 
-// A wildcard bind already serves the v4 loopback — measured for both — so it needs no second
-// listener, and this is the case that makes "just widen the bind" wrong as a fix: `0.0.0.0`
-// serves loopback perfectly well while naming every other interface too, which is more exposure
-// than the operator asked for.
+// `0.0.0.0` is the v4 wildcard, so it serves the v4 loopback by definition — no kernel setting
+// changes that, and nothing more is needed.
+const V4_WILDCARD = "0.0.0.0";
+
+// `::` is the one genuinely ambiguous bind. It usually accepts v4 as well, but a Linux kernel with
+// `net.ipv6.bindv6only=1` makes it v6-only, and there the fixed 127.0.0.1 urls stay unreachable
+// (Codex on #1838).
 //
-// KNOWN GAP: a Linux kernel with `net.ipv6.bindv6only=1` makes `::` v6-only, and there this would
-// wrongly conclude loopback is covered. Left alone deliberately — the alternative is to attempt
-// the bind and warn on the EADDRINUSE that a correct dual-stack setup would produce every time,
-// which trains the operator to ignore the one warning that means something.
-const WILDCARD_ADDRESSES = new Set(["0.0.0.0", "::"]);
+// Rather than guess which kind of kernel this is, ATTEMPT the bind and read the answer: holding
+// `[::]:P` dual-stack is what makes `127.0.0.1:P` unavailable, so EADDRINUSE PROVES the primary
+// already covers loopback — and if it binds instead, that kernel did not, and the gap just closed.
+const V6_WILDCARD = "::";
 
-/** Whether the primary bind already answers on `127.0.0.1`. The family distinction is the whole
- *  point and is easy to lose: `isLoopbackAddress("::1")` is true and correct, yet a server bound
- *  to `::1` REFUSES a client dialing 127.0.0.1 (measured) — which is why `MULMOTERMINAL_HOST=localhost`
- *  is broken today, since it resolves to `::1` while the GUI MCP url says `127.0.0.1`. */
-const servesV4Loopback = (address: string): boolean => WILDCARD_ADDRESSES.has(address) || (isLoopbackAddress(address) && !address.includes(":"));
+/** Whether the primary bind already answers on `127.0.0.1` for certain. The family distinction is
+ *  the whole point and is easy to lose: `isLoopbackAddress("::1")` is true and correct, yet a
+ *  server bound to `::1` REFUSES a client dialing 127.0.0.1 (measured) — which is why
+ *  `MULMOTERMINAL_HOST=localhost` is broken today, since it resolves to `::1` while the GUI MCP
+ *  url says `127.0.0.1`. */
+const servesV4Loopback = (address: string): boolean => isLoopbackAddress(address) && !address.includes(":");
 
-/**
- * The loopback address to ALSO listen on, or null when the primary already serves it.
- */
-export function loopbackListenAddress(bound: BoundAddress): string | null {
-  // A string address is a pipe or a UNIX socket, and null is "not listening" — neither is a
-  // network bind this can reason about, and neither is reachable by a url a session would build.
-  if (bound === null || typeof bound === "string") return null;
-  return servesV4Loopback(bound.address) ? null : V4_LOOPBACK;
+export interface LoopbackPlan {
+  address: string;
+  /**
+   * Whether EADDRINUSE is a fine outcome rather than something to warn about.
+   *
+   * True only under a wildcard primary, where the port being taken is the primary itself and
+   * therefore proof that loopback is already served. Warning there would fire on every correct
+   * dual-stack boot, which is how an operator learns to ignore the warning that means something.
+   */
+  inUseIsFine: boolean;
 }
 
 /**
- * Serve loopback as well, when the primary bind took it away.
- *
- * BEST EFFORT, and deliberately not fatal: the operator asked for the address they named, and
- * that one is already listening by the time this runs. Failing the boot because the extra one
- * could not bind would turn a degraded setup into no setup at all — so it warns, naming the
- * symptom rather than the errno, and carries on. EADDRINUSE is the realistic failure (another
- * MulmoTerminal already holds loopback on this port), and it is exactly the case where taking
- * the port would be the wrong thing to do.
+ * How to serve `127.0.0.1` alongside the primary bind, or null when the primary already does.
  */
+export function loopbackListenPlan(bound: BoundAddress): LoopbackPlan | null {
+  // A string address is a pipe or a UNIX socket, and null is "not listening" — neither is a
+  // network bind this can reason about, and neither is reachable by a url a session would build.
+  if (bound === null || typeof bound === "string") return null;
+  if (bound.address === V4_WILDCARD || servesV4Loopback(bound.address)) return null;
+  return { address: V4_LOOPBACK, inUseIsFine: bound.address === V6_WILDCARD };
+}
+
 export interface PrimaryListener {
   address(): BoundAddress;
 }
@@ -85,15 +91,24 @@ export interface LoopbackListener {
   listen(port: number, host: string, onListening: () => void): unknown;
 }
 
+/**
+ * Serve loopback as well, when the primary bind did not.
+ *
+ * BEST EFFORT, and deliberately not fatal: the operator asked for the address they named, and
+ * that one is already listening by the time this runs. Failing the boot because the extra one
+ * could not bind would turn a degraded setup into no setup at all — so it warns, naming the
+ * symptom rather than the errno, and carries on.
+ */
 export function startLoopbackListener(primary: PrimaryListener, loopback: LoopbackListener, port: string | number): void {
-  const address = loopbackListenAddress(primary.address());
-  if (address === null) return;
+  const plan = loopbackListenPlan(primary.address());
+  if (plan === null) return;
   loopback.once("error", (err: NodeJS.ErrnoException) => {
+    if (plan.inUseIsFine && err.code === "EADDRINUSE") return;
     console.warn(
-      `\x1b[33m[bind]\x1b[0m could not also listen on ${address}:${port} (${err.code ?? err.message}) — this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.`,
+      `\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.`,
     );
   });
-  loopback.listen(Number(port), address, () => {
-    console.log(`[bind] also listening on ${address}:${port} so this machine's own sessions can reach the server`);
+  loopback.listen(Number(port), plan.address, () => {
+    console.log(`[bind] also listening on ${plan.address}:${port} so this machine's own sessions can reach the server`);
   });
 }

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -1,0 +1,99 @@
+// Does this server need a SECOND listener on loopback? (#1834)
+//
+// Everything this server spawns reaches back to it over loopback, and none of those callers can
+// be told otherwise: a claude session's hooks curl `http://localhost:<port>/api/hook`, its GUI MCP
+// url is `http://127.0.0.1:<port>/api/mcp/...`, a grid cell's url is baked into the user's OWN
+// `.mcp.json` on disk, the muse bridge builds its origin from an argv port, and two routes here
+// call this same server over HTTP. Eight places, all resting on one assumption.
+//
+// `MULMOTERMINAL_HOST=<a specific address>` breaks that assumption, because binding ONE address
+// means loopback is no longer served — so every one of those callers gets ECONNREFUSED, which is
+// the reported symptom: hooks failing on every tool call, and a GUI MCP stuck on "still
+// connecting".
+//
+// The fix restores the assumption rather than rewriting the eight callers. That matters beyond
+// tidiness, and the alternative is worth recording because it looks obvious and is not:
+//
+//   Pointing the sessions at the bound address instead trades ECONNREFUSED for 403. A hook is
+//   `curl`, which sends no Origin, and `isAllowedOrigin` trusts an Origin-less request only when
+//   the PEER is loopback — a local process reaching us on `192.168.64.1` has peer
+//   `192.168.64.1` (measured), so it is refused. Making that work means widening the one
+//   predicate standing between a visited web page and the user's terminal, AND a migration for
+//   the urls already written into users' config files. Serving loopback again needs neither.
+//
+// It widens nothing: loopback is reachable only from this machine, and it is what an untouched
+// install already serves. The operator asked to ADD an interface, not to remove that one.
+import { isLoopbackAddress } from "./loopback.js";
+
+/** What the OS says the primary listener bound — `server.address()` — and nothing else. Asking
+ *  after the fact rather than classifying `MULMOTERMINAL_HOST` is the rule loopback.ts already
+ *  states: `localhost`, `127.1` and `127.000.000.001` all mean loopback, and `localhost` can be
+ *  pointed elsewhere by a hosts file, so only the resolved answer covers every spelling. */
+export type BoundAddress = string | { address: string } | null;
+
+// The address the second listener takes, and the only one worth taking: it is what our own
+// callers DIAL. Six of the eight write `127.0.0.1` literally, and the two that write `localhost`
+// reach it by falling back to v4 when v6 refuses. Nothing here dials `::1`, so serving it would
+// answer a question nobody asks.
+const V4_LOOPBACK = "127.0.0.1";
+
+// A wildcard bind already serves the v4 loopback — measured for both — so it needs no second
+// listener, and this is the case that makes "just widen the bind" wrong as a fix: `0.0.0.0`
+// serves loopback perfectly well while naming every other interface too, which is more exposure
+// than the operator asked for.
+//
+// KNOWN GAP: a Linux kernel with `net.ipv6.bindv6only=1` makes `::` v6-only, and there this would
+// wrongly conclude loopback is covered. Left alone deliberately — the alternative is to attempt
+// the bind and warn on the EADDRINUSE that a correct dual-stack setup would produce every time,
+// which trains the operator to ignore the one warning that means something.
+const WILDCARD_ADDRESSES = new Set(["0.0.0.0", "::"]);
+
+/** Whether the primary bind already answers on `127.0.0.1`. The family distinction is the whole
+ *  point and is easy to lose: `isLoopbackAddress("::1")` is true and correct, yet a server bound
+ *  to `::1` REFUSES a client dialing 127.0.0.1 (measured) — which is why `MULMOTERMINAL_HOST=localhost`
+ *  is broken today, since it resolves to `::1` while the GUI MCP url says `127.0.0.1`. */
+const servesV4Loopback = (address: string): boolean => WILDCARD_ADDRESSES.has(address) || (isLoopbackAddress(address) && !address.includes(":"));
+
+/**
+ * The loopback address to ALSO listen on, or null when the primary already serves it.
+ */
+export function loopbackListenAddress(bound: BoundAddress): string | null {
+  // A string address is a pipe or a UNIX socket, and null is "not listening" — neither is a
+  // network bind this can reason about, and neither is reachable by a url a session would build.
+  if (bound === null || typeof bound === "string") return null;
+  return servesV4Loopback(bound.address) ? null : V4_LOOPBACK;
+}
+
+/**
+ * Serve loopback as well, when the primary bind took it away.
+ *
+ * BEST EFFORT, and deliberately not fatal: the operator asked for the address they named, and
+ * that one is already listening by the time this runs. Failing the boot because the extra one
+ * could not bind would turn a degraded setup into no setup at all — so it warns, naming the
+ * symptom rather than the errno, and carries on. EADDRINUSE is the realistic failure (another
+ * MulmoTerminal already holds loopback on this port), and it is exactly the case where taking
+ * the port would be the wrong thing to do.
+ */
+export interface PrimaryListener {
+  address(): BoundAddress;
+}
+
+/** Only what this needs from the second server, so `http.Server` satisfies it structurally and a
+ *  test can hand over a recorder without a cast. */
+export interface LoopbackListener {
+  once(event: "error", handler: (err: NodeJS.ErrnoException) => void): unknown;
+  listen(port: number, host: string, onListening: () => void): unknown;
+}
+
+export function startLoopbackListener(primary: PrimaryListener, loopback: LoopbackListener, port: string | number): void {
+  const address = loopbackListenAddress(primary.address());
+  if (address === null) return;
+  loopback.once("error", (err: NodeJS.ErrnoException) => {
+    console.warn(
+      `\x1b[33m[bind]\x1b[0m could not also listen on ${address}:${port} (${err.code ?? err.message}) — this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.`,
+    );
+  });
+  loopback.listen(Number(port), address, () => {
+    console.log(`[bind] also listening on ${address}:${port} so this machine's own sessions can reach the server`);
+  });
+}

--- a/server/infra/pubsub.ts
+++ b/server/infra/pubsub.ts
@@ -12,8 +12,18 @@ export interface Publisher {
   publish(channel: string, data: unknown): void;
 }
 
-export function createPubSub(server: HttpServer, isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean = () => true) {
-  const io = new IOServer(server, {
+// `servers` is plural for #1834: a non-loopback bind gets a second listener on loopback, and the
+// pub/sub socket has to work on whichever one the browser reached. socket.io attaches to any
+// number of http servers and pools their sockets, so the rooms — and therefore publish — stay one
+// set however many are listening.
+export function createPubSub(
+  servers: readonly [HttpServer, ...HttpServer[]],
+  isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean = () => true,
+) {
+  // A non-empty tuple rather than an array: socket.io needs one server to construct against, and
+  // a plain array would make "someone passed []" a runtime error instead of a type error.
+  const [primary, ...rest] = servers;
+  const io = new IOServer(primary, {
     path: "/ws/pubsub",
     transports: ["websocket"],
     // Reject cross-origin connections so an untrusted website can't subscribe to
@@ -28,6 +38,8 @@ export function createPubSub(server: HttpServer, isAllowedOrigin: (origin: strin
       credentials: true,
     },
   });
+
+  rest.forEach((server) => io.attach(server));
 
   io.on("connection", (socket) => {
     socket.on("subscribe", (channel) => {

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -7,7 +7,8 @@
 // off, the origin check, the working/waiting flags, and the spawners it built.
 import type { IPty } from "node-pty";
 import { WebSocketServer, WebSocket } from "ws";
-import type { Server } from "node:http";
+import type { IncomingMessage, Server } from "node:http";
+import type { Duplex } from "node:stream";
 import { randomUUID } from "node:crypto";
 import { messageOf } from "../errors.js";
 import { CLAUDE_CWD, SESSION_ID_RE } from "../config/env.js";
@@ -74,8 +75,13 @@ import { createKeySerializer } from "../infra/serialize-per-key.js";
 const sessionConnects = createKeySerializer();
 
 export interface WsRouteDeps {
-  /** The http server these endpoints hang their `upgrade` handler off. */
-  server: Server;
+  /** The http servers these endpoints hang their `upgrade` handler off.
+   *
+   *  Plural because a non-loopback bind gets a SECOND listener on loopback (#1834), and a
+   *  terminal has to work on whichever one the browser reached. A single `server` plus an
+   *  optional extra would be the same defect the origin predicate's factory exists to avoid:
+   *  the caller that forgets the second argument gets the old behaviour silently. */
+  servers: readonly Server[];
   /** Only same-machine browser origins may open a terminal socket. */
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
   claudeBin: string;
@@ -1002,7 +1008,7 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
     grok: runGrokWss,
     muse: runMuseWss,
   };
-  deps.server.on("upgrade", (req, socket, head) => {
+  const onUpgrade = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
     const { pathname } = new URL(req.url ?? "/", "http://localhost");
     const kind = terminalWsKind(pathname);
     // Not ours (e.g. /ws/pubsub) — leave it for socket.io's own upgrade handler. This
@@ -1019,7 +1025,8 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
       attachSocketErrorLogger(ws, kind);
       target.emit("connection", ws, req);
     });
-  });
+  };
+  deps.servers.forEach((server) => server.on("upgrade", onUpgrade));
 
   wss.on("connection", (ws, req) => void handleClaudeConnection(deps, ws, req));
   runWss.on("connection", (ws, req) => handleRunConnection(deps, ws, req));

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+// Whether a second listener on loopback is needed, and which loopback address it takes.
+//
+// The whole of #1834 rests on this one decision: get it wrong towards "not needed" and every hook
+// and GUI MCP url in the session keeps failing; wrong towards "needed" and the boot tries to bind
+// a port it already holds.
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  loopbackListenAddress,
+  startLoopbackListener,
+  type BoundAddress,
+  type LoopbackListener,
+  type PrimaryListener,
+} from "../../../server/infra/loopback-listener.js";
+
+describe("loopbackListenAddress", () => {
+  it("is not needed for the default bind — nothing changes for an untouched install", () => {
+    expect(loopbackListenAddress({ address: "127.0.0.1" })).toBeNull();
+  });
+
+  it("is not needed for any of 127.0.0.0/8, which is all loopback", () => {
+    for (const address of ["127.0.0.1", "127.0.0.53", "127.1.2.3"]) {
+      expect(loopbackListenAddress({ address })).toBeNull();
+    }
+  });
+
+  it("IS needed for the IPv6 loopback, which does not serve the v4 one", () => {
+    // `MULMOTERMINAL_HOST=localhost` resolves to `::1` on a dual-stack machine, and a server there
+    // REFUSES a client dialing 127.0.0.1 (both measured) — so the GUI MCP url, which says
+    // 127.0.0.1 literally, is unreachable today. This is the second bug #1834 turned up.
+    expect(loopbackListenAddress({ address: "::1" })).toBe("127.0.0.1");
+  });
+
+  it("is not needed for a wildcard bind, which already serves loopback", () => {
+    // The case that makes "just widen the bind" wrong as a fix: 0.0.0.0 serves loopback fine, and
+    // a second listener on the same port would collide with the wildcard that already holds it.
+    expect(loopbackListenAddress({ address: "0.0.0.0" })).toBeNull();
+    expect(loopbackListenAddress({ address: "::" })).toBeNull();
+  });
+
+  it("IS needed for a specific non-loopback address — the reported case", () => {
+    expect(loopbackListenAddress({ address: "192.168.64.1" })).toBe("127.0.0.1");
+    expect(loopbackListenAddress({ address: "100.101.102.103" })).toBe("127.0.0.1");
+  });
+
+  it("takes the v4 loopback for a v6 bind too, because that is what our callers dial", () => {
+    // Not a family match: six of the eight callers write `127.0.0.1` literally and none writes
+    // `::1`, so serving `::1` would answer a question nobody asks.
+    expect(loopbackListenAddress({ address: "fe80::1" })).toBe("127.0.0.1");
+    expect(loopbackListenAddress({ address: "2001:db8::5" })).toBe("127.0.0.1");
+  });
+
+  it("says no for a pipe or UNIX socket, which no session url can name", () => {
+    expect(loopbackListenAddress("/tmp/mulmoterminal.sock")).toBeNull();
+  });
+
+  it("says no when the server is not listening at all", () => {
+    expect(loopbackListenAddress(null)).toBeNull();
+  });
+});
+
+// The effect, not just the decision: whether it binds, and what it does when it cannot.
+describe("startLoopbackListener", () => {
+  const fakeServer = (address: BoundAddress): PrimaryListener => ({ address: () => address });
+
+  const recorder = () => {
+    const calls: { address: string; port: number }[] = [];
+    const handlers: ((err: NodeJS.ErrnoException) => void)[] = [];
+    const loopback: LoopbackListener = {
+      listen: (port, address, onListening) => {
+        calls.push({ address, port });
+        onListening();
+      },
+      once: (_event, handler) => handlers.push(handler),
+    };
+    return { calls, handlers, loopback };
+  };
+
+  it("does not bind anything when loopback is already served", () => {
+    const { calls, loopback } = recorder();
+    startLoopbackListener(fakeServer({ address: "127.0.0.1" }), loopback, 34567);
+    expect(calls).toEqual([]);
+  });
+
+  it("binds the v4 loopback on the port the server was given", () => {
+    const { calls, loopback } = recorder();
+    startLoopbackListener(fakeServer({ address: "192.168.64.1" }), loopback, "34567");
+    expect(calls).toEqual([{ address: "127.0.0.1", port: 34567 }]);
+  });
+
+  it("warns and carries on when the extra bind fails, rather than taking down the boot", () => {
+    // The operator's own address is already listening by now; refusing to run because the EXTRA
+    // one collided would turn a degraded setup into no setup at all.
+    const { handlers, loopback } = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListener(fakeServer({ address: "192.168.64.1" }), loopback, 34567);
+    expect(handlers).toHaveLength(1);
+    expect(() => handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }))).not.toThrow();
+    // Names the symptom the operator would otherwise have to diagnose from failing hooks.
+    expect(warn.mock.calls[0]?.[0]).toContain("hooks");
+    warn.mockRestore();
+  });
+});

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -7,21 +7,21 @@
 import { describe, it, expect, vi } from "vitest";
 
 import {
-  loopbackListenAddress,
+  loopbackListenPlan,
   startLoopbackListener,
   type BoundAddress,
   type LoopbackListener,
   type PrimaryListener,
 } from "../../../server/infra/loopback-listener.js";
 
-describe("loopbackListenAddress", () => {
+describe("loopbackListenPlan", () => {
   it("is not needed for the default bind — nothing changes for an untouched install", () => {
-    expect(loopbackListenAddress({ address: "127.0.0.1" })).toBeNull();
+    expect(loopbackListenPlan({ address: "127.0.0.1" })).toBeNull();
   });
 
   it("is not needed for any of 127.0.0.0/8, which is all loopback", () => {
     for (const address of ["127.0.0.1", "127.0.0.53", "127.1.2.3"]) {
-      expect(loopbackListenAddress({ address })).toBeNull();
+      expect(loopbackListenPlan({ address })).toBeNull();
     }
   });
 
@@ -29,34 +29,40 @@ describe("loopbackListenAddress", () => {
     // `MULMOTERMINAL_HOST=localhost` resolves to `::1` on a dual-stack machine, and a server there
     // REFUSES a client dialing 127.0.0.1 (both measured) — so the GUI MCP url, which says
     // 127.0.0.1 literally, is unreachable today. This is the second bug #1834 turned up.
-    expect(loopbackListenAddress({ address: "::1" })).toBe("127.0.0.1");
+    expect(loopbackListenPlan({ address: "::1" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
   });
 
-  it("is not needed for a wildcard bind, which already serves loopback", () => {
-    // The case that makes "just widen the bind" wrong as a fix: 0.0.0.0 serves loopback fine, and
-    // a second listener on the same port would collide with the wildcard that already holds it.
-    expect(loopbackListenAddress({ address: "0.0.0.0" })).toBeNull();
-    expect(loopbackListenAddress({ address: "::" })).toBeNull();
+  it("needs nothing for the v4 wildcard, which serves the v4 loopback by definition", () => {
+    // Not merely "usually": 0.0.0.0 IS the v4 wildcard, and no kernel setting takes loopback out
+    // of it. Attempting a bind here would only add a log line to a configuration that works.
+    expect(loopbackListenPlan({ address: "0.0.0.0" })).toBeNull();
+  });
+
+  it("ATTEMPTS the bind for the v6 wildcard, treating a clash as proof rather than failure", () => {
+    // `::` usually accepts v4 too, so the bind is expected to fail — and that failure is the
+    // proof. On a kernel with net.ipv6.bindv6only=1 it succeeds instead, which is exactly the host
+    // where `::` leaves the fixed 127.0.0.1 urls unreachable (Codex on #1838).
+    expect(loopbackListenPlan({ address: "::" })).toEqual({ address: "127.0.0.1", inUseIsFine: true });
   });
 
   it("IS needed for a specific non-loopback address — the reported case", () => {
-    expect(loopbackListenAddress({ address: "192.168.64.1" })).toBe("127.0.0.1");
-    expect(loopbackListenAddress({ address: "100.101.102.103" })).toBe("127.0.0.1");
+    expect(loopbackListenPlan({ address: "192.168.64.1" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
+    expect(loopbackListenPlan({ address: "100.101.102.103" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
   });
 
   it("takes the v4 loopback for a v6 bind too, because that is what our callers dial", () => {
     // Not a family match: six of the eight callers write `127.0.0.1` literally and none writes
     // `::1`, so serving `::1` would answer a question nobody asks.
-    expect(loopbackListenAddress({ address: "fe80::1" })).toBe("127.0.0.1");
-    expect(loopbackListenAddress({ address: "2001:db8::5" })).toBe("127.0.0.1");
+    expect(loopbackListenPlan({ address: "fe80::1" })?.address).toBe("127.0.0.1");
+    expect(loopbackListenPlan({ address: "2001:db8::5" })?.address).toBe("127.0.0.1");
   });
 
   it("says no for a pipe or UNIX socket, which no session url can name", () => {
-    expect(loopbackListenAddress("/tmp/mulmoterminal.sock")).toBeNull();
+    expect(loopbackListenPlan("/tmp/mulmoterminal.sock")).toBeNull();
   });
 
   it("says no when the server is not listening at all", () => {
-    expect(loopbackListenAddress(null)).toBeNull();
+    expect(loopbackListenPlan(null)).toBeNull();
   });
 });
 
@@ -99,6 +105,34 @@ describe("startLoopbackListener", () => {
     expect(() => handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }))).not.toThrow();
     // Names the symptom the operator would otherwise have to diagnose from failing hooks.
     expect(warn.mock.calls[0]?.[0]).toContain("hooks");
+    warn.mockRestore();
+  });
+});
+
+describe("startLoopbackListener under a v6 wildcard primary", () => {
+  const wildcard = (): PrimaryListener => ({ address: () => ({ address: "::" }) });
+
+  const recorder = () => {
+    const handlers: ((err: NodeJS.ErrnoException) => void)[] = [];
+    const loopback: LoopbackListener = { listen: () => {}, once: (_event, handler) => handlers.push(handler) };
+    return { handlers, loopback };
+  };
+
+  it("says nothing when the port is already taken — that IS the wildcard covering loopback", () => {
+    const { handlers, loopback } = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListener(wildcard(), loopback, 34567);
+    handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("still warns about a failure that is NOT the expected clash", () => {
+    const { handlers, loopback } = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListener(wildcard(), loopback, 34567);
+    handlers[0]?.(Object.assign(new Error("denied"), { code: "EACCES" }));
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

`MULMOTERMINAL_HOST` に個別アドレスを指定すると、**このサーバが起動したセッションがサーバ自身に繋ぎ返せなくなる** — hooks が毎ツール失敗し、GUI MCP が「still connecting」のまま繋がらない（#1834）。

原因は報告のとおりです。ただし調べた結果、**報告の修正案（接続先を実 bind に差し替える）では直らない**ことと、**対象が報告の 2 か所より広い**ことが分かったので、別の直し方にしました。

### 接続先の差し替えでは直りません（実測）

```
$ curl -s -X POST http://192.168.64.1:34710/api/hook -d '{}'
{"error":"forbidden origin"}          # HTTP 403 — ECONNREFUSED が 403 になるだけ
```

hook は `curl` で Origin を送らず、`isAllowedOrigin` は **Origin 無しを peer が loopback のときだけ**信用します。同一マシンから `192.168.64.1` に繋ぐと **peer は `192.168.64.1` になります**（実測）。通すには**セキュリティ判定そのものを緩める**必要があり、しかもそれでも足りません:

| | loopback を叩く場所 | コード変更で届くか |
|---|---|---|
| `spawn-claude.ts:220-221` | claude の hooks / GUI MCP | はい |
| `mcp-config.ts` `DEFAULT_HOST` | **codex セル** | はい |
| `index.ts` レート制限プローブ | はい |
| `gui-mcp-registration.ts` | **グリッドセル** | **いいえ — url は既にユーザーの `.mcp.json` に書き込み済み** |
| `mcp/bridge.mjs` | muse ブリッジ | **いいえ — machine-wide な manifest の argv** |
| `mcp-routes.ts` / `plugin-routes.ts` | **サーバが自分自身に繋ぐ箇所** | はい |

### 代わりに前提の方を戻します

**loopback を提供していない bind のときだけ、`127.0.0.1` でも listen します。**

- 上の 8 か所すべてが**現状のコードのまま**直ります
- **origin 判定に触りません** — セッションは今までどおり loopback から繋ぐので、既存のルールがそのまま正しく働きます
- **ディスク上の設定の移行が要りません**（グリッドセルの `.mcp.json` が自然に直る）
- **露出は広がりません。** loopback はこのマシンからしか届かず、素のインストールが元から提供しているものです。オペレータは「インターフェースを足す」ことを求めたのであって、loopback を外すことを求めたわけではありません

### 未報告の 2 つ目のバグも直ります

判定は「**v4 loopback が提供されているか**」で、「bind が loopback か」ではありません。`MULMOTERMINAL_HOST=localhost` は `::1` に解決され、そこは `127.0.0.1` を**拒否します**（どちらも実測）。GUI MCP の url は `127.0.0.1` 決め打ちなので、**この設定は今日すでに壊れています。** 同じルールで閉じました。

判定は `MULMOTERMINAL_HOST` ではなく `server.address()` を読みます。理由は `infra/loopback.ts` が既に書いているとおりで、`127.1` も `127.000.000.001` も loopback、hosts ファイルは `localhost` を別の場所に向けられるからです。

## Items to Confirm / Review

1. **2 つ目の listener を足したこと自体。** `ws` の upgrade と socket.io を両方に張るため、`WsRouteDeps.server` を `servers`（複数）に、`createPubSub` を非空タプル受けに変えています。**全リクエストと全 WebSocket が通る場所**なので、ここが一番見てほしい箇所です
2. **`eslint.config.js` を触っています。** spec ファイルに限り `sonarjs/no-hardcoded-ip` と `publicly-writable-directories` を off にしました。どちらも**フィクスチャを配備設定として読んでいる**ためで、回避のために `192.168.64.1` を分割して組み立てるのは、そのケースが何を試しているかを隠すだけだと判断しました。理由はコメントに書いてあります
3. **2 つのワイルドカードを別扱いにしていること**（Codex の指摘で追加）。`0.0.0.0` は v4 のワイルドカードそのものなので v4 loopback を定義上覆い、何もしません。`::` だけが曖昧で（`net.ipv6.bindv6only=1` の Linux では v6 専用になる）、そこは**当てにいかず bind を試して答えを読みます** — dual-stack で握っていることが 127.0.0.1 を塞ぐので、`EADDRINUSE` は「既に覆っている」証明であって失敗ではなく、黙ります
4. **失敗を fatal にしていません。** オペレータが指定したアドレスはその時点で既に listen 済みなので、追加分が bind できないことで boot ごと落とすと、劣化した構成が「起動しない」に変わります。警告して続行します

## 動作確認

`yarn typecheck` / `lint` / `build` / `test`（10975 passed）に加えて、**全 bind 構成を実アプリで**確認しました。hook の POST、GUI MCP の url、端末の PTY（CI と同じ `ci-ws-smoke.mjs`）:

| `MULMOTERMINAL_HOST` | 2つ目 | hook | GUI MCP | 端末 |
|---|---|---|---|---|
| 未設定 | なし | 200 | 到達可 | ✓ |
| `0.0.0.0` | なし | 200 | 到達可 | ✓ |
| `::` | 試行 | 200 | 到達可 | ✓ |
| `localhost` | **あり** | 200 | **到達可（従来は拒否）** | ✓ |
| `192.168.64.1` | **あり** | **200（従来は拒否）** | **到達可（従来は拒否）** | ✓ |

**既定構成は完全に不変**です（ソケット 1 つ、新しいログ行なし、端末動作）。**警告が出る構成は 1 つもありません。**

さらに **2 つの listener 両方に実ブラウザでグリッドを開き**、shell セルがプロンプトに到達すること・console error が 0 件であることを確認しました。build が通っても WebSocket が繋がらない形の壊れ方があり得るためです。

MCP は実際にハンドシェイクまで通しました:

```
$ curl -X POST http://127.0.0.1:34720/api/mcp/<session> \
    -H 'accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
data: {"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"mt",...
```

判定の spec には 4 通りの mutation（常に null / 常に v4 / ワイルドカード判定を外す / loopback 判定を外す）を入れて**全部 red になること**を確認済みです。

途中で 1 つ自分のミスを実機確認で見つけました: `startLoopbackListener` をセキュリティ警告の `if` の中に置いていたため、`::1` bind では呼ばれていませんでした。2 つは別の問いなので分けてあります（コメントに理由）。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1834 これ、原因わかる？副作用無く直せる？
- （確認の結果）案B: loopback も listen する。検証は実機で端末まで動かす。

work in mulmoterminal3

