### PR TITLE
docs: 親の状態で子の create を止める refIn と、agent に owner を渡す取引

### DIFF
--- a/docs/shared-app-principles.md
+++ b/docs/shared-app-principles.md
@@ -190,9 +190,10 @@ uid に正規表現メタ文字が入っても壊れないためであり、`<vi
 **破れ方**: 「owner は何でもできる」を素直に書いてしまうこと。owner が持つのは**運用の広さ**で
 あって、**レコードの整合性の免除**ではない。
 
-### 6b. 親の状態で子の create を止めるには、宣言が 2 つ要る
+### 6b. 親の状態で子の create を止めるには、宣言が 3 つ要る
 
-「閉じたスレッドに新しい発言が入らない」は、**片方の宣言だけでは成立しない**。
+「閉じたスレッドに新しい発言が入らない」は、**どれか 1 つでは成立しない**。owner のサインインを
+持つ相手に対しては、どの穴も**書き込み 2 回**で抜けられるからである。
 
 - `collections.<子>.refIn` — `{ "ref": "topicId", "collection": "topics", "where": { "field":
   "status", "equals": "open" } }`。ref フィールドが名指す親がその状態にある間しか、子の行は
@@ -201,13 +202,20 @@ uid に正規表現メタ文字が入っても壊れないためであり、`<vi
   何も言わない。これは owner を縛る。**create のみ**（既に入っている行を直す道は残す）
 - 親の `transitions` に、閉じた状態から**出る道を書かない**。原則 6 のとおり `transitions` は
   update で writer を縛るので、これで close が最終になる
+- `collections.<親>.sealed: ["closed"]` — その状態の行は**誰も削除できない**。`deleteWith` は
+  writer に何も訊かない（`writerDelete` はページが読む宣言で、ルールは見ていない）ので、これが
+  無いと「閉じた親を消して、initial の状態で書き直す」で close が戻る。しかもそのとき `refIn`
+  は**本当に開いている親**を見ているので、正しく通してしまう
 
-`refIn` だけなら、agent は親を開け直してから合法的に投稿できる。`transitions` だけなら、閉じた
-親に子を作れる。**2 つで 1 つの保証**。
+塞いでいる穴はそれぞれ別: 閉じた親に作る（`refIn`）、開け直す（`transitions`）、消して作り直す
+（`sealed`）。**4 つ目は宣言なしでルールが塞ぐ** —— `refIn` を宣言したコレクションでは
+**参照そのものが動かせない**（`refHeld`）。開いている親に作った行を、あとから閉じた親に
+付け替えることはできない。`refIn` を create だけで見てよいのはこれがあるから。
 
 守られている場所: `firestore.rules` の `refInOk()`（`createWith` の分岐 OR の**あと** ——
-原則 10 の予算のため）と `transitionOk()`。宣言の検査は `@receptron/sharedapp` の
-`refInTargetProblems` / `refInRefProblems`。
+原則 10 の予算のため。読みは `getAfter()`、でないと「閉じる update と create を同じ batch に
+束ねる」で最後の一言が入る）、`refHeld()`、`sealedNow()`、`transitionOk()`。宣言の検査は
+`@receptron/sharedapp` の `refInTargetProblems` / `refInRefProblems` / `sealedProblems`。
 
 **そしてここが限界**: これは**アプリのデータを通して**しか縛らない。owner のサインインを持つ
 agent は `manageSharedApp publish` で宣言そのものを書き換えられる。共有アプリに agent を
@@ -394,5 +402,5 @@ React アプリに戻っただけで、それはもう新しくない。
 - **著者のマシンや訪問者のブラウザが開いていることに依存する定期処理**（原則 1）
 - **owner のサインインを渡した相手を、owner と区別すること。** AI agent を座らせる共有アプリは
   agent に著者の身元をそのまま渡すので、Firestore から見て agent は owner そのものである。
-  データを通した拘束（原則 6b）は書けるが、publish・members の書き換え・任意の削除は**渡した
-  時点で渡っている**。別の身元を与える以外に閉じ方はない
+  データを通した拘束（原則 6b）は書けるが、publish と members の書き換えは**渡した時点で渡って
+  いる**。別の身元を与える以外に閉じ方はない

--- a/docs/shared-app-principles.md
+++ b/docs/shared-app-principles.md
@@ -190,6 +190,29 @@ uid に正規表現メタ文字が入っても壊れないためであり、`<vi
 **破れ方**: 「owner は何でもできる」を素直に書いてしまうこと。owner が持つのは**運用の広さ**で
 あって、**レコードの整合性の免除**ではない。
 
+### 6b. 親の状態で子の create を止めるには、宣言が 2 つ要る
+
+「閉じたスレッドに新しい発言が入らない」は、**片方の宣言だけでは成立しない**。
+
+- `collections.<子>.refIn` — `{ "ref": "topicId", "collection": "topics", "where": { "field":
+  "status", "equals": "open" } }`。ref フィールドが名指す親がその状態にある間しか、子の行は
+  作れない。`public.submit` ではなく**コレクション側**に置くのがこのキーの要点で、submit 側の
+  cross-record チェック（`idIn`、`window.fromField`）はすべて訪問者だけを縛り、writer には
+  何も言わない。これは owner を縛る。**create のみ**（既に入っている行を直す道は残す）
+- 親の `transitions` に、閉じた状態から**出る道を書かない**。原則 6 のとおり `transitions` は
+  update で writer を縛るので、これで close が最終になる
+
+`refIn` だけなら、agent は親を開け直してから合法的に投稿できる。`transitions` だけなら、閉じた
+親に子を作れる。**2 つで 1 つの保証**。
+
+守られている場所: `firestore.rules` の `refInOk()`（`createWith` の分岐 OR の**あと** ——
+原則 10 の予算のため）と `transitionOk()`。宣言の検査は `@receptron/sharedapp` の
+`refInTargetProblems` / `refInRefProblems`。
+
+**そしてここが限界**: これは**アプリのデータを通して**しか縛らない。owner のサインインを持つ
+agent は `manageSharedApp publish` で宣言そのものを書き換えられる。共有アプリに agent を
+座らせるとは、そういう取引である（下の「できない」も見よ）。
+
 ---
 
 ## 7. `assignee` は書きだけスコープされる。読みは全部見える
@@ -369,3 +392,7 @@ React アプリに戻っただけで、それはもう新しくない。
 - **任意区間の重なり判定**（「このシフトと重なる予約があるか」）。離散的な枠 id なら書ける
 - **秘密投票。** 表示で投票者を隠すのは秘密投票ではない。信頼された匿名化が要る
 - **著者のマシンや訪問者のブラウザが開いていることに依存する定期処理**（原則 1）
+- **owner のサインインを渡した相手を、owner と区別すること。** AI agent を座らせる共有アプリは
+  agent に著者の身元をそのまま渡すので、Firestore から見て agent は owner そのものである。
+  データを通した拘束（原則 6b）は書けるが、publish・members の書き換え・任意の削除は**渡した
+  時点で渡っている**。別の身元を与える以外に閉じ方はない

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^3.1.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.25.0",
+    "@receptron/sharedapp": "^0.26.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -961,7 +961,7 @@ the cost in the text the reader can see.
   `transitions` (for a member) or `public.submit.<cid>.selfTransitions` (for a participant). Those
   are different tables, so a staff page and a participant page draw different buttons for the same
   collection. Ask for a move the record cannot make and the answer names it.
-- **Closing a thread takes TWO declarations, and either alone is only advice.** The case: a
+- **Closing a thread takes THREE declarations, and any one alone is only advice.** The case: a
   discussion, a submission window, a shift — a parent row whose state is supposed to stop new
   child rows arriving. `transitions` on the parent is not enough on its own, because nothing
   connects it to the children; and where the writers are the people to be stopped (an app that
@@ -978,10 +978,21 @@ the cost in the text the reader can see.
     writers on update, so an app that means "closed is final" simply declares no transition out of
     `closed`. Without this, `refIn` is defeated in two writes: reopen the parent, post, and both
     writes are legal.
+  - **`collections.<parent>.sealed: ["closed"]`** — the statuses a record may not be DELETED from,
+    by anybody. `deleteWith` asks a writer nothing (`writerDelete` is read by the pages; the rules
+    never look at it), so without this the close is undone by deleting the parent and writing it
+    again in its initial state — and `refIn` then reports a genuinely open parent and is right to.
+
+  Each of the three closes a different two-write bypass, which is why none of them is optional:
+  create into a closed parent (`refIn`), reopen it (`transitions`), delete and recreate it
+  (`sealed`). A fourth is closed by the rules themselves without a declaration: **the reference
+  cannot MOVE**, so a row created in an open parent can never be rewritten to point at a closed
+  one. That is why `refIn` is safe to check on create only — the record stays correctable where it
+  stands, but it cannot change which parent it belongs to, ever.
 
   Reopening then means posting a NEW parent row, which is usually what the app wanted anyway. Note
   the limit: this binds an agent through the app's DATA. An agent holding the owner's session can
-  still re-publish the app and rewrite the declaration — see the note on what a shared app can and
+  still re-publish the app and rewrite the declarations — see the note on what a shared app can and
   cannot enforce in [docs/shared-app-principles.md](../../../docs/shared-app-principles.md).
 - **`transitions` says nothing about the OTHER rows.** It judges one record's move, so "only one
   question is open", "only one item is being served", "only one draft at a time" cannot be declared

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1012,6 +1012,11 @@ the cost in the text the reader can see.
     collection declares `writerDelete: true`. A boolean, because the rules ask no status of a
     writer (`deleteWith` opens with `isWriter`). This is the staff half, and it is the one to give
     an owner who needs to remove a task somebody abandoned or a name registered by mistake.
+  - `viewer.can.<cid>.sealed` — statuses NO delete succeeds from, whichever of the two above the
+    reader holds (`collections.<cid>.sealed`). "Any row" means "any row the RECORD has not sealed":
+    `sealedNow` sits above the `isWriter` branch and refuses the owner too. **A page holding
+    `withdrawAny` must skip the rows whose status is in this list** — the control would only ever
+    fail on them. Empty for the collections that seal nothing, which is nearly all of them.
 
   The staff half did not exist before `@receptron/sharedapp` 0.20.0, and its absence used to be
   worked around by publishing the OWNER's page as `audience: "participant"` — which costs

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -961,6 +961,28 @@ the cost in the text the reader can see.
   `transitions` (for a member) or `public.submit.<cid>.selfTransitions` (for a participant). Those
   are different tables, so a staff page and a participant page draw different buttons for the same
   collection. Ask for a move the record cannot make and the answer names it.
+- **Closing a thread takes TWO declarations, and either alone is only advice.** The case: a
+  discussion, a submission window, a shift — a parent row whose state is supposed to stop new
+  child rows arriving. `transitions` on the parent is not enough on its own, because nothing
+  connects it to the children; and where the writers are the people to be stopped (an app that
+  seats AI agents hands them the OWNER's sign-in, so Firestore sees every one of them as an
+  `owner`) the writer branch of `create` asks nothing about the row at all.
+  - **`collections.<child>.refIn`** (`@receptron/sharedapp` 0.26.0 and the rules deployed with it)
+    — `{ "ref": "topicId", "collection": "topics", "where":
+    { "field": "status", "equals": "open" } }`. A child may be created only while the record its
+    `ref` field names is in that state. On the COLLECTION, not under `public.submit`, and that is
+    the point: everything under `public.submit` binds the visitor and says nothing to a writer.
+    This one binds the owner. CREATE only — a closed thread takes no new message, but fixing one
+    already in it stays possible.
+  - **No way out of the closing state in `collections.<parent>.transitions`.** `transitions` binds
+    writers on update, so an app that means "closed is final" simply declares no transition out of
+    `closed`. Without this, `refIn` is defeated in two writes: reopen the parent, post, and both
+    writes are legal.
+
+  Reopening then means posting a NEW parent row, which is usually what the app wanted anyway. Note
+  the limit: this binds an agent through the app's DATA. An agent holding the owner's session can
+  still re-publish the app and rewrite the declaration — see the note on what a shared app can and
+  cannot enforce in [docs/shared-app-principles.md](../../../docs/shared-app-principles.md).
 - **`transitions` says nothing about the OTHER rows.** It judges one record's move, so "only one
   question is open", "only one item is being served", "only one draft at a time" cannot be declared
   — no rule keeps them and publish cannot refuse an app that breaks them. Where the app's meaning

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -107,6 +107,19 @@ const asCapability = (cid: string, value: unknown): ViewCapability => {
     // REQUIRED, so leaving it out was a compile error rather than a staff page previewing without
     // the delete control that the published page draws.
     withdrawAny: from.withdrawAny === true,
+    // The statuses NO delete succeeds from, whichever of the two permissions above the reader
+    // holds. It has to be here for the pane to be worth anything: `withdrawAny` says "any row" and
+    // the rules mean "any row the RECORD has not sealed", so a pane without it draws a delete on a
+    // closed topic and the author learns the truth from production.
+    //
+    // The ONE field here that does not floor in the refusing direction, and it cannot: an empty
+    // list reads as "nothing is sealed", and there is no value that means "assume everything is".
+    // What makes that acceptable is where the floor is reached from — this JSON comes from this
+    // host's own server, running the same package, where `capabilityOf` always sets the key. An
+    // absent one therefore means an OLDER server, whose published pages do not honour seals
+    // either, so the pane matches what that server actually serves. The refusal that is not a
+    // matter of taste stays in `firestore.rules`.
+    sealed: strings(from.sealed),
   };
 };
 

--- a/test/src/components/SharedAppPreview.spec.ts
+++ b/test/src/components/SharedAppPreview.spec.ts
@@ -25,7 +25,16 @@ const FORM_FIELD = { name: "name", label: "お名前", required: true, type: "st
 /** One collection's capability, as the server resolves it for the author. Written out rather than
  *  built, so the SHAPE a page reads is pinned here too: `can` is keyed by collection, and a page
  *  reaching for `viewer.can.transitionAny` gets undefined for every app that has ever existed. */
-const MEMBER_CAPABILITY = { cid: "bookings", transitionAny: true, transitionOwn: false, assign: false, assignees: [], withdrawFrom: [], withdrawAny: false };
+const MEMBER_CAPABILITY = {
+  cid: "bookings",
+  transitionAny: true,
+  transitionOwn: false,
+  assign: false,
+  assignees: [],
+  withdrawFrom: [],
+  withdrawAny: false,
+  sealed: [],
+};
 
 /** And one as it resolves for a PUBLIC page, which carries a viewer too: the rules let whoever
  *  submitted a row move it and take it away, so `selfTransitions` and `selfDelete` resolve to

--- a/test/src/utils/sharedAppPreviewPayload.spec.ts
+++ b/test/src/utils/sharedAppPreviewPayload.spec.ts
@@ -29,6 +29,7 @@ describe("the preview payload", () => {
           assigneeField: "coach",
           withdrawFrom: ["requested"],
           withdrawAny: false,
+          sealed: [],
         },
       },
     });
@@ -49,7 +50,21 @@ describe("the preview payload", () => {
       assignees: [],
       withdrawFrom: [],
       withdrawAny: true,
+      sealed: [],
     });
+  });
+
+  it("carries the SEAL, so the pane does not offer a delete the rules refuse", () => {
+    // `withdrawAny` says "any row" and the rules mean "any row the RECORD has not sealed"
+    // (`sealedNow` refuses the owner too). Dropped here, the pane draws a delete on a closed topic
+    // and the author finds out from production — the preview/production divergence this rebuild
+    // exists to prevent, in the direction that matters.
+    //
+    // A NON-EMPTY list on purpose: the neighbouring assertions would pass just as well against a
+    // field that is always `[]`, which is what a forgotten key looks like.
+    const viewer = { me: "desk@gym.jp", can: { topics: { withdrawAny: true, sealed: ["closed"] } } };
+    const parsed = asPayload({ aid: "a", pages: [page({ viewer })] });
+    expect(parsed?.pages[0]?.viewer?.can.topics?.sealed).toEqual(["closed"]);
   });
 
   it("floors every permission to false, so a renamed field removes a control rather than inventing one", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,10 +2252,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.25.0.tgz#57be1b6368647003322d6c5e87bce2fe454b2361"
-  integrity sha512-oTXjziCqO6zWLoYPYizmwscu+wtaYcOkp+SDEyY8ohmm2U8FcM2LcBfgmB+1+5PTcbkY/lHROmrWWpCEemCSmg==
+"@receptron/sharedapp@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.26.0.tgz#0da5e8bcb4812d49b58d362bee850712dc317324"
+  integrity sha512-ifOrxQ9ROJ95UcEgV+vZY5FSYk2hjri85tO7AR4qWFNPTU4gLjZZEh1Tx3CJ8p0mZeubSR/JPWpmH1cuZmOpRA==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
receptron/sharedapp#50（コンパイラ）と receptron/mulmoserver#240（ルール）のドキュメント側。**この 2 本がマージ・publish・deploy されるまで、ここで説明しているキーは使えない。**

## なにが問題だったか

`../apps/roles`（AI Roundtable）は、ホストが議題を閉じても AI agent が投稿を続けられた。agent は owner のサインインをそのまま使うので Firestore から見れば全員 `owner` で、`createWith` の writer 分岐は書かれる行について何も訊かない。close を守っていたのはページと agent の brief だけだった。

## なにを書いたか

**`server/skills/mulmoterminal-shared-app/SKILL.md`** —— 「閉じたスレッドに新しい発言が入らない」には宣言が 2 つ要る、という項目を運用セクションに追加:

- `collections.<子>.refIn` —— ref フィールドが名指す親がその状態にある間しか子の行を作れない。`public.submit` ではなく**コレクション側**に置くのが要点（submit 側の cross-record チェックはすべて訪問者だけを縛り、writer には何も言わない）。**create のみ**
- 親の `transitions` に、閉じた状態から**出る道を書かない**。無いと `refIn` は「開け直して投稿する」の 2 手で迂回できる

**`docs/shared-app-principles.md`** —— 原則 6（状態機械は全員を縛る）の下に **6b** として同じことを、守られている場所を名指して追加。あわせて「明示的にできないと言うもの」に 1 行:

> owner のサインインを渡した相手を、owner と区別すること。データを通した拘束（原則 6b）は書けるが、publish・members の書き換え・任意の削除は**渡した時点で渡っている**。別の身元を与える以外に閉じ方はない

## 続き

`@receptron/sharedapp` を 0.26.0 に上げる bump は npm 公開後に別 PR で。それまでこの 2 ファイルは「まだ動かないキー」を説明しているので、マージは sharedapp の公開に合わせるのが正しい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented configuration requirements for preventing new child entries under closed discussions, submission windows, or shifts.
  * Clarified how reference restrictions prevent existing entries from being moved to a closed parent.
  * Explained how sealed statuses override deletion permissions and prevent reopening loopholes.
  * Added guidance for hiding deletion controls when entries are in sealed statuses.
  * Clarified reopening through a new parent entry and remaining owner-credential limitations.

* **Bug Fixes**
  * Preview capabilities now accurately carry sealed statuses, preventing unavailable deletion actions from being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->