### PR TITLE
docs: put the fold to work for Show HN

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,13 @@ and a **phone push** reaches you when a turn finishes.
 of object here — which is why the one-session-per-worktree limit applies to **agents only**, and
 a shell or a `yarn dev` launcher can sit in the same worktree an agent is working in.
 
-### 📖 Documentation — **[receptron.github.io/mulmoterminal](https://receptron.github.io/mulmoterminal/)**
-
-- **User guide:** [English](https://receptron.github.io/mulmoterminal/guide/en/) — the grid
-  view, everyday workflows, the full feature list, configuration, and mobile push notifications.
-- **ユーザーガイド:** [日本語](https://receptron.github.io/mulmoterminal/guide/ja/) —
-  グリッドの使い方・日々のワークフロー・機能一覧・設定・スマホ通知の設定はこちら。
-- **Updates / アップデート情報:** new releases and features are announced **in Japanese** on X —
-  新バージョンや新機能のお知らせは X の
-  [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) で。
-
 ## Demo
 
 https://github.com/user-attachments/assets/0b8dd582-6c0d-4be3-b0b4-3740ad0bdba6
+
+*90 seconds, with sound — one agent, then a grid of them, each cell coloured **working**, **done** or **needs you**. Zoom into one and the roster still holds what every other session asked, answered and did, so you go to whichever is lit and lose nothing catching up. Then the same grid, live:*
+
+![MulmoTerminal — a grid of live Claude Code sessions, each color-coded by state, updating in real time](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/hero.gif)
 
 <details markdown="block">
 <summary>Transcript of the narration</summary>
@@ -51,10 +45,6 @@ That is the whole install.
 
 </details>
 
-*90 seconds, with sound — one agent, then a grid of them, each cell coloured **working**, **done** or **needs you**. Zoom into one and the roster still holds what every other session asked, answered and did, so you go to whichever is lit and lose nothing catching up. Then the same grid, live:*
-
-![MulmoTerminal — a grid of live Claude Code sessions, each color-coded by state, updating in real time](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/hero.gif)
-
 MulmoTerminal turns [Claude Code](https://claude.com/claude-code) (and OpenAI's **Codex**)
 into a parallel, observable workspace: many agent sessions at once in a grid, each one
 color-coded so you see at a glance which are **working**, which **need you**, and which are
@@ -65,20 +55,22 @@ ping to your phone when a task finishes. One `npx` command, no Electron, no conf
 npx mulmoterminal@latest        # starts on http://localhost:34567 and opens your browser
 ```
 
+Requires **Node ≥ 22.9** and the [`claude`](https://claude.com/claude-code) CLI on your
+`PATH`, already logged in. `npx mulmoterminal@latest init` reports what it can't find.
+
+### Why not tmux + iTerm panes?
+
+Running agents in parallel was never the hard part — tmux does that fine. What gets lost
+is **which** of the five is waiting for you. A pane is opaque: working, finished and
+blocked-on-a-permission all look the same until you read it. Here every cell reports its
+state back to one grid — working (blue), done (green), **needs you** (amber) — with a chime
+when one goes amber off-screen, and a [cockpit roster](#why-youll-want-it) of one line per
+session so you can answer one without losing your place in the other four. It runs *on*
+tmux when you have it, for [persistence across restarts](#session-persistence-tmux).
+
 Built by **[receptron](https://github.com/receptron)** — **[Satoshi Nakajima](https://x.com/snakajima)**,
 software architect for **Windows 95** at Microsoft, and **[Isamu Arimoto](https://github.com/isamu)**;
 the same two behind **[GraphAI](https://github.com/receptron/graphai)**. [More ↓](#who-builds-this)
-
-> **Something looks wrong?** Type `/mulmoterminal-bug-report` in any MulmoTerminal session. The
-> bundled skill hears the symptom out, checks your **real** config, schema and version to see
-> whether the behaviour is configuration or by design, searches the existing issues — and only
-> helps you file one if none of that explains it, with the environment collected and secrets
-> masked. Getting you unstuck is the goal; an issue is what is left when the first three steps
-> fail.
-
-![MulmoTerminal's grid view — four live Claude sessions running side by side, each in its own color-coded project](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/grid-2x2-live.png)
-
-*The grid is a **cockpit for parallel agents** — here, four live Claude sessions, each in its own color-coded project. Every cell's header carries what you need to triage at a glance: **model · context %**, **token counts** (`⇡in ⇣out`), the **git branch / changes** chip, and an AI summary of what the agent is doing. A cell's **border color signals state** — working (blue), done (green), needs-you (amber — e.g. waiting on a permission), idle — with an attention chime so a stuck cell off-screen still pulls you back. Supervise many; only step in where you're called.*
 
 ## Why you'll want it
 
@@ -108,6 +100,10 @@ the same two behind **[GraphAI](https://github.com/receptron/graphai)**. [More �
 - **Make it yours.** Per-directory **themes, colors, and name badges** (`prod` in red,
   `staging` in amber), a configurable header (buttons + info chips), custom attention sounds,
   and Run / Skill menus to launch a project's scripts and `.claude/skills` right inside a cell.
+
+![MulmoTerminal's grid view — four live Claude sessions running side by side, each in its own color-coded project](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/grid-2x2-live.png)
+
+*The grid is a **cockpit for parallel agents** — here, four live Claude sessions, each in its own color-coded project. Every cell's header carries what you need to triage at a glance: **model · context %**, **token counts** (`⇡in ⇣out`), the **git branch / changes** chip, and an AI summary of what the agent is doing. A cell's **border color signals state** — working (blue), done (green), needs-you (amber — e.g. waiting on a permission), idle — with an attention chime so a stuck cell off-screen still pulls you back. Supervise many; only step in where you're called.*
 
 ![The cockpit roster — a one-row-per-session summary list beside the enlarged terminal](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/cockpit-roster.png)
 
@@ -239,6 +235,18 @@ more.
 
 ---
 
+### 📖 Documentation — **[receptron.github.io/mulmoterminal](https://receptron.github.io/mulmoterminal/)**
+
+- **User guide:** [English](https://receptron.github.io/mulmoterminal/guide/en/) — the grid
+  view, everyday workflows, the full feature list, configuration, and mobile push notifications.
+- **ユーザーガイド:** [日本語](https://receptron.github.io/mulmoterminal/guide/ja/) —
+  グリッドの使い方・日々のワークフロー・機能一覧・設定・スマホ通知の設定はこちら。
+- **Updates / アップデート情報:** new releases and features are announced **in Japanese** on X —
+  新バージョンや新機能のお知らせは X の
+  [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) で。
+
+---
+
 ## Install & run
 
 Needs **Node ≥ 22.9**, plus these CLIs on your `PATH`:
@@ -337,6 +345,13 @@ server, and opens the browser. For local development from a clone, see
 
 **Won't start with `ERR_MODULE_NOT_FOUND`?** If a first `npx` run was interrupted, a half-unpacked `~/.npm/_npx/<hash>` cache can remain and a later run fails at startup — a corrupted npx cache, not a bug in the published package.
 The launcher detects it and prints the exact, OS-appropriate removal command; run that, then `npx mulmoterminal@latest` again.
+
+> **Something looks wrong?** Type `/mulmoterminal-bug-report` in any MulmoTerminal session. The
+> bundled skill hears the symptom out, checks your **real** config, schema and version to see
+> whether the behaviour is configuration or by design, searches the existing issues — and only
+> helps you file one if none of that explains it, with the environment collected and secrets
+> masked. Getting you unstuck is the goal; an issue is what is left when the first three steps
+> fail.
 
 ---
 


### PR DESCRIPTION
Show HN の読者は折り目（最初の2スクロール）までしか読まない。そこに「これは何か」と「動くのか」を答えるものだけを置き、それ以外を下へ降ろす。**文章の書き直しはなく、コード・エラーメッセージ・必須ツール表には一切触っていない** — 並べ替えと短い追記2つだけ。

## 折り目より上（変更後）

1. H1 ＋ タグライン ＋ "Every cell is a real pty"
2. `## Demo` ＋ 90秒動画
3. `hero.gif`
4. 説明段落 ＋ `npx mulmoterminal@latest`
5. **新規**: `Requires Node ≥ 22.9 and the claude CLI …` の2行（詰まったら `init`）
6. **新規**: `### Why not tmux + iTerm panes?`
7. Built by

## 下へ降ろしたもの

| 移動したもの | 移動先 |
|---|---|
| 📖 Documentation リンク集 | `## Install & run` の直前 |
| ナレーション全文の `<details>` | `hero.gif` の下（動画と GIF を隣り合わせにするため） |
| `/mulmoterminal-bug-report` の注意書き | `## Install & run` の末尾 |
| `grid-2x2-live.png` ＋ キャプション | `## Why you'll want it` の中 |

## なぜ「Why not tmux?」を README に書くのか

この種のスレッドで最初に来る質問だからで、当日コメント欄で考えると間に合わない。並列に走らせること自体は tmux で足りる、と認めた上で、境界（ペインは working / done / permission 待ちを区別できない）を示す形にしてある。

## 検証

`sort` で全行を突き合わせ、**削除された行はゼロ**、追加は上記2ブロックのみであることを確認済み。リンクは既存のアンカー（`#session-persistence-tmux`, `#why-youll-want-it`）を指している。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized the opening demo to improve readability and remove duplicated content.
  - Added prerequisites for Node and the Claude CLI.
  - Added an explanation of the alternative to using tmux and iTerm panes.
  - Improved feature visuals, contributor attribution, documentation links, and bug-report guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->