### PR TITLE
docs: put the gif before the video in the Demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ a shell or a `yarn dev` launcher can sit in the same worktree an agent is workin
 
 ## Demo
 
+![MulmoTerminal — a grid of live Claude Code sessions, each color-coded by state, updating in real time](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/hero.gif)
+
+*The grid, live — each cell coloured **working**, **done** or **needs you**.*
+
 https://github.com/user-attachments/assets/0b8dd582-6c0d-4be3-b0b4-3740ad0bdba6
 
-*90 seconds, with sound — one agent, then a grid of them, each cell coloured **working**, **done** or **needs you**. Zoom into one and the roster still holds what every other session asked, answered and did, so you go to whichever is lit and lose nothing catching up. Then the same grid, live:*
-
-![MulmoTerminal — a grid of live Claude Code sessions, each color-coded by state, updating in real time](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/hero.gif)
+*90 seconds, with sound: one agent, then a grid of them. Zoom into one and the roster still holds what every other session asked, answered and did, so you go to whichever is lit and lose nothing catching up.*
 
 <details markdown="block">
 <summary>Transcript of the narration</summary>


### PR DESCRIPTION
## Summary

`## Demo` の先頭を **動画 → GIF** から **GIF → 動画** に入れ替えました。Markdown のみ、コードには触れていません。

**GitHub は添付動画を自動再生しません。** いまの順序だと、`## Demo` を開いた読者が最初に見るのは**再生ボタンの付いた黒い四角**です。GIF は自分で動きます。リポジトリを流し読みする人にとって、**動く証拠はクリック0回で届くべき**で、90秒のナレーション付きはその後ろの深さ、という並びにしました。

Show HN の投稿を控えていて、読者の多くは折り目までしか読まない、というのが直接の動機です。

| | Before | After |
|---|---|---|
| 1つ目 | 動画（要クリック・音あり） | **GIF（自動で動く）** |
| 2つ目 | GIF | 動画 |

旧キャプションは末尾が `Then the same grid, live:` で、**GIF への受け渡し**になっていました。順序が変わって成立しなくなるので、**資産ごとに1行ずつ**に分けています。

## Items to Confirm / Review

- **GIF のキャプションの文言** — `The grid, live — each cell coloured working, done or needs you.` としました。旧キャプションから状態の3語だけを引き継いだ形です。もっと短く／長くしたい場合は指摘してください
- **動画側のキャプション** — 旧文から「一台→グリッド」の説明を残し、GIF への受け渡し部分だけ落としました。`90 seconds, with sound:` で始めています
- **`#demo` アンカーは変わっていません** — 1st comment などからのリンクはそのまま有効です
- **レンダリング未確認** — GitHub 上での実際の表示は確認していません。マージ後に一度見てください

## User Prompt

> mulmoterminal/readme、動画 -> gif だけど gif のほうがすぐ見えるから入れ替えたほうがよい？もしそうなら自然に修正して。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal-marketing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reordered the Demo section to show the hero animation first.
  * Updated the caption, video link, and video description for improved clarity and brevity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->