### PR TITLE
feat: 記事の長さを、送る前にホストが断る（sharedapp 0.28.0）

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.27.0",
+    "@receptron/sharedapp": "^0.28.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/server/backends/sharedApp/participate/correct.ts
+++ b/server/backends/sharedApp/participate/correct.ts
@@ -25,7 +25,10 @@ import { itemsPath } from "../itemWrites.js";
 import { refused } from "../refused.js";
 import { quotedList, quotedTerm } from "../quoted.js";
 import { isRecord } from "../../../../common/isRecord.js";
+import { overLongFields } from "@receptron/sharedapp/view";
+
 import { capabilitiesOn, readRecord, TIERS, type JoinedApp } from "./app.js";
+import { submitSpecOf } from "../submitSpec.js";
 
 export interface AskedCorrection {
   cid: string;
@@ -152,6 +155,32 @@ function whyNot(allowed: { fields: string[]; status: string } | null, asked: Ask
   );
 }
 
+/** Anything in this correction that is longer than the app allows.
+ *
+ *  A CORRECTION IS WHERE THE LENGTH ACTUALLY MOVES. A submission is written once; `selfUpdate` is
+ *  the verb that lets the same person come back and make the field bigger, so a cap enforced only
+ *  on create bounds the first version of an article and nothing after it.
+ *
+ *  Read off `app.authorizing` — `apps/{aid}`'s own `public.submit`, which is the document the
+ *  deployed rules judge by and the same one `authorizedFields` reads. Absent for a reader who
+ *  cannot see that document (the collection-scoped role), and then there is no cap to apply: the
+ *  tier projections carry `selfUpdate` but not `maxBytes`, and inventing one from a document this
+ *  reader never read would be a refusal the app never declared. The rules do not enforce this
+ *  either way, so what is lost is a named refusal, not a bound the deployment was relying on. */
+function overLong(app: JoinedApp, asked: AskedCorrection): string | null {
+  const held = app.authorizing;
+  if (held === undefined) return null;
+  const submit = held.submit[asked.cid];
+  if (!isRecord(submit)) return null;
+  const over = overLongFields(asked.values, submitSpecOf(submit));
+  if (over.length === 0) return null;
+  return (
+    `too long for ${quotedTerm(asked.cid)}: ` +
+    over.map((field) => `${quotedTerm(field.name)} is ${field.bytes} bytes and this app allows ${field.cap}`).join("; ") +
+    ". Nothing was written. Bytes of UTF-8, not characters — Japanese runs about 2.4 bytes a character."
+  );
+}
+
 /** Write the correction, as the signed-in person.
  *
  *  `new FieldPath(name)` for each field, and not the object form, for the reason `commitIntent` uses
@@ -197,6 +226,8 @@ export async function performCorrection(app: JoinedApp, asked: AskedCorrection):
   const allowed = correctableFields(app, asked.cid, found.row, Object.keys(asked.values));
   const why = whyNot(allowed, asked);
   if (why !== null || allowed === null) return { ok: false, refusal: true, error: why ?? "nothing is correctable here." };
+  const tooLong = overLong(app, asked);
+  if (tooLong !== null) return { ok: false, refusal: true, error: tooLong };
   const failed = await commitCorrection(app.aid, asked);
   if (failed !== null) return { ok: false, error: failed.error, refusal: failed.refusal };
   return { ok: true, fields: Object.keys(asked.values), status: allowed.status };

--- a/server/backends/sharedApp/participate/correct.ts
+++ b/server/backends/sharedApp/participate/correct.ts
@@ -27,7 +27,7 @@ import { quotedList, quotedTerm } from "../quoted.js";
 import { isRecord } from "../../../../common/isRecord.js";
 import { overLongFields } from "@receptron/sharedapp/view";
 
-import { capabilitiesOn, readRecord, TIERS, type JoinedApp } from "./app.js";
+import { capabilitiesOn, readRecord, submitBlockOf, TIERS, type JoinedApp } from "./app.js";
 import { submitSpecOf } from "../submitSpec.js";
 
 export interface AskedCorrection {
@@ -155,24 +155,42 @@ function whyNot(allowed: { fields: string[]; status: string } | null, asked: Ask
   );
 }
 
+/** The length caps this app declares for a collection, from whichever document is readable.
+ *
+ *  THE APP DOCUMENT IS NOT REQUIRED HERE, and that is the difference between this and
+ *  `authorizedFields` directly above. That one must read `apps/{aid}` because `selfWriteOk`
+ *  reads it: the question there is what the DEPLOYED RULES will judge the write by, and during
+ *  an interrupted publish `config/public` has moved on while the rules have not.
+ *
+ *  `maxBytes` is read by NO RULE. So there is no "what the rules will judge by" to agree with,
+ *  and the question collapses to what the author published — which `config/public` states, world
+ *  readably, and which this host already trusts for exactly this on the submit path.
+ *
+ *  Requiring the app document made the cap depend on the READER: a collection-scoped role cannot
+ *  see `apps/{aid}`, so the same person was capped when they created a record and uncapped when
+ *  they corrected it — through a `selfUpdate` the tier projection grants them. A cap that a
+ *  second write escapes is not a cap, and correcting is the write where the length actually
+ *  moves. */
+function capsFor(app: JoinedApp, cid: string): Record<string, unknown> | null {
+  const held = app.authorizing;
+  // `Object.hasOwn` before the lookup: a collection id may be `constructor`, and a plain index
+  // into a map that does not name it reaches Object.prototype.
+  if (held !== undefined && Object.hasOwn(held.submit, cid)) {
+    const declared = held.submit[cid];
+    if (isRecord(declared)) return declared;
+  }
+  return submitBlockOf(app, cid);
+}
+
 /** Anything in this correction that is longer than the app allows.
  *
  *  A CORRECTION IS WHERE THE LENGTH ACTUALLY MOVES. A submission is written once; `selfUpdate` is
  *  the verb that lets the same person come back and make the field bigger, so a cap enforced only
- *  on create bounds the first version of an article and nothing after it.
- *
- *  Read off `app.authorizing` — `apps/{aid}`'s own `public.submit`, which is the document the
- *  deployed rules judge by and the same one `authorizedFields` reads. Absent for a reader who
- *  cannot see that document (the collection-scoped role), and then there is no cap to apply: the
- *  tier projections carry `selfUpdate` but not `maxBytes`, and inventing one from a document this
- *  reader never read would be a refusal the app never declared. The rules do not enforce this
- *  either way, so what is lost is a named refusal, not a bound the deployment was relying on. */
+ *  on create bounds the first version of an article and nothing after it. */
 function overLong(app: JoinedApp, asked: AskedCorrection): string | null {
-  const held = app.authorizing;
-  if (held === undefined) return null;
-  const submit = held.submit[asked.cid];
-  if (!isRecord(submit)) return null;
-  const over = overLongFields(asked.values, submitSpecOf(submit));
+  const declared = capsFor(app, asked.cid);
+  if (declared === null) return null;
+  const over = overLongFields(asked.values, submitSpecOf(declared));
   if (over.length === 0) return null;
   return (
     `too long for ${quotedTerm(asked.cid)}: ` +

--- a/server/backends/sharedApp/participate/submit.ts
+++ b/server/backends/sharedApp/participate/submit.ts
@@ -18,6 +18,7 @@ import {
   badSlugField,
   missingIdField,
   missingRequired,
+  overLongFields,
   plannedWrite,
   recordId,
   recordOf,
@@ -116,6 +117,11 @@ const submitReason = (failed: { error: string; refusal: boolean }): "taken" | "r
   return failed.refusal ? "rules" : "failed";
 };
 
+/** One over-long field, said with BOTH numbers: told only that something is too long, an agent
+ *  rewrites and retries blind — which for an article means doing it more than once. */
+const saidTooLong = (field: { name: string; bytes: number; cap: number }): string =>
+  `${quoted(field.name)} is ${field.bytes} bytes and this app allows ${field.cap}`;
+
 /** Send one submission. */
 export async function submitToApp(app: JoinedApp, cid: string, values: Record<string, string>): Promise<SubmitResult> {
   const plan = submitPlan(app, cid);
@@ -131,6 +137,25 @@ export async function submitToApp(app: JoinedApp, cid: string, values: Record<st
   // a report the model reads. Quoting at the narration would have missed them: this string travels
   // to the agent whole.
   if (missing.length > 0) return { ok: false, reason: "host", error: `missing: ${quotedList(missing, " / ")}` };
+
+  // AND WHETHER ANYTHING IS TOO LONG. Unlike every other refusal in this function, NOTHING BEHIND
+  // THIS ONE WILL CATCH IT: `maxBytes` is not in `firestore.rules` (a length test on `items` create
+  // is paid by every app in the deployment, against a bound whose writers the owner invited by
+  // name), so a host that skips this simply writes the record. The declaration says what the app
+  // can afford; this is where an agent finds out before spending it.
+  //
+  // The measurement comes from the package rather than from here, so both hosts count the same
+  // thing — BYTES of UTF-8, where a Japanese article runs about 2.4 bytes a character and a host
+  // counting `length` would let through nearly two and a half times the cap.
+  const tooLong = overLongFields(values, plan.submit);
+  if (tooLong.length > 0)
+    return {
+      ok: false,
+      reason: "host",
+      // The size AND the cap, per field: told only that something is too long, an agent rewrites
+      // and retries blind — which for an article means doing it more than once.
+      error: `too-long: ${tooLong.map(saidTooLong).join(" / ")}`,
+    };
 
   // `serverTimestamp` is what this host offers where the rules require GOOGLE's clock, and it is
   // handed over whether or not the app declares a `stampField` — that is the declaration's answer

--- a/server/backends/sharedApp/submitSpec.ts
+++ b/server/backends/sharedApp/submitSpec.ts
@@ -8,6 +8,7 @@
 // keys by the AUTHOR's own names — so a cast would be a claim about a document neither caller
 // wrote. What is not a string is absent, which is what every one of these keys means to the rules.
 import type { SubmitSpec } from "@receptron/sharedapp/view";
+import { isRecord } from "../../../common/isRecord.js";
 
 export function submitSpecOf(raw: Record<string, unknown>): SubmitSpec {
   const text = (key: string): string | undefined => {
@@ -29,5 +30,19 @@ export function submitSpecOf(raw: Record<string, unknown>): SubmitSpec {
     // beside it carries the same name, and this is deliberately not that one: `stampOk` tests
     // `"stampField" in s` against the submit block, so the submit block is the authority.
     stampField: text("stampField"),
+    // THE ONE KEY HERE THAT NO RULE ENFORCES. Every other field above is read by `firestore.rules`,
+    // so a host that drops one collects a permission error and somebody notices; a dropped
+    // `maxBytes` fails silently in the other direction — the write is ACCEPTED, at any length, and
+    // the index the author published pays for it on every open. This copier is exactly the closed
+    // list the package's own note warns about, so the key is copied here and the check itself comes
+    // from the package (`overLongFields`) rather than being re-derived.
+    //
+    // Numbers only, and own properties only: a field name has no grammar, so `toString` is a legal
+    // one and a plain index would hand back a function.
+    ...(isRecord(raw.maxBytes) ? { maxBytes: capsOf(raw.maxBytes) } : {}),
   };
+}
+
+function capsOf(raw: Record<string, unknown>): Record<string, number> {
+  return Object.fromEntries(Object.entries(raw).filter((entry): entry is [string, number] => typeof entry[1] === "number"));
 }

--- a/test/server/backends/sharedAppParticipateWrites.spec.ts
+++ b/test/server/backends/sharedAppParticipateWrites.spec.ts
@@ -501,16 +501,32 @@ describe("useSharedApp — writing to somebody else's app", () => {
     expect(await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "abcdef" } })).toContain("Corrected");
   });
 
-  it("applies no cap to a correction when the app document is DENIED", async () => {
-    // The tier projections carry `selfUpdate` and not `maxBytes`, so a collection-scoped role has
-    // no declaration to read one from. Inventing a cap out of a document this reader never saw
-    // would be a refusal the app never made — and the rules do not enforce this either way, so
-    // what is lost is a named refusal rather than a bound the deployment relied on.
+  it("caps a correction from the WORLD-READABLE declaration when the app document is denied", async () => {
+    // Codex on #1866. A collection-scoped role cannot read `apps/{aid}`, and requiring it made the
+    // cap depend on the reader: the same person was capped when they CREATED a record and uncapped
+    // when they corrected it, through a `selfUpdate` the tier projection grants them. A cap a
+    // second write escapes is not a cap.
+    //
+    // Reading `config/public` here is right for a reason that does not apply to `selfUpdate` one
+    // function above: THAT one must agree with the deployed rules, which read `apps/{aid}`.
+    // `maxBytes` is read by no rule at all, so there is nothing to agree with and the question is
+    // only what the author published — which this host already trusts for the same key on submit.
     publish({ rosterTier: true });
     declareCaps(bag, { note: 6 });
     bag.docs.denyGet.add(`apps/${AID}`);
     bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
-    expect(await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "a much longer note" } })).toContain("Corrected");
+    const said = await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "a much longer note" } });
+    expect(said).toContain("too long");
+    expect(said).toContain("allows 6");
+    expect(bag.batched).toEqual([]);
+  });
+
+  it("still corrects at the cap with the app document denied, so the fallback is not a blanket refusal", async () => {
+    publish({ rosterTier: true });
+    declareCaps(bag, { note: 6 });
+    bag.docs.denyGet.add(`apps/${AID}`);
+    bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
+    expect(await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "abcdef" } })).toContain("Corrected");
   });
 
   it("says so when the record is not there", async () => {

--- a/test/server/backends/sharedAppParticipateWrites.spec.ts
+++ b/test/server/backends/sharedAppParticipateWrites.spec.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { setFirestoreAccessor, setSharedCollectionsSupport } from "@mulmoclaude/core/collection/server";
 import { useSharedApp } from "../../../server/infra/use-shared-app-tool.js";
-import { AID, bookingsPath, freshBag, ME, publishApp, slotsPath, type Bag } from "../../support/participateHarness.js";
+import { AID, bookingsPath, declareCaps, freshBag, ME, publishApp, slotsPath, type Bag } from "../../support/participateHarness.js";
 import { makeTempDir } from "../../support/tempDir";
 
 // CREATED WITH `vi.hoisted` because the mock factory below is hoisted above the imports: a plain
@@ -437,6 +437,80 @@ describe("useSharedApp — writing to somebody else's app", () => {
     bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
     const said = await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "new" } });
     expect(said).toContain("Corrected");
+  });
+
+  // --- the declared length cap, which no rule enforces ------------------------------------------
+  //
+  // Every other refusal these two verbs make is checked again by `firestore.rules`, so a host that
+  // skipped one would collect a permission error and somebody would notice. `maxBytes` is not in
+  // the rules at all — a length test on `items` create is paid by every app in the deployment,
+  // against a bound whose writers the owner invited by name — so a host that skips THIS simply
+  // writes the record, at any length, and the index the author published pays on every open.
+
+  it("refuses a submission longer than the app allows, naming the size and the cap", async () => {
+    // Both numbers, because an agent told only that something is too long rewrites and retries
+    // blind — which for an article means doing it more than once.
+    publish();
+    declareCaps(bag, { slot: 8 });
+    const said = await run({ action: "submit", slug: "sakura", cid: "bookings", values: { slot: "10:00 in the morning" } });
+    expect(said).toContain("too-long");
+    expect(said).toContain("20 bytes");
+    expect(said).toContain("allows 8");
+    expect(bag.batched).toEqual([]);
+  });
+
+  it("counts BYTES of UTF-8, not characters", async () => {
+    // The whole reason the key is called `maxBytes`. Five Japanese characters are 15 bytes, so a
+    // host counting `length` would accept this against a cap of 9 — and the store, the index and
+    // the reader's connection are all paid in bytes.
+    publish();
+    declareCaps(bag, { slot: 9 });
+    const said = await run({ action: "submit", slug: "sakura", cid: "bookings", values: { slot: "\u3042\u3044\u3046\u3048\u304a" } });
+    expect(said).toContain("15 bytes");
+    expect(bag.batched).toEqual([]);
+  });
+
+  it("accepts a value of exactly the cap, and any value at all where none is declared", async () => {
+    // The acceptance half. A check that refused everything would satisfy both tests above, and an
+    // app that has never declared a cap must go on submitting whatever it likes.
+    publish();
+    declareCaps(bag, { slot: 5 });
+    expect(await run({ action: "submit", slug: "sakura", cid: "bookings", values: { slot: "10:00" } })).toContain("Submitted");
+    bag.batched.length = 0;
+    publish();
+    expect(await run({ action: "submit", slug: "sakura", cid: "bookings", values: { slot: "x".repeat(500) } })).toContain("Submitted");
+  });
+
+  it("refuses a CORRECTION that would exceed the cap, which is where the length actually moves", async () => {
+    // A submission is written once; `selfUpdate` is the verb that lets the same person come back
+    // and make the field bigger. A cap enforced only on create bounds the first version of an
+    // article and nothing after it.
+    publish({ rosterTier: true });
+    declareCaps(bag, { note: 6 });
+    bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
+    const said = await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "a much longer note" } });
+    expect(said).toContain("too long");
+    expect(said).toContain("allows 6");
+    expect(bag.batched).toEqual([]);
+  });
+
+  it("lets a correction through at exactly the cap", async () => {
+    publish({ rosterTier: true });
+    declareCaps(bag, { note: 6 });
+    bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
+    expect(await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "abcdef" } })).toContain("Corrected");
+  });
+
+  it("applies no cap to a correction when the app document is DENIED", async () => {
+    // The tier projections carry `selfUpdate` and not `maxBytes`, so a collection-scoped role has
+    // no declaration to read one from. Inventing a cap out of a document this reader never saw
+    // would be a refusal the app never made — and the rules do not enforce this either way, so
+    // what is lost is a named refusal rather than a bound the deployment relied on.
+    publish({ rosterTier: true });
+    declareCaps(bag, { note: 6 });
+    bag.docs.denyGet.add(`apps/${AID}`);
+    bag.docs.put(bookingsPath, "b1", { requesterEmail: ME.email, slot: "10:00", status: "booked", note: "old" });
+    expect(await run({ action: "update", slug: "sakura", cid: "bookings", id: "b1", values: { note: "a much longer note" } })).toContain("Corrected");
   });
 
   it("says so when the record is not there", async () => {

--- a/test/support/participateHarness.ts
+++ b/test/support/participateHarness.ts
@@ -447,7 +447,10 @@ const appAuthorizingBlock = (selfUpdate: Record<string, string[]> | null | undef
   const submit = isRecord(held.submit) ? held.submit : {};
   const bookings = isRecord(submit.bookings) ? submit.bookings : {};
   return {
-    public: { ...held, submit: { ...submit, bookings: { ...bookings, selfUpdate: selfUpdate ?? MIRRORED_SELF_UPDATE } } },
+    public: {
+      ...held,
+      submit: { ...submit, bookings: { ...bookings, selfUpdate: selfUpdate ?? MIRRORED_SELF_UPDATE } },
+    },
     collections: { bookings: { statusField: "status" } },
   };
 };
@@ -494,6 +497,29 @@ function putAppDoc(
     // and a second spread would drop whichever half a test had set deliberately.
     ...appAuthorizingBlock(appSelfUpdate, publicBlock),
   });
+}
+
+/** Declare a length cap on this app's fields, AFTER `publish()`.
+ *
+ *  Its own function rather than an option on `publishApp`, for the reason `putRosterTier` gives:
+ *  that signature is at its complexity cap and every default parameter counts against it, so a
+ *  thing exactly one kind of test asks for does not belong there.
+ *
+ *  It patches BOTH documents, and that is the point rather than convenience. `submit` reads the
+ *  declaration out of `config/public`; `update` reads it out of `apps/{aid}`, because that is the
+ *  one the deployed rules judge by. A cap written to only one of them would be enforced by one
+ *  verb and not the other, which is a state a finished publish never leaves. */
+export function declareCaps(bag: Bag, maxBytes: Record<string, number>): void {
+  for (const [path, id] of [
+    ["apps", AID],
+    [`apps/${AID}/config`, "public"],
+  ] as const) {
+    const doc = bag.docs.store.get(path)?.get(id);
+    if (!isRecord(doc)) continue;
+    const block = path === "apps" ? doc.public : doc;
+    if (!isRecord(block) || !isRecord(block.submit) || !isRecord(block.submit.bookings)) continue;
+    block.submit.bookings = { ...block.submit.bookings, maxBytes };
+  }
 }
 
 /** A participant page's own projection, left behind by an EARLIER publish: it names the same

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.27.0.tgz#1dbe1d643736ab642b5009be719a5ab02b3a63e4"
-  integrity sha512-LUvNzNGAPz0YXgsU2kFErNDXfw4pmKONLRDoECt2jVnMknVXQ2pamIqR0pzSf2VKuWhcnOHiP3ExSXxk2jqz0Q==
+"@receptron/sharedapp@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.28.0.tgz#52ddcc7d311a7b4fd22aa104121a2e00da3f5008"
+  integrity sha512-WKxe0mmA1XmxrWKrDnSSo7DbfeYEClTv0zytrYdXlKcKqFBofVoqQjUkoOxl89QztH9baDOx/t0a3CDMw9/wVA==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
A8（`plans/feat-shared-app-articles.md`）のホスト側。publish が宣言を検査するように
なった（`receptron/sharedapp#53`）ので、**値**を検査する側を入れる。

**#1864 の上に積んでいる。** `update` の verb があちらで入るので、base は
`feat/article-pages`。あちらがマージされれば main に付け替わる。

## ここだけ、後ろに誰も控えていない

`useSharedApp` の他の拒否はすべて `firestore.rules` がもう一度見るので、ホストが
飛ばせば permission エラーが返って誰かが気づく。**`maxBytes` はルールに無い** ——
`items` の create/update は全アプリが通る共有パスで、そこに式を 1 つ置く代金は記事を
持たないアプリも払う（原則 10）—— ので、**飛ばしたホストは黙って書く**。長さの制限
なく、著者が publish した索引が毎回それを払う。

計測はパッケージの `overLongFields` を呼ぶ。両ホストが同じものを数えるためで、数える
のは **UTF-8 のバイト**である。文字数で数えたホストは宣言の約 2.4 倍を通す。

## 入っているもの

- **`submitSpecOf` が `maxBytes` を運ぶ。** これは Grok が #53 で名指した closed-list
  そのもので、落としても型は通る —— だから検査**関数**の側をパッケージから取る。
- **`submit`**: 長すぎる値を、**サイズと上限の両方**を名指して断る。片方だけ知らされた
  agent は書き直して当てずっぽうに再試行する（記事なら何度も、ということ）。
- **`update`**: **長さが実際に動くのはここである。** submit は一度きりだが `selfUpdate`
  は同じ人が戻ってきて欄を大きくできる verb なので、create にだけ上限があるアプリは
  記事の**初版しか縛れていない**。

  判定はアプリ文書（`apps/{aid}` = ルールが読む方）を優先し、**読めないときは
  `config/public` に落ちる**。後者で十分なのは `maxBytes` を**どのルールも読まない**からで、
  合わせるべき「ルールが判断する文書」が存在しない —— 残るのは著者が公開した宣言だけで、
  それは submit の経路が既に同じキーをそこから読んでいる。

  当初はアプリ文書を必須にしていて、それは**上限が読者によって変わる**という穴だった
  （CODEX P1）: コレクション単位のロールは `apps/{aid}` を読めないので、同じ人が record を
  作るときは縛られ、訂正するときは縛られなかった。2 回目の書き込みで逃げられる上限は
  上限ではない。

## harness

`declareCaps` は `publishApp` の外に置いた。この harness 自身の規則に従っている
（あの signature は complexity 上限にあり、1 種類のテストしか使わないものは置かない
—— `putRosterTier` と同じ理由）。

**両方の文書に書く。** `submit` は `config/public` を、`update` は `apps/{aid}` を読むので、
片方だけの上限は片方の verb でしか効かず、完成した publish が残さない状態になる。

## 検証

テスト 6 本（バイト実測・ちょうど・宣言なし・訂正・アプリ文書が denied）。
`yarn typecheck` / `yarn lint` / `yarn test` **11,382**。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforcement of declared maximum byte limits for submitted and corrected fields.
  * Error messages now identify fields that exceed their configured limits and report their byte sizes.
  * Length checks correctly account for UTF-8 characters.
  * Fields without a configured limit remain unrestricted.

* **Bug Fixes**
  * Prevented oversized submissions and corrections from being written.
  * Preserved limit enforcement when the app’s public declaration cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
