### PR TITLE
chore: @receptron/sharedapp を 0.29.0 に上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.28.0",
+    "@receptron/sharedapp": "^0.29.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.28.0.tgz#52ddcc7d311a7b4fd22aa104121a2e00da3f5008"
-  integrity sha512-WKxe0mmA1XmxrWKrDnSSo7DbfeYEClTv0zytrYdXlKcKqFBofVoqQjUkoOxl89QztH9baDOx/t0a3CDMw9/wVA==
+"@receptron/sharedapp@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.29.0.tgz#e999f543dd280e1cfe68a62532e874481b0a00aa"
+  integrity sha512-E0WnHYZsUdRAIVzU63EDKTw/6eEglDfqjiXka5WslixybV22T44zxODii0tLozg5UeCBClpg8oVJ24piGhy7nQ==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
`receptron/sharedapp#54` の取り込み —— **閉じた window を持つアプリを記事ゲートが断っていた誤検知**の修正。

## なぜ急ぐか

これは理屈の上の修正ではなく、**実地で1つアプリを壊している**。

`~/git/ai/apps/blogs`（公開 slug `ai-notes`）を記事ビューに移行しようとした別セッションが、
0.28.0 の `check` に `audience: "participant"` を要求され、従った。すると `submitOnly` も
要求され、両方入れた結果:

- `submitCreate` の `s.get("audience","") != "participant" || r == "participant"` は、
  owner（`"*": "owner"`）に対して**偽**
- `submitOnly: true` は writer の枝（`isWriter(r) && !flagOn(c, "submitOnly")`）を**閉じる**

`createWith` の選言が両方とも偽になり、**誰も create できないアプリが公開された**。
いまも `/a/ai-notes` は読めるが投稿は全拒否である。

ゲートが守りたかったのは「書けるのは owner が招いた人だけ」で、**閉じた window は
その保証をすでに与えていた** —— `inWindow` は `publicCreate` からしか到達せず、writer の
枝は window を見ない。成り立っている保証を買い直させ、その代金がアプリの機能停止だった。

## 検証

- `yarn typecheck` / `yarn lint` / `yarn test` **11,383**
- 併せて `mulmoserver` の rules emulator で、当該アプリの宣言そのもの（閉じた window・
  participant なし・`idFrom: "slug"`・`stampField`）を再現し、**owner の create が通ること**を
  実行確認した
- ホスト側も 0.29.0 で id = slug、`publishedAt` = サーバー時刻を組み立てる

## マージ後にもう一手要る

**動いている MulmoTerminal の再起動。** `yarn install` は起動済みプロセスに効かないので、
再起動するまで `check` は同じ誤った要求を出し続ける（別セッションで実測済み）。
再起動 → `ai-notes` を publish → 記事の復元、の順。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared application package to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->