### PR TITLE
chore: @receptron/sharedapp を 0.30.0 に上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.29.0",
+    "@receptron/sharedapp": "^0.30.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.29.0.tgz#e999f543dd280e1cfe68a62532e874481b0a00aa"
-  integrity sha512-E0WnHYZsUdRAIVzU63EDKTw/6eEglDfqjiXka5WslixybV22T44zxODii0tLozg5UeCBClpg8oVJ24piGhy7nQ==
+"@receptron/sharedapp@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.30.0.tgz#159bc5bea2fa1bdf3e29717a09ea9cd8160e1af2"
+  integrity sha512-15UrzrXHhCzLlIEVUtxTV9E2kagL8DKYh9gXDhcJEjuJWxXSG4+sNPz/bKL+8X+LFww2TEeN0gZhr4cIrQmYhA==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
`receptron/sharedapp#57` の取り込み —— **描かれるページに、アプリ自身の色を持たせる**
（`theme: { hue }`）。

## この bump が要る理由

**publish するのはこのホストである。** 0.30.0 より前の `parseAuthoredApp` は `.strict()` で
`theme` を知らないので、色を宣言した `app.json` は**パースの時点で拒否される** —— 公開中の
ブログに色を足そうとした瞬間に、アプリごと publish できなくなる。

読む側（`receptron/mulmoserver#245`）はこの bump を必要としない。あちらが `hue` を読むのは
Firestore の生の文書から自前の型としてで、パッケージからは `ProjectedViewWrite` と
`AuthoredMail` しか取っていない。2 本は独立にマージできる。

## 0.30.0 が持ち込むもの

- `theme: { hue }`（0-359 の整数 1 つ）を app.json が宣言できる
- publish が `views[].type` のあるページに `hue` を射影する
- 描かれるページを持たないアプリの `theme` は**断る**（何もしない鍵が、設定できているように
  読めるのを防ぐ）
- **protocol は動かさない** —— `hue` を知らない reader はページを自分の色で描く。それでも
  ページである（`type` を知らない reader が生成フォームを描くのとは違う）

## 検証

`yarn typecheck` / `yarn lint` / `yarn test` **11,383**。

## マージ後にもう一手

**動いている MulmoTerminal の再起動。** `yarn install` は起動済みプロセスに効かないので、
再起動するまで `check` は `theme` を知らないままである。前回（0.29.0）で実測済み。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared application package to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->