### PR TITLE
fix: 手元プレビューの intent ルートが correct を読めなかった

### DIFF
--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -102,6 +102,18 @@ function submissionOf(body: unknown): PreviewSubmission | null {
   return { cid: body.cid, values: Object.fromEntries(entries) };
 }
 
+/** A correction's values, or null when the request does not describe a set of them.
+ *
+ *  Its own function rather than `submissionOf`'s inline filter, because the two differ in one place
+ *  that matters: an empty map is a legitimate correction message (answered `nothing-to-correct` by
+ *  name) and never a legitimate submission. */
+function correctionValues(raw: unknown): Record<string, string> | null {
+  if (!isRecord(raw)) return null;
+  const entries = Object.entries(raw);
+  if (!entries.every((entry): entry is [string, string] => typeof entry[1] === "string")) return null;
+  return Object.fromEntries(entries);
+}
+
 /** The intent a member's page asked for, narrowed off the request.
  *
  *  SHAPE ONLY. Whether the move is legal, whether this reader may make it and whether the record is
@@ -111,13 +123,24 @@ function intentOf(body: unknown): PreviewIntent | null {
   if (!isRecord(body) || !isRecord(body.page)) return null;
   const { id, audience } = body.page;
   if (typeof id !== "string" || (audience !== "public" && audience !== "member" && audience !== "roster")) return null;
-  if (body.kind !== "transition" && body.kind !== "assign" && body.kind !== "withdraw") return null;
+  if (body.kind !== "transition" && body.kind !== "assign" && body.kind !== "withdraw" && body.kind !== "correct") return null;
   if (typeof body.cid !== "string" || typeof body.itemId !== "string") return null;
   // A withdrawal names no destination, and one arriving with a `to` is not a withdrawal with
   // decoration — it is an ask this host cannot describe, so it is not read as one.
   if (body.kind === "withdraw") {
     if (body.to !== undefined) return null;
     return { page: { id, audience }, kind: body.kind, cid: body.cid, itemId: body.itemId };
+  }
+  // A correction names none either, and carries values instead. STRINGS ONLY, and the whole message
+  // is refused rather than trimmed — `submissionOf` above draws the same line for the same reason:
+  // the rules compare stored values without coercing, so writing the string half of a mixed payload
+  // produces a record that differs BY TYPE from the identical-looking one the published page
+  // writes. An EMPTY map still passes: `nothing-to-correct` is a refusal with a name, and the page
+  // is holding a promise while it happens.
+  if (body.kind === "correct") {
+    const values = correctionValues(body.values);
+    if (body.to !== undefined || values === null) return null;
+    return { page: { id, audience }, kind: body.kind, cid: body.cid, itemId: body.itemId, values };
   }
   if (typeof body.to !== "string") return null;
   return { page: { id, audience }, kind: body.kind, cid: body.cid, itemId: body.itemId, to: body.to };

--- a/test/server/backends/sharedAppPreviewRoutes.spec.ts
+++ b/test/server/backends/sharedAppPreviewRoutes.spec.ts
@@ -52,6 +52,22 @@ async function get(url: string): Promise<{ status: number; body: unknown }> {
   return { status: res.status, body: await res.json() };
 }
 
+/** The intent route, called the way the pane calls it: one JSON body, one answer. */
+async function postIntent(body: unknown): Promise<{ status: number; body: unknown }> {
+  const { mountSharedAppPreviewRoutes } = await import("../../../server/backends/sharedAppPreviewRoutes.js");
+  const server = express();
+  server.use(express.json());
+  mountSharedAppPreviewRoutes(server);
+  const res = await appRequest(server)(`/api/shared-app/preview/intent?cwd=${encodeURIComponent(root)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+const CORRECTION = { page: { id: "desk", audience: "member" }, kind: "correct", cid: "posts", itemId: "hello", values: { title: "again" } };
+
 describe("shared app preview routes", () => {
   beforeAll(() => {
     app = express();
@@ -132,6 +148,49 @@ describe("shared app preview routes", () => {
     // The guard answered and the handler returned without touching the response.
     expect(preview).not.toHaveBeenCalled();
     expect(result.status).toBe(400);
+  });
+
+  // --- what the intent route will read off a request ---------------------------------------------
+  //
+  // THE THIRD NARROWING OF THE SAME MESSAGE, and the one that had no test. The browser narrows an
+  // ask before it posts (`askedIntent`), this route narrows the request, and the package narrows it
+  // again before judging (`readIntentMessage`). When `correct` was added, the first and the third
+  // learned it and this one did not — so a correction the page sent and the parent would have
+  // performed came back `not-an-intent`, from the layer nobody was looking at. Every kind belongs
+  // here, or the route is a filter on the vocabulary rather than a check of the shape.
+
+  it("reads a correction, values and all", async () => {
+    const result = await postIntent(CORRECTION);
+
+    // Past the narrowing: what comes back is the BACKEND's answer about a directory with no app,
+    // not this route's refusal to read the message. `not-an-intent` here would be the bug.
+    expect(result.status).toBe(200);
+    expect(result.body).not.toEqual({ ok: false, error: "not-an-intent" });
+  });
+
+  it("refuses a correction whose values are not all strings", async () => {
+    // The rules compare stored values without coercing, so writing the string half of a mixed
+    // payload produces a record that differs BY TYPE from the identical-looking one the published
+    // page writes. Refused whole rather than trimmed, exactly as a submission is.
+    const result = await postIntent({ ...CORRECTION, values: { title: "ok", views: 12 } });
+
+    expect(result.body).toEqual({ ok: false, error: "not-an-intent" });
+  });
+
+  it("carries an EMPTY correction through to be refused BY NAME", async () => {
+    // The one place this differs from a submission: a page that names no fields is holding a
+    // promise, and `nothing-to-correct` is an answer where a dropped message is a dead button.
+    const result = await postIntent({ ...CORRECTION, values: {} });
+
+    expect(result.body).not.toEqual({ ok: false, error: "not-an-intent" });
+  });
+
+  it("refuses a correction that also names a destination", async () => {
+    // A correction names fields, not a `to`. One arriving with both is an ask this host cannot
+    // describe — the same line the withdrawal above draws.
+    const result = await postIntent({ ...CORRECTION, to: "archived" });
+
+    expect(result.body).toEqual({ ok: false, error: "not-an-intent" });
   });
 
   it("mounts on an express app without touching anything else", async () => {


### PR DESCRIPTION
`apps/blogs` の編集ボタンがペインで `not-an-intent` になる、という報告の原因。

## 同じメッセージを 3 か所で narrow していて、真ん中だけが取り残されていた

| どこ | 何を見る |
|---|---|
| `src/utils/sharedAppPreviewIntent.ts` の `askedIntent` | ブラウザが**送る前** |
| **`server/backends/sharedAppPreviewRoutes.ts` の `intentOf`** | **HTTP リクエスト** ← ここ |
| `@receptron/sharedapp` の `readIntentMessage` | 親が**判定する前** |

#1870 で 1 つ目と 3 つ目に `correct` を教えて、真ん中を忘れていた。`body.kind !== "transition" && … !== "withdraw"` に引っかかって `{ ok: false, error: "not-an-intent" }` を返す。

## 見つけにくかった理由

返ってくるのが「読めるメッセージではなかった」だけで、**ページにもパッケージにもビルドにも異常が見えない**。実際に別セッションが `node_modules/@receptron/sharedapp`（0.31.0、`dist/view/srcdoc.js` に `kind: "correct"` あり）、Vite の依存キャッシュ、`dist/assets/*.js`、dev server と vite のプロセス起動時刻まで確認したうえで特定できず、引き継いできた。

## テストが 1 つも無かった

`intentOf` は**両隣に narrowing のテストがあるのに、ここだけ無かった** —— それがこの抜けが CI を全緑で通った理由そのもの。kind ごとに 4 本足した:

- correct が narrowing を**通る**こと（`not-an-intent` で返らない）
- 混在 payload（`{ title: "ok", views: 12 }`）を**丸ごと**断ること — ルールは型を強制しないので、文字列の半分だけ書くと公開ページが同じ答えで書く文書と**型が違う**レコードができる。submission と同じ線
- **空の `values` は通す**こと — submission と違う唯一の点。欄を名指さないページは promise を握っているので、握りつぶすと死んだボタンになる。`nothing-to-correct` という名前のある拒否に落とす
- `to` を伴う correct は読まないこと

修正前のコードに当てると 1 つ目と 3 つ目が落ちることを確認済み。

## 確認

typecheck / lint 0、11,396 pass / 0 fail。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for correction intents in preview requests.
  * Valid correction values are now accepted, including empty corrections representing nothing to correct.

* **Bug Fixes**
  * Invalid correction requests are rejected when they contain non-string values, null values, or an unsupported destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->