### PR TITLE
fix(cli): PORT を launcher が読み、server へは argv で渡す (#1861, #1857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ ships while it is running still reaches the badge; the startup console notice is
 and is not repeated. Disable with `MULMOTERMINAL_NO_UPDATE_CHECK=1` (or `NO_UPDATE_NOTIFIER=1`).
 
 Options: `--cwd <dir>` (working directory — relative paths allowed; defaults to the
-directory you run the command from), `--port <n>` (default 34567), `--no-open`,
+directory you run the command from), `--port <n>` (default 34567; the
+`PORT` environment variable is used when the flag is absent), `--no-open`,
 `--version`, `--help`.
 
 ```bash

--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -1,6 +1,6 @@
 export type PortChoice = { port: number; explicit: boolean } | { error: string };
 export type CwdChoice = { path: string; mustExist: boolean } | { error: string };
-export declare function parsePortArg(args: string[], defaultPort: number): PortChoice;
+export declare function parsePortArg(args: string[], env: Record<string, string | undefined>, defaultPort: number): PortChoice;
 export declare function chooseCwd(args: string[], env: Record<string, string | undefined>): CwdChoice;
 export declare function portInUseMessage(port: number, explicit: boolean): string;
 export declare function portInUseAction(explicit: boolean, isTTY: boolean | undefined): "ask" | "stop";
@@ -9,8 +9,8 @@ export declare function saysYes(answer: unknown): boolean;
 export declare const SECOND_INSTANCE_NOTE: string;
 export declare const MIN_NODE_LABEL: string;
 export declare function nodeMeetsMinimum(version: string): boolean;
-export declare function serverNodeArgs(serverEntry: string, launchDir: string): string[];
-export declare function serverSpawnEnv(env: Record<string, string | undefined>, port: number, cwd: string): Record<string, string | undefined>;
+export declare function serverNodeArgs(serverEntry: string, launchDir: string, port: number): string[];
+export declare function serverSpawnEnv(env: Record<string, string | undefined>, cwd: string): Record<string, string | undefined>;
 export interface RunningInstance {
   pid: number;
   port: number | null;

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -11,21 +11,36 @@
 // environment or the filesystem.
 import { join } from "node:path";
 
-/**
- * Which port the launcher should ask for.
- * `--port` must be a plain integer in range: a value that merely starts with digits ("80x")
- * or carries a sign or padding ("+80", "080") is a typo, and silently launching on 80 is
- * worse than saying so.
- */
-export function parsePortArg(args, defaultPort) {
-  const at = args.indexOf("--port");
-  if (at === -1) return { port: defaultPort, explicit: false };
-  const raw = args[at + 1];
+/** A port a user typed, in either of the two places they can type one. `parseInt` stops at the
+ *  first non-digit, so a typo would otherwise launch on a port nobody named — "80x" silently
+ *  becoming 80 is worse than being told. `source` names the place, so the message points at
+ *  what to correct. */
+function readPort(raw, source) {
   const parsed = Number.parseInt(raw ?? "", 10);
   if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed < 1 || parsed > 65535) {
-    return { error: `Invalid --port value: "${raw ?? ""}" (expected integer 1..65535)` };
+    return { error: `Invalid ${source} value: "${raw ?? ""}" (expected integer 1..65535)` };
   }
   return { port: parsed, explicit: true };
+}
+
+/**
+ * Which port the launcher should ask for: `--port` > `PORT` > the default — the order
+ * `bin/room.js` already uses, so the two entry points of this package agree.
+ *
+ * `PORT` was ignored entirely until #1861, while the busy-port message told people to set it.
+ * An invalid one is refused rather than dropped for the same reason a bad `--port` is: falling
+ * back to the default silently IS the bug being fixed. An empty or unset `PORT` is not a value
+ * and falls through.
+ *
+ * A `PORT` from the environment counts as `explicit`, which is what decides whether a busy port
+ * stops the launch or offers a second instance on another one. The user named a port either
+ * way, and offering a different one answers a question nobody asked.
+ */
+export function parsePortArg(args, env, defaultPort) {
+  const at = args.indexOf("--port");
+  if (at !== -1) return readPort(args[at + 1], "--port");
+  if (env.PORT === undefined || env.PORT === "") return { port: defaultPort, explicit: false };
+  return readPort(env.PORT, "PORT");
 }
 
 /**
@@ -68,10 +83,10 @@ export function portInUseMessage(port, explicit) {
  * What to do when the wanted port is taken: "ask" whether to start a second instance,
  * or "stop".
  *
- * Two conditions rule the question out. An explicit --port already named the port that
- * was wanted, so offering a different one answers a question nobody asked; and with no
- * terminal to type into (a script, a service, CI) a prompt has nobody to answer it and
- * would hang the start instead of failing it.
+ * Two conditions rule the question out. A port the user NAMED — `--port`, or `PORT` in the
+ * environment (#1861) — already says which one was wanted, so offering a different one answers
+ * a question nobody asked; and with no terminal to type into (a script, a service, CI) a prompt
+ * has nobody to answer it and would hang the start instead of failing it.
  */
 export function portInUseAction(explicit, isTTY) {
   return explicit || !isTTY ? "stop" : "ask";
@@ -176,23 +191,31 @@ export function nodeMeetsMinimum(version) {
  *
  * Node options must precede the script path; anything after it is an argument to the script.
  * The launch directory is passed rather than read here so the choice stays checkable.
+ *
+ * The port goes here rather than in the environment because ARGV IS NOT INHERITED. The server
+ * hands its own environment to every PTY it spawns, so a port set there reaches every terminal
+ * in every cell — which is how a raw `PORT` made a dev server started in a cell try to take
+ * MulmoTerminal's own port (#1857). Renaming it would only move that: `MULMOTERMINAL_PORT` is
+ * deliberately given to PTYs (server/session/mcp-config.ts) for the MCP URLs, so a server
+ * reading it as its bind port would clash with itself the moment `yarn dev` ran inside a cell.
  */
-export function serverNodeArgs(serverEntry, launchDir) {
-  return ["--import", "tsx", `--env-file-if-exists=${join(launchDir, ".env")}`, serverEntry];
+export function serverNodeArgs(serverEntry, launchDir, port) {
+  return ["--import", "tsx", `--env-file-if-exists=${join(launchDir, ".env")}`, serverEntry, "--port", String(port)];
 }
 
 /**
  * The environment the launcher spawns the server with.
  *
- * Only the two values the server cannot work out for itself. In particular NOT `NODE_ENV`:
+ * Only the ONE value the server cannot work out for itself. In particular NOT `NODE_ENV`:
  * the server hands its own environment to every PTY it spawns, so a `NODE_ENV=production`
  * set here reaches every terminal in every cell — where yarn v1 reads it and installs
  * WITHOUT devDependencies while still reporting success (#955). Express is pinned to
  * production separately, in the server, so nothing here needs to say it.
  *
- * A `NODE_ENV` the user exported themselves passes through untouched: this decides what the
- * launcher adds, not what it removes.
+ * `PORT` was the same bug with a different name (#1857) and left by the same route; it is now
+ * an argument instead (see serverNodeArgs). A `PORT` or `NODE_ENV` the user exported themselves
+ * passes through untouched: this decides what the launcher adds, not what it removes.
  */
-export function serverSpawnEnv(env, port, cwd) {
-  return { ...env, PORT: String(port), CLAUDE_CWD: cwd };
+export function serverSpawnEnv(env, cwd) {
+  return { ...env, CLAUDE_CWD: cwd };
 }

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -421,13 +421,18 @@ Options:
  *
  * A `PORT` can arrive from a shell profile or direnv, so the number alone leaves the user no way
  * to see why we wanted it (#1861 review). Both facts are said out loud because they are separate
- * surprises: we TOOK the port they may have meant for something else, and — unlike a `--port`
- * launch — that variable is still in every cell, since it is theirs and the launcher only decides
- * what it ADDS (see serverSpawnEnv).
+ * surprises: we are asking for a port they may have meant for something else, and — unlike a
+ * `--port` launch — that variable is still in every cell, since it is theirs and the launcher
+ * only decides what it ADDS (see serverSpawnEnv).
+ *
+ * It says ASKING FOR, not taking. This prints before confirmNoRunningInstance, choosePort and the
+ * bind, any of which can end the launch — so "taking" was a completed action claimed twenty lines
+ * before anything was attempted (Codex round 2). Printing it later instead would lose it on the
+ * busy-port path, which is the one where "why does it want 34601?" is the actual question.
  */
 function notePortFromEnvironment(port) {
-  log(`Port ${port} comes from the PORT environment variable — MulmoTerminal is taking it as its own server port.`);
-  log(`  Your PORT is also inherited by terminals inside cells, as in any shell you exported it from.`);
+  log(`Port ${port} comes from the PORT environment variable — that is the port MulmoTerminal is asking for.`);
+  log(`  Terminals inside cells inherit that PORT too, as in any shell you exported it from.`);
 }
 
 async function main() {

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -341,9 +341,9 @@ function runServer(port, noOpen, cwd, onChild) {
     // and without reading stderr the launcher cannot tell that from a real bug.
     // The .env comes from where the user ran the command — the spawn's own cwd is the
     // package directory, so serverNodeArgs makes that path absolute (#795).
-    const server = spawn(process.execPath, serverNodeArgs(SERVER_ENTRY, process.cwd()), {
+    const server = spawn(process.execPath, serverNodeArgs(SERVER_ENTRY, process.cwd(), port), {
       cwd: PKG_DIR,
-      env: serverSpawnEnv(process.env, port, cwd),
+      env: serverSpawnEnv(process.env, cwd),
       stdio: ["inherit", "inherit", "pipe"],
     });
     let stderrTail = "";
@@ -406,9 +406,10 @@ Commands:
 
 Options:
   --cwd <dir>       Working directory claude runs in (default: current directory; relative paths allowed)
-  --port <number>   Server port (default: ${DEFAULT_PORT}). If it is in use, you are asked
-                    whether to start a second instance on a free port; with --port, or
-                    with no terminal to ask, startup stops instead.
+  --port <number>   Server port (default: ${DEFAULT_PORT}; the PORT environment variable is
+                    used when this flag is absent). If it is in use, you are asked
+                    whether to start a second instance on a free port; with a port
+                    named, or with no terminal to ask, startup stops instead.
   --no-open         Don't open the browser automatically
   --version         Show version
   --help            Show this help
@@ -463,7 +464,10 @@ async function main() {
     process.exit(1);
   }
 
-  const { port: requestedPort, explicit: portExplicit } = decideOrExit(parsePortArg(args, DEFAULT_PORT));
+  const { port: requestedPort, explicit: portExplicit } = decideOrExit(parsePortArg(args, process.env, DEFAULT_PORT));
+  // A PORT can come from a shell profile or direnv rather than from this command line, so the
+  // number alone leaves the user no way to see why we wanted it (#1861 review).
+  if (portExplicit && !args.includes("--port")) log(`Port ${requestedPort} comes from the PORT environment variable`);
   const noOpen = args.includes("--no-open");
   const cwd = resolveCwd(args);
   log(`Workspace: ${cwd}`);

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -416,6 +416,20 @@ Options:
 `);
 }
 
+/**
+ * Where a port nobody typed on this command line came from.
+ *
+ * A `PORT` can arrive from a shell profile or direnv, so the number alone leaves the user no way
+ * to see why we wanted it (#1861 review). Both facts are said out loud because they are separate
+ * surprises: we TOOK the port they may have meant for something else, and — unlike a `--port`
+ * launch — that variable is still in every cell, since it is theirs and the launcher only decides
+ * what it ADDS (see serverSpawnEnv).
+ */
+function notePortFromEnvironment(port) {
+  log(`Port ${port} comes from the PORT environment variable — MulmoTerminal is taking it as its own server port.`);
+  log(`  Your PORT is also inherited by terminals inside cells, as in any shell you exported it from.`);
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -465,9 +479,7 @@ async function main() {
   }
 
   const { port: requestedPort, explicit: portExplicit } = decideOrExit(parsePortArg(args, process.env, DEFAULT_PORT));
-  // A PORT can come from a shell profile or direnv rather than from this command line, so the
-  // number alone leaves the user no way to see why we wanted it (#1861 review).
-  if (portExplicit && !args.includes("--port")) log(`Port ${requestedPort} comes from the PORT environment variable`);
+  if (portExplicit && !args.includes("--port")) notePortFromEnvironment(requestedPort);
   const noOpen = args.includes("--no-open");
   const cwd = resolveCwd(args);
   log(`Workspace: ${cwd}`);

--- a/bin/room.js
+++ b/bin/room.js
@@ -47,11 +47,18 @@ function splitAtTerminator(args) {
   return at < 0 ? { options: args, literal: [] } : { options: args.slice(0, at), literal: args.slice(at + 1) };
 }
 
-/** The port to talk to: `--port`, else PORT from the environment, else the default. Read the same
- *  way the server itself reads it, so a user who moved the server does not have to say so twice. */
+/** The port to talk to: `--port`, else MULMOTERMINAL_PORT, else PORT, else the default.
+ *
+ *  MULMOTERMINAL_PORT is what a terminal INSIDE MulmoTerminal is given (server/session/pty-spawn.ts),
+ *  and it has to be preferred: `PORT` used to carry the same answer only because the launcher
+ *  exported it to every PTY, which is the leak #1857 is about. Without this, `room` run in a cell
+ *  of a server on 34601 would talk to whatever holds 34567 — or to another instance entirely.
+ *
+ *  `PORT` is kept behind it for a user running `room` in their own shell against a server they
+ *  moved with `PORT=<n>`, which is the same variable the launcher now reads (#1861). */
 function portFrom(options) {
   const at = options.indexOf("--port");
-  const named = at >= 0 ? Number(options[at + 1]) : Number(process.env.PORT);
+  const named = at >= 0 ? Number(options[at + 1]) : Number(process.env.MULMOTERMINAL_PORT || process.env.PORT);
   return Number.isFinite(named) && named > 0 ? named : DEFAULT_PORT;
 }
 

--- a/plans/fix-1861-port-env.md
+++ b/plans/fix-1861-port-env.md
@@ -50,8 +50,12 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
 ## 触らないもの
 
 - `server/session/mcp-config.ts` の `MULMOTERMINAL_PORT`（PTY 向け、正しい）
-- `bin/room.js`（既に `PORT` を読む）
 - `scripts/dev-server-config.js` の `set PORT=<n>`（dev 経路では元から正しい）
+
+> **当初ここに `bin/room.js` を「既に `PORT` を読むので触らない」と書いていたが、これは誤り
+> だった。** room がセル内で読んでいた `PORT` の唯一の供給源が、この変更で消す行そのもの
+> だったため、触らなければ room が別インスタンスに話しかける。code-review が見つけた。
+> 実際の変更は下の「code-review 対応」節の 1 番。
 
 ## 検証
 
@@ -66,9 +70,11 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
   **意図して** `PORT` を配る opt-in 機能。launcher が生の `PORT` を全 PTY に撒いていた間は、
   この機能を使っていないディレクトリにも `PORT` が入っていた。今回の変更で「`PORT` が入るのは
   ユーザーが export したときか、この機能を有効にしたときだけ」になる
-- `bin/room.js` は `Number(process.env.PORT)` で不正値を黙ってデフォルトに落とす。今回 launcher 側だけ
+- `bin/room.js` は `Number(...)` で不正値を黙ってデフォルトに落とす。今回 launcher 側だけ
   厳しくしたので、`PORT=abc mulmoterminal` は止まるが `PORT=abc mulmoterminal room` は 34567 を使う。
-  room は既存サーバに話しかけるだけで bind しないため今回は触っていない（レビュー対象）
+  room は既存サーバに話しかけるだけで bind しないので、**不正値の扱いは**触っていない（レビュー対象）。
+  ただし **room の優先順位そのものは変更した** —— `--port` > `MULMOTERMINAL_PORT` > `PORT` > default。
+  理由は下の「code-review 対応」節の 1 番
 
 ## 実機検証（2026-08-27、clean env + scratch HOME で実施）
 
@@ -154,4 +160,5 @@ tmux -L mt-porttest show-environment -g | grep -iE '^-?PORT=|^-?MULMOTERMINAL_PO
 | `MULMOTERMINAL_PORT=34615 mulmoterminal room list` | exit 0（到達） |
 | `MULMOTERMINAL_PORT=34699` で同上 | `could not reach the server at http://localhost:34699` |
 
-ゲート: format / lint / typecheck / build すべて 0、`yarn test` **11438 passed**（+8）。
+ゲート: format / lint / typecheck / build すべて 0。`yarn test` は **commit 77db6135 の時点で
+11438 passed**（sha に紐づけた事実なので、あとから増えても嘘にならない）。

--- a/plans/fix-1861-port-env.md
+++ b/plans/fix-1861-port-env.md
@@ -1,5 +1,15 @@
 # fix(cli): PORT を launcher が読み、server へは argv で渡す (#1861 / #1857)
 
+> **この文書の読み方 —— 時系列のログであって、現状の仕様書ではない。**
+>
+> 設計時の判断・実測・レビュー対応を、起きた順に記録している。**節の見出しに「（設計時）」
+> と付いたものは、その時点のコードについての記述**で、以後の修正で当てはまらなくなっている
+> ことがある（当てはまらなくなった経緯も、消さずに後ろの節に書いてある）。
+>
+> **現在のコードの仕様はコードが唯一の情報源。** この文書のコード片や関数シグネチャを、
+> 現在のものとして引用しないこと。codex-cross-review round 3・4 が拾ったのは、まさにこれを
+> 現在の主張として読める形で置いていたため。
+
 ## 症状
 
 - `PORT=34601 npx mulmoterminal` が **34567 で起動する**。`--port` だけが効く (#1861)
@@ -9,9 +19,14 @@
 
 両方とも `bin/cli-args.js` の同じ 1 行が発生源。
 
-## 再現（ユニットレベル、2026-08-27 実測）
+## 再現（設計時、修正前のコードに対する 2026-08-27 の実測）
+
+**下の 2 行は修正前のシグネチャで、現在のツリーでは動かない**（現在は
+`parsePortArg(args, env, defaultPort)` と `serverSpawnEnv(env, cwd)`）。バグが実在したことの
+記録として残してある。
 
 ```
+# 修正前（origin/main 51067ecb）の signature に対して
 parsePortArg([], 34567)                        -> {"port":34567,"explicit":false}   # env 完全無視
 serverSpawnEnv({PORT:'34601'}, 34567, '/x')    -> {"PORT":"34567","CLAUDE_CWD":"/x"} # 上書き
 ```
@@ -29,7 +44,7 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
 
 → **argv で渡す。** argv は PTY に継承されないので leak 面がゼロになる。
 
-## 変更
+## 変更（設計時の計画。実際に入ったものは下の「code-review 対応」まで読むこと）
 
 1. `parsePortArg(args, env, defaultPort)` — 優先順位 **`--port` > `env.PORT` > default**
    （`bin/room.js:54` が既に持っている順序に合わせる）
@@ -40,7 +55,9 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
 2. `serverSpawnEnv(env, cwd)` — `PORT` を足すのをやめる（#1857 の発生源）。
    ユーザー自身の `PORT` はそのまま通す
 3. `serverNodeArgs(serverEntry, launchDir, port)` — `--port <n>` を script 引数として付ける
-4. `server/config/env.ts` — `portFromArgv(process.argv) ?? process.env.PORT ?? 34567`
+4. `server/config/env.ts` — `ARGV_PORT ?? (process.env.PORT || 34567)`、`ARGV_PORT = portFromArgv(process.argv)`
+   - **`??` ではなく `||` なのは意図的。** `PORT=""` は `??` だと空文字が通ってしまい、
+     `Number("")` = 0 でランダムポートに bind する。空文字は「値なし」でなければならない
    - launcher 経由: argv が勝つ
    - `yarn dev` 経由: `PORT`（`vite.config.ts:9` が同じ変数でプロキシ先を決めているので、
      この経路は従来どおりでなければならない）
@@ -57,7 +74,7 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
 > だったため、触らなければ room が別インスタンスに話しかける。code-review が見つけた。
 > 実際の変更は下の「code-review 対応」節の 1 番。
 
-## 検証
+## 検証（設計時に立てた計画。実施結果は下の実機検証・再検証の節）
 
 - ユニット: `parsePortArg` の優先順位・不正値・explicit、`serverSpawnEnv` に `PORT` が無いこと、
   `serverNodeArgs` が `--port` を entry の **後ろ** に置くこと、`portFromArgv` の純関数テスト
@@ -85,9 +102,15 @@ PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユ�
 | `PORT=abc` | `Invalid PORT value: "abc" (expected integer 1..65535)`、exit 1、サーバは起動しない |
 | 実 PTY（`/ws/run`）の env | `RAWPORT=[]` — 生の `PORT` が入らないことを実測（#1857） |
 
-`MULMOTERMINAL_PORT` がエージェントセルに届くことは直接は測れていない（`ps eww` が実行できず）。
-`spawn-claude.ts:195` が `guiMcpEnv(sessionId, PORT)` に渡すのは `server/config/env.ts` の同じ定数で、
-その定数が正しいことは 34611/34612 に bind したこと自体が示している。
+`MULMOTERMINAL_PORT` について、**測れた範囲と測れていない範囲**（後続の追試で範囲が変わったので、
+ここに最新の切り分けを置く）:
+
+- **測れた**: シェル PTY（`/ws/run`）に `MTPORT=[34614]` / `[34615]` が届くこと。tmux 有り・無しの
+  両方で実測（下の 2 節）。これは `spawnEnvFor` 経由で、**全 PTY 共通の経路**
+- **測れていない**: エージェントセル（claude 等）の env を直接読むこと。`ps eww` が
+  このセッションでは実行できないため。ただしエージェントセルは上の共通経路に加えて
+  `spawn-claude.ts:195` の `guiMcpEnv(sessionId, PORT)` が同じ名前に同じ値を重ねるだけで、
+  その `PORT` は `server/config/env.ts` の同じ定数 —— 正しさは 34611/34612 に bind したこと自体が示す
 
 ## tmux 経路の検証（2026-08-27 追試）
 

--- a/plans/fix-1861-port-env.md
+++ b/plans/fix-1861-port-env.md
@@ -1,0 +1,157 @@
+# fix(cli): PORT を launcher が読み、server へは argv で渡す (#1861 / #1857)
+
+## 症状
+
+- `PORT=34601 npx mulmoterminal` が **34567 で起動する**。`--port` だけが効く (#1861)
+- ポート衝突時のメッセージが、その効かない `PORT=<n>` を使えと言う
+- launcher が置いた生の `PORT` が全 PTY に配られ、セル内の dev サーバーが
+  MulmoTerminal のポートを掴みにいって落ちる (#1857)
+
+両方とも `bin/cli-args.js` の同じ 1 行が発生源。
+
+## 再現（ユニットレベル、2026-08-27 実測）
+
+```
+parsePortArg([], 34567)                        -> {"port":34567,"explicit":false}   # env 完全無視
+serverSpawnEnv({PORT:'34601'}, 34567, '/x')    -> {"PORT":"34567","CLAUDE_CWD":"/x"} # 上書き
+```
+
+## なぜ「MULMOTERMINAL_PORT に改名」では駄目か
+
+`MULMOTERMINAL_PORT` は `server/session/mcp-config.ts:75` が **意図してセル内の全 PTY に配って
+いる**（MCP URL と bundled skills がそれを読む）。server がそれを bind ポートとして読むと、
+セル内で `yarn dev` した瞬間に MulmoTerminal 自身のポートを掴みにいく — #1857 が名前を変えて
+再発するだけになる。
+
+PTY サニタイザで落とす案も採らない。`sanitizePtyEnv` は **ユーザー自身が export した値を残す**
+のが役目で、`NODE_ENV` を #955 で launcher 側に直したのと同じ理由（`test/server/infra/pty-env.spec.ts`
+のコメントが明示している）。
+
+→ **argv で渡す。** argv は PTY に継承されないので leak 面がゼロになる。
+
+## 変更
+
+1. `parsePortArg(args, env, defaultPort)` — 優先順位 **`--port` > `env.PORT` > default**
+   （`bin/room.js:54` が既に持っている順序に合わせる）
+   - env 由来も `explicit: true`。ユーザーがポートを名指ししている以上、埋まっていたときに
+     別ポートで 2 個目を提案するのは訊かれていない質問への答えになる（`--port` と同じ理屈）
+   - 不正値 (`PORT=abc`) は `--port` と同じくエラーで停止。黙って default に落ちるのは
+     「設定したのに効かない」という今回のバグそのもの。**空文字・未設定は default へ**
+2. `serverSpawnEnv(env, cwd)` — `PORT` を足すのをやめる（#1857 の発生源）。
+   ユーザー自身の `PORT` はそのまま通す
+3. `serverNodeArgs(serverEntry, launchDir, port)` — `--port <n>` を script 引数として付ける
+4. `server/config/env.ts` — `portFromArgv(process.argv) ?? process.env.PORT ?? 34567`
+   - launcher 経由: argv が勝つ
+   - `yarn dev` 経由: `PORT`（`vite.config.ts:9` が同じ変数でプロキシ先を決めているので、
+     この経路は従来どおりでなければならない）
+5. `server/infra/server-exit.ts:25` の `set PORT=<n>` は **変更しない**。1 によって
+   launcher 経由でも実際に効くようになるため、メッセージが真になる
+
+## 触らないもの
+
+- `server/session/mcp-config.ts` の `MULMOTERMINAL_PORT`（PTY 向け、正しい）
+- `bin/room.js`（既に `PORT` を読む）
+- `scripts/dev-server-config.js` の `set PORT=<n>`（dev 経路では元から正しい）
+
+## 検証
+
+- ユニット: `parsePortArg` の優先順位・不正値・explicit、`serverSpawnEnv` に `PORT` が無いこと、
+  `serverNodeArgs` が `--port` を entry の **後ろ** に置くこと、`portFromArgv` の純関数テスト
+- 実機: `PORT=<n> node bin/mulmoterminal.js` で起動し、その番号で `GET /` が 200 を返すこと。
+  `--port` が `PORT` に勝つこと。セル内 PTY の env に生の `PORT` が入らないこと
+
+## 追加で分かったこと
+
+- `worktreeEnv` の `{"PORT": {"kind":"port"}}`（`server/config/worktree-env.ts`）は、ディレクトリごとに
+  **意図して** `PORT` を配る opt-in 機能。launcher が生の `PORT` を全 PTY に撒いていた間は、
+  この機能を使っていないディレクトリにも `PORT` が入っていた。今回の変更で「`PORT` が入るのは
+  ユーザーが export したときか、この機能を有効にしたときだけ」になる
+- `bin/room.js` は `Number(process.env.PORT)` で不正値を黙ってデフォルトに落とす。今回 launcher 側だけ
+  厳しくしたので、`PORT=abc mulmoterminal` は止まるが `PORT=abc mulmoterminal room` は 34567 を使う。
+  room は既存サーバに話しかけるだけで bind しないため今回は触っていない（レビュー対象）
+
+## 実機検証（2026-08-27、clean env + scratch HOME で実施）
+
+| 条件 | 結果 |
+|---|---|
+| `PORT=34611`（`--port` なし） | `Starting MulmoTerminal on port 34611` / `GET / -> 200` |
+| `--port 34612` + env に `PORT` なし | `port 34612` / `GET / -> 200` |
+| `PORT=abc` | `Invalid PORT value: "abc" (expected integer 1..65535)`、exit 1、サーバは起動しない |
+| 実 PTY（`/ws/run`）の env | `RAWPORT=[]` — 生の `PORT` が入らないことを実測（#1857） |
+
+`MULMOTERMINAL_PORT` がエージェントセルに届くことは直接は測れていない（`ps eww` が実行できず）。
+`spawn-claude.ts:195` が `guiMcpEnv(sessionId, PORT)` に渡すのは `server/config/env.ts` の同じ定数で、
+その定数が正しいことは 34611/34612 に bind したこと自体が示している。
+
+## tmux 経路の検証（2026-08-27 追試）
+
+初回の実機測定は `env -i` の最小 PATH に tmux が無く、ログに `[tmux] not found` が出ていた
+＝ tmux を通らない直接 spawn しか測れていなかった。`server/infra/tmux.ts` の `SERVER_SOCKET` を
+一時的に `mt-porttest` へ変えて**ユーザーの稼働中 tmux サーバから隔離**し、再測定した。
+
+```
+[tmux] persistence on
+tmux -L mt-porttest show-environment -g | grep -iE '^-?PORT=|^-?MULMOTERMINAL_PORT=|^-?NODE_ENV='
+  -> (何も出ない)
+```
+
+#989 が「ペインは mulmoterminal のプロセスではなく **tmux サーバーの環境**を継承する」と特定した
+その環境に `PORT` が入らないことを確認。テスト後、tmux サーバは kill、ソケット名は復元済み
+（`git diff -- server/infra/tmux.ts` が空であることを確認）。
+
+**残留は別問題として残る。** 修正前の版が起動した tmux サーバが生き残っている場合、そのグローバル
+環境の `PORT` は配られ続ける。#989 は「ユーザー自身が export した値と区別できない」ため
+**自動 scrub しない**方針で CLOSE されており、同じ判断を踏襲するなら回避策の案内になる:
+`tmux -L mulmoterminal set-environment -gu PORT`
+
+## code-review 対応（2026-08-27、`/code-review high`）
+
+5 件の指摘。うち 1 件は**私が入れた本物のリグレッション**だった。
+
+### 1. `mulmoterminal room` がセル内で壊れる（対応済み・最重要）
+
+`bin/room.js:54` はサーバの場所を `process.env.PORT` からしか得ておらず、セル内でのその値の
+唯一の供給源が、今回消した launcher の `PORT` だった。34567 以外で動かしていると `room` は
+**別インスタンスに話しかける**。
+
+対応:
+- `server/session/pty-spawn.ts` の `spawnEnvFor` で **全 PTY** に `MULMOTERMINAL_PORT` を渡す
+  （従来は `guiMcpEnv` 経由でエージェント spawn だけだった）
+- `bin/room.js` の優先順位を `--port` > `MULMOTERMINAL_PORT` > `PORT` > default に
+
+**置き場所を最初 `ptyEnv` にして間違えた。** tmux パスではペインの env が `new-session -e` から
+来るので `ptyEnv` の値は届かない（`ptySpawn` のコメントが明記している）。追加したテストが赤で
+捕まえたので `spawnEnvFor` に移した。両パスがここから作られる。
+
+### 2. ユーザー自身の `PORT` は依然 PTY に届く（仕様として明記）
+
+`export PORT=3000` していると launcher は 3000 に bind し、`serverSpawnEnv` はその `PORT` を
+素通しするので PTY にも入る。セル内の `yarn dev` は 3000 を掴もうとして衝突する。
+ただしこれは #1857 が要求した挙動そのもの（「`PORT` は自分が設定したときだけ入っていてほしい」）で、
+セルはユーザーのシェルと同じ振る舞いをしている。**変更せず、PR に明記する。**
+
+### 3. どこから来た番号か分からない（対応済み）
+
+`.envrc` やシェルプロファイル由来の `PORT` で黙って別ポートに行くのを避けるため、
+`--port` が無く env 由来のときだけ `Port <n> comes from the PORT environment variable` を出す。
+`portInUseAction` の「An explicit --port already named...」という古くなったコメントも直した。
+
+### 4. server 側の不正な `--port` が無言（対応済み）
+
+`server/config/env.ts` で、`--port` があるのに解釈できなかった場合に警告を出す。
+
+### 5. README（対応済み）
+
+`--port <n> (default 34567)` に `PORT` の記載を追加。`printHelp` は先に直していた。
+
+## 再検証（tmux 隔離、2026-08-27）
+
+| 条件 | 結果 |
+|---|---|
+| `PORT=34614`（`--port` なし）+ tmux | `Port 34614 comes from the PORT environment variable` / 34614 で起動 |
+| 同上の実 PTY | `RAWPORT=[34614] MTPORT=[34614]` — 生 PORT はユーザー自身の値、名前空間付きも届く |
+| `--port 34615`、env に `PORT` なし + tmux | `RAWPORT=[] MTPORT=[34615]` — leak 無し、セルはサーバを見つけられる |
+| `MULMOTERMINAL_PORT=34615 mulmoterminal room list` | exit 0（到達） |
+| `MULMOTERMINAL_PORT=34699` で同上 | `could not reach the server at http://localhost:34699` |
+
+ゲート: format / lint / typecheck / build すべて 0、`yarn test` **11438 passed**（+8）。

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -1,11 +1,23 @@
-// Process-wide settings read from the environment. Their own module because the session
-// registry persists under MULMOTERMINAL_HOME and validates ids with SESSION_ID_RE — taking
-// them from index.ts would make the registry import its own importer.
+// Process-wide settings read from the environment (and, for the port, the command line).
+// Their own module because the session registry persists under MULMOTERMINAL_HOME and
+// validates ids with SESSION_ID_RE — taking them from index.ts would make the registry
+// import its own importer.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { portFromArgv } from "./port-from-argv.js";
 
-export const PORT = process.env.PORT || 34567;
+// `--port` is the launcher's channel (see port-from-argv.ts for why it is not an env var).
+// `PORT` is the DEV channel and must stay: `yarn dev` runs server/index.ts directly, and
+// vite.config.ts decides its proxy target from the same variable — the two have to agree.
+const ARGV_PORT = portFromArgv(process.argv);
+// Said out loud rather than swallowed: binding a port nobody asked for is the same class of
+// surprise this whole change is about, and a hand-run `--port $UNSET_VAR` would otherwise
+// diverge from whatever the caller probed or registered, with nothing erring anywhere.
+if (ARGV_PORT === null && process.argv.includes("--port")) {
+  console.warn("[mulmoterminal] ignoring an unusable --port argument (expected integer 1..65535)");
+}
+export const PORT = ARGV_PORT ?? (process.env.PORT || 34567);
 
 // The interface the HTTP server binds to. LOOPBACK BY DEFAULT — this server has no
 // authentication of its own: every /api route, the terminal WebSockets, and the routes that

--- a/server/config/port-from-argv.ts
+++ b/server/config/port-from-argv.ts
@@ -1,0 +1,25 @@
+// The port the LAUNCHER chose, handed over on the command line rather than in the environment.
+//
+// Its own module, and pure, because the alternative is a decision that can only be checked by
+// starting a process on a port.
+//
+// Why argv at all: the server hands its own environment to every PTY it spawns, so a port put
+// there reaches every terminal in every cell — a raw `PORT` made a dev server started in a cell
+// try to take MulmoTerminal's own port (#1857). `MULMOTERMINAL_PORT` cannot stand in for it
+// either: that one is deliberately given to PTYs (server/session/mcp-config.ts) so the MCP URLs
+// and the bundled skills can find the server, so reading it here would clash with ourselves the
+// moment `yarn dev` ran inside a cell. argv is not inherited, so it has no such reach.
+
+const MAX_PORT = 65535;
+
+/** `null` for absent or unusable, so the caller falls through to `PORT` and then the default.
+ *  The launcher validates before it spawns (bin/cli-args.js), so this only has to refuse what
+ *  a hand-run `--port` could carry. */
+export const portFromArgv = (argv: readonly string[]): number | null => {
+  const at = argv.indexOf("--port");
+  if (at === -1) return null;
+  const raw = argv[at + 1];
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed < 1 || parsed > MAX_PORT) return null;
+  return parsed;
+};

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -11,7 +11,7 @@ import { resolvePtyLaunchForEnv } from "../infra/resolve-bin.js";
 import { binaryProblemMessage, diagnoseBinary, type BinaryDiagnosis } from "../infra/has-binary.js";
 import { cwdProblemMessage, diagnoseSpawnCwd, type CwdDiagnosis } from "../infra/spawn-cwd.js";
 import { withoutUnset } from "./provider-env.js";
-import { SESSION_ID_RE } from "../config/env.js";
+import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { reservedWorktreeEnv } from "../config/worktree-env.js";
 import { tmuxAvailable, tmuxHasSession, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 
@@ -48,7 +48,21 @@ export function ptyEnv(unset: readonly string[] = [], extra: Readonly<Record<str
  *
  *  Reserved, never allocated — allocation is async and happens before the spawn (see
  *  config/worktree-env.ts for why a probe at this moment would move a running server's port). */
-const spawnEnvFor = (cwd: string, requested: Readonly<Record<string, string>>): Record<string, string> => ({ ...reservedWorktreeEnv(cwd), ...requested });
+//  MULMOTERMINAL_PORT is first because it is the weakest: it is a fact about this server that
+//  EVERY terminal needs, agent or not. `mulmoterminal room` is a plain CLI a user runs in a shell
+//  cell and it has to reach THIS server rather than whatever holds 34567 — it used to find the
+//  port through the raw `PORT` the launcher gave every PTY, which is the leak #1857 is about and
+//  had to go. It belongs HERE rather than in ptyEnv: a tmux pane's environment comes from
+//  `new-session -e`, which is built from this and not from ptyEnv, so a shell cell under tmux
+//  would otherwise get nothing. guiMcpEnv sets the same name for agent spawns, same value.
+//
+//  Written out, never read back by server/config/env.ts — a `yarn dev` inside a cell would then
+//  bind MulmoTerminal's own port. See config/port-from-argv.ts.
+const spawnEnvFor = (cwd: string, requested: Readonly<Record<string, string>>): Record<string, string> => ({
+  MULMOTERMINAL_PORT: String(PORT),
+  ...reservedWorktreeEnv(cwd),
+  ...requested,
+});
 
 // pty.spawn with the binary as a PARAMETER (never a string literal at the call site),
 // so the tmux/shell/claude spawns aren't flagged as spawn-of-a-string-literal.

--- a/test/bin/cli-args.spec.ts
+++ b/test/bin/cli-args.spec.ts
@@ -18,13 +18,48 @@ import {
 } from "../../bin/cli-args.js";
 
 const DEFAULT_PORT = 34567;
-const port = (args: string[]) => parsePortArg(args, DEFAULT_PORT);
+const port = (args: string[], env: Record<string, string | undefined> = {}) => parsePortArg(args, env, DEFAULT_PORT);
 const cwd = (args: string[], env: Record<string, string | undefined> = {}) => chooseCwd(args, env);
 
 describe("parsePortArg", () => {
-  it("falls back to the default when the flag is absent", () => {
+  it("falls back to the default when neither the flag nor PORT is set", () => {
     expect(port([])).toEqual({ port: DEFAULT_PORT, explicit: false });
     expect(port(["--cwd", "/tmp"])).toEqual({ port: DEFAULT_PORT, explicit: false });
+  });
+
+  // #1861: PORT was read by nothing here, so `PORT=34601 npx mulmoterminal` started on 34567 —
+  // while the busy-port message told the user to set exactly that. The order is bin/room.js's,
+  // so the two entry points of this package cannot disagree about what a port is.
+  describe("PORT from the environment", () => {
+    it("is used when there is no flag", () => {
+      expect(port([], { PORT: "34601" })).toEqual({ port: 34601, explicit: true });
+    });
+
+    it("loses to --port", () => {
+      expect(port(["--port", "3000"], { PORT: "34601" })).toEqual({ port: 3000, explicit: true });
+    });
+
+    // `explicit` decides whether a busy port stops the launch or offers a second instance on
+    // another one. The user named a port either way.
+    it("counts as explicit, so a busy port is not silently swapped for a different one", () => {
+      expect(port([], { PORT: "34601" })).toHaveProperty("explicit", true);
+    });
+
+    // An exported-but-empty PORT is not a value. `??` here would bind port 0.
+    it.each(["", undefined])("falls through to the default for %o", (value) => {
+      expect(port([], { PORT: value })).toEqual({ port: DEFAULT_PORT, explicit: false });
+    });
+
+    // Silently launching on the default is the bug being fixed, not the safe fallback.
+    it.each(["abc", "80x", "0", "65536", "3000.5", "+3000", " 3000"])("refuses %s", (value) => {
+      expect(port([], { PORT: value })).toHaveProperty("error");
+    });
+
+    it("names PORT, not --port, when PORT is the one at fault", () => {
+      const result = port([], { PORT: "80x" });
+      expect("error" in result && result.error).toContain("PORT");
+      expect("error" in result && result.error).not.toContain("--port");
+    });
   });
 
   // `explicit` is what decides whether a busy port is a hard error or a silent retry on
@@ -305,30 +340,38 @@ describe("serverNodeArgs", () => {
   // The gap #795 closes: the dev scripts always passed this flag and the launcher never did,
   // so a key written into .env was silently absent from the server.
   it("reads .env from the launch directory, by absolute path", () => {
-    expect(serverNodeArgs(ENTRY, "/home/u/project")).toContain(`--env-file-if-exists=${path.join("/home/u/project", ".env")}`);
+    expect(serverNodeArgs(ENTRY, "/home/u/project", 34567)).toContain(`--env-file-if-exists=${path.join("/home/u/project", ".env")}`);
   });
 
   // The spawn runs with cwd set to the package directory, so a relative path would be looked
   // for inside node_modules.
   it("does not pass a bare relative .env", () => {
-    expect(serverNodeArgs(ENTRY, "/home/u/project")).not.toContain("--env-file-if-exists=.env");
+    expect(serverNodeArgs(ENTRY, "/home/u/project", 34567)).not.toContain("--env-file-if-exists=.env");
   });
 
-  // A node option after the script path is an argument to the script, not to node.
-  it("keeps every node option ahead of the entry script", () => {
-    const args = serverNodeArgs(ENTRY, "/home/u/project");
-    expect(args[args.length - 1]).toBe(ENTRY);
-    expect(args.filter((a) => a.startsWith("--")).every((a) => args.indexOf(a) < args.indexOf(ENTRY))).toBe(true);
+  // A node option after the script path is an argument to the script, not to node — and that
+  // is exactly what --port has to be, so the entry script is the boundary between the two.
+  it("keeps every node option ahead of the entry script, and --port behind it", () => {
+    const args = serverNodeArgs(ENTRY, "/home/u/project", 34601);
+    const entryAt = args.indexOf(ENTRY);
+    expect(args.slice(0, entryAt).filter((a) => a.startsWith("--"))).toEqual(["--import", `--env-file-if-exists=${path.join("/home/u/project", ".env")}`]);
+    expect(args.slice(entryAt + 1)).toEqual(["--port", "34601"]);
+  });
+
+  // #1857: the port used to travel in the environment, which the server hands to every PTY, so
+  // a dev server started in a cell tried to take MulmoTerminal's own port. argv is not inherited.
+  it("carries the port as a string argument", () => {
+    expect(serverNodeArgs(ENTRY, "/home/u/project", 34601)).toContain("34601");
   });
 
   it("still loads tsx, which is what lets the server entry be TypeScript", () => {
-    expect(serverNodeArgs(ENTRY, "/home/u/p").slice(0, 2)).toEqual(["--import", "tsx"]);
+    expect(serverNodeArgs(ENTRY, "/home/u/p", 34567).slice(0, 2)).toEqual(["--import", "tsx"]);
   });
 
   // No shell is involved in the spawn, so a directory with spaces needs no quoting — and
   // must not get any, or the path would carry literal quote characters.
   it("leaves a launch directory containing spaces as one unquoted argument", () => {
-    const flag = serverNodeArgs(ENTRY, "/home/u/My Projects/app").find((a) => a.startsWith("--env-file"));
+    const flag = serverNodeArgs(ENTRY, "/home/u/My Projects/app", 34567).find((a) => a.startsWith("--env-file"));
     expect(flag).toBe(`--env-file-if-exists=${path.join("/home/u/My Projects/app", ".env")}`);
     expect(flag).not.toContain('"');
   });

--- a/test/bin/env-file-precedence.spec.ts
+++ b/test/bin/env-file-precedence.spec.ts
@@ -67,7 +67,7 @@ describe("node --env-file-if-exists", () => {
     writeFileSync(stub, "console.log(process.env.MT_ONLY_A ?? '<unset>');\n");
     // --import tsx is dropped: this exercises the .env flag, and loading tsx here would only
     // add a dependency on the transform.
-    const args = serverNodeArgs(stub, launchDir).filter((arg) => arg !== "--import" && arg !== "tsx");
+    const args = serverNodeArgs(stub, launchDir, 34567).filter((arg) => arg !== "--import" && arg !== "tsx");
     try {
       const out = execFileSync(process.execPath, args, { cwd: process.cwd(), env: { ...process.env }, encoding: "utf8" });
       expect(out.trim()).toBe("from-launch-dir");

--- a/test/bin/server-spawn-env.spec.ts
+++ b/test/bin/server-spawn-env.spec.ts
@@ -3,22 +3,20 @@
 // it must NOT add. The server hands its own environment to every PTY it spawns, so anything
 // set here is set in every terminal of every cell: NODE_ENV=production shipped from the first
 // npx release until #955, where yarn v1 read it and installed without devDependencies while
-// still printing "Done".
+// still printing "Done". PORT left by the same route until #1857, where a dev server started
+// in a cell read it and tried to take MulmoTerminal's own port.
 import { describe, it, expect } from "vitest";
 import { serverSpawnEnv } from "../../bin/cli-args.js";
 
-const PORT = 34567;
 const CWD = "/Users/u/project";
 
 describe("serverSpawnEnv", () => {
-  it("adds the port as a string and the launch directory", () => {
-    const env = serverSpawnEnv({ HOME: "/Users/u" }, PORT, CWD);
-    expect(env.PORT).toBe("34567");
-    expect(env.CLAUDE_CWD).toBe(CWD);
+  it("adds the launch directory", () => {
+    expect(serverSpawnEnv({ HOME: "/Users/u" }, CWD).CLAUDE_CWD).toBe(CWD);
   });
 
   it("carries the rest of the environment through", () => {
-    const env = serverSpawnEnv({ HOME: "/Users/u", PATH: "/usr/bin", ANTHROPIC_API_KEY: "sk-x" }, PORT, CWD);
+    const env = serverSpawnEnv({ HOME: "/Users/u", PATH: "/usr/bin", ANTHROPIC_API_KEY: "sk-x" }, CWD);
     expect(env.HOME).toBe("/Users/u");
     expect(env.PATH).toBe("/usr/bin");
     expect(env.ANTHROPIC_API_KEY).toBe("sk-x");
@@ -26,20 +24,32 @@ describe("serverSpawnEnv", () => {
 
   // Regression (#955): the whole bug was one extra key here.
   it("does not invent a NODE_ENV", () => {
-    const env = serverSpawnEnv({ HOME: "/Users/u" }, PORT, CWD);
+    const env = serverSpawnEnv({ HOME: "/Users/u" }, CWD);
     expect("NODE_ENV" in env).toBe(false);
-    expect(Object.keys(env).sort()).toEqual(["CLAUDE_CWD", "HOME", "PORT"]);
+    expect(Object.keys(env).sort()).toEqual(["CLAUDE_CWD", "HOME"]);
+  });
+
+  // Regression (#1857): the port travels in argv now (serverNodeArgs), because argv is not
+  // inherited by the PTYs the server spawns.
+  it("does not invent a PORT", () => {
+    expect("PORT" in serverSpawnEnv({ HOME: "/Users/u" }, CWD)).toBe(false);
   });
 
   // The launcher decides what it ADDS. A user who runs their whole shell in one mode keeps it —
   // stripping it here would be the same bug pointed the other way.
   it.each(["production", "development", "test"])("passes a user's own NODE_ENV=%s through untouched", (value) => {
-    expect(serverSpawnEnv({ NODE_ENV: value }, PORT, CWD).NODE_ENV).toBe(value);
+    expect(serverSpawnEnv({ NODE_ENV: value }, CWD).NODE_ENV).toBe(value);
+  });
+
+  // Same rule for PORT, and the half of #1857 that #1861 asked for: a PORT the user exported is
+  // theirs, and every terminal in every cell should see the one they set — not ours.
+  it("passes a user's own PORT through untouched", () => {
+    expect(serverSpawnEnv({ PORT: "3000" }, CWD).PORT).toBe("3000");
   });
 
   it("never mutates the environment it was given", () => {
     const original = { HOME: "/Users/u" };
-    serverSpawnEnv(original, PORT, CWD);
+    serverSpawnEnv(original, CWD);
     expect(original).toEqual({ HOME: "/Users/u" });
   });
 });

--- a/test/bin/server-spawn-env.spec.ts
+++ b/test/bin/server-spawn-env.spec.ts
@@ -6,7 +6,7 @@
 // still printing "Done". PORT left by the same route until #1857, where a dev server started
 // in a cell read it and tried to take MulmoTerminal's own port.
 import { describe, it, expect } from "vitest";
-import { serverSpawnEnv } from "../../bin/cli-args.js";
+import { parsePortArg, serverSpawnEnv } from "../../bin/cli-args.js";
 
 const CWD = "/Users/u/project";
 
@@ -51,5 +51,37 @@ describe("serverSpawnEnv", () => {
     const original = { HOME: "/Users/u" };
     serverSpawnEnv(original, CWD);
     expect(original).toEqual({ HOME: "/Users/u" });
+  });
+});
+
+// The two halves of the launcher's port decision, asserted TOGETHER — which is the only place
+// the #1861/#1857 trade-off is visible. Codex read the passthrough above as the old injection
+// still happening (round 1, P2); what distinguishes them is PROVENANCE, and provenance is a
+// property of the pair, not of either function alone.
+describe("what a launcher-chosen port leaves in the server's environment", () => {
+  const DEFAULT_PORT = 34567;
+
+  // The user's own variable, read as the request AND left alone. A cell then sees exactly what
+  // the shell that launched us saw — which is what #1857 asked for. Stripping it here would be
+  // #955's bug pointed the other way, and it would not free the port we are holding anyway.
+  it("keeps a PORT the user exported, having taken it as the request", () => {
+    const env = { HOME: "/Users/u", PORT: "34601" };
+    expect(parsePortArg([], env, DEFAULT_PORT)).toEqual({ port: 34601, explicit: true });
+    expect(serverSpawnEnv(env, CWD).PORT).toBe("34601");
+  });
+
+  // Regression (#1857): with no PORT in the user's shell, nothing invents one. The port the
+  // launcher chose travels in argv (serverNodeArgs), which no pty inherits.
+  it("adds no PORT of its own when the port came from --port", () => {
+    const env = { HOME: "/Users/u" };
+    expect(parsePortArg(["--port", "34601"], env, DEFAULT_PORT)).toEqual({ port: 34601, explicit: true });
+    expect("PORT" in serverSpawnEnv(env, CWD)).toBe(false);
+  });
+
+  // And --port winning does NOT turn into a licence to strip: the user's variable is still theirs.
+  it("keeps the user's PORT even when --port overrode it as the request", () => {
+    const env = { HOME: "/Users/u", PORT: "3000" };
+    expect(parsePortArg(["--port", "34601"], env, DEFAULT_PORT)).toEqual({ port: 34601, explicit: true });
+    expect(serverSpawnEnv(env, CWD).PORT).toBe("3000");
   });
 });

--- a/test/server/config/port-from-argv.spec.ts
+++ b/test/server/config/port-from-argv.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+// The launcher → server port channel. It is argv rather than an env var because the server
+// hands its own environment to every PTY, so a port set there reaches every terminal in every
+// cell — which made a dev server started in a cell try to take MulmoTerminal's own port
+// (#1857). `MULMOTERMINAL_PORT` cannot stand in: that one is given to PTYs on purpose.
+import { describe, it, expect } from "vitest";
+import { portFromArgv } from "../../../server/config/port-from-argv";
+
+// The shape node actually hands over: execPath, script, then the script's own arguments.
+const argv = (...rest: string[]) => ["/usr/bin/node", "/pkg/server/index.ts", ...rest];
+
+describe("portFromArgv", () => {
+  it("reads the port the launcher passed", () => {
+    expect(portFromArgv(argv("--port", "34601"))).toBe(34601);
+  });
+
+  // null, not the default: the caller falls through to PORT and only then to 34567, and
+  // deciding the default here would take the dev channel away.
+  it("is null when no --port was passed", () => {
+    expect(portFromArgv(argv())).toBeNull();
+    expect(portFromArgv(argv("--other", "x"))).toBeNull();
+  });
+
+  it.each([1, 80, 1024, 65535])("accepts %i", (value) => {
+    expect(portFromArgv(argv("--port", String(value)))).toBe(value);
+  });
+
+  // parseInt stops at the first non-digit, so "80x" would otherwise bind port 80.
+  it.each(["0", "65536", "-1", "80x", "3000.5", "0300", "+3000", " 3000", "0x1f90", ""])("refuses %o", (value) => {
+    expect(portFromArgv(argv("--port", value))).toBeNull();
+  });
+
+  it("refuses a --port at the very end, with no value after it", () => {
+    expect(portFromArgv(argv("--port"))).toBeNull();
+  });
+
+  // Otherwise "--port --cwd /tmp" would bind whatever "--cwd" parsed to.
+  it("refuses the next flag as a value", () => {
+    expect(portFromArgv(argv("--port", "--cwd", "/tmp"))).toBeNull();
+  });
+});

--- a/test/server/roomCli.spec.ts
+++ b/test/server/roomCli.spec.ts
@@ -41,6 +41,49 @@ describe("room CLI arguments", () => {
     expect(portForTest(["post", "r", "--", "try", "--port", "9999"])).not.toBe(9999);
     expect(portForTest(["post", "r", "--port", "34599", "hello"])).toBe(34599);
   });
+
+  // Run INSIDE a cell, `room` has to reach the server that owns the cell. It used to find it
+  // through the raw `PORT` the launcher gave every PTY — the leak #1857 is about, now gone — so
+  // the namespaced name every terminal gets (server/session/pty-spawn.ts) has to be preferred.
+  // Without this, `room` in a cell of a server on 34601 talks to whatever holds 34567.
+  describe("which server it talks to", () => {
+    const saved = { mt: process.env.MULMOTERMINAL_PORT, port: process.env.PORT };
+    const set = (mt?: string, port?: string) => {
+      if (mt === undefined) delete process.env.MULMOTERMINAL_PORT;
+      else process.env.MULMOTERMINAL_PORT = mt;
+      if (port === undefined) delete process.env.PORT;
+      else process.env.PORT = port;
+    };
+    afterEach(() => set(saved.mt, saved.port));
+
+    it("prefers MULMOTERMINAL_PORT, which is what a cell is given", () => {
+      set("34601", undefined);
+      expect(portForTest(["list"])).toBe(34601);
+    });
+
+    // A user's own PORT is not this server's port; ours wins where both are present.
+    it("prefers MULMOTERMINAL_PORT over a PORT the user exported for something else", () => {
+      set("34601", "3000");
+      expect(portForTest(["list"])).toBe(34601);
+    });
+
+    // Kept behind it for someone running `room` in their own shell against a server they moved
+    // with PORT=<n> — the same variable the launcher now reads (#1861).
+    it("falls back to PORT outside a cell", () => {
+      set(undefined, "34602");
+      expect(portForTest(["list"])).toBe(34602);
+    });
+
+    it("--port still beats both", () => {
+      set("34601", "3000");
+      expect(portForTest(["list", "--port", "34603"])).toBe(34603);
+    });
+
+    it("falls back to the default when neither is set", () => {
+      set(undefined, undefined);
+      expect(portForTest(["list"])).toBe(34567);
+    });
+  });
 });
 
 // What the parser decides is only half of it — CodeRabbit asked for the REQUEST. This asserts the

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -43,6 +43,7 @@ const S1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
 const S2 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2";
 
 const { spawnPty, ptySpawn, ptyWouldReattach, TMUX_CLIENT_CWD } = await import("../../../server/session/pty-spawn.js");
+const { PORT } = await import("../../../server/config/env.js");
 
 const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
 const cwdOf = (call: number = 0): string => (spawn.mock.calls[call] as unknown as [string, string[], { cwd: string }])[2].cwd;
@@ -75,6 +76,30 @@ describe("spawnPty — the environment it hands the pty", () => {
   it("leaves the environment alone when nothing is named", () => {
     spawnPty("claude", [], EXISTING_CWD);
     expect(envOf().ANTHROPIC_API_KEY).toBe("sk-ant-leftover");
+  });
+});
+
+// Every terminal, not only the agent ones. `mulmoterminal room` is a plain CLI a user runs in a
+// shell cell and it has to reach THIS server: it used to find the port through the raw `PORT` the
+// launcher exported to every PTY, which is the leak #1857 is about and had to go. guiMcpEnv still
+// sets the same name on agent spawns, with the same value.
+describe("spawnPty — the port a terminal can find this server on", () => {
+  it("gives every terminal MULMOTERMINAL_PORT, agent or not", () => {
+    spawnPty("zsh", [], EXISTING_CWD);
+    expect(envOf().MULMOTERMINAL_PORT).toBe(String(PORT));
+  });
+
+  // Regression (#1857): the generic name is what a third-party dev server reads.
+  it("does not put the port under the generic PORT name", () => {
+    spawnPty("zsh", [], EXISTING_CWD);
+    expect(envOf()).not.toHaveProperty("PORT");
+  });
+
+  it("reaches a tmux pane too, where the environment comes from -e", () => {
+    tmuxOn = true;
+    ptySpawn(S1, "claude", [], EXISTING_CWD, true);
+    const args = (spawn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(args).toContain(`MULMOTERMINAL_PORT=${PORT}`);
   });
 });
 


### PR DESCRIPTION
## Summary

`PORT=34601 npx mulmoterminal` が **34567 で起動していた** (#1861)。`parsePortArg` が env を一切見ておらず、`serverSpawnEnv` がユーザーの `PORT` を上書きしていたため。そして「ポートが埋まっています」のメッセージが、その効かない `PORT=<n>` を使えと言っていた。

**同じ 1 行が反対向きにも壊れていた。** 生の `PORT` が全 PTY に配られ、セル内で起動した dev サーバーが MulmoTerminal 自身のポートを掴みにいって落ちる (#1857)。#1861 が inbound、#1857 が outbound で、原因は `serverSpawnEnv` の `PORT: String(port)` 一行。片方だけ直すともう片方が別の壊れ方をするので、まとめて直した。

| 変更 | 場所 |
|---|---|
| 優先順位を `--port` > `PORT` > default に（`bin/room.js` と同じ順序） | `bin/cli-args.js` |
| `serverSpawnEnv` が `PORT` を足すのをやめる | `bin/cli-args.js` |
| ポートを **argv** で server に渡す | `bin/cli-args.js`, `bin/mulmoterminal.js` |
| server 側の読み取り（純関数を新設） | `server/config/env.ts`, `server/config/port-from-argv.ts` |
| 全 PTY に `MULMOTERMINAL_PORT` を渡す | `server/session/pty-spawn.ts` |
| `room` の優先順位 `--port` > `MULMOTERMINAL_PORT` > `PORT` > default | `bin/room.js` |

`server/infra/server-exit.ts` の `set PORT=<n>` は**変更していない**。launcher が実際に `PORT` を読むようになったので、メッセージが真になったため（issue の suggested fix 3 は 1 によって不要になった）。

## Items to Confirm / Review

**1. `MULMOTERMINAL_PORT` への改名を採らなかった理由。** issue の suggested fix はそれを提案していますが、採ると**バグが移動するだけ**です。`MULMOTERMINAL_PORT` は `server/session/mcp-config.ts` が MCP URL のために**意図してセル内の PTY に配っている**名前で、server が bind ポートとしてそれを読むと、セル内で `yarn dev` した瞬間に自分自身と衝突します。argv は PTY に継承されないので leak 面がゼロになる、というのが選んだ根拠です。ここは判断が分かれうるので見てください。

**2. ユーザー自身が `export PORT=3000` している場合、その `PORT` は依然 PTY に届きます。** launcher は 3000 に bind し、セル内の `yarn dev` も 3000 を掴もうとして衝突します。ただしこれは #1857 が要求した挙動そのもの（「`PORT` は自分が設定したときだけ入っていてほしい」）で、セルがユーザーのシェルと同じに振る舞っている状態です。**意図的に直していません。**

**3. env 由来の `PORT` を `--port` と同じ「explicit」扱いにしました。** ポートが埋まっていたとき、別ポートで 2 個目を提案せずエラーで止まります。`PORT` を常時 export している人は、2 個目起動時のプロンプトが出なくなります。

**4. 不正な `PORT`（`PORT=abc`）はエラーで停止します。** 黙ってデフォルトに落ちるのは「設定したのに効かない」という今回のバグそのものなので。`bin/room.js` の**不正値の扱いは**従来どおり黙ってデフォルトに落ちます（bind せず既存サーバに話しかけるだけなので、そこは触っていません）。ただし room の**優先順位そのものは変更しています** —— `--port` > `MULMOTERMINAL_PORT` > `PORT` > default。理由は Summary の表と、下の「実装のアプローチ」を参照。

**5. 残留は直りません。** 修正前の版が起動した tmux サーバが生き残っていると、そのグローバル環境の `PORT` が新規ペインに配られ続けます。#989 は「ユーザー自身が export した値と区別できない」ため**自動 scrub しない**方針で CLOSE されており、同じ判断を踏襲しました。回避策は `tmux -L mulmoterminal set-environment -gu PORT`。ガイドに一行入れるべきなら別 PR で。

**6. `spawnEnvFor` の `MULMOTERMINAL_PORT` は最弱の優先度に置いています。** ディレクトリが `worktreeEnv` で同名を宣言すると上書きできます（`MULMOTERMINAL_SESSION` と同じ既存の穴で、今回広げても狭めてもいません）。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1861 なおせる？
- 修正範囲は「#1861 + #1857 を argv で」。env の `PORT` は `--port` と同じ explicit 扱いにする。`PORT=abc` のような不正値はエラーで止める
- https://github.com/receptron/mulmoterminal/issues/1857 これって一緒？
- できれば確認して review
- PR

## 実装のアプローチ

**なぜ argv なのか。** サーバは自分の環境を全 PTY に渡すので、そこに置いたポートは全セルの全ターミナルに入ります。`NODE_ENV` が #955 で同じ経路を通って同じ壊れ方をし、**launcher 側で直す**と決着しています（`test/server/infra/pty-env.spec.ts` のコメントが「PTY サニタイザで落とすのはユーザー自身の値を奪うので違う」と明記）。`PORT` も同じ判断。ただし `PORT` は launcher が server に伝える必要があるので、経路自体を env の外——argv——に移しました。

**`PORT` は dev 経路の契約なので残します。** `yarn dev` は `server/index.ts` を直接動かし、`vite.config.ts:9` が同じ `PORT` で proxy 先を決めています。なので `env.ts` は `argv > PORT > 34567`。`??` ではなく `(process.env.PORT || 34567)` にしてあるのは、`PORT=""` が `??` だとポート 0 に bind してしまうためです。

**`room` の件はレビューで見つかった、この変更が入れたリグレッションです。** `bin/room.js:54` はサーバの場所を `process.env.PORT` からしか得ておらず、セル内でのその唯一の供給源が消した行でした。34567 以外で動かしていると `room` が別インスタンスに話しかけます。全 PTY に `MULMOTERMINAL_PORT` を配り、`room` にそれを優先させて解決。なお最初 `ptyEnv` に置いて間違えました——tmux パスではペインの env が `new-session -e` から来るので届かず、追加したテストが赤で捕まえたので `spawnEnvFor` に移しています。

設計判断と検証の全記録は [`plans/fix-1861-port-env.md`](plans/fix-1861-port-env.md)。

## 検証

ユニットだけでなく、**clean env + scratch HOME で実際に起動**して確認しています（tmux ありの測定は、`SERVER_SOCKET` を一時的に変えて稼働中の tmux サーバから隔離して実施。ソケット名は復元済み）。

| 条件 | 結果 |
|---|---|
| `PORT=34611`（`--port` なし） | `Starting MulmoTerminal on port 34611` / `GET / → 200` |
| `--port 34612`、env に `PORT` なし | `port 34612` / `GET / → 200` |
| `PORT=abc` | `Invalid PORT value: "abc" (expected integer 1..65535)`、exit 1、起動しない |
| `PORT=34614` + tmux → 実 PTY | `RAWPORT=[34614] MTPORT=[34614]`（生 PORT はユーザー自身の値） |
| `--port 34615`、env に `PORT` なし + tmux → 実 PTY | `RAWPORT=[] MTPORT=[34615]` — **leak 無し、セルはサーバを見つけられる** |
| tmux サーバのグローバル env | `PORT` / `MULMOTERMINAL_PORT` / `NODE_ENV` いずれも無し |
| `MULMOTERMINAL_PORT=34615 mulmoterminal room list` | exit 0（到達） |
| `MULMOTERMINAL_PORT=34699` で同上 | `could not reach the server at http://localhost:34699` |

`yarn format` / `lint` / `typecheck` / `build` すべて 0。`yarn test` は **commit `77db6135` の時点で 11438 passed**（sha に紐づけた事実なので、あとからテストが増えても嘘になりません）。

> この PR はその後 `/codex-cross-review` を通しています。ラウンドごとの指摘・反論・決着はこのスレッドのコメントに逐語で残してあり、最終的な数値はループ終了時の報告コメントにあります。

Closes #1861
Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the server port through `PORT` when `--port` is not provided.
  * `--port` takes precedence over environment settings, with validation for invalid values.
  * Terminal sessions and commands run inside terminal cells now reliably connect to the correct server port.
* **Bug Fixes**
  * Improved port-conflict handling and warnings for unusable port arguments.
* **Documentation**
  * Updated CLI help and README guidance for port configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
