### PR TITLE
chore: @receptron/sharedapp を 0.32.0 に上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.31.0",
+    "@receptron/sharedapp": "^0.32.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.31.0.tgz#9eabefc805828ded8658a1d2ea600ef116f1a09f"
-  integrity sha512-GANJabqpQMEM4OVZLjHwlQKI50MzzHdNFaGzWqZEkX0bEj6wxPKeWyz3eBAXa2Y+SqFTVoGU5KB1RgW1tlSo1w==
+"@receptron/sharedapp@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.32.0.tgz#bcc1631bbe8876640d9d3c14a855358c4403b6d8"
+  integrity sha512-iUzQC2MmIrKE3O8KJtdsx/qEjyyIDAFt2pK/XLLS9ruUrk5zmrB2oegAl1sMOg1yaSkb8M/8be5f3iwIV1fP+w==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
`article.byline` を受け付けるための版上げです。

宣言のスキーマは `.strict()` なので、これを上げないと **MulmoTerminal 自身の `check` / `publish` が `byline` を断ります** —— 描くのは mulmoserver でも、著者が publish するのはこちら側なので、この 1 行が無いと署名を宣言したアプリは公開できません。

MulmoTerminal は記事ビューを**描きません**（ペインが描くのは著者が書いた HTML だけで、`views[].type` のページはファイルを持たない）。なので変更は依存の版だけです。

11,396 pass / 0 fail、typecheck・lint とも 0。

順番: receptron/sharedapp#66 をマージして 0.32.0 を公開 → receptron/mulmoserver#248 とこれの `yarn.lock` を更新 → CI 緑。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared application dependency to version 0.32.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->