### PR TITLE
公開のトップページをアプリに返す（プレビュー側と計画）

### DIFF
--- a/common/sharedAppPreview.ts
+++ b/common/sharedAppPreview.ts
@@ -105,6 +105,15 @@ export interface SharedAppPreview {
    *  reads as "your declaration is wrong" about a declaration that is fine. That shipped once
    *  (2026-08-14) and cost an author a debugging session pointed at the wrong repository. */
   submit: Record<string, { createFields: string[] }>;
+  /** The collection whose records the platform draws as ARTICLES, when this app publishes any.
+   *
+   *  Carried for the same reason `submit` is: the PARENT judges an `open` against it, and the pane
+   *  hands it to `viewParent` as `articleCid`. Absent on every app that publishes no articles,
+   *  where a page asking to open one is refused because there is no such page to reach.
+   *
+   *  It is what a page's index links THROUGH — a sandboxed frame cannot navigate for itself — so an
+   *  app whose front page is a list of headlines has all of them dead without it. */
+  articleCid?: string;
   /** Every page this publish would put live, public first. */
   pages: PreviewPage[];
   /** Whether this publish would leave the app open to anonymous visitors. False is normal: an app

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.32.0",
+    "@receptron/sharedapp": "^0.33.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/plans/feat-shared-app-app-owned-index.md
+++ b/plans/feat-shared-app-app-owned-index.md
@@ -1,0 +1,152 @@
+# 公開のトップページをアプリに返す
+
+共有アプリが記事を出せるようになった（`plans/feat-shared-app-articles.md`）。そのとき
+`views[].type: "article"` に**住所を 2 つ**渡してしまった。この計画はその 1 本を返す。
+
+## いま起きていること
+
+| 住所 | いま描くもの | 誰のものであるべきか |
+|---|---|---|
+| `/a/{slug}` | プラットフォームの索引 | **アプリ** |
+| `/a/{slug}/{id}` | プラットフォームの記事ページ | プラットフォーム |
+
+`appViews.ts` の `viewSourceProblems` は **`path` と `type` の同時宣言を断る** — 「a view is
+either HTML you wrote or a page the platform draws, and publishing would have to choose one
+silently」。そして `viewAudienceProblems`（同 243）は public ビューをアプリに 1 つしか許さない。
+2 つ合わせると、**記事を出すアプリは公開の顔を丸ごと手放す**。表紙も、About も、セクションの
+ナビも、刊行物としての体裁も置けない。プラットフォーム上の記事アプリは全部おなじページになる。
+
+断り文句の *「publishing would have to choose one silently」* が真なのは、`type` が**両方の
+住所を取っているから**でしかない。前提のほうが動く。
+
+## 2 つの半分は等価ではない
+
+**記事ページはプラットフォームのもの**である。markdown は sandbox の外・この origin で
+`v-html` されるので、`mulmoserver/src/utils/articleMarkdown.ts`（`marked` → `DOMPurify`、生 HTML は
+パーサで落とし、`class` は剥がす）が**セキュリティ境界そのもの**になっている。手書きページに
+渡せる代物ではない。サインアウトで描けて共有できる URL でもある。
+
+**索引はそうではない。** ただのレコードの一覧で、手書きの公開ページは**同じ datasets を
+すでに受け取っている**。プラットフォームが持つ理由がない。
+
+## 決めたこと
+
+### D1 プラットフォームは索引を描くのをやめる
+
+`/a/{slug}` は**常に**アプリの HTML。`PublicArticles.vue` の索引の枝は消える。記事ページと
+「その id の記事は無い」の枝だけが残る。
+
+### D2 `views[].type` は語彙から消し、`article` ブロック単独が宣言になる
+
+```json
+{ "id": "public", "audience": "public",
+  "path": "views/home.html",
+  "collections": ["articles"],
+  "article": { "title": "title", "body": "body", "byline": "byline" } }
+```
+
+`article` があること＝**このコレクションのレコードは `/a/{slug}/{id}` で markdown として
+描かれる**。`type` は「何がこのページを描くか」を言う鍵だったが、描くのは `path` に戻るので
+言うことが無くなる。今日の `article` without `type` の拒否（`appViews.ts:190`）は**逆になる**。
+
+`type` は残さず消す。ただし **`.strict()` の "Unrecognized key" ではなく、名指しの拒否**を出す:
+`type` を消して `path` を足せ、と著者の言葉で言う。
+
+### D3 `path` はすべてのビューで必須
+
+`viewSourceProblems` は「`path` か `type` のどちらか片方」から「`path` が要る」に縮む。
+記事だけ出したいアプリも索引 HTML を書く — それがこの計画の払う代金であり、目的でもある。
+
+### D4 protocol はバンプしない
+
+`protocolFor` は `type` の代わりに `article` を見る。記事アプリは 2.0.0 のまま、それ以外は
+1.0.0 のまま。
+
+**古い reader がこの形をどう読むか**は数えてある: `path` は 1.0.0 から知っている鍵なので、
+**アプリ自身の HTML を描く**。知らないのは `article` だけで、その結果は `/a/{slug}/{id}` に
+記事が出ないこと — 劣化であって、別のアプリを見せることではない。索引の位置に生成フォームが
+出る（＝major を上げた理由）とは種類が違う。
+
+### D5 新しい橋の動詞 `view.open(cid, id)`
+
+フレームは **`sandbox="allow-scripts"` のみ**（`mulmoserver/src/components/AppPageFrame.vue:34`）。
+`allow-top-navigation` も `allow-popups` も無く、自己ナビゲーションには backstop がある。
+**アプリの表紙から記事ページへリンクが張れない。** これがこの計画の唯一の新語彙。
+
+`href` を親が横取りして解釈する案は採らない。ページが書いた文字列を読んで挙動を決めるのは、
+この一族がずっと断ってきた形（mulmoterminal の CLAUDE.md、ランチャーチップの項）である。
+**宣言された動詞にする。**
+
+- ページ: `await view.open("articles", "my-slug")`
+- 線: `{ type: "mc-public-view:open", cid, id, requestId }`
+- 親: `cid` が `article` を宣言したコレクションであることを確かめ、`/a/{slug}/{id}` へ push
+
+**slug はページが名乗らない。** 親が持っている。だからページはこのアプリの外へ人を送れない —
+構造で保証される。
+
+### D6 `open` は答えが返る
+
+`{ opened: boolean; reason?: OpenRefusal }`。`unknown-collection` / `invalid-id` /
+`no-navigation`。最後のが要るのは、**navigate ポートを持たない親が実在する**から:
+MulmoTerminal のプレビューのペイン。ペインは `opened: false` を返し、押されたことを診断ログに
+書く（「ページが `articles/my-slug` を開こうとした」）。本番では push が走ってこの文書は
+置き換わるので、promise は通常 settle しない — それは**リンクの意味論**であって、契約の穴では
+ない。ページはこれを `await` してから何かする書き方をしない。
+
+### D7 この回は public だけ
+
+`/m/{slug}` のデスクから公開記事を開くのは同じ動詞で足りるが、親が別（`AppViewFrame.vue`）
+なので別の回にする。
+
+### D8 `theme` は `article` を見る
+
+`themeProblems`（`publishChecks.ts:1673`）は「プラットフォームが描くページが 1 つも無いのに
+`theme` がある」を断っている。描くページは記事ページとして残るので、条件を `type` から
+`article` に付け替える。
+
+### D9 記事コレクションはアプリに 1 つのまま
+
+`/a/{slug}/{id}` に「どのコレクションか」を書く場所が無い（`appViews.ts:199` の理由）。
+2 本目の markdown コレクション（About ページなど）は **URL を 1 段深くする決定**と一緒に、
+別の回に。
+
+### D10 既存の 2 本は著者が直す
+
+`~/git/ai/apps/blogs`（`ai-notes`）と `~/git/ai/apps/ai-blogs`（`ai-journal`）は、
+`type` を消して `path` に索引ページを足す。互換の受け皿は作らない（依頼どおり）。
+
+## リポジトリごとの作業
+
+**`sharedapp`（先）**
+
+- `publishManifest.ts` — `ViewZ.type` を消す
+- `appViews.ts` — `NormalizedView.type` を消す / `viewSourceProblems` を `path` 必須に /
+  `type` を名指しで拒否 / `articleCollectionProblems` を `article` で判定
+- `appProtocol.ts` — `protocolFor` が `article` を見る
+- `publishChecks.ts` — `articleCostProblems` / `articleRefProblems` / `themeProblems` を
+  `article` で判定
+- `publishProject.ts` — 射影から `type` を落とす
+- `view/protocol.ts` — `VIEW_MESSAGE.open` / `openResult`
+- `view/message.ts` — `readOpenMessage` / `OpenAsk` / `OpenRefusal` / `OpenAnswer`
+- `view/parent.ts` — `navigate` ポート（optional）と、無い親の `no-navigation`
+- `view/bridge.ts` — `BridgePorts.navigate`
+- `view/srcdoc.ts` — `view.open(cid, id)`
+
+**`mulmoserver`（次）**
+
+- `PublicArticles.vue` — 索引の枝を削除
+- `PublicApp.vue` — `/a/{slug}` は常に `AppPageFrame`、`/a/{slug}/{articleId}` が
+  `PublicArticles`。`navigate` ポートを渡す
+- `publicViewConfig.ts` — `type` を見るのをやめる
+
+**`mulmoterminal`（最後）**
+
+- プレビューのペイン — `open` を受けて診断に書く（`no-navigation` を返す）
+- `server/skills/mulmoterminal-shared-app` — 記事アプリの書き方が変わる
+- テンプレート `magazine.md` を（改めて）書くならこの形で
+
+## 範囲外
+
+- 2 本目の markdown コレクション（D9）
+- member / participant のページからの `open`（D7）
+- 記事ページ自体の見た目（`plans/feat-shared-app-articles.md` のまま）

--- a/server/backends/sharedApp/preview.ts
+++ b/server/backends/sharedApp/preview.ts
@@ -550,6 +550,11 @@ export async function previewSharedApp(root: string, opts: SharedAppOptions = {}
     ok: true,
     aid,
     submit: submitDeclarations(face.config),
+    // WHICH collection the platform draws as articles, resolved by the projection rather than
+    // re-derived here: `articleCid` in the package settles the single-collection case once, and a
+    // second answer computed in the preview is how a pane comes to refuse an `open` the published
+    // page performs.
+    ...(face.config.view?.article === undefined ? {} : { articleCid: face.config.view.article.collection }),
     config: face.config,
     form,
     writes,

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -78,6 +78,7 @@ async function respondPreview(req: Request, res: Response): Promise<void> {
   const preview: SharedAppPreview = {
     aid: result.aid,
     submit: result.submit,
+    ...(result.articleCid === undefined ? {} : { articleCid: result.articleCid }),
     pages: result.pages,
     publicOpen: result.publicOpen,
     fromLiveApp: result.fromLiveApp,

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -301,6 +301,53 @@ The rules are not the obstacle here and do not need working around: a submitter 
 their own row (`emailField`, or `idFrom: "auth.uid"`). What is missing in that third case is a page
 they are allowed to open. `participantRead` does not fix it.
 
+### 2c-2. If the app publishes ARTICLES, the platform draws ONE page and you draw the rest
+
+An `article` block on the public view says "this collection's records are markdown, and the platform
+draws one of them at **`/a/{slug}/{id}`**":
+
+```json
+{ "id": "public", "audience": "public",
+  "path": "views/home.html",
+  "collections": ["articles"],
+  "article": { "title": "title", "body": "body", "summary": "summary", "byline": "byline" } }
+```
+
+**`path` is still required, and the page it names is the front page.** `/a/{slug}` is yours — the
+index, the masthead, the sections, an About. It is handed the same datasets any public page gets, so
+the list of articles is a loop over records you write however the publication should look. The
+platform draws the article itself because markdown is rendered on the host's own origin without a
+sandbox, which makes the render a security boundary rather than a layout.
+
+**Link an entry to its article with `view.open(cid, id)`.** A published page is
+`sandbox="allow-scripts"` and nothing else, so an `<a href>` out of it is inert — no top navigation,
+no popups. The page names a RECORD and the host builds the address, which is also why a page cannot
+send a reader anywhere but into an article of its own app.
+
+```js
+card.addEventListener("click", () => { view.open("articles", record.id); });
+```
+
+It answers `{ opened, reason }` and **usually does not answer at all**, because a navigation that
+happened took the document with it. `opened: false` with `reason: "no-navigation"` is a host that
+does not navigate — the preview pane, where the log line says the page asked — and there is nothing
+for the page to do about it. Do not `await` it and then act.
+
+Four more things this shape settles:
+
+- **`collection` inside the `article` block**, when the view names more than one collection. With
+  one, it is inferred. `/a/{slug}/{id}` carries nothing that says which collection an id is in.
+- **`summary` is the article's standfirst**, under the title. Your index draws its own summaries out
+  of the records, so the two are not the same line.
+- **`byline` is a string somebody typed**, not an identity the rules hold. Never put an address in
+  it — the field is drawn to the whole world.
+- **`theme.hue` colours the article page and nothing else.** Your own pages carry their own CSS, and
+  publish refuses `theme` on an app that declares no `article` block.
+
+`type: "article"` is REFUSED. It used to mean "the platform draws this page", and it took the index
+with it — an app that published articles had no public face of its own. If you meet one in an
+existing `app.json`: delete `type`, keep `article`, add `path`.
+
 ### 2d. If an AGENT is going to sit at this app, give it a written job
 
 A page tells a person what the app is for. Nothing told an **agent** — an LLM at another

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -20,8 +20,9 @@
 // a role may WRITE is not tested; nobody else exists, so nothing here is concurrent; and it cannot
 // tell whether the Firestore rules a new declaration needs have been deployed at all.
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from "vue";
-import { portChannel, publicViewSrcdoc, viewNonce, viewParent, VIEW_MESSAGE, type LookupAsk, type PendingSubmit } from "@receptron/sharedapp/view";
+import { portChannel, publicViewSrcdoc, viewNonce, viewParent, VIEW_MESSAGE, type PendingSubmit } from "@receptron/sharedapp/view";
 import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "../utils/fetchWithTimeout";
+import { lookupOwnRow } from "../utils/sharedAppPreviewLookup";
 import { isRecord } from "../../common/isRecord";
 import { createPreviewLog, renderPreviewLog, type PreviewLogEvent } from "../utils/sharedAppPreviewLog";
 import { useUpdateStatus } from "../composables/useUpdateStatus";
@@ -182,25 +183,6 @@ const recover = () => window.setTimeout(() => void load(), 0);
  *  pinned without a frame. */
 const sendIntent = createIntentSender({ page: () => page.value, url: () => writeUrl("intent"), remember, refresh, recover });
 
-/** "Have I already got this row?", asked of the server for the one key the page names.
- *
- *  A REJECTION is the honest failure and `{ found: false }` is not: a refused read, an app that has
- *  never been published and a collection whose ids cannot be built from a key are all "nobody
- *  looked", and the parent turns a rejection into exactly that. Answering "no" instead would tell
- *  the author's page that they have not submitted, and it would stop offering an action they are
- *  entitled to. */
-async function lookupOwn(ask: LookupAsk): Promise<{ found: boolean; record?: Record<string, unknown> }> {
-  const res = await fetchWithTimeout(
-    writeUrl("lookup"),
-    { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ cid: ask.cid, key: ask.key }) },
-    SLOW_COMMAND_TIMEOUT_MS,
-  );
-  const body: unknown = await res.json();
-  if (!isRecord(body) || body.ok !== true) throw new Error("nothing could be looked up");
-  const record = isRecord(body.record) ? body.record : undefined;
-  return { found: body.found === true, ...(record === undefined ? {} : { record }) };
-}
-
 /** ONE PARENT, for whichever page is on screen.
  *
  *  There were two — the package's public bridge for `/a/`-style pages and its member bridge for the
@@ -260,7 +242,13 @@ const parent = viewParent(
     // "Have I already got this row?", for the one key the page names — the half `mine` cannot
     // cover, because a composite id has no range the rules will list. A REJECTION here is answered
     // `known: false`, which is the honest "nobody looked".
-    lookup: (ask) => lookupOwn(ask),
+    lookup: (ask) => lookupOwnRow(writeUrl("lookup"), ask),
+    // THE WAY OUT OF THE FRAME, which this pane does not take — see the `open` entry in
+    // `sharedAppPreviewLog.ts` for why the line matters more here than the navigation.
+    navigate: (ask) => {
+      remember({ kind: "open", cid: ask.cid, id: ask.id });
+      return false;
+    },
     // A DEFECT OF OURS — a port rejected, or threw before it could answer. The page has already
     // been told `ok: false` with a fixed code and never sees this; what is left is whether the
     // author does. It goes in the same log as everything else the pane collects, as a `host` line:
@@ -278,7 +266,10 @@ const parent = viewParent(
   // `unknown-collection`, which reads as "the cid your page submits to is not declared" about a
   // declaration that is correct. That shipped, and it sent an author debugging the wrong
   // repository: the page was fine, the app was fine, and the preview was the only thing wrong.
-  () => (payload.value === null ? null : { submit: payload.value.submit }),
+  () =>
+    payload.value === null
+      ? null
+      : { submit: payload.value.submit, ...(payload.value.articleCid === undefined ? {} : { articleCid: payload.value.articleCid }) },
   () => nonce.value,
   cells,
 );

--- a/src/components/SharedAppPreview.vue
+++ b/src/components/SharedAppPreview.vue
@@ -183,6 +183,26 @@ const recover = () => window.setTimeout(() => void load(), 0);
  *  pinned without a frame. */
 const sendIntent = createIntentSender({ page: () => page.value, url: () => writeUrl("intent"), remember, refresh, recover });
 
+/** The declaration the PARENT judges an ask against: what may be submitted, and the one collection
+ *  `view.open` may name.
+ *
+ *  THE REAL DECLARATION, never an empty map. An empty one does not switch the check off — it makes
+ *  the parent refuse every submission with `unknown-collection`, which reads as "the cid your page
+ *  submits to is not declared" about a declaration that is correct. That shipped, and it sent an
+ *  author debugging the wrong repository: the page was fine, the app was fine, and the preview was
+ *  the only thing wrong.
+ *
+ *  `articleCid` ONLY WHILE A PUBLIC PAGE IS ON SCREEN, and that is not tidiness. The article page
+ *  is published under the public entrance alone; a member page's own parent in production
+ *  (mulmoserver's `AppViewFrame`) is handed no article declaration and refuses the ask. Offered
+ *  here on every page, the pane would answer a `/m/` page's `view.open` with "the published page
+ *  would go there" — which is false, and false in the direction a preview exists to prevent. */
+const viewConfig = () => {
+  if (payload.value === null) return null;
+  const cid = page.value?.audience === "public" ? payload.value.articleCid : undefined;
+  return { submit: payload.value.submit, ...(cid === undefined ? {} : { articleCid: cid }) };
+};
+
 /** ONE PARENT, for whichever page is on screen.
  *
  *  There were two — the package's public bridge for `/a/`-style pages and its member bridge for the
@@ -260,16 +280,7 @@ const parent = viewParent(
         note: `the preview could not answer request ${requestId ?? "(none)"}: ${error instanceof Error ? error.message : String(error)}`,
       }),
   },
-  // The REAL declaration, never an empty map.
-  //
-  // An empty one does not switch the check off — it makes the parent refuse every submission with
-  // `unknown-collection`, which reads as "the cid your page submits to is not declared" about a
-  // declaration that is correct. That shipped, and it sent an author debugging the wrong
-  // repository: the page was fine, the app was fine, and the preview was the only thing wrong.
-  () =>
-    payload.value === null
-      ? null
-      : { submit: payload.value.submit, ...(payload.value.articleCid === undefined ? {} : { articleCid: payload.value.articleCid }) },
+  () => viewConfig(),
   () => nonce.value,
   cells,
 );

--- a/src/utils/sharedAppPreviewLog.ts
+++ b/src/utils/sharedAppPreviewLog.ts
@@ -82,6 +82,13 @@ export type PreviewLogEvent =
       error: string | null;
       mailed?: boolean;
     }
+  /** The page asked to OPEN one of its articles, and this pane did not go anywhere.
+   *
+   *  NOT A PROBLEM, and deliberately not counted as one (`isProblem`): the pane has no browser
+   *  history to push onto, and the published page will navigate. It is here because the alternative
+   *  is a link that looks broken — the author clicks a headline in their own front page, nothing
+   *  moves, and there is nothing anywhere to say whether the page asked or simply did nothing. */
+  | { kind: "open"; cid: string; id: string }
   | { kind: "notice"; code: ViewNoticeCode; detail: string }
   | { kind: "host"; note: string };
 
@@ -240,6 +247,8 @@ const lineFor = (entry: PreviewLogEntry): string[] => {
         : [`the write to '${entry.cid}' was REFUSED:`, `  ${entry.error}`];
     case "intent":
       return intentLine(entry);
+    case "open":
+      return [`the page asked to open '${entry.id}' in '${entry.cid}' — the published page would go there; this pane stays where it is`];
     case "notice":
       // PAGE-AUTHORED, and marked as such. The reader is often a model, and a sentence the page
       // chose must not arrive looking like something this host is saying.

--- a/src/utils/sharedAppPreviewLookup.ts
+++ b/src/utils/sharedAppPreviewLookup.ts
@@ -1,0 +1,27 @@
+// "HAVE I ALREADY GOT THIS ROW?", asked of the server for the ONE key a page names.
+//
+// Its own module for the reason `sharedAppPreviewPayload.ts` is: the pane it serves is at its
+// line limit, and this is a request and a narrowing with no browser and no component in it.
+//
+// The question exists because `viewer.mine` cannot answer it. A composite id is `uid + "_" +
+// <field>` and the rules grant a submitter the document they can NAME rather than a range of
+// them, so the key is the half the host is missing and the page has.
+import { fetchWithTimeout, SLOW_COMMAND_TIMEOUT_MS } from "./fetchWithTimeout";
+import { isRecord } from "../../common/isRecord";
+
+/** A REJECTION is the honest failure and `{ found: false }` is not: a refused read, an app that
+ *  has never been published and a collection whose ids cannot be built from a key are all "nobody
+ *  looked", and the parent turns a rejection into exactly that. Answering "no" instead would tell
+ *  the author's page that they have not submitted, and it would stop offering an action they are
+ *  entitled to. */
+export async function lookupOwnRow(url: string, ask: { cid: string; key: string }): Promise<{ found: boolean; record?: Record<string, unknown> }> {
+  const res = await fetchWithTimeout(
+    url,
+    { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ cid: ask.cid, key: ask.key }) },
+    SLOW_COMMAND_TIMEOUT_MS,
+  );
+  const body: unknown = await res.json();
+  if (!isRecord(body) || body.ok !== true) throw new Error("nothing could be looked up");
+  const record = isRecord(body.record) ? body.record : undefined;
+  return { found: body.found === true, ...(record === undefined ? {} : { record }) };
+}

--- a/src/utils/sharedAppPreviewPayload.ts
+++ b/src/utils/sharedAppPreviewPayload.ts
@@ -17,6 +17,10 @@ export function asPayload(value: unknown): SharedAppPreview | null {
   return {
     aid: typeof value.aid === "string" ? value.aid : "",
     submit: asSubmit(value.submit),
+    // ABSENT rather than "", because "" is a collection id nothing declares and the parent compares
+    // this against the cid a page names. Absent is the app that publishes no articles, which is the
+    // shape that must refuse an `open` rather than one that accidentally matches nothing.
+    ...(typeof value.articleCid === "string" && value.articleCid !== "" ? { articleCid: value.articleCid } : {}),
     pages: Array.isArray(value.pages) ? value.pages.flatMap(asPage) : [],
     publicOpen: value.publicOpen === true,
     fromLiveApp: value.fromLiveApp === true,

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -322,7 +322,9 @@ describe("shared app preview", () => {
     const result = await previewSharedApp(root, stamp);
 
     expect(result.ok === false ? result.problems : []).toEqual([]);
-    expect(result.ok && result.articleCid).toBe("bookings");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.articleCid).toBe("bookings");
   });
 
   it("has no article collection to name on an app that publishes none", async () => {
@@ -330,7 +332,13 @@ describe("shared app preview", () => {
     // from `collections` here would let a page open an address the platform does not draw.
     const result = await previewSharedApp(root, stamp);
 
-    expect(result.ok && "articleCid" in result).toBe(false);
+    // THE SUCCESS FIRST. `result.ok && …` is false whenever the preview failed, so an assertion
+    // written that way passes without ever reaching the thing it claims to check — a green that
+    // means "the declaration was refused", which is not what this test is about.
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("articleCid" in result).toBe(false);
   });
 
   it("hands back what the AUTHOR has already submitted, projected as the page will see it", async () => {

--- a/test/server/backends/sharedAppPreview.spec.ts
+++ b/test/server/backends/sharedAppPreview.spec.ts
@@ -274,6 +274,65 @@ describe("shared app preview", () => {
     expect(docs.writes).toEqual([]);
   });
 
+  it("names the article collection even when the author did not have to", async () => {
+    // THE CROSS-REPOSITORY JOIN, executed. `article.collection` is OPTIONAL in an authored app when
+    // the view reads exactly one collection — which is the shape both blogs are written in — and
+    // publish resolves it, so the PROJECTION always carries it. A preview that re-derived it from
+    // `view.collections` instead would be the second reader of an inference publish already made,
+    // and the two eventually disagree on a document neither can ask about.
+    //
+    // What is at stake if this is undefined: the payload omits `articleCid`, the parent judges every
+    // `view.open("articles", id)` against nothing, and every headline on the app's own front page
+    // is refused as `unknown-collection`.
+    mkdirSync(path.join(root, "views"), { recursive: true });
+    writeFileSync(path.join(root, "views", "home.html"), "<h1>Journal</h1>");
+    writeApp(
+      root,
+      declaration({
+        theme: { hue: 200 },
+        collections: { bookings: { submitOnly: true } },
+        public: {
+          enabled: true,
+          read: ["bookings"],
+          submit: {
+            bookings: {
+              auth: "verifiedEmail",
+              audience: "participant",
+              createFields: ["note", "stampedAt"],
+              stampField: "stampedAt",
+              maxBytes: { note: 60_000 },
+            },
+          },
+        },
+        // NO `article.collection`, on purpose: this is the documented one-collection shape, and the
+        // one both blogs are written in.
+        views: [
+          {
+            id: "public",
+            audience: "public",
+            path: "views/home.html",
+            collections: ["bookings"],
+            article: { title: "note", body: "note" },
+            limit: { bookings: 16 },
+          },
+        ],
+      }),
+    );
+
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok === false ? result.problems : []).toEqual([]);
+    expect(result.ok && result.articleCid).toBe("bookings");
+  });
+
+  it("has no article collection to name on an app that publishes none", async () => {
+    // Absent rather than guessed. Most apps declare no `article` block at all, and a cid invented
+    // from `collections` here would let a page open an address the platform does not draw.
+    const result = await previewSharedApp(root, stamp);
+
+    expect(result.ok && "articleCid" in result).toBe(false);
+  });
+
   it("hands back what the AUTHOR has already submitted, projected as the page will see it", async () => {
     // The port that did not exist. A collection people submit to is exactly the one `public.read`
     // cannot open — one visitor would be reading every other visitor's answer — so a page cannot

--- a/test/src/components/SharedAppPreviewOpen.spec.ts
+++ b/test/src/components/SharedAppPreviewOpen.spec.ts
@@ -1,0 +1,186 @@
+// OPENING ONE OF THE APP'S OWN ARTICLES, from inside the sandbox.
+//
+// The index at `/a/{slug}` is the app's own HTML — the platform draws one page for an app and it is
+// the ARTICLE at `/a/{slug}/{id}`. So a magazine's front page is nothing but links, and a link is
+// the one thing a published page cannot follow: the frame is `sandbox="allow-scripts"`, with no
+// top navigation and no popups. It asks the host instead.
+//
+// This pane does not go anywhere, and BOTH halves of that are what these pin. The page must be
+// ANSWERED — a promise nothing settles is a headline that does nothing — and the author must be
+// TOLD, or a click that moves nothing on their own front page looks exactly like one they failed to
+// wire.
+//
+// Its own file rather than another block in `SharedAppPreview.spec.ts`: that file is at its
+// 600-line cap, and the harness below is the small half of its own — no writes, no clipboard
+// beyond the record, no tiers.
+//
+// Imported at module scope, not inside a test: the component's module graph is billed to whichever
+// test first reaches it, and that has made a file's first test look 100x slower than its siblings.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises, type VueWrapper } from "@vue/test-utils";
+import SharedAppPreview from "../../../src/components/SharedAppPreview.vue";
+import { until } from "../../helpers/hopUntil";
+
+const PAGE = "<h1>AI Journal</h1>";
+
+/** An app that publishes articles: a front page of its own, and the `articleCid` the parent judges
+ *  an `open` against. */
+const magazine = (over: Record<string, unknown> = {}) => ({
+  declared: true,
+  ok: true,
+  preview: {
+    aid: "aid-1",
+    submit: { articles: { createFields: ["slug", "title", "body"] } },
+    articleCid: "articles",
+    pages: [{ id: "public", html: PAGE, audience: "public" }],
+    publicOpen: true,
+    fromLiveApp: false,
+    generatedForm: false,
+    datasets: { "public:public": { articles: [] } },
+    unreadable: [],
+    warnings: [],
+    ...over,
+  },
+});
+
+const answering = (body: unknown) => vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(body) });
+
+let clipboard = "";
+
+beforeEach(() => {
+  clipboard = "";
+  Object.defineProperty(window.navigator, "clipboard", {
+    value: {
+      writeText: (text: string) => {
+        clipboard = text;
+        return Promise.resolve();
+      },
+    },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const mountPreview = async () => {
+  const wrapper = mount(SharedAppPreview, { props: { cwd: "/repo" } });
+  await flushPromises();
+  return wrapper;
+};
+
+/** Do the handshake and return the far end of the private channel. */
+const connect = async (wrapper: VueWrapper) => {
+  const frame = wrapper.find("iframe").element as HTMLIFrameElement;
+  const nonce = /const nonce = "([^"]+)"/.exec(frame.getAttribute("srcdoc") ?? "")?.[1] ?? "";
+
+  let far: MessagePort | null = null;
+  const contentWindow = {
+    postMessage: (_message: unknown, _origin: string, ports?: MessagePort[]) => {
+      far = ports?.[0] ?? null;
+    },
+  };
+  vi.spyOn(frame, "contentWindow", "get").mockReturnValue(contentWindow as unknown as Window);
+
+  const ready = new MessageEvent("message", { data: { type: "mc-public-view:ready", nonce } });
+  Object.defineProperty(ready, "source", { value: contentWindow });
+  window.dispatchEvent(ready);
+  await flushPromises();
+
+  const port = far as MessagePort | null;
+  if (port === null) throw new Error("the parent never handed over a channel");
+  const answers: Record<string, unknown>[] = [];
+  port.onmessage = (event: MessageEvent) => answers.push(event.data as Record<string, unknown>);
+  port.start();
+  // The name only the injected document knows, echoed on the port it was handed.
+  port.postMessage({ nonce });
+  await flushPromises();
+  return { port, answers };
+};
+
+const answered = (answers: Record<string, unknown>[], requestId: string) => () => answers.some((answer) => answer.requestId === requestId);
+
+/** What the pane put on the clipboard, once it says what the test is about to assert. Re-read on
+ *  each hop: the block is built when the button is pressed, so waiting on one copy would wait for
+ *  ever, and the block that SATISFIED the wait is the one handed back. */
+const untilBlock = async (wrapper: VueWrapper, text: string): Promise<string> => {
+  let found = "";
+  const says = async (): Promise<boolean> => {
+    const button = wrapper.findAll("button").find((candidate) => (candidate.attributes("title") ?? "").startsWith("Everything the parent saw"));
+    if (button === undefined) return false;
+    await button.trigger("click");
+    await flushPromises();
+    found = clipboard;
+    return found.includes(text);
+  };
+  await until(says, `the record to mention ${JSON.stringify(text)}`);
+  return found;
+};
+
+/** The ask, as the bootstrap posts it. */
+const open = (over: Record<string, unknown> = {}) => ({
+  type: "mc-public-view:open",
+  requestId: "r-open",
+  cid: "articles",
+  id: "why-terminals-won",
+  ...over,
+});
+
+describe("opening one of the app's own articles", () => {
+  it("answers the page, and tells the author what the published one would have done", async () => {
+    vi.stubGlobal("fetch", answering(magazine()));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+
+    port.postMessage(open());
+    await until(answered(answers, "r-open"), "an answer for r-open");
+
+    // ANSWERED AS AN OPEN — `{ opened }` rather than `{ ok }`, so a page cannot read "this host does
+    // not navigate" as "that article does not exist".
+    expect(answers).toContainEqual(expect.objectContaining({ type: "mc-public-view:openResult", requestId: "r-open", opened: false, reason: "no-navigation" }));
+    const block = await untilBlock(wrapper, "asked to open");
+    expect(block).toContain("the page asked to open 'why-terminals-won' in 'articles'");
+  });
+
+  it("refuses a collection this app does not draw articles from", async () => {
+    // `/a/{slug}/{id}` has nothing in it to say which collection an id belongs to, so a host that
+    // navigated anyway would land the reader on a page reading a record of another collection —
+    // an address that looks broken to whoever was handed the link.
+    vi.stubGlobal("fetch", answering(magazine()));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+
+    port.postMessage(open({ requestId: "r-wrong", cid: "notes" }));
+    await until(answered(answers, "r-wrong"), "an answer for r-wrong");
+
+    expect(answers).toContainEqual(expect.objectContaining({ requestId: "r-wrong", opened: false, reason: "unknown-collection" }));
+  });
+
+  it("has no article page to reach on an app that publishes none", async () => {
+    // `articleCid` absent, which is most apps. Absent has to REFUSE rather than match nothing by
+    // accident — see `sharedAppPreviewPayload.spec.ts` on why it is not floored to "".
+    vi.stubGlobal("fetch", answering(magazine({ articleCid: undefined })));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+
+    port.postMessage(open({ requestId: "r-none" }));
+    await until(answered(answers, "r-none"), "an answer for r-none");
+
+    expect(answers).toContainEqual(expect.objectContaining({ requestId: "r-none", opened: false, reason: "unknown-collection" }));
+  });
+
+  it("refuses an id that is not a single path segment, before it can reach a URL", async () => {
+    // The grammar is the defence that does not depend on a host remembering to encode. Pinned here
+    // as well as in the package because this is the path a real page takes.
+    vi.stubGlobal("fetch", answering(magazine()));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+
+    port.postMessage(open({ requestId: "r-bad", id: "../secrets" }));
+    await until(answered(answers, "r-bad"), "an answer for r-bad");
+
+    expect(answers).toContainEqual(expect.objectContaining({ requestId: "r-bad", opened: false, reason: "invalid-open" }));
+  });
+});

--- a/test/src/components/SharedAppPreviewOpen.spec.ts
+++ b/test/src/components/SharedAppPreviewOpen.spec.ts
@@ -171,6 +171,20 @@ describe("opening one of the app's own articles", () => {
     expect(answers).toContainEqual(expect.objectContaining({ requestId: "r-none", opened: false, reason: "unknown-collection" }));
   });
 
+  it("does not offer it on a MEMBER page, which production never would", async () => {
+    // The article page is published under the PUBLIC entrance alone. A member page's own parent in
+    // production is handed no article declaration and refuses the ask — so a pane that answered
+    // "the published page would go there" here would be validating a link that does not exist.
+    vi.stubGlobal("fetch", answering(magazine({ pages: [{ id: "desk", html: PAGE, audience: "member", viewer: { me: "owner@x.jp", can: {} } }] })));
+    const wrapper = await mountPreview();
+    const { port, answers } = await connect(wrapper);
+
+    port.postMessage(open({ requestId: "r-desk" }));
+    await until(answered(answers, "r-desk"), "an answer for r-desk");
+
+    expect(answers).toContainEqual(expect.objectContaining({ requestId: "r-desk", opened: false, reason: "unknown-collection" }));
+  });
+
   it("refuses an id that is not a single path segment, before it can reach a URL", async () => {
     // The grammar is the defence that does not depend on a host remembering to encode. Pinned here
     // as well as in the package because this is the path a real page takes.

--- a/test/src/utils/sharedAppPreviewLog.spec.ts
+++ b/test/src/utils/sharedAppPreviewLog.spec.ts
@@ -134,6 +134,24 @@ describe("the pane's log", () => {
     expect(block).toContain("a name this host does not know");
   });
 
+  it("says the page asked to open an article, and that this pane stayed put", () => {
+    // The alternative is a link that looks broken. The author clicks a headline on their own front
+    // page — which is HTML they wrote, since the platform gave the index back — nothing moves, and
+    // there is nothing anywhere to say whether the page asked or simply did nothing.
+    const block = render((log) => log.add({ kind: "open", cid: "articles", id: "why-terminals-won" }));
+    expect(block).toContain("the page asked to open 'why-terminals-won' in 'articles'");
+    expect(block).toContain("the published page would go there");
+  });
+
+  it("does not count that as a problem, because nothing about it went wrong", () => {
+    // The pane has no browser history to push onto, which is a fact about the pane. Counted, it
+    // would light the amber on every correctly-wired magazine.
+    const log = createPreviewLog({ now: ticking() });
+    log.add({ kind: "open", cid: "articles", id: "why-terminals-won" });
+    expect(log.problems()).toBe(0);
+    expect(log.size()).toBe(1);
+  });
+
   it("counts the problems and leaves an ordinary event alone", () => {
     const log = createPreviewLog({ now: ticking() });
     log.add({ kind: "handshake" });

--- a/test/src/utils/sharedAppPreviewPayload.spec.ts
+++ b/test/src/utils/sharedAppPreviewPayload.spec.ts
@@ -114,6 +114,19 @@ describe("the preview payload", () => {
     expect(asPayload({ aid: "a", pages: [page({ audience: "staff" })] })?.pages).toEqual([]);
   });
 
+  it("carries the article collection, which is the only cid `view.open` may name", () => {
+    expect(asPayload({ aid: "a", articleCid: "articles", pages: [page()] })?.articleCid).toBe("articles");
+  });
+
+  it("leaves it ABSENT rather than empty on an app that publishes no articles", () => {
+    // "" is a collection id nothing declares, and the parent compares this against the cid a page
+    // names. Absent refuses every `open` — which is right, there is no such page to reach — where a
+    // floor of "" would be a value that happens to match nothing, for as long as that holds.
+    for (const bad of [undefined, "", 7, null, {}]) {
+      expect("articleCid" in (asPayload({ aid: "a", articleCid: bad, pages: [] }) ?? {})).toBe(false);
+    }
+  });
+
   it("answers a payload it cannot read at all with null, rather than throwing", () => {
     expect(asPayload("nope")).toBeNull();
     expect(asPayload({})?.pages).toEqual([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.32.0.tgz#bcc1631bbe8876640d9d3c14a855358c4403b6d8"
-  integrity sha512-iUzQC2MmIrKE3O8KJtdsx/qEjyyIDAFt2pK/XLLS9ruUrk5zmrB2oegAl1sMOg1yaSkb8M/8be5f3iwIV1fP+w==
+"@receptron/sharedapp@^0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.33.0.tgz#435194398ec723d3ce8c1c0100faf4a997cd5e64"
+  integrity sha512-K+bjApORMbvmW4LMXAeiWz1OrSNVvBeAcYTpLb3oc+durnPRR9CHvRkBET1g9kNjfjcf1rit+1O8C8339W36sw==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
receptron/sharedapp#73 と receptron/mulmoserver#249 のこちら側。**sharedapp が npm に出るまで CI は赤**です（`OpenAsk` / `readOpenMessage` が 0.32.0 に無い）。手元では 0.32.0 をローカルビルドに差し替えて全ゲートを通してあります。公開後に `package.json` の bump を積みます。

## 何の話か

`plans/feat-shared-app-app-owned-index.md`。プラットフォームが描くのは**記事 1 ページ（`/a/{slug}/{id}`）だけ**になり、**`/a/{slug}` は常にアプリ自身の HTML** になります。索引はもともとレコードの一覧で、手書きの公開ページは**同じ datasets を受け取っている**のに、`views[].type` が両方の住所を取っていたので、記事を出すアプリは公開の顔を丸ごと手放していました。

## このリポジトリの変更

**プレビューのペインが `view.open(cid, id)` に答えます。そして遷移はしません。**

ペインには押す先の履歴が無いので `opened: false, reason: "no-navigation"` を返し——これは**拒否ではない**、ask に問題は無い——代わりに診断ログに 1 行書きます:

```
the page asked to open 'why-terminals-won' in 'articles' — the published page would go there; this pane stays where it is
```

**これが無いと、著者が自分の表紙で見出しを押しても何も動かず、配線を忘れたページと見分けがつきません。** ログの数え上げでは**問題として数えない**（数えると、正しく書けた雑誌すべてで警告が点く）。

**`articleCid` をワイヤに載せます**（`preview.ts` → `sharedAppPreviewRoutes.ts` → ペイン → `viewParent`）。親が `open` を判定する材料で、`submit` と同じ理由でブラウザまで運ぶ必要があります。記事を出さないアプリでは**欠落**で、`""` には落としません——「たまたま何にも一致しない値」ではなく「届く先が無い」を表す必要があるので。

**SKILL に 2c-2 節。** `path` + `article` の形、`view.open` の呼び方（`await` して続きを書かないこと）、`article.collection`、standfirst になった `summary`、`byline` に住所を入れないこと、`theme.hue` が記事ページだけを塗ること、`type` が断られること。

## 付随

`lookupOwnRow` を `src/utils/sharedAppPreviewLookup.ts` に分離しました（ペインが 600 行の上限に当たったため。CLAUDE.md の debt list に足すのではなく分けるのがこのリポジトリの慣習）。判断は動いていません。

## 検証

`yarn typecheck` / `yarn lint` / `yarn test`（11449 pass）。

新規 `test/src/components/SharedAppPreviewOpen.spec.ts` は 4 本——答えが返ること・ログに出ること・記事のコレクションでない cid を断ること・記事を出さないアプリで断ること・パスのセグメントでない id を断ること。

## 手順

sharedapp → mulmoserver（reader が先）→ ここ。既存のブログアプリ 2 本は互換の受け皿を作らず、`type` を消して索引ページを足します。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared app previews now identify the article collection when an app publishes articles.
  * Apps can request opening their own articles through supported preview interactions.
  * Preview activity now records article-open requests.
* **Documentation**
  * Documented article publishing, article links, page paths, and migration guidance.
* **Bug Fixes**
  * Preview payloads now omit invalid or empty article collection identifiers.
  * Article-open requests validate collections, identifiers, and page visibility before navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->