### PR TITLE
chore: @receptron/sharedapp@0.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
-    "@receptron/sharedapp": "^0.33.0",
+    "@receptron/sharedapp": "^0.34.0",
     "@receptron/task-scheduler": "^1.0.3",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,10 +2259,10 @@
     modern-tar "^0.8.0"
     yargs "^18.0.0"
 
-"@receptron/sharedapp@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.33.0.tgz#435194398ec723d3ce8c1c0100faf4a997cd5e64"
-  integrity sha512-K+bjApORMbvmW4LMXAeiWz1OrSNVvBeAcYTpLb3oc+durnPRR9CHvRkBET1g9kNjfjcf1rit+1O8C8339W36sw==
+"@receptron/sharedapp@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@receptron/sharedapp/-/sharedapp-0.34.0.tgz#6f370d319a8183dab8568861398dce5846b1876a"
+  integrity sha512-jZU2IqZsl8DGqhZJiGpyusMI9szlfT+MIBiTXIjuhyaFEpwGNgVppWDNcnQGbo6JKne7QaFAIzNNLsOQChIaCg==
   dependencies:
     zod "^4.1.13"
 


### PR DESCRIPTION
mulmoserver は receptron/mulmoserver#250 で 0.34.0 に上がり、ここは 0.33.0 のままでした。

**2 つのホストは同じページに同じブートストラップを注入します。** プレビューが本番より甘くならないことがこのペインの存在理由なので（`SharedAppPreview.spec.ts` の冒頭がその宣言です）、**版が割れていること自体が食い違い**になります。

**このペインの挙動は変わりません。** ペインの `navigate` は `false` を返す側なので、0.34.0 で足された「成功したときも答える」経路を通りません。揃えることそのものが目的です。

0.34.0 が持っているもの（receptron/sharedapp#75）:

- `open` が成功したときも答える——`parent.ts` 自身の規則「Nothing is dropped」
- 答えを**頼んだ channel** に返す（`open` は新しい文書を連れてくることが目的の唯一の ask）
- 成功の答えに `reason: undefined` を自分の鍵として付けない

`yarn typecheck` / `yarn lint` / `yarn test`（11452 pass）。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared application package to the latest compatible version, bringing in maintenance updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->