### PR TITLE
chore: @mulmoclaude/markdown-plugin@4.1.0（TeX 数式の MathJax 描画）

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",
-    "@mulmoclaude/markdown-plugin": "^4.0.0",
+    "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,16 +1891,17 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/markdown-plugin@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-4.0.0.tgz#8f3928bbfad041f534550b32760384a944c88321"
-  integrity sha512-QF/ftLm72NenSv4tQf3W56fzY9Ba7UaRsCRP0FEyLvn+xDm/8fR/dbwxLDpb9xa0kkAW5AIRSU/qwwb3secftw==
+"@mulmoclaude/markdown-plugin@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-4.1.0.tgz#19c1e4888513e0664cbf8dbcb81fe08a0419c697"
+  integrity sha512-Rm1jN1KHpdiht4hQsFMrZdyaKBu/uaZlibfDZ6sOW4UFmALNyTLgXN4ftcOkgE3YsS5w1oiOLgdSzt5B1klOjg==
   dependencies:
     "@marp-team/marp-core" "^4.4.0"
     "@mulmoclaude/common" "^1.2.0"
-    "@mulmoclaude/markdown-utils" "^1.3.5"
+    "@mulmoclaude/markdown-utils" "^1.4.0"
     js-yaml "^5.2.3"
-    marked "^18.0.7"
+    marked "^18.0.11"
+    mathjax-full "^3.2.2"
     mermaid "^11.16.1"
 
 "@mulmoclaude/markdown-utils@^1.3.5":
@@ -1911,6 +1912,16 @@
     "@mulmoclaude/common" "^1.1.2"
     js-yaml "^5.2.3"
     marked "^18.0.7"
+
+"@mulmoclaude/markdown-utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-utils/-/markdown-utils-1.4.0.tgz#0061552ac0c182112f46d7ff9396f8d9a6cd580a"
+  integrity sha512-+HeAf1pyFy0HwxMy5lC9Uof/3ukGGJbf5d/r088Rzj3XJ2tMvXy2SHoquD0Xkd4g+l1VzWWJWbmmw7KH/yrJmQ==
+  dependencies:
+    "@mulmoclaude/common" "^1.2.0"
+    dompurify "^3.4.13"
+    js-yaml "^5.2.3"
+    marked "^18.0.11"
 
 "@mulmoclaude/mulmoscript-plugin@^4.4.0":
   version "4.4.0"


### PR DESCRIPTION
MulmoClaude 側で入った markdown の更新（[mulmoclaude#2978](https://github.com/receptron/mulmoclaude/pull/2978)）を取り込む。

## 何が入るか

`presentDocument` のプレビューで TeX 数式 `$…$` / `$$…$$` が MathJax SVG で描画されるようになる。Marp デッキ側は marp-core が元から MathJax SVG で描いていたので、同じ文書の両面がようやく一致する。`$` の判定は Pandoc のルールセット（`US$5` や `$5-$10` を数式にしない、日本語のために「直前が ASCII 英数字なら不成立」に限定）。

## ホスト側の変更が要らない理由

数式は plugin の `View.vue` が完結して持っている — marked 拡張の登録も、DOM を走査して SVG に差し替えるところも、`.math-block` などの scoped スタイルも。MulmoTerminal は `@mulmoclaude/markdown-plugin/style.css?inline` を Shadow DOM へ流しているので、そのスタイルはそのまま届く（`dist/style.css` に入っていることを確認済み）。

`mathjax-full` は数式のある文書でだけ遅延ロードされ、build も `AllPackages`（194KB）と `svg`（1.2MB）を別チャンクに切り出した。本体 bundle は増えていない。

## 確認したこと

- `yarn typecheck` / `yarn build` / `yarn lint` 通過
- `yarn test` — 773 files, 11452 passed
- `dist/style.css` に math のスタイルが入っている

## 気づいた点（このPRでは触っていない）

`@mulmoclaude/markdown-utils` が 2 コピーになる。markdown-plugin@4.1.0 は `^1.4.0`、`@mulmoclaude/core@4.4.2` はまだ `^1.3.5` を要求しているため。core が次に publish されれば揃う見込みなので、`resolutions` は足していない。

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown plugin dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->