### PR TITLE
chore: @mulmoclaude/markdown-plugin を 4.1.0 に上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",
-    "@mulmoclaude/markdown-plugin": "^4.0.0",
+    "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,16 +1891,17 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/markdown-plugin@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-4.0.0.tgz#8f3928bbfad041f534550b32760384a944c88321"
-  integrity sha512-QF/ftLm72NenSv4tQf3W56fzY9Ba7UaRsCRP0FEyLvn+xDm/8fR/dbwxLDpb9xa0kkAW5AIRSU/qwwb3secftw==
+"@mulmoclaude/markdown-plugin@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-4.1.0.tgz#19c1e4888513e0664cbf8dbcb81fe08a0419c697"
+  integrity sha512-Rm1jN1KHpdiht4hQsFMrZdyaKBu/uaZlibfDZ6sOW4UFmALNyTLgXN4ftcOkgE3YsS5w1oiOLgdSzt5B1klOjg==
   dependencies:
     "@marp-team/marp-core" "^4.4.0"
     "@mulmoclaude/common" "^1.2.0"
-    "@mulmoclaude/markdown-utils" "^1.3.5"
+    "@mulmoclaude/markdown-utils" "^1.4.0"
     js-yaml "^5.2.3"
-    marked "^18.0.7"
+    marked "^18.0.11"
+    mathjax-full "^3.2.2"
     mermaid "^11.16.1"
 
 "@mulmoclaude/markdown-utils@^1.3.5":
@@ -1911,6 +1912,16 @@
     "@mulmoclaude/common" "^1.1.2"
     js-yaml "^5.2.3"
     marked "^18.0.7"
+
+"@mulmoclaude/markdown-utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-utils/-/markdown-utils-1.4.0.tgz#0061552ac0c182112f46d7ff9396f8d9a6cd580a"
+  integrity sha512-+HeAf1pyFy0HwxMy5lC9Uof/3ukGGJbf5d/r088Rzj3XJ2tMvXy2SHoquD0Xkd4g+l1VzWWJWbmmw7KH/yrJmQ==
+  dependencies:
+    "@mulmoclaude/common" "^1.2.0"
+    dompurify "^3.4.13"
+    js-yaml "^5.2.3"
+    marked "^18.0.11"
 
 "@mulmoclaude/mulmoscript-plugin@^4.4.0":
   version "4.4.0"


### PR DESCRIPTION
## Summary

`presentDocument` を提供する共有プラグインの minor 更新（4.0.0 → 4.1.0）。この repo は `src/plugins-registry.ts` でその Vue View と `style.css` を読み込んでいます。

宣言だけの変更で、この repo のソースは 1 行も触っていません。

## Items to Confirm / Review

**1. warm な node_modules では検証していません。** 依存を動かす PR なので、CLAUDE.md の規約どおり **committed lockfile からのクリーン解決**で確認しました。warm な木は、dedupe/hoist の巻き添えで落ちた推移的依存を隠して「ローカルは緑・CI は赤」を作るためです。

```
rm -rf node_modules && yarn install --frozen-lockfile   -> 0
@mulmoclaude/markdown-plugin                            -> 4.1.0
```

**2. build 通過を「動作した」と報告していません。** プラグインは Canvas に描画するので、実機で確認しました:

- サーバ起動 → `GET / -> 200`、boot ログに uncaught / `Cannot find module` なし
- Puppeteer で実ブラウザから読み込み → title あり、本文あり、**console error 0**

**3. リリース直前の取り込みです。** 4.11.0 の publish 準備中に依頼を受けたもので、バージョン bump はこの PR に含めていません（リリースコミット側の仕事）。

## User Prompt

- `@mulmoclaude/markdown-plugin latest 4.0.0 ❯ 4.1.0　これもいれて！！`
- 「なんなら先にPRでとりこんでから。」
- 「review不要で」

## 検証

`yarn lint` / `typecheck` / `build` / `test` すべて exit **0**、**11507 tests pass**（クリーン install 後）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3