### PR TITLE
fix: presentMulmoScript のビート差し替えが黙って無視される (#1880)

### DIFF
--- a/plans/fix-1880-beat-replacement.md
+++ b/plans/fix-1880-beat-replacement.md
@@ -124,3 +124,43 @@ POST … {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"
 ゲート: format / lint / typecheck / build / test すべて 0。
 `yarn test` は **11514 passed**（+7、この PR が足したもの）。
 
+
+## レビューループ（`/gh-review-loop`、2026-08-28）
+
+PR #1886。codex は 1〜3 巡すべて `LGTM`。CodeRabbit は 1 巡目で 1 件、2 巡目は **rate limit で
+レビューできず**（沈黙は承認ではないので clean round に数えない）。Sourcery はこのリポジトリに
+設定されていない。
+
+**指摘を受けて直したもの**
+
+- CodeRabbit: MD040 —— 症状の再現ブロックに言語タグが無かった（`text`、他の 2 つに揃えた）
+
+**bot が挙げず、こちらの読み直しで見つけたもの**
+
+- spec が temp workspace を消していなかった。このリポジトリの `mkdtempSync` を使う spec 69 本の
+  うち 65 本は消している。1 つのテストがルートを 2 回呼ぶので、変数 1 つではなく配列で追跡する
+- **レスポンスが書き込み後のスクリプトを返すことを何も pin していなかった。** エージェントが
+  読めるのはレスポンスだけで、修正前はそれが**書き込み前**のスクリプトを成功に見えるメッセージ
+  付きで返していた。以前のスナップショットを返すホストでも全アサーションが緑のままになる
+
+**確認して「欠陥ではない」と判断したもの**（根拠付き、パッケージのソースを読んで）
+
+- **書き込みが起きていないのに publish し得るか** → しない。`executeMulmoScriptSave` は
+  `hasScript === hasFilePath` で `script`+`filePath` の同時指定も `script` 単独＋beat 対も
+  badRequest にし、`executeUpdateBeat` が失敗したらその失敗をそのまま返す。
+  よって `outcome.ok` かつ両フィールドあり ⇒ 書き込みは起きている
+- **検証されていない書き込み経路が増えるか** → 増えない。届く先は View の `updateBeat` kind が
+  既に使っている `executeUpdateBeat` そのもので、`mulmoBeatSchema.safeParse`・整数/非負・
+  ディスク上のスクリプト長との境界チェックを通り、`parsed.data` を書く
+- **publish の形はパッケージ自身のものと一致するか** → する。kind ルータも `outcome.ok` の後に
+  `ops.publishScriptChanged(filePath, origin)` を呼ぶ。こちらはそれの `origin` 無し版で、
+  wire path の正規化は `publishScriptChanged` 自身がやる
+- **メッセージを「ビートを差し替えた」にすべきか** → スコープ外。`outcome.message` はパッケージの
+  もの。エージェントの ground truth は返ってくるスクリプトで、それは上記のテストで pin した
+
+**break-verify の更新（`515cb848` 時点）**
+
+レスポンスのアサーションを足したので、M1（allowlist を #1880 に戻す）で赤くなるのが
+**4 件 → 5 件**（全 8 件中）になった。`yarn test` は **11515 passed**。
+
+`origin/main`（#1887）を取り込み、マージ結果で全ゲートを再実行。

--- a/plans/fix-1880-beat-replacement.md
+++ b/plans/fix-1880-beat-replacement.md
@@ -1,0 +1,126 @@
+# fix: presentMulmoScript のビート差し替えが黙って無視される (#1880)
+
+> **この文書の読み方 —— 時系列のログであって、現状の仕様書ではない。**
+> 現在のコードの仕様はコードが唯一の情報源。数値は sha に紐づけて書くこと。
+
+## 症状
+
+MCP ツール `presentMulmoScript` の「ビート差し替え」（`filePath` + `beatIndex` + `beat`）が
+**何も書き換えずに成功として返る**。呼んだ側から成功と区別がつかない。
+
+## 再現（実行中のサーバに対して、2026-08-28 実測）
+
+```
+POST /api/plugin/presentMulmoScript
+  {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"…}}
+-> 200、通常の再表示と同じ data.script が返る
+-> ファイルの beat[2] は "# 1 つの台本から何でも" のまま（変わっていない）
+```
+
+## 原因 2 つ
+
+### 1. ホストが引数を落としている
+
+`server/backends/mulmoscript.ts` の `handleToolCall` が組み立てる allowlist に
+`beatIndex` / `beat` が無い。パッケージ側は実装済みで、型にも入っている
+（`SaveMulmoScriptArgs.beatIndex` / `.beat`、`executeMulmoScriptSave` の分岐）。
+両方 undefined のまま渡るので分岐に入らず、`loadExistingScript` に素通りする。
+
+### 2. 書き込んでも pubsub が飛ばない
+
+`publishScriptChanged` を呼んでいるのはパッケージ側の kind ルータ（`updateKind`）だけ。
+ホストの `handleToolCall` は `executeMulmoScriptSave` を直接呼ぶので publish されない。
+
+新規保存で画面が変わって見えるのは、レスポンスの `Display the storyboard to the user.` を
+受けてキャンバスが**その新しいファイルを開く**ため。既存ファイルを開いたまま中身だけ
+差し替えるビート差し替えでは **pubsub が唯一の更新経路**なので、何も起きない。
+
+## 直し方
+
+1. allowlist に `beatIndex`（`typeof === "number"`）と `beat`（`!== undefined`）を足す
+2. **書き込みが起きたときだけ** `publishScriptChanged` を呼ぶ。
+   `executeMulmoScriptSave` は「差し替えたか」を返さないので、ホスト側で
+   「`beatIndex` と `beat` が両方あり、かつ outcome が ok」を条件にする
+
+## 触らないもの
+
+- パッケージ側 `saveKind` の同じ取りこぼし（別リポジトリ。upstream issue に分ける）
+
+## 検証（計画）
+
+- ユニット: ツール呼び出し経路で `beatIndex` + `beat` を渡すと**ディスクの中身が変わり**、
+  `script-changed` が publish されること。allowlist の取りこぼしはこの形でしか捕まらない
+- 実機: 実行中のサーバに POST して、ファイルが変わることを確認
+
+## 実装（2026-08-28）
+
+- `server/backends/mulmoscript.ts`
+  - allowlist を `saveArgsFrom(body)` として抽出し、そこに `beatIndex` / `beat` を追加。
+    抽出は複雑度上限（`sonarjs/cognitive-complexity` 17 > 15）を超えたための対応でもあるが、
+    **「何がパッケージに届くか」を決める場所が 1 つになる**ので読みやすさとしても良い
+  - 書き込みが起きたときだけ `publishScriptChanged` を呼ぶ
+
+### `origin` は渡さない
+
+パッケージの契約に明記されていた:
+
+> `origin` is who wrote it. A View passes its own id on every write and ignores the echo of
+> its own … **An agent write carries no origin, so every View reloads.**
+
+最初 `"agent"` を渡していたが、View 側が「自分のエコー」と判断して reload をスキップし得る。
+それは直そうとしている沈黙そのもの。
+
+### publish の条件は `body` ではなく `args` を見る
+
+最初 `typeof body.beatIndex === "number" && body.beat !== undefined` と書いていた。
+**ミューテーションが弱さを暴いた**: allowlist を #1880 の状態に戻しても broadcast のテストが
+緑のままだった —— 条件が `body` から**同じ判断を二重に**導出していたので、パッケージに何も
+届いていないのに publish していた（「何も書いていないファイルについての嘘」そのもの）。
+
+`args`（実際にパッケージへ渡したもの）を見るようにして、allowlist と条件が乖離できなくした。
+M1 で赤くなるテストが **1 件 → 4 件**に増えた。
+
+## テストで踏んだ落とし穴 2 つ（どちらも自分のテストのバグ）
+
+1. **`express.json()` を付けていなかった。** body が空のままルートに届き、パッケージは
+   `Provide either 'script' or 'filePath'` を **200 で**返す。「status 200 かつファイル不変」
+   だけを見ていた 4 件が、**まったく違う理由で緑**になっていた
+2. **`initArtifactsBackend` を呼んでいなかった。** publish 経路はファイルに触らないので既存の
+   channels spec では露見しないが、save 経路は 500 になる
+
+3 件目として、**`leaves the other beats alone` が no-op でも通っていた** —— 「他が変わっていない」
+は何も起きていないときに自明に真。対象 beat も assert するようにした。
+
+## break-verify
+
+| ミューテーション | 結果 |
+|---|---|
+| allowlist から `beatIndex`/`beat` を戻す（#1880 そのもの） | **4 red** |
+| publish を消す | 2 red |
+| publish を無条件にする | 1 red |
+| `origin` を付ける | 2 red |
+
+各回のあと `diff -q` で byte-identical 復元を確認。
+
+## 実機検証（2026-08-28）
+
+修正前（実行中のサーバ、`c8901e90` 相当）:
+
+```text
+POST … {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"…}}
+-> 200、通常の再表示と同じ data.script
+-> beat[2] は "# 1 つの台本から何でも" のまま
+```
+
+修正後（`--port 34910` で起動）:
+
+```text
+-> 200
+-> beat[2] が "# FIXED" に変わった
+```
+
+検証に使ったストーリーは元の内容に戻してある。
+
+ゲート: format / lint / typecheck / build / test すべて 0。
+`yarn test` は **11514 passed**（+7、この PR が足したもの）。
+

--- a/plans/fix-1880-beat-replacement.md
+++ b/plans/fix-1880-beat-replacement.md
@@ -91,7 +91,7 @@ M1 で赤くなるテストが **1 件 → 4 件**に増えた。
 3 件目として、**`leaves the other beats alone` が no-op でも通っていた** —— 「他が変わっていない」
 は何も起きていないときに自明に真。対象 beat も assert するようにした。
 
-## break-verify
+## break-verify（すべて `bd1df482` のツリーで測定、テストは 7 件）
 
 | ミューテーション | 結果 |
 |---|---|
@@ -122,7 +122,7 @@ POST … {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"
 検証に使ったストーリーは元の内容に戻してある。
 
 ゲート: format / lint / typecheck / build / test すべて 0。
-`yarn test` は **11514 passed**（+7、この PR が足したもの）。
+`yarn test` は `bd1df482` で **11514 passed**（+7、この PR が足したもの）。
 
 
 ## レビューループ（`/gh-review-loop`、2026-08-28）
@@ -158,9 +158,13 @@ PR #1886。codex は 1〜3 巡すべて `LGTM`。CodeRabbit は 1 巡目で 1 �
 - **メッセージを「ビートを差し替えた」にすべきか** → スコープ外。`outcome.message` はパッケージの
   もの。エージェントの ground truth は返ってくるスクリプトで、それは上記のテストで pin した
 
-**break-verify の更新（`515cb848` 時点）**
+**break-verify の更新** —— 数値はそれぞれ測定したツリーの sha に紐づける。
 
-レスポンスのアサーションを足したので、M1（allowlist を #1880 に戻す）で赤くなるのが
-**4 件 → 5 件**（全 8 件中）になった。`yarn test` は **11515 passed**。
+| 測定対象の sha | テスト件数 | M1（allowlist を #1880 に戻す） | `yarn test` |
+|---|---|---|---|
+| `bd1df482`（当初の実装） | 7 | 4 red | 11514 passed |
+| `515cb848`（レスポンスのアサーション追加後） | 8 | **5 red** | 11515 passed |
+| `2bad6623`（`origin/main` #1887 をマージ後、再実行） | 8 | 未測定（M1 は `515cb848` で確定） | 11515 passed |
 
-`origin/main`（#1887）を取り込み、マージ結果で全ゲートを再実行。
+`+1` はレスポンスのアサーションを 1 件足したぶん。M1 が 4→5 に増えたのは、その 1 件が
+「エージェントが読むもの」を pin したから。

--- a/plans/fix-1880-beat-replacement.md
+++ b/plans/fix-1880-beat-replacement.md
@@ -10,7 +10,7 @@ MCP ツール `presentMulmoScript` の「ビート差し替え」（`filePath` +
 
 ## 再現（実行中のサーバに対して、2026-08-28 実測）
 
-```
+```text
 POST /api/plugin/presentMulmoScript
   {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"…}}
 -> 200、通常の再表示と同じ data.script が返る

--- a/plans/fix-1880-beat-replacement.md
+++ b/plans/fix-1880-beat-replacement.md
@@ -168,3 +168,20 @@ PR #1886。codex は 1〜3 巡すべて `LGTM`。CodeRabbit は 1 巡目で 1 �
 
 `+1` はレスポンスのアサーションを 1 件足したぶん。M1 が 4→5 に増えたのは、その 1 件が
 「エージェントが読むもの」を pin したから。
+
+### エンドツーエンド検証（`8d65c237`、2026-08-28）
+
+「開いたままのキャンバスが更新される」は**この PR の主張そのもの**なのに、それまで証明していたのは
+「publish が呼ばれる」（unit）と「ファイルが変わる」（実機）の 2 つで、**ブラウザに届くところまでは
+測っていなかった**。届く経路は socket.io（`/ws/pubsub`、`server/infra/pubsub.ts`）なので、
+ブラウザと同じ購読をする node クライアントを繋いで外から測った。
+
+scratch な `HOME` と workspace で 34911 に起動（ユーザーの実サーバ 34567 には触れていない）:
+
+| POST | 受信イベント | ディスク |
+|---|---|---|
+| `{filePath, beatIndex: 1, beat}` | **1 件** —— `plugin:mulmoScript:scriptChanged` / `{"filePath":"stories/canvas.json"}`、**`origin` 無し** | `# BEFORE TWO` → `# AFTER TWO` |
+| `{filePath}`（ただの再表示） | **0 件** | 変化なし |
+
+`origin` がワイヤ上に無いことが、ここで初めて外から確認できた —— 契約が「エージェントの書き込みは
+origin を持たないので全 View が reload する」と言っている、その通りの形で届いている。

--- a/server/backends/mulmoscript.ts
+++ b/server/backends/mulmoscript.ts
@@ -126,25 +126,67 @@ function stringQuery(req: Request, name: string): string | null {
 // phase-1 execute, then the host-side `autoGenerateMovie` trigger (the dedup
 // key is the realpath, so re-resolve the wire path). Failures answer as
 // `{ message }` (HTTP 200) so the agent reads them and can self-correct.
+/**
+ * The tool call's body, narrowed to what the package accepts.
+ *
+ * Built from checked fields rather than asserted: every field of `SaveMulmoScriptArgs` is
+ * optional, so a body that is missing or mistypes one is a valid call the package rejects on its
+ * own terms — while an assertion would hand it, say, a numeric `filePath` typed as a string.
+ *
+ * Which is also why leaving a field OUT of this list is silent rather than an error, and why
+ * `beatIndex` / `beat` being absent from it was #1880: the package saw a plain re-display request,
+ * answered "Loaded MulmoScript from …", and changed nothing — indistinguishable from success to
+ * the agent that asked. The tool's own description tells agents to use that pair whenever the user
+ * wants part of a presentation changed, so the path was documented and dead at the same time.
+ *
+ * Its own function so the route can be read at a glance, and so the ONE place that decides what
+ * reaches the package is a thing a test can point at.
+ */
+function saveArgsFrom(body: Record<string, unknown>): SaveMulmoScriptArgs {
+  return {
+    ...(body.script !== undefined ? { script: body.script } : {}),
+    ...(typeof body.filename === "string" ? { filename: body.filename } : {}),
+    ...(typeof body.filePath === "string" ? { filePath: body.filePath } : {}),
+    ...(typeof body.autoGenerateMovie === "boolean" ? { autoGenerateMovie: body.autoGenerateMovie } : {}),
+    ...(typeof body.beatIndex === "number" ? { beatIndex: body.beatIndex } : {}),
+    ...(body.beat !== undefined ? { beat: body.beat } : {}),
+  };
+}
+
 async function handleToolCall(body: Record<string, unknown>, res: Response, instance: MulmoScriptServerOps): Promise<void> {
   const guard = instance.guardStoryWirePath(body.filePath);
   if (guard) {
     res.json({ message: guard.error });
     return;
   }
-  // Built from the checked fields rather than asserted: every field of SaveMulmoScriptArgs is
-  // optional, so a body that is missing or mistypes one is a valid call the package rejects on its
-  // own terms — while the assertion handed it, say, a numeric `filePath` typed as a string.
-  const args: SaveMulmoScriptArgs = {
-    ...(body.script !== undefined ? { script: body.script } : {}),
-    ...(typeof body.filename === "string" ? { filename: body.filename } : {}),
-    ...(typeof body.filePath === "string" ? { filePath: body.filePath } : {}),
-    ...(typeof body.autoGenerateMovie === "boolean" ? { autoGenerateMovie: body.autoGenerateMovie } : {}),
-  };
+  const args = saveArgsFrom(body);
   const outcome = await executeMulmoScriptSave({ files: { artifacts: instance.backend.artifacts } }, args);
   if (!outcome.ok) {
     res.json({ message: outcome.error, instructions: "Acknowledge the error and retry with a valid `script` (new) or an existing `filePath`." });
     return;
+  }
+  // A beat replacement rewrote a file the canvas may ALREADY have open, and the pubsub broadcast
+  // is the only way that canvas hears about it — a new save gets redrawn because the response
+  // tells the agent to display the story, which opens the new file, but replacing one beat of an
+  // open story changes nothing on screen without this (#1880).
+  //
+  // Read off `args`, NOT off `body`, and the difference is not cosmetic: `args` is what the
+  // package was actually handed, so the allowlist above and this condition cannot drift into
+  // disagreeing. Asking `body` again re-derives the same decision twice — and a mutation proved
+  // it, by restoring #1880's dropped allowlist and leaving these broadcasts green, publishing a
+  // change to a file nothing had written.
+  //
+  // `executeMulmoScriptSave` does not report which branch it took, so this is the closest
+  // available fact: the package requires the pair together (it refuses one without the other) and
+  // `outcome.ok` is established, so "both reached it and the save succeeded" is "a beat was
+  // written".
+  //
+  // No `origin`, deliberately. The package's own contract says why: "A View passes its own id on
+  // every write and ignores the echo of its own … An agent write carries no origin, so every View
+  // reloads." This IS an agent write, and inventing an id here would make some View treat our
+  // broadcast as its own echo and skip the reload — the exact silence being fixed.
+  if (args.beatIndex !== undefined && args.beat !== undefined) {
+    instance.publishScriptChanged(outcome.filePath);
   }
   // The save succeeded either way; `movieNote` tells the agent whether the
   // requested background generation actually started. The package only

--- a/test/server/backends/mulmoscriptBeatReplace.spec.ts
+++ b/test/server/backends/mulmoscriptBeatReplace.spec.ts
@@ -101,6 +101,19 @@ describe("presentMulmoScript — replacing one beat", () => {
     expect(beats[2].image.markdown).toBe("# third");
   });
 
+  // The other half of the ground truth: what the agent is TOLD. The response is the only thing the
+  // caller can read, and before the fix it carried the PRE-write script under a message that reads
+  // like success — so nothing pins that the host returns the post-write load rather than a snapshot
+  // it took earlier. Asserted on the raw text because `res.body`'s fields are `unknown` by design
+  // and the marker is unique in this story; a shape assertion would cost a type guard to prove what
+  // the on-disk assertions already prove.
+  it("returns the updated script to the caller", async () => {
+    const res = await call({ filePath: STORY, beatIndex: 1, beat: beat("REPLACED") });
+
+    expect(res.text).toContain("# REPLACED");
+    expect(res.text).not.toContain("# second");
+  });
+
   // The write is only half of it. A canvas that already has this story open learns about the
   // change from the broadcast and from nothing else — a new save gets redrawn because the response
   // tells the agent to display the story, which opens the new file, but replacing a beat of an

--- a/test/server/backends/mulmoscriptBeatReplace.spec.ts
+++ b/test/server/backends/mulmoscriptBeatReplace.spec.ts
@@ -11,9 +11,9 @@
 //
 // Which is why these assertions are about the FILE ON DISK and the PUBLISH, never about the
 // response: the response was already correct while the feature did nothing.
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import express from "express";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { routeCall, jsonPost } from "../../helpers/routeCall";
@@ -33,6 +33,9 @@ const script = {
 };
 
 let workspace: string;
+// Every workspace this file made, not just the current one: a test that calls the route twice
+// makes two, and tracking only `workspace` would leave the first behind in the temp dir.
+let workspaces: string[];
 let published: { channel: string; data: unknown }[];
 
 /** A story on disk plus a mounted route, which is the only way to reach `handleToolCall` — it is
@@ -40,6 +43,7 @@ let published: { channel: string; data: unknown }[];
  *  actually calls. */
 const appWithStory = () => {
   workspace = mkdtempSync(join(tmpdir(), "mulmoscript-beat-"));
+  workspaces.push(workspace);
   const stories = join(workspace, "artifacts", "stories");
   mkdirSync(stories, { recursive: true });
   writeFileSync(join(stories, "deck.json"), JSON.stringify(script, null, 2));
@@ -69,6 +73,11 @@ const call = (body: Record<string, unknown>) => routeCall(appWithStory())("/api/
 
 beforeEach(() => {
   published = [];
+  workspaces = [];
+});
+
+afterEach(() => {
+  workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true }));
 });
 
 describe("presentMulmoScript — replacing one beat", () => {

--- a/test/server/backends/mulmoscriptBeatReplace.spec.ts
+++ b/test/server/backends/mulmoscriptBeatReplace.spec.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+// The tool-call path for `presentMulmoScript`, and specifically the branch that replaces ONE beat
+// of an existing story.
+//
+// It was documented and dead at the same time (#1880). The tool's own description tells an agent
+// to use it "whenever the user asks to change part of an existing presentation", while the host's
+// argument allowlist dropped `beatIndex` and `beat` on the way to the package — and every field of
+// `SaveMulmoScriptArgs` is optional, so what arrived looked like a plain re-display request. The
+// package answered "Loaded MulmoScript from …", changed nothing, and the agent could not tell that
+// from success.
+//
+// Which is why these assertions are about the FILE ON DISK and the PUBLISH, never about the
+// response: the response was already correct while the feature did nothing.
+import { describe, it, expect, beforeEach } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { routeCall, jsonPost } from "../../helpers/routeCall";
+import { initMulmoScriptBackend, mountMulmoScriptDispatchRoute } from "../../../server/backends/mulmoscript.js";
+import { initArtifactsBackend } from "../../../server/backends/artifacts.js";
+
+const SCRIPT_CHANGED = "plugin:mulmoScript:scriptChanged";
+const STORY = "stories/deck.json";
+
+const beat = (heading: string) => ({ speaker: "Presenter", text: heading, image: { type: "markdown", markdown: `# ${heading}`, style: "corporate-blue" } });
+
+const script = {
+  $mulmocast: { version: "1.1" },
+  title: "Deck",
+  lang: "en",
+  beats: [beat("first"), beat("second"), beat("third")],
+};
+
+let workspace: string;
+let published: { channel: string; data: unknown }[];
+
+/** A story on disk plus a mounted route, which is the only way to reach `handleToolCall` — it is
+ *  not exported, and exporting it to test it would let the allowlist drift from what the route
+ *  actually calls. */
+const appWithStory = () => {
+  workspace = mkdtempSync(join(tmpdir(), "mulmoscript-beat-"));
+  const stories = join(workspace, "artifacts", "stories");
+  mkdirSync(stories, { recursive: true });
+  writeFileSync(join(stories, "deck.json"), JSON.stringify(script, null, 2));
+  published = [];
+  // Both, and in this order — the same pairing server/index.ts uses. The mulmoScript ops read and
+  // write through the artifacts backend, so without this the save path 500s with "artifacts
+  // backend not initialised" while the publish path (which touches no file) works fine.
+  initArtifactsBackend({ workspace });
+  initMulmoScriptBackend({
+    workspace,
+    pubsub: { publish: (channel, data) => published.push({ channel, data }) },
+    isFfmpegAvailable: () => false,
+  });
+  const app = express();
+  // Not optional, and its absence is quiet: without a JSON parser the route sees an EMPTY body,
+  // the package answers "Provide either `script` or `filePath`" with a 200, and an assertion that
+  // only checks the status and that the file is unchanged passes for entirely the wrong reason.
+  // Four of these tests did exactly that before this line existed.
+  app.use(express.json());
+  mountMulmoScriptDispatchRoute(app);
+  return app;
+};
+
+const onDisk = () => JSON.parse(readFileSync(join(workspace, "artifacts", "stories", "deck.json"), "utf8"));
+
+const call = (body: Record<string, unknown>) => routeCall(appWithStory())("/api/plugin/presentMulmoScript", jsonPost(body));
+
+beforeEach(() => {
+  published = [];
+});
+
+describe("presentMulmoScript — replacing one beat", () => {
+  it("writes the replacement to disk", async () => {
+    const res = await call({ filePath: STORY, beatIndex: 1, beat: beat("REPLACED") });
+
+    expect(res.status).toBe(200);
+    // The assertion that would have caught #1880. The response was always fine.
+    expect(onDisk().beats[1].image.markdown).toBe("# REPLACED");
+  });
+
+  it("leaves the other beats alone", async () => {
+    await call({ filePath: STORY, beatIndex: 1, beat: beat("REPLACED") });
+
+    const beats = onDisk().beats;
+    expect(beats).toHaveLength(3);
+    // The target too, or this passes when NOTHING was written — which a mutation showed it doing.
+    // "the others are unchanged" is trivially true of a no-op, and a no-op is the whole bug.
+    expect(beats[1].image.markdown).toBe("# REPLACED");
+    expect(beats[0].image.markdown).toBe("# first");
+    expect(beats[2].image.markdown).toBe("# third");
+  });
+
+  // The write is only half of it. A canvas that already has this story open learns about the
+  // change from the broadcast and from nothing else — a new save gets redrawn because the response
+  // tells the agent to display the story, which opens the new file, but replacing a beat of an
+  // ALREADY OPEN story changes nothing on screen without this.
+  it("broadcasts the change, so an open canvas reloads", async () => {
+    await call({ filePath: STORY, beatIndex: 1, beat: beat("REPLACED") });
+
+    expect(published).toEqual([{ channel: SCRIPT_CHANGED, data: { filePath: STORY } }]);
+  });
+
+  // No `origin`, and the package's contract is explicit about why: "A View passes its own id on
+  // every write and ignores the echo of its own … An agent write carries no origin, so every View
+  // reloads." An invented id here would make some View skip the reload as its own echo.
+  it("carries no origin, because an agent wrote it", async () => {
+    await call({ filePath: STORY, beatIndex: 1, beat: beat("REPLACED") });
+
+    expect(published[0]?.data).not.toHaveProperty("origin");
+  });
+});
+
+describe("presentMulmoScript — when no beat was replaced", () => {
+  // A re-display touches nothing, so a broadcast would be a claim about a file nothing wrote.
+  it("does not broadcast for a plain re-display", async () => {
+    const res = await call({ filePath: STORY });
+
+    expect(res.status).toBe(200);
+    expect(published).toEqual([]);
+    expect(onDisk().beats[1].image.markdown).toBe("# second");
+  });
+
+  // The package requires the pair together and refuses half of it. What matters here is that the
+  // host does not broadcast for a request that wrote nothing — the refusal itself is the
+  // package's to make.
+  it("does not broadcast when only one half of the pair is given", async () => {
+    await call({ filePath: STORY, beatIndex: 1 });
+    expect(published).toEqual([]);
+
+    published = [];
+    await call({ filePath: STORY, beat: beat("REPLACED") });
+    expect(published).toEqual([]);
+    expect(onDisk().beats[1].image.markdown).toBe("# second");
+  });
+
+  // A string index is not an index. It has to be dropped rather than coerced, or `"1"` would edit
+  // beat 1 while `"x"` reached the package as a value its own validation never expected.
+  it("ignores a beatIndex that is not a number", async () => {
+    await call({ filePath: STORY, beatIndex: "1", beat: beat("REPLACED") });
+
+    expect(published).toEqual([]);
+    expect(onDisk().beats[1].image.markdown).toBe("# second");
+  });
+});


### PR DESCRIPTION
## Summary

`presentMulmoScript` の**ビート差し替え**（`filePath` + `beatIndex` + `beat`）が、**何も書き換えずに成功として返って**いました。レスポンスは通常の再表示と同じで、呼んだ側から成功と区別がつきません。

**実行中のサーバで再現してから直しています:**

```
POST /api/plugin/presentMulmoScript
  {"filePath":"stories/…json","beatIndex":2,"beat":{…"# REPRO MARKER"…}}
-> 200、通常の再表示と同じ data.script
-> ファイルの beat[2] は変わっていない
```

原因は 2 つとも `handleToolCall` にありました。

| # | 原因 |
|---|---|
| 1 | 引数の allowlist が `beatIndex` / `beat` を落としていた。`SaveMulmoScriptArgs` は全フィールドが optional なので、パッケージには「ただの再表示要求」として届き、分岐に入らず素通り。**パッケージ側は実装済みで、ツールの description はこの機能を使えと明示的に案内している** —— ドキュメント済みかつ死んでいた |
| 2 | 書き込めても `script-changed` が publish されない。新規保存で画面が変わって見えるのはレスポンスの `Display the storyboard to the user.` でキャンバスが**新しいファイルを開く**ため。既存ファイルを開いたまま中身だけ差し替える場合、**pubsub が唯一の更新経路** |

## Items to Confirm / Review

**1. `origin` を渡していません。** パッケージの契約が理由を書いていました —— *"A View passes its own id on every write and ignores the echo of its own … **An agent write carries no origin, so every View reloads.**"* 最初 `"agent"` を渡していましたが、View が自分のエコーと見て reload をスキップし得ます。それは直そうとしている沈黙そのものです。

**2. publish の条件は `body` ではなく `args`（実際にパッケージへ渡したもの）を見ています。** これは**ミューテーションが私のコードの弱さを暴いた**結果です: 最初の `body` 版は、allowlist を #1880 の状態に戻しても broadcast のテストが緑のままでした —— 同じ判断を二重に導出していたので、パッケージに何も届いていないのに publish していた（「何も書いていないファイルについての嘘」そのもの）。`args` にしたら、M1 で赤くなるテストが **1 件 → 4 件**に増えました（`bd1df482` 時点、テスト 7 件）。

**3. allowlist を `saveArgsFrom(body)` に抽出しました。** `sonarjs/cognitive-complexity` が 17 > 15 で落ちたための対応でもありますが、「何がパッケージに届くか」を決める場所が 1 つになるので読みやすさとしても良いと判断しています。`eslint-disable` は使っていません。

**4. パッケージ側 `saveKind` の同じ取りこぼしは直していません。** 別リポジトリなので upstream issue に分けるべきものです。この PR はホスト側の経路だけです。

**5. テストで私自身が踏んだ落とし穴が 3 つあり、いずれもコメントに残しました。** レビューで見ていただきたいのはここです:

- **`express.json()` を付け忘れていた** —— body が空のままルートに届き、パッケージは `Provide either 'script' or 'filePath'` を **200 で**返します。「status 200 かつファイル不変」だけを見ていた 4 件が、**まったく違う理由で緑**になっていました
- **`initArtifactsBackend` を呼んでいなかった** —— publish 経路はファイルに触らないので既存の channels spec では露見せず、save 経路だけが 500 になります
- **`leaves the other beats alone` が no-op でも通っていた** —— 「他が変わっていない」は何も起きていないときに自明に真。対象 beat も assert するようにしました

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1880　これ直せる？

## 検証

**break-verify**（各回のあと `diff -q` で byte-identical 復元を確認）

| ミューテーション | 結果（`bd1df482`、テスト 7 件） |
|---|---|
| allowlist から `beatIndex`/`beat` を戻す（#1880 そのもの） | **4 red** |
| publish を消す | 2 red |
| publish を無条件にする | 1 red |
| `origin` を付ける | 2 red |

レビュー中にレスポンスのアサーションを 1 件足したので、M1 は `515cb848` 以降 **5 red / 8 件**になっています（下の「レビューループ」参照）。

**実機**（`--port 34910` で起動して POST）

| | beat[2] |
|---|---|
| 修正前 | `# 1 つの台本から何でも`（変わらない） |
| 修正後 | `# FIXED`（書き換わる） |

検証に使ったストーリーは元の内容に戻してあります。

`yarn format` / `lint` / `typecheck` / `build` / `test` すべて exit **0**。テスト数は測定したツリーに紐づけて:

| sha | `yarn test` | この spec | M1 |
|---|---|---|---|
| `bd1df482`（当初） | 11514 | 7 | 4 red |
| `515cb848` 以降 | 11515 | 8 | **5 red** |

## レビューループで足したもの（`/gh-review-loop`）

- **CodeRabbit**: MD040（言語タグ）、および「数値を測定した sha に紐づけよ」—— 後者は plan 文書**自身のヘッダーが定めている規則**を、その文書が破っていたという指摘でした。この PR 本文にも同じ問題があったので、あわせて直しています
- **bot が挙げず、読み直しで見つけたもの**: spec が temp workspace を消していなかった（このリポジトリの `mkdtempSync` 系 69 本中 65 本は消している）。**レスポンスが書き込み後のスクリプトを返すことを何も pin していなかった** —— エージェントが読めるのはレスポンスだけで、修正前はそれが書き込み前のスクリプトを成功に見えるメッセージ付きで返していた。M1 が 4→5 red になったのはこの 1 件
- **エンドツーエンド検証**: 「開いたままのキャンバスが更新される」がこの PR の主張なのに、証明していたのは publish が呼ばれること（unit）とファイルが変わること（実機）だけでした。ブラウザと同じ socket.io 購読（`/ws/pubsub`）を外から繋いで測り直し、**ビート差し替えで 1 件・`origin` 無し / ただの再表示で 0 件**を確認しています（scratch な `HOME` の 34911、実サーバ 34567 には触れていません）

Closes #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where replacing a specific beat in a presented script could fail to save the update.
  * Updated scripts now retain all other beats and correctly notify connected features when a replacement succeeds.
  * Invalid or incomplete beat replacement requests no longer trigger change notifications.
  * Successful replacements now return the updated script.
  * Re-displaying a script without changes no longer triggers unnecessary notifications.

* **Tests**
  * Added coverage for successful replacements, unchanged beats, invalid requests, and change notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
