### PR TITLE
fix: refresh OpenRouter prices in modelPresets from the catalog (#1849)

### DIFF
--- a/common/modelPresets.ts
+++ b/common/modelPresets.ts
@@ -205,22 +205,6 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
   // ── Frontier vendors: cheapest first ─────────────────────────────────────────
   {
     provider: "openrouter",
-    id: "google/gemini-3.5-flash-lite",
-    label: "Gemini 3.5 Flash-Lite",
-    contextLength: 1_048_576,
-    pricePerMTok: { input: 0.3, output: 2.5 },
-    trials: measured(3, 3, 11),
-  },
-  {
-    provider: "openrouter",
-    id: "amazon/nova-2-lite-v1",
-    label: "Nova 2 Lite",
-    contextLength: 1_000_000,
-    pricePerMTok: { input: 0.3, output: 2.5 },
-    trials: measured(2, 3, 20),
-  },
-  {
-    provider: "openrouter",
     id: "openai/gpt-5.6-luna",
     label: "GPT-5.6 Luna",
     contextLength: 1_050_000,
@@ -234,6 +218,22 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     contextLength: 1_050_000,
     pricePerMTok: { input: 0.2, output: 1.2 },
     trials: measured(3, 3, 69),
+  },
+  {
+    provider: "openrouter",
+    id: "google/gemini-3.5-flash-lite",
+    label: "Gemini 3.5 Flash-Lite",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.3, output: 2.5 },
+    trials: measured(3, 3, 11),
+  },
+  {
+    provider: "openrouter",
+    id: "amazon/nova-2-lite-v1",
+    label: "Nova 2 Lite",
+    contextLength: 1_000_000,
+    pricePerMTok: { input: 0.3, output: 2.5 },
+    trials: measured(2, 3, 20),
   },
   {
     provider: "openrouter",

--- a/common/modelPresets.ts
+++ b/common/modelPresets.ts
@@ -78,7 +78,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "nvidia/nemotron-3-super-120b-a12b",
     label: "Nemotron 3 Super 120B",
     contextLength: 1_000_000,
-    pricePerMTok: { input: 0.08, output: 0.45 },
+    pricePerMTok: { input: 0.085, output: 0.4 },
     trials: measured(3, 3, 18),
   },
   {
@@ -86,7 +86,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "qwen/qwen3-235b-a22b-2507",
     label: "Qwen3 235B A22B",
     contextLength: 262_144,
-    pricePerMTok: { input: 0.09, output: 0.55 },
+    pricePerMTok: { input: 0.0875, output: 0.35 },
     trials: measured(3, 3, 16),
   },
   {
@@ -94,7 +94,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "minimax/minimax-m2.7",
     label: "MiniMax M2.7",
     contextLength: 204_800,
-    pricePerMTok: { input: 0.25, output: 1.0 },
+    pricePerMTok: { input: 0.3, output: 1.2 },
     trials: measured(3, 3, 16),
   },
   {
@@ -102,7 +102,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "deepseek/deepseek-v3.2",
     label: "DeepSeek V3.2",
     contextLength: 163_840,
-    pricePerMTok: { input: 0.269, output: 0.4 },
+    pricePerMTok: { input: 0.26, output: 0.38 },
     trials: measured(3, 3, 42),
   },
   {
@@ -118,7 +118,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "deepseek/deepseek-v4-pro",
     label: "DeepSeek V4 Pro",
     contextLength: 1_048_576,
-    pricePerMTok: { input: 0.435, output: 0.87 },
+    pricePerMTok: { input: 0.87, output: 1.74 },
     trials: measured(3, 3, 20),
   },
   {
@@ -126,7 +126,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "deepseek/deepseek-v4-flash",
     label: "DeepSeek V4 Flash",
     contextLength: 1_048_576,
-    pricePerMTok: { input: 0.094, output: 0.188 },
+    pricePerMTok: { input: 0.088606, output: 0.177212 },
     trials: measured(3, 4, 26),
   },
   {
@@ -158,7 +158,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "moonshotai/kimi-k2.6",
     label: "Kimi K2.6",
     contextLength: 262_144,
-    pricePerMTok: { input: 0.684, output: 3.42 },
+    pricePerMTok: { input: 0.95, output: 4.0 },
     trials: measured(3, 3, 46),
   },
   {
@@ -166,7 +166,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "z-ai/glm-5.2",
     label: "GLM 5.2",
     contextLength: 1_048_576,
-    pricePerMTok: { input: 0.819, output: 2.574 },
+    pricePerMTok: { input: 1.19, output: 3.74 },
     trials: measured(3, 3, 21),
   },
   {
@@ -174,7 +174,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "moonshotai/kimi-k2.7-code",
     label: "Kimi K2.7 Code",
     contextLength: 262_144,
-    pricePerMTok: { input: 0.82, output: 3.75 },
+    pricePerMTok: { input: 0.66, output: 3.4 },
     trials: measured(3, 3, 14),
   },
   {
@@ -190,15 +190,15 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "tencent/hy3",
     label: "Tencent Hy3",
     contextLength: 262_144,
-    pricePerMTok: { input: 0.14, output: 0.58 },
+    pricePerMTok: { input: 0.132, output: 0.528 },
     trials: measured(3, 3, 17),
   },
   {
     provider: "openrouter",
     id: "nvidia/nemotron-3-ultra-550b-a55b",
     label: "Nemotron 3 Ultra 550B",
-    contextLength: 524_288, // 512 KiB = 512 * 1024; was 512_288 (a typo)
-    pricePerMTok: { input: 0.6, output: 3.6 },
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.5, output: 2.2 },
     trials: measured(3, 3, 13),
   },
 
@@ -224,7 +224,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "openai/gpt-5.6-luna",
     label: "GPT-5.6 Luna",
     contextLength: 1_050_000,
-    pricePerMTok: { input: 1.0, output: 6.0 },
+    pricePerMTok: { input: 0.2, output: 1.2 },
     trials: measured(3, 3, 27),
   },
   {
@@ -232,7 +232,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "openai/gpt-5.6-luna-pro",
     label: "GPT-5.6 Luna Pro",
     contextLength: 1_050_000,
-    pricePerMTok: { input: 1.0, output: 6.0 },
+    pricePerMTok: { input: 0.2, output: 1.2 },
     trials: measured(3, 3, 69),
   },
   {
@@ -240,7 +240,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "google/gemini-3.6-flash",
     label: "Gemini 3.6 Flash",
     contextLength: 1_048_576,
-    pricePerMTok: { input: 1.5, output: 7.5 },
+    pricePerMTok: { input: 0.75, output: 3.75 },
     trials: measured(3, 3, 16),
   },
   {
@@ -256,7 +256,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "openai/gpt-5.6-terra-pro",
     label: "GPT-5.6 Terra Pro",
     contextLength: 1_050_000,
-    pricePerMTok: { input: 2.5, output: 15.0 },
+    pricePerMTok: { input: 2.0, output: 12.0 },
     trials: measured(3, 3, 38),
   },
 
@@ -303,7 +303,7 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
     id: "mistralai/devstral-2512",
     label: "Devstral 2512",
     contextLength: 262_144,
-    pricePerMTok: { input: 0.4, output: 2.0 },
+    pricePerMTok: { input: 0.44, output: 2.2 },
     trials: unreachable(ACCOUNT_PRIVACY),
   },
 ];

--- a/plans/fix-1849-openrouter-prices.md
+++ b/plans/fix-1849-openrouter-prices.md
@@ -1,0 +1,81 @@
+# fix: refresh OpenRouter prices in modelPresets from the catalog (#1849)
+
+## What
+
+`common/modelPresets.ts` documents `pricePerMTok` as "US dollars per million tokens, as
+published by the provider's catalog". Sixteen of the 27 `provider: "openrouter"` presets no
+longer matched it, and one `contextLength` was 2x over.
+
+Source: `GET https://openrouter.ai/api/v1/models`, read 2026-08-28 (380 models). No key needed:
+
+```bash
+curl -s https://openrouter.ai/api/v1/models \
+  | jq -r '.data[] | [.id, (.pricing.prompt|tonumber*1e6), (.pricing.completion|tonumber*1e6)] | @tsv'
+```
+
+The file's convention is the top-level `context_length`, not `top_provider.context_length` —
+all 27 presets agree with the former (once nemotron-ultra is corrected) and several disagree
+with the latter.
+
+## Changed
+
+| id | was | now |
+|---|---|---|
+| `openai/gpt-5.6-luna` | 1.0 / 6.0 | 0.2 / 1.2 |
+| `openai/gpt-5.6-luna-pro` | 1.0 / 6.0 | 0.2 / 1.2 |
+| `google/gemini-3.6-flash` | 1.5 / 7.5 | 0.75 / 3.75 |
+| `deepseek/deepseek-v4-pro` | 0.435 / 0.87 | 0.87 / 1.74 |
+| `z-ai/glm-5.2` | 0.819 / 2.574 | 1.19 / 3.74 |
+| `moonshotai/kimi-k2.6` | 0.684 / 3.42 | 0.95 / 4.0 |
+| `nvidia/nemotron-3-ultra-550b-a55b` | 0.6 / 3.6 | 0.5 / 2.2 |
+| `qwen/qwen3-235b-a22b-2507` | 0.09 / 0.55 | 0.0875 / 0.35 |
+| `moonshotai/kimi-k2.7-code` | 0.82 / 3.75 | 0.66 / 3.4 |
+| `openai/gpt-5.6-terra-pro` | 2.5 / 15.0 | 2.0 / 12.0 |
+| `minimax/minimax-m2.7` | 0.25 / 1.0 | 0.3 / 1.2 |
+| `mistralai/devstral-2512` | 0.4 / 2.0 | 0.44 / 2.2 |
+| `deepseek/deepseek-v4-flash` | 0.094 / 0.188 | 0.088606 / 0.177212 |
+| `tencent/hy3` | 0.14 / 0.58 | 0.132 / 0.528 |
+| `deepseek/deepseek-v3.2` | 0.269 / 0.4 | 0.26 / 0.38 |
+| `nvidia/nemotron-3-super-120b-a12b` | 0.08 / 0.45 | 0.085 / 0.4 |
+
+Plus `nvidia/nemotron-3-ultra-550b-a55b` `contextLength` 524_288 -> 262_144. The comment that
+explained the old value ("512 KiB = 512 * 1024; was 512_288") went with it — 262_144 needs no
+explanation, and the catalog is the authority.
+
+## Why the issue's table was not applied as filed
+
+#1849 was filed 2026-08-24 with 13 rows. Read again on 2026-08-28 the catalog gives 16, and
+five of the overlapping rows had moved AGAIN in those four days:
+
+| id | file | #1849 (08-24) | catalog (08-28) |
+|---|---|---|---|
+| `deepseek/deepseek-v4-pro` | 0.435 / 0.87 | 0.5222 / 1.0443 | 0.87 / 1.74 |
+| `deepseek/deepseek-v4-flash` | 0.094 / 0.188 | 0.056 / 0.112 | 0.088606 / 0.177212 |
+| `z-ai/glm-5.2` | 0.819 / 2.574 | 0.966 / 3.036 | 1.19 / 3.74 |
+| `minimax/minimax-m2.7` | 0.25 / 1.0 | 0.24 / 0.96 | 0.3 / 1.2 |
+| `moonshotai/kimi-k2.7-code` | 0.82 / 3.75 | 0.67 / 3.4 | 0.66 / 3.4 |
+
+`minimax/minimax-m2.7` had reversed direction: the issue reported the file as too HIGH, and it
+is now too LOW.
+
+Three rows the issue did not have: `qwen/qwen3-235b-a22b-2507` (reported as matching),
+`nvidia/nemotron-3-ultra-550b-a55b`, and `mistralai/devstral-2512`.
+
+`mistralai/devstral-2512` is back in the catalog (0.44 / 2.2), so the issue's other proposal —
+drop the row or give it a distinct status because the id had left the catalog — no longer
+applies. Its `unreachable(ACCOUNT_PRIVACY)` note is about the measuring account's privacy
+settings, which is a different fact and is left alone.
+
+## Deliberately not done
+
+- **No reordering.** Both list sections are commented "cheapest first". The open-models section
+  already violated it before this change (0.037 and 0.094 sit after 0.435), and the frontier
+  section is newly violated by the luna pair falling to 0.2. Reordering changes what the picker
+  shows and should be one decision over both sections, not a side effect of a price refresh.
+- **No automated catalog check.** #1849 proposes one, and the prices are the field that moves
+  without anyone touching the repo — this refresh is the evidence. But a test that reaches the
+  network on every PR contradicts "tests must run without API keys" and would go red on an
+  offline runner or a catalog outage. If it is wanted, it belongs on a schedule with a named
+  route for failures, not in `yarn test`.
+- **No `pricesCheckedAt` stamp.** Worth having for the same reason `MEASURED_AT` exists, but it
+  is a schema addition rather than a data correction.

--- a/plans/fix-1849-openrouter-prices.md
+++ b/plans/fix-1849-openrouter-prices.md
@@ -68,10 +68,7 @@ settings, which is a different fact and is left alone.
 
 ## Deliberately not done
 
-- **No reordering.** Both list sections are commented "cheapest first". The open-models section
-  already violated it before this change (0.037 and 0.094 sit after 0.435), and the frontier
-  section is newly violated by the luna pair falling to 0.2. Reordering changes what the picker
-  shows and should be one decision over both sections, not a side effect of a price refresh.
+- **No reordering beyond the frontier section** — see below.
 - **No automated catalog check.** #1849 proposes one, and the prices are the field that moves
   without anyone touching the repo — this refresh is the evidence. But a test that reaches the
   network on every PR contradicts "tests must run without API keys" and would go red on an
@@ -79,3 +76,36 @@ settings, which is a different fact and is left alone.
   route for failures, not in `yarn test`.
 - **No `pricesCheckedAt` stamp.** Worth having for the same reason `MEASURED_AT` exists, but it
   is a schema addition rather than a data correction.
+
+## Ordering: the frontier section WAS reordered
+
+The first draft of this change left the order alone, on the reading that "cheapest first" was a
+stale comment. That was wrong, and codex-review caught it.
+
+`sortedModels()` (`src/components/modelOption.ts`) orders only by `modelRank`, and
+`Array.prototype.sort` is stable, so the order in `MODEL_PRESETS` **is** the order the picker
+shows within a reliability bucket. `modelOption.ts` states the contract itself: "Within a bucket
+the built-in order is kept — it runs cheapest-first, which is the next thing worth comparing once
+reliability is equal."
+
+The refreshed Luna prices (0.2) left both entries below the 0.3 Flash pair, so the frontier
+section stopped honouring it. Both moved to the head of that section, which now reads
+0.2, 0.2, 0.3, 0.3, 0.75, 2.0, 2.0 — grok-4.5 ahead of gpt-5.6-terra-pro on output, their inputs
+being equal.
+
+### Left alone, and pre-existing
+
+Measured per RELIABILITY BUCKET rather than per section — which is what the picker actually
+groups by — the order was already not ascending before this change:
+
+| bucket | breaks before | breaks after the price refresh, before the reorder |
+|---|---|---|
+| RELIABLE | 2 (`tencent/hy3` 0.14 and `google/gemini-3.5-flash-lite` 0.3 both after `moonshotai/kimi-k3` 3.0) | 6 |
+| UNTESTED | 1 (`openai/gpt-oss-120b` 0.037 after `deepseek/deepseek-v4-flash`) | 1 |
+| TROUBLED | 1 (`mistralai/devstral-2512` after `mistralai/mistral-medium-3-5` 1.5) | 1 |
+
+The frontier reorder above removes the breaks this change introduced. The remaining ones predate
+it and fixing them means reordering ACROSS the section boundaries — `tencent/hy3` and
+`nvidia/nemotron-3-ultra-550b-a55b` would have to move up among the open models, and the UNTESTED
+and TROUBLED entries are interleaved with sections chosen for a different reason. That is a wider
+change than a price refresh should carry, and it should be decided once for the whole list.

--- a/test/server/modelPresets.spec.ts
+++ b/test/server/modelPresets.spec.ts
@@ -38,9 +38,11 @@ describe("presetsForProvider", () => {
 });
 
 describe("MODEL_PRESETS data", () => {
-  // Regression (#748): a 512_288 typo for a "512K" context — the real value is 512 * 1024.
-  it("uses power-of-two context lengths (no 512_288 typo)", () => {
+  // Regression (#748): a 512_288 typo for the context length. That fix inferred what the typo
+  // had meant (512 * 1024) instead of reading the catalog, which publishes 262_144 for this
+  // model — so the guard pins the published value rather than the arithmetic (#1849).
+  it("takes nemotron-3-ultra's context length from the published catalog", () => {
     const nemotron = MODEL_PRESETS.find((p) => p.id === "nvidia/nemotron-3-ultra-550b-a55b");
-    expect(nemotron?.contextLength).toBe(524_288);
+    expect(nemotron?.contextLength).toBe(262_144);
   });
 });


### PR DESCRIPTION
## Summary

`common/modelPresets.ts` documents `pricePerMTok` as "US dollars per million tokens, as published by the provider's catalog". It had drifted: **16 of the 27 `provider: "openrouter"` presets** disagreed with `https://openrouter.ai/api/v1/models`, and one `contextLength` was 2x over.

Read from the catalog on **2026-08-28** (380 models). After this change all 27 presets agree with it exactly on both price and context length, verified programmatically (0 mismatches).

| id | was | now |
|---|---|---|
| `openai/gpt-5.6-luna` | 1.0 / 6.0 | 0.2 / 1.2 |
| `openai/gpt-5.6-luna-pro` | 1.0 / 6.0 | 0.2 / 1.2 |
| `google/gemini-3.6-flash` | 1.5 / 7.5 | 0.75 / 3.75 |
| `deepseek/deepseek-v4-pro` | 0.435 / 0.87 | 0.87 / 1.74 |
| `z-ai/glm-5.2` | 0.819 / 2.574 | 1.19 / 3.74 |
| `moonshotai/kimi-k2.6` | 0.684 / 3.42 | 0.95 / 4.0 |
| `nvidia/nemotron-3-ultra-550b-a55b` | 0.6 / 3.6 | 0.5 / 2.2 |
| `qwen/qwen3-235b-a22b-2507` | 0.09 / 0.55 | 0.0875 / 0.35 |
| `moonshotai/kimi-k2.7-code` | 0.82 / 3.75 | 0.66 / 3.4 |
| `openai/gpt-5.6-terra-pro` | 2.5 / 15.0 | 2.0 / 12.0 |
| `minimax/minimax-m2.7` | 0.25 / 1.0 | 0.3 / 1.2 |
| `mistralai/devstral-2512` | 0.4 / 2.0 | 0.44 / 2.2 |
| `deepseek/deepseek-v4-flash` | 0.094 / 0.188 | 0.088606 / 0.177212 |
| `tencent/hy3` | 0.14 / 0.58 | 0.132 / 0.528 |
| `deepseek/deepseek-v3.2` | 0.269 / 0.4 | 0.26 / 0.38 |
| `nvidia/nemotron-3-super-120b-a12b` | 0.08 / 0.45 | 0.085 / 0.4 |

Plus `nvidia/nemotron-3-ultra-550b-a55b` `contextLength` 524_288 -> 262_144.

## Items to Confirm / Review

**1. The context length change rewrites a test #748 added deliberately.** This is the one judgment call here and is easy to revert on its own.

`#748` found `512_288`, read it as a typo for "512K", and wrote `512 * 1024 = 524_288` — then pinned that with a regression test. But the catalog publishes **262_144** for this model, in both `context_length` and `top_provider.context_length` (`max_completion_tokens: 16384`). So the earlier fix filled the value in by arithmetic rather than from the source, which is the same class of error this PR is correcting. The guard is kept but now asserts the published number instead of the inference.

**2. #1849's table was NOT applied as filed, because it is already stale.** The issue was written 2026-08-24 with 13 rows. Four days later the catalog gives 16, and five of the overlapping rows had moved again:

| id | file | #1849 (08-24) | catalog (08-28) |
|---|---|---|---|
| `deepseek/deepseek-v4-pro` | 0.435 / 0.87 | 0.5222 / 1.0443 | 0.87 / 1.74 |
| `deepseek/deepseek-v4-flash` | 0.094 / 0.188 | 0.056 / 0.112 | 0.088606 / 0.177212 |
| `z-ai/glm-5.2` | 0.819 / 2.574 | 0.966 / 3.036 | 1.19 / 3.74 |
| `minimax/minimax-m2.7` | 0.25 / 1.0 | 0.24 / 0.96 | 0.3 / 1.2 |
| `moonshotai/kimi-k2.7-code` | 0.82 / 3.75 | 0.67 / 3.4 | 0.66 / 3.4 |

`minimax/minimax-m2.7` had reversed direction: the issue reports the file as too high; it is now too low.

Three rows the issue did not list: `qwen/qwen3-235b-a22b-2507` (reported as matching), `nvidia/nemotron-3-ultra-550b-a55b`, `mistralai/devstral-2512`.

**3. `mistralai/devstral-2512` is back in the catalog** (0.44 / 2.2), so #1849's other proposal — drop the row or give it a distinct status because the id had left the catalog — no longer applies. Its `unreachable(ACCOUNT_PRIVACY)` note is about the measuring account's privacy settings, a separate fact, and is left alone.

**4. The frontier section was reordered so it stays cheapest-first** (raised by codex-review, fixed in b236ee24).

"Cheapest first" is not a stale comment — it is load-bearing. `sortedModels()` orders only by `modelRank`, and `Array.prototype.sort` is stable, so the order in this array **is** the order the picker shows within a reliability bucket. `modelOption.ts` says so itself: *"Within a bucket the built-in order is kept — it runs cheapest-first, which is the next thing worth comparing once reliability is equal."* The refreshed Luna prices (0.2) left both entries sitting below the 0.3 Flash pair, so the section stopped honouring it. Both moved to the head of the section: 0.2, 0.2, 0.3, 0.3, 0.75, 2.0, 2.0.

**Left alone, and pre-existing:** measured per reliability bucket rather than per section, the RELIABLE bucket was already not ascending before this PR — `tencent/hy3` (0.14) and `google/gemini-3.5-flash-lite` (0.3) both sit after `moonshotai/kimi-k3` (3.0) — and UNTESTED and TROUBLED have one break each. Those predate this change and fixing them means reordering across the section boundaries, which is wider than a price refresh should carry.

## Implementation approach and key decisions

Values come from one unauthenticated GET, no key needed:

```bash
curl -s https://openrouter.ai/api/v1/models \
  | jq -r '.data[] | [.id, (.pricing.prompt|tonumber*1e6), (.pricing.completion|tonumber*1e6)] | @tsv'
```

The file's convention is the **top-level `context_length`**, not `top_provider.context_length` — all 27 presets agree with the former once nemotron-ultra is corrected, and several disagree with the latter (e.g. `minimax/minimax-m3` 1048576 vs 524288). That is what settles which field the corrected value comes from.

Deliberately out of scope, with reasons recorded in `plans/fix-1849-openrouter-prices.md`:

- **No automated catalog check.** #1849 proposes one and the argument is sound — prices are the field that moves without anyone touching the repo, and this refresh is the evidence. But a test that reaches the network on every PR contradicts "tests must run without API keys" and would go red on an offline runner or a catalog outage. If wanted, it belongs on a schedule with a named route for failures, not in `yarn test`.
- **No `pricesCheckedAt` stamp.** Worth having for the same reason `MEASURED_AT` exists, but it is a schema addition rather than a data correction.

### Verification

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` and `yarn test` (774 files, 11507 tests) all pass locally.

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1849 — オリジナルの情報にあたって更新して
- PR してマージ

work in mulmoterminal2
