### PR TITLE
fix(cli): ブラウザに渡す URL を localhost に戻す —— 4.11.0 で grid 配置が旧 origin に置き去りになっていた (#1889)

### DIFF
--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -6,6 +6,8 @@ export declare function probeFailureIsPortInUse(err: { code?: string } | null | 
 export declare function companionHostsFor(boundAddress: string): string[];
 export declare function launcherReachHost(bindHost: string): string | null;
 export declare function launcherUrl(reachHost: string, port: number): string;
+export declare function browserUrl(port: number): string;
+export declare function boundAddressNote(reachHost: string, port: number): string | null;
 export declare function chooseCwd(args: string[], env: Record<string, string | undefined>): CwdChoice;
 export declare function portInUseMessage(port: number, explicit: boolean): string;
 export declare function portInUseAction(explicit: boolean, isTTY: boolean | undefined): "ask" | "stop";

--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -7,7 +7,7 @@ export declare function companionHostsFor(boundAddress: string): string[];
 export declare function launcherReachHost(bindHost: string): string | null;
 export declare function launcherUrl(reachHost: string, port: number): string;
 export declare function browserUrl(port: number): string;
-export declare function boundAddressNote(reachHost: string, port: number): string | null;
+export declare function launchTarget(reachHost: string, port: number, localhostIsUnambiguous: boolean): { url: string; note: string | null };
 export declare function chooseCwd(args: string[], env: Record<string, string | undefined>): CwdChoice;
 export declare function portInUseMessage(port: number, explicit: boolean): string;
 export declare function portInUseAction(explicit: boolean, isTTY: boolean | undefined): "ask" | "stop";

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -210,21 +210,44 @@ export function browserUrl(port) {
 }
 
 /**
- * The line naming the address actually bound, or null when it says nothing the browser URL did
- * not already say.
+ * Where to send the browser, and what to say about it — as one decision, because the two answers
+ * have to agree.
  *
- * `browserUrl` sends everyone to `localhost`, which is right for the machine the launcher runs on
- * and useless to the operator who set `MULMOTERMINAL_HOST` so ANOTHER machine could open the app.
- * 4.11.0 told them their address by putting it in the banner; keeping that here means restoring
- * the origin costs them nothing.
+ * `localhostIsUnambiguous` is a MEASUREMENT, not a guess: the launcher tried to bind `[::1]:port`
+ * before spawning, so `false` means something else already answers there. That is the hole Codex
+ * flagged on this change and it is real for the DEFAULT bind, not only a widened one —
+ * `companionHostsFor` requires `127.0.0.1` free for every launch but never asks about `::1`, and
+ * `localhost` resolves to BOTH (measured). Sending the browser to `localhost` while a stranger
+ * holds the v6 loopback is exactly the case #1876's review was worried about.
  *
- * It is asked about the address the kernel REPORTED, so the two loopback spellings below are the
- * finite output vocabulary `launcherReachHost` already reasons about — not an attempt to classify
- * what someone typed.
+ * So the rule is: use the name the user's state is filed under WHEN NOTHING ELSE CAN ANSWER TO
+ * IT, and otherwise say plainly that we stepped aside — including where their layout went, since
+ * a silent switch here is #1889 all over again for that one user.
+ *
+ * The probe cannot close the window, only narrow it: `::1` is free when asked, and unless the
+ * server binds it (a `::1` or `::` bind), a stranger could still take it afterwards. That is the
+ * same probe/bind race `isPortFree` already documents and accepts.
+ *
+ * The loopback spellings below are compared against the address the kernel REPORTED, whose output
+ * vocabulary is finite — not against anything a user typed.
  */
-export function boundAddressNote(reachHost, port) {
-  if (reachHost === V4_LOOPBACK_CLIENTS_DIAL || reachHost === "::1") return null;
-  return `Bound to ${reachHost} — reachable from another machine at ${launcherUrl(reachHost, port)}`;
+export function launchTarget(reachHost, port, localhostIsUnambiguous) {
+  if (!localhostIsUnambiguous) {
+    const checked = launcherUrl(reachHost, port);
+    return {
+      url: checked,
+      note: `Something else is already listening on [::1]:${port}, so the browser is being sent to ${checked} — the address that was checked. If your layout and settings look empty, they are filed under http://localhost:${port}.`,
+    };
+  }
+  const bound = reachHost === V4_LOOPBACK_CLIENTS_DIAL || reachHost === "::1";
+  return {
+    url: browserUrl(port),
+    // `browserUrl` sends everyone to `localhost`, which is right for the machine the launcher runs
+    // on and useless to the operator who set `MULMOTERMINAL_HOST` so ANOTHER machine could open
+    // the app. 4.11.0 told them their address by putting it in the banner; saying it here means
+    // restoring the origin costs them nothing.
+    note: bound ? null : `Bound to ${reachHost} — reachable from another machine at ${launcherUrl(reachHost, port)}`,
+  };
 }
 
 /**

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -156,13 +156,13 @@ export function launcherReachHost(bindHost) {
   return isIP(bindHost) ? bindHost : null;
 }
 
-/** What to PRINT for a concrete address — never `localhost`.
+/** What to name a concrete address with — never `localhost`, because this one exists to say
+ *  WHICH ADDRESS WAS CHECKED. `launcherReachHost` picks `::1` precisely so an IPv4 listener
+ *  cannot answer for us, and writing `localhost` would hand that choice straight back: measured,
+ *  `localhost` resolves to BOTH `::1` and `127.0.0.1`.
  *
- *  It did say `localhost` for the loopback cases, because that is friendlier. CodeRabbit caught
- *  what that throws away: `launcherReachHost` picks `::1` precisely so an IPv4 listener cannot
- *  answer for us, and printing `localhost` hands the choice straight back — measured, `localhost`
- *  resolves to BOTH `::1` and `127.0.0.1`, so the browser may open the very process the poll was
- *  written to avoid. A URL the user clicks has to name the address that was checked.
+ *  This is no longer what the BROWSER is sent to — see `browserUrl`, and #1889 for why those are
+ *  two different questions.
  *
  *  Built through `URL` so the platform does the escaping: an IPv6 literal has to be bracketed or
  *  `http://::1:34567` is not a URL at all. The brackets go on BEFORE the assignment because the
@@ -172,6 +172,59 @@ export function launcherUrl(reachHost, port) {
   const url = new URL(`http://localhost:${port}`);
   url.hostname = reachHost.includes(":") ? `[${reachHost}]` : reachHost;
   return url.origin;
+}
+
+/**
+ * The URL the BROWSER is opened at — always `localhost`, and that is a COMPATIBILITY constraint,
+ * not a preference about which spelling reads better.
+ *
+ * The grid layout (`grid_v2`), the theme, the font size and eleven other things live in
+ * `localStorage`, which is partitioned by ORIGIN. So this string is not merely an address the
+ * user is sent to; it is the key their state is filed under. Changing it silently empties the
+ * app: 4.11.0 moved it to `http://127.0.0.1:<port>` as part of #1876's review and every upgrading
+ * user's grid came up blank, with their sessions alive in tmux and nothing on screen to say the
+ * layout was one hostname away (#1889).
+ *
+ * And there is no way back for state left on the old origin. Measured on Chrome 152: a hidden
+ * iframe on the old origin reads an EMPTY store (third-party storage partitioning), and
+ * `document.requestStorageAccess()` resolving does not change that — it governs cookies. Only a
+ * TOP-LEVEL visit to the old origin can see it. A URL that has to be stable is therefore cheaper
+ * to keep stable than to migrate.
+ *
+ * Reachability is not the reason it is safe; #1834 is. `server/infra/loopback-listener.ts` makes
+ * this server serve `127.0.0.1` in EVERY configuration — as the primary bind, or as a second
+ * listener when the operator widens it — because eight local callers write that address as a
+ * literal. So `localhost` arrives here whatever `MULMOTERMINAL_HOST` says, falling back to v4
+ * when v6 refuses.
+ *
+ * What this deliberately does NOT do is decide anything about the port PROBE or the readiness
+ * POLL. Those still follow the address the child reports binding, which is what #1876 actually
+ * fixed — the second-instance guard, and a ready banner that was reporting a stranger's 200. The
+ * residual risk restored here is only the one 4.10.1 and every release before it carried: another
+ * APP holding this port on `::1` alone could answer a browser resolving `localhost` that way. A
+ * second MulmoTerminal cannot, because `companionHostsFor` requires `127.0.0.1` free for every
+ * bind before the child is ever spawned.
+ */
+export function browserUrl(port) {
+  return new URL(`http://localhost:${port}`).origin;
+}
+
+/**
+ * The line naming the address actually bound, or null when it says nothing the browser URL did
+ * not already say.
+ *
+ * `browserUrl` sends everyone to `localhost`, which is right for the machine the launcher runs on
+ * and useless to the operator who set `MULMOTERMINAL_HOST` so ANOTHER machine could open the app.
+ * 4.11.0 told them their address by putting it in the banner; keeping that here means restoring
+ * the origin costs them nothing.
+ *
+ * It is asked about the address the kernel REPORTED, so the two loopback spellings below are the
+ * finite output vocabulary `launcherReachHost` already reasons about — not an attempt to classify
+ * what someone typed.
+ */
+export function boundAddressNote(reachHost, port) {
+  if (reachHost === V4_LOOPBACK_CLIENTS_DIAL || reachHost === "::1") return null;
+  return `Bound to ${reachHost} — reachable from another machine at ${launcherUrl(reachHost, port)}`;
 }
 
 /**

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -19,8 +19,7 @@ import { waitUntilReady } from "./wait-ready.js";
 import {
   bindHostFor,
   chooseCwd,
-  boundAddressNote,
-  browserUrl,
+  launchTarget,
   companionHostsFor,
   launcherReachHost,
   probeFailureIsPortInUse,
@@ -296,6 +295,24 @@ async function isPortFree(port) {
   return primary;
 }
 
+// Can `localhost` reach anything OTHER than the server this launcher is about to start? (#1889)
+//
+// The browser is sent to `localhost` so a user's saved layout stays where it has always been, and
+// `localhost` resolves to BOTH `::1` and `127.0.0.1` (measured). `isPortFree` already proves
+// `127.0.0.1` is free for every launch — `companionHostsFor` requires it — but nothing asks about
+// `::1`, so a stranger holding the v6 loopback could answer a browser that resolves that way.
+//
+// Asked by BINDING rather than by classifying the host string, which is this file's rule
+// throughout: free means nobody is there, and that is true whether the server is about to take
+// `::1` itself (a `::1` or `::` bind) or leave it empty. Both are answers the browser can only
+// reach us with. A machine with no IPv6 fails EADDRNOTAVAIL, which probeFailureIsPortInUse
+// correctly reports as "not in use" — and there `localhost` is v4-only, so it is unambiguous.
+//
+// Must run BEFORE the server is spawned, or the server's own `::1` listener answers the probe.
+async function localhostReachesOnlyUs(port) {
+  return (await canBind(port, "::1")).free;
+}
+
 function printReadyBanner(url, stopCommand) {
   const bar = "\x1b[32m" + "─".repeat(48) + "\x1b[0m";
   console.log(`\n${bar}`);
@@ -368,7 +385,7 @@ async function confirmNoRunningInstance() {
   log(SECOND_INSTANCE_NOTE);
 }
 
-async function choosePort(requested, explicit) {
+async function pickPort(requested, explicit) {
   const asked = await isPortFree(requested);
   if (asked.free) return { port: requested, address: asked.address };
   // No SILENT fallback: starting a second server on another port without saying so is how
@@ -387,15 +404,23 @@ async function choosePort(requested, explicit) {
   return fallback;
 }
 
+// The port, the address a probe of it landed on, and whether `localhost` can reach anything but us
+// on it — settled together because all three have to be known BEFORE the spawn, which is the only
+// moment `::1` can be asked about honestly (see localhostReachesOnlyUs).
+async function choosePort(requested, explicit) {
+  const chosen = await pickPort(requested, explicit);
+  return { ...chosen, localhostIsUnambiguous: await localhostReachesOnlyUs(chosen.port) };
+}
+
 // What the launcher does the moment the server answers: say where it is, and open it there.
 //
-// `url` is where the BROWSER goes and `addressNote` is what was actually bound — two different
-// facts since #1889, and the note is null whenever they would say the same thing.
-function announceReady(url, addressNote, noOpen) {
+// `url` is where the BROWSER goes and `note` is what launchTarget wants said about that choice —
+// two different facts since #1889, and the note is null whenever the URL already covers it.
+function announceReady(url, note, noOpen) {
   printReadyBanner(url, STOP_COMMAND);
-  // Only for a bind the operator widened: `localhost` is right for THIS machine and says nothing
-  // to the one they opened the port for.
-  if (addressNote) log(addressNote);
+  // Either the address a widened bind serves other machines on, or why the browser was NOT sent
+  // to `localhost`. Null whenever the URL above already said everything.
+  if (note) log(note);
   if (noOpen) return;
   try {
     // The command is a hardcoded literal; url is built by browserUrl from a numeric port, so it
@@ -411,7 +436,7 @@ function announceReady(url, addressNote, noOpen) {
 // the port was taken at bind time before it became ready — the caller then
 // reports that and stops. In every other case (clean shutdown, fatal error,
 // or the server simply running) the process exits with the server's code.
-function runServer(port, probedAddress, noOpen, cwd, onChild) {
+function runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, onChild) {
   return new Promise((resolveExit) => {
     log(`Starting MulmoTerminal on port ${port}...`);
     // stderr is piped (and passed through) so a fatal boot error can be inspected once the
@@ -456,9 +481,8 @@ function runServer(port, probedAddress, noOpen, cwd, onChild) {
     const beginReady = (reachHost) => {
       if (readyStarted) return;
       readyStarted = true;
-      const url = browserUrl(port);
-      const addressNote = boundAddressNote(reachHost, port);
-      cancelReady = waitUntilReady(port, () => announceReady(url, addressNote, noOpen), { host: reachHost });
+      const { url, note } = launchTarget(reachHost, port, localhostIsUnambiguous);
+      cancelReady = waitUntilReady(port, () => announceReady(url, note, noOpen), { host: reachHost });
     };
     server.on("message", (msg) => {
       if (!isRecordLike(msg) || msg.type !== "listening" || typeof msg.address !== "string") return;
@@ -625,12 +649,12 @@ async function main() {
   // The address comes back with the port because the PROBE learned it from the kernel, which is
   // the one answer that needs no interpreting (#1876). It is the fallback the readiness poll uses
   // when the child reports nothing.
-  const { port, address: probedAddress } = await choosePort(requestedPort, portExplicit);
+  const { port, address: probedAddress, localhostIsUnambiguous } = await choosePort(requestedPort, portExplicit);
   // Named only now, because the port is half the name — and named at all so that the user who
   // loses this terminal has something to search for (#1820). The server child names itself the
   // same, so `pkill mulmoterminal` reaches whichever half is found first.
   setProcessTitle(port);
-  await runServer(port, probedAddress, noOpen, cwd, (c) => {
+  await runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, (c) => {
     child = c;
   });
   error(portInUseMessage(port, portExplicit));

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -19,9 +19,10 @@ import { waitUntilReady } from "./wait-ready.js";
 import {
   bindHostFor,
   chooseCwd,
+  boundAddressNote,
+  browserUrl,
   companionHostsFor,
   launcherReachHost,
-  launcherUrl,
   probeFailureIsPortInUse,
   parsePortArg,
   portInUseAction,
@@ -386,6 +387,25 @@ async function choosePort(requested, explicit) {
   return fallback;
 }
 
+// What the launcher does the moment the server answers: say where it is, and open it there.
+//
+// `url` is where the BROWSER goes and `addressNote` is what was actually bound — two different
+// facts since #1889, and the note is null whenever they would say the same thing.
+function announceReady(url, addressNote, noOpen) {
+  printReadyBanner(url, STOP_COMMAND);
+  // Only for a bind the operator widened: `localhost` is right for THIS machine and says nothing
+  // to the one they opened the port for.
+  if (addressNote) log(addressNote);
+  if (noOpen) return;
+  try {
+    // The command is a hardcoded literal; url is built by browserUrl from a numeric port, so it
+    // is http://localhost:<n>.
+    execSync(`${pickOpenCommand()} ${url}`, { stdio: "pipe" });
+  } catch {
+    log(`Open your browser: ${url}`);
+  }
+}
+
 // Spawn the server on `port` and report the child via `onChild` (so signal
 // handlers target the live process). Resolves only when the server exits because
 // the port was taken at bind time before it became ready — the caller then
@@ -427,26 +447,18 @@ function runServer(port, probedAddress, noOpen, cwd, onChild) {
     let readyStarted = false;
     let cancelReady = () => {};
     // Takes a CONCRETE address — callers resolve first, and a caller that cannot does not call.
+    //
+    // Two different questions, and #1889 is what happens when one answer is given to both. The
+    // POLL asks "did the server we started come up", so it uses the address the child reported
+    // binding — that is #1876's fix and it stays. The URL asks "where does this user's browser
+    // keep its state", and the only answer that does not empty the app is the one it has always
+    // been given: see browserUrl.
     const beginReady = (reachHost) => {
       if (readyStarted) return;
       readyStarted = true;
-      const url = launcherUrl(reachHost, port);
-      cancelReady = waitUntilReady(
-        port,
-        () => {
-          printReadyBanner(url, STOP_COMMAND);
-          if (noOpen) return;
-          try {
-            // The command is a hardcoded literal; url is built by launcherUrl from the address the
-            // child reported and a numeric port, so it is http://<addr>:<n> or http://[<v6>]:<n>.
-
-            execSync(`${pickOpenCommand()} ${url}`, { stdio: "pipe" });
-          } catch {
-            log(`Open your browser: ${url}`);
-          }
-        },
-        { host: reachHost },
-      );
+      const url = browserUrl(port);
+      const addressNote = boundAddressNote(reachHost, port);
+      cancelReady = waitUntilReady(port, () => announceReady(url, addressNote, noOpen), { host: reachHost });
     };
     server.on("message", (msg) => {
       if (!isRecordLike(msg) || msg.type !== "listening" || typeof msg.address !== "string") return;

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -29,6 +29,12 @@ binding — what changed back is only the URL handed to the browser, which is a 
 is filed under rather than a claim about which socket answered. If you set `MULMOTERMINAL_HOST` to
 reach the app from another machine, the banner now names that address on its own line.
 
+`localhost` is used only when the launcher has **checked** that nothing else can answer to it.
+`localhost` resolves to `[::1]` as well as `127.0.0.1`, and the startup probe never asked about the
+first of those — so before opening anything, the launcher now tries to take `[::1]:<port>` too. If
+something else already holds it, the browser goes to the address that was actually checked, and the
+banner says so and tells you where your layout is filed.
+
 ## mulmoterminal@4.11.0 — 2026-08-28
 
 > **Setup guide:** [Stopping it, and the ports it takes](https://receptron.github.io/mulmoterminal/guide/en/v4.11.0.html) — written at release time. ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.11.0.html))

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,27 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+### The browser opens at `localhost` again, so your grid comes back (#1889)
+
+4.11.0 started opening `http://127.0.0.1:<port>` instead of `http://localhost:<port>`. Nothing
+errored, and the app came up **empty**: the grid layout, the theme, the font size and eleven other
+preferences live in `localStorage`, which browsers partition by origin, so a different hostname is a
+different drawer. Sessions were all still running in tmux and nothing on screen connected the two.
+
+**If you upgraded to 4.11.0 and your grid was blank, this restores it** — the layout was never
+deleted, only filed under the other hostname, and that is the hostname the launcher opens again.
+
+One thing to know if you rebuilt your grid during 4.11.0: that newer arrangement is on
+`http://127.0.0.1:<port>` and stays there. Open that address directly to get it back. There is no
+way for the app to fetch it for you — measured on Chrome, a page cannot read another origin's
+`localStorage` even through an embedded frame, and `requestStorageAccess()` does not change that.
+
+The port fixes that shipped in 4.11.0 are untouched. The second-instance guard still probes the
+address the server will bind, and the readiness check still polls the address the server reports
+binding — what changed back is only the URL handed to the browser, which is a name your saved state
+is filed under rather than a claim about which socket answered. If you set `MULMOTERMINAL_HOST` to
+reach the app from another machine, the banner now names that address on its own line.
+
 ## mulmoterminal@4.11.0 — 2026-08-28
 
 > **Setup guide:** [Stopping it, and the ports it takes](https://receptron.github.io/mulmoterminal/guide/en/v4.11.0.html) — written at release time. ([日本語](https://receptron.github.io/mulmoterminal/guide/ja/v4.11.0.html))

--- a/plans/fix-1889-launcher-origin.md
+++ b/plans/fix-1889-launcher-origin.md
@@ -144,3 +144,50 @@ third-party storage partitioning は localStorage にも効き、Storage Access 
 **未検証** —— Windows / Linux での挙動は実機確認していない（macOS 26.5.1 arm64 のみ）。
 ただし変更は URL 文字列の組み立てのみで、probe / bind / poll のプラットフォーム依存部分は
 触っていない。`localhost` の到達性は #1834 の二次 listener に依存し、そちらは既存の仕組み。
+
+## レビュー iter-1 —— Codex の指摘と、それに対する設計変更
+
+`CODEX VERDICT: CHANGES REQUESTED`:
+
+> `browserUrl()` restores the saved-state origin but can open an unrelated service bound to
+> `::1:<port>` when the launcher uses a widened bind. … reserve/serve IPv6 loopback too, or do
+> not auto-open this ambiguous origin.
+
+**妥当で、しかも指摘より範囲が広い。** `companionHostsFor` は全 bind で `127.0.0.1` を必須 probe
+するが `::1` は**一度も聞かない**（既定 `127.0.0.1` bind では companion が空になる）。つまり
+widened bind に限らず**既定構成でも**穴がある。
+
+**採った答え —— 推測をやめて計測する。** spawn の前に `canBind(port, "::1")` を 1 回撃つ
+(`localhostReachesOnlyUs`)。free なら `localhost` は我々にしか届かない（`::1` を我々が取るか、
+誰も取らないかのどちらか）ので `localhost` を開く。誰かが居るなら 4.11.0 と同じ具体アドレスに
+退避し、**なぜ退避したか・利用者の状態がどこにあるか**を 1 行で言う。
+
+- host 文字列を分類せず **bind して聞く**。この file の一貫した流儀に合わせた
+- IPv6 の無いマシンは `EADDRNOTAVAIL` → `probeFailureIsPortInUse` が正しく「使用中でない」と
+  答える。そこでは `localhost` は v4 のみなので曖昧さが無く、結論も正しい
+- **黙って退避しない**のが要点。黙ると、その 1 人にとっては #1889 の再演になる
+- probe/bind のレースは閉じない。窓を狭めるだけで、`isPortFree` が既に認めている同じレース
+
+`boundAddressNote` は `launchTarget` に置き換えた —— URL と注記は必ず一緒に決まる必要があり
+（退避したときは URL 自身がアドレスを名乗るので「bind したのはこれ」の注記は要らない）、
+2 つの関数に分けると食い違い得るため。
+
+`main` が 61 行になり `max-lines-per-function` に触れたので、`choosePort` を `pickPort` +
+薄いラッパに分け、「port・probe したアドレス・`localhost` の一意性」を 1 か所で決めるようにした。
+
+### iter-1 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| `launchTarget` が `::1` の計測結果を無視する | 3 red |
+
+**実機**（scratch HOME、`--no-open`）—— `::1` を別プロセス（`I am NOT MulmoTerminal` を返す
+素の http サーバ）に握らせて再現:
+
+| 条件 | バナーの URL | 追加行 |
+|---|---|---|
+| `::1` は空、port 34693 | `http://localhost:34693` | なし |
+| `::1` を他プロセスが保持、port 34694 | `http://127.0.0.1:34694` | `Something else is already listening on [::1]:34694 … they are filed under http://localhost:34694.` |
+
+ゲート再実行: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
+`yarn test` **11523 passed / 50 skipped**。

--- a/plans/fix-1889-launcher-origin.md
+++ b/plans/fix-1889-launcher-origin.md
@@ -1,0 +1,146 @@
+# fix(cli): ブラウザに渡す URL を `localhost` に戻す (#1889)
+
+> 時系列のログであって現状の仕様書ではない。数値は必ず sha に紐づけて書く。
+
+## 症状（observed）
+
+4.10.1 でグリッドにセッションを並べた環境を、同じ port のまま 4.11.0 で起動すると
+**グリッドが空で立ち上がる**。tmux のセッションは全部生きているが、どのセルがどのセッション
+だったかを憶えているのはブラウザだけなので何も戻らない。エラーは出ない。
+
+`http://localhost:<port>` を手で開き直すと以前のグリッドがそのまま出てくる。状態は消えていない。
+
+## 原因
+
+グリッドの配置は `localStorage` の `grid_v2` にしかない（`src/components/gridTabs.ts:77`、
+読み書きは `src/components/GridView.vue:92,94`）。**`localStorage` は origin 単位**なので、
+開く URL のホスト名が変われば別の引き出しになる。
+
+git で確定した変更点:
+
+| version | ブラウザに渡す URL |
+|---|---|
+| 4.10.1 | `bin/mulmoterminal.js:352` … `const url = \`http://localhost:${port}\`;` |
+| 4.11.0 | `launcherUrl(reachHost, port)` → 既定 bind `127.0.0.1` なので `http://127.0.0.1:<port>` |
+
+`launcherUrl` は PR #1877（issue #1876）で入った。
+
+## これは #1876 の修正ではない
+
+#1876 の報告された不具合は **二重起動ガードが既定構成で発火しない** こと ——
+`isPortFree` が `::` を probe するのにサーバは `127.0.0.1` に bind し、bind は同一アドレスと
+しか衝突しないので稼働中インスタンスを検出できない。修正の核は `probe.listen(port, BIND_HOST)`。
+
+表示 URL を変えたのは**レビュー由来の追加**で、PR #1877 の変更表がそう書いている:
+
+> **readiness チェックと表示 URL も同じアドレスに従わせる**（gh-review-loop iter-2/3 で追加）
+
+したがって **URL だけ戻しても #1876 は再発しない**。probe・readiness ポーリング・IPC による
+bind アドレス報告は #1877 のまま一切触らない。
+
+## 戻して再び受け入れる risk と、その大きさ
+
+`launcherUrl` のコメントが挙げている懸念はこれ:
+
+> `localhost` resolves to BOTH `::1` and `127.0.0.1`, so the browser may open the very process
+> the poll was written to avoid.
+
+実体を切り分けると:
+
+- **MulmoTerminal の 2 個目は該当しない** —— `companionHostsFor` が全 bind で `127.0.0.1` を
+  必須 probe するので spawn 前に弾かれる（#1877 のこの部分は戻さない）
+- 残るのは「**別アプリ**が同じ port を `::1` だけで掴んでいる」場合のみ
+- 起きても他人のページが表示されるだけ。ready バナーの検証自体は実 bind アドレスに対して行う
+  （`waitUntilReady({ host: reachHost })` は変えない）
+- **4.10.1 以前は何ヶ月もこの挙動で、報告はゼロ**
+
+対して失うものは、アップグレードした利用者**全員**のグリッド配置。observed で、いま起きている。
+
+## `localhost` の到達性は #1834 が保証している
+
+`server/infra/loopback-listener.ts` の設計により、サーバは**必ず `127.0.0.1` を serve する** ——
+primary の bind がそれか、`MULMOTERMINAL_HOST` を広げたときは二次 listener が付く。同ファイルの
+コメントが「`localhost` と書く caller は v6 が refuse したら v4 に落ちて届く」と明言している。
+LAN bind (`192.168.x.x`)・`::1`・`127.0.0.2` のいずれでも `http://localhost:<port>` は届く。
+
+## issue の「本命」案（隠し iframe での移行）は不可能 —— 実測
+
+Chrome 152（`Google Chrome for Testing`、puppeteer 25.8.0）で計測:
+
+| 読み方 | 結果 |
+|---|---|
+| `localhost` をトップレベルで開く | `{"grid_v2":"FROM_OLD_ORIGIN"}` |
+| `127.0.0.1` の中に `localhost` の iframe | `{}` |
+| 同上 + `document.requestStorageAccess()` = **granted** | `{}` のまま |
+
+third-party storage partitioning は localStorage にも効き、Storage Access API は cookie 用なので
+解放されない。**旧 origin に触る手段はそのオリジンをトップレベルで開くことだけ**。
+だから「戻す」以外の選択肢は、どれも利用者に一手を要求する。
+
+## 4.11.0 の公開は 4 時間前
+
+`npm view mulmoterminal time` → `4.11.0: 2026-08-28T04:29:30.892Z`（確認時刻 2026-08-28T08:29Z）。
+新 origin に状態が溜まる前なので、戻すだけで被害者は自動的に元へ戻る。移行 UI もサーバ側の
+受け渡しも要らない。**急ぐ理由もここにある** —— 待つほど `127.0.0.1` 側に溜まる。
+
+## 変更
+
+`bin/cli-args.js`
+
+- `browserUrl(port)` を追加 —— ブラウザに渡す URL。常に `http://localhost:<port>`。
+  「正しいアドレス」ではなく「**変えてはいけない識別子**」を返す関数として分ける。
+- `launcherUrl(reachHost, port)` はそのまま残す —— 検証したアドレスを名指しする用途。
+
+`bin/mulmoterminal.js`
+
+- `beginReady` が open/print に `browserUrl(port)` を使う。`waitUntilReady` の `host` は
+  `reachHost` のまま（変更なし）。
+- bind が loopback でないときだけ、検証したアドレスを 1 行足す。LAN 運用者が 4.11.0 で得た
+  情報を失わないため。
+
+## 検証
+
+ツリー: `4bc15da1`（origin/main）+ 本変更。すべて pipe 越しではなく実 exit code を取得。
+
+**ゲート** —— `format` / `lint` / `typecheck` / `build` / `test` すべて exit **0**。
+`yarn test` は **11520 passed / 50 skipped**。
+
+> lint は最初 43 errors だったが、**node_modules が 4.10.1 当時のままだったのが原因**
+> （`mulmocast` 未インストール → "type that could not be resolved"）。`yarn install` 後は 0。
+> 42 件は既存ファイル側で、stash した状態でも同じものが出ることを確認済み。
+> 自分の変更由来だったのは 1 件 —— `runServer` が 62 行になり `max-lines-per-function` 超過。
+> `announceReady` を module level に抽出して解消（eslint-disable は使っていない）。
+
+**break-verify**（各回のあと `diff -q` でバックアップと byte-identical を確認）
+
+| ミューテーション | 結果 |
+|---|---|
+| `browserUrl` を `launcherUrl("127.0.0.1", port)` に戻す（= 4.11.0 の不具合） | 2 red |
+| `boundAddressNote` の loopback 早期 return を削る | 1 red |
+
+**実機**（scratch HOME、`--no-open`、実ブラウザは puppeteer 25.8.0 / Chrome 152）
+
+| 条件 | バナーの URL | 追加行 | 結果 |
+|---|---|---|---|
+| 既定 bind（`127.0.0.1`）, port 34688 | `http://localhost:34688` | なし | ✓ |
+| 同 port で 2 個目（レジストリ空の別 HOME） | —— | —— | `Port 34688 is already in use.` / exit 1、**`Starting...` も偽 ready バナーも無し**（#1876 非再発） |
+| `MULMOTERMINAL_HOST=192.168.11.12`, port 34689 | `http://localhost:34689` | `Bound to 192.168.11.12 — reachable from another machine at http://192.168.11.12:34689` | ✓ |
+| `MULMOTERMINAL_HOST=::1`, port 34690 | `http://localhost:34690` | なし | ✓ |
+
+**`localhost` の到達性**（#1834 の二次 listener が効いていることの実測）—— curl の HTTP status:
+
+| bind | `localhost` | `127.0.0.1` | 実 bind アドレス |
+|---|---|---|---|
+| `192.168.11.12` | 200 | 200 | 200 |
+| `::1` | 200 | 200 | 200 |
+
+**ブラウザ**（Chrome 152 で実際に読み込み）
+
+| origin | status | mount | localStorage | console error |
+|---|---|---|---|---|
+| `http://localhost:34688` | 200 | ✓ | writable | 0 |
+| `http://127.0.0.1:34688` | 200 | ✓ | writable | 0 |
+
+**未検証** —— Windows / Linux での挙動は実機確認していない（macOS 26.5.1 arm64 のみ）。
+ただし変更は URL 文字列の組み立てのみで、probe / bind / poll のプラットフォーム依存部分は
+触っていない。`localhost` の到達性は #1834 の二次 listener に依存し、そちらは既存の仕組み。

--- a/plans/fix-1889-launcher-origin.md
+++ b/plans/fix-1889-launcher-origin.md
@@ -27,7 +27,7 @@ git で確定した変更点:
 
 ## これは #1876 の修正ではない
 
-#1876 の報告された不具合は **二重起動ガードが既定構成で発火しない** こと ——
+Issue #1876 の報告された不具合は **二重起動ガードが既定構成で発火しない** こと ——
 `isPortFree` が `::` を probe するのにサーバは `127.0.0.1` に bind し、bind は同一アドレスと
 しか衝突しないので稼働中インスタンスを検出できない。修正の核は `probe.listen(port, BIND_HOST)`。
 
@@ -191,3 +191,45 @@ widened bind に限らず**既定構成でも**穴がある。
 
 ゲート再実行: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
 `yarn test` **11523 passed / 50 skipped**。
+
+## レビュー iter-2 —— `localhost` が実際にどちらへ行くかを測った
+
+CodeRabbit が Major (CWE-367, TOCTOU) を出した:
+
+> `canBind` closes its successful `[::1]:port` probe before `runServer` starts. … `launchTarget`
+> then opens `http://localhost:<port>`, which can reach that process over IPv6 … A served page
+> could access the existing `localhost` localStorage.
+
+**レースは実在する**（この plan も「窓を狭めるだけで閉じない」と最初から書いている）。
+そこで、判断の土台になる事実を測った —— **同じ port の `127.0.0.1` と `::1` に別々のサーバが
+居るとき、`localhost` はどちらへ行くか。**
+
+Chrome 152 / macOS 26.5.1 arm64、`127.0.0.1` に `OURS-v4`、`::1` に `STRANGER-v6`:
+
+```
+Chrome  http://localhost:39221 -> STRANGER-v6
+```
+
+**Chrome は `::1` を優先する。** つまりこれは稀な取り合いではなく、`::1` に誰かが居れば
+**必ず**そちらが選ばれる。CR の懸念は私の見積もりより重い。同時に、この計測は
+**pre-spawn の `::1` 計測が必須**であることも示している —— 無ければ squatter が
+ブラウザごと `localhost` origin の localStorage を受け取る。
+
+### CR が挙げた 2 つの対処は、どちらもこの repo では悪化する
+
+1. **「reservation を launch まで保持する」** —— 保持したソケットは**ブラウザに応答してしまう**。
+   上の計測どおり Chrome は `::1` を優先するので、launcher が握る空ソケットが本体の代わりに
+   答え、利用者は死んだページを見る。レースを確実な故障に変える。
+2. **「サーバが `::1` を持てないときは具体アドレスを使う」** —— 既定の `127.0.0.1` bind は
+   `::1` を持たないので、**既定構成では二度と `localhost` を使わない**ことになる。それは
+   4.11.0 の挙動そのもの、すなわち全既定利用者にとっての #1889 の再演。
+
+### 本当の close は「サーバが `::1` を serve する」で、別 PR にする
+
+`server/infra/loopback-listener.ts` を 1 プランから複数プランへ広げ、`server/index.ts` の
+listener タプル（`createPubSub` / `mountTerminalWebSockets` が受ける）を 3 本にする変更。
+**全利用者の起動時に bind が 1 本増える**ので、実機確認込みで独立した PR に値する。
+この PR（URL を戻す revert）への相乗りにはしない。→ follow-up issue へ。
+
+窓は「全リリースで一度も聞いていない」から「1 回の probe とブラウザ起動の間」まで狭まり、
+起動時に既に居る squatter は捕まえて理由ごと告げる。それが本 PR の到達点。

--- a/test/bin/probe-bind-host.spec.ts
+++ b/test/bin/probe-bind-host.spec.ts
@@ -15,7 +15,7 @@ import { createServer, type Server } from "node:net";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { bindHostFor, boundAddressNote, browserUrl, companionHostsFor, launcherReachHost, launcherUrl, probeFailureIsPortInUse } from "../../bin/cli-args.js";
+import { bindHostFor, browserUrl, companionHostsFor, launchTarget, launcherReachHost, launcherUrl, probeFailureIsPortInUse } from "../../bin/cli-args.js";
 import { boundAddress } from "../../server/infra/loopback.js";
 import { BIND_HOST } from "../../server/config/env.js";
 
@@ -213,19 +213,49 @@ describe("the URL the browser is opened at", () => {
 
   // Restoring the origin must not cost the operator who widened the bind the address 4.11.0
   // started telling them — `localhost` is right for this machine and useless to the other one.
-  describe("and the note naming what was actually bound", () => {
-    it("says nothing for a loopback bind, where the browser URL already said it", () => {
-      ["127.0.0.1", "::1"].forEach((reach) => expect(boundAddressNote(reach, 34567)).toBeNull());
+  describe("and what the banner says about that choice", () => {
+    const target = (reach: string) => launchTarget(reach, 34567, true);
+
+    it("says nothing extra for a loopback bind, where the browser URL already said it", () => {
+      ["127.0.0.1", "::1"].forEach((reach) => expect(target(reach).note).toBeNull());
     });
 
     it("names the address, and the URL another machine would use, for a widened bind", () => {
-      const note = boundAddressNote("192.168.11.12", 34567);
+      const { note } = target("192.168.11.12");
       expect(note).toContain("192.168.11.12");
       expect(note).toContain(launcherUrl("192.168.11.12", 34567));
     });
 
     it("brackets a v6 literal in the note, since it goes through launcherUrl", () => {
-      expect(boundAddressNote("fd00::1", 34567)).toContain("[fd00::1]:34567");
+      expect(target("fd00::1").note).toContain("[fd00::1]:34567");
+    });
+  });
+
+  // Codex, reviewing this change, flagged the hole the revert would otherwise re-open: `localhost`
+  // resolves to `::1` as well as `127.0.0.1`, and `companionHostsFor` never asks about `::1` — so
+  // a stranger there could answer the browser. The launcher MEASURES it (localhostReachesOnlyUs)
+  // and this is what it does with a `false`.
+  describe("when something else already answers on the v6 loopback", () => {
+    const target = (reach: string) => launchTarget(reach, 34567, false);
+
+    it("sends the browser to the address that was actually checked, not to localhost", () => {
+      expect(target("127.0.0.1").url).toBe(launcherUrl("127.0.0.1", 34567));
+      expect(target("127.0.0.1").url).not.toContain("localhost");
+    });
+
+    // The silent version of this IS #1889 for that one user: an empty grid and nothing on screen
+    // saying where it went. Stepping aside is fine; doing it quietly is not.
+    it("says why, and where the user's saved state actually is", () => {
+      const { note } = target("127.0.0.1");
+      expect(note).toContain("[::1]:34567");
+      expect(note).toContain("http://localhost:34567");
+    });
+
+    // A widened bind takes the same branch — the ambiguity is about `localhost`, not about what
+    // the server bound, so the reason must not change with the bind.
+    it("steps aside for a widened bind too", () => {
+      expect(target("192.168.11.12").url).toBe(launcherUrl("192.168.11.12", 34567));
+      expect(target("192.168.11.12").note).toContain("[::1]:34567");
     });
   });
 });

--- a/test/bin/probe-bind-host.spec.ts
+++ b/test/bin/probe-bind-host.spec.ts
@@ -15,7 +15,7 @@ import { createServer, type Server } from "node:net";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { bindHostFor, companionHostsFor, launcherReachHost, launcherUrl, probeFailureIsPortInUse } from "../../bin/cli-args.js";
+import { bindHostFor, boundAddressNote, browserUrl, companionHostsFor, launcherReachHost, launcherUrl, probeFailureIsPortInUse } from "../../bin/cli-args.js";
 import { boundAddress } from "../../server/infra/loopback.js";
 import { BIND_HOST } from "../../server/config/env.js";
 
@@ -138,11 +138,11 @@ describe("the address the launcher uses to reach the server it started", () => {
     expect(launcherReachHost("::")).toBe("::1");
   });
 
-  // The URL names the CONCRETE address, never `localhost`. Printing `localhost` throws away the
-  // precision the reach host just established: measured on macOS, `localhost` resolves to BOTH
-  // `::1` and `127.0.0.1`, so a browser can open the very process the poll avoided. Flagged by
-  // CodeRabbit as a Major on the first head it reviewed after the readiness fix.
-  describe("and the URL it prints for that address", () => {
+  // `launcherUrl` names the CONCRETE address, never `localhost` — that is what it is FOR, and it
+  // is no longer what the browser is opened at (see the browserUrl block below, and #1889). It
+  // survives as the way `boundAddressNote` tells an operator who widened the bind which address
+  // another machine should use.
+  describe("and the way it names that address", () => {
     // launcherUrl now takes the CONCRETE address launcherReachHost produced, so these compose the
     // two the way the launcher does.
     const urlFor = (bindHost: string) => {
@@ -168,7 +168,7 @@ describe("the address the launcher uses to reach the server it started", () => {
     // Asserted through URL rather than against a literal string: `http://<a LAN address>` trips
     // sonarjs/no-clear-text-protocols, and this says the thing that matters anyway — which host
     // and port the launcher will send the user to.
-    it("names the real address when localhost would not reach it", () => {
+    it("names the real address for a bind localhost does not describe", () => {
       const url = new URL(urlFor("192.168.11.12"));
       expect(url.hostname).toBe("192.168.11.12");
       expect(url.port).toBe("34567");
@@ -183,6 +183,49 @@ describe("the address the launcher uses to reach the server it started", () => {
       // `hostname` round-trips WITH the brackets, so this pins the serialized form without
       // spelling a clear-text URL out as a literal.
       expect(new URL(launcherUrl("fd00::1", 34567)).hostname).toBe("[fd00::1]");
+    });
+  });
+});
+
+// The URL the BROWSER gets is a separate question from the address the launcher checked, and
+// #1889 is what giving one answer to both cost: 4.11.0 sent the browser to `http://127.0.0.1:
+// <port>`, `localStorage` is partitioned by origin, and every upgrading user's grid layout came
+// up blank while their sessions were still running in tmux.
+//
+// Nothing here is about which spelling is friendlier. `browserUrl` returns the key the user's
+// state is FILED UNDER, so the test that matters is that a bind — any bind — cannot move it.
+describe("the URL the browser is opened at", () => {
+  it("is localhost, so the origin holding grid_v2 never moves", () => {
+    expect(browserUrl(34567)).toBe("http://localhost:34567");
+  });
+
+  // The whole point: `MULMOTERMINAL_HOST` decides what the server binds and what the launcher
+  // polls, and it must decide NOTHING about where the browser keeps its state. This composes the
+  // launcher's own chain — bindHostFor -> launcherReachHost -> the poll host — and asserts the
+  // browser URL is unmoved by all of it.
+  it("does not follow the bind, whatever the bind is", () => {
+    ["127.0.0.1", "0.0.0.0", "::", "192.168.11.12", "fd00::1"].forEach((bindHost) => {
+      const reach = launcherReachHost(bindHostFor({ MULMOTERMINAL_HOST: bindHost }));
+      expect(reach, `launcherReachHost(${bindHost}) should be nameable`).not.toBeNull();
+      expect(browserUrl(34567), `a ${bindHost} bind moved the browser origin`).toBe("http://localhost:34567");
+    });
+  });
+
+  // Restoring the origin must not cost the operator who widened the bind the address 4.11.0
+  // started telling them — `localhost` is right for this machine and useless to the other one.
+  describe("and the note naming what was actually bound", () => {
+    it("says nothing for a loopback bind, where the browser URL already said it", () => {
+      ["127.0.0.1", "::1"].forEach((reach) => expect(boundAddressNote(reach, 34567)).toBeNull());
+    });
+
+    it("names the address, and the URL another machine would use, for a widened bind", () => {
+      const note = boundAddressNote("192.168.11.12", 34567);
+      expect(note).toContain("192.168.11.12");
+      expect(note).toContain(launcherUrl("192.168.11.12", 34567));
+    });
+
+    it("brackets a v6 literal in the note, since it goes through launcherUrl", () => {
+      expect(boundAddressNote("fd00::1", 34567)).toContain("[fd00::1]:34567");
     });
   });
 });


### PR DESCRIPTION
## Summary

4.11.0 がブラウザを `http://127.0.0.1:<port>` で開くようになり、**アップグレードした利用者のグリッド配置が消えた**ように見える状態になっていました。`localStorage` は origin 単位なので、ホスト名が変わると別の引き出しになります。tmux のセッションは全部生きているのに画面は空で、エラーは出ません。

**戻すのは「印字して open する URL」1 本だけです。** #1876 が直した部分 —— probe を `BIND_HOST` に追随させること、readiness poll、IPC で報告された bind アドレス —— は一切触っていません。

| | 4.10.1 | 4.11.0 | この PR |
|---|---|---|---|
| ブラウザに渡す URL | `http://localhost:<port>` | `http://127.0.0.1:<port>` | `http://localhost:<port>` |
| readiness poll の宛先 | `127.0.0.1` 決め打ち | 子が報告した実 bind アドレス | **4.11.0 のまま** |
| port probe | `::`（バグ） | `BIND_HOST` | **4.11.0 のまま** |
| bind を広げたとき | 情報なし | URL が実アドレス | URL は `localhost` + 実アドレスを 1 行追加 |

### なぜ「戻す」で良いのか —— これは #1876 の修正ではない

#1876 の報告された不具合は **二重起動ガードが既定構成で発火しない** ことでした。表示 URL を変えたのは**レビュー由来の追加**で、PR #1877 の変更表自身がそう書いています:

> **readiness チェックと表示 URL も同じアドレスに従わせる**（gh-review-loop iter-2/3 で追加）

実機で #1876 の非再発を確認済みです（下記「検証」）。

### 戻して再び受け入れる risk

`launcherUrl` のコメントが挙げていた懸念は「`localhost` は `::1` と `127.0.0.1` の両方に解決するので、browser が poll の避けたプロセスを開きうる」でした。実体を切り分けると:

- **MulmoTerminal の 2 個目は該当しません** —— `companionHostsFor` が全 bind で `127.0.0.1` を必須 probe するので spawn 前に弾かれます（この PR で触っていません）
- 残るのは「**別アプリ**が同じ port を `::1` だけで掴んでいる」場合のみ
- 起きても他人のページが表示されるだけで、ready バナーの検証自体は実 bind アドレスに対して行われます
- **4.10.1 以前は何ヶ月もこの挙動で、報告はゼロ**

対して失うものは、アップグレードした利用者**全員**のグリッド配置です。

### `localhost` の到達性は #1834 が保証している

`server/infra/loopback-listener.ts` により、サーバは**必ず `127.0.0.1` を serve します** —— primary の bind がそれか、`MULMOTERMINAL_HOST` を広げたときは二次 listener が付きます。実測で確認しました（下記）。

### issue が「本命」としていた自動移行は不可能です

Chrome 152 で計測したところ、`127.0.0.1` の中に置いた `localhost` の iframe が読む `localStorage` は **空**でした（third-party storage partitioning）。`document.requestStorageAccess()` が **granted** になっても空のままです（あれは cookie 用）。**旧 origin に触る手段はそのオリジンをトップレベルで開くことだけ**なので、「戻す」以外の案はどれも利用者に一手を要求します。

## Items to Confirm / Review

1. **`boundAddressNote` を足したのは純粋な revert より 1 歩多い判断です。** `localhost` に戻すと、`MULMOTERMINAL_HOST` を設定して別マシンから開いている運用者が 4.11.0 で得ていたアドレス表示を失います。バナーの下に 1 行足して補いました（loopback bind では出ません）。不要なら落とせます。

2. **4.11.0 の 4 時間で作られた状態は `127.0.0.1` 側に残ります。** 消えはしませんが、この PR は取りに行きません（上記のとおり技術的に不可能）。ChangeLog にその旨と、直接開けば戻ることを書きました。4.11.0 の npm 公開は `2026-08-28T04:29:30Z` で、窓は狭いはずです。

3. **4.11.0 の ChangeLog 記述は直していません。** 「The URL it prints is the address it checked, never `localhost`」は 4.11.0 が実際にしたことの記録として正しいので、履歴として残し、Unreleased 側で戻したことを書く形にしました。この扱いで良いか確認してください。

4. **Windows / Linux は実機確認していません**（macOS 26.5.1 arm64 のみ）。変更は URL 文字列の組み立てだけで、probe / bind / poll のプラットフォーム依存部分は触っていません。

## User Prompt

- 「これって何かの副作用だよね。緊急で直さないと。。。」（issue #1889 のリンク付き）
- 「いや、portかわったissueあったよね」
- 「そのPRなどをしらべて、どう戻すかかんがえる」
- 「mcpまわりのissueでportをhost名をかえたきおくがある、portじゃかなった」
- 「1876ってどんな問題？対して影響ないなら戻せばよいとお思う」

## 実装のアプローチ

**2 つの別々の問いに 1 つの答えを与えたのが原因**です。**POLL** が問うのは「起動したサーバは上がったか」で、答えは子が報告した実 bind アドレス。**URL** が問うのは「この利用者のブラウザは状態をどこに置いているか」で、答えは変えてはいけない識別子。#1877 は前者の答えを後者にも使いました。

- `browserUrl(port)` を新設 —— 常に `http://localhost:<port>`。「正しいアドレス」ではなく「**変えてはいけない識別子**」を返す関数として分離し、なぜ変えられないかを doc コメントに書きました。
- `launcherUrl(reachHost, port)` は残します —— 検証したアドレスを名指しする用途で、`boundAddressNote` が使います。
- `runServer` が 62 行になり `max-lines-per-function` に触れたので、ready 時の処理を `announceReady` として module level に抽出しました（`eslint-disable` は使っていません）。

設計判断と実測の記録は [`plans/fix-1889-launcher-origin.md`](plans/fix-1889-launcher-origin.md)。

## 検証

ツリー: `4bc15da1`（origin/main）+ 本変更。すべて実 exit code を取得。

**ゲート** —— `format` / `lint` / `typecheck` / `build` / `test` すべて exit **0**。`yarn test` は **11520 passed / 50 skipped**。

> lint は最初 43 errors でしたが、原因は **node_modules が 4.10.1 当時のままだったこと**（`mulmocast` 未インストール → "type that could not be resolved"）。`yarn install` 後は 0 です。42 件は stash した状態でも出ることを確認済みで、自分の変更由来は `runServer` の行数 1 件のみでした。

**break-verify**（各回のあと `diff -q` で byte-identical を確認）

| ミューテーション | 結果 |
|---|---|
| `browserUrl` を `launcherUrl("127.0.0.1", port)` に戻す（= 4.11.0 の不具合） | 2 red |
| `boundAddressNote` の loopback 早期 return を削る | 1 red |

**実機**（scratch HOME、`--no-open`）

| 条件 | バナーの URL | 追加行 | 結果 |
|---|---|---|---|
| 既定 bind（`127.0.0.1`）, port 34688 | `http://localhost:34688` | なし | ✓ |
| 同 port で 2 個目（レジストリ空の別 HOME） | —— | —— | `Port 34688 is already in use.` / exit 1、**`Starting...` も偽 ready バナーも無し**（#1876 非再発） |
| `MULMOTERMINAL_HOST=192.168.11.12`, port 34689 | `http://localhost:34689` | `Bound to 192.168.11.12 — reachable from another machine at http://192.168.11.12:34689` | ✓ |
| `MULMOTERMINAL_HOST=::1`, port 34690 | `http://localhost:34690` | なし | ✓ |

**`localhost` の到達性**（#1834 の二次 listener の実測、curl の HTTP status）

| bind | `localhost` | `127.0.0.1` | 実 bind アドレス |
|---|---|---|---|
| `192.168.11.12` | 200 | 200 | 200 |
| `::1` | 200 | 200 | 200 |

**ブラウザ**（Chrome 152 で実際に読み込み）

| origin | status | mount | localStorage | console error |
|---|---|---|---|---|
| `http://localhost:34688` | 200 | ✓ | writable | 0 |
| `http://127.0.0.1:34688` | 200 | ✓ | writable | 0 |

Closes #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry9BpQtMSkZ9D64fv3cztP

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser launches now consistently use the `localhost` origin, preserving saved layouts and preferences.
  * Added safeguards for IPv6 loopback conflicts, automatically using a verified address when needed.
  * Remote-bind scenarios now display an explanatory connection note.
  * Existing port availability and readiness checks remain supported.

* **Documentation**
  * Added changelog and design documentation covering launcher URL behavior and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->