### PR TITLE
fix(server): サーバ自身が `::1` も serve して、localhost の宛先を一意にする (#1893)

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -478,16 +478,23 @@ function runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, onC
     // binding — that is #1876's fix and it stays. The URL asks "where does this user's browser
     // keep its state", and the only answer that does not empty the app is the one it has always
     // been given: see browserUrl.
-    const beginReady = (reachHost) => {
+    // `serverHoldsV6` is the child's own report and OUTRANKS the probe when present. The probe ran
+    // before the child existed, so it cannot see a process that claimed `[::1]:<port>` during the
+    // boot — only the child knows how its own bind went (Codex, PR #1903). `undefined` means the
+    // child said nothing about it, and then the probe is all there is.
+    const beginReady = (reachHost, serverHoldsV6) => {
       if (readyStarted) return;
       readyStarted = true;
-      const { url, note } = launchTarget(reachHost, port, localhostIsUnambiguous);
+      const localhostIsOurs = localhostIsUnambiguous && serverHoldsV6 !== false;
+      const { url, note } = launchTarget(reachHost, port, localhostIsOurs);
       cancelReady = waitUntilReady(port, () => announceReady(url, note, noOpen), { host: reachHost });
     };
     server.on("message", (msg) => {
       if (!isRecordLike(msg) || msg.type !== "listening" || typeof msg.address !== "string") return;
       const reported = launcherReachHost(msg.address);
-      if (reported) beginReady(reported);
+      // Absent rather than false when the field is missing, so "an older child said nothing" and
+      // "this child could not take it" stay different answers.
+      if (reported) beginReady(reported, typeof msg.v6LoopbackServed === "boolean" ? msg.v6LoopbackServed : undefined);
     });
     // The fallback runs ONLY on an address we can name without asking anyone. Guessing from a
     // NAME is what the child's report exists to replace, and a fallback that guessed anyway just
@@ -499,7 +506,8 @@ function runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, onC
     // into something connectable; BIND_HOST is the last resort and returns null for a name.
     const guessed = probedAddress ? launcherReachHost(probedAddress) : launcherReachHost(BIND_HOST);
     const fallbackReady = setTimeout(() => {
-      if (guessed) return beginReady(guessed);
+      // No report, so no v6 answer either — the probe is all this path ever had.
+      if (guessed) return beginReady(guessed, undefined);
       if (!readyStarted)
         log(`Started, but ${BIND_HOST} is a name and the server has not reported which address it bound — not guessing. It may still be starting.`);
     }, REPORTED_ADDRESS_GRACE_MS);

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -478,14 +478,14 @@ function runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, onC
     // binding — that is #1876's fix and it stays. The URL asks "where does this user's browser
     // keep its state", and the only answer that does not empty the app is the one it has always
     // been given: see browserUrl.
-    // `serverHoldsV6` is the child's own report and OUTRANKS the probe when present. The probe ran
-    // before the child existed, so it cannot see a process that claimed `[::1]:<port>` during the
-    // boot — only the child knows how its own bind went (Codex, PR #1903). `undefined` means the
-    // child said nothing about it, and then the probe is all there is.
-    const beginReady = (reachHost, serverHoldsV6) => {
+    // `serverSaysLocalhostIsOurs` is the child's own report and OUTRANKS the probe when present.
+    // The probe ran before the child existed, so it cannot see a process that claimed EITHER
+    // loopback during the boot — only the child knows how its own binds went (Codex, PR #1903).
+    // `undefined` means the child said nothing about it, and then the probe is all there is.
+    const beginReady = (reachHost, serverSaysLocalhostIsOurs) => {
       if (readyStarted) return;
       readyStarted = true;
-      const localhostIsOurs = localhostIsUnambiguous && serverHoldsV6 !== false;
+      const localhostIsOurs = localhostIsUnambiguous && serverSaysLocalhostIsOurs !== false;
       const { url, note } = launchTarget(reachHost, port, localhostIsOurs);
       cancelReady = waitUntilReady(port, () => announceReady(url, note, noOpen), { host: reachHost });
     };
@@ -494,7 +494,7 @@ function runServer(port, probedAddress, localhostIsUnambiguous, noOpen, cwd, onC
       const reported = launcherReachHost(msg.address);
       // Absent rather than false when the field is missing, so "an older child said nothing" and
       // "this child could not take it" stay different answers.
-      if (reported) beginReady(reported, typeof msg.v6LoopbackServed === "boolean" ? msg.v6LoopbackServed : undefined);
+      if (reported) beginReady(reported, typeof msg.localhostIsOurs === "boolean" ? msg.localhostIsOurs : undefined);
     });
     // The fallback runs ONLY on an address we can name without asking anyone. Guessing from a
     // NAME is what the child's report exists to replace, and a fallback that guessed anyway just

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -356,3 +356,59 @@ mulmoterminal running at http://localhost:34765
 CodeRabbit の Minor（MD040、ログの code fence に言語が無い）も対応した。
 
 ゲート: すべて exit 0、`yarn test` **11613 passed / 50 skipped**。
+
+## レビュー iter-6 —— 推測をやめて、カーネルに直接聞く
+
+Codex（`CHANGES REQUESTED`）:
+
+> treats every IPv4 `EADDRINUSE` after a `::` bind as proof of dual-stack ownership. On
+> `net.ipv6.bindv6only=1` hosts, it can instead be an unrelated `127.0.0.1` listener.
+
+**iter-5 の裏返しで、これも正しい。** `inUseProvesPrimary` は「`::` なら dual-stack だろう」と
+いう**推測**だった。#1834 の時点ではその推測が外れても失うのは警告 1 本だったが、いまは
+`localhost` を安全と名乗るかどうかが乗っている。**同じ推測でも、賭け金が変わった。**
+
+保守側に倒す（`::` では常に taken 扱い）案は取らなかった。Linux の dual-stack という**よくある
+構成**で `localhost` origin を黙って失うことになり、それはこの一連の作業が直した不具合そのもの。
+
+代わりに**測る**。`kernelV6WildcardTakesV4()`:
+
+1. `[::]:0` に bind し、カーネルが選んだ ephemeral port を取る
+2. その port の `127.0.0.1` に bind してみる
+3. `EADDRINUSE` → このカーネルの `::` は v4 も取る / 成功 → `bindv6only`
+
+**カーネルが今しがた配ったポートを他人が握っていることはあり得ない**ので、ここでの
+`EADDRINUSE` は wildcard ソケット自身以外にならない。実 port について同じ問いを立てても
+「自分か他人か」を分けられないが、この問いなら分けられる。答えはポートではなく**カーネルの
+性質**なので、そのまま転用できる。
+
+これはこのファイルの元からの流儀（"ATTEMPT the bind and read the answer"）を、推測が残っていた
+最後の 1 箇所に適用しただけ。
+
+驚いたときは `false` を返す。「dual-stack でない」に倒れると本来使えたカーネルで `localhost`
+origin を失うだけだが、逆に倒れると `127.0.0.1` を握っている相手に origin を渡す。
+
+### iter-6 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| `::` を無条件に dual-stack とみなす（= 指摘された挙動） | 2 red |
+| probe が「どの失敗も dual-stack」と読む | **このカーネルでは観測不能**（v4 bind が別理由で失敗しないと到達しない）。正直に記録する |
+
+**probe をこのマシンで実行**: `:: takes v4 = false`。これは iter-1 の bind マトリクスで
+`::` の補助 v4 bind が**成功**した観測と一致する —— 独立に測った 2 つが同じことを言っている。
+
+**実機（probe 追加後の回帰確認）**
+
+| bind | banner | localhost | 127.0.0.1 | [::1] |
+|---|---|---|---|---|
+| 既定 | `→ http://localhost:34770` | 200 | 200 | 200 |
+| `::` | `→ http://localhost:34771` | 200 | 200 | 200 |
+
+**未検証** —— `bindv6only=1` のカーネル。macOS では作れない。probe の分岐そのものは spec で
+両方向を固定してある。
+
+lint の `sonarjs/no-nested-functions` に触れたので、probe は callback のネストではなく
+`bindOutcome` / `closeQuietly` を使った 3 手順の async として書いた。
+
+ゲート: すべて exit 0、`yarn test` **11619 passed / 50 skipped**。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -184,3 +184,50 @@ http://127.0.0.1:34731 … they are filed under http://localhost:34731.
 > ごと固定していて、引数が増えて red になった。**欠陥ではなく guard の脆さ**で、そのすぐ上の
 > コメントが「この guard は 2 度それで壊れた」と警告していた（今回で 3 度目）。第 1 引数だけを
 > 見る形に緩め、何を守っているのかを書き足した。
+
+## レビュー iter-2 —— 印字も「答えが出てから」
+
+Codex（`CHANGES REQUESTED`）:
+
+> `server/index.ts` still prints a `localhost` URL before the asynchronous `::1` bind outcome is
+> known. Direct `npm run server` starts have no IPC parent to replace that announcement.
+
+**iter-1 で IPC は直したのに、その隣の `console.log` を見落としていた。** listen callback の
+先頭で `mulmoterminal running at http://localhost:${PORT}` を無条件に出していて、これは
+**launcher の居ない直起動（`yarn dev` / `npm run server`）では operator が持つ唯一の情報**。
+直す対象は「readiness の名乗り」ではなく「**まだ答えの出ていないことを断言する行すべて**」
+だった、というのが本質。
+
+`localBrowserUrl(port, boundAddress, outcome)` を追加し、印字も bind の後に移した。降り方は
+「まだ真であること」の順:
+
+1. `::1` を持っている → `http://localhost:<port>`
+2. 持っていないが `127.0.0.1` は持っている → `http://127.0.0.1:<port>`
+3. どちらも無い → カーネルが報告した bind アドレス（v6 literal は bracket する）
+
+`localhost` を出さなかったときは理由も 1 行出す。黙って別アドレスを出すと、operator は見慣れない
+アドレスを前に検索語すら持たない。
+
+`LoopbackOutcome` に `v4LoopbackServed` を足したが、**wire には載せない**。launcher が決める
+ことは 1 つ（ブラウザを `localhost` へ送ってよいか）だけで、v4 の可否はこの process だけが
+使う。読まれないフィールドは、いつか間違って読まれる。
+
+### iter-2 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| 常に `localhost` を印字する（= 指摘された挙動） | 4 red |
+
+**実機 —— 直起動**（`npx tsx server/index.ts`、launcher 無し）
+
+| 条件 | 印字 |
+|---|---|
+| `::1` が空、port 34740 | `[bind] also listening on ::1:34740 …` → `mulmoterminal running at http://localhost:34740` |
+| `::1` を他プロセスが保持、port 34741 | `mulmoterminal running at http://127.0.0.1:34741` + `[bind] not printing http://localhost:34741 — something else holds [::1]:34741 …`。サーバは生存（`127.0.0.1` = 200） |
+
+ゲート: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
+`yarn test` **11601 passed / 50 skipped**。
+
+> spec が `sonarjs/no-clear-text-protocols` に引っかかった（LAN アドレスの literal URL）。
+> `test/bin/probe-bind-host.spec.ts` が同じ問題を `new URL()` で assert して回避しているので
+> それに合わせた。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -1,0 +1,120 @@
+# fix(server): サーバ自身が `::1` も serve する (#1893)
+
+> 時系列のログであって現状の仕様書ではない。数値は必ず sha に紐づけて書く。
+
+## なぜ
+
+#1889 で、ブラウザに渡す URL を `http://localhost:<port>` に戻した。`localStorage` は origin 単位
+なので、この URL は**利用者の状態が filed されている名前**であって変えられない。
+
+`localhost` は `::1` と `127.0.0.1` の両方に解決する。既定構成でサーバが bind するのは
+`127.0.0.1` だけなので、`[::1]:<port>` は誰でも取れる。
+
+**実測（2026-08-28、Chrome 152 / macOS 26.5.1 arm64）** —— 同じ port の `127.0.0.1` に `OURS-v4`、
+`::1` に `STRANGER-v6` を立て `http://localhost:<port>` を開く:
+
+```
+Chrome  http://localhost:39221 -> STRANGER-v6
+```
+
+**Chrome は `::1` を優先する。** 取り合いに負けうる、ではなく、居れば必ずそちらが選ばれる。
+そのページは `localhost` origin なので、MulmoTerminal の `grid_v2` / `theme` /
+`remoteHost.session` を読める。
+
+#1891 は launcher 側で spawn 前に 1 回 `canBind(port, "::1")` を撃つところまでやった。塞がって
+いるのは**起動時点で既に居る**ケースだけで、probe 後に取られる窓はセッション中ずっと開いている。
+Codex と CodeRabbit が独立に同じ点を指摘し、どちらも「サーバが `::1` を持て」と言った。
+
+## 何を変えるか
+
+`server/infra/loopback-listener.ts` は「`127.0.0.1` を serve すべきか」1 問だけを扱っていた。
+**問いが 2 つになる**ので、プランを 1 個から**リスト**にする。
+
+| プラン | なぜ要るか | 落ちたときに壊れるもの |
+|---|---|---|
+| `127.0.0.1` | ローカルの caller 8 箇所が literal で dial する（#1834） | hooks と GUI MCP が届かない |
+| `::1` | ブラウザが `localhost` を引き、Chrome は `::1` を優先する（#1889） | 他人が origin を取れる |
+
+**壊れ方が違うので警告文も違う。** 同じ文言を使い回すと、片方の症状を見た人がもう片方の説明を
+読むことになる。だからプランは自分の理由を持ち、警告はそこから引く。
+
+`inUseIsFine` は v4 プランだけ true になりうる（primary が `::` のとき、dual-stack が既に
+`127.0.0.1:P` を握っているので EADDRINUSE は「もう覆われている」証拠）。**v6 プランでは常に
+false** —— primary が `::` / `::1` ならそもそもプランを出さないので、EADDRINUSE は他人しかない。
+
+`server/index.ts` は spare を 2 本作り、listener タプルは 3 本になる
+（`createPubSub` と `mountTerminalWebSockets` が受ける `readonly [HttpServer, ...HttpServer[]]`
+はそのまま満たす）。
+
+## 変えないこと
+
+- **best effort のまま。** bind に失敗しても致命的にしない。IPv6 の無いマシンは
+  `EADDRNOTAVAIL` になるが、そこでは `localhost` は v4 のみなので実害が無い。
+- **launcher の pre-spawn probe（#1891）は残す。** 起動時点で既に他人が居るケースは、サーバが
+  listen を試みるより前に URL の選択で答える必要がある。両者は別の瞬間を守る。
+- **shutdown は触らない。** `installShutdownHandlers` は `process.exit(0)` で終わるので、ソケットは
+  OS が閉じる。listener が 2 本でも 3 本でも同じ（実機で port 解放を確認する）。
+
+## 検証
+
+ツリー: `8a2b6753`（origin/main）+ 本変更。すべて実 exit code を取得。
+
+**ゲート** —— `format` / `lint` / `typecheck` / `build` / `test` すべて exit **0**。
+`yarn test` は **11585 passed / 50 skipped**。
+
+**break-verify**（各回のあと `diff -q` で byte-identical を確認）
+
+| ミューテーション | 結果 |
+|---|---|
+| v6 プランを一切出さない（= #1893 以前の挙動） | 11 red |
+| `::1` の `inUseIsFine` を true にする | 2 red |
+| 警告文を v4/v6 で共用にする | 5 red |
+| `0.0.0.0` が `::1` を serve すると判定する | 2 red |
+
+**実機 —— bind マトリクス**（scratch HOME、`--no-open`。curl の HTTP status が ground truth で、
+ログではない）
+
+| `MULMOTERMINAL_HOST` | `127.0.0.1` | `[::1]` | `localhost` | 追加で listen したもの |
+|---|---|---|---|---|
+| 未設定（既定） | 200 | 200 | 200 | `::1` |
+| `0.0.0.0` | 200 | 200 | 200 | `::1` |
+| `::` | 200 | 200 | 200 | `127.0.0.1` |
+| `::1` | 200 | 200 | 200 | `127.0.0.1` |
+| `192.168.11.12` | 200 | 200 | 200 | `127.0.0.1` と `::1` の**両方** |
+
+LAN の case は 1 度目に `ipconfig getifaddr en0` が空を返して**実質未実行**だった（`MULMOTERMINAL_HOST=""`
+は既定に落ちる）。`en1` から取り直して再実行した結果が上の行。
+
+**shutdown** —— 各 case で kill 後に `127.0.0.1` が `000`。`installShutdownHandlers` は
+`process.exit(0)` で終わり、ソケットは OS が閉じるので listener が 3 本でも同じ。
+
+**穴が閉じたことの証明** —— サーバ稼働中に別プロセスが `[::1]:34724` を取ろうとする:
+
+```
+stranger REFUSED: EADDRINUSE
+```
+
+`#1891` の時点では取れていた。これが本 issue の目的。
+
+**squatter が先に居る場合**（`[::1]:34726` を別プロセスが保持した状態で起動）
+
+- サーバは**起動する**（`127.0.0.1` が 200）。致命的にしない設計どおり
+- サーバの警告: `could not also listen on ::1:34726 (EADDRINUSE) — the browser opens
+  http://localhost:<port>, which resolves here first — …`
+- launcher（#1891）は独立に `→ http://127.0.0.1:34726` を開き、状態の在り処も告げる
+
+2 層が同じ状況について食い違わずに話す。
+
+**WebSocket が新しい listener を通ること** —— ここが HTTP 200 だけでは足りない部分。Chrome で
+`http://localhost:34727` を開き、シェルを起動して `echo WS_ROUNDTRIP_OK` を実行:
+
+- OS 側で見た接続は 3 本とも **`[::1]:34727`**（`lsof -nP -iTCP:34727 -sTCP:ESTABLISHED`）。
+  つまりページも WS も新しい listener 経由
+- 画面に `WS_ROUNDTRIP_OK` が返っている（スクリーンショットで確認）
+
+> 最初 `document.body.innerText` で判定して「返っていない」と出たが、これは**判定の誤り**。
+> xterm の内容はそこに現れない。画面という外部の ground truth で見直して往復を確認した。
+
+**未検証** —— IPv6 を持たないマシン。`EADDRNOTAVAIL` の扱いは spec で固定してあるが実機は無い
+（macOS では `::1` を落とせない）。そこでは `localhost` は v4 のみに解決するので、listener が
+立たなくても失うものが無い、というのが設計上の主張。Windows / Linux も未実機（CI 任せ）。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -13,7 +13,7 @@
 **実測（2026-08-28、Chrome 152 / macOS 26.5.1 arm64）** —— 同じ port の `127.0.0.1` に `OURS-v4`、
 `::1` に `STRANGER-v6` を立て `http://localhost:<port>` を開く:
 
-```
+```text
 Chrome  http://localhost:39221 -> STRANGER-v6
 ```
 
@@ -90,7 +90,7 @@ LAN の case は 1 度目に `ipconfig getifaddr en0` が空を返して**実質
 
 **穴が閉じたことの証明** —— サーバ稼働中に別プロセスが `[::1]:34724` を取ろうとする:
 
-```
+```text
 stranger REFUSED: EADDRINUSE
 ```
 
@@ -159,7 +159,7 @@ timeout は置かない —— マイクロ秒で終わるローカル syscall �
 
 **実機 A —— 順序**（既定 bind, port 34730）。ログ行番号で見て bind が banner より前:
 
-```
+```text
 15:[bind] also listening on ::1:34730 so http://localhost:<port> can only mean this server
 22:  ✓ MulmoTerminal is ready
 23:  → http://localhost:34730
@@ -168,7 +168,7 @@ timeout は置かない —— マイクロ秒で終わるローカル syscall �
 **実機 B —— 起動中の横取り**（port 34731、launcher の probe が終わったあと 6 秒目で `::1` を
 別プロセスが取る）。この round より前なら launcher は `localhost` を開いていた:
 
-```
+```text
 [bind] could not also listen on ::1:34731 (EADDRINUSE) — the browser opens http://localhost:<port> …
   → http://127.0.0.1:34731
 [mulmoterminal] Something else is already listening on [::1]:34731, so the browser is being sent to
@@ -263,7 +263,7 @@ Codex（`CHANGES REQUESTED`）:
 **実機 —— 指摘そのもののケース**（直起動、`MULMOTERMINAL_HOST=::1`、`127.0.0.1:34750` を
 別プロセスが保持）:
 
-```
+```text
 [bind] could not also listen on 127.0.0.1:34750 (EADDRINUSE) — … hooks and the GUI MCP will fail …
 mulmoterminal running at http://[::1]:34750
 [bind] not printing http://localhost:34750 — something else holds 127.0.0.1:34750, …
@@ -317,3 +317,42 @@ spec のみ。分類そのもの（errno → 状態）と、そこから先の�
 `mulmoterminal running at http://localhost:34760` → launcher も `→ http://localhost:34760`。
 
 ゲート: すべて exit 0、`yarn test` **11612 passed / 50 skipped**。
+
+## レビュー iter-5 —— 「衝突が答えである」ケースを名前が隠していた
+
+Codex（`CHANGES REQUESTED`、CodeRabbit も同じ箇所に inline）:
+
+> The `::` dual-stack path still classifies the intentionally accepted `127.0.0.1` `EADDRINUSE`
+> as `taken` rather than `ours`, so it unnecessarily suppresses `localhost` even though the
+> primary listener owns both loopbacks.
+
+**そのとおり。** `::` の primary が dual-stack で v4 も取っているカーネルでは、補助の
+`127.0.0.1` bind は **primary 自身**と衝突する。それは「負けた」のではなく「もう持っている」
+ことの証明で、`loopbackListenPlan` のコメントは最初からそう書いていた。iter-4 で 3 状態に
+したとき、この分岐を通していなかった。
+
+**原因の半分は名前だった。** フラグは `inUseIsFine` —— 「fine」は「無視してよい」と読める。
+実際の意味は「**この EADDRINUSE は primary が持っている証拠**」で、無視ではなく `ours` と
+数えるべきもの。`inUseProvesPrimary` に改名し、分類もそこを通す。
+
+### iter-5 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| dual-stack の衝突を `taken` として扱う（= 指摘された挙動） | 3 red |
+
+**実機（`MULMOTERMINAL_HOST=::`, port 34765）** —— `localhost` を名乗り、3 アドレスとも 200:
+
+```text
+[bind] also listening on 127.0.0.1:34765 so this machine's own sessions can reach the server
+mulmoterminal running at http://localhost:34765
+  → http://localhost:34765
+```
+
+**ただしこの run は衝突経路を通っていない。** macOS の `::` は v4 を取らないので補助 bind が
+**成功**する（測定済み）。衝突が起きるのは dual-stack のカーネル（Linux）だけで、そこは spec で
+固定してある。**macOS で緑になることが、この修正が効いている証拠にはならない**ので明記する。
+
+CodeRabbit の Minor（MD040、ログの code fence に言語が無い）も対応した。
+
+ゲート: すべて exit 0、`yarn test` **11613 passed / 50 skipped**。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -118,3 +118,69 @@ stranger REFUSED: EADDRINUSE
 **未検証** —— IPv6 を持たないマシン。`EADDRNOTAVAIL` の扱いは spec で固定してあるが実機は無い
 （macOS では `::1` を落とせない）。そこでは `localhost` は v4 のみに解決するので、listener が
 立たなくても失うものが無い、というのが設計上の主張。Windows / Linux も未実機（CI 任せ）。
+
+## レビュー iter-1 —— 「先に名乗って、あとから bind していた」
+
+CodeRabbit: 指摘なし。Codex: 1 回目 `LGTM`、同じ head で再実行したら
+`CHANGES REQUESTED`（同一コードで割れた）。内容は正しかった。
+
+> `server/index.ts`: startup publishes the `listening` IPC event before it requests the required
+> `::1` bind, leaving the localhost-origin takeover race open.
+
+**そのとおりだった。** `process.send({type:"listening"})` が `startLoopbackListeners` より前に
+あった。launcher はこのメッセージで banner を出しブラウザを開くので、**まだ我々のものでない
+アドレスへ招待していた**ことになる。「timing ではなく construction で所有する」という本 PR の
+主張が、その一点で成立していなかった。
+
+### 直し方 —— 2 つある
+
+**1. bind が済んでから名乗る。** `startLoopbackListeners` を await 可能にし、announcement は
+その後。`listen()` は `listening` か `error` のどちらか一方を必ず返す（第三の結末が無い）ので
+timeout は置かない —— マイクロ秒で終わるローカル syscall に上限秒数を決める根拠が無く、切れた
+ときにカーネルが今まさに返そうとしている答えを推測することしかできない。
+
+**2. 結果を launcher に伝える。** これが無いと 1 だけでは足りない。launcher の `::1` probe は
+**この process が存在する前**に走るので、**起動中に**横取りする相手を見られない。そこで
+`listening` メッセージに `v6LoopbackServed` を載せ、launcher は自分の probe と child の報告の
+**両方**が肯定したときだけ `localhost` を使う。フィールドが無い（古い child）ときは `undefined`
+で、probe だけの判断に戻る —— 「言わなかった」と「取れなかった」を別の答えとして保つため。
+
+`server/index.ts` が 600 行の上限を超えたので、announcement は
+`server/infra/announce-listening.ts` に切り出した。**順序が意味を持つコードを boot script に
+置いておくと、整理のつもりで動かされる。** 独立モジュールなら 2 手順と理由が 1 か所にある。
+
+### iter-1 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| bind を待たずに名乗る（= 指摘された挙動） | 2 red |
+| `v6LoopbackServed` を常に true にする | 1 red |
+| parent が disconnect していても送る | 1 red |
+
+**実機 A —— 順序**（既定 bind, port 34730）。ログ行番号で見て bind が banner より前:
+
+```
+15:[bind] also listening on ::1:34730 so http://localhost:<port> can only mean this server
+22:  ✓ MulmoTerminal is ready
+23:  → http://localhost:34730
+```
+
+**実機 B —— 起動中の横取り**（port 34731、launcher の probe が終わったあと 6 秒目で `::1` を
+別プロセスが取る）。この round より前なら launcher は `localhost` を開いていた:
+
+```
+[bind] could not also listen on ::1:34731 (EADDRINUSE) — the browser opens http://localhost:<port> …
+  → http://127.0.0.1:34731
+[mulmoterminal] Something else is already listening on [::1]:34731, so the browser is being sent to
+http://127.0.0.1:34731 … they are filed under http://localhost:34731.
+```
+
+サーバは通常どおり起動（`127.0.0.1` = 200）。2 層が同じ状況について食い違わずに話す。
+
+ゲート再実行: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
+`yarn test` **11593 passed / 50 skipped**。
+
+> `test/bin/probe-bind-host.spec.ts` の source-text ガードが `beginReady(reported)` を閉じ括弧
+> ごと固定していて、引数が増えて red になった。**欠陥ではなく guard の脆さ**で、そのすぐ上の
+> コメントが「この guard は 2 度それで壊れた」と警告していた（今回で 3 度目）。第 1 引数だけを
+> 見る形に緩め、何を守っているのかを書き足した。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -231,3 +231,46 @@ Codex（`CHANGES REQUESTED`）:
 > spec が `sonarjs/no-clear-text-protocols` に引っかかった（LAN アドレスの literal URL）。
 > `test/bin/probe-bind-host.spec.ts` が同じ問題を `new URL()` で assert して回避しているので
 > それに合わせた。
+
+## レビュー iter-3 —— 「半分の保証は、小さい保証ではなく無い」
+
+Codex（`CHANGES REQUESTED`）:
+
+> `localBrowserUrl` selects `localhost` when only `v6LoopbackServed` is true. If the primary owns
+> `::1` but the auxiliary `127.0.0.1` bind loses to another process, IPv4-preferring clients can
+> still reach that other process at `localhost:<port>`.
+
+**対称のケースを見落としていた。** `localhost` は v4 と v6 の**どちらにも**解決し、クライアントに
+よってどちらを先に試すかが違う（Chrome は `::1`、他は v4）。片方を持っているだけでは、もう片方は
+誰でも取れるまま残る。**半分の保証は小さい保証ではなく、無い。**
+
+- `localhostIsOurs(outcome) = v4 && v6` を導入し、印字も wire もこれ 1 つで決める
+- `localBrowserUrl` の降り方も直した。以前は「v6 を持っていれば localhost、でなければ
+  127.0.0.1」だったので、**`::1` を持ち v4 を失った状態で 127.0.0.1 を印字**していた ——
+  読者を手ずから相手のプロセスへ送る、欠陥そのものの縮図。いまは「持っている方の loopback」を
+  名乗る
+- 理由の行は**失った側のアドレス**を名指しする（両方失えば両方）。operator が空けに行くのは
+  そこなので
+- wire は `v6LoopbackServed` から `localhostIsOurs` へ。**入力ではなく答えを載せる。**
+  片方だけを wire に出すと、読む側がそれを全体だと扱う余地が残る（iter-2 で私がやった間違い）
+
+### iter-3 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| `localhostIsOurs` が v6 だけを見る（= 指摘された挙動） | 2 red |
+
+**実機 —— 指摘そのもののケース**（直起動、`MULMOTERMINAL_HOST=::1`、`127.0.0.1:34750` を
+別プロセスが保持）:
+
+```
+[bind] could not also listen on 127.0.0.1:34750 (EADDRINUSE) — … hooks and the GUI MCP will fail …
+mulmoterminal running at http://[::1]:34750
+[bind] not printing http://localhost:34750 — something else holds 127.0.0.1:34750, …
+```
+
+`curl http://127.0.0.1:34750` は `STRANGER-v4` を返し、`[::1]` は我々が 200 を返す。
+`localhost` は名乗らない。
+
+ゲート: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
+`yarn test` **11604 passed / 50 skipped**。

--- a/plans/fix-1893-serve-v6-loopback.md
+++ b/plans/fix-1893-serve-v6-loopback.md
@@ -274,3 +274,46 @@ mulmoterminal running at http://[::1]:34750
 
 ゲート: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
 `yarn test` **11604 passed / 50 skipped**。
+
+## レビュー iter-4 —— 「取られた」と「そもそも無い」は別物
+
+Codex（`CHANGES REQUESTED`）:
+
+> On IPv4-only hosts, `EADDRNOTAVAIL` for `::1` is treated as though another process owns it, so
+> the launcher unnecessarily avoids the safe `localhost` origin and misreports a collision.
+
+**この plan の最初の版が「IPv6 の無いマシンは `EADDRNOTAVAIL` になるが、そこでは `localhost` は
+v4 のみなので実害が無い」と書いていて、コードがそれを実装していなかった。** 主張と実装のずれ。
+
+boolean をやめ、3 状態にした:
+
+| 状態 | 意味 | `localhost` への影響 |
+|---|---|---|
+| `ours` | primary が既に応答するか、補助 listener が取った | 使える |
+| `absent` | このマシンにそのアドレスが無い（`EADDRNOTAVAIL` / `EAFNOSUPPORT`） | **誰も応答できないので無害** |
+| `taken` | 他人が応答する | 使えない |
+
+`localhostIsOurs = v4 !== "taken" && v6 !== "taken" && (どちらかが "ours")`。
+最後の条件は「両方 absent なら `localhost` は何も指さない」ため —— 名前が何も指さない方が、
+リテラルのアドレスより悪い。
+
+`absent` には**警告を出さない**。居ない相手を告発することになるので。理由の行も `taken` の
+アドレスだけを名指しする。
+
+**`bin/cli-args.js` の `probeFailureIsPortInUse` が既に同じ規則を書いていた** ——
+「`EADDRINUSE` だけがこの問いに答える」。repo は答えを知っていて、このファイルだけが
+適用していなかった。#1876 のときと同じ形。
+
+### iter-4 の検証
+
+| ミューテーション | 結果 |
+|---|---|
+| どの失敗も rival として扱う（= 指摘された挙動） | 7 red |
+
+**未検証（実機）** —— IPv4-only ホスト。macOS では `::1` を外せないので `absent` 経路は
+spec のみ。分類そのもの（errno → 状態）と、そこから先の判断は spec で固定してある。
+
+既定ホストでの回帰が無いことは実機で確認: `[bind] also listening on ::1:34760` →
+`mulmoterminal running at http://localhost:34760` → launcher も `→ http://localhost:34760`。
+
+ゲート: すべて exit 0、`yarn test` **11612 passed / 50 skipped**。

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,7 +32,7 @@ import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } fr
 import { serverErrorExit } from "./infra/server-exit.js";
 import { PORT, BIND_HOST, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { boundAddress, isLoopbackBinding } from "./infra/loopback.js";
-import { startLoopbackListener } from "./infra/loopback-listener.js";
+import { startLoopbackListeners } from "./infra/loopback-listener.js";
 import { messageOf } from "./errors.js";
 import { hookSettingsJson } from "./session/hook-settings.js";
 import { mcpConfigJson } from "./session/mcp-config.js";
@@ -531,14 +531,19 @@ mountAppRoutes(app, {
 });
 
 const server = http.createServer(app);
-// The second listener, for the case where the operator bound a specific non-loopback address and
-// everything this server spawns can therefore no longer reach it (#1834). Built unconditionally
-// and wired into the same app, sockets and upgrade routing as the primary, because that wiring
-// happens well before `listen()` tells us which address the OS actually chose; whether it ever
-// serves anything is decided down at the bind, and an http server that never listens costs
-// nothing.
-const loopbackServer = http.createServer(app);
-const listeners: readonly [http.Server, http.Server] = [server, loopbackServer];
+// The extra listeners: one for the case where the operator bound a specific non-loopback address
+// and everything this server spawns can therefore no longer reach it (#1834), one so that
+// `http://localhost:<port>` — the origin the browser files its saved settings under — cannot be
+// answered by anything else on this machine (#1893). Built unconditionally and wired into the same
+// app, sockets and upgrade routing as the primary, because that wiring happens well before
+// `listen()` tells us which address the OS actually chose; whether either ever serves anything is
+// decided down at the bind, and an http server that never listens costs nothing.
+// TWO spares, because there are two loopback addresses to answer for and a bind can need both at
+// once (a specific LAN address serves neither). They are interchangeable — same app, same sockets,
+// same upgrade routing — so loopbackListenPlans decides what each one becomes, and a spare that is
+// never asked for anything simply never listens.
+const loopbackServers = [http.createServer(app), http.createServer(app)] as const;
+const listeners: readonly [http.Server, http.Server, http.Server] = [server, ...loopbackServers];
 pubsub = createPubSub(listeners, isAllowedOrigin);
 
 // Wire the shared file-change publisher (markdown + html live-refresh) against
@@ -987,7 +992,7 @@ server.listen(Number(PORT), BIND_HOST, () => {
   // "can our own sessions still reach us?" — false for BOTH, because a server on `::1` refuses a
   // client dialing 127.0.0.1. Gating this on the warning left `MULMOTERMINAL_HOST=localhost`
   // broken, which is how that wiring mistake showed up here.
-  startLoopbackListener(server, loopbackServer, PORT);
+  startLoopbackListeners(server, loopbackServers, PORT);
   const surviving = tmuxAvailable() ? tmuxListSessionIds() : [];
   const reaped: string[] = [];
   if (tmuxAvailable()) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -966,7 +966,6 @@ server.on("error", (err) => {
 // Number(): PORT comes from the environment as a string, and the (port, host, cb) overload
 // takes a number — the (port, cb) form we used before accepted either.
 server.listen(Number(PORT), BIND_HOST, () => {
-  console.log(`mulmoterminal running at http://localhost:${PORT}`);
   // Takes the loopback addresses this bind did not, and only then tells the parent — the order,
   // the guards on the send and the reason each field is on the wire are all in that module.
   void announceListening(server, loopbackServers, Number(PORT), boundAddress(server.address()), process);

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,7 +32,7 @@ import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } fr
 import { serverErrorExit } from "./infra/server-exit.js";
 import { PORT, BIND_HOST, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { boundAddress, isLoopbackBinding } from "./infra/loopback.js";
-import { startLoopbackListeners } from "./infra/loopback-listener.js";
+import { announceListening } from "./infra/announce-listening.js";
 import { messageOf } from "./errors.js";
 import { hookSettingsJson } from "./session/hook-settings.js";
 import { mcpConfigJson } from "./session/mcp-config.js";
@@ -967,32 +967,12 @@ server.on("error", (err) => {
 // takes a number — the (port, cb) form we used before accepted either.
 server.listen(Number(PORT), BIND_HOST, () => {
   console.log(`mulmoterminal running at http://localhost:${PORT}`);
-  // The dev supervisor (scripts/dev-server.mjs) resets its crash count on THIS, not on how long
-  // the process lived. Everything above runs before the bind and can take any amount of time, so
-  // elapsed time never proved the port was reached — which is how a slow crash loop stayed
-  // invisible (#1735).
-  //
-  // Three guards, and none is decoration. `process.send` is undefined unless a parent opened an
-  // IPC channel, so this is a no-op under `npx mulmoterminal`. `process.connected` is the one
-  // that matters: after the parent disconnects, `send` STAYS a function, and calling it raises
-  // ERR_IPC_CHANNEL_CLOSED **asynchronously** — measured, it lands as an uncaughtException and
-  // kills the process, so neither `?.` nor a try/catch stops it. That is reachable: Ctrl+C on the
-  // supervisor while this server is still in its ~3s of setup. The callback catches the same
-  // error for a channel that closes between the check and the write.
-  // The ADDRESS goes with it, not just the port, and that is what stops the launcher guessing.
-  // `BIND_HOST` can be a NAME — `localhost` resolves to `::1` here and `127.0.0.1` elsewhere —
-  // and a launcher that guesses wrong polls a stranger and calls it ready (#1876). Only this
-  // process knows what it actually bound. Additive: the dev supervisor keys on `type` alone.
-  if (process.connected) process.send?.({ type: "listening", port: Number(PORT), address: boundAddress(server.address()) }, undefined, undefined, () => {});
+  // Takes the loopback addresses this bind did not, and only then tells the parent — the order,
+  // the guards on the send and the reason each field is on the wire are all in that module.
+  void announceListening(server, loopbackServers, Number(PORT), boundAddress(server.address()), process);
   if (!isLoopbackBinding(server.address())) {
     console.warn(bindSecurityWarning(BIND_HOST, PORT, browserHostnames));
   }
-  // Unconditional, and NOT folded into the branch above: the two ask different questions. That
-  // one is "is this exposed?" — true for a specific LAN address, false for `::1`. This one is
-  // "can our own sessions still reach us?" — false for BOTH, because a server on `::1` refuses a
-  // client dialing 127.0.0.1. Gating this on the warning left `MULMOTERMINAL_HOST=localhost`
-  // broken, which is how that wiring mistake showed up here.
-  startLoopbackListeners(server, loopbackServers, PORT);
   const surviving = tmuxAvailable() ? tmuxListSessionIds() : [];
   const reaped: string[] = [];
   if (tmuxAvailable()) {

--- a/server/infra/announce-listening.ts
+++ b/server/infra/announce-listening.ts
@@ -78,8 +78,8 @@ export function localBrowserUrl(port: number, boundAddress: string | null, outco
   // Descending by what is still true. Naming the loopback we DID keep is better than naming the
   // bind, and naming the wrong one is the defect in miniature: with `::1` ours and `127.0.0.1`
   // lost, printing `127.0.0.1` sends the reader to the stranger by hand.
-  if (outcome.v4LoopbackServed) return `http://127.0.0.1:${port}`;
-  if (outcome.v6LoopbackServed) return withHost(port, "::1");
+  if (outcome.v4 === "ours") return `http://127.0.0.1:${port}`;
+  if (outcome.v6 === "ours") return withHost(port, "::1");
   if (boundAddress === null) return `http://127.0.0.1:${port}`;
   return withHost(port, boundAddress);
 }
@@ -99,14 +99,24 @@ function withHost(port: number, host: string): string {
  * measured), and holding one of the two leaves the other free for anything on this machine to
  * answer with. Half an answer here is not a smaller guarantee, it is none.
  */
-export const localhostIsOurs = (outcome: LoopbackOutcome): boolean => outcome.v4LoopbackServed && outcome.v6LoopbackServed;
+export const localhostIsOurs = (outcome: LoopbackOutcome): boolean =>
+  // Nothing a client could reach instead of us …
+  outcome.v4 !== "taken" &&
+  outcome.v6 !== "taken" &&
+  // … and at least one address it can actually reach us at. Both `absent` cannot happen on a host
+  // that has a loopback at all, but a name resolving to nothing is worse than a literal address,
+  // so it is excluded rather than assumed away.
+  (outcome.v4 === "ours" || outcome.v6 === "ours");
 
 /** Why the URL above is not `localhost`, or null when it is. Silence would leave an operator
  *  looking at an address they did not expect with nothing to search for — so it names the
  *  address that was lost, which is the one they have to go and free. */
 export function notLocalhostReason(port: number, outcome: LoopbackOutcome): string | null {
   if (localhostIsOurs(outcome)) return null;
-  const lost = [outcome.v4LoopbackServed ? null : `127.0.0.1:${port}`, outcome.v6LoopbackServed ? null : `[::1]:${port}`].filter((entry) => entry !== null);
+  // Only a `taken` address is somebody else's. An `absent` one is not a rival and must not be
+  // reported as one — on an IPv4-only host that would accuse a stranger who does not exist.
+  const lost = [outcome.v4 === "taken" ? `127.0.0.1:${port}` : null, outcome.v6 === "taken" ? `[::1]:${port}` : null].filter((entry) => entry !== null);
+  if (lost.length === 0) return `[bind] not printing http://localhost:${port} — this machine has no loopback address this server could take.`;
   return `[bind] not printing http://localhost:${port} — something else holds ${lost.join(" and ")}, and a browser resolving localhost would reach it under this app's saved settings.`;
 }
 

--- a/server/infra/announce-listening.ts
+++ b/server/infra/announce-listening.ts
@@ -12,6 +12,10 @@ export interface IpcParent {
   send?: (message: unknown, handle: undefined, options: undefined, callback: () => void) => unknown;
 }
 
+/** Deliberately NARROWER than `LoopbackOutcome`: the launcher decides one thing from this — may
+ *  the browser be sent to `localhost` — and `v4LoopbackServed` answers a question only this
+ *  process asks (which URL to print for a direct start). A field nobody reads is a field someone
+ *  later reads by mistake. */
 export interface ListeningMessage {
   type: "listening";
   port: number;
@@ -56,6 +60,35 @@ export const listeningMessage = (port: number, address: string | null, outcome: 
  * supervisor while this server is still in its ~3s of setup. The callback catches the same error
  * for a channel that closes between the check and the write.
  */
+/**
+ * The URL a HUMAN should be given, once the loopback binds have been attempted.
+ *
+ * `localhost` is the one to print — it is the origin the browser files its settings under
+ * (#1889) — but ONLY once this server holds every address it resolves to. Printing it before the
+ * `::1` outcome is known is the same defect as announcing readiness early, and it reaches further:
+ * a direct `npm run server` has no launcher to correct it, so this line is all the operator has
+ * (Codex, PR #1903).
+ *
+ * The fallbacks descend by what is still true: the v4 loopback if we hold it, otherwise the
+ * address the kernel says we bound, which is the last thing that can be asserted at all.
+ */
+export function localBrowserUrl(port: number, boundAddress: string | null, outcome: LoopbackOutcome): string {
+  if (outcome.v6LoopbackServed) return `http://localhost:${port}`;
+  if (outcome.v4LoopbackServed) return `http://127.0.0.1:${port}`;
+  if (boundAddress === null) return `http://127.0.0.1:${port}`;
+  // Built through `URL` so an IPv6 literal is bracketed: `http://::1:34567` is not a URL at all.
+  const url = new URL(`http://localhost:${port}`);
+  url.hostname = boundAddress.includes(":") ? `[${boundAddress}]` : boundAddress;
+  return url.origin;
+}
+
+/** Why the URL above is not `localhost`, or null when it is. Silence would leave an operator
+ *  looking at an address they did not expect with nothing to search for. */
+export const notLocalhostReason = (port: number, outcome: LoopbackOutcome): string | null =>
+  outcome.v6LoopbackServed
+    ? null
+    : `[bind] not printing http://localhost:${port} — something else holds [::1]:${port}, and a browser resolving localhost would reach it under this app's saved settings.`;
+
 export async function announceListening(
   primary: PrimaryListener,
   spares: readonly LoopbackListener[],
@@ -64,6 +97,11 @@ export async function announceListening(
   parent: IpcParent,
 ): Promise<void> {
   const outcome = await startLoopbackListeners(primary, spares, port);
+  // AFTER the binds, for the same reason the IPC message is: this line is what a direct
+  // `npm run server` hands its operator, and there is no launcher behind it to correct.
+  console.log(`mulmoterminal running at ${localBrowserUrl(port, boundAddress, outcome)}`);
+  const reason = notLocalhostReason(port, outcome);
+  if (reason !== null) console.warn(`\x1b[33m${reason}\x1b[0m`);
   if (!parent.connected) return;
   parent.send?.(listeningMessage(port, boundAddress, outcome), undefined, undefined, () => {});
 }

--- a/server/infra/announce-listening.ts
+++ b/server/infra/announce-listening.ts
@@ -1,0 +1,69 @@
+// Saying "this server is listening" — after it holds every address it told anyone to use.
+//
+// Out of index.ts because the ORDER here is load-bearing and index.ts is where an ordering
+// constraint goes to be forgotten: the file is a boot script, and a line moved for tidiness reads
+// like a line moved for nothing. Here the two steps are one function with the reason attached.
+import type { LoopbackListener, LoopbackOutcome, PrimaryListener } from "./loopback-listener.js";
+import { startLoopbackListeners } from "./loopback-listener.js";
+
+/** Only what this needs from the process, so a test hands over a recorder rather than forking. */
+export interface IpcParent {
+  connected: boolean;
+  send?: (message: unknown, handle: undefined, options: undefined, callback: () => void) => unknown;
+}
+
+export interface ListeningMessage {
+  type: "listening";
+  port: number;
+  address: string | null;
+  v6LoopbackServed: boolean;
+}
+
+/** The message a parent gets, built where the answers are known.
+ *
+ *  `address` is the one the KERNEL reported, not `BIND_HOST`: that can be a NAME — `localhost`
+ *  resolves to `::1` here and `127.0.0.1` elsewhere — and a launcher that guesses wrong polls a
+ *  stranger and calls it ready (#1876).
+ *
+ *  `v6LoopbackServed` is the second thing only this side can answer. The launcher probes `::1`
+ *  before this process exists, so a process claiming `[::1]:<port>` DURING the boot is invisible
+ *  to it — and the launcher would then send a browser to `localhost`, which prefers `::1`
+ *  (measured on Chrome), straight into that process under this app's origin. Reported rather than
+ *  merely logged for exactly that reason (Codex, PR #1903). */
+export const listeningMessage = (port: number, address: string | null, outcome: LoopbackOutcome): ListeningMessage => ({
+  type: "listening",
+  port,
+  address,
+  v6LoopbackServed: outcome.v6LoopbackServed,
+});
+
+/**
+ * Take the loopback addresses the primary bind did not, and only THEN announce.
+ *
+ * The launcher acts on this message — it prints the banner and opens the browser at
+ * `http://localhost:<port>` — so announcing before `::1` is held invites the browser to an
+ * address this process has not claimed yet. Awaiting the binds first is what closes that.
+ *
+ * The dev supervisor (scripts/dev-server.mjs) resets its crash count on this message, not on how
+ * long the process lived, because elapsed time never proved the port was reached (#1735). It keys
+ * on `type` alone, so new fields are additive.
+ *
+ * Three guards on the send, and none is decoration. `send` is undefined unless a parent opened an
+ * IPC channel, so this is a no-op under `npx mulmoterminal`. `connected` is the one that matters:
+ * after the parent disconnects, `send` STAYS a function, and calling it raises
+ * ERR_IPC_CHANNEL_CLOSED **asynchronously** — measured, it lands as an uncaughtException and kills
+ * the process, so neither `?.` nor a try/catch stops it. That is reachable: Ctrl+C on the
+ * supervisor while this server is still in its ~3s of setup. The callback catches the same error
+ * for a channel that closes between the check and the write.
+ */
+export async function announceListening(
+  primary: PrimaryListener,
+  spares: readonly LoopbackListener[],
+  port: number,
+  boundAddress: string | null,
+  parent: IpcParent,
+): Promise<void> {
+  const outcome = await startLoopbackListeners(primary, spares, port);
+  if (!parent.connected) return;
+  parent.send?.(listeningMessage(port, boundAddress, outcome), undefined, undefined, () => {});
+}

--- a/server/infra/announce-listening.ts
+++ b/server/infra/announce-listening.ts
@@ -12,15 +12,17 @@ export interface IpcParent {
   send?: (message: unknown, handle: undefined, options: undefined, callback: () => void) => unknown;
 }
 
-/** Deliberately NARROWER than `LoopbackOutcome`: the launcher decides one thing from this — may
- *  the browser be sent to `localhost` — and `v4LoopbackServed` answers a question only this
- *  process asks (which URL to print for a direct start). A field nobody reads is a field someone
- *  later reads by mistake. */
+/** Carries the ANSWER the launcher needs, not the inputs it would have to combine.
+ *
+ *  It said `v6LoopbackServed` for one iteration, and that was the wrong shape: `localhost`
+ *  resolves to EITHER loopback, so the question "may a browser be sent there" needs both halves,
+ *  and a wire that reports one half invites the reader to treat it as the whole (Codex, PR #1903).
+ *  One field, answering the one thing the launcher decides. */
 export interface ListeningMessage {
   type: "listening";
   port: number;
   address: string | null;
-  v6LoopbackServed: boolean;
+  localhostIsOurs: boolean;
 }
 
 /** The message a parent gets, built where the answers are known.
@@ -29,16 +31,15 @@ export interface ListeningMessage {
  *  resolves to `::1` here and `127.0.0.1` elsewhere — and a launcher that guesses wrong polls a
  *  stranger and calls it ready (#1876).
  *
- *  `v6LoopbackServed` is the second thing only this side can answer. The launcher probes `::1`
- *  before this process exists, so a process claiming `[::1]:<port>` DURING the boot is invisible
- *  to it — and the launcher would then send a browser to `localhost`, which prefers `::1`
- *  (measured on Chrome), straight into that process under this app's origin. Reported rather than
- *  merely logged for exactly that reason (Codex, PR #1903). */
+ *  `localhostIsOurs` is the second thing only this side can answer. The launcher checks the
+ *  loopbacks before this process exists, so anything claiming one DURING the boot is invisible to
+ *  it — and the launcher would then send a browser to `localhost` straight into that process
+ *  under this app's origin. Reported rather than merely logged for exactly that reason. */
 export const listeningMessage = (port: number, address: string | null, outcome: LoopbackOutcome): ListeningMessage => ({
   type: "listening",
   port,
   address,
-  v6LoopbackServed: outcome.v6LoopbackServed,
+  localhostIsOurs: localhostIsOurs(outcome),
 });
 
 /**
@@ -73,21 +74,41 @@ export const listeningMessage = (port: number, address: string | null, outcome: 
  * address the kernel says we bound, which is the last thing that can be asserted at all.
  */
 export function localBrowserUrl(port: number, boundAddress: string | null, outcome: LoopbackOutcome): string {
-  if (outcome.v6LoopbackServed) return `http://localhost:${port}`;
+  if (localhostIsOurs(outcome)) return `http://localhost:${port}`;
+  // Descending by what is still true. Naming the loopback we DID keep is better than naming the
+  // bind, and naming the wrong one is the defect in miniature: with `::1` ours and `127.0.0.1`
+  // lost, printing `127.0.0.1` sends the reader to the stranger by hand.
   if (outcome.v4LoopbackServed) return `http://127.0.0.1:${port}`;
+  if (outcome.v6LoopbackServed) return withHost(port, "::1");
   if (boundAddress === null) return `http://127.0.0.1:${port}`;
-  // Built through `URL` so an IPv6 literal is bracketed: `http://::1:34567` is not a URL at all.
+  return withHost(port, boundAddress);
+}
+
+/** Built through `URL` so an IPv6 literal is bracketed: `http://::1:34567` is not a URL at all. */
+function withHost(port: number, host: string): string {
   const url = new URL(`http://localhost:${port}`);
-  url.hostname = boundAddress.includes(":") ? `[${boundAddress}]` : boundAddress;
+  url.hostname = host.includes(":") ? `[${host}]` : host;
   return url.origin;
 }
 
+/**
+ * Whether `http://localhost:<port>` can only mean this server.
+ *
+ * BOTH loopbacks, and that is the correction Codex made twice over: `localhost` resolves to
+ * `::1` and to `127.0.0.1`, clients differ on which they try first (Chrome prefers `::1`,
+ * measured), and holding one of the two leaves the other free for anything on this machine to
+ * answer with. Half an answer here is not a smaller guarantee, it is none.
+ */
+export const localhostIsOurs = (outcome: LoopbackOutcome): boolean => outcome.v4LoopbackServed && outcome.v6LoopbackServed;
+
 /** Why the URL above is not `localhost`, or null when it is. Silence would leave an operator
- *  looking at an address they did not expect with nothing to search for. */
-export const notLocalhostReason = (port: number, outcome: LoopbackOutcome): string | null =>
-  outcome.v6LoopbackServed
-    ? null
-    : `[bind] not printing http://localhost:${port} — something else holds [::1]:${port}, and a browser resolving localhost would reach it under this app's saved settings.`;
+ *  looking at an address they did not expect with nothing to search for — so it names the
+ *  address that was lost, which is the one they have to go and free. */
+export function notLocalhostReason(port: number, outcome: LoopbackOutcome): string | null {
+  if (localhostIsOurs(outcome)) return null;
+  const lost = [outcome.v4LoopbackServed ? null : `127.0.0.1:${port}`, outcome.v6LoopbackServed ? null : `[::1]:${port}`].filter((entry) => entry !== null);
+  return `[bind] not printing http://localhost:${port} — something else holds ${lost.join(" and ")}, and a browser resolving localhost would reach it under this app's saved settings.`;
+}
 
 export async function announceListening(
   primary: PrimaryListener,

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -30,11 +30,22 @@
  *  pointed elsewhere by a hosts file, so only the resolved answer covers every spelling. */
 export type BoundAddress = string | { address: string } | null;
 
-// The address the second listener takes, and the only one worth taking: it is what our own
-// callers DIAL. Six of the eight write `127.0.0.1` literally, and the two that write `localhost`
-// reach it by falling back to v4 when v6 refuses. Nothing here dials `::1`, so serving it would
-// answer a question nobody asks.
+// What our own callers DIAL. Six of the eight write `127.0.0.1` literally, and the two that write
+// `localhost` reach it by falling back to v4 when v6 refuses.
 const V4_LOOPBACK = "127.0.0.1";
+
+// This used to say `Nothing here dials ::1, so serving it would answer a question nobody asks`.
+// That premise was true of the SPAWNED callers above and false of the one caller it did not count:
+// the user's BROWSER, which is sent to `http://localhost:<port>` because that is the origin their
+// grid layout and settings are filed under (#1889).
+//
+// `localhost` resolves to both loopbacks, and measured on Chrome 152 / macOS, the browser tries
+// `::1` FIRST — with `OURS-v4` on `127.0.0.1` and a stranger on `[::1]`, the stranger is what
+// loads. So an unserved `::1` is not a gap nobody reaches; it is an address anything on this
+// machine can take to receive our users' browser under our origin, with the `localStorage` that
+// origin holds. Serving it is what makes `localhost` mean this server by construction rather than
+// by timing (#1893).
+const V6_LOOPBACK = "::1";
 
 // `0.0.0.0` is the v4 wildcard, so it serves the v4 loopback by definition — no kernel setting
 // changes that, and nothing more is needed.
@@ -78,17 +89,59 @@ export interface LoopbackPlan {
    * dual-stack boot, which is how an operator learns to ignore the warning that means something.
    */
   inUseIsFine: boolean;
+  /** What this listener is FOR, which is what decides the warning when it cannot be taken. The
+   *  two failures look identical in the log and are nothing alike to the person reading it. */
+  reason: LoopbackReason;
 }
 
+/** `sessions`: hooks and the GUI MCP dial `127.0.0.1` as a literal (#1834).
+ *  `browser`: the user's browser is sent to `localhost`, which prefers `::1` (#1889). */
+export type LoopbackReason = "sessions" | "browser";
+
+const WARNING_TEXT: Record<LoopbackReason, string> = {
+  sessions: "this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.",
+  browser:
+    "the browser opens http://localhost:<port>, which resolves here first — while something else holds it, that page is somebody else's server under this app's saved settings. Stop the other process, or open the address the launcher printed.",
+};
+
+/** Whether the primary bind already answers on `::1`.
+ *
+ *  A v6 wildcard always covers the v6 loopback — the `bindv6only` question that makes `::` awkward
+ *  for V4 does not arise here, because that setting decides whether a `::` socket ALSO takes v4,
+ *  never whether it takes v6. So unlike the v4 side, this needs no attempt-and-read. */
+const servesV6Loopback = (address: string): boolean => address === V6_LOOPBACK || address === V6_WILDCARD;
+
 /**
- * How to serve `127.0.0.1` alongside the primary bind, or null when the primary already does.
+ * Which loopback addresses this server must take for itself, beyond whatever the primary bound.
+ *
+ * TWO questions, not one, and they are answered together only because the mechanism is shared:
+ *
+ *   - `127.0.0.1` — because everything this server SPAWNS dials it as a literal (#1834). Missing
+ *     it breaks hooks and the GUI MCP.
+ *   - `::1` — because the user's BROWSER is sent to `localhost`, which prefers it (#1889). Missing
+ *     it lets anything on this machine answer for our origin.
+ *
+ * Each plan carries its own `reason` so the warning can name the right symptom. One text for both
+ * would tell whoever is looking at a broken hook about browser origins, or the reverse.
+ *
+ * Returns at most one plan per address, and never more than two — pinned by a spec, because
+ * `startLoopbackListeners` hands plan `i` to spare server `i` and index.ts creates exactly two.
  */
-export function loopbackListenPlan(bound: BoundAddress): LoopbackPlan | null {
+export function loopbackListenPlans(bound: BoundAddress): LoopbackPlan[] {
   // A string address is a pipe or a UNIX socket, and null is "not listening" — neither is a
   // network bind this can reason about, and neither is reachable by a url a session would build.
-  if (bound === null || typeof bound === "string") return null;
-  if (bound.address === V4_WILDCARD || servesV4Loopback(bound.address)) return null;
-  return { address: V4_LOOPBACK, inUseIsFine: bound.address === V6_WILDCARD };
+  if (bound === null || typeof bound === "string") return [];
+  const { address } = bound;
+  const plans: LoopbackPlan[] = [];
+  if (address !== V4_WILDCARD && !servesV4Loopback(address)) {
+    plans.push({ address: V4_LOOPBACK, inUseIsFine: address === V6_WILDCARD, reason: "sessions" });
+  }
+  // No `inUseIsFine` counterpart here: the only bind that could already hold `[::1]:P` is one that
+  // serves the v6 loopback, and those return no plan at all. So EADDRINUSE means somebody else.
+  if (!servesV6Loopback(address)) {
+    plans.push({ address: V6_LOOPBACK, inUseIsFine: false, reason: "browser" });
+  }
+  return plans;
 }
 
 export interface PrimaryListener {
@@ -102,24 +155,43 @@ export interface LoopbackListener {
   listen(port: number, host: string, onListening: () => void): unknown;
 }
 
-/**
- * Serve loopback as well, when the primary bind did not.
- *
- * BEST EFFORT, and deliberately not fatal: the operator asked for the address they named, and
- * that one is already listening by the time this runs. Failing the boot because the extra one
- * could not bind would turn a degraded setup into no setup at all — so it warns, naming the
- * symptom rather than the errno, and carries on.
- */
-export function startLoopbackListener(primary: PrimaryListener, loopback: LoopbackListener, port: string | number): void {
-  const plan = loopbackListenPlan(primary.address());
-  if (plan === null) return;
+const START_TEXT: Record<LoopbackReason, string> = {
+  sessions: "so this machine's own sessions can reach the server",
+  browser: "so http://localhost:<port> can only mean this server",
+};
+
+function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): void {
   loopback.once("error", (err: NodeJS.ErrnoException) => {
     if (plan.inUseIsFine && err.code === "EADDRINUSE") return;
-    console.warn(
-      `\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.`,
-    );
+    console.warn(`\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — ${WARNING_TEXT[plan.reason]}`);
   });
   loopback.listen(Number(port), plan.address, () => {
-    console.log(`[bind] also listening on ${plan.address}:${port} so this machine's own sessions can reach the server`);
+    console.log(`[bind] also listening on ${plan.address}:${port} ${START_TEXT[plan.reason]}`);
+  });
+}
+
+/**
+ * Serve the loopback addresses the primary bind did not.
+ *
+ * BEST EFFORT, and deliberately not fatal: the operator asked for the address they named, and
+ * that one is already listening by the time this runs. Failing the boot because an extra one
+ * could not bind would turn a degraded setup into no setup at all — so it warns, naming the
+ * symptom rather than the errno, and carries on. A machine with no IPv6 lands here with
+ * `EADDRNOTAVAIL` and is fine: `localhost` is v4-only there, so nothing was at stake.
+ *
+ * Plan `i` goes to spare `i`. The spares are interchangeable — index.ts builds them all from the
+ * same app — so this needs no matching by address, only enough of them. Being handed too few is
+ * a wiring mistake rather than a runtime condition, and it would otherwise drop a listener in
+ * silence, so it says so.
+ */
+export function startLoopbackListeners(primary: PrimaryListener, spares: readonly LoopbackListener[], port: string | number): void {
+  const plans = loopbackListenPlans(primary.address());
+  plans.forEach((plan, i) => {
+    const spare = spares[i];
+    if (spare === undefined) {
+      console.warn(`\x1b[33m[bind]\x1b[0m no spare server for ${plan.address}:${port} — ${WARNING_TEXT[plan.reason]}`);
+      return;
+    }
+    startOne(spare, plan, port);
   });
 }

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -98,6 +98,28 @@ export interface LoopbackPlan {
  *  `browser`: the user's browser is sent to `localhost`, which prefers `::1` (#1889). */
 export type LoopbackReason = "sessions" | "browser";
 
+/**
+ * What became of one loopback address.
+ *
+ * Three states and not a boolean, because "we did not get it" hides the distinction that decides
+ * everything downstream. Only `EADDRINUSE` says somebody else is there; `EADDRNOTAVAIL` /
+ * `EAFNOSUPPORT` say the address does not exist on this machine, and there `localhost` cannot
+ * resolve to it at all — so nothing is at stake and avoiding `localhost` would be a lie told to
+ * an IPv4-only host (Codex, PR #1903).
+ *
+ * `bin/cli-args.js` already states this rule for the port probe — "only EADDRINUSE answers the
+ * question" — and this file was the one place that had not applied it.
+ *
+ *   `ours`   — the primary bind already answers here, or the extra listener took it
+ *   `absent` — this machine has no such address; nothing can answer here, ever
+ *   `taken`  — something else answers here
+ */
+export type LoopbackStatus = "ours" | "absent" | "taken";
+
+/** Errnos that mean the address is not a thing on this machine, rather than not free. */
+const ABSENT_CODES = new Set(["EADDRNOTAVAIL", "EAFNOSUPPORT"]);
+const statusFromError = (err: NodeJS.ErrnoException): LoopbackStatus => (ABSENT_CODES.has(err.code ?? "") ? "absent" : "taken");
+
 /** What the caller has to know once the extra listeners have been attempted. */
 export interface LoopbackOutcome {
   /**
@@ -109,11 +131,8 @@ export interface LoopbackOutcome {
    * existed — so a process that claimed `[::1]:<port>` during the boot was invisible to it, and
    * the browser went to that process under this app's origin (Codex, PR #1903).
    */
-  v6LoopbackServed: boolean;
-  /** The same question for `127.0.0.1`. Only used to decide what URL to PRINT when `::1` was
-   *  lost — `localhost` is out at that point, and this says whether the v4 loopback is a truthful
-   *  thing to name instead or whether the bound address is all that is left. */
-  v4LoopbackServed: boolean;
+  v6: LoopbackStatus;
+  v4: LoopbackStatus;
 }
 
 const WARNING_TEXT: Record<LoopbackReason, string> = {
@@ -183,17 +202,20 @@ const START_TEXT: Record<LoopbackReason, string> = {
  *  `listen()` answers with exactly one of `listening` or `error` — there is no third outcome and
  *  so no timeout here. A cap would have to choose a duration for a local syscall that takes
  *  microseconds, and on expiry it could only guess at an answer the kernel is about to give. */
-function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): Promise<boolean> {
+function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): Promise<LoopbackStatus> {
   return new Promise((resolve) => {
     loopback.once("error", (err: NodeJS.ErrnoException) => {
-      if (!(plan.inUseIsFine && err.code === "EADDRINUSE")) {
+      const status = statusFromError(err);
+      // An address this machine does not have costs nobody anything: no client can dial it, so
+      // there is nothing to warn about and nothing to lose. Only a rival gets a warning.
+      if (status === "taken" && !(plan.inUseIsFine && err.code === "EADDRINUSE")) {
         console.warn(`\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — ${WARNING_TEXT[plan.reason]}`);
       }
-      resolve(false);
+      resolve(status);
     });
     loopback.listen(Number(port), plan.address, () => {
       console.log(`[bind] also listening on ${plan.address}:${port} ${START_TEXT[plan.reason]}`);
-      resolve(true);
+      resolve("ours");
     });
   });
 }
@@ -219,17 +241,15 @@ export async function startLoopbackListeners(primary: PrimaryListener, spares: r
       const spare = spares[i];
       if (spare === undefined) {
         console.warn(`\x1b[33m[bind]\x1b[0m no spare server for ${plan.address}:${port} — ${WARNING_TEXT[plan.reason]}`);
-        return Promise.resolve(false);
+        return Promise.resolve<LoopbackStatus>("taken");
       }
       return startOne(spare, plan, port);
     }),
   );
-  // No plan for an address means the PRIMARY already answers there — served, with nothing to take.
-  // A plan that FAILED is the only way either of these is false, and the v6 one is the case the
-  // launcher must not send a browser to `localhost` into.
-  const served = (address: string): boolean => {
+  // No plan for an address means the PRIMARY already answers there — ours, with nothing to take.
+  const statusOf = (address: string): LoopbackStatus => {
     const at = plans.findIndex((plan) => plan.address === address);
-    return at === -1 || results[at] === true;
+    return at === -1 ? "ours" : (results[at] ?? "taken");
   };
-  return { v6LoopbackServed: served(V6_LOOPBACK), v4LoopbackServed: served(V4_LOOPBACK) };
+  return { v6: statusOf(V6_LOOPBACK), v4: statusOf(V4_LOOPBACK) };
 }

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -88,7 +88,16 @@ export interface LoopbackPlan {
    * therefore proof that loopback is already served. Warning there would fire on every correct
    * dual-stack boot, which is how an operator learns to ignore the warning that means something.
    */
-  inUseIsFine: boolean;
+  /**
+   * Whether an `EADDRINUSE` here PROVES the primary already serves this address, rather than
+   * meaning a rival holds it.
+   *
+   * It was called `inUseIsFine`, and that name is what let the bug in: "fine" reads as "ignore
+   * it", so the clash was classified `taken` and `localhost` was suppressed for a `::` bind that
+   * owns both loopbacks (Codex/CodeRabbit, PR #1903). The clash is not something to tolerate —
+   * it is the ANSWER, and the answer is `ours`.
+   */
+  inUseProvesPrimary: boolean;
   /** What this listener is FOR, which is what decides the warning when it cannot be taken. The
    *  two failures look identical in the log and are nothing alike to the person reading it. */
   reason: LoopbackReason;
@@ -171,12 +180,13 @@ export function loopbackListenPlans(bound: BoundAddress): LoopbackPlan[] {
   const { address } = bound;
   const plans: LoopbackPlan[] = [];
   if (address !== V4_WILDCARD && !servesV4Loopback(address)) {
-    plans.push({ address: V4_LOOPBACK, inUseIsFine: address === V6_WILDCARD, reason: "sessions" });
+    plans.push({ address: V4_LOOPBACK, inUseProvesPrimary: address === V6_WILDCARD, reason: "sessions" });
   }
-  // No `inUseIsFine` counterpart here: the only bind that could already hold `[::1]:P` is one that
-  // serves the v6 loopback, and those return no plan at all. So EADDRINUSE means somebody else.
+  // No `inUseProvesPrimary` counterpart here: the only bind that could already hold `[::1]:P` is
+  // one that serves the v6 loopback, and those return no plan at all. So EADDRINUSE means
+  // somebody else.
   if (!servesV6Loopback(address)) {
-    plans.push({ address: V6_LOOPBACK, inUseIsFine: false, reason: "browser" });
+    plans.push({ address: V6_LOOPBACK, inUseProvesPrimary: false, reason: "browser" });
   }
   return plans;
 }
@@ -205,10 +215,12 @@ const START_TEXT: Record<LoopbackReason, string> = {
 function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): Promise<LoopbackStatus> {
   return new Promise((resolve) => {
     loopback.once("error", (err: NodeJS.ErrnoException) => {
-      const status = statusFromError(err);
+      // A clash under a dual-stack primary is not a loss — it is the primary itself holding the
+      // address, which is exactly what this listener wanted done.
+      const status: LoopbackStatus = plan.inUseProvesPrimary && err.code === "EADDRINUSE" ? "ours" : statusFromError(err);
       // An address this machine does not have costs nobody anything: no client can dial it, so
       // there is nothing to warn about and nothing to lose. Only a rival gets a warning.
-      if (status === "taken" && !(plan.inUseIsFine && err.code === "EADDRINUSE")) {
+      if (status === "taken") {
         console.warn(`\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — ${WARNING_TEXT[plan.reason]}`);
       }
       resolve(status);

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -24,6 +24,8 @@
 // It widens nothing: loopback is reachable only from this machine, and it is what an untouched
 // install already serves. The operator asked to ADD an interface, not to remove that one.
 
+import { createServer, type Server } from "node:net";
+
 /** What the OS says the primary listener bound — `server.address()` — and nothing else. Asking
  *  after the fact rather than classifying `MULMOTERMINAL_HOST` is the rule loopback.ts already
  *  states: `localhost`, `127.1` and `127.000.000.001` all mean loopback, and `localhost` can be
@@ -173,14 +175,19 @@ const servesV6Loopback = (address: string): boolean => address === V6_LOOPBACK |
  * Returns at most one plan per address, and never more than two — pinned by a spec, because
  * `startLoopbackListeners` hands plan `i` to spare server `i` and index.ts creates exactly two.
  */
-export function loopbackListenPlans(bound: BoundAddress): LoopbackPlan[] {
+export function loopbackListenPlans(bound: BoundAddress, v6WildcardTakesV4: boolean): LoopbackPlan[] {
   // A string address is a pipe or a UNIX socket, and null is "not listening" — neither is a
   // network bind this can reason about, and neither is reachable by a url a session would build.
   if (bound === null || typeof bound === "string") return [];
   const { address } = bound;
   const plans: LoopbackPlan[] = [];
   if (address !== V4_WILDCARD && !servesV4Loopback(address)) {
-    plans.push({ address: V4_LOOPBACK, inUseProvesPrimary: address === V6_WILDCARD, reason: "sessions" });
+    // A clash proves the primary only where the primary CAN hold this address. `::` does on a
+    // dual-stack kernel and does not under `net.ipv6.bindv6only=1`, and the difference is not a
+    // detail: read the wrong way, an unrelated `127.0.0.1` listener is counted as ourselves and
+    // `localhost` is advertised straight at it (Codex, PR #1903). So the caller MEASURES which
+    // kind of kernel this is — see kernelV6WildcardTakesV4 — rather than assuming.
+    plans.push({ address: V4_LOOPBACK, inUseProvesPrimary: address === V6_WILDCARD && v6WildcardTakesV4, reason: "sessions" });
   }
   // No `inUseProvesPrimary` counterpart here: the only bind that could already hold `[::1]:P` is
   // one that serves the v6 loopback, and those return no plan at all. So EADDRINUSE means
@@ -189,6 +196,50 @@ export function loopbackListenPlans(bound: BoundAddress): LoopbackPlan[] {
     plans.push({ address: V6_LOOPBACK, inUseProvesPrimary: false, reason: "browser" });
   }
   return plans;
+}
+
+/**
+ * Does a `::` bind on THIS kernel also take the v4 loopback?
+ *
+ * `net.ipv6.bindv6only=1` makes `::` v6-only, and every guess about which kind of kernel this is
+ * has been wrong somewhere — this file's history is a list of them. So it is measured, on a PORT
+ * NOBODY ELSE IS USING: bind `[::]:0`, take the ephemeral port the kernel picks, and see whether
+ * `127.0.0.1` on that port is now unavailable. Nothing else can be holding a port the kernel just
+ * handed out, so an `EADDRINUSE` there can only be the wildcard socket itself.
+ *
+ * That is the whole point. The same question asked about the REAL port cannot tell our primary
+ * from a stranger; asked here it can, and the answer transfers because it is a property of the
+ * kernel rather than of the port.
+ *
+ * `false` on any surprise. Wrong towards "not dual-stack" costs a `localhost` origin on a kernel
+ * that would have been fine; wrong the other way hands that origin to whoever holds `127.0.0.1`.
+ */
+/** Resolves the errno a bind failed with, or null when it succeeded. Kept separate so the probe
+ *  below reads as three steps rather than as four levels of callback. */
+function bindOutcome(server: Server, port: number, host: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    server.once("error", (err: NodeJS.ErrnoException) => resolve(err.code ?? "EUNKNOWN"));
+    server.once("listening", () => resolve(null));
+    server.listen(port, host);
+  });
+}
+
+const closeQuietly = (server: Server): Promise<void> => new Promise((resolve) => server.close(() => resolve()));
+
+export async function kernelV6WildcardTakesV4(): Promise<boolean> {
+  const wildcard = createServer();
+  if ((await bindOutcome(wildcard, 0, V6_WILDCARD)) !== null) return false;
+  const bound = wildcard.address();
+  const port = bound !== null && typeof bound !== "string" ? bound.port : null;
+  if (port === null) {
+    await closeQuietly(wildcard);
+    return false;
+  }
+  const v4 = createServer();
+  const errno = await bindOutcome(v4, port, V4_LOOPBACK);
+  if (errno === null) await closeQuietly(v4);
+  await closeQuietly(wildcard);
+  return errno === "EADDRINUSE";
 }
 
 export interface PrimaryListener {
@@ -246,8 +297,16 @@ function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string |
  * a wiring mistake rather than a runtime condition, and it would otherwise drop a listener in
  * silence, so it says so.
  */
-export async function startLoopbackListeners(primary: PrimaryListener, spares: readonly LoopbackListener[], port: string | number): Promise<LoopbackOutcome> {
-  const plans = loopbackListenPlans(primary.address());
+export async function startLoopbackListeners(
+  primary: PrimaryListener,
+  spares: readonly LoopbackListener[],
+  port: string | number,
+  v6WildcardTakesV4: () => Promise<boolean> = kernelV6WildcardTakesV4,
+): Promise<LoopbackOutcome> {
+  const bound = primary.address();
+  // Only a `::` primary raises the question, and only then is the probe worth a syscall.
+  const dualStack = bound !== null && typeof bound !== "string" && bound.address === V6_WILDCARD ? await v6WildcardTakesV4() : false;
+  const plans = loopbackListenPlans(bound, dualStack);
   const results = await Promise.all(
     plans.map((plan, i) => {
       const spare = spares[i];

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -110,6 +110,10 @@ export interface LoopbackOutcome {
    * the browser went to that process under this app's origin (Codex, PR #1903).
    */
   v6LoopbackServed: boolean;
+  /** The same question for `127.0.0.1`. Only used to decide what URL to PRINT when `::1` was
+   *  lost — `localhost` is out at that point, and this says whether the v4 loopback is a truthful
+   *  thing to name instead or whether the bound address is all that is left. */
+  v4LoopbackServed: boolean;
 }
 
 const WARNING_TEXT: Record<LoopbackReason, string> = {
@@ -220,9 +224,12 @@ export async function startLoopbackListeners(primary: PrimaryListener, spares: r
       return startOne(spare, plan, port);
     }),
   );
-  // No v6 plan means the PRIMARY already answers there — served, with nothing to take. A plan that
-  // failed is the only way this is false, and it is the case the launcher must not send a browser
-  // to `localhost` into.
-  const v6 = plans.findIndex((plan) => plan.address === V6_LOOPBACK);
-  return { v6LoopbackServed: v6 === -1 || results[v6] === true };
+  // No plan for an address means the PRIMARY already answers there — served, with nothing to take.
+  // A plan that FAILED is the only way either of these is false, and the v6 one is the case the
+  // launcher must not send a browser to `localhost` into.
+  const served = (address: string): boolean => {
+    const at = plans.findIndex((plan) => plan.address === address);
+    return at === -1 || results[at] === true;
+  };
+  return { v6LoopbackServed: served(V6_LOOPBACK), v4LoopbackServed: served(V4_LOOPBACK) };
 }

--- a/server/infra/loopback-listener.ts
+++ b/server/infra/loopback-listener.ts
@@ -98,6 +98,20 @@ export interface LoopbackPlan {
  *  `browser`: the user's browser is sent to `localhost`, which prefers `::1` (#1889). */
 export type LoopbackReason = "sessions" | "browser";
 
+/** What the caller has to know once the extra listeners have been attempted. */
+export interface LoopbackOutcome {
+  /**
+   * Whether this server answers on `::1` — either because the primary bind already did, or
+   * because the extra listener took it.
+   *
+   * It exists to be REPORTED, not just logged. The launcher decides whether to send the browser
+   * to `localhost`, and until this was reported it decided from a probe taken BEFORE the server
+   * existed — so a process that claimed `[::1]:<port>` during the boot was invisible to it, and
+   * the browser went to that process under this app's origin (Codex, PR #1903).
+   */
+  v6LoopbackServed: boolean;
+}
+
 const WARNING_TEXT: Record<LoopbackReason, string> = {
   sessions: "this machine's own sessions reach the server over loopback, so hooks and the GUI MCP will fail until it is free.",
   browser:
@@ -160,13 +174,23 @@ const START_TEXT: Record<LoopbackReason, string> = {
   browser: "so http://localhost:<port> can only mean this server",
 };
 
-function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): void {
-  loopback.once("error", (err: NodeJS.ErrnoException) => {
-    if (plan.inUseIsFine && err.code === "EADDRINUSE") return;
-    console.warn(`\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — ${WARNING_TEXT[plan.reason]}`);
-  });
-  loopback.listen(Number(port), plan.address, () => {
-    console.log(`[bind] also listening on ${plan.address}:${port} ${START_TEXT[plan.reason]}`);
+/** Resolves true when this listener took its address, false when it could not.
+ *
+ *  `listen()` answers with exactly one of `listening` or `error` — there is no third outcome and
+ *  so no timeout here. A cap would have to choose a duration for a local syscall that takes
+ *  microseconds, and on expiry it could only guess at an answer the kernel is about to give. */
+function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string | number): Promise<boolean> {
+  return new Promise((resolve) => {
+    loopback.once("error", (err: NodeJS.ErrnoException) => {
+      if (!(plan.inUseIsFine && err.code === "EADDRINUSE")) {
+        console.warn(`\x1b[33m[bind]\x1b[0m could not also listen on ${plan.address}:${port} (${err.code ?? err.message}) — ${WARNING_TEXT[plan.reason]}`);
+      }
+      resolve(false);
+    });
+    loopback.listen(Number(port), plan.address, () => {
+      console.log(`[bind] also listening on ${plan.address}:${port} ${START_TEXT[plan.reason]}`);
+      resolve(true);
+    });
   });
 }
 
@@ -184,14 +208,21 @@ function startOne(loopback: LoopbackListener, plan: LoopbackPlan, port: string |
  * a wiring mistake rather than a runtime condition, and it would otherwise drop a listener in
  * silence, so it says so.
  */
-export function startLoopbackListeners(primary: PrimaryListener, spares: readonly LoopbackListener[], port: string | number): void {
+export async function startLoopbackListeners(primary: PrimaryListener, spares: readonly LoopbackListener[], port: string | number): Promise<LoopbackOutcome> {
   const plans = loopbackListenPlans(primary.address());
-  plans.forEach((plan, i) => {
-    const spare = spares[i];
-    if (spare === undefined) {
-      console.warn(`\x1b[33m[bind]\x1b[0m no spare server for ${plan.address}:${port} — ${WARNING_TEXT[plan.reason]}`);
-      return;
-    }
-    startOne(spare, plan, port);
-  });
+  const results = await Promise.all(
+    plans.map((plan, i) => {
+      const spare = spares[i];
+      if (spare === undefined) {
+        console.warn(`\x1b[33m[bind]\x1b[0m no spare server for ${plan.address}:${port} — ${WARNING_TEXT[plan.reason]}`);
+        return Promise.resolve(false);
+      }
+      return startOne(spare, plan, port);
+    }),
+  );
+  // No v6 plan means the PRIMARY already answers there — served, with nothing to take. A plan that
+  // failed is the only way this is false, and it is the case the launcher must not send a browser
+  // to `localhost` into.
+  const v6 = plans.findIndex((plan) => plan.address === V6_LOOPBACK);
+  return { v6LoopbackServed: v6 === -1 || results[v6] === true };
 }

--- a/test/bin/probe-bind-host.spec.ts
+++ b/test/bin/probe-bind-host.spec.ts
@@ -367,8 +367,13 @@ describe("the launcher asks the child rather than classifying BIND_HOST", () => 
     expect(launcher).toMatch(/launcherReachHost\(msg\.address\)/);
   });
 
+  // Anchored on the FIRST argument only. `beginReady` grew a second one (the child's own report
+  // about `::1`, #1903) and a closed `\)` made this go red for a reason that was not a defect —
+  // which is the third time this guard has done that, and exactly what the note above warns of.
+  // What it is actually about is that the poll starts from the RESOLVED address, so that is all
+  // it now pins.
   it("starts the readiness check from that resolved address", () => {
-    expect(launcher).toMatch(/beginReady\(reported\)/);
+    expect(launcher).toMatch(/beginReady\(reported\b/);
   });
 
   // The fallback prefers the address the PROBE learned from the kernel, and never passes a raw

--- a/test/server/infra/announce-listening.spec.ts
+++ b/test/server/infra/announce-listening.spec.ts
@@ -7,7 +7,7 @@
 // claimed yet, and whatever claims it in between answers under this app's origin (Codex, #1903).
 import { describe, it, expect, vi } from "vitest";
 
-import { announceListening, listeningMessage, type IpcParent } from "../../../server/infra/announce-listening.js";
+import { announceListening, listeningMessage, localBrowserUrl, notLocalhostReason, type IpcParent } from "../../../server/infra/announce-listening.js";
 import type { LoopbackListener, PrimaryListener } from "../../../server/infra/loopback-listener.js";
 
 const primaryOn = (address: string): PrimaryListener => ({ address: () => ({ address }) });
@@ -98,12 +98,54 @@ describe("announceListening", () => {
 describe("listeningMessage", () => {
   // The dev supervisor keys on `type` alone (#1735), so the shape may grow but must not lose it.
   it("always names itself, whatever else it carries", () => {
-    expect(listeningMessage(34567, null, { v6LoopbackServed: false }).type).toBe("listening");
+    expect(listeningMessage(34567, null, { v6LoopbackServed: false, v4LoopbackServed: true }).type).toBe("listening");
   });
 
   // A bind that is a pipe or is not listening reports no address; the launcher falls back rather
   // than guessing from a name.
   it("passes a null address through rather than inventing one", () => {
-    expect(listeningMessage(34567, null, { v6LoopbackServed: true }).address).toBeNull();
+    expect(listeningMessage(34567, null, { v6LoopbackServed: true, v4LoopbackServed: true }).address).toBeNull();
+  });
+});
+
+// What a direct `npm run server` prints is all its operator has — there is no launcher behind it
+// to correct an address, so the line must not be written before the answer is known (#1903).
+describe("localBrowserUrl", () => {
+  const ok = { v6LoopbackServed: true, v4LoopbackServed: true };
+
+  it("names localhost once every address it resolves to is ours", () => {
+    expect(localBrowserUrl(34567, "127.0.0.1", ok)).toBe("http://localhost:34567");
+  });
+
+  // The whole point: `localhost` prefers `::1`, so naming it while a stranger holds that address
+  // sends the operator to the stranger under this app's origin.
+  it("refuses localhost when the v6 loopback was lost, and says why", () => {
+    const lost = { v6LoopbackServed: false, v4LoopbackServed: true };
+    expect(localBrowserUrl(34567, "127.0.0.1", lost)).toBe("http://127.0.0.1:34567");
+    expect(notLocalhostReason(34567, lost)).toContain("[::1]:34567");
+  });
+
+  it("says nothing extra when localhost IS the answer", () => {
+    expect(notLocalhostReason(34567, ok)).toBeNull();
+  });
+
+  // Neither loopback held: the bound address is the last thing that can still be asserted.
+  // Asserted through `URL` rather than against a literal, which trips sonarjs/no-clear-text-
+  // protocols — the same dodge test/bin/probe-bind-host.spec.ts uses, and it pins what matters.
+  it("falls back to the address the kernel reported when neither loopback is ours", () => {
+    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    const url = new URL(localBrowserUrl(34567, "192.168.64.1", none));
+    expect(url.hostname).toBe("192.168.64.1");
+    expect(url.port).toBe("34567");
+  });
+
+  it("brackets an IPv6 literal, which is not a URL unbracketed", () => {
+    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    expect(new URL(localBrowserUrl(34567, "fd00::1", none)).hostname).toBe("[fd00::1]");
+  });
+
+  it("still names an address when the bind reported none at all", () => {
+    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    expect(localBrowserUrl(34567, null, none)).toBe("http://127.0.0.1:34567");
   });
 });

--- a/test/server/infra/announce-listening.spec.ts
+++ b/test/server/infra/announce-listening.spec.ts
@@ -105,20 +105,20 @@ describe("announceListening", () => {
 describe("listeningMessage", () => {
   // The dev supervisor keys on `type` alone (#1735), so the shape may grow but must not lose it.
   it("always names itself, whatever else it carries", () => {
-    expect(listeningMessage(34567, null, { v6LoopbackServed: false, v4LoopbackServed: true }).type).toBe("listening");
+    expect(listeningMessage(34567, null, { v6: "taken", v4: "ours" } as const).type).toBe("listening");
   });
 
   // A bind that is a pipe or is not listening reports no address; the launcher falls back rather
   // than guessing from a name.
   it("passes a null address through rather than inventing one", () => {
-    expect(listeningMessage(34567, null, { v6LoopbackServed: true, v4LoopbackServed: true }).address).toBeNull();
+    expect(listeningMessage(34567, null, { v6: "ours", v4: "ours" } as const).address).toBeNull();
   });
 });
 
 // What a direct `npm run server` prints is all its operator has — there is no launcher behind it
 // to correct an address, so the line must not be written before the answer is known (#1903).
 describe("localBrowserUrl", () => {
-  const ok = { v6LoopbackServed: true, v4LoopbackServed: true };
+  const ok = { v6: "ours", v4: "ours" } as const;
 
   it("names localhost once every address it resolves to is ours", () => {
     expect(localBrowserUrl(34567, "127.0.0.1", ok)).toBe("http://localhost:34567");
@@ -127,7 +127,7 @@ describe("localBrowserUrl", () => {
   // The whole point: `localhost` prefers `::1`, so naming it while a stranger holds that address
   // sends the operator to the stranger under this app's origin.
   it("refuses localhost when the v6 loopback was lost, and says why", () => {
-    const lost = { v6LoopbackServed: false, v4LoopbackServed: true };
+    const lost = { v6: "taken", v4: "ours" } as const;
     expect(localBrowserUrl(34567, "127.0.0.1", lost)).toBe("http://127.0.0.1:34567");
     expect(notLocalhostReason(34567, lost)).toContain("[::1]:34567");
   });
@@ -140,19 +140,19 @@ describe("localBrowserUrl", () => {
   // Asserted through `URL` rather than against a literal, which trips sonarjs/no-clear-text-
   // protocols — the same dodge test/bin/probe-bind-host.spec.ts uses, and it pins what matters.
   it("falls back to the address the kernel reported when neither loopback is ours", () => {
-    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    const none = { v6: "taken", v4: "taken" } as const;
     const url = new URL(localBrowserUrl(34567, "192.168.64.1", none));
     expect(url.hostname).toBe("192.168.64.1");
     expect(url.port).toBe("34567");
   });
 
   it("brackets an IPv6 literal, which is not a URL unbracketed", () => {
-    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    const none = { v6: "taken", v4: "taken" } as const;
     expect(new URL(localBrowserUrl(34567, "fd00::1", none)).hostname).toBe("[fd00::1]");
   });
 
   it("still names an address when the bind reported none at all", () => {
-    const none = { v6LoopbackServed: false, v4LoopbackServed: false };
+    const none = { v6: "taken", v4: "taken" } as const;
     expect(localBrowserUrl(34567, null, none)).toBe("http://127.0.0.1:34567");
   });
 });
@@ -161,23 +161,59 @@ describe("localBrowserUrl", () => {
 // holding one of the two is not a smaller guarantee — it is none (Codex, #1903).
 describe("localhostIsOurs", () => {
   it("needs both loopbacks, not either", () => {
-    expect(localhostIsOurs({ v4LoopbackServed: true, v6LoopbackServed: true })).toBe(true);
-    expect(localhostIsOurs({ v4LoopbackServed: true, v6LoopbackServed: false })).toBe(false);
-    expect(localhostIsOurs({ v4LoopbackServed: false, v6LoopbackServed: true })).toBe(false);
-    expect(localhostIsOurs({ v4LoopbackServed: false, v6LoopbackServed: false })).toBe(false);
+    expect(localhostIsOurs({ v4: "ours", v6: "ours" } as const)).toBe(true);
+    expect(localhostIsOurs({ v4: "ours", v6: "taken" } as const)).toBe(false);
+    expect(localhostIsOurs({ v4: "taken", v6: "ours" } as const)).toBe(false);
+    expect(localhostIsOurs({ v4: "taken", v6: "taken" } as const)).toBe(false);
   });
 
   // The reported case: a `::1` primary serves v6 itself, so only the v4 auxiliary can lose — and
   // an IPv4-preferring client would then reach whatever took it.
   it("refuses localhost when a ::1 primary lost the v4 bind", () => {
-    const outcome = { v4LoopbackServed: false, v6LoopbackServed: true };
+    const outcome = { v4: "taken", v6: "ours" } as const;
     expect(localBrowserUrl(34567, "::1", outcome)).toBe("http://[::1]:34567");
     expect(notLocalhostReason(34567, outcome)).toContain("127.0.0.1:34567");
   });
 
   it("names both addresses when both were lost", () => {
-    const reason = notLocalhostReason(34567, { v4LoopbackServed: false, v6LoopbackServed: false });
+    const reason = notLocalhostReason(34567, { v4: "taken", v6: "taken" } as const);
     expect(reason).toContain("127.0.0.1:34567");
     expect(reason).toContain("[::1]:34567");
+  });
+});
+
+// An IPv4-only host fails the `::1` bind with EADDRNOTAVAIL, and there `localhost` resolves only
+// to v4 — so nothing is at stake and refusing `localhost` would be a lie (Codex, #1903).
+describe("an address this machine does not have", () => {
+  const ipv4Only = { v4: "ours", v6: "absent" } as const;
+
+  it("does not stop localhost from being ours", () => {
+    expect(localhostIsOurs(ipv4Only)).toBe(true);
+    expect(localBrowserUrl(34567, "127.0.0.1", ipv4Only)).toBe("http://localhost:34567");
+  });
+
+  it("is not reported as a collision, because there is nobody to collide with", () => {
+    expect(notLocalhostReason(34567, ipv4Only)).toBeNull();
+  });
+
+  // The mirror, so the rule is not written only for the direction that happens to be common.
+  it("holds the same way round for a missing v4 loopback", () => {
+    const v6Only = { v4: "absent", v6: "ours" } as const;
+    expect(localhostIsOurs(v6Only)).toBe(true);
+    expect(localBrowserUrl(34567, "::1", v6Only)).toBe("http://localhost:34567");
+  });
+
+  // Absent everywhere means `localhost` names nothing at all — worse than a literal address.
+  it("refuses localhost when no loopback exists to reach us at", () => {
+    const none = { v4: "absent", v6: "absent" } as const;
+    expect(localhostIsOurs(none)).toBe(false);
+    expect(notLocalhostReason(34567, none)).toContain("no loopback address");
+  });
+
+  // A real rival alongside a missing address must still be named, and only it.
+  it("names only the taken address when one is absent and the other is taken", () => {
+    const reason = notLocalhostReason(34567, { v4: "taken", v6: "absent" } as const);
+    expect(reason).toContain("127.0.0.1:34567");
+    expect(reason).not.toContain("[::1]");
   });
 });

--- a/test/server/infra/announce-listening.spec.ts
+++ b/test/server/infra/announce-listening.spec.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+// The ORDER between taking the loopback addresses and telling the parent we are listening.
+//
+// It is not tidiness. The launcher acts on this message — it prints the banner and opens the
+// browser at `http://localhost:<port>` — and `localhost` prefers `::1` (measured on Chrome). So a
+// message sent before `::1` is held invites the browser to an address this process has not
+// claimed yet, and whatever claims it in between answers under this app's origin (Codex, #1903).
+import { describe, it, expect, vi } from "vitest";
+
+import { announceListening, listeningMessage, type IpcParent } from "../../../server/infra/announce-listening.js";
+import type { LoopbackListener, PrimaryListener } from "../../../server/infra/loopback-listener.js";
+
+const primaryOn = (address: string): PrimaryListener => ({ address: () => ({ address }) });
+
+/** Records the order of everything that happens, which is the thing under test. */
+const harness = (outcomes: readonly ("ok" | "taken")[]) => {
+  const events: string[] = [];
+  const spares: LoopbackListener[] = outcomes.map((outcome) => {
+    let onError: ((err: NodeJS.ErrnoException) => void) | undefined;
+    return {
+      once: (_event, handler) => {
+        onError = handler;
+        return undefined;
+      },
+      listen: (_port, address, onListening) => {
+        // Asynchronously, as a real bind answers — so a caller that forgets to await sends first.
+        setTimeout(() => {
+          if (outcome === "ok") {
+            events.push(`bound:${address}`);
+            onListening();
+          } else {
+            events.push(`failed:${address}`);
+            onError?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+          }
+        }, 0);
+        return undefined;
+      },
+    };
+  });
+  const sent: unknown[] = [];
+  const parent: IpcParent = {
+    connected: true,
+    send: (message) => {
+      events.push("announced");
+      sent.push(message);
+      return undefined;
+    },
+  };
+  return { events, spares, parent, sent };
+};
+
+describe("announceListening", () => {
+  it("takes the loopback addresses BEFORE it announces", async () => {
+    const { events, spares, parent } = harness(["ok", "ok"]);
+    await announceListening(primaryOn("192.168.64.1"), spares, 34567, "192.168.64.1", parent);
+    expect(events).toEqual(["bound:127.0.0.1", "bound:::1", "announced"]);
+  });
+
+  it("reports the v6 loopback as served when the listener took it", async () => {
+    const { spares, parent, sent } = harness(["ok"]);
+    await announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", parent);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", v6LoopbackServed: true }]);
+  });
+
+  // The case the report exists for: the launcher's own probe ran before this process started, so
+  // only this side can see a claim made during the boot.
+  it("reports it as NOT served when the bind lost, and still announces", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { events, spares, parent, sent } = harness(["taken"]);
+    await announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", parent);
+    expect(events).toEqual(["failed:::1", "announced"]);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", v6LoopbackServed: false }]);
+    warn.mockRestore();
+  });
+
+  // A `::` bind serves `::1` itself, so there is no plan and nothing to lose.
+  it("reports it as served when the primary bind already answers there", async () => {
+    const { spares, parent, sent } = harness(["ok"]);
+    await announceListening(primaryOn("::"), spares, 34567, "::", parent);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "::", v6LoopbackServed: true }]);
+  });
+
+  // `send` STAYS a function after the parent disconnects, and calling it then kills this process
+  // with an async ERR_IPC_CHANNEL_CLOSED that no try/catch reaches.
+  it("does not send to a parent that has disconnected", async () => {
+    const { spares, parent, sent } = harness(["ok"]);
+    await announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", { ...parent, connected: false });
+    expect(sent).toEqual([]);
+  });
+
+  it("is a no-op with no IPC channel at all — the `npx mulmoterminal` case", async () => {
+    const { spares } = harness(["ok"]);
+    const parent: IpcParent = { connected: true };
+    await expect(announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", parent)).resolves.toBeUndefined();
+  });
+});
+
+describe("listeningMessage", () => {
+  // The dev supervisor keys on `type` alone (#1735), so the shape may grow but must not lose it.
+  it("always names itself, whatever else it carries", () => {
+    expect(listeningMessage(34567, null, { v6LoopbackServed: false }).type).toBe("listening");
+  });
+
+  // A bind that is a pipe or is not listening reports no address; the launcher falls back rather
+  // than guessing from a name.
+  it("passes a null address through rather than inventing one", () => {
+    expect(listeningMessage(34567, null, { v6LoopbackServed: true }).address).toBeNull();
+  });
+});

--- a/test/server/infra/announce-listening.spec.ts
+++ b/test/server/infra/announce-listening.spec.ts
@@ -7,7 +7,14 @@
 // claimed yet, and whatever claims it in between answers under this app's origin (Codex, #1903).
 import { describe, it, expect, vi } from "vitest";
 
-import { announceListening, listeningMessage, localBrowserUrl, notLocalhostReason, type IpcParent } from "../../../server/infra/announce-listening.js";
+import {
+  announceListening,
+  listeningMessage,
+  localBrowserUrl,
+  localhostIsOurs,
+  notLocalhostReason,
+  type IpcParent,
+} from "../../../server/infra/announce-listening.js";
 import type { LoopbackListener, PrimaryListener } from "../../../server/infra/loopback-listener.js";
 
 const primaryOn = (address: string): PrimaryListener => ({ address: () => ({ address }) });
@@ -56,28 +63,28 @@ describe("announceListening", () => {
     expect(events).toEqual(["bound:127.0.0.1", "bound:::1", "announced"]);
   });
 
-  it("reports the v6 loopback as served when the listener took it", async () => {
+  it("reports localhost as ours when the listener took the missing loopback", async () => {
     const { spares, parent, sent } = harness(["ok"]);
     await announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", parent);
-    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", v6LoopbackServed: true }]);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", localhostIsOurs: true }]);
   });
 
   // The case the report exists for: the launcher's own probe ran before this process started, so
   // only this side can see a claim made during the boot.
-  it("reports it as NOT served when the bind lost, and still announces", async () => {
+  it("reports localhost as NOT ours when a bind lost, and still announces", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { events, spares, parent, sent } = harness(["taken"]);
     await announceListening(primaryOn("127.0.0.1"), spares, 34567, "127.0.0.1", parent);
     expect(events).toEqual(["failed:::1", "announced"]);
-    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", v6LoopbackServed: false }]);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "127.0.0.1", localhostIsOurs: false }]);
     warn.mockRestore();
   });
 
   // A `::` bind serves `::1` itself, so there is no plan and nothing to lose.
-  it("reports it as served when the primary bind already answers there", async () => {
+  it("reports localhost as ours when the primary bind already answers there", async () => {
     const { spares, parent, sent } = harness(["ok"]);
     await announceListening(primaryOn("::"), spares, 34567, "::", parent);
-    expect(sent).toEqual([{ type: "listening", port: 34567, address: "::", v6LoopbackServed: true }]);
+    expect(sent).toEqual([{ type: "listening", port: 34567, address: "::", localhostIsOurs: true }]);
   });
 
   // `send` STAYS a function after the parent disconnects, and calling it then kills this process
@@ -147,5 +154,30 @@ describe("localBrowserUrl", () => {
   it("still names an address when the bind reported none at all", () => {
     const none = { v6LoopbackServed: false, v4LoopbackServed: false };
     expect(localBrowserUrl(34567, null, none)).toBe("http://127.0.0.1:34567");
+  });
+});
+
+// `localhost` resolves to EITHER loopback and clients disagree about which they try first, so
+// holding one of the two is not a smaller guarantee — it is none (Codex, #1903).
+describe("localhostIsOurs", () => {
+  it("needs both loopbacks, not either", () => {
+    expect(localhostIsOurs({ v4LoopbackServed: true, v6LoopbackServed: true })).toBe(true);
+    expect(localhostIsOurs({ v4LoopbackServed: true, v6LoopbackServed: false })).toBe(false);
+    expect(localhostIsOurs({ v4LoopbackServed: false, v6LoopbackServed: true })).toBe(false);
+    expect(localhostIsOurs({ v4LoopbackServed: false, v6LoopbackServed: false })).toBe(false);
+  });
+
+  // The reported case: a `::1` primary serves v6 itself, so only the v4 auxiliary can lose — and
+  // an IPv4-preferring client would then reach whatever took it.
+  it("refuses localhost when a ::1 primary lost the v4 bind", () => {
+    const outcome = { v4LoopbackServed: false, v6LoopbackServed: true };
+    expect(localBrowserUrl(34567, "::1", outcome)).toBe("http://[::1]:34567");
+    expect(notLocalhostReason(34567, outcome)).toContain("127.0.0.1:34567");
+  });
+
+  it("names both addresses when both were lost", () => {
+    const reason = notLocalhostReason(34567, { v4LoopbackServed: false, v6LoopbackServed: false });
+    expect(reason).toContain("127.0.0.1:34567");
+    expect(reason).toContain("[::1]:34567");
   });
 });

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -149,14 +149,15 @@ describe("startLoopbackListeners", () => {
   });
 
   // A machine with no IPv6 lands here, and it is not a problem there: `localhost` is v4-only, so
-  // nothing was at stake. It still says so rather than failing the boot.
-  it("carries on when the v6 loopback is not an address this machine has", () => {
+  // nothing is at stake and there is no rival to report. This asserted a warning until Codex
+  // pointed out that the warning is an accusation against a stranger who does not exist (#1903).
+  it("carries on SILENTLY when the v6 loopback is not an address this machine has", () => {
     const a = recorder();
     const b = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     startLoopbackListeners(fakeServer({ address: "127.0.0.1" }), [a.loopback, b.loopback], 34567);
     expect(() => a.handlers[0]?.(Object.assign(new Error("unavailable"), { code: "EADDRNOTAVAIL" }))).not.toThrow();
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
@@ -203,7 +204,7 @@ describe("startLoopbackListeners under a v6 wildcard primary", () => {
 
 // The v4 half of the outcome exists only to decide what URL to print when `::1` was lost.
 describe("the outcome it reports", () => {
-  const recorder = (succeed: boolean) => {
+  const recorder = (succeed: boolean, code = "EADDRINUSE") => {
     let onError: ((err: NodeJS.ErrnoException) => void) | undefined;
     const loopback: LoopbackListener = {
       once: (_event, handler) => {
@@ -212,23 +213,49 @@ describe("the outcome it reports", () => {
       },
       listen: (_port, _address, onListening) => {
         if (succeed) onListening();
-        else onError?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+        else onError?.(Object.assign(new Error(code), { code }));
         return undefined;
       },
     };
     return loopback;
   };
 
-  it("counts an address the primary already serves as served", async () => {
+  it("counts an address the primary already serves as ours", async () => {
     const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [recorder(true), recorder(true)], 34567);
-    expect(outcome).toEqual({ v6LoopbackServed: true, v4LoopbackServed: true });
+    expect(outcome).toEqual({ v6: "ours", v4: "ours" });
   });
 
   it("reports each half separately when only one bind lost", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     // A LAN bind plans both; the first spare takes 127.0.0.1 and the second loses ::1.
     const outcome = await startLoopbackListeners({ address: () => ({ address: "192.168.64.1" }) }, [recorder(true), recorder(false)], 34567);
-    expect(outcome).toEqual({ v6LoopbackServed: false, v4LoopbackServed: true });
+    expect(outcome).toEqual({ v6: "taken", v4: "ours" });
+    warn.mockRestore();
+  });
+
+  // Only EADDRINUSE says somebody else is there. An IPv4-only host fails the `::1` bind with
+  // EADDRNOTAVAIL, and calling that "taken" accuses a stranger who does not exist (#1903).
+  it("calls an address this machine does not have `absent`, not `taken`", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "127.0.0.1" }) }, [recorder(false, "EADDRNOTAVAIL")], 34567);
+    expect(outcome).toEqual({ v6: "absent", v4: "ours" });
+    // And says nothing: there is no rival to tell the operator about.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("treats an unsupported address family the same way", async () => {
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "127.0.0.1" }) }, [recorder(false, "EAFNOSUPPORT")], 34567);
+    expect(outcome.v6).toBe("absent");
+  });
+
+  // Anything it cannot classify stays conservative — a refusal we do not understand might still
+  // be an address somebody else can bind.
+  it("keeps an unrecognised failure as taken", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "127.0.0.1" }) }, [recorder(false, "EACCES")], 34567);
+    expect(outcome.v6).toBe("taken");
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 });

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from "vitest";
 
 import {
+  kernelV6WildcardTakesV4,
   loopbackListenPlans,
   startLoopbackListeners,
   type BoundAddress,
@@ -18,8 +19,9 @@ import {
   type PrimaryListener,
 } from "../../../server/infra/loopback-listener.js";
 
-const addressesFor = (bound: BoundAddress): string[] => loopbackListenPlans(bound).map((p) => p.address);
-const planFor = (bound: BoundAddress, address: string): LoopbackPlan | undefined => loopbackListenPlans(bound).find((p) => p.address === address);
+const addressesFor = (bound: BoundAddress, dualStack = false): string[] => loopbackListenPlans(bound, dualStack).map((p) => p.address);
+const planFor = (bound: BoundAddress, address: string, dualStack = false): LoopbackPlan | undefined =>
+  loopbackListenPlans(bound, dualStack).find((p) => p.address === address);
 
 describe("loopbackListenPlans", () => {
   // The default bind. It answers for 127.0.0.1 by being it, and answers for nothing on v6 — which
@@ -45,7 +47,7 @@ describe("loopbackListenPlans", () => {
   // v4, never whether it takes v6 — while its v4 coverage is the thing that has to be attempted.
   it("takes nothing for the v6 wildcard beyond the v4 attempt, whose clash is proof rather than failure", () => {
     expect(addressesFor({ address: "::" })).toEqual(["127.0.0.1"]);
-    expect(planFor({ address: "::" }, "127.0.0.1")?.inUseProvesPrimary).toBe(true);
+    expect(planFor({ address: "::" }, "127.0.0.1", true)?.inUseProvesPrimary).toBe(true);
   });
 
   it("takes both for a specific non-loopback address — the reported case", () => {
@@ -69,16 +71,16 @@ describe("loopbackListenPlans", () => {
   // index.ts creates exactly two spares and startLoopbackListeners hands plan i to spare i.
   it("never asks for more spares than index.ts builds", () => {
     ["127.0.0.1", "127.0.0.2", "0.0.0.0", "::", "::1", "192.168.64.1", "fe80::1"].forEach((address) =>
-      expect(loopbackListenPlans({ address }).length, address).toBeLessThanOrEqual(2),
+      expect(loopbackListenPlans({ address }, false).length, address).toBeLessThanOrEqual(2),
     );
   });
 
   it("says no for a pipe or UNIX socket, which no session url can name", () => {
-    expect(loopbackListenPlans("/tmp/mulmoterminal.sock")).toEqual([]);
+    expect(loopbackListenPlans("/tmp/mulmoterminal.sock", false)).toEqual([]);
   });
 
   it("says no when the server is not listening at all", () => {
-    expect(loopbackListenPlans(null)).toEqual([]);
+    expect(loopbackListenPlans(null, false)).toEqual([]);
   });
 });
 
@@ -174,6 +176,9 @@ describe("startLoopbackListeners", () => {
   });
 });
 
+// Handlers are registered only AFTER the kernel probe resolves, so these await the setup before
+// firing anything — and they inject the kernel answer rather than inheriting the runner's, which
+// would make them assert different things on macOS and on Linux.
 describe("startLoopbackListeners under a v6 wildcard primary", () => {
   const wildcard = (): PrimaryListener => ({ address: () => ({ address: "::" }) });
 
@@ -183,20 +188,26 @@ describe("startLoopbackListeners under a v6 wildcard primary", () => {
     return { handlers, loopback };
   };
 
-  it("says nothing when the port is already taken — that IS the wildcard covering loopback", () => {
+  const startOnDualStack = async (spares: readonly LoopbackListener[]) => startLoopbackListeners(wildcard(), spares, 34567, () => Promise.resolve(true));
+
+  it("says nothing when the port is already taken — that IS the wildcard covering loopback", async () => {
     const a = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    startLoopbackListeners(wildcard(), [a.loopback, recorder().loopback], 34567);
+    const pending = startOnDualStack([a.loopback, recorder().loopback]);
+    await Promise.resolve();
     a.handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+    await pending;
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
-  it("still warns about a failure that is NOT the expected clash", () => {
+  it("still warns about a failure that is NOT the expected clash", async () => {
     const a = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    startLoopbackListeners(wildcard(), [a.loopback, recorder().loopback], 34567);
+    const pending = startOnDualStack([a.loopback, recorder().loopback]);
+    await Promise.resolve();
     a.handlers[0]?.(Object.assign(new Error("denied"), { code: "EACCES" }));
+    await pending;
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
@@ -260,10 +271,19 @@ describe("the outcome it reports", () => {
   });
 });
 
-// A `::` primary is dual-stack on most kernels, so its 127.0.0.1 auxiliary clashes with the
-// primary ITSELF. Reading that as a rival suppressed `localhost` for a server that owns both
-// loopbacks (Codex/CodeRabbit, #1903) — and macOS hides it, because there the bind succeeds.
-describe("a clash that proves the primary already covers the address", () => {
+// `net.ipv6.bindv6only=1` makes `::` v6-only, and then a `127.0.0.1` clash is a STRANGER rather
+// than the primary. Guessing which kernel this is has been wrong in both directions, so the answer
+// is measured and passed in (Codex, #1903).
+describe("whether a clash proves the primary", () => {
+  it("is true only for a `::` bind on a kernel whose `::` takes v4", () => {
+    expect(planFor({ address: "::" }, "127.0.0.1", true)?.inUseProvesPrimary).toBe(true);
+    expect(planFor({ address: "::" }, "127.0.0.1", false)?.inUseProvesPrimary).toBe(false);
+  });
+
+  it("is never true for a bind that could not hold the v4 loopback anyway", () => {
+    ["192.168.64.1", "::1", "127.0.0.2"].forEach((address) => expect(planFor({ address }, "127.0.0.1", true)?.inUseProvesPrimary, address).toBe(false));
+  });
+
   const clashing = (): LoopbackListener => {
     let onError: ((err: NodeJS.ErrnoException) => void) | undefined;
     return {
@@ -278,11 +298,41 @@ describe("a clash that proves the primary already covers the address", () => {
     };
   };
 
-  it("counts as ours, not as taken", async () => {
+  it("counts the clash as ours on a dual-stack kernel", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [clashing(), clashing()], 34567);
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [clashing(), clashing()], 34567, () => Promise.resolve(true));
     expect(outcome).toEqual({ v4: "ours", v6: "ours" });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  // The reported case. Same clash, same code path, opposite kernel — and here it IS a stranger.
+  it("counts the same clash as taken under bindv6only, and warns", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [clashing(), clashing()], 34567, () => Promise.resolve(false));
+    expect(outcome.v4).toBe("taken");
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  // Only a `::` primary raises the question, so nothing else should pay for the probe.
+  it("does not ask the kernel for a bind that is not the v6 wildcard", async () => {
+    const asked = vi.fn(() => Promise.resolve(true));
+    await startLoopbackListeners({ address: () => ({ address: "127.0.0.1" }) }, [clashing()], 34567, asked);
+    expect(asked).not.toHaveBeenCalled();
+  });
+});
+
+// The probe binds real sockets. Its ANSWER is platform-dependent, so this pins only that it gives
+// one — asserting the value would red the suite on a kernel where no defect exists, which is the
+// trap test/bin/probe-bind-host.spec.ts already documents for the wildcard question.
+describe("kernelV6WildcardTakesV4", () => {
+  it("answers with a boolean rather than throwing or hanging", async () => {
+    expect(typeof (await kernelV6WildcardTakesV4())).toBe("boolean");
+  });
+
+  it("leaves nothing listening behind — it can be asked twice", async () => {
+    await kernelV6WildcardTakesV4();
+    expect(typeof (await kernelV6WildcardTakesV4())).toBe("boolean");
   });
 });

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -1,86 +1,88 @@
 // @vitest-environment node
-// Whether a second listener on loopback is needed, and which loopback address it takes.
+// Which loopback addresses this server must take for itself, beyond whatever the primary bound.
 //
-// The whole of #1834 rests on this one decision: get it wrong towards "not needed" and every hook
-// and GUI MCP url in the session keeps failing; wrong towards "needed" and the boot tries to bind
-// a port it already holds.
+// Two decisions ride on this, and they fail in different directions:
+//   - #1834 — get `127.0.0.1` wrong towards "not needed" and every hook and GUI MCP url in the
+//     session keeps failing; wrong towards "needed" and the boot tries to bind a port it holds.
+//   - #1893 — get `::1` wrong towards "not needed" and anything on this machine can take the
+//     address the user's browser resolves `localhost` to FIRST (measured on Chrome), and answer
+//     for our origin with the settings that origin holds.
 import { describe, it, expect, vi } from "vitest";
 
 import {
-  loopbackListenPlan,
-  startLoopbackListener,
+  loopbackListenPlans,
+  startLoopbackListeners,
   type BoundAddress,
   type LoopbackListener,
+  type LoopbackPlan,
   type PrimaryListener,
 } from "../../../server/infra/loopback-listener.js";
 
-describe("loopbackListenPlan", () => {
-  it("is not needed for the default bind — nothing changes for an untouched install", () => {
-    expect(loopbackListenPlan({ address: "127.0.0.1" })).toBeNull();
+const addressesFor = (bound: BoundAddress): string[] => loopbackListenPlans(bound).map((p) => p.address);
+const planFor = (bound: BoundAddress, address: string): LoopbackPlan | undefined => loopbackListenPlans(bound).find((p) => p.address === address);
+
+describe("loopbackListenPlans", () => {
+  // The default bind. It answers for 127.0.0.1 by being it, and answers for nothing on v6 — which
+  // is the whole of #1893, since this is what almost every install runs.
+  it("takes the v6 loopback for the default bind, and nothing else", () => {
+    expect(addressesFor({ address: "127.0.0.1" })).toEqual(["::1"]);
   });
 
-  // This used to assert the opposite — "not needed for any of 127.0.0.0/8, which is all
-  // loopback" — and the premise was the wrong question. Being loopback is not what matters;
-  // answering on 127.0.0.1 is, because guiMcpUrlTemplate and the hooks write that address as a
-  // LITERAL. A socket bound to one specific address accepts connections to that address and no
-  // other, which is how TCP works rather than a platform quirk: measured on this machine, a
-  // server on 192.168.11.12 answers 192.168.11.12 and gives ECONNREFUSED to 127.0.0.1.
-  //
-  // So a server on 127.0.0.53 leaves every local client unable to reach it at all, and planning
-  // no secondary listener is what made that silent. Found by the CI reviewer on #1877.
-  it("IS needed for the rest of 127.0.0.0/8, which does not answer for 127.0.0.1", () => {
-    for (const address of ["127.0.0.2", "127.0.0.53", "127.1.2.3"]) {
-      expect(loopbackListenPlan({ address }), address).toEqual({ address: "127.0.0.1", inUseIsFine: false });
-    }
+  it("takes BOTH for the rest of 127.0.0.0/8, which answers for neither", () => {
+    // A server bound to 127.0.0.2 refuses a client dialing 127.0.0.1 exactly as a `::1` one does.
+    ["127.0.0.2", "127.1.2.3"].forEach((address) => expect(addressesFor({ address }), address).toEqual(["127.0.0.1", "::1"]));
   });
 
-  it("is still not needed for 127.0.0.1 itself, which is the address in question", () => {
-    expect(loopbackListenPlan({ address: "127.0.0.1" })).toBeNull();
+  it("takes only the v4 loopback for a v6 loopback bind, which already serves ::1", () => {
+    expect(addressesFor({ address: "::1" })).toEqual(["127.0.0.1"]);
   });
 
-  it("IS needed for the IPv6 loopback, which does not serve the v4 one", () => {
-    // `MULMOTERMINAL_HOST=localhost` resolves to `::1` on a dual-stack machine, and a server there
-    // REFUSES a client dialing 127.0.0.1 (both measured) — so the GUI MCP url, which says
-    // 127.0.0.1 literally, is unreachable today. This is the second bug #1834 turned up.
-    expect(loopbackListenPlan({ address: "::1" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
+  it("takes only the v6 loopback for the v4 wildcard, which serves the v4 one by definition", () => {
+    expect(addressesFor({ address: "0.0.0.0" })).toEqual(["::1"]);
   });
 
-  it("needs nothing for the v4 wildcard, which serves the v4 loopback by definition", () => {
-    // Not merely "usually": 0.0.0.0 IS the v4 wildcard, and no kernel setting takes loopback out
-    // of it. Attempting a bind here would only add a log line to a configuration that works.
-    expect(loopbackListenPlan({ address: "0.0.0.0" })).toBeNull();
+  // `::` covers the v6 loopback for certain — bindv6only decides whether a v6 socket ALSO takes
+  // v4, never whether it takes v6 — while its v4 coverage is the thing that has to be attempted.
+  it("takes nothing for the v6 wildcard beyond the v4 attempt, whose clash is proof rather than failure", () => {
+    expect(addressesFor({ address: "::" })).toEqual(["127.0.0.1"]);
+    expect(planFor({ address: "::" }, "127.0.0.1")?.inUseIsFine).toBe(true);
   });
 
-  it("ATTEMPTS the bind for the v6 wildcard, treating a clash as proof rather than failure", () => {
-    // `::` usually accepts v4 too, so the bind is expected to fail — and that failure is the
-    // proof. On a kernel with net.ipv6.bindv6only=1 it succeeds instead, which is exactly the host
-    // where `::` leaves the fixed 127.0.0.1 urls unreachable (Codex on #1838).
-    expect(loopbackListenPlan({ address: "::" })).toEqual({ address: "127.0.0.1", inUseIsFine: true });
+  it("takes both for a specific non-loopback address — the reported case", () => {
+    ["192.168.64.1", "100.101.102.103", "fe80::1", "2001:db8::5"].forEach((address) =>
+      expect(addressesFor({ address }), address).toEqual(["127.0.0.1", "::1"]),
+    );
   });
 
-  it("IS needed for a specific non-loopback address — the reported case", () => {
-    expect(loopbackListenPlan({ address: "192.168.64.1" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
-    expect(loopbackListenPlan({ address: "100.101.102.103" })).toEqual({ address: "127.0.0.1", inUseIsFine: false });
+  // A clash on `::1` can only be somebody else: every bind that could already hold it produces no
+  // v6 plan at all. Treating it as "fine" would silence the one warning #1893 exists to raise.
+  it("never excuses a clash on the v6 loopback, whatever the bind", () => {
+    ["127.0.0.1", "0.0.0.0", "192.168.64.1", "127.0.0.2"].forEach((address) => expect(planFor({ address }, "::1")?.inUseIsFine, address).toBe(false));
   });
 
-  it("takes the v4 loopback for a v6 bind too, because that is what our callers dial", () => {
-    // Not a family match: six of the eight callers write `127.0.0.1` literally and none writes
-    // `::1`, so serving `::1` would answer a question nobody asks.
-    expect(loopbackListenPlan({ address: "fe80::1" })?.address).toBe("127.0.0.1");
-    expect(loopbackListenPlan({ address: "2001:db8::5" })?.address).toBe("127.0.0.1");
+  // The two listeners fail in ways that look identical in a log and are nothing alike to read.
+  it("labels each plan with what it is for, so the warning can name the right symptom", () => {
+    expect(planFor({ address: "192.168.64.1" }, "127.0.0.1")?.reason).toBe("sessions");
+    expect(planFor({ address: "192.168.64.1" }, "::1")?.reason).toBe("browser");
+  });
+
+  // index.ts creates exactly two spares and startLoopbackListeners hands plan i to spare i.
+  it("never asks for more spares than index.ts builds", () => {
+    ["127.0.0.1", "127.0.0.2", "0.0.0.0", "::", "::1", "192.168.64.1", "fe80::1"].forEach((address) =>
+      expect(loopbackListenPlans({ address }).length, address).toBeLessThanOrEqual(2),
+    );
   });
 
   it("says no for a pipe or UNIX socket, which no session url can name", () => {
-    expect(loopbackListenPlan("/tmp/mulmoterminal.sock")).toBeNull();
+    expect(loopbackListenPlans("/tmp/mulmoterminal.sock")).toEqual([]);
   });
 
   it("says no when the server is not listening at all", () => {
-    expect(loopbackListenPlan(null)).toBeNull();
+    expect(loopbackListenPlans(null)).toEqual([]);
   });
 });
 
-// The effect, not just the decision: whether it binds, and what it does when it cannot.
-describe("startLoopbackListener", () => {
+describe("startLoopbackListeners", () => {
   const fakeServer = (address: BoundAddress): PrimaryListener => ({ address: () => address });
 
   const recorder = () => {
@@ -96,33 +98,82 @@ describe("startLoopbackListener", () => {
     return { calls, handlers, loopback };
   };
 
-  it("does not bind anything when loopback is already served", () => {
-    const { calls, loopback } = recorder();
-    startLoopbackListener(fakeServer({ address: "127.0.0.1" }), loopback, 34567);
-    expect(calls).toEqual([]);
+  it("binds nothing when the primary already answers for both loopbacks", () => {
+    const a = recorder();
+    const b = recorder();
+    startLoopbackListeners(fakeServer("/tmp/mulmoterminal.sock"), [a.loopback, b.loopback], 34567);
+    expect([...a.calls, ...b.calls]).toEqual([]);
   });
 
-  it("binds the v4 loopback on the port the server was given", () => {
-    const { calls, loopback } = recorder();
-    startLoopbackListener(fakeServer({ address: "192.168.64.1" }), loopback, "34567");
-    expect(calls).toEqual([{ address: "127.0.0.1", port: 34567 }]);
+  it("gives each plan its own spare, on the port the server was given", () => {
+    const a = recorder();
+    const b = recorder();
+    startLoopbackListeners(fakeServer({ address: "192.168.64.1" }), [a.loopback, b.loopback], "34567");
+    expect(a.calls).toEqual([{ address: "127.0.0.1", port: 34567 }]);
+    expect(b.calls).toEqual([{ address: "::1", port: 34567 }]);
+  });
+
+  it("takes only the v6 loopback for the default bind, leaving the other spare unused", () => {
+    const a = recorder();
+    const b = recorder();
+    startLoopbackListeners(fakeServer({ address: "127.0.0.1" }), [a.loopback, b.loopback], 34567);
+    expect(a.calls).toEqual([{ address: "::1", port: 34567 }]);
+    expect(b.calls).toEqual([]);
   });
 
   it("warns and carries on when the extra bind fails, rather than taking down the boot", () => {
     // The operator's own address is already listening by now; refusing to run because the EXTRA
     // one collided would turn a degraded setup into no setup at all.
-    const { handlers, loopback } = recorder();
+    const a = recorder();
+    const b = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    startLoopbackListener(fakeServer({ address: "192.168.64.1" }), loopback, 34567);
-    expect(handlers).toHaveLength(1);
-    expect(() => handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }))).not.toThrow();
+    startLoopbackListeners(fakeServer({ address: "192.168.64.1" }), [a.loopback, b.loopback], 34567);
+    expect(() => a.handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }))).not.toThrow();
     // Names the symptom the operator would otherwise have to diagnose from failing hooks.
     expect(warn.mock.calls[0]?.[0]).toContain("hooks");
     warn.mockRestore();
   });
+
+  // The v6 failure is the one a user meets as "my grid is empty", so it must not borrow the v4
+  // text about hooks — the two are diagnosed from opposite ends.
+  it("explains a v6 failure in terms of the browser, not of hooks", () => {
+    const a = recorder();
+    const b = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListeners(fakeServer({ address: "127.0.0.1" }), [a.loopback, b.loopback], 34567);
+    a.handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+    const text = String(warn.mock.calls[0]?.[0]);
+    expect(text).toContain("localhost");
+    expect(text).not.toContain("hooks");
+    warn.mockRestore();
+  });
+
+  // A machine with no IPv6 lands here, and it is not a problem there: `localhost` is v4-only, so
+  // nothing was at stake. It still says so rather than failing the boot.
+  it("carries on when the v6 loopback is not an address this machine has", () => {
+    const a = recorder();
+    const b = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListeners(fakeServer({ address: "127.0.0.1" }), [a.loopback, b.loopback], 34567);
+    expect(() => a.handlers[0]?.(Object.assign(new Error("unavailable"), { code: "EADDRNOTAVAIL" }))).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  // Being handed too few spares is a wiring mistake, and the failure it would otherwise cause is
+  // a listener that silently never starts.
+  it("says so rather than dropping a plan when there are not enough spares", () => {
+    const a = recorder();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    startLoopbackListeners(fakeServer({ address: "192.168.64.1" }), [a.loopback], 34567);
+    expect(a.calls).toEqual([{ address: "127.0.0.1", port: 34567 }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("::1");
+    warn.mockRestore();
+  });
 });
 
-describe("startLoopbackListener under a v6 wildcard primary", () => {
+describe("startLoopbackListeners under a v6 wildcard primary", () => {
   const wildcard = (): PrimaryListener => ({ address: () => ({ address: "::" }) });
 
   const recorder = () => {
@@ -132,19 +183,19 @@ describe("startLoopbackListener under a v6 wildcard primary", () => {
   };
 
   it("says nothing when the port is already taken — that IS the wildcard covering loopback", () => {
-    const { handlers, loopback } = recorder();
+    const a = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    startLoopbackListener(wildcard(), loopback, 34567);
-    handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+    startLoopbackListeners(wildcard(), [a.loopback, recorder().loopback], 34567);
+    a.handlers[0]?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
   it("still warns about a failure that is NOT the expected clash", () => {
-    const { handlers, loopback } = recorder();
+    const a = recorder();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    startLoopbackListener(wildcard(), loopback, 34567);
-    handlers[0]?.(Object.assign(new Error("denied"), { code: "EACCES" }));
+    startLoopbackListeners(wildcard(), [a.loopback, recorder().loopback], 34567);
+    a.handlers[0]?.(Object.assign(new Error("denied"), { code: "EACCES" }));
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -200,3 +200,35 @@ describe("startLoopbackListeners under a v6 wildcard primary", () => {
     warn.mockRestore();
   });
 });
+
+// The v4 half of the outcome exists only to decide what URL to print when `::1` was lost.
+describe("the outcome it reports", () => {
+  const recorder = (succeed: boolean) => {
+    let onError: ((err: NodeJS.ErrnoException) => void) | undefined;
+    const loopback: LoopbackListener = {
+      once: (_event, handler) => {
+        onError = handler;
+        return undefined;
+      },
+      listen: (_port, _address, onListening) => {
+        if (succeed) onListening();
+        else onError?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+        return undefined;
+      },
+    };
+    return loopback;
+  };
+
+  it("counts an address the primary already serves as served", async () => {
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [recorder(true), recorder(true)], 34567);
+    expect(outcome).toEqual({ v6LoopbackServed: true, v4LoopbackServed: true });
+  });
+
+  it("reports each half separately when only one bind lost", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    // A LAN bind plans both; the first spare takes 127.0.0.1 and the second loses ::1.
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "192.168.64.1" }) }, [recorder(true), recorder(false)], 34567);
+    expect(outcome).toEqual({ v6LoopbackServed: false, v4LoopbackServed: true });
+    warn.mockRestore();
+  });
+});

--- a/test/server/infra/loopback-listener.spec.ts
+++ b/test/server/infra/loopback-listener.spec.ts
@@ -45,7 +45,7 @@ describe("loopbackListenPlans", () => {
   // v4, never whether it takes v6 — while its v4 coverage is the thing that has to be attempted.
   it("takes nothing for the v6 wildcard beyond the v4 attempt, whose clash is proof rather than failure", () => {
     expect(addressesFor({ address: "::" })).toEqual(["127.0.0.1"]);
-    expect(planFor({ address: "::" }, "127.0.0.1")?.inUseIsFine).toBe(true);
+    expect(planFor({ address: "::" }, "127.0.0.1")?.inUseProvesPrimary).toBe(true);
   });
 
   it("takes both for a specific non-loopback address — the reported case", () => {
@@ -57,7 +57,7 @@ describe("loopbackListenPlans", () => {
   // A clash on `::1` can only be somebody else: every bind that could already hold it produces no
   // v6 plan at all. Treating it as "fine" would silence the one warning #1893 exists to raise.
   it("never excuses a clash on the v6 loopback, whatever the bind", () => {
-    ["127.0.0.1", "0.0.0.0", "192.168.64.1", "127.0.0.2"].forEach((address) => expect(planFor({ address }, "::1")?.inUseIsFine, address).toBe(false));
+    ["127.0.0.1", "0.0.0.0", "192.168.64.1", "127.0.0.2"].forEach((address) => expect(planFor({ address }, "::1")?.inUseProvesPrimary, address).toBe(false));
   });
 
   // The two listeners fail in ways that look identical in a log and are nothing alike to read.
@@ -256,6 +256,33 @@ describe("the outcome it reports", () => {
     const outcome = await startLoopbackListeners({ address: () => ({ address: "127.0.0.1" }) }, [recorder(false, "EACCES")], 34567);
     expect(outcome.v6).toBe("taken");
     expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});
+
+// A `::` primary is dual-stack on most kernels, so its 127.0.0.1 auxiliary clashes with the
+// primary ITSELF. Reading that as a rival suppressed `localhost` for a server that owns both
+// loopbacks (Codex/CodeRabbit, #1903) — and macOS hides it, because there the bind succeeds.
+describe("a clash that proves the primary already covers the address", () => {
+  const clashing = (): LoopbackListener => {
+    let onError: ((err: NodeJS.ErrnoException) => void) | undefined;
+    return {
+      once: (_event, handler) => {
+        onError = handler;
+        return undefined;
+      },
+      listen: () => {
+        onError?.(Object.assign(new Error("in use"), { code: "EADDRINUSE" }));
+        return undefined;
+      },
+    };
+  };
+
+  it("counts as ours, not as taken", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const outcome = await startLoopbackListeners({ address: () => ({ address: "::" }) }, [clashing(), clashing()], 34567);
+    expect(outcome).toEqual({ v4: "ours", v6: "ours" });
+    expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

`localhost` resolves to **both** `[::1]` and `127.0.0.1`, and measured on Chrome 152 / macOS the browser tries **`::1` first**. The default bind takes only `127.0.0.1`, so `[::1]:<port>` is free for anything on this machine to take — and whatever takes it receives our users' browser under **our origin**, which since #1889 is where the grid layout and every browser-side setting is filed.

This makes the server own it, so `http://localhost:<port>` means this server **by construction rather than by timing**.

**The measurement this rests on** — one server on each loopback, same port, opened with Chrome:

```
127.0.0.1:39221 -> "OURS-v4"
[::1]:39221     -> "STRANGER-v6"
Chrome  http://localhost:39221 -> STRANGER-v6
```

**And the proof that it is closed** — a stranger trying to take `[::1]` while this build runs:

```
stranger REFUSED: EADDRINUSE
```

Before this change it got the address.

### What changed

`server/infra/loopback-listener.ts` answered one question — "should we also serve `127.0.0.1`?". There are now two, so the plan becomes a **list**:

| plan | why it exists | what breaks without it |
|---|---|---|
| `127.0.0.1` | eight spawned callers dial it as a literal (#1834) | hooks and the GUI MCP cannot reach the server |
| `::1` | the browser is sent to `localhost`, which prefers it (#1889) | anything local can answer for our origin |

**The two failures look identical in a log and are nothing alike to read**, so each plan carries its own `reason` and the warning is drawn from it. One shared text would tell someone staring at a broken hook about browser origins, or the reverse.

`server/index.ts` builds two spares instead of one (a specific LAN bind serves neither loopback and needs both); the listener tuple `createPubSub` and `mountTerminalWebSockets` receive goes from two servers to three.

### What deliberately did not change

- **Still best effort.** A failed extra bind warns and carries on. A machine with no IPv6 lands on `EADDRNOTAVAIL`, and that is fine: `localhost` is v4-only there, so nothing was at stake.
- **#1891's pre-spawn probe stays.** The two guard different moments — a squatter already present at launch has to be answered by choosing the URL, before any of this runs. Verified below that the two layers say consistent things.
- **Shutdown untouched.** `installShutdownHandlers` ends with `process.exit(0)`, so the OS closes the sockets; three listeners behave as two did. Confirmed by measuring port release, not by reading the code.

## Items to Confirm / Review

1. **`inUseIsFine` is false for `::1` in every case, and that asymmetry is deliberate.** The only binds that could already hold `[::1]:P` are `::` and `::1`, and both produce no v6 plan — so an `EADDRINUSE` there can only be somebody else, and excusing it would silence the one warning this PR exists to raise. A spec pins it across four bind spellings.

2. **Plan `i` goes to spare `i`, matched by index rather than by address.** The spares are interchangeable (same app, same sockets, same upgrade routing), so this needs only *enough* of them. Being handed too few is a wiring mistake that would otherwise drop a listener silently, so it warns; a spec also pins that `loopbackListenPlans` never returns more than the two `index.ts` builds. Say if you would rather they were matched by address.

3. **This widens what every boot binds**, which is why it was kept out of #1891. It is loopback only — reachable from this machine alone, and the v4 half has been bound this way since #1834. The full bind matrix was run on a real server (below).

4. **Not verified on a machine without IPv6**, since macOS will not let me remove `::1`. The `EADDRNOTAVAIL` path is pinned by spec only. Windows/Linux likewise rest on CI.

## User Prompt

- 「1893」（#1891 のレビューで deferred にした残件に着手せよ、との指示）

## 実装のアプローチ

The file's own comment said *"Nothing here dials `::1`, so serving it would answer a question nobody asks."* That was true of the **spawned** callers it was counting and false of the caller it did not count — the user's browser. So the change is justified by the file's own reasoning, and the comment now records why the premise moved rather than quietly contradicting it.

`servesV6Loopback` needs no attempt-and-read, unlike its v4 sibling: `bindv6only` decides whether a `::` socket **also** takes v4, never whether it takes v6. So a v6 wildcard covers `::1` for certain.

Design notes and the full record: [`plans/fix-1893-serve-v6-loopback.md`](plans/fix-1893-serve-v6-loopback.md).

## 検証

Tree: `8a2b6753` (origin/main) + this change. Real exit codes throughout.

**Gates** — `format` / `lint` / `typecheck` / `build` / `test` all exit **0**. `yarn test` **11585 passed / 50 skipped**.

**break-verify** (each restore checked byte-identical with `diff -q`)

| mutation | result |
|---|---|
| never produce the v6 plan (the pre-#1893 behaviour) | 11 red |
| `inUseIsFine: true` for `::1` | 2 red |
| one warning text shared by both reasons | 5 red |
| treat `0.0.0.0` as serving `::1` | 2 red |

**Bind matrix, on a real server** (scratch HOME, `--no-open`; curl status is the ground truth, not the log)

| `MULMOTERMINAL_HOST` | `127.0.0.1` | `[::1]` | `localhost` | extra listeners taken |
|---|---|---|---|---|
| unset (default) | 200 | 200 | 200 | `::1` |
| `0.0.0.0` | 200 | 200 | 200 | `::1` |
| `::` | 200 | 200 | 200 | `127.0.0.1` |
| `::1` | 200 | 200 | 200 | `127.0.0.1` |
| `192.168.11.12` | 200 | 200 | 200 | **both** `127.0.0.1` and `::1` |

> The LAN row did not actually run the first time: `ipconfig getifaddr en0` returned empty, and `MULMOTERMINAL_HOST=""` falls back to the default. Re-run from `en1` — the row above is the re-run.

**Shutdown** — every case released the port (`000` after kill).

**Squatter already holding `[::1]`** — the server still boots (`127.0.0.1` = 200), warns in browser terms, and #1891's launcher independently opens `http://127.0.0.1:<port>` and says where the user's state is filed. The two layers agree rather than contradicting each other.

**WebSockets through the new listener** — HTTP 200 on `[::1]` does not prove a terminal attaches. Chrome opened `http://localhost:34727`, started a shell and ran `echo WS_ROUNDTRIP_OK`:

- all three established connections were on **`[::1]:34727`** (`lsof -nP -iTCP:34727 -sTCP:ESTABLISHED`) — page and WebSocket both through the new listener
- `WS_ROUNDTRIP_OK` came back on screen

> A first pass judged this from `document.body.innerText` and reported "not echoed". That was the **test** being wrong — xterm's content is not there. Re-checked against the screen, which is the external ground truth, and the round trip is fine.

Closes #1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry9BpQtMSkZ9D64fv3cztP

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `localhost` access across IPv4 and IPv6 loopback configurations.
  * Added address-specific startup diagnostics and fallback URLs when loopback access is unavailable.

* **Bug Fixes**
  * Ensured loopback listeners are ready before startup is reported.
  * Prevented incorrect `localhost` links when another process controls a loopback address.
  * Preserved session connectivity while improving browser access and startup reporting.

* **Tests**
  * Expanded coverage for loopback configurations, startup ordering, warnings, fallback URLs, and readiness reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->