### PR TITLE
fix: -header skill の指示どおりに書くと既存の buttons / chips が消える (#1896)

### DIFF
--- a/plans/fix-1896-header-whole-array-write.md
+++ b/plans/fix-1896-header-whole-array-write.md
@@ -52,6 +52,25 @@ const updated = <T>(key: keyof AppConfig, sanitize: (input: unknown) => T, curre
 - **`mergeConfigUpdate` の挙動そのものは変えない。** 全置換は他の skill（`-theme` / `-model` /
   `-notify`）が既に前提にしている仕様で、変えれば全部が壊れる。直すのは**指示の側**
 
+## リポジトリ自身のテストに捕まった
+
+説明用に書いた JSON ブロックを `{ "buttons": [ { "id": "build", … } ] }` と省略記号で書いたところ、
+**`test/server/config/doc-button-samples.spec.ts` が落ちた。**
+
+このリポジトリには、**ガイドと `-header` skill の中の `buttons` を含む ```json ブロックを全部
+パースして、実バリデータ `sanitizeButtons` に通す** spec がある。省略記号は JSON ではないので
+`JSON.parse` で落ちた。
+
+直したら 2 度目も落ちた —— `"run": "send"` は無効な run type で、ビルドボタンの正しい形は
+`"run": "shell", "cmd": "yarn build"` だった。ガイドに既に検証済みの例があったのでそれに合わせた。
+
+**この spec は良いガード**で、「ドキュメントのサンプルが実際には動かない」を防いでいる。
+自分の説明用サンプルもその対象だと分かっていなかった。
+
+**なお、この失敗に気づく前に一度 red のまま push している。** `yarn test` の直後に
+`echo "test=$?"` を挟んだせいで `&&` チェーンが成功として続いた —— 終了コードを見たつもりで
+`echo` の終了コードを見ていた。
+
 ## 検証
 
 skill は散文なのでテストで赤くできない。確認したのは:

--- a/plans/fix-1896-header-whole-array-write.md
+++ b/plans/fix-1896-header-whole-array-write.md
@@ -79,7 +79,44 @@ skill は散文なのでテストで赤くできない。確認したのは:
   `prRepos` / `keymap`）が `app-config.ts` の `updated(...)` 経由であること —— 全部 1 件ヒット
 - 3 つの replace 規則それぞれの根拠（`app-config.ts` / `header-config.ts:51` /
   `header-config.ts:196`）
-- 他の writing skill を掃いた結果、同じ欠落は `-header` だけだった
-  （`-theme` / `-model` / `-notify` / `-config` は既に「complete」と書いている。
-  `-keys` は #1892 で追加済み）
+- 他の writing skill を掃いた結果、`-theme`（`themes`）/ `-model`（`providers` /
+  `customAgents`）/ `-keys`（`keymap`、#1892 で追加済み）は既に「complete を送れ」と書いている
 - `test/server/skills/skillFrontmatter.spec.ts` が緑（frontmatter を壊していない）
+
+## codex review で見つかった追加の欠落 —— `sounds`（PR #1904 レビュー）
+
+上の掃き方が甘かった。`-notify` を「既に complete と書いてある」と数えたが、実際の文面は
+
+> Partial `POST /api/config` merge — write only the keys you are changing, and **send arrays complete**.
+
+で、**`sounds` は配列ではなくオブジェクト**なので、この指示は `sounds` を覆っていなかった。
+`mergeConfigUpdate` は `sounds` も `updated("sounds", sanitizeSounds, …)` で通し、
+`sanitizeSounds` は `out` を**新規に組み直す**（`app-config.ts:384`）。つまり
+
+```json
+{ "sounds": { "waiting": "preset:coin" } }
+```
+
+は **他の kind の音を全部消す**。#1896 と同じ欠陥が、別の skill に残っていた。
+
+**直し方を「列挙」から「原則」に変えた。** 元の直しは配列名を並べた表現で、
+`sounds` が漏れたのはまさにその列挙が伸びなかったからなので、同じ形で 1 語足しても次に同じ穴が開く。
+ルーター側（`-config`）を
+
+- **トップレベルだけが merge。送ったキーは丸ごと置換され、その下は一切 merge されない**
+
+という原則の書き方に変え、配列（13 個）と**オブジェクト**（`sounds` / `keymap` / `repoDirs` /
+`headerStatusColors`）の両方を例として挙げた。**オブジェクトの方が事故る**（map は 1 キー足せる
+ように見える）ことを明記している。
+
+`-notify` 側も「arrays complete」を、`sounds` を名指しで
+「`GET /api/config` で現在の map を読み、そこに足して、丸ごと返せ」に書き換えた。
+
+**オブジェクト値 4 キーの sanitizer が全部「新規に組み直す」ことを確認済み**:
+`sanitizeSounds`（`app-config.ts:384`）/ `sanitizeRepoDirs`（`:350`）/
+`sanitizeKeymap`（`common/keymap.ts:247`）/ `sanitizeHeaderStatusColors`
+（`common/headerStatusColors.ts:100`）。
+
+**`-dirs` は対象外**だった。`headerStatusColors` をグローバルにも書けるとは書いているが、
+グローバルへの**書き込み手順を持たない**（プロジェクトの `.mulmoterminal.json` を書く skill で、
+グローバルは「読む」だけ）ので、`POST` を誤らせる文面が無い。

--- a/plans/fix-1896-header-whole-array-write.md
+++ b/plans/fix-1896-header-whole-array-write.md
@@ -1,0 +1,66 @@
+# fix: `-header` skill の指示どおりに書くと既存の buttons / chips が消える (#1896)
+
+> **この文書の読み方 —— 時系列のログであって、現状の仕様書ではない。**
+> 現在のコードの仕様はコードが唯一の情報源。数値は sha に紐づけて書くこと。
+
+## 症状
+
+`mulmoterminal-header` skill はこう書いていた:
+
+> Global writes are a **partial `POST /api/config` merge** — send only `buttons` / `chips`.
+
+「partial merge」は正しいが、**それはトップレベルのキー単位**。`server/config/app-config.ts` の
+`mergeConfigUpdate`:
+
+```ts
+const updated = <T>(key: keyof AppConfig, sanitize: (input: unknown) => T, current: T): T =>
+  body[key] !== undefined ? sanitize(body[key]) : current;
+```
+
+ボタンを 1 つ足すつもりで足したものだけを POST すると、**それが `buttons` の全体になり、既存の
+ボタンが消える**。警告は出ず、レスポンスは成功。
+
+## この skill には「replace」が 3 つあって、混ざりやすい
+
+読んでいて分かったのは、同じファイルが**別々の replace 規則を 2 つ既に説明していた**こと。
+足りなかったのは 3 つ目（グローバル書き込み）だけだった。
+
+| | どこに書いてあったか |
+|---|---|
+| `buttons` を**グローバル設定に書く**と、グローバルの配列が全置換 | **どこにも無かった** ← これ |
+| `buttons` を**どのレベルであれ列挙**すると `DEFAULT_BUTTONS` が置き換わる（組み込みはマージされない） | `header-config.ts:51`、skill 本文 |
+| **プロジェクト** と **グローバル** は `id` でマージ | `header-config.ts:196`、skill の例の末尾 |
+
+3 つを表にして並べた。ここを混同すると「例のとおりに書いたのに消えた」になる。
+
+## 総論の skill は知っていた
+
+`mulmoterminal-config`（ルーター）は既にこう書いていた:
+
+> Arrays (`themes`, `providers`, `buttons`, `chips`, `soundKinds`) **replace** rather than append —
+> send them complete, or you delete the rest.
+
+**`buttons` / `chips` を名指ししている。** つまり**総論が知っていて、それを所有する skill が
+知らなかった**。
+
+ただしその配列リストは、ルーター自身が所有する `gitlabHosts` と `prRepos` を落としていたので
+足した。`keymap` はオブジェクトだが同じ理由で全置換なので、その旨も 1 行。
+**列挙した 8 キーすべてが `updated(...)` 経由であることを確認済み。**
+
+## やらないこと
+
+- **`mergeConfigUpdate` の挙動そのものは変えない。** 全置換は他の skill（`-theme` / `-model` /
+  `-notify`）が既に前提にしている仕様で、変えれば全部が壊れる。直すのは**指示の側**
+
+## 検証
+
+skill は散文なのでテストで赤くできない。確認したのは:
+
+- 列挙した 8 キー（`themes` / `providers` / `buttons` / `chips` / `soundKinds` / `gitlabHosts` /
+  `prRepos` / `keymap`）が `app-config.ts` の `updated(...)` 経由であること —— 全部 1 件ヒット
+- 3 つの replace 規則それぞれの根拠（`app-config.ts` / `header-config.ts:51` /
+  `header-config.ts:196`）
+- 他の writing skill を掃いた結果、同じ欠落は `-header` だけだった
+  （`-theme` / `-model` / `-notify` / `-config` は既に「complete」と書いている。
+  `-keys` は #1892 で追加済み）
+- `test/server/skills/skillFrontmatter.spec.ts` が緑（frontmatter を壊していない）

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -120,8 +120,9 @@ Offer to fix what you found, and route to the owning skill for anything they pic
 State these when they matter; they are the ones that cost people an afternoon.
 
 - **Global writes are a partial `POST /api/config` merge.** Write only the keys you are changing.
-  Arrays (`themes`, `providers`, `buttons`, `chips`, `soundKinds`) **replace** rather than append —
-  send them complete, or you delete the rest.
+  Arrays (`themes`, `providers`, `buttons`, `chips`, `soundKinds`, `gitlabHosts`, `prRepos`)
+  **replace** rather than append — send them complete, or you delete the rest. `keymap` is an object
+  and is replaced whole for the same reason.
 - **`<project>/.mulmoterminal.json` applies live, and writing it with your Write/Edit tool is
   itself the reload signal.** There is **no filesystem watcher**: a file the user edits by hand does
   nothing until something re-reads it. Always write it yourself rather than asking them to.

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -119,10 +119,15 @@ Offer to fix what you found, and route to the owning skill for anything they pic
 
 State these when they matter; they are the ones that cost people an afternoon.
 
-- **Global writes are a partial `POST /api/config` merge.** Write only the keys you are changing.
-  Arrays (`themes`, `providers`, `buttons`, `chips`, `soundKinds`, `gitlabHosts`, `prRepos`)
-  **replace** rather than append — send them complete, or you delete the rest. `keymap` is an object
-  and is replaced whole for the same reason.
+- **Global writes are a partial `POST /api/config` merge — at the TOP level only.** Write only the
+  keys you are changing; every key you *do* send **replaces** what was there, whole. Nothing below
+  the top level is merged, so a key holding a collection has to be sent **complete** or you delete
+  the rest of it. That is true of the arrays (`themes`, `providers`, `buttons`, `chips`,
+  `soundKinds`, `pushKinds`, `gitlabHosts`, `prRepos`, `launchers`, `customAgents`, `quickCommands`,
+  `userMcpServers`, `cwdPresets`) **and equally of the objects** (`sounds`, `keymap`, `repoDirs`,
+  `headerStatusColors`) — the objects are the ones that surprise people, because a map *looks* like
+  something you can add one key to. Posting `{"sounds": {"waiting": "preset:coin"}}` leaves the user
+  with exactly one sound. Read the current value from `GET /api/config`, change it, send it back.
 - **`<project>/.mulmoterminal.json` applies live, and writing it with your Write/Edit tool is
   itself the reload signal.** There is **no filesystem watcher**: a file the user edits by hand does
   nothing until something re-reads it. Always write it yourself rather than asking them to.

--- a/server/skills/mulmoterminal-header/SKILL.md
+++ b/server/skills/mulmoterminal-header/SKILL.md
@@ -27,7 +27,7 @@ there is no filesystem watcher.
 `body[key] !== undefined ? sanitize(body[key]) : current` (`server/config/app-config.ts`), so posting
 
 ```json
-{ "buttons": [ { "id": "build", … } ] }
+{ "buttons": [{ "id": "build", "icon": "build", "label": "Build", "run": "shell", "cmd": "yarn build" }] }
 ```
 
 does not add a button — it **makes that the entire global set**, deleting every other button the

--- a/server/skills/mulmoterminal-header/SKILL.md
+++ b/server/skills/mulmoterminal-header/SKILL.md
@@ -23,6 +23,29 @@ Global writes are a **partial `POST /api/config` merge** — send only `buttons`
 writes go through your Write/Edit tool, and **writing the file is itself the live-reload signal**;
 there is no filesystem watcher.
 
+**"Partial" is per TOP-LEVEL key, and `buttons` / `chips` are each replaced WHOLE.** The merge is
+`body[key] !== undefined ? sanitize(body[key]) : current` (`server/config/app-config.ts`), so posting
+
+```json
+{ "buttons": [ { "id": "build", … } ] }
+```
+
+does not add a button — it **makes that the entire global set**, deleting every other button the
+user had. Nothing warns, and the reply is a success.
+
+So a global write always sends the **complete** array: read the current one first, add or change
+your entry in memory, and post the whole thing. Every example below shows the entries under
+discussion on their own for readability — none of them is a body to post as-is unless the user
+genuinely has no others.
+
+Three different "replace" rules live here and are easy to run together:
+
+| | |
+|---|---|
+| writing `buttons` to the **global config** | replaces the whole global array — **the one this section is about** |
+| listing `buttons` **at any level** | replaces `DEFAULT_BUTTONS`; the built-ins are not merged in |
+| **project** vs **global** | merged, keyed by `id` — a project adds or overrides without restating |
+
 ## How the two are merged — not the same rule
 
 **Buttons merge by `id`.** Global buttons load first, then the project's: a project button with the
@@ -161,6 +184,9 @@ than `isGitRepo`: a git repo with no remote, or one whose remote is not GitHub, 
 Then check the real header. A button that doesn't appear is nearly always `when` (a non-git
 directory, an agent mismatch) or a `pr` button on a branch with no PR — both are working as
 designed, and both look like a broken config.
+
+- **Every other button vanished** — a partial write. `buttons` is replaced whole; always send the
+  array complete. Same for `chips`.
 
 ## Example — pinning the defaults, globally
 

--- a/server/skills/mulmoterminal-notify/SKILL.md
+++ b/server/skills/mulmoterminal-notify/SKILL.md
@@ -57,7 +57,11 @@ The preset audio is **fetched once** from GitHub into `~/.mulmoterminal/sounds/`
 afterwards, so it keeps working offline — but the **first** play of a preset needs the network. If
 the user is offline and a new preset is silent, that is why; it isn't a config error.
 
-Partial `POST /api/config` merge — write only the keys you are changing, and send arrays complete.
+Partial `POST /api/config` merge — write only the keys you are changing, and send each of them
+**complete**. `sounds` is an object, but it is replaced whole exactly as `soundKinds` is: posting
+`{"sounds": {"waiting": "preset:coin"}}` deletes every other kind's sound, with no warning and a
+successful response. Read the current `sounds` from `GET /api/config`, add your entry to that map,
+and send the merged map back.
 
 ## Sound — per project
 


### PR DESCRIPTION
## Summary

`mulmoterminal-header` skill の指示どおりに書くと、**ユーザーが持っていた他のボタン / チップが黙って消えます。**

skill はこう書いていました:

> Global writes are a **partial `POST /api/config` merge** — send only `buttons` / `chips`.

「partial merge」は正しいのですが、**それはトップレベルのキー単位**です。`mergeConfigUpdate`:

```ts
const updated = <T>(key: keyof AppConfig, sanitize: (input: unknown) => T, current: T): T =>
  body[key] !== undefined ? sanitize(body[key]) : current;
```

ボタンを 1 つ足すつもりで足したものだけを POST すると、**それが `buttons` の全体になり、既存のボタンが消えます。** 警告は出ず、レスポンスは成功です。

## Items to Confirm / Review

**1. この skill には「replace」が 3 つあって、混ざりやすい。** 読んでいて分かったのは、同じファイルが**別々の replace 規則を 2 つ既に説明していた**ことです。足りなかったのは 3 つ目だけでした:

| | どこに書いてあったか |
|---|---|
| `buttons` を**グローバル設定に書く**と、グローバルの配列が全置換 | **どこにも無かった** ← これ |
| `buttons` を**どのレベルであれ列挙**すると `DEFAULT_BUTTONS` が置き換わる | `header-config.ts:51`、skill 本文 |
| **プロジェクト** と **グローバル** は `id` でマージ | `header-config.ts:196`、skill の例の末尾 |

3 つを表にして並べました。混同すると「例のとおりに書いたのに消えた」になります。

**2. 総論の skill は知っていました。** `mulmoterminal-config`（ルーター）は既にこう書いていて、しかも `buttons` / `chips` を名指ししています:

> Arrays (`themes`, `providers`, `buttons`, `chips`, `soundKinds`) **replace** rather than append — send them complete, or you delete the rest.

**総論が知っていて、それを所有する skill が知らなかった**形です。ついでにその配列リストが、ルーター自身が所有する `gitlabHosts` と `prRepos` を落としていたので足しました（`keymap` はオブジェクトですが同じ理由で全置換なので 1 行）。**列挙した 8 キーすべてが `updated(...)` 経由であることを確認しています。**

**3. `mergeConfigUpdate` の挙動そのものは変えていません。** 全置換は `-theme` / `-model` / `-notify` が既に前提にしている仕様で、変えれば全部が壊れます。直したのは**指示の側**です。

**5. codex review で `sounds` の同じ欠落が見つかり、直しました（`bb53b4a2`）。** 上の掃き方が甘く、`-notify` を「既に complete と書いてある」と数えていました。実際の文面は「send **arrays** complete」で、**`sounds` は配列ではなくオブジェクト**なので覆われていません。`sanitizeSounds`（`app-config.ts:384`）は map を新規に組み直すため、`{"sounds": {"waiting": "preset:coin"}}` は**他の kind の音を全部消します**。

**`sounds` を list に足すだけにはしていません。** 2 回とも**列挙が伸びなかったこと**が原因なので、同じ形で 1 語足せば 3 度目が来ます。ルーター側を原則の書き方に変えました:

> **トップレベルだけが merge。**送ったキーは丸ごと置換され、その下は一切 merge されない。

配列（13 個）と**オブジェクト**（`sounds` / `keymap` / `repoDirs` / `headerStatusColors`）はその例として並べ、**オブジェクトの方が事故る**（map は 1 キー足せるように見える）ことを明記しています。`-notify` 側も `sounds` を名指しで「現在の map を読んで、足して、丸ごと返せ」に書き換えました。

**4. 一度 red のまま push しました。** 説明用の JSON を省略記号で書いたところ、**`test/server/config/doc-button-samples.spec.ts`** が落ちました —— このリポジトリには**ガイドと この skill の中の `buttons` を含む ```json ブロックを全部パースして実バリデータに通す** spec があります。良いガードで、「ドキュメントのサンプルが実際には動かない」を防いでいます。

直した 2 度目も落ちました（`"run": "send"` は無効な run type、正しくは `"run": "shell"` + `"cmd"`）。ガイドに既に検証済みの例があったのでそれに合わせています。

**red を push した原因も記録しました**: `yarn test` の直後に `echo "test=$?"` を挟んだせいで、`&&` チェーンが**テストの終了コードではなく `echo` の終了コード**を見ていました。

## User Prompt

- #1888・#1894・#1896・#1897・#1901 を順次やろう

（#1888 はクローズ済み、#1894 は PR #1902。これは 3 件目の #1896 です。）

## 検証

skill は散文なのでテストで赤くできません。確認したのは:

- 挙げた **17 キーすべて**が `app-config.ts` の `updated(...)` 経由であること（全部 1 件ヒット）
- オブジェクト値 4 キーの sanitizer が**全部**新規に組み直すこと —— `sanitizeSounds`（`app-config.ts:384`）/ `sanitizeRepoDirs`（`:350`）/ `sanitizeKeymap`（`common/keymap.ts:247`）/ `sanitizeHeaderStatusColors`（`common/headerStatusColors.ts:100`）
- **`-dirs` は対象外**であること（`headerStatusColors` をグローバルにも書けるとは書いているが、グローバルへの**書き込み手順を持たない**ので部分 POST を誘発する文面が無い）
- 3 つの replace 規則それぞれの根拠（`app-config.ts` / `header-config.ts:51` / `header-config.ts:196`）
- 他の writing skill の掃き出し（`-theme` / `-model` / `-keys` は既に「complete を送れ」と書いている）。**この掃き方が `-notify` を取りこぼしていた —— 下の 5. を参照**
- `doc-button-samples.spec.ts` と `skillFrontmatter.spec.ts` が緑

`yarn format` / `lint` / `typecheck` / `build` / `test` すべて exit **0**、**11580 tests pass**。

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3

