### PR TITLE
fix(ui): CopyCodeBlock が渡された class をボタンに届ける (#1895)

### DIFF
--- a/plans/fix-1895-copy-button-attrs.md
+++ b/plans/fix-1895-copy-button-attrs.md
@@ -1,0 +1,87 @@
+# fix(ui): CopyCodeBlock が渡された class を落とす (#1895)
+
+> 時系列のログであって現状の仕様書ではない。
+
+## 症状（実測で再現）
+
+`TerminalCell` は他のセルボタンと同じ `CELL_BTN` を渡している:
+
+```vue
+<CopyCodeBlock v-if="sessionId" :class="CELL_BTN" :session-id="sessionId" ... />
+```
+
+`CopyCodeBlock` のテンプレートはルートが 2 つ（`<span>` と `<Teleport>`）なので Vue は
+attribute を自動継承できず、**class はどこにも載らずに消える**。unit で観測:
+
+```text
+ROOT html: <span class="relative inline-flex"><button class="cell-btn" ...
+button has MARKER_CLASS: false
+warnings: 1   ← [Vue warn] Extraneous non-props attributes (class)
+```
+
+実アプリ（claude セル、Chrome）でも確認。`.cell-btn` は CSS 規則を持たないマーカーなので、
+ボタンはブラウザ既定の chrome で描かれる:
+
+| | class | border | background | サイズ |
+|---|---|---|---|---|
+| 修正前の copy ボタン | `cell-btn` のみ | `2px outset` | `rgb(239,239,239)` | 19.2 × 17.3px |
+| 隣のセルボタン | CELL_BTN 一式 | `0px none` | transparent | 26 × 28px |
+
+## issue が提案していた案1 は「直ったように見えて直らない」
+
+issue は 2 案を挙げていた。案1 は「`Teleport` を `<span>` の中へ入れて単一ルートにする」。
+**実際に当てて測った:**
+
+```text
+ROOT html: <span class="relative inline-flex MARKER_CLASS"><button class="cell-btn" ...
+button has MARKER_CLASS: false
+warnings: 0
+```
+
+**警告は消えるが、class は外側の `<span>` に載り、ボタンは unstyled のまま。** しかも
+`h-[26px] w-7` がラッパーに付くので、状況としては少し悪くなる。
+
+理由は `CELL_BTN` の中身がボタンの装飾だから —— `bg-transparent border-none h-[26px] w-7
+cursor-pointer hover:bg-hover`。repo の他の使い方も全て `<button class="cell-btn"
+:class="CELL_BTN">` と**ボタン自身**に載せている（`TerminalCell.vue:1434,1437`,
+`LauncherCell.vue:77` 等）。`CopyCodeBlock` の button だけがマーカーしか持っていなかった。
+
+## 採った直し方 —— 案2
+
+`defineOptions({ inheritAttrs: false })` + 内側の `<button>` に `v-bind="$attrs"`。
+**行き先を推測（継承）に任せず名指しする。** ラッパーの `<span class="relative inline-flex">`
+はそのまま残す —— 一時表示される note がそこに絶対配置されるため。
+
+副次的な利点として、将来 2 つ目のルートを足しても壊れない。
+
+## 検証
+
+**unit（`test/src/components/codeBlockCopy.spec.ts` に 5 件追加）**
+
+すべて **button** に対して assert する。これは細部ではなく要点で、`wrapper.classes()` に
+書いたテストは案1 の「直ったように見える」修正を通してしまう。
+
+> 最初 `wrapper.element` に対して書いたが、multi-root コンポーネントではそれが test-utils の
+> コンテナ `<div data-v-app>` で、**class が絶対に載らない要素を見る空振りのテスト**だった。
+> 実際のルート要素（`firstElementChild`）を見るヘルパに直し、その理由をコメントに残した。
+
+| ミューテーション | 結果 |
+|---|---|
+| 出荷時の状態に戻す（`inheritAttrs` も `$attrs` も無し） | 2 red |
+| **issue の案1**（単一ルート化、class は span へ） | 2 red |
+
+**実機**（claude セル、Chrome、`getComputedStyle` で隣のボタンと比較）
+
+| | border | background | 高さ | 幅 | font | cursor |
+|---|---|---|---|---|---|---|
+| copy ボタン | `0px none` | transparent | 26px | 28px | 16px | pointer |
+| 隣（Move terminal left） | `0px none` | transparent | 26px | 28px | 16px | pointer |
+
+完全一致。`Extraneous non-props attributes` の警告は 0 件。
+
+> 修正前の実機測定では警告が **0 件**だった —— production build は dev の警告を落とすため。
+> つまり配布物では**見た目だけが症状**で、警告は `yarn dev` でしか見えない。issue が
+> dev サーバで見つけたのはそのため。unit 側で警告を固定してあるのはこの穴を埋めるため。
+
+ゲート: `format` / `lint` / `typecheck` / `build` / `test` すべて exit 0、
+`yarn test` **11659 passed / 50 skipped**。

--- a/src/components/CopyCodeBlock.vue
+++ b/src/components/CopyCodeBlock.vue
@@ -14,6 +14,17 @@ import { MODAL_FOCUSABLE } from "../utils/focusTrap";
 import { modalKeydownHandler } from "../composables/useModalKeyboard";
 import type { TerminalAgent } from "../../common/sessionAgent";
 
+// The caller styles this button — `TerminalCell` passes CELL_BTN, the same class every other
+// button in that toolbar row carries — and the class has to reach the BUTTON, not the wrapper.
+//
+// Two things made that fail silently. The template has two roots (the span and the Teleport), so
+// Vue could not auto-inherit at all and dropped the class with a console warning (#1895). And the
+// obvious repair — folding the Teleport inside the span for a single root — MEASURED as putting
+// the class on the `<span>` instead: the warning goes away and the button stays unstyled, because
+// `.cell-btn` is a marker with no CSS rule of its own. So the target is named explicitly here
+// rather than left to inheritance, which also means a second root can be added back safely.
+defineOptions({ inheritAttrs: false });
+
 const props = defineProps<{ sessionId: string; cwd: string | null; agent: TerminalAgent }>();
 
 const busy = ref(false);
@@ -87,6 +98,7 @@ function closeManual(): void {
 <template>
   <span class="relative inline-flex">
     <button
+      v-bind="$attrs"
       type="button"
       class="cell-btn"
       title="Copy the last code block from this session's latest reply"

--- a/test/src/components/codeBlockCopy.spec.ts
+++ b/test/src/components/codeBlockCopy.spec.ts
@@ -127,3 +127,65 @@ describe("the manual-copy dialog", () => {
     w.unmount();
   });
 });
+
+// #1895. `TerminalCell` styles this button by passing CELL_BTN — the same class every other button
+// in that toolbar row carries — and nothing asserted that it arrived, which is why a dropped class
+// survived from the day the Teleport was added.
+//
+// Every assertion here is on the BUTTON and not on the root, and that is the point rather than a
+// detail: the repair the issue first suggested (fold the Teleport in for a single root) silences
+// the Vue warning and puts the class on the wrapping `<span>`, leaving the button exactly as
+// unstyled as before — `.cell-btn` is a marker with no CSS rule of its own. Measured both ways
+// before choosing. A spec written against `wrapper.classes()` would have passed that repair.
+describe("the class the caller styles this button with", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  const mounted = async (attrs: Record<string, string>) => {
+    const { default: CopyCodeBlock } = await import("../../../src/components/CopyCodeBlock.vue");
+    return mount(CopyCodeBlock, { props: { sessionId: "s", cwd: "/x", agent: "claude" as const }, attrs });
+  };
+
+  // NOT `wrapper.element`. For a multi-root component that is test-utils' own `<div data-v-app>`
+  // container, which never carries the class — so an assertion against it passes whatever the
+  // component does. Both wrapper checks below were written that way first and were vacuous.
+  const rootOf = (w: Awaited<ReturnType<typeof mounted>>): HTMLElement => {
+    const root = (w.element as HTMLElement).firstElementChild;
+    if (!(root instanceof HTMLElement)) throw new Error("the component rendered no element root");
+    return root;
+  };
+
+  it("reaches the button, which is the element it describes", async () => {
+    const w = await mounted({ class: "h-[26px] w-7 bg-transparent" });
+    expect(w.find("button").classes()).toEqual(expect.arrayContaining(["h-[26px]", "w-7", "bg-transparent"]));
+  });
+
+  it("does not land on the wrapper instead — that looks fixed and is not", async () => {
+    const w = await mounted({ class: "bg-transparent" });
+    expect(rootOf(w).classList.contains("bg-transparent")).toBe(false);
+  });
+
+  it("keeps the `cell-btn` marker, which other code selects on", async () => {
+    const w = await mounted({ class: "bg-transparent" });
+    expect(w.find("button").classes()).toContain("cell-btn");
+  });
+
+  // The warning is the symptom rather than the defect, but it fires once per agent cell that
+  // mounts, so a console full of it is how anyone finds this at all.
+  it("mounts without Vue complaining that it could not inherit the attribute", async () => {
+    const warnings: string[] = [];
+    const warn = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => void warnings.push(String(args[0])));
+    await mounted({ class: "bg-transparent" });
+    expect(warnings.filter((w) => w.includes("Extraneous non-props attributes"))).toEqual([]);
+    warn.mockRestore();
+  });
+
+  // The wrapper earns its place by positioning the transient note, so it must stay a positioned
+  // box even though it is no longer what the class lands on.
+  it("leaves the wrapper positioned, which the note is placed against", async () => {
+    const w = await mounted({ class: "bg-transparent" });
+    expect(rootOf(w).classList.contains("relative")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`TerminalCell` styles this button by passing `CELL_BTN` — the same class every other button in that toolbar row carries — and the class was reaching **nothing**. The template has two roots (the `<span>` and the `<Teleport>`), so Vue could not auto-inherit it.

`.cell-btn` is a marker with no CSS rule of its own, so the button fell back to the browser's default chrome. Measured in the real app against its neighbour:

| | class | border | background | size |
|---|---|---|---|---|
| copy button, **before** | `cell-btn` only | `2px outset` | `rgb(239, 239, 239)` | 19.2 × 17.3px |
| its neighbour (Move terminal left) | full `CELL_BTN` | `0px none` | transparent | 26 × 28px |
| copy button, **after** | full `CELL_BTN` + `cell-btn` | `0px none` | transparent | 26 × 28px |

## The repair the issue suggested first would have looked fixed and not been

The issue offered two options. Option 1 was "move the `<Teleport>` inside the wrapping `<span>` for a single root". I applied it and measured:

```text
ROOT html: <span class="relative inline-flex MARKER_CLASS"><button class="cell-btn" ...
button has MARKER_CLASS: false
warnings: 0
```

**The warning goes away and the button stays unstyled** — the class lands on the wrapper. Slightly worse, in fact, since `h-[26px] w-7` then sizes the wrapper.

That follows from what `CELL_BTN` contains: `bg-transparent border-none h-[26px] w-7 cursor-pointer hover:bg-hover` is button decoration. Every other use in the repo puts it on the `<button>` itself (`TerminalCell.vue:1434,1437`, `LauncherCell.vue:77`, …); `CopyCodeBlock`'s button was the only one carrying just the marker.

So this takes **option 2**: `defineOptions({ inheritAttrs: false })` and `v-bind="$attrs"` on the inner `<button>` — the destination is named rather than left to inheritance, and a second root can be added back later without breaking it again. The wrapping `<span class="relative inline-flex">` stays, because the transient note is positioned against it.

## Items to Confirm / Review

1. **The specs assert on the BUTTON, never on the wrapper, and that is the point rather than a detail.** A spec written against `wrapper.classes()` passes option 1's repair. The mutation table below includes that repair for exactly this reason.

2. **My first draft of two of those specs was vacuous.** They used `wrapper.element`, which for a multi-root component is test-utils' own `<div data-v-app>` container — an element the class can never land on, so they would have passed whatever the component did. They now go through a `rootOf()` helper that takes `firstElementChild`, with the reason recorded next to it.

3. **In a production build the warning does not appear at all** — measured 0 before the fix, because dev-only warnings are stripped. So for anyone running a release, the *only* symptom was the visual one, and the console evidence in the issue came from `yarn dev`. The warning is pinned at the unit level, where it does fire.

4. `defineOptions` is new to this repo's components (`inheritAttrs: false` exists only in the plugin runtime today). Say if you would rather it were spelled with a separate `<script>` block.

## User Prompt

- 「ではつぎはこれ https://github.com/receptron/mulmoterminal/issues/1895」

## 実装のアプローチ

The issue is precise and its diagnosis is right; only its first suggested remedy is not, and that was settled by applying it and looking rather than by reasoning about it. Both wrong shapes are kept as mutations so the next person does not have to redo that.

Design notes and the full record: [`plans/fix-1895-copy-button-attrs.md`](plans/fix-1895-copy-button-attrs.md).

## 検証

Tree: `5682f673` (origin/main) + this change.

**Gates** — `format` / `lint` / `typecheck` / `build` / `test` all exit **0**. `yarn test` **11659 passed / 50 skipped**.

**break-verify** (restores checked byte-identical)

| mutation | result |
|---|---|
| revert to the shipped state (no `inheritAttrs`, no `$attrs`) | 2 red |
| **the issue's option 1** — single root, class inherited onto the span | 2 red |

**Real app** — a claude cell in Chrome, `getComputedStyle` on the copy button and on a sibling `button.cell-btn`:

| | border | background | height | width | font | cursor |
|---|---|---|---|---|---|---|
| copy button | `0px none` | transparent | 26px | 28px | 16px | pointer |
| Move terminal left | `0px none` | transparent | 26px | 28px | 16px | pointer |

Identical, and zero `Extraneous non-props attributes` warnings in the console. The before-state in the same setup is the first table in this description.

Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry9BpQtMSkZ9D64fv3cztP

work in mulmoterminal4
