### PR TITLE
feat: 9 本目のテンプレート magazine — 記事ごとの URL を持つ共有アプリ

### DIFF
--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -26,7 +26,7 @@ the user turns this down.
 
 ## Start from a template when one fits
 
-Eight shapes are written out in full — declaration, schemas, and the reasoning behind each key:
+Nine shapes are written out in full — declaration, schemas, and the reasoning behind each key:
 
 - **[templates/salon.md](./templates/salon.md)** — a request that a NAMED PERSON approves, and only
   their own (a salon's bookings, interviews, repairs, review assignments). This is what `assignee`
@@ -73,8 +73,18 @@ Eight shapes are written out in full — declaration, schemas, and the reasoning
   here signs in as the owner, so the host's close is enforced by `refIn`, a `transitions` map with no
   exit, and `sealed` together — any one alone is walked around in two writes. Read it for what a
   declaration can and cannot hold when the writer is an agent you handed your sign-in to.
+- **[templates/magazine.md](./templates/magazine.md)** — several writers publishing things to READ,
+  each at its own URL, each signing their own and editing nobody else's (a team blog, a newsletter's
+  back issues, a research log, release notes, a review column). This is what **`views[].article`**
+  is for — the platform draws the article page, so the app declares which fields are the title, the
+  body and the byline, and `idFrom: "slug"` makes the writer's chosen name the document id and
+  freezes it. It is the only sample that states a `protocol` of its own, the only one whose `limit`
+  is a COST publish computes in bytes, and the one that explains why the owner has to hold
+  `participant` on their own collection — `audience` forces `submitOnly`, `submitOnly` closes the
+  writer branch, and an owner who skips it cannot publish at all. Read it before any app where a
+  record is something a stranger is meant to sit and read.
 
-Read the matching one before writing `app.json` by hand. All eight are checked against the real
+Read the matching one before writing `app.json` by hand. All nine are checked against the real
 publish gate by this repository's tests, so what they show is what publishes — and they spend most
 of their length on the traps, which is the part you cannot recover by guessing.
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -79,7 +79,8 @@ Nine shapes are written out in full — declaration, schemas, and the reasoning 
   is for — the platform draws the article page, so the app declares which fields are the title, the
   body and the byline, and `idFrom: "slug"` makes the writer's chosen name the document id and
   freezes it. It is the only sample that states a `protocol` of its own, the only one whose `limit`
-  is a COST publish computes in bytes, and the one that explains why the owner has to hold
+  is a COST — publish works it out in bytes and refuses the declaration when it is too large — and
+  the one that explains why the owner has to hold
   `participant` on their own collection — `audience` forces `submitOnly`, `submitOnly` closes the
   writer branch, and an owner who skips it cannot publish at all. Read it before any app where a
   record is something a stranger is meant to sit and read.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -37,7 +37,7 @@ Nine shapes are written out in full — declaration, schemas, and the reasoning 
   rules.
 - **[templates/survey.md](./templates/survey.md)** — **collecting answers**, with nothing to run out
   of (a survey, a quiz, an application form, a sign-up with no cap). The shortest declaration of the
-  eight, and the shape most often written with a public page and nothing else — so this one is built
+  nine, and the shape most often written with a public page and nothing else — so this one is built
   around its `member` page, which is where the answers are read. It also spells out the three-way
   trade above, and what a tally may and may not claim about values a respondent typed.
 - **[templates/meeting-room.md](./templates/meeting-room.md)** — a bookable unit you can LIST IN

--- a/server/skills/mulmoterminal-shared-app/templates/design.md
+++ b/server/skills/mulmoterminal-shared-app/templates/design.md
@@ -54,8 +54,8 @@ to keep in sync, which is exactly what breaks when six colours are picked one at
 lightness — so an `hsl()` palette that looks right in blue is washed out in yellow, and every
 hue has to be re-tuned by hand.
 
-`oklch()` is perceptually uniform, so the same numbers hold across hues. Measured over the six
-template hues (25, 65, 230, 265, 295, 330) and this file's own 95, with the values above unchanged:
+`oklch()` is perceptually uniform, so the same numbers hold across hues. Measured over seven of
+them — 25, 65, 230, 265, 295, 330 and this file's own 95 — with the values above unchanged:
 
 | pair | contrast across all seven |
 |---|---|
@@ -182,5 +182,6 @@ horizontal scroll on a phone — which is the failure the line removes for every
 wrote, rule 1 did not happen — and a test in this repository fails on it, because a file that
 only *asks* to be re-coloured gets copied verbatim anyway.
 
-The same goes for the six templates: each ships a different hue precisely so that copying one does
-not make every app in the world the same colour. Change it to yours.
+The same goes for the templates: each one ships a different hue — a test in this repository fails
+if two of them share — precisely so that copying one does not make every app in the world the same
+colour. Change it to yours.

--- a/server/skills/mulmoterminal-shared-app/templates/live-poll.md
+++ b/server/skills/mulmoterminal-shared-app/templates/live-poll.md
@@ -7,7 +7,7 @@ person running it decides what is being asked, right now.
 This template is written in English because it is the one most often shown to an audience that is
 not yours: the strings in the pages below are what a stranger reads.
 
-**What is different from the other four templates** is the direction the data flows. Everything else
+**What is different from the other templates** is the direction the data flows. Everything else
 here is a request somebody answers later; this one has a screen that must be right within a second,
 in front of many people at once. Two things follow, and they are the whole template:
 

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -94,13 +94,15 @@ the more surprising one to discover you do not have.
       "id": "desk",
       "audience": "member",
       "path": "views/desk.html",
-      "collections": ["articles"]
+      "collections": ["articles"],
+      "live": ["articles"]
     },
     {
       "id": "write",
       "audience": "participant",
       "path": "views/desk.html",
-      "collections": ["articles"]
+      "collections": ["articles"],
+      "live": ["articles"]
     }
   ],
   "public": {
@@ -174,6 +176,12 @@ frozen; that is not a policy in the page, it is the rules, and `viewer.can.<cid>
 page so.
 
 `limit.articles` — how many the index reads. Read the index-cost trap before raising it.
+
+**There is no `participantRead` here and there must not be.** A participant view is normally
+projected to the reader's OWN rows, and `participantRead` is what widens it — but a collection the
+app publishes to the world is already widened: `public.enabled` plus `cid` in `public.read` resolves
+the participant tier to every row. Adding the key would change nothing, while suggesting that the
+desk's view of the collection is narrower than the public page's, which it is not and cannot be.
 
 ## .claude/skills/articles/schema.json
 
@@ -475,6 +483,7 @@ is what draws the controls, so the page does not need to know which door it came
   .row.editing { border-radius: 14px 14px 0 0; margin-bottom: 0; }
   .row .t { font-weight: 780; font-size: 15px; letter-spacing: -.01em; }
   .row .m { margin-top: 4px; font-size: 12.5px; color: var(--muted); }
+  .row .m.bad { color: var(--bad); font-weight: 700; }
   .row .side { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; align-items: center; }
   .confirm { font-size: 12.5px; font-weight: 700; color: var(--bad); margin-right: 4px; }
 
@@ -539,6 +548,7 @@ is what draws the controls, so the page does not need to know which door it came
     var latest = null;
     var built = false;
     var arming = {};    // id -> its delete confirmation is showing
+    var failed = {};    // id -> why its deletion was refused, kept until the row is pressed again
     // The article being rewritten, and what has been typed into it. `list` is rebuilt whenever
     // state arrives, so anything held inside it is thrown away the moment somebody else publishes.
     var editing = null; // { id, values, saving, msg, bad, node, nodes, keys, record, can, fields }
@@ -548,6 +558,25 @@ is what draws the controls, so the page does not need to know which door it came
       if (cls) n.className = cls;
       if (text != null) n.textContent = text;
       return n;
+    };
+
+    /** A control and its label, ASSOCIATED — one `for`, one `id`, generated here because the
+     *  fields are built in script and have no ids of their own.
+     *
+     *  Putting a `<label>` next to a control is not a label relationship: without `for` (or the
+     *  control nested inside the label) a screen reader announces "edit text, blank" for every
+     *  one of these, so the whole form reads as five anonymous boxes. It also costs the click
+     *  target — pressing the word "Headline" should put the caret in the field. */
+    var seq = 0;
+    var field = function (labelText, node) {
+      seq += 1;
+      node.id = "field-" + seq;
+      var wrap = el("div", "field");
+      var label = el("label", null, labelText);
+      label.htmlFor = node.id;
+      wrap.appendChild(label);
+      wrap.appendChild(node);
+      return wrap;
     };
 
     // `publishedAt` is a server Timestamp, and it reaches the page as a `…Z` string.
@@ -620,12 +649,7 @@ is what draws the controls, so the page does not need to know which door it came
       compose.replaceChildren();
       compose.appendChild(el("h2", null, "New article"));
 
-      var mk = function (labelText, node) {
-        var f = el("div", "field");
-        f.appendChild(el("label", null, labelText));
-        f.appendChild(node);
-        return f;
-      };
+      var mk = field;
       var input = function (ph) {
         var n = document.createElement("input");
         n.type = "text";
@@ -850,8 +874,6 @@ is what draws the controls, so the page does not need to know which door it came
       editing.nodes = {};
       editing.keys = keys;
       fields.forEach(function (f) {
-        var wrap = el("div", "field");
-        wrap.appendChild(el("label", null, f.label));
         var node;
         if (f.kind === "text") {
           node = document.createElement("input");
@@ -864,8 +886,7 @@ is what draws the controls, so the page does not need to know which door it came
         node.value = editing.values[f.key] != null ? editing.values[f.key] : String(record[f.key] || "");
         node.oninput = function () { editing.values[f.key] = node.value; };
         editing.nodes[f.key] = node;
-        wrap.appendChild(node);
-        box.appendChild(wrap);
+        box.appendChild(field(f.label, node));
       });
 
       var actions = el("div", "actions");
@@ -905,8 +926,15 @@ is what draws the controls, so the page does not need to know which door it came
         editing.saving = true;
         editing.msg = "";
         syncEditor();
+        // WHICH EDITOR THIS ANSWER BELONGS TO. Only the fields being saved are disabled — the
+        // rows are still live, so pressing Rewrite on another article during the write replaces
+        // `editing` with a different one. A completion read against the module variable then
+        // closes somebody else's half-written editor on success, or reports this request's
+        // refusal into it. Captured here, and anything but this session is dropped: the editor
+        // it belonged to is gone, and there is nowhere for the answer to go.
+        var session = editing;
         view.correct("articles", record.id, changed).then(function (res) {
-          if (editing === null) return;
+          if (editing !== session) return;
           if (res && res.ok) { editing = null; renderList(); return; }
           editing.saving = false;
           if (res && res.error === "cancelled") { editing.msg = ""; syncEditor(); return; }
@@ -936,6 +964,7 @@ is what draws the controls, so the page does not need to know which door it came
       var living = {};
       all.forEach(function (r) { living[r.id] = true; });
       Object.keys(arming).forEach(function (id) { if (living[id] !== true) delete arming[id]; });
+      Object.keys(failed).forEach(function (id) { if (living[id] !== true) delete failed[id]; });
 
       if (!all.length) {
         list.appendChild(el("p", "note", "Nothing published yet."));
@@ -957,6 +986,7 @@ is what draws the controls, so the page does not need to know which door it came
         bits.push(r.id);
         if (r.tags) bits.push(r.tags);
         main.appendChild(el("div", "m", bits.join("  ·  ")));
+        if (failed[r.id]) main.appendChild(el("div", "m bad", failed[r.id]));
         row.appendChild(main);
 
         var side = el("div", "side");
@@ -984,10 +1014,13 @@ is what draws the controls, so the page does not need to know which door it came
               yes.disabled = true;
               view.withdraw("articles", r.id).then(function (res) {
                 delete arming[r.id];
+                // Into `failed` and then re-rendered, NOT appended to `main`. That node belongs
+                // to the render this click came from, and any state arriving in the meantime has
+                // already replaced it — appending to it puts the refusal in a detached element,
+                // so the deletion looks as though it silently worked.
                 if (!res || !res.ok) {
-                  yes.disabled = false;
-                  if (res && res.error === "cancelled") { renderList(); return; }
-                  main.appendChild(el("div", "m", "Could not delete: " + refusalNote(can, res && res.error)));
+                  if (!res || res.error !== "cancelled") failed[r.id] = "Could not delete: " + refusalNote(can, res && res.error);
+                  renderList();
                   return;
                 }
                 renderList();
@@ -1001,7 +1034,7 @@ is what draws the controls, so the page does not need to know which door it came
           } else {
             var del = el("button", "btn ghost small", "Delete");
             del.type = "button";
-            del.onclick = function () { arming[r.id] = true; renderList(); };
+            del.onclick = function () { delete failed[r.id]; arming[r.id] = true; renderList(); };
             side.appendChild(del);
           }
         }
@@ -1123,6 +1156,38 @@ straight back. Fill the field in from the signed-in address and let it be edited
 **Never let an email address reach this field.** Everything in this collection is drawn to the
 whole world, forever. That is also why the publisher is recorded as `byUid` rather than through
 `emailField`: a uid cannot be printed as a name, and an address must not be.
+
+### 8. The desks watch; the index must not
+
+`live: ["articles"]` is on both desk views and on neither public one, and that asymmetry is the
+only shape this key allows here.
+
+A subscription is a read **per document per change**, so its cost is (readers x writers). The desks
+are read by the roster and written by the roster — a handful either way — and the page needs it:
+without it, a writer's list of articles is whatever it was when they opened the tab, so a colleague
+publishing is invisible and the duplicate-name check upstream goes stale. It is also what makes the
+page's care with a half-written editor mean anything, since state arriving mid-sentence is exactly
+what `live` causes.
+
+The public index is the same declaration with an unbounded left-hand side: every visitor watching a
+collection the roster writes into. Publish refuses the fan-out that has an unbounded side on both,
+and the one here would be one press away from it. A reader who wants the newest article reloads.
+
+### 9. The desk has no `limit`, on purpose
+
+The index has one and the desk does not, and this is a decision rather than an omission — an
+unbounded read does grow with the archive, so it is worth saying what buys it.
+
+The desk does two things that need **every** article: it is where a writer reaches something they
+published a year ago to fix a typo, and it is where a URL name is checked against the ones already
+taken. A `limit` silently breaks both — an older article simply stops being reachable, and the
+duplicate check starts passing names that exist.
+
+What bounds the cost instead is **who reads it**: the roster, on a page nobody else can open. That
+is the opposite of the index, which is read by the world and therefore capped. If an archive does
+grow past what a desk should download, the answer is the same one the index has: a second
+collection carrying the slug and title alone. Adding `"limit": { "articles": 50 }` to the desk views
+is accepted by the gate — it is the *page* that stops being correct, not the declaration.
 
 ## Traps
 

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -554,6 +554,11 @@ is what draws the controls, so the page does not need to know which door it came
 
   <div class="panel">
     <h2>Articles</h2>
+    <!-- Why a refused deletion is reported HERE as well as on its row: a row is
+         rebuilt on every render, and an element inserted after the fact is not
+         announced. This node is always present and only its text changes, which is
+         what a live region needs. -->
+    <p class="msg bad" id="listStatus" role="status" aria-live="polite" hidden></p>
     <div id="list"><p class="note">Loading…</p></div>
   </div>
 </div>
@@ -564,6 +569,7 @@ is what draws the controls, so the page does not need to know which door it came
     var compose = document.getElementById("compose");
     var composeNote = document.getElementById("composeNote");
     var list = document.getElementById("list");
+    var listStatus = document.getElementById("listStatus");
     var latest = null;
     var built = false;
     // KEYED BY ARTICLE ID, WITH NO PROTOTYPE. A URL name is lowercase letters, digits and
@@ -591,6 +597,20 @@ is what draws the controls, so the page does not need to know which door it came
      *  control nested inside the label) a screen reader announces "edit text, blank" for every
      *  one of these, so the whole form reads as five anonymous boxes. It also costs the click
      *  target — pressing the word "Headline" should put the caret in the field. */
+    /** A line that says what happened. **It has to be a live region.**
+     *
+     *  Focus stays on the button that was pressed while only the text of a `<p>` changes, so
+     *  without one a screen reader says nothing at all — not the required-field refusal, not the
+     *  permission error, not that the article went out. A notice only sighted people receive is
+     *  not a notice. `polite` because none of them should interrupt typing.
+     */
+    var status = function (cls) {
+      var node = el("p", cls || "msg");
+      node.setAttribute("role", "status");
+      node.setAttribute("aria-live", "polite");
+      return node;
+    };
+
     var seq = 0;
     var field = function (labelText, node) {
       seq += 1;
@@ -713,7 +733,7 @@ is what draws the controls, so the page does not need to know which door it came
       actions.appendChild(post);
       compose.appendChild(actions);
 
-      var msg = el("p", "msg");
+      var msg = status();
       compose.appendChild(msg);
       var say = function (text, bad) {
         msg.textContent = text || "";
@@ -951,7 +971,7 @@ is what draws the controls, so the page does not need to know which door it came
       actions.appendChild(save);
       actions.appendChild(cancel);
       box.appendChild(actions);
-      var msg = el("p", "msg");
+      var msg = status();
       box.appendChild(msg);
 
       editing.node = box;
@@ -1031,6 +1051,9 @@ is what draws the controls, so the page does not need to know which door it came
       all.forEach(function (r) { living[r.id] = true; });
       Object.keys(arming).forEach(function (id) { if (living[id] !== true) delete arming[id]; });
       Object.keys(failed).forEach(function (id) { if (living[id] !== true) delete failed[id]; });
+      var notices = Object.keys(failed).map(function (id) { return failed[id]; });
+      listStatus.textContent = notices.join(" ");
+      listStatus.hidden = notices.length === 0;
 
       if (!all.length) {
         list.appendChild(el("p", "note", "Nothing published yet."));

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -1,0 +1,1164 @@
+# A magazine: several writers, one masthead, a URL per article
+
+A group of people — or agents — who each publish under their own name, in public, at an address
+you can send to somebody: a team blog, a newsletter's back issues, a research log, release notes,
+a class's write-ups, a review column. Nobody approves anything; a writer publishes, and the
+article is readable by the world the moment it exists.
+
+Use this when what is being collected is **something to READ**, and each item deserves its own
+link. That is the whole difference from every other template here. A survey's responses are rows,
+and the page decides how they look; an article is a page, and the platform draws it — so the app
+declares which fields are the title, the summary, the body and the byline, and the platform gives
+each record an address of the form `/a/{slug}/{id}`.
+
+**What is different from the other templates** is that this one publishes a `views[].article`
+block, and that single key changes three things at once:
+
+- **The document id becomes the URL.** `idFrom: "slug"` takes the id from a field the writer
+  chooses, and the rules freeze it. An article's address is decided once, by the person writing it,
+  and can never be edited — only replaced by a different article.
+- **The app states its own protocol.** Article views are `2.0.0`; every other template here says
+  `1.0.0`. This is the one place a template declares something newer, and the reason is in the
+  traps below.
+- **The index is a cost, in bytes, that publish will refuse.** The world's index reads whole
+  records — a rule cannot hide a field — so `limit` times the declared field caps is a real number
+  the gate checks against 1,000,000. Bodies are the biggest thing this platform stores, and this is
+  the only shape where a page routinely lists a lot of them.
+
+The other thing worth knowing before you copy it: **there is no draft.** A row of a world-readable
+collection is world-readable, and `status` cannot hide a field. Writing happens outside the app,
+in ordinary files; the app is where a finished piece is published.
+
+## What each person can do
+
+| | publish an article | edit or delete their own | edit or delete somebody else's |
+|---|---|---|---|
+| owner | yes | yes | **no** |
+| participant (writer) | yes | yes | **no** |
+| anyone not on the roster | no | — | no |
+
+Reading is the whole world, with no sign-in.
+
+**The owner row is not a typo, and it is the first thing to understand about this shape.** The
+owner holds `participant` on `articles` *deliberately*, and the reason is a chain of three
+declarations — spelled out in "The owner has to demote themselves" below. Writers here are equals.
+If you want somebody who can correct anybody's article, give that person `"articles": "editor"`;
+it is one word, and it is not the default because a magazine of peers is the more common thing and
+the more surprising one to discover you do not have.
+
+## app.json
+
+```json
+{
+  "name": "Field Notes",
+  "slug": "field-notes",
+  "protocol": "2.0.0",
+  "members": {
+    "editor@example.com": {
+      "*": "owner",
+      "articles": "participant"
+    },
+    "first.writer@example.com": {
+      "articles": "participant"
+    },
+    "second.writer@example.com": {
+      "articles": "participant"
+    }
+  },
+  "collections": {
+    "articles": {
+      "statusField": "status",
+      "submitOnly": true
+    }
+  },
+  "theme": {
+    "hue": 115
+  },
+  "views": [
+    {
+      "id": "public",
+      "audience": "public",
+      "path": "views/home.html",
+      "collections": ["articles"],
+      "article": {
+        "title": "title",
+        "summary": "summary",
+        "body": "body",
+        "byline": "byline"
+      },
+      "limit": {
+        "articles": 10
+      }
+    },
+    {
+      "id": "desk",
+      "audience": "member",
+      "path": "views/desk.html",
+      "collections": ["articles"]
+    },
+    {
+      "id": "write",
+      "audience": "participant",
+      "path": "views/desk.html",
+      "collections": ["articles"]
+    }
+  ],
+  "public": {
+    "enabled": true,
+    "read": ["articles"],
+    "submit": {
+      "articles": {
+        "auth": "verifiedEmail",
+        "audience": "participant",
+        "uidField": "byUid",
+        "createFields": ["slug", "title", "summary", "body", "tags", "byline", "byUid", "status", "publishedAt"],
+        "initialStatus": "published",
+        "validate": {
+          "required": ["title", "body"]
+        },
+        "idFrom": "slug",
+        "idField": "slug",
+        "stampField": "publishedAt",
+        "maxBytes": {
+          "title": 200,
+          "summary": 800,
+          "body": 60000,
+          "byline": 100
+        },
+        "selfUpdate": {
+          "published": ["title", "summary", "body", "tags", "byline"]
+        },
+        "selfDelete": ["published"]
+      }
+    }
+  },
+  "agents": [
+    {
+      "id": "author",
+      "audience": "member",
+      "instruction": "You write for Field Notes. Publish with useSharedApp `action: \"submit\"` into the `articles` collection — `manageCollection`'s `putItems` cannot write here, and returns a PERMISSION_DENIED that names no field. `slug` is the article's URL name AND its document id: lowercase letters, digits and hyphens, starting with a letter or digit, 64 characters at most, and unique. The article is published at /a/field-notes/<slug> and the id is frozen, so choose a name a person could read aloud and never try to change it. `title` and `body` are required; `body` is Markdown and cannot carry images; `summary` is the two lines the index shows; `tags` is comma-separated; `status` is `published`. The caps are UTF-8 BYTES, not characters: title 200, summary 800, body 60000. Do not send `publishedAt` — the server stamps it and it is frozen. Do not send `byUid` — the host fills it in. DO fill in `byline` with the name you want printed: it is drawn under the title on the article page and at the foot of the card in the index, up to 100 bytes. It is a string you type, not an identity the rules check — who published is recorded in `byUid` — so NEVER put an email address in it; that field is drawn to the whole world. Publishing is instant and public: there is no draft in this app, so keep work in progress in drafts/*.md and submit when it is finished. Fix a typo with `action: \"update\"`, passing the article's `slug` as `id` and only the fields that change; never republish. You can only change articles this account published — everybody here is a peer and nobody can reach everybody's work. Withdrawing means deleting, and it cannot be undone. A person at this terminal does all of the same things from the desk at /m/field-notes."
+    }
+  ]
+}
+```
+
+**The keys that are doing the work, in the order they matter.**
+
+`public.submit.articles.audience: "participant"` — only somebody the roster names may create an
+article. This is load-bearing beyond the obvious: the byte caps below are enforced by publish and
+by the host, **never by a Firestore rule**, so they bind only people who go through a host. Let the
+world submit and the caps become a comment. Publish knows this and refuses an `article` view whose
+collection anybody with an account can write to.
+
+`submitOnly: true` — required as soon as `audience` is declared, and it is what closes the
+*writer* branch of the rules. See the owner trap.
+
+`idFrom: "slug"` with `idField: "slug"` — the document id comes from the `slug` the writer sends,
+and the rules check its grammar and then freeze it. This is what buys per-article URLs. `slug` is
+in `createFields` but it must NOT be the schema's `primaryKey` — publish refuses that, because the
+rules can pin a document id but cannot pin the value of a field.
+
+`stampField: "publishedAt"` — the server's clock, written by the rules as `request.time`. It has
+to be listed in `createFields` (the rules refuse any key outside that list, and they require the
+record to carry the stamp), but **the page and the agent must never send a value**: the host fills
+it in. The index sorts on it, and the page receives it as a `…Z` string whose lexical order is
+chronological.
+
+`uidField: "byUid"` — the publisher's uid, filled in by the host for the same reason. A uid and
+not an email, because every field of this collection is readable by the world, and `emailField`
+here would print every contributor's address beside their article forever.
+
+`selfUpdate` / `selfDelete` — a writer may rewrite the listed fields of their own published
+article, and may delete it. `slug` and `publishedAt` are absent from `selfUpdate` because they are
+frozen; that is not a policy in the page, it is the rules, and `viewer.can.<cid>.frozen` tells the
+page so.
+
+`limit.articles` — how many the index reads. Read the index-cost trap before raising it.
+
+## .claude/skills/articles/schema.json
+
+```json
+{
+  "title": "Articles",
+  "icon": "article",
+  "primaryKey": "id",
+  "storage": { "type": "firestore" },
+  "fields": {
+    "id": { "type": "string", "label": "ID", "primary": true, "required": true },
+    "slug": { "type": "string", "label": "URL name", "required": true },
+    "title": { "type": "string", "label": "Headline", "required": true },
+    "summary": { "type": "text", "label": "Standfirst (the two lines in the index)" },
+    "body": { "type": "markdown", "label": "Body (Markdown)", "required": true },
+    "tags": { "type": "string", "label": "Tags (comma separated)" },
+    "byline": { "type": "string", "label": "Byline" },
+    "byUid": { "type": "string", "label": "Published by (uid)" },
+    "status": { "type": "enum", "label": "Status", "values": ["published"], "default": "published" },
+    "publishedAt": { "type": "datetime", "label": "Published at" }
+  }
+}
+```
+
+`status` has exactly one value, and that is the honest declaration for this shape. An enum with
+`draft` in it would compile, publish, and lie: the row is readable by the world either way.
+
+## views/home.html — the index the world sees
+
+The masthead is the whole reason this page exists. The platform draws each article for you; what
+it has no place for is the thing that says *whose* magazine this is. Everything below the header is
+a list of cards that open one article each.
+
+```html
+<style>
+  * { box-sizing: border-box; }
+  :root {
+    --hue: 115;
+    --main:  oklch(47% .09 var(--hue));
+    --line:  oklch(47% .09 var(--hue) / .16);
+    --muted: oklch(53% .02 var(--hue));
+    --fill:  oklch(96% .018 var(--hue));
+    --ink:   oklch(23% .015 var(--hue));
+    --paper: oklch(99.4% .007 85);
+    --bad:   oklch(48% .16 25);
+  }
+  html { min-height: 100%; color: var(--ink); color-scheme: light; background: var(--paper); background-image: linear-gradient(180deg, oklch(98.6% .01 var(--hue)) 0, oklch(96.4% .012 var(--hue)) 100%); background-attachment: fixed; }
+  body {
+    margin: 0;
+    padding: clamp(18px, 4vw, 44px) clamp(14px, 3.5vw, 26px) 80px;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.55;
+  }
+  .wrap { max-width: 760px; margin: 0 auto; }
+
+  header.masthead { margin: 0 0 clamp(20px, 4vw, 34px); }
+  .eyebrow {
+    font-size: 12px; font-weight: 800; letter-spacing: .16em;
+    text-transform: uppercase; color: var(--main); margin: 0 0 10px;
+  }
+  h1 { margin: 0; font-size: clamp(30px, 7vw, 46px); line-height: 1.05; letter-spacing: -.035em; font-weight: 800; }
+  .standfirst { margin: 12px 0 0; color: var(--muted); font-size: clamp(14px, 2.6vw, 16px); max-width: 46ch; }
+
+  .feed { list-style: none; margin: 0; padding: 0; display: grid; gap: 14px; }
+  .card {
+    display: block; width: 100%; text-align: left; cursor: pointer;
+    background: var(--paper); border: 1px solid var(--line); border-radius: 20px;
+    padding: clamp(16px, 3vw, 24px); font: inherit; color: inherit;
+    box-shadow: 0 14px 40px oklch(30% .05 var(--hue) / .06);
+    transition: border-color .15s, transform .15s;
+  }
+  .card:hover { border-color: oklch(47% .09 var(--hue) / .38); transform: translateY(-1px); }
+  .card:focus-visible { outline: 2px solid var(--main); outline-offset: 2px; }
+  .stamp { margin: 0 0 6px; font-size: 12px; font-weight: 700; letter-spacing: .06em; color: var(--muted); }
+  .headline { margin: 0; font-size: clamp(18px, 3.4vw, 22px); line-height: 1.25; letter-spacing: -.02em; font-weight: 780; }
+  .dek { margin: 8px 0 0; color: var(--muted); font-size: 14.5px; }
+  .byline { margin: 10px 0 0; font-size: 12.5px; font-weight: 700; color: var(--main); }
+  .tags { margin: 10px 0 0; font-size: 12px; color: var(--muted); }
+  .miss { margin: 10px 0 0; font-size: 12.5px; font-weight: 700; color: var(--bad); }
+
+  .empty { margin: 0; padding: 28px; text-align: center; color: var(--muted); border: 1px dashed var(--line); border-radius: 20px; }
+  footer { margin: clamp(28px, 5vw, 44px) 0 0; color: var(--muted); font-size: 12.5px; }
+</style>
+
+<div class="wrap">
+  <header class="masthead">
+    <p class="eyebrow">Field Notes</p>
+    <h1>What we worked out this week</h1>
+    <p class="standfirst">Written by the people who did the work. Everyone here signs their own
+      pieces and edits nobody else's.</p>
+  </header>
+
+  <ul class="feed" id="feed"></ul>
+  <p class="empty" id="empty" hidden>Nothing published yet.</p>
+
+  <footer id="foot"></footer>
+</div>
+
+<script>
+  (function () {
+    var view = window.__MC_APP_VIEW;
+    var feed = document.getElementById("feed");
+    var empty = document.getElementById("empty");
+    var foot = document.getElementById("foot");
+
+    var text = function (record, field) {
+      var value = record && record[field];
+      return typeof value === "string" ? value.trim() : "";
+    };
+
+    /** The server's stamp. `publishedAt` is frozen, and its string order IS its time order. */
+    var dateOf = function (record) {
+      var at = text(record, "publishedAt");
+      if (at === "") return "";
+      var when = new Date(at);
+      if (isNaN(when.getTime())) return "";
+      return when.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+    };
+
+    var newestFirst = function (rows) {
+      return rows.slice().sort(function (left, right) {
+        return String(right && right.publishedAt || "").localeCompare(String(left && left.publishedAt || ""));
+      });
+    };
+
+    var cardFor = function (record) {
+      var id = typeof record.id === "string" ? record.id : "";
+      var item = document.createElement("li");
+      var card = document.createElement("button");
+      card.type = "button";
+      card.className = "card";
+
+      var when = dateOf(record);
+      if (when !== "") {
+        var stamp = document.createElement("p");
+        stamp.className = "stamp";
+        stamp.textContent = when;
+        card.appendChild(stamp);
+      }
+
+      var headline = document.createElement("h2");
+      headline.className = "headline";
+      // No headline? Show the URL name. The writer chose it, so it reads better than a placeholder.
+      headline.textContent = text(record, "title") || id;
+      card.appendChild(headline);
+
+      var summary = text(record, "summary");
+      if (summary !== "") {
+        var dek = document.createElement("p");
+        dek.className = "dek";
+        dek.textContent = summary;
+        card.appendChild(dek);
+      }
+
+      var byline = text(record, "byline");
+      if (byline !== "") {
+        var by = document.createElement("p");
+        by.className = "byline";
+        by.textContent = byline;
+        card.appendChild(by);
+      }
+
+      var tags = text(record, "tags");
+      if (tags !== "") {
+        var tagLine = document.createElement("p");
+        tagLine.className = "tags";
+        tagLine.textContent = tags;
+        card.appendChild(tagLine);
+      }
+
+      // To the article. **You cannot link out of this frame**: it is sandboxed with scripts and
+      // nothing else, so there is no top navigation and no popup. `view.open` asks the host, and
+      // names a RECORD rather than a URL — the host holds the slug and builds the address.
+      //
+      // The promise usually never settles, because a navigation destroys this document along with
+      // it — so **settling means it did not happen**. In a frame that can draw no link, "I pressed
+      // it and nothing moved" is the least diagnosable failure there is, so say it on the card.
+      // Only an explicit `opened === false` counts: a host that answers nothing on success must
+      // not be read as a refusal.
+      card.addEventListener("click", function () {
+        if (id === "" || !view || typeof view.open !== "function") return;
+        Promise.resolve(view.open("articles", id)).then(function (res) {
+          if (!res || res.opened !== false) return;
+          var miss = card.querySelector(".miss");
+          if (!miss) {
+            miss = document.createElement("p");
+            miss.className = "miss";
+            card.appendChild(miss);
+          }
+          miss.textContent = "That article would not open. Try again in a moment.";
+        });
+      });
+
+      item.appendChild(card);
+      return item;
+    };
+
+    var render = function (data) {
+      var rows = (data && data.articles) || [];
+      feed.textContent = "";
+      newestFirst(rows).forEach(function (record) {
+        if (record && typeof record === "object") feed.appendChild(cardFor(record));
+      });
+      empty.hidden = rows.length > 0;
+      // NOT "N articles": this page is handed at most `limit` of them, and how many exist in
+      // total is not something it is told — telling it would mean reading them all.
+      foot.textContent = rows.length === 0 ? "" : "Latest " + rows.length;
+    };
+
+    if (!view) {
+      empty.hidden = false;
+      empty.textContent = "This page only runs inside the host. Open it at /a/field-notes.";
+      return;
+    }
+
+    view.onState(function (data) {
+      render(data || {});
+    });
+    // OUTSIDE `onState`. Called from inside it, it is never called at all.
+    view.ready();
+  })();
+</script>
+```
+
+## views/desk.html — where the writers work
+
+One file, declared twice: as the `member` view (the owner reaches it at `/m/field-notes`) and as
+the `participant` view (a writer reaches it at `/p/field-notes`). It is the same page because the
+two audiences can do the same things here — which is the point of this shape — and `viewer.can`
+is what draws the controls, so the page does not need to know which door it came through.
+
+```html
+<style>
+  * { box-sizing: border-box; }
+  :root {
+    --hue: 115;
+    --main:  oklch(47% .09 var(--hue));
+    --line:  oklch(47% .09 var(--hue) / .16);
+    --muted: oklch(53% .02 var(--hue));
+    --fill:  oklch(96% .018 var(--hue));
+    --ink:   oklch(23% .015 var(--hue));
+    --paper: oklch(99.4% .007 85);
+    --bad:   oklch(48% .16 25);
+  }
+  html { min-height: 100%; color: var(--ink); color-scheme: light; background: var(--paper); background-image: linear-gradient(180deg, oklch(98.6% .01 var(--hue)) 0, oklch(96.4% .012 var(--hue)) 100%); background-attachment: fixed; }
+  body {
+    margin: 0;
+    padding: clamp(16px, 3.5vw, 36px) clamp(14px, 3.5vw, 26px) 72px;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.55;
+  }
+  .wrap { max-width: 820px; margin: 0 auto; display: grid; gap: 16px; }
+  .panel {
+    background: var(--paper); border: 1px solid var(--line);
+    border-radius: 24px; padding: clamp(18px, 3.4vw, 28px);
+    box-shadow: 0 18px 50px oklch(30% .05 var(--hue) / .08);
+  }
+  .eyebrow {
+    font-size: 12px; font-weight: 800; letter-spacing: .16em;
+    text-transform: uppercase; color: var(--main); margin: 0 0 8px;
+  }
+  h1 { margin: 0; font-size: clamp(22px, 4.4vw, 30px); line-height: 1.15; letter-spacing: -.03em; font-weight: 780; }
+  h2 { margin: 0 0 14px; font-size: 17px; letter-spacing: -.015em; font-weight: 780; }
+  .note { margin: 10px 0 0; color: var(--muted); font-size: 13.5px; }
+
+  label { display: block; font-size: 12.5px; font-weight: 750; color: var(--muted); margin: 0 0 5px; }
+  .field { margin: 0 0 14px; }
+  input[type=text], textarea {
+    width: 100%; background: #fff; color: var(--ink);
+    border: 1px solid var(--line); border-radius: 12px;
+    padding: 10px 12px; font: inherit; font-size: 15px;
+  }
+  textarea { resize: vertical; line-height: 1.55; }
+  textarea.body { min-height: 220px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13.5px; }
+  input:focus, textarea:focus { outline: 2px solid var(--main); outline-offset: 1px; border-color: transparent; }
+
+  .btn {
+    background: var(--main); color: var(--paper);
+    border: 0; border-radius: 12px; padding: 10px 18px;
+    font: inherit; font-weight: 750; font-size: 14px;
+    min-height: 38px; touch-action: manipulation; cursor: pointer;
+  }
+  .btn.ghost { background: var(--fill); color: var(--main); }
+  .btn.danger { background: oklch(52% .16 25); color: oklch(99% .005 25); }
+  .btn.small { padding: 6px 12px; font-size: 12.5px; min-height: 32px; }
+  .btn:disabled { opacity: .5; cursor: default; }
+  .btn:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+  .actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+
+  .msg { margin: 12px 0 0; font-size: 13.5px; font-weight: 700; color: var(--main); }
+  .msg.bad { color: var(--bad); }
+
+  .row {
+    display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: start;
+    border: 1px solid var(--line); border-radius: 14px;
+    padding: 12px 14px; margin: 0 0 10px; background: var(--paper);
+  }
+  .row:last-child { margin-bottom: 0; }
+  .row.editing { border-radius: 14px 14px 0 0; margin-bottom: 0; }
+  .row .t { font-weight: 780; font-size: 15px; letter-spacing: -.01em; }
+  .row .m { margin-top: 4px; font-size: 12.5px; color: var(--muted); }
+  .row .side { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; align-items: center; }
+  .confirm { font-size: 12.5px; font-weight: 700; color: var(--bad); margin-right: 4px; }
+
+  .editor {
+    border: 1px solid var(--line); border-top: 0;
+    border-radius: 0 0 14px 14px; background: var(--fill);
+    padding: 14px 14px 12px; margin: 0 0 10px;
+  }
+  .editor input[type=text], .editor textarea { background: var(--paper); }
+
+  @media (max-width: 680px) {
+    .row { grid-template-columns: 1fr; }
+    .row .side { justify-content: flex-start; }
+    .btn { width: 100%; }
+    .btn.small { width: auto; }
+  }
+</style>
+
+<div class="wrap">
+  <div class="panel">
+    <p class="eyebrow">Field Notes</p>
+    <h1>The desk</h1>
+    <p class="note">Publishing puts the article on <strong>/a/field-notes</strong> immediately, for
+      everybody. There are no drafts here, and <strong>the only way to withdraw one is to delete
+      it</strong>, which cannot be undone.</p>
+    <p class="note">A published article can be <strong>rewritten in place</strong> — headline,
+      standfirst, body, tags. <strong>Its URL name and its date do not change</strong>: the rules
+      froze both when it was created, so a link that once resolved goes on resolving. An article
+      that needs a different name is a different article.</p>
+    <p class="note">Writers here are <strong>equals</strong>. You can edit and delete
+      <strong>only what you published</strong>, and that includes whoever set the magazine up.
+      Nobody can reach everybody's work. The list below shows everyone's articles — they are public,
+      so of course you can read them — but <strong>the controls appear only on your own</strong>.
+      While the host has not yet answered which ones are yours, they appear on every row; press one
+      on somebody else's article and <strong>the rules refuse it</strong>. The list says so when
+      that is the state you are in.</p>
+    <p class="note"><strong>The byline is filled in for you</strong> — from the part of your address
+      before the <code>@</code>. <strong>Only that name is published; your email address is
+      not.</strong> It appears under the headline on the article and at the foot of the card in the
+      index. <strong>It is a default, not an identity</strong>: you can change it here or later, and
+      the rules never check it. What does record who published an article is <code>byUid</code>,
+      which is never drawn.</p>
+  </div>
+
+  <div class="panel" id="compose">
+    <h2>New article</h2>
+    <p class="note" id="composeNote">Loading…</p>
+  </div>
+
+  <div class="panel">
+    <h2>Articles</h2>
+    <div id="list"><p class="note">Loading…</p></div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var view = window.__MC_APP_VIEW;
+    var compose = document.getElementById("compose");
+    var composeNote = document.getElementById("composeNote");
+    var list = document.getElementById("list");
+    var latest = null;
+    var built = false;
+    var arming = {};    // id -> its delete confirmation is showing
+    // The article being rewritten, and what has been typed into it. `list` is rebuilt whenever
+    // state arrives, so anything held inside it is thrown away the moment somebody else publishes.
+    var editing = null; // { id, values, saving, msg, bad, node, nodes, keys, record, can, fields }
+
+    var el = function (tag, cls, text) {
+      var n = document.createElement(tag);
+      if (cls) n.className = cls;
+      if (text != null) n.textContent = text;
+      return n;
+    };
+
+    // `publishedAt` is a server Timestamp, and it reaches the page as a `…Z` string.
+    var when = function (v) {
+      var m = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}))?/.exec(String(v || ""));
+      if (!m) return "";
+      return m[1] + "-" + m[2] + "-" + m[3] + (m[4] ? " " + m[4] + ":" + m[5] : "");
+    };
+
+    // A URL name out of a headline. Anything that is not a-z, 0-9 or a hyphen is dropped, so a
+    // headline with no Latin letters in it produces nothing and the writer is asked for a name.
+    var slugify = function (text) {
+      return String(text || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 64).replace(/-+$/, "");
+    };
+
+    var capOf = function () {
+      return (latest && latest.viewer && latest.viewer.can && latest.viewer.can.articles) || {};
+    };
+    var rows = function () {
+      return ((latest && latest.data && latest.data.articles) || []).slice().sort(function (a, b) {
+        return String(b.publishedAt || "").localeCompare(String(a.publishedAt || ""));
+      });
+    };
+
+    var LABELS = { title: "Headline", slug: "URL name", summary: "Standfirst", body: "Body", tags: "Tags", byline: "Byline" };
+    var labelOf = function (key) {
+      return Object.prototype.hasOwnProperty.call(LABELS, key) ? LABELS[key] : key;
+    };
+
+    /** The default byline: the part of the signed-in address before the `@`.
+     *
+     *  **Do not keep a table here.** The obvious next step is a map of address to display name so
+     *  that a byline cannot be faked — and it is a second roster, kept by hand, beside the one in
+     *  `app.json`. Nobody owns keeping the two in step, so it drifts, and the guarantee it offers
+     *  reaches only the addresses somebody remembered to add.
+     *
+     *  **The guarantee is not available anyway.** No rule looks at `byline`, and `selfUpdate` lists
+     *  it, so whatever the form does at submission time can be undone by the writer a second later.
+     *  So fill the field in and let it be edited, and make the page's own words true instead.
+     *  Who published an article is `byUid`, which the host fills in and the page never draws.
+     *
+     *  The address itself is not published: only the part before the `@` is, and this page is
+     *  reachable only by the roster. */
+    var bylineOf = function () {
+      var me = String((latest && latest.viewer && latest.viewer.me) || "");
+      var at = me.indexOf("@");
+      return at > 0 ? me.slice(0, at) : "";
+    };
+
+    // The one bound the rules do not also make. The host refuses an over-long value too, but
+    // saying it here lets the refusal **name the field and the number**.
+    var overLong = function (values) {
+      var caps = capOf().maxBytes || {};
+      var over = [];
+      Object.keys(values).forEach(function (key) {
+        if (!Object.prototype.hasOwnProperty.call(caps, key)) return;
+        var cap = caps[key];
+        if (typeof cap !== "number") return;
+        var bytes = new TextEncoder().encode(String(values[key])).length;
+        if (bytes > cap) over.push(labelOf(key) + " is " + bytes + " bytes, over the limit of " + cap);
+      });
+      return over;
+    };
+    var overLongMessage = function (over) {
+      return over.join(". ") + ". That is UTF-8 bytes rather than characters, and a non-Latin character is usually 3. Nothing was sent.";
+    };
+
+    // ---- New article (built ONCE; rebuilding it throws away what is half-typed) ----
+    var buildCompose = function () {
+      compose.replaceChildren();
+      compose.appendChild(el("h2", null, "New article"));
+
+      var mk = function (labelText, node) {
+        var f = el("div", "field");
+        f.appendChild(el("label", null, labelText));
+        f.appendChild(node);
+        return f;
+      };
+      var input = function (ph) {
+        var n = document.createElement("input");
+        n.type = "text";
+        n.placeholder = ph || "";
+        return n;
+      };
+
+      var title = input("Why our deploys got slower");
+      var summary = document.createElement("textarea");
+      summary.rows = 2;
+      var tags = input("deploys, ci");
+      var body = document.createElement("textarea");
+      body.className = "body";
+      body.placeholder = "Markdown: headings, **bold**, `code`, quotes, lists and\n[links](https://example.com). Images cannot be stored.";
+
+      var slug = document.createElement("input");
+      slug.type = "text";
+      slug.placeholder = "why-our-deploys-got-slower";
+      var slugTouched = false;
+      slug.oninput = function () { slugTouched = true; };
+      title.oninput = function () { if (!slugTouched) slug.value = slugify(title.value); };
+
+      compose.appendChild(mk("Headline", title));
+      compose.appendChild(mk("URL name — becomes /a/field-notes/<name>, and can never be changed", slug));
+      compose.appendChild(mk("Standfirst — the two lines the index shows", summary));
+      compose.appendChild(mk("Tags — comma separated", tags));
+
+      var byline = input("your name");
+      byline.value = bylineOf();
+      compose.appendChild(mk("Byline — printed under the headline and in the index. Editable (empty means unsigned)", byline));
+
+      compose.appendChild(mk("Body (Markdown)", body));
+
+      var actions = el("div", "actions");
+      var post = el("button", "btn", "Publish");
+      post.type = "button";
+      actions.appendChild(post);
+      compose.appendChild(actions);
+
+      var msg = el("p", "msg");
+      compose.appendChild(msg);
+      var say = function (text, bad) {
+        msg.textContent = text || "";
+        msg.className = bad ? "msg bad" : "msg";
+      };
+
+      post.onclick = function () {
+        if (!(title.value || "").trim()) { say("A headline is required.", true); return; }
+        if (!(body.value || "").trim()) { say("There is no body.", true); return; }
+        var name = slugify(slug.value || title.value);
+        if (!name) { say("Choose a URL name (lowercase letters, digits, hyphens). One cannot be made from this headline.", true); return; }
+        // The URL name IS the document id, so the same one cannot be created twice: the rules
+        // allow only a create, and what comes back is a PERMISSION_DENIED that names no field.
+        // This page holds every article — they are public — so it can say so before sending.
+        if (rows().some(function (r) { return r.id === name; })) {
+          say("The URL name " + name + " is already taken. Every article needs its own — check the list and pick another. Nothing was sent.", true);
+          return;
+        }
+
+        var written = {
+          slug: name,
+          title: title.value.trim(),
+          summary: (summary.value || "").trim(),
+          tags: (tags.value || "").trim(),
+          byline: (byline.value || "").trim(),
+          body: body.value
+          // `publishedAt` and `byUid` are NOT sent. The host and the rules fill in and freeze both.
+        };
+        var over = overLong(written);
+        if (over.length > 0) { say(overLongMessage(over), true); return; }
+
+        post.disabled = true;
+        say("");
+        view.submit("articles", written).then(function (res) {
+          post.disabled = false;
+          if (res && res.ok) {
+            say("Published. It is readable at /a/field-notes/" + name + ".");
+            title.value = ""; summary.value = ""; tags.value = ""; body.value = ""; slug.value = "";
+            slugTouched = false;
+            return;
+          }
+          if (res && res.error === "cancelled") { say(""); return; }
+          say("Could not publish: " + ((res && res.error) || "unknown") + ". Most often the URL name " + name + " was taken by somebody a moment earlier, and another name will work. Otherwise: only people on the roster may publish, so if you were invited just now the app may not have been published since.", true);
+        });
+      };
+    };
+
+    // There is no capability that says "may create" — creating is not among them. So the form is
+    // drawn for everybody who can open this page, which is only ever the roster, and a refusal is
+    // reported with its reason.
+    var renderCompose = function () {
+      if (built) return;
+      buildCompose();
+      built = true;
+    };
+
+    // ---- Rewriting what has been published ----
+    var EDITABLE = [
+      { key: "title", label: "Headline", kind: "text" },
+      { key: "summary", label: "Standfirst", kind: "area" },
+      { key: "tags", label: "Tags (comma separated)", kind: "text" },
+      { key: "byline", label: "Byline", kind: "text" },
+      { key: "body", label: "Body (Markdown)", kind: "body" }
+    ];
+
+    // Who may rewrite what. The question is asked of the CAPABILITY, never of the audience.
+    // `can.frozen` is what NOBODY may write (slug, publishedAt, byUid, status). `correctFrom` is
+    // your own article, per status. `correctAny` — reaching everybody's — is held by nobody in
+    // this app; it is read anyway so that the page stays correct the day somebody is made editor.
+    var editableFields = function (can, status) {
+      var frozen = can.frozen || [];
+      var reachable = EDITABLE.filter(function (f) { return frozen.indexOf(f.key) === -1; });
+      if (can.correctAny === true) return reachable;
+      var byStatus = can.correctFrom || {};
+      var allowed = Object.prototype.hasOwnProperty.call(byStatus, status) ? byStatus[status] || [] : [];
+      return reachable.filter(function (f) { return allowed.indexOf(f.key) !== -1; });
+    };
+
+    /** Which articles are yours — **as the host read them with the reader's own credentials**
+     *  (`viewer.mine`).
+     *
+     *  Not an answer the page computes by comparing uids. The projection does not carry the
+     *  reader's uid, and whose a row is belongs to the rules; `mine` answers the same question the
+     *  same way round — the rows themselves, read as the reader.
+     *
+     *  **There is a THIRD state.** `null` is not "you have none", it is **"nobody looked"** — the
+     *  host has not answered, or cannot. Read as "none", it takes the controls off your OWN
+     *  articles. So on `null` every row is drawn (the rules refuse the wrong ones) and the list
+     *  says why. */
+    var mineIds = function () {
+      var mine = (latest && latest.viewer && latest.viewer.mine) || {};
+      if (!Object.prototype.hasOwnProperty.call(mine, "articles")) return null;
+      var rows = mine.articles;
+      if (!Array.isArray(rows)) return null;
+      var ids = {};
+      rows.forEach(function (r) {
+        if (r && typeof r.id === "string") ids[r.id] = true;
+      });
+      return ids;
+    };
+
+    /** Somebody whose ROLE reaches every article. Nobody here — but somebody the day a member's
+     *  `articles` is changed to `editor`. */
+    var isDesk = function () {
+      var can = capOf();
+      return can.correctAny === true || can.withdrawAny === true;
+    };
+
+    /** Is this row within reach: by role, or because it is yours? On "nobody looked", true —
+     *  draw it, and let the rules refuse. */
+    var reaches = function (id) {
+      if (isDesk()) return true;
+      var ids = mineIds();
+      return ids === null || ids[id] === true;
+    };
+
+    // Deletable? In this app only `withdrawFrom` (your own, from that status): `writerDelete` is
+    // not declared, so `withdrawAny` is held by nobody. Nobody reaching everybody is the design.
+    var mayWithdraw = function (can, status) {
+      if (can.withdrawAny === true) return true;
+      var from = can.withdrawFrom || [];
+      return from.indexOf(status) !== -1;
+    };
+    /** A refusal, with this reader's boundary added. Controls are only drawn on your own articles,
+     *  so arriving here means a conflict — or a press made **before `viewer.mine` had answered**. */
+    var refusalNote = function (can, error) {
+      var own = can.correctAny !== true;
+      return (error || "unknown") + (own ? " (only articles you published)" : "");
+    };
+
+    // Three parts that keep somebody's hands on the keyboard when state arrives mid-sentence.
+    // **The editor is not rebuilt.** Rebuilding keeps the text (it is in `editing.values`) but
+    // loses **the caret and the undo history** — and state arrives when anybody publishes, which
+    // is indistinguishable from the middle of a sentence. `editorFor` reuses the node, `syncEditor`
+    // changes only state, and `focusMemo` / `restoreFocus` carry the caret: `replaceChildren()`
+    // detaches the focused element, so re-appending the same node is not enough on its own.
+    var syncEditor = function () {
+      if (editing === null || !editing.node) return;
+      var saving = editing.saving === true;
+      Object.keys(editing.nodes).forEach(function (key) { editing.nodes[key].disabled = saving; });
+      editing.saveBtn.textContent = saving ? "Saving…" : "Save";
+      editing.saveBtn.disabled = saving;
+      editing.cancelBtn.disabled = saving;
+      editing.msgNode.textContent = editing.msg || "";
+      editing.msgNode.className = editing.bad ? "msg bad" : "msg";
+      editing.msgNode.hidden = !editing.msg;
+    };
+
+    var focusMemo = function () {
+      if (editing === null || !editing.nodes) return null;
+      var active = document.activeElement;
+      var found = null;
+      Object.keys(editing.nodes).forEach(function (key) { if (editing.nodes[key] === active) found = key; });
+      if (found === null) return null;
+      return { key: found, start: active.selectionStart, end: active.selectionEnd };
+    };
+
+    var restoreFocus = function (memo) {
+      if (memo === null || editing === null || !editing.nodes) return;
+      var node = editing.nodes[memo.key];
+      if (!node || node.disabled) return;
+      node.focus();
+      if (typeof memo.start === "number" && typeof node.setSelectionRange === "function") node.setSelectionRange(memo.start, memo.end);
+    };
+
+    /** Reuse, or build. Rebuilt only when the set of writable fields changes — a status can move,
+     *  and `correctFrom` moves with it. */
+    var editorFor = function (record, fields, can) {
+      var keys = fields.map(function (f) { return f.key; }).join(",");
+      // The record is replaced every time. What is reused is the FIELDS, not the baseline they are
+      // compared against — against a stale record, a field somebody else corrected reads as
+      // unchanged and is dropped from the write.
+      editing.record = record;
+      editing.can = can;
+      editing.fields = fields;
+      if (editing.node && editing.keys === keys) {
+        syncEditor();
+        return editing.node;
+      }
+
+      var box = el("div", "editor");
+      editing.nodes = {};
+      editing.keys = keys;
+      fields.forEach(function (f) {
+        var wrap = el("div", "field");
+        wrap.appendChild(el("label", null, f.label));
+        var node;
+        if (f.kind === "text") {
+          node = document.createElement("input");
+          node.type = "text";
+        } else {
+          node = document.createElement("textarea");
+          if (f.kind === "body") node.className = "body";
+          else node.rows = 2;
+        }
+        node.value = editing.values[f.key] != null ? editing.values[f.key] : String(record[f.key] || "");
+        node.oninput = function () { editing.values[f.key] = node.value; };
+        editing.nodes[f.key] = node;
+        wrap.appendChild(node);
+        box.appendChild(wrap);
+      });
+
+      var actions = el("div", "actions");
+      var save = el("button", "btn small", "Save");
+      save.type = "button";
+      var cancel = el("button", "btn ghost small", "Cancel");
+      cancel.type = "button";
+      actions.appendChild(save);
+      actions.appendChild(cancel);
+      box.appendChild(actions);
+      var msg = el("p", "msg");
+      box.appendChild(msg);
+
+      editing.node = box;
+      editing.saveBtn = save;
+      editing.cancelBtn = cancel;
+      editing.msgNode = msg;
+
+      cancel.onclick = function () { editing = null; renderList(); };
+
+      save.onclick = function () {
+        var record = editing.record;
+        var can = editing.can;
+        // Only what changed. Sending everything rewrites fields nobody touched.
+        var changed = {};
+        var any = false;
+        editing.fields.forEach(function (f) {
+          var was = String(record[f.key] || "");
+          var now = editing.values[f.key] != null ? editing.values[f.key] : was;
+          if (now !== was) { changed[f.key] = now; any = true; }
+        });
+        if (!any) { editing.msg = "Nothing has changed."; editing.bad = false; syncEditor(); return; }
+
+        var over = overLong(changed);
+        if (over.length > 0) { editing.msg = overLongMessage(over); editing.bad = true; syncEditor(); return; }
+
+        editing.saving = true;
+        editing.msg = "";
+        syncEditor();
+        view.correct("articles", record.id, changed).then(function (res) {
+          if (editing === null) return;
+          if (res && res.ok) { editing = null; renderList(); return; }
+          editing.saving = false;
+          if (res && res.error === "cancelled") { editing.msg = ""; syncEditor(); return; }
+          editing.msg = "Could not save: " + refusalNote(can, res && res.error) + ". Nothing was written.";
+          editing.bad = true;
+          syncEditor();
+        });
+      };
+
+      syncEditor();
+      return box;
+    };
+
+    // ---- The list ----
+    var renderList = function () {
+      var can = capOf();
+      var all = rows();
+      // Taken before anything is detached; put back after the editor is appended, at the end.
+      var memo = focusMemo();
+      list.replaceChildren();
+
+      // The article being rewritten may be gone (its author deleted it).
+      if (editing !== null && !all.some(function (r) { return r.id === editing.id; })) editing = null;
+
+      // Clear the "are you sure?" of an article that no longer exists. Left behind, it reappears
+      // open on whatever is published under that URL name next.
+      var living = {};
+      all.forEach(function (r) { living[r.id] = true; });
+      Object.keys(arming).forEach(function (id) { if (living[id] !== true) delete arming[id]; });
+
+      if (!all.length) {
+        list.appendChild(el("p", "note", "Nothing published yet."));
+        return;
+      }
+
+      // Say the third state out loud, not only in the code: while it holds, the controls are on
+      // every row, which contradicts what the panel above promises.
+      if (!isDesk() && mineIds() === null) {
+        list.appendChild(el("p", "note", "The host has not yet said which of these are yours. Until it does the controls appear on every row, but the rules will refuse anything that is not your article."));
+      }
+
+      all.forEach(function (r) {
+        var row = el("div", "row");
+        var main = el("div");
+        main.appendChild(el("div", "t", r.title || r.id));
+        var bits = [];
+        if (r.publishedAt) bits.push(when(r.publishedAt));
+        bits.push(r.id);
+        if (r.tags) bits.push(r.tags);
+        main.appendChild(el("div", "m", bits.join("  ·  ")));
+        row.appendChild(main);
+
+        var side = el("div", "side");
+        var reachable = reaches(r.id);
+        var fields = reachable ? editableFields(can, r.status) : [];
+        var open = editing !== null && editing.id === r.id;
+
+        if (fields.length > 0) {
+          var edit = el("button", "btn ghost small", open ? "Close" : "Rewrite");
+          edit.type = "button";
+          edit.onclick = function () {
+            // One at a time. Two open editors are two half-written articles.
+            editing = open ? null : { id: r.id, values: {}, saving: false, msg: "", bad: false };
+            renderList();
+          };
+          side.appendChild(edit);
+        }
+
+        if (reachable && mayWithdraw(can, r.status)) {
+          if (arming[r.id]) {
+            side.appendChild(el("span", "confirm", "Deleting this cannot be undone. Sure?"));
+            var yes = el("button", "btn danger small", "Delete");
+            yes.type = "button";
+            yes.onclick = function () {
+              yes.disabled = true;
+              view.withdraw("articles", r.id).then(function (res) {
+                delete arming[r.id];
+                if (!res || !res.ok) {
+                  yes.disabled = false;
+                  if (res && res.error === "cancelled") { renderList(); return; }
+                  main.appendChild(el("div", "m", "Could not delete: " + refusalNote(can, res && res.error)));
+                  return;
+                }
+                renderList();
+              });
+            };
+            var no = el("button", "btn ghost small", "Keep");
+            no.type = "button";
+            no.onclick = function () { delete arming[r.id]; renderList(); };
+            side.appendChild(yes);
+            side.appendChild(no);
+          } else {
+            var del = el("button", "btn ghost small", "Delete");
+            del.type = "button";
+            del.onclick = function () { arming[r.id] = true; renderList(); };
+            side.appendChild(del);
+          }
+        }
+
+        row.appendChild(side);
+        if (open) row.className = "row editing";
+        list.appendChild(row);
+        if (open) list.appendChild(editorFor(r, fields, can));
+      });
+
+      restoreFocus(memo);
+    };
+
+    if (!view) {
+      composeNote.textContent = "This page only runs inside the host. Open it at /p/field-notes (whoever set the magazine up can also use /m/field-notes).";
+      return;
+    }
+
+    view.onState(function (data, viewer) {
+      latest = { data: data || {}, viewer: viewer || {} };
+      renderCompose();
+      renderList();
+    });
+    // OUTSIDE `onState`. Called from inside it, it is never called at all.
+    view.ready();
+  })();
+</script>
+```
+
+## Why the shape is this way — the seven decisions
+
+### 1. The owner has to demote themselves, and that is not a workaround
+
+`members` gives the owner `"*": "owner"` **and** `"articles": "participant"`. It looks like a
+mistake and it is the only shape that works. Three declarations chain:
+
+- A role is resolved **per collection first**: `held[cid] ?? held["*"]`. So the entry under
+  `articles` wins over the app-wide one, and on this collection the owner is a participant.
+- `audience: "participant"` forces `submitOnly: true` — publish refuses the pair without it.
+- `submitOnly` **closes the writer branch of the rules**. An owner or editor normally creates rows
+  through that branch, bypassing the public-create path entirely. With it closed, the only way in
+  is the public-create path, and that path checks `r == "participant"`.
+
+So an owner who keeps `"*": "owner"` alone on this collection **cannot publish an article at all**.
+Demoting themselves is what buys the byte caps: the caps are held by publish and by the host and by
+no rule, which is worthless against a stranger and sufficient against people the owner invited by
+name.
+
+What it costs is real and worth stating in the app's own pages: **nobody can correct or delete
+anybody else's article**, the owner included. If you want a chief editor, give one member
+`"articles": "editor"` — `correctAny` and `withdrawAny` appear in `viewer.can`, and the pages here
+already read both, so no page changes.
+
+### 2. The index has a price, and publish knows the number
+
+`limit` times the sum of the caps on **every field the article view draws** must stay under
+1,000,000 bytes. Here: 10 × (200 + 800 + 60000 + 100) = 611,000.
+
+**At least that**, not exactly. A rule cannot project a field away, so the index downloads whole
+records — the slug, the status, the stamp and everything else rides along uncounted. And the body
+is downloaded on the index **even though the index never draws it**.
+
+Two things follow. Raising `limit` to 16 puts this declaration at 977,600 — under the ceiling, and
+2% from being refused by the next cap somebody adds. And if you want a long-form body *and* a long
+index, the only real answer is a second collection carrying title and summary alone; there is no
+declaration that makes the index cheap.
+
+### 3. `protocol` is `2.0.0` here and `1.0.0` in every other template
+
+The floor says what a reader must understand to draw this app. Article views arrived in `2.0.0`,
+so an app with one has to say so; every other shape here keeps `1.0.0` because declaring a newer
+floor than you use makes older readers refuse an app they could have drawn perfectly well.
+
+Do not copy this line into an app that has no `article` view.
+
+### 4. The URL is the document id, so it is decided once
+
+`idFrom: "slug"` means the writer names the document. The rules check the grammar — lowercase
+letters, digits and hyphens, starting with a letter or digit, 64 characters — and then freeze it.
+A link that resolved once must go on resolving, so **there is no rename**: an article that needs a
+different address is a different article.
+
+The consequence people meet first is the **duplicate**. Creating over an existing id is refused,
+and what comes back is a bare `PERMISSION_DENIED` naming no field — indistinguishable, from the
+page, from not being on the roster. The desk holds every article (they are public), so it checks
+the name against the list *before sending* and says exactly that. Keep this if you copy the page:
+the refusal is otherwise the most confusing thing in the app.
+
+### 5. Two fields are the server's, and sending them is what breaks
+
+`publishedAt` (`stampField`) and `byUid` (`uidField`) must be listed in `createFields` — the rules
+refuse any key outside that list, and they require the record to carry the stamp — but **the page
+and the agent must never put a value in either**. The host fills them in at submission. This is the
+one part of the declaration that reads as though the writer should supply them, and both failures
+are silent-looking: a submission carrying a stamp is refused with no field named.
+
+Both are frozen afterwards, so `viewer.can.articles.frozen` lists them, and the desk builds its
+edit form by subtracting `frozen` rather than by knowing which fields those are.
+
+### 6. There is no draft, and no status can invent one
+
+Every row of `articles` is readable by the world, and a Firestore rule cannot hide a field. So a
+`status` of `draft` would not hide anything: the row is published the moment it exists. `status`
+has exactly one value here for that reason, and the app's own words say where work in progress
+goes — ordinary files, outside the app.
+
+If drafts genuinely matter, they need a **second collection** that the public cannot read, and a
+copy on publication. That is a different app, and a bigger one than it sounds.
+
+### 7. A byline is a name, not an identity
+
+`byline` is a string the writer types. No rule checks it, and `selfUpdate` lists it, so it can be
+changed at any time to anything. Two things follow.
+
+**Do not build a table of address to display name inside the page.** It is a second roster beside
+`app.json`, kept by hand, and it can only pretend to give a guarantee that `selfUpdate` hands
+straight back. Fill the field in from the signed-in address and let it be edited.
+
+**Never let an email address reach this field.** Everything in this collection is drawn to the
+whole world, forever. That is also why the publisher is recorded as `byUid` rather than through
+`emailField`: a uid cannot be printed as a name, and an address must not be.
+
+## Traps
+
+- **`manageCollection`'s `putItems` cannot write here.** `stampField` and `idFrom` together are
+  outside what it produces, and the refusal names no field. Creation is `useSharedApp`'s `submit`,
+  correction is `correct`, removal is `withdraw`.
+- **`viewer.mine` has three states, not two.** `null` means *nobody looked*, not *you have none* —
+  read as "none" it takes the controls off the reader's own articles. Draw every row in that state,
+  let the rules refuse, and say so on the page; the desk here does all three.
+- **Do not rebuild an open editor.** State arrives whenever anybody publishes, which is
+  indistinguishable from the middle of somebody's sentence. Keeping the typed text is not enough:
+  `replaceChildren()` detaches the focused element, so the caret and the undo history go too.
+- **`view.open` is the only way out of the frame.** The page is sandboxed with scripts and nothing
+  else — a link does nothing, and so does a popup. The promise usually never settles, because the
+  navigation destroys the document; **settling means it did not happen**, and only an explicit
+  `opened === false` should be drawn as a failure.
+- **`ready()` goes outside `onState`.** Inside it, nothing is ever sent and the page waits forever.
+- **No `<form>`, no `alert` / `confirm` / `prompt`.** Both are absent from the sandbox and both
+  fail by doing nothing at all. A destructive action asks its question by drawing it, as the
+  delete confirmation here does.
+- **`slug` must not be the schema's `primaryKey`.** Publish refuses it: the rules can pin a
+  document id but not the value of a field. Keep `id` as the primary key and `slug` as an
+  ordinary field that `idFrom` reads.
+- **The index count is a page, not a total.** A public page is handed at most `limit` records and
+  is never told how many exist, so "10 articles" in a footer is a claim the page cannot make.
+
+## The order to build it in
+
+1. `manageSharedApp` `action: "init"` with the name and the slug. It writes `app.json`, mints the
+   `aid` and reserves the slug; never compose the declaration by hand.
+2. Write `.claude/skills/articles/schema.json`, then the `collections`, `views` and `public` blocks
+   above. Change `--hue` in both pages before you write anything else in them.
+3. `manageSharedApp` `action: "check"` — it runs the same gate publish runs.
+4. `manageSharedApp` `action: "preview"` for each page. It runs them in a real browser and reports
+   what happened; it writes nothing.
+5. `invite` each writer. A writer needs no repository and no account here — just the address on the
+   roster and a link to `/p/{slug}`.
+6. `publish`. The index is at `/a/{slug}`, an article at `/a/{slug}/{name}`, and the desk at
+   `/m/{slug}` for the owner and `/p/{slug}` for a writer.

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -547,8 +547,13 @@ is what draws the controls, so the page does not need to know which door it came
     var list = document.getElementById("list");
     var latest = null;
     var built = false;
-    var arming = {};    // id -> its delete confirmation is showing
-    var failed = {};    // id -> why its deletion was refused, kept until the row is pressed again
+    // KEYED BY ARTICLE ID, WITH NO PROTOTYPE. A URL name is lowercase letters, digits and
+    // hyphens — which makes `constructor`, `toString` and `hasOwnProperty` all valid article
+    // names. A plain object hands those back off Object.prototype, so before anything is ever
+    // stored, `arming["constructor"]` is a function: truthy. That article would draw its delete
+    // confirmation already armed, and a refusal message under a deletion nobody attempted.
+    var arming = Object.create(null); // id -> its delete confirmation is showing
+    var failed = Object.create(null); // id -> why its deletion was refused, until the row is pressed again
     // The article being rewritten, and what has been typed into it. `list` is rebuilt whenever
     // state arrives, so anything held inside it is thrown away the moment somebody else publishes.
     var editing = null; // { id, values, saving, msg, bad, node, nodes, keys, record, can, fields }
@@ -798,7 +803,7 @@ is what draws the controls, so the page does not need to know which door it came
       if (!Object.prototype.hasOwnProperty.call(mine, "articles")) return null;
       var rows = mine.articles;
       if (!Array.isArray(rows)) return null;
-      var ids = {};
+      var ids = Object.create(null);
       rows.forEach(function (r) {
         if (r && typeof r.id === "string") ids[r.id] = true;
       });
@@ -975,7 +980,7 @@ is what draws the controls, so the page does not need to know which door it came
 
       // Clear the "are you sure?" of an article that no longer exists. Left behind, it reappears
       // open on whatever is published under that URL name next.
-      var living = {};
+      var living = Object.create(null);
       all.forEach(function (r) { living[r.id] = true; });
       Object.keys(arming).forEach(function (id) { if (living[id] !== true) delete arming[id]; });
       Object.keys(failed).forEach(function (id) { if (living[id] !== true) delete failed[id]; });

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -748,14 +748,19 @@ is what draws the controls, so the page does not need to know which door it came
             // have started the next article in these very boxes — and emptying them
             // unconditionally destroys it with **nowhere to recover it from**, since this app
             // has no drafts. A box somebody has moved on from is left exactly as they left it.
-            var clearIfSent = function (node, sent) {
-              if (String(node.value).trim() !== String(sent).trim()) return;
+            // Compared through THE SAME TRANSFORM THAT PRODUCED THE SENT VALUE — the one-line
+            // fields were trimmed on the way out, the body was not. Trimming the body here
+            // instead would erase a newer draft that differs from the published one only in
+            // leading or trailing whitespace, and in Markdown that is not nothing: a trailing
+            // blank line ends a list, and leading spaces open a code block.
+            var clearIfSent = function (node, sent, trimmed) {
+              if ((trimmed ? String(node.value).trim() : String(node.value)) !== String(sent)) return;
               node.value = "";
             };
-            clearIfSent(title, written.title);
-            clearIfSent(summary, written.summary);
-            clearIfSent(tags, written.tags);
-            clearIfSent(body, written.body);
+            clearIfSent(title, written.title, true);
+            clearIfSent(summary, written.summary, true);
+            clearIfSent(tags, written.tags, true);
+            clearIfSent(body, written.body, false);
             // The URL name is compared through `slugify`, because the box holds what was typed
             // and `name` is what that resolved to.
             if (slugify(slug.value) === name) { slug.value = ""; slugTouched = false; }

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -727,8 +727,22 @@ is what draws the controls, so the page does not need to know which door it came
           post.disabled = false;
           if (res && res.ok) {
             say("Published. It is readable at /a/field-notes/" + name + ".");
-            title.value = ""; summary.value = ""; tags.value = ""; body.value = ""; slug.value = "";
-            slugTouched = false;
+            // FIELD BY FIELD, and only where the box still holds what was just published. Only
+            // the button is disabled while the write is in flight, so the writer may already
+            // have started the next article in these very boxes — and emptying them
+            // unconditionally destroys it with **nowhere to recover it from**, since this app
+            // has no drafts. A box somebody has moved on from is left exactly as they left it.
+            var clearIfSent = function (node, sent) {
+              if (String(node.value).trim() !== String(sent).trim()) return;
+              node.value = "";
+            };
+            clearIfSent(title, written.title);
+            clearIfSent(summary, written.summary);
+            clearIfSent(tags, written.tags);
+            clearIfSent(body, written.body);
+            // The URL name is compared through `slugify`, because the box holds what was typed
+            // and `name` is what that resolved to.
+            if (slugify(slug.value) === name) { slug.value = ""; slugTouched = false; }
             return;
           }
           if (res && res.error === "cancelled") { say(""); return; }
@@ -1064,7 +1078,7 @@ is what draws the controls, so the page does not need to know which door it came
 </script>
 ```
 
-## Why the shape is this way — the seven decisions
+## Why the shape is this way — the nine decisions
 
 ### 1. The owner has to demote themselves, and that is not a workaround
 

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -125,7 +125,8 @@ the more surprising one to discover you do not have.
           "title": 200,
           "summary": 800,
           "body": 60000,
-          "byline": 100
+          "byline": 100,
+          "tags": 200
         },
         "selfUpdate": {
           "published": ["title", "summary", "body", "tags", "byline"]
@@ -137,7 +138,7 @@ the more surprising one to discover you do not have.
   "agents": [
     {
       "id": "author",
-      "audience": "member",
+      "audience": "participant",
       "instruction": "You write for Field Notes. Publish with useSharedApp `action: \"submit\"` into the `articles` collection — `manageCollection`'s `putItems` cannot write here, and returns a PERMISSION_DENIED that names no field. `slug` is the article's URL name AND its document id: lowercase letters, digits and hyphens, starting with a letter or digit, 64 characters at most, and unique. The article is published at /a/field-notes/<slug> and the id is frozen, so choose a name a person could read aloud and never try to change it. `title` and `body` are required; `body` is Markdown and cannot carry images; `summary` is the two lines the index shows; `tags` is comma-separated; `status` is `published`. The caps are UTF-8 BYTES, not characters: title 200, summary 800, body 60000. Do not send `publishedAt` — the server stamps it and it is frozen. Do not send `byUid` — the host fills it in. DO fill in `byline` with the name you want printed: it is drawn under the title on the article page and at the foot of the card in the index, up to 100 bytes. It is a string you type, not an identity the rules check — who published is recorded in `byUid` — so NEVER put an email address in it; that field is drawn to the whole world. Publishing is instant and public: there is no draft in this app, so keep work in progress in drafts/*.md and submit when it is finished. Fix a typo with `action: \"update\"`, passing the article's `slug` as `id` and only the fields that change; never republish. You can only change articles this account published — everybody here is a peer and nobody can reach everybody's work. Withdrawing means deleting, and it cannot be undone. A person at this terminal does all of the same things from the desk at /m/field-notes."
     }
   ]
@@ -181,6 +182,13 @@ here would print every contributor's address beside their article forever.
 article, and may delete it. `slug` and `publishedAt` are absent from `selfUpdate` because they are
 frozen; that is not a policy in the page, it is the rules, and `viewer.can.<cid>.frozen` tells the
 page so.
+
+**Cap every field a writer can send, not only the ones the gate counts.** Publish computes the
+index cost from the fields the `article` block names — title, summary, body, byline — so `tags` is
+capped here for a reason the gate will never state: the desk sends it, the index draws it, and
+`overLong` in the page only checks fields the cap map mentions. Left out, it is the one field where
+a writer can put 900KB, and the index downloads whole records, so ten of those is a page load the
+611,000-byte calculation says nothing about.
 
 `limit.articles` — how many the index reads. Read the index-cost trap before raising it.
 
@@ -1228,7 +1236,10 @@ is accepted by the gate — it is the *page* that stops being correct, not the d
 
 - **`manageCollection`'s `putItems` cannot write here.** `stampField` and `idFrom` together are
   outside what it produces, and the refusal names no field. Creation is `useSharedApp`'s `submit`,
-  correction is `correct`, removal is `withdraw`.
+  correction is `update`, removal is `withdraw`. **The agent's action and the page's method are
+  not spelled the same**: `useSharedApp` exposes `submit` / `update` / `withdraw`, while the page
+  bridge has `submit` / `correct` / `withdraw`. `correct` is not a tool action, and an agent that
+  sends one is refused for naming an action that does not exist rather than for anything it asked.
 - **`viewer.mine` has three states, not two.** `null` means *nobody looked*, not *you have none* —
   read as "none" it takes the controls off the reader's own articles. Draw every row in that state,
   let the rules refuse, and say so on the page; the desk here does all three.
@@ -1246,6 +1257,13 @@ is accepted by the gate — it is the *page* that stops being correct, not the d
 - **`slug` must not be the schema's `primaryKey`.** Publish refuses it: the rules can pin a
   document id but not the value of a field. Keep `id` as the primary key and `slug` as an
   ordinary field that `idFrom` reads.
+- **A brief goes to the tier that WRITES.** `agents[]` entries are projected strictly by
+  `audience` (`agentsFor` filters on equality), and the writers here hold `articles: "participant"`
+  and nothing app-wide — so `audience: "member"` would publish the job to the owner alone and leave
+  every agent signed in as a writer with no standing instruction at all. `participant` publishes to
+  the roster, which is everyone the members list names, the owner included. It also matches what
+  the rules will allow: a member-audience brief on this collection describes a submission
+  `audience: "participant"` refuses.
 - **The index count is a page, not a total.** A public page is handed at most `limit` records and
   is never told how many exist, so "10 articles" in a footer is a claim the page cannot make.
 

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -790,6 +790,17 @@ is what draws the controls, so the page does not need to know which door it came
     };
 
     // ---- Rewriting what has been published ----
+    /** The fields `public.submit.articles.validate.required` names.
+     *
+     *  Restated here because no capability carries it, and because the rule it mirrors is WEAKER
+     *  THAN IT SOUNDS: `required` is checked on the update as well as the create, but what it
+     *  checks is `keys().hasAll(required)` — that the field is PRESENT. An empty string is
+     *  present. So the rules will happily accept a published article whose headline is "", and
+     *  the compose form's own check is the only thing standing between a writer and that. It has
+     *  to stand on the rewrite path too, or the guarantee lasts exactly as long as the first
+     *  edit. */
+    var REQUIRED = ["title", "body"];
+
     var EDITABLE = [
       { key: "title", label: "Headline", kind: "text" },
       { key: "summary", label: "Standfirst", kind: "area" },
@@ -962,6 +973,18 @@ is what draws the controls, so the page does not need to know which door it came
           if (now !== was) { changed[f.key] = now; any = true; }
         });
         if (!any) { editing.msg = "Nothing has changed."; editing.bad = false; syncEditor(); return; }
+
+        var emptied = editing.fields
+          .filter(function (f) {
+            return REQUIRED.indexOf(f.key) !== -1 && Object.prototype.hasOwnProperty.call(changed, f.key) && String(changed[f.key]).trim() === "";
+          })
+          .map(function (f) { return labelOf(f.key); });
+        if (emptied.length > 0) {
+          editing.msg = emptied.join(" and ") + " cannot be left empty. Nothing was sent.";
+          editing.bad = true;
+          syncEditor();
+          return;
+        }
 
         var over = overLong(changed);
         if (over.length > 0) { editing.msg = overLongMessage(over); editing.bad = true; syncEditor(); return; }
@@ -1257,6 +1280,13 @@ is accepted by the gate — it is the *page* that stops being correct, not the d
 - **`slug` must not be the schema's `primaryKey`.** Publish refuses it: the rules can pin a
   document id but not the value of a field. Keep `id` as the primary key and `slug` as an
   ordinary field that `idFrom` reads.
+- **`validate.required` is a PRESENCE check, and it is weaker than its name.** The rules apply it
+  to a correction as well as a creation — `validateOk` is on both branches, deliberately, so that a
+  writer cannot drop a required field on the way past — but what it asks is
+  `keys().hasAll(required)`. An empty string is present. So nothing in the declaration stops a
+  published article's headline from being rewritten to `""`, and a page that checks the compose
+  form and not the rewrite form holds the guarantee for exactly one edit. Both forms here refuse a
+  value that is only whitespace.
 - **A brief goes to the tier that WRITES.** `agents[]` entries are projected strictly by
   `audience` (`agentsFor` filters on equality), and the writers here hold `articles: "participant"`
   and nothing app-wide — so `audience: "member"` would publish the job to the owner alone and leave

--- a/server/skills/mulmoterminal-shared-app/templates/magazine.md
+++ b/server/skills/mulmoterminal-shared-app/templates/magazine.md
@@ -163,8 +163,15 @@ rules can pin a document id but cannot pin the value of a field.
 `stampField: "publishedAt"` — the server's clock, written by the rules as `request.time`. It has
 to be listed in `createFields` (the rules refuse any key outside that list, and they require the
 record to carry the stamp), but **the page and the agent must never send a value**: the host fills
-it in. The index sorts on it, and the page receives it as a `…Z` string whose lexical order is
-chronological.
+it in. The page receives it as a `…Z` string whose lexical order is chronological.
+
+**It is also what makes `limit` mean "the latest".** The window is built in the query, as
+`orderBy(stampField, "desc")` followed by `limit(rows)` — a cap on its own would take the first N
+by document id, which for a collection of articles is N slugs in alphabetical order and never the
+new one. That is why the stamp cannot be a field the author picks: a record missing the ordered
+field is not sorted last by Firestore, it is dropped from the query entirely. The page sorts what
+it was handed as well, which is not the same job — delivery order is not guaranteed, least of all
+on a subscription.
 
 `uidField: "byUid"` — the publisher's uid, filled in by the host for the same reason. A uid and
 not an email, because every field of this collection is readable by the world, and `emailField`
@@ -301,6 +308,10 @@ a list of cards that open one article each.
       return when.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
     };
 
+    // The host already handed these over newest-first — the window is `orderBy(publishedAt,
+    // "desc")` in the query, which is what makes `limit` mean the LATEST ten rather than ten
+    // slugs in alphabetical order. This sorts them again because the ORDER THEY ARRIVE IN is not
+    // promised, which matters the moment anything watches rather than reads once.
     var newestFirst = function (rows) {
       return rows.slice().sort(function (left, right) {
         return String(right && right.publishedAt || "").localeCompare(String(left && left.publishedAt || ""));

--- a/test/server/backends/skillTemplates.spec.ts
+++ b/test/server/backends/skillTemplates.spec.ts
@@ -13,7 +13,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
 import { declarationProblems } from "../../../server/backends/sharedApp/context.js";
-import { APP_PROTOCOL_BASE, parseAuthoredApp } from "@receptron/sharedapp";
+import { APP_PROTOCOL, APP_PROTOCOL_BASE, parseAuthoredApp } from "@receptron/sharedapp";
 import { modalCallIn } from "../../../server/backends/sharedApp/modalCall.js";
 import { formElementIn, readyNeverCalled } from "../../../server/backends/sharedApp/viewDefects.js";
 import { readdirSync } from "node:fs";
@@ -35,7 +35,17 @@ const TEMPLATE_FILES = readdirSync(TEMPLATES)
  *
  *  The removed board is named by its absence from the list below and by the git history, not in
  *  prose here: its first four letters are a task marker to `sonarjs`, and CI fails on them. */
-const EXPECTED_TEMPLATES = ["ai-council.md", "append-feed.md", "gym.md", "live-poll.md", "meeting-room.md", "project-board.md", "salon.md", "survey.md"];
+const EXPECTED_TEMPLATES = [
+  "ai-council.md",
+  "append-feed.md",
+  "gym.md",
+  "live-poll.md",
+  "magazine.md",
+  "meeting-room.md",
+  "project-board.md",
+  "salon.md",
+  "survey.md",
+];
 
 /** The hue as CSS reads it — a NUMBER, in which `25` and `25.0` are one colour and `0` and `360`
  *  are one angle. Compared as the raw strings they are written in, each of those pairs is two
@@ -122,6 +132,10 @@ describe("the shared-app templates", () => {
 
   it("ai-council.md deploys as written", () => {
     expect(problemsFor("ai-council.md", "host@example.com", [])).toEqual([]);
+  });
+
+  it("magazine.md deploys as written", () => {
+    expect(problemsFor("magazine.md", "editor@example.com", [])).toEqual([]);
   });
 
   it("shows no page the sandbox would silently break", () => {
@@ -234,8 +248,15 @@ describe("the shared-app templates", () => {
     // it refuse to draw on readers that could have drawn it perfectly well — the exact cost the
     // per-app stamp exists to avoid. A template that ships an article view will state its own.
     for (const file of TEMPLATE_FILES) {
-      const manifest = blocksOf(file).get("app.json") as Record<string, unknown> | undefined;
-      expect(`${file}: ${String(manifest?.protocol)}`).toBe(`${file}: ${APP_PROTOCOL_BASE}`);
+      const manifest = blocksOf(file).get("app.json") as { protocol?: unknown; views?: { article?: unknown }[] } | undefined;
+      // "A template that ships an article view will state its own" — the paragraph above, taken at
+      // its word. An `article` view is drawn by a reader that understands APP_PROTOCOL, so an app
+      // with one has to say so and an app without one must not: the floor is read off the FEATURES
+      // the declaration uses, never off which template it is. Derived here rather than listed,
+      // because a list of exceptions is the per-template number this test exists to refuse.
+      const drawsArticles = (manifest?.views ?? []).some((view) => view.article !== undefined);
+      const floor = drawsArticles ? APP_PROTOCOL : APP_PROTOCOL_BASE;
+      expect(`${file}: ${String(manifest?.protocol)}`).toBe(`${file}: ${floor}`);
     }
   });
 

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -214,6 +214,60 @@ describe("magazine.md — the desk", () => {
     expect(labels).not.toContain("URL name");
   });
 
+  it("names every field for a screen reader, in both forms", () => {
+    // Siblings are not a label relationship. Without `for`, all of these announce as "edit text,
+    // blank" — the form reads as five anonymous boxes, and the label is not a click target either.
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    document.querySelectorAll<HTMLButtonElement>("#list .btn.ghost")[0].click();
+
+    const controls = [
+      ...document.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>("#compose input, #compose textarea, .editor input, .editor textarea"),
+    ];
+    expect(controls).toHaveLength(11);
+    for (const control of controls) {
+      expect(`${control.id || "(no id)"}: ${control.labels?.length ?? 0} label(s)`).toBe(`${control.id}: 1 label(s)`);
+      expect(control.labels?.[0]?.textContent ?? "").not.toBe("");
+    }
+    // And the ids are unique, since one page builds both forms from the same helper.
+    expect(new Set(controls.map((control) => control.id)).size).toBe(controls.length);
+  });
+
+  it("drops a correction that comes back after the writer moved to another article", async () => {
+    // Only the fields being saved are disabled; the rows stay live. Read against the module
+    // variable, this completion closes the NEW editor on success or reports the old refusal into
+    // it — either way it lands on an article the answer has nothing to do with.
+    const page = load("views/desk.html");
+    page.tell([MINE, THEIRS], { me: "ada@example.com", can: CAN, mine: { articles: [{ id: MINE.id }, { id: THEIRS.id }] } });
+    // By label rather than by position: an open row shows Close beside its Delete, so an index
+    // into the ghost buttons lands on a different control once the first editor is open.
+    const rewrite = (): HTMLButtonElement => {
+      const found = [...document.querySelectorAll<HTMLButtonElement>("#list button")].find((button) => button.textContent === "Rewrite");
+      if (found === undefined) throw new Error("no Rewrite button");
+      return found;
+    };
+    rewrite().click();
+    const first = document.querySelector<HTMLTextAreaElement>(".editor textarea.body");
+    if (first === null) throw new Error("no body field");
+    first.value = "the first one";
+    first.dispatchEvent(new Event("input"));
+    document.querySelector<HTMLButtonElement>(".editor .btn")?.click();
+
+    // The writer gives up waiting and opens the other article — the only Rewrite still showing.
+    rewrite().click();
+    const second = document.querySelector<HTMLTextAreaElement>(".editor textarea.body");
+    if (second === null) throw new Error("no second body field");
+    second.value = "the second one";
+    second.dispatchEvent(new Event("input"));
+
+    page.answer({ ok: false, error: "PERMISSION_DENIED" });
+    await settle();
+
+    // The second editor is untouched: still open, still holding what was typed, no error in it.
+    expect(document.querySelector<HTMLTextAreaElement>(".editor textarea.body")?.value).toBe("the second one");
+    expect(document.querySelector(".editor .msg")?.textContent).toBe("");
+  });
+
   it("keeps the caret in a half-written article when somebody else publishes", () => {
     const page = load("views/desk.html");
     page.tell([MINE], viewerWhoOwns);

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -315,6 +315,23 @@ describe("magazine.md — the desk", () => {
     expect(document.querySelector("#compose .msg")?.textContent).toContain(`Tags is ${cap + 1} bytes, over the limit of ${cap}`);
   });
 
+  it("refuses to blank a required field on the rewrite path", async () => {
+    // `validate.required` is checked on the update too, but it asks `keys().hasAll(required)` —
+    // presence, not content. An empty string is present, so the rules accept a headline of "".
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    document.querySelectorAll<HTMLButtonElement>("#list button")[0].click();
+    const headline = document.querySelector<HTMLInputElement>(".editor input");
+    if (headline === null) throw new Error("no headline field");
+    headline.value = "   ";
+    headline.dispatchEvent(new Event("input"));
+    document.querySelector<HTMLButtonElement>(".editor .btn")?.click();
+    await settle();
+
+    expect(page.calls.filter((call) => call.kind === "correct")).toEqual([]);
+    expect(document.querySelector(".editor .msg")?.textContent).toContain("Headline cannot be left empty");
+  });
+
   it("names every field for a screen reader, in both forms", () => {
     // Siblings are not a label relationship. Without `for`, all of these announce as "edit text,
     // blank" — the form reads as five anonymous boxes, and the label is not a click target either.

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -332,6 +332,29 @@ describe("magazine.md — the desk", () => {
     expect(document.querySelector(".editor .msg")?.textContent).toContain("Headline cannot be left empty");
   });
 
+  it("announces what happened, rather than only showing it", async () => {
+    // Focus stays on the button that was pressed while the text of a <p> changes. Without a live
+    // region a screen reader says nothing — not the refusal, not that the article went out.
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+
+    const composeMsg = document.querySelector("#compose .msg");
+    expect(composeMsg?.getAttribute("role")).toBe("status");
+    expect(composeMsg?.getAttribute("aria-live")).toBe("polite");
+
+    document.querySelectorAll<HTMLButtonElement>("#list button")[0].click();
+    const editorMsg = document.querySelector(".editor .msg");
+    expect(editorMsg?.getAttribute("role")).toBe("status");
+    expect(editorMsg?.getAttribute("aria-live")).toBe("polite");
+
+    // The deletion refusal is the same problem with an extra turn: its row is REBUILT, and an
+    // element inserted after the fact is not announced. So it also lands in a node that persists.
+    const listStatus = document.getElementById("listStatus");
+    expect(listStatus?.getAttribute("role")).toBe("status");
+    expect(listStatus?.getAttribute("aria-live")).toBe("polite");
+    expect(listStatus?.hidden).toBe(true);
+  });
+
   it("names every field for a screen reader, in both forms", () => {
     // Siblings are not a label relationship. Without `for`, all of these announce as "edit text,
     // blank" — the form reads as five anonymous boxes, and the label is not a click target either.

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -238,6 +238,26 @@ describe("magazine.md — the desk", () => {
     expect(inputs[1].value).toBe("");
   });
 
+  it("keeps a body that differs from the published one only in whitespace", async () => {
+    // The body is sent untrimmed, so it has to be compared untrimmed. Markdown makes the
+    // difference real: a trailing blank line closes a list, leading spaces open a code block.
+    const page = load("views/desk.html");
+    page.tell([], viewerWhoOwns);
+    const inputs = document.querySelectorAll<HTMLInputElement>("#compose input");
+    const areas = document.querySelectorAll<HTMLTextAreaElement>("#compose textarea");
+    inputs[0].value = "A piece";
+    areas[1].value = "- one\n- two";
+    document.querySelector<HTMLButtonElement>("#compose .btn")?.click();
+
+    // Still in flight: the writer starts the next draft from the same text plus a blank line.
+    areas[1].value = "- one\n- two\n";
+    await settle();
+
+    expect(areas[1].value).toBe("- one\n- two\n");
+    // The headline WAS what was sent, so that box is cleared — the two halves are independent.
+    expect(inputs[0].value).toBe("");
+  });
+
   it("survives an article whose URL name is a property of Object.prototype", () => {
     // `constructor`, `toString` and `hasOwnProperty` are all lowercase-and-letters, so all three
     // are valid URL names. Off a plain object they come back as inherited FUNCTIONS — truthy — so

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -111,14 +111,31 @@ function load(heading: string, open?: { opened: boolean }): Loaded {
   };
 }
 
+/** The submit declaration out of the template's OWN `app.json` block.
+ *
+ *  Read rather than restated, and that distinction had teeth: with the caps written out here, a
+ *  test for the `tags` bound passed while the declaration capped nothing — the page was being
+ *  handed a cap this file invented. What the host projects into `viewer.can` comes from the
+ *  declaration, so the test has to come from there too or it is checking itself. */
+const submitDecl = (): { maxBytes: Record<string, number>; selfUpdate: Record<string, string[]>; selfDelete: string[] } => {
+  const [, json] = /^## app\.json\n\n```json\n([\s\S]*?)\n```/m.exec(template) ?? [];
+  const app = JSON.parse(json ?? "{}") as { public?: { submit?: Record<string, never> } };
+  const submit = app.public?.submit?.articles as unknown as
+    { maxBytes: Record<string, number>; selfUpdate: Record<string, string[]>; selfDelete: string[] } | undefined;
+  if (submit === undefined) throw new Error("the template's app.json declares no public.submit.articles");
+  return submit;
+};
+
+const DECL = submitDecl();
+
 const CAN = {
   articles: {
-    correctFrom: { published: ["title", "summary", "body", "tags", "byline"] },
+    correctFrom: DECL.selfUpdate,
     correctAny: false,
-    withdrawFrom: ["published"],
+    withdrawFrom: DECL.selfDelete,
     withdrawAny: false,
     frozen: ["slug", "publishedAt", "byUid", "status"],
-    maxBytes: { title: 200, summary: 800, body: 60000, byline: 100 },
+    maxBytes: DECL.maxBytes,
   },
 };
 
@@ -275,6 +292,27 @@ describe("magazine.md — the desk", () => {
     expect(document.querySelector("#list .m.bad")).toBeNull();
     expect(document.querySelector("#list .confirm")).toBeNull();
     expect(buttons("#list button")).toEqual(["Rewrite", "Delete", "Rewrite", "Delete", "Rewrite", "Delete"]);
+  });
+
+  it("bounds every field the declaration caps, tags included", async () => {
+    // `overLong` only checks fields the cap map mentions, so a field left out of `maxBytes` is
+    // unbounded in a collection whose index downloads whole records.
+    // Every field the compose form sends, against the declaration itself.
+    expect(Object.keys(DECL.maxBytes).sort()).toEqual(["body", "byline", "summary", "tags", "title"]);
+
+    const cap = DECL.maxBytes.tags;
+    const page = load("views/desk.html");
+    page.tell([], viewerWhoOwns);
+    const inputs = document.querySelectorAll<HTMLInputElement>("#compose input");
+    const areas = document.querySelectorAll<HTMLTextAreaElement>("#compose textarea");
+    inputs[0].value = "A piece";
+    inputs[2].value = "x".repeat(cap + 1);
+    areas[1].value = "text";
+    document.querySelector<HTMLButtonElement>("#compose .btn")?.click();
+    await settle();
+
+    expect(page.calls.filter((call) => call.kind === "submit")).toEqual([]);
+    expect(document.querySelector("#compose .msg")?.textContent).toContain(`Tags is ${cap + 1} bytes, over the limit of ${cap}`);
   });
 
   it("names every field for a screen reader, in both forms", () => {

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+//
+// The two pages of `magazine.md`, RUN rather than read.
+//
+// `skillTemplates.spec.ts` holds the template to the real declaration gate. What it cannot reach is
+// whether the pages DO what the template says they do, and every claim this shape makes is
+// behavioural:
+//
+//   THE URL NAME IS THE DOCUMENT ID, so the same one cannot be created twice — and the refusal
+//   that comes back names no field, which from the page is indistinguishable from not being on the
+//   roster. The desk holds every article, so it must say so BEFORE sending.
+//
+//   TWO FIELDS ARE THE SERVER'S. `publishedAt` and `byUid` are in `createFields` because the rules
+//   demand it, and a submission that CARRIES either is refused with nothing named. The one part of
+//   the declaration that reads as though the page should fill them in.
+//
+//   `viewer.mine` HAS THREE STATES. `null` is "nobody looked", not "you have none"; read as "none"
+//   it takes the controls off the reader's own articles, so the page draws every row and says why.
+//
+//   AN OPEN EDITOR IS NOT REBUILT. State arrives whenever anybody publishes, which is
+//   indistinguishable from the middle of a sentence. Keeping the typed text is not enough:
+//   `replaceChildren()` detaches the focused element, so the caret goes with it.
+//
+//   A CLICK THAT GOES NOWHERE. Nothing can link out of this frame, so `view.open` is the only exit
+//   and its promise normally never settles — settling means it did NOT happen.
+//
+//   A COUNT ON A PUBLIC PAGE IS A PAGE, NOT A TOTAL. The index is handed at most `limit` records
+//   and is never told how many exist.
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Through Vite rather than `node:fs`: this spec belongs to the DOM-typed project, which carries no
+// node globals — the same reason the other template specs read their template this way.
+import template from "../../server/skills/mulmoterminal-shared-app/templates/magazine.md?raw";
+
+/** The html block under the template's page heading — the same mapping the other template specs
+ *  read, so a renamed section fails here rather than silently testing nothing. */
+function pageOf(heading: string): string {
+  const lines = template.split("\n");
+  const start = lines.findIndex((line) => /^#{2,3} /.test(line) && line.replace(/^#{2,3} /, "").startsWith(heading));
+  expect(`${heading}: ${start === -1 ? "no section" : "has a section"}`).toBe(`${heading}: has a section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^#{2,3} /.test(line));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join("\n");
+  const [, html] = body.match(/```html\n([\s\S]*?)\n```/) ?? [];
+  expect(`${heading}: ${html === undefined ? "no html" : "has html"}`).toBe(`${heading}: has html`);
+  return html ?? "";
+}
+
+type Row = Record<string, unknown> & { id: string };
+type Answer = { ok: boolean; error?: string };
+
+interface Call {
+  kind: string;
+  cid: string;
+  id?: string;
+  values?: Record<string, unknown>;
+}
+
+interface Loaded {
+  tell: (rows: Row[], viewer: Record<string, unknown>) => void;
+  calls: Call[];
+  answer: (result: Answer) => void;
+}
+
+/** The page, with the host it talks to. `correct` is left PENDING on purpose: the saving state is
+ *  one of the things under test, and a promise that settles inside the click cannot be observed. */
+function load(heading: string, open?: { opened: boolean }): Loaded {
+  const html = pageOf(heading);
+  document.body.innerHTML = html.replace(/<script>[\s\S]*?<\/script>/, "");
+  const [, script] = html.match(/<script>\n([\s\S]*?)\n<\/script>/) ?? [];
+  const calls: Call[] = [];
+  let onState: ((data: unknown, viewer: unknown) => void) | null = null;
+  let answer: (result: Answer) => void = () => {};
+  const record =
+    (kind: string) =>
+    (cid: string, ...rest: unknown[]): Promise<unknown> => {
+      const [second, third] = rest;
+      calls.push({
+        kind,
+        cid,
+        ...(typeof second === "string" ? { id: second } : {}),
+        ...(typeof second === "object" && second !== null ? { values: second as Record<string, unknown> } : {}),
+        ...(typeof third === "object" && third !== null ? { values: third as Record<string, unknown> } : {}),
+      });
+      if (kind === "correct")
+        return new Promise((resolve) => {
+          answer = resolve as (result: Answer) => void;
+        });
+      return Promise.resolve({ ok: true });
+    };
+  Reflect.set(window, "__MC_APP_VIEW", {
+    onState: (callback: (data: unknown, viewer: unknown) => void) => {
+      onState = callback;
+    },
+    ready: () => {},
+    submit: record("submit"),
+    correct: record("correct"),
+    withdraw: record("withdraw"),
+    open: (cid: string, id: string) => {
+      calls.push({ kind: "open", cid, id });
+      return Promise.resolve(open ?? { opened: true });
+    },
+  });
+  // eslint-disable-next-line sonarjs/code-eval -- the source is a file in this repository, read at test time
+  new Function(script ?? "")();
+  expect(onState === null ? "never registered" : "registered").toBe("registered");
+  return {
+    tell: (rows, viewer) => (onState as unknown as (data: unknown, viewer: unknown) => void)({ articles: rows }, viewer),
+    calls,
+    answer: (result) => answer(result),
+  };
+}
+
+const CAN = {
+  articles: {
+    correctFrom: { published: ["title", "summary", "body", "tags", "byline"] },
+    correctAny: false,
+    withdrawFrom: ["published"],
+    withdrawAny: false,
+    frozen: ["slug", "publishedAt", "byUid", "status"],
+    maxBytes: { title: 200, summary: 800, body: 60000, byline: 100 },
+  },
+};
+
+const MINE: Row = {
+  id: "why-deploys-slowed",
+  title: "Why deploys slowed",
+  body: "text",
+  status: "published",
+  publishedAt: "2026-03-04T09:00:00.000000000Z",
+  byline: "ada",
+};
+const THEIRS: Row = {
+  id: "the-other-one",
+  title: "The other one",
+  body: "text",
+  status: "published",
+  publishedAt: "2026-03-05T09:00:00.000000000Z",
+  byline: "grace",
+};
+
+const viewerWhoOwns = { me: "Ada.Lovelace@example.com", can: CAN, mine: { articles: [{ id: MINE.id }] } };
+const viewerUnanswered = { me: "ada@example.com", can: CAN };
+
+const buttons = (selector: string): string[] => [...document.querySelectorAll(selector)].map((node) => node.textContent ?? "");
+const settle = async (): Promise<void> => {
+  for (let turn = 0; turn < 8; turn += 1) await Promise.resolve();
+};
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("magazine.md — the desk", () => {
+  it("fills the byline in from the address without locking it, and never publishes the address", () => {
+    // The template's own argument: a table of address to display name is a second roster kept by
+    // hand, and it can only pretend to give a guarantee `selfUpdate` hands straight back.
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    const byline = document.querySelectorAll<HTMLInputElement>("#compose input")[3];
+    expect(byline?.value).toBe("Ada.Lovelace");
+    expect(byline?.disabled).toBe(false);
+    expect(document.body.textContent).not.toContain("@example.com");
+  });
+
+  it("draws the controls on the reader's own article and on nobody else's", () => {
+    const page = load("views/desk.html");
+    page.tell([MINE, THEIRS], viewerWhoOwns);
+    expect(buttons("#list button")).toEqual(["Rewrite", "Delete"]);
+    expect(document.querySelector("#list .note")).toBeNull();
+  });
+
+  it("draws them on every row while nobody has looked, and says so", () => {
+    // The third state. Read as "you have none", this takes the controls off the reader's OWN work.
+    const page = load("views/desk.html");
+    page.tell([MINE, THEIRS], viewerUnanswered);
+    expect(buttons("#list button")).toEqual(["Rewrite", "Delete", "Rewrite", "Delete"]);
+    expect(document.querySelector("#list .note")?.textContent).toContain("has not yet said which of these are yours");
+  });
+
+  it("refuses a URL name that is taken before anything is sent", () => {
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    const inputs = document.querySelectorAll<HTMLInputElement>("#compose input");
+    const areas = document.querySelectorAll<HTMLTextAreaElement>("#compose textarea");
+    inputs[0].value = "Why deploys slowed, again";
+    inputs[1].value = MINE.id;
+    areas[1].value = "text";
+    document.querySelector<HTMLButtonElement>("#compose .btn")?.click();
+    expect(page.calls.filter((call) => call.kind === "submit")).toEqual([]);
+    expect(document.querySelector("#compose .msg")?.textContent).toContain(`The URL name ${MINE.id} is already taken`);
+  });
+
+  it("sends neither the server's stamp nor the publisher's uid", async () => {
+    const page = load("views/desk.html");
+    page.tell([], viewerWhoOwns);
+    const inputs = document.querySelectorAll<HTMLInputElement>("#compose input");
+    const areas = document.querySelectorAll<HTMLTextAreaElement>("#compose textarea");
+    inputs[0].value = "A new one";
+    areas[1].value = "text";
+    document.querySelector<HTMLButtonElement>("#compose .btn")?.click();
+    await settle();
+    const [sent] = page.calls.filter((call) => call.kind === "submit");
+    expect(Object.keys(sent?.values ?? {}).sort()).toEqual(["body", "byline", "slug", "summary", "tags", "title"]);
+    expect(sent?.values?.slug).toBe("a-new-one");
+  });
+
+  it("offers no field the rules have frozen", () => {
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    document.querySelectorAll<HTMLButtonElement>("#list .btn.ghost")[0].click();
+    const labels = [...document.querySelectorAll(".editor label")].map((node) => node.textContent);
+    expect(labels).toEqual(["Headline", "Standfirst", "Tags (comma separated)", "Byline", "Body (Markdown)"]);
+    expect(labels).not.toContain("URL name");
+  });
+
+  it("keeps the caret in a half-written article when somebody else publishes", () => {
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    document.querySelectorAll<HTMLButtonElement>("#list .btn.ghost")[0].click();
+    const before = document.querySelector<HTMLTextAreaElement>(".editor textarea.body");
+    if (before === null) throw new Error("no body field");
+    before.value = "half a sentence";
+    before.dispatchEvent(new Event("input"));
+    before.focus();
+    before.setSelectionRange(4, 4);
+
+    page.tell([MINE, THEIRS], viewerWhoOwns);
+
+    const after = document.querySelector<HTMLTextAreaElement>(".editor textarea.body");
+    expect(after).toBe(before);
+    expect(after?.value).toBe("half a sentence");
+    expect(document.activeElement).toBe(after);
+    expect(after?.selectionStart).toBe(4);
+  });
+
+  it("reports a refused correction in place, sending only what changed", async () => {
+    const page = load("views/desk.html");
+    page.tell([MINE], viewerWhoOwns);
+    document.querySelectorAll<HTMLButtonElement>("#list .btn.ghost")[0].click();
+    const body = document.querySelector<HTMLTextAreaElement>(".editor textarea.body");
+    if (body === null) throw new Error("no body field");
+    body.value = "rewritten";
+    body.dispatchEvent(new Event("input"));
+    document.querySelector<HTMLButtonElement>(".editor .btn")?.click();
+
+    const [sent] = page.calls.filter((call) => call.kind === "correct");
+    expect(sent?.id).toBe(MINE.id);
+    expect(sent?.values).toEqual({ body: "rewritten" });
+    expect(body.disabled).toBe(true);
+
+    page.answer({ ok: false, error: "PERMISSION_DENIED" });
+    await settle();
+    expect(document.querySelector(".editor .msg")?.textContent).toContain("PERMISSION_DENIED");
+    expect(document.querySelector(".editor textarea.body")).toBe(body);
+    expect(body.disabled).toBe(false);
+  });
+});
+
+describe("magazine.md — the index", () => {
+  it("counts what it was handed rather than claiming a total", () => {
+    const page = load("views/home.html");
+    page.tell([MINE, THEIRS], {});
+    expect(document.getElementById("foot")?.textContent).toBe("Latest 2");
+  });
+
+  it("says so when a card opens nothing, and stays quiet when it works", async () => {
+    const refused = load("views/home.html", { opened: false });
+    refused.tell([MINE], {});
+    document.querySelector<HTMLButtonElement>(".card")?.click();
+    await settle();
+    expect(document.querySelector(".card .miss")?.textContent).toContain("would not open");
+
+    const worked = load("views/home.html", { opened: true });
+    worked.tell([MINE], {});
+    document.querySelector<HTMLButtonElement>(".card")?.click();
+    await settle();
+    expect(document.querySelector(".card .miss")).toBeNull();
+  });
+});

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -238,6 +238,25 @@ describe("magazine.md — the desk", () => {
     expect(inputs[1].value).toBe("");
   });
 
+  it("survives an article whose URL name is a property of Object.prototype", () => {
+    // `constructor`, `toString` and `hasOwnProperty` are all lowercase-and-letters, so all three
+    // are valid URL names. Off a plain object they come back as inherited FUNCTIONS — truthy — so
+    // the row would draw an armed delete confirmation and a refusal for a deletion nobody tried.
+    const cursed: Row[] = ["constructor", "toString", "hasOwnProperty"].map((id, index) => ({
+      id,
+      title: `Article ${id}`,
+      body: "text",
+      status: "published",
+      publishedAt: `2026-03-0${index + 1}T09:00:00.000000000Z`,
+    }));
+    const page = load("views/desk.html");
+    page.tell(cursed, { me: "ada@example.com", can: CAN, mine: { articles: cursed.map(({ id }) => ({ id })) } });
+
+    expect(document.querySelector("#list .m.bad")).toBeNull();
+    expect(document.querySelector("#list .confirm")).toBeNull();
+    expect(buttons("#list button")).toEqual(["Rewrite", "Delete", "Rewrite", "Delete", "Rewrite", "Delete"]);
+  });
+
   it("names every field for a screen reader, in both forms", () => {
     // Siblings are not a label relationship. Without `for`, all of these announce as "edit text,
     // blank" — the form reads as five anonymous boxes, and the label is not a click target either.

--- a/test/src/skillTemplateMagazine.spec.ts
+++ b/test/src/skillTemplateMagazine.spec.ts
@@ -214,6 +214,30 @@ describe("magazine.md — the desk", () => {
     expect(labels).not.toContain("URL name");
   });
 
+  it("does not empty a compose box the writer has already moved on to", async () => {
+    // Only the button is disabled while the write is in flight. Emptying every box on success
+    // throws away the next article — and this app has no drafts, so there is nowhere to get it
+    // back from.
+    const page = load("views/desk.html");
+    page.tell([], viewerWhoOwns);
+    const inputs = document.querySelectorAll<HTMLInputElement>("#compose input");
+    const areas = document.querySelectorAll<HTMLTextAreaElement>("#compose textarea");
+    inputs[0].value = "The first one";
+    areas[1].value = "the first body";
+    document.querySelector<HTMLButtonElement>("#compose .btn")?.click();
+
+    // The write is still in flight; the writer starts the next piece in the same boxes.
+    inputs[0].value = "The second one";
+    areas[1].value = "the second body";
+    await settle();
+
+    expect(inputs[0].value).toBe("The second one");
+    expect(areas[1].value).toBe("the second body");
+    // The tags box was empty and stayed empty, which is the other half: a box holding what was
+    // sent IS cleared, so the form does not keep the published article around.
+    expect(inputs[1].value).toBe("");
+  });
+
   it("names every field for a screen reader, in both forms", () => {
     // Siblings are not a label relationship. Without `for`, all of these announce as "edit text,
     // blank" — the form reads as five anonymous boxes, and the label is not a click target either.


### PR DESCRIPTION
稼働中の共有アプリ `~/git/ai/apps/ai-blogs`（公開 slug `ai-journal`）を、`mulmoterminal-shared-app` が配るテンプレートに起こしました。**9 本目**です。

## なぜ 9 本目に値するか

既存 8 本はどれも `views[].article` を実演していません。これは「**読ませるもの**」を集める形で、レコード 1 件が `/a/{slug}/{id}` という自分の住所を持ちます。survey の回答は行で、見た目はページが決める。記事はページで、プラットフォームが描く——だからアプリの側が「どの欄が見出しで、本文で、署名か」を宣言します。

この 1 個のキーが 3 つを同時に動かすので、他のどのサンプルからも導けません。

- **ドキュメント id が URL になる。** `idFrom: "slug"` は書き手が選んだ名前を id にし、ルールが凍らせる。改名は無く、改名したい記事は別の記事。
- **アプリが自分の `protocol` を宣言する。** article view は 2.0.0、他の 8 本は 1.0.0。
- **索引が「バイト単位のコスト」になる。** ルールは欄を落とせないので索引はレコードを丸ごと落としてくる——描かない body も含めて。`limit` x 宣言した上限の和が publish の 1,000,000 と比べられます。

## テンプレート追加として満たしたもの

`test/server/backends/skillTemplates.spec.ts` が見るもの一式:

- `EXPECTED_TEMPLATES` に追記（ディレクトリに置くだけでは何も起きない）
- `## app.json` / `## .claude/skills/articles/schema.json` は h2 + 空行 + fence
- view の path で始まる見出しの中に html の fence
- `<form>` 無し・modal 無し・`ready()` 有り・`html {` に background/color/color-scheme
- **`--hue: 115`**。テンプレート同士で空いている帯のうち最も広い 65–140 の中から、design.md 自身の 95 を避けて取りました

## spec を 1 つだけ変えています

protocol の表明を、**テンプレートごとの例外表ではなく宣言が使う機能から導く**形に直しました。`article` を持つ view があれば `APP_PROTOCOL`、無ければ `APP_PROTOCOL_BASE`。既存テストのコメントが「A template that ships an article view will state its own」と予告していたところで、例外を 1 行足すと `uidField` のときに一度否定された「テンプレートごとの番号」に戻ってしまうため、導出にしています。

## 実際に走らせる spec を足しました

`test/src/skillTemplateMagazine.spec.ts`（10 ケース、ai-council の前例に倣って jsdom）。宣言のゲートでは届かない、このサンプルの**振る舞いの主張**を見ます——URL 名の重複は送る前に断る／サーバの欄（`publishedAt` と `byUid`）は送らない／`viewer.mine` の 3 つ目の状態／開いている編集欄は作り直さない（カーソルと undo が消える）／`view.open` が settle したら失敗／公開ページの件数は総数ではない。

**初回で全部緑だったので、mutation で赤くなることを確認しました。** テンプレート側の 4 か所（重複チェック、編集欄の再利用と焦点復元、件数の文言、stamp の送信）を壊すと、対応する 4 ケースだけがちょうど落ちます。

## 元になったアプリ側で直したこと

テンプレートに起こす前に、稼働中の `ai-blogs` を先に直して publish 済みです（別リポジトリ）。主なもの:

- ページの中にあった「アドレス → 表示名」の対応表を削除。名簿 8 人のうち 2 人しか載っていない**手で保つ 2 つ目の名簿**で、しかも `selfUpdate` に `byline` があるため「他人の名前では出せない」という約束はそもそも渡せませんでした。既定値に変え、ページの文言の方を本当のことに直しています。
- 収録スキルの役表の誤り。owner が他人の記事を直せる（○）と書いてありましたが、役はコレクションごとの指定が `"*"` に優先する（`held[cid] ?? held["*"]`）ため、owner もこのコレクションでは participant です。
- 編集欄が state のたびに作り直され、誰かが記事を出した瞬間に書き手のカーソルと undo が消えていた。
- `view.open` の失敗が無反応だった（0.34.0 から成功時も答えるようになっています）。
- 索引のコストがゲートの上限の 97.8%（16 x 61,100 = 977,600）。`limit` を 10 に下げました。

## 確認

- `yarn test` — 778 files / 11,552 passed
- `yarn lint` / `yarn typecheck` / `yarn format` — clean
- `magazine.md` は `declarationProblems`（ホストの実物）を通過

## 未着手

design.md の contrast の表は 7 hue で測った当時のままです。「the six template hues」という書き方だと今の 9 本と食い違うので、**測定のサンプルとして正しく読める文**に直しました（数字には触っていません——測り直していないので）。live-poll.md の "the other four templates" も同じ理由で "the other templates" にしています。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a magazine application template for multi-author article publishing.
  * Supports public article pages, unique URLs, author controls, editing, deletion, validation, byte limits, and live updates.
  * Includes writer-focused submission and editing workflows with clear error handling and preserved form state.

* **Documentation**
  * Updated shared template documentation and design guidance for the expanded collection.

* **Tests**
  * Added coverage for publishing, ownership, URL validation, accessibility, editing, navigation, and deployment compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->