### PR TITLE
feat(files): ツリーの行を右クリックして、そのファイルを Canvas で開く (#1923)

### DIFF
--- a/plans/feat-1923-row-menu-canvas.md
+++ b/plans/feat-1923-row-menu-canvas.md
@@ -1,0 +1,77 @@
+# feat(#1923): ツリーの行を右クリックして Canvas で開く
+
+## 何を足すか
+
+Files ペインの行メニュー（#1859 / #1912）に **Canvas で開く** を 1 項目足す。判定と emit は既にあるものをそのまま使い、**サーバ側の変更はゼロ**。
+
+## なぜこの形か
+
+`filesRowActions()` は最初からこれを想定して書かれている:
+
+> A LIST rather than two booleans so a later action (a text file's contents, say) is an entry here and nothing else.
+
+判定も 2 つ目を作らない。ヘッダーの Canvas ボタンが使っている `canOpenInCanvas(絶対パス, workspace)` を**そのまま**呼ぶ。ここで独自の拡張子判定を書くと、`canvasOpenFile.ts` の冒頭が警告しているとおり「開けると言ったのに何も描かれない」を作れてしまう:
+
+> Which files qualify is decided by each PLUGIN rather than by an extension test here. A second opinion in this file could only be a weaker one that reports success for a file that never renders.
+
+## 決定
+
+### D1: アクションの型は `id` で判別する union にする
+
+いまの `FilesRowAction` は `text: string` が必須で、その意味は「ターミナルに送る文字列」に固定されている（コメントで明記）。Canvas の項目は送る文字列を持たず、**行の相対パス**を持つ。`text` を `string | undefined` に緩めると、呼び出し側が「空文字を送る」経路を作れてしまうので、`id` を判別子にした union にする。
+
+```ts
+export type FilesRowAction =
+  | { id: "insert-relative" | "insert-absolute"; label: string; icon: string; text: string }
+  | { id: "open-canvas"; label: string; icon: string; pathRel: string };
+```
+
+### D2: 相対パスを載せる（絶対パスではない）
+
+`open-in-canvas` の既存 emit（ヘッダーの Canvas ボタン）は `openPath`＝**ツリー root からの相対**を渡し、受け側の `TerminalGrid.openFileInCanvas` が `absoluteUnder(paneCwd, path)` で絶対にしている。メニューだけ絶対を渡すと受け側で二重解決になるので、**同じ相対**を載せる。判定に要る絶対パスは `filesRowActions` の中だけで作る。
+
+### D3: ゲートは insert と独立させる
+
+`canvasTarget`（Canvas を置く相手のセルがあるか）と `insertTarget`（挿入先のターミナルがあるか）は FilesPane で**別の prop** になっている（ペインがセルを trailing しているときに割れるため）。なので Canvas の項目は `terminal` ではなく `canvas` の可否で決める。全画面の Files ビューはどちらも false なので、メニューが出ないという現在の挙動は変わらない。
+
+### D4: 位置は挿入 2 項目の**前**
+
+行を右クリックする動機として「見せる」は「パスを打ち込む」より強い（#1374 がそのために作られている）。先頭にあるとキーボードで開いたとき最初にフォーカスが載るのも同じ理由で望ましい。
+
+### D5: アイコンは `space_dashboard`
+
+挿入 2 つは `attach_file` を共用している（「同じ仕事を木から呼んでいるので、区別はラベルの仕事」）。Canvas は別の仕事なので別アイコンにする。
+
+## 触るファイル
+
+| ファイル | 変更 |
+|---|---|
+| `src/components/filesRowActions.ts` | 型を union に、`canvas` 可否と `workspace` を受け取り、`open-canvas` を先頭に積む |
+| `src/components/FilesPane.vue` | `filesRowActions` に `canvas` を渡す、`runRowAction` を分岐 |
+| `test/src/components/filesRowActions.spec.ts` | 出る/出ない条件（md / html / workspace の story / リポジトリ内の story / 対象外 / canvas 相手なし） |
+| `test/src/components/filesRowMenu.spec.ts` | クリックで `open-in-canvas` が相対パスで飛ぶこと |
+
+## 出ないケース（意図的）
+
+リポジトリ内に置いた mulmoScript は開けない。プラグインが絶対パスを拒否し、stories の根が起動時に 1 個へ固定されているため（receptron/mulmoclaude#3014）。#3014 が入れば `storyWirePath` の拡張だけで、このメニューは何も変えずに mulmoScript が並ぶ。
+
+## 検証（2026-08-30）
+
+**ユニット。** `filesRowActions.spec.ts` に 6 件、`filesRowMenu.spec.ts` に 2 件追加。判定を落とす mutation
+（`canOpenInCanvas` の分岐を無効化）で **5 件が赤**になることを確認済み。`yarn test` は 11802 passed / 50 skipped。
+
+**実機。** `SERVER_SOCKET` を `mt-verify1923` に隔離し、scratch HOME + 別ポート（34723）で実サーバを起動、
+system Chrome を Playwright で駆動して、シェルセル → 拡大 → ファイルペイン → `talk.md` を右クリック、まで実行。
+
+| 見たこと | 結果 |
+|---|---|
+| メニューの項目 | `Open in the Canvas` / `Insert relative path` / `Insert absolute path` の 3 つ、この順 |
+| クリック後 | **Canvas が開き、md が描画された**（`---` が区切り線として出る。PDF ボタンと Edit Markdown Source つき） |
+| ディレクトリ行 | 項目は挿入 2 つのまま |
+| console error | 無し |
+
+**最初の測定は嘘をついた。** クライアントは `dist/` から配信されるので、`yarn build` 前の実行ではメニューに
+項目が出ず「実装が効いていない」ように見えた。ビルド後に出た。ソースだけ直して実機を見るときの落とし穴。
+
+**シェルセルでも Canvas は開く。** #1598 が指摘している「シェルセルは MCP グループを学習していないので
+パネルが開かない」は、このクライアント側 seed 経路には当たらない（実測）。

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -184,7 +184,15 @@ function menuPosition(actions: FilesRowAction[], x: number, y: number): { top: n
 }
 
 function openRowMenu(node: Node, event: MouseEvent | KeyboardEvent): void {
-  const actions = filesRowActions({ pathRel: node.path, cwd: props.cwd, terminal: insertTerminal.value });
+  const actions = filesRowActions({
+    pathRel: node.path,
+    cwd: props.cwd,
+    terminal: insertTerminal.value,
+    // The same pair the header's Canvas button is drawn from, so a row can never offer what that
+    // button would refuse — `canvasTarget` is "there is a cell to put a Canvas beside" and the
+    // overlay mount has none.
+    canvas: props.canvasTarget ? { workspace: props.workspace ?? null } : null,
+  });
   // Nothing to offer — the full-screen view is here on every row, having no terminal to insert
   // into. Leave the browser's own menu rather than swallowing the gesture for an empty panel.
   if (actions.length === 0) return;
@@ -257,7 +265,10 @@ function onRowKeydown(node: Node, event: KeyboardEvent): void {
 // useTerminalConnections), and the terminal is where the user is about to type the sentence the
 // path belongs to. Restoring the row here would take the keyboard straight back off them.
 function runRowAction(action: FilesRowAction): void {
-  emit("insert-text", action.text);
+  // The Canvas entry carries the row's path, not text for the terminal — and it goes out on the
+  // SAME emit as the header button, relative to the tree's root, so the receiver resolves it once.
+  if (action.id === "open-canvas") emit("open-in-canvas", action.pathRel);
+  else emit("insert-text", action.text);
   closeRowMenu();
 }
 

--- a/src/components/filesRowActions.ts
+++ b/src/components/filesRowActions.ts
@@ -5,16 +5,30 @@
 // Pure, and separate from the pane, because every rule here is about a path resolving somewhere
 // OTHER than where it was clicked — which is precisely what a DOM test would not catch.
 import { toInsertText } from "./dropPaths";
-import { absoluteUnder } from "../composables/canvasOpenFile";
+import { absoluteUnder, canOpenInCanvas } from "../composables/canvasOpenFile";
 
-export interface FilesRowAction {
-  id: "insert-relative" | "insert-absolute";
+interface RowActionChrome {
   label: string;
   /** Material Symbols ligature. */
   icon: string;
-  /** Exactly what goes to the terminal — quoted and space-terminated by `toInsertText`. */
-  text: string;
 }
+
+/** Discriminated on `id` because the two carry different payloads and neither is optional: an
+ *  insert is only ever a string for the terminal, and the Canvas entry has no such string at all.
+ *  Widening `text` to `string | undefined` instead would let a caller send an empty one. */
+export type FilesRowAction =
+  | (RowActionChrome & {
+      id: "insert-relative" | "insert-absolute";
+      /** Exactly what goes to the terminal — quoted and space-terminated by `toInsertText`. */
+      text: string;
+    })
+  | (RowActionChrome & {
+      id: "open-canvas";
+      /** RELATIVE to the tree's root, which is what `open-in-canvas` already carries from the
+       *  pane's own button — the receiver resolves it against the pane's cwd, so an absolute one
+       *  would be resolved twice. */
+      pathRel: string;
+    });
 
 export interface FilesRowTarget {
   /** The row's path, relative to the tree's root. */
@@ -23,12 +37,21 @@ export interface FilesRowTarget {
   cwd: string | null;
   /** The terminal an insert goes to, or null where there is none — the full-screen Files view. */
   terminal: { cwd: string | null } | null;
+  /** Where a Canvas could be opened, or null where there is no cell to put one beside. Separate
+   *  from `terminal` because the pane keeps its own two props for these: it can trail a cell after
+   *  a declined re-root, so "a terminal to insert into" and "a cell to draw beside" genuinely part
+   *  company. `workspace` is consulted for stories only (see canOpenInCanvas). */
+  canvas: { workspace: string | null } | null;
 }
 
 // The same icon for both, and it is the one the header's "Insert a file path" button already
 // uses: these are that button's job reached from the tree, and telling them apart is the label's
 // work, not an icon's.
 const ICON = "attach_file";
+
+// Its own, because this is a different job from the two inserts — not the same job reached from
+// the tree. The Canvas panel's own icon.
+const CANVAS_ICON = "space_dashboard";
 
 // Compared without a trailing separator, because `absoluteUnder` JOINS without doubling one: a
 // root spelled `/proj/` builds the same absolute path as `/proj`, so it has to answer the same
@@ -43,11 +66,22 @@ const withoutTrailingSeparator = (dir: string): string => (dir.endsWith("/") || 
  * A LIST rather than two booleans so a later action (a text file's contents, say) is an entry
  * here and nothing else.
  */
-export function filesRowActions({ pathRel, cwd, terminal }: FilesRowTarget): FilesRowAction[] {
-  // No root means no path worth inserting: the tree is on the server's default and its rows
-  // cannot be resolved against anything the terminal knows.
-  if (pathRel === "" || cwd === null || terminal === null) return [];
+export function filesRowActions({ pathRel, cwd, terminal, canvas }: FilesRowTarget): FilesRowAction[] {
+  // No root means no path worth offering: the tree is on the server's default and its rows cannot
+  // be resolved against anything the terminal — or the plugins' file layer — knows.
+  if (pathRel === "" || cwd === null) return [];
   const actions: FilesRowAction[] = [];
+  // First, because "show me this" is the stronger reason to right-click a row than "type its path"
+  // — it is what #1374 exists for — and a keyboard opening focuses the first item.
+  //
+  // Asked of canOpenInCanvas rather than answered here: a second opinion could only be a weaker
+  // one, reporting success for a file that then renders nothing (canvasOpenFile.ts says so at
+  // length). Which is also why a mulmoScript inside a PROJECT is absent — the plugin resolves
+  // stories against the workspace alone (receptron/mulmoclaude#3014).
+  if (canvas && canOpenInCanvas(absoluteUnder(cwd, pathRel), canvas.workspace)) {
+    actions.push({ id: "open-canvas", label: "Open in the Canvas", icon: CANVAS_ICON, pathRel });
+  }
+  if (terminal === null) return actions;
   // Only when a relative path means the same thing at the other end. The pane keeps the cell it
   // is on when a re-root could not be saved out of, so the tree and the terminal on screen can
   // be two different projects — and `src/index.ts` would then name a file in the wrong one.

--- a/test/src/components/filesRowActions.spec.ts
+++ b/test/src/components/filesRowActions.spec.ts
@@ -6,10 +6,59 @@ import { filesRowActions, menuFocusMove } from "../../../src/components/filesRow
 // pure function rather than an assertion about a menu.
 
 const ids = (...args: Parameters<typeof filesRowActions>) => filesRowActions(...args).map((a) => a.id);
-const textOf = (id: string, ...args: Parameters<typeof filesRowActions>) => filesRowActions(...args).find((a) => a.id === id)?.text;
+// Narrowed rather than asserted: only the insert entries carry text, which is the whole point of
+// the union — the Canvas one has a path instead.
+const textOf = (id: string, ...args: Parameters<typeof filesRowActions>) => {
+  const action = filesRowActions(...args).find((a) => a.id === id);
+  return action && "text" in action ? action.text : undefined;
+};
+
+// What the Canvas entry is offered on (#1923). The rule is not this module's: it asks
+// canOpenInCanvas — the same gate the pane's own Canvas button is drawn from — so a row can never
+// offer what that button would refuse.
+describe("filesRowActions — the Canvas entry", () => {
+  const WORKSPACE = "/ws";
+  const inProject = { cwd: "/proj", terminal: { cwd: "/proj" }, canvas: { workspace: WORKSPACE } };
+
+  it("offers it on a file a plugin can render, before the inserts", () => {
+    expect(ids({ ...inProject, pathRel: "notes/talk.md" })).toEqual(["open-canvas", "insert-relative", "insert-absolute"]);
+    expect(ids({ ...inProject, pathRel: "site/page.html" })[0]).toBe("open-canvas");
+  });
+
+  // RELATIVE, because `open-in-canvas` already carries that from the pane's own button and the
+  // receiver resolves it against the pane's cwd — an absolute one would be resolved twice.
+  it("carries the row's path relative to the tree root", () => {
+    const action = filesRowActions({ ...inProject, pathRel: "notes/talk.md" }).find((a) => a.id === "open-canvas");
+    expect(action).toEqual({ id: "open-canvas", label: "Open in the Canvas", icon: "space_dashboard", pathRel: "notes/talk.md" });
+  });
+
+  it("offers nothing extra on a file no plugin renders", () => {
+    expect(ids({ ...inProject, pathRel: "src/index.ts" })).toEqual(["insert-relative", "insert-absolute"]);
+  });
+
+  // A story opens only from the WORKSPACE's stories directory: the plugin resolves `stories/…`
+  // against that one root, so a project's own copy is a different file it would not read
+  // (receptron/mulmoclaude#3014).
+  it("offers it on a story in the workspace, and not on one inside a project", () => {
+    const inWorkspace = { cwd: WORKSPACE, terminal: { cwd: WORKSPACE }, canvas: { workspace: WORKSPACE } };
+    expect(ids({ ...inWorkspace, pathRel: "artifacts/stories/deck.json" })[0]).toBe("open-canvas");
+    expect(ids({ ...inProject, pathRel: "artifacts/stories/deck.json" })).toEqual(["insert-relative", "insert-absolute"]);
+  });
+
+  // The full-screen Files view mounts the same pane with no cell to put a Canvas beside.
+  it("offers nothing where there is no cell to draw beside", () => {
+    expect(ids({ ...inProject, pathRel: "notes/talk.md", canvas: null })).toEqual(["insert-relative", "insert-absolute"]);
+  });
+
+  // The two halves are independent: the pane can trail a cell after a declined re-root, which is
+  // why the pane keeps `canvasTarget` and `insertTarget` as separate props.
+  it("stands alone when there is no terminal to insert into", () => {
+    expect(ids({ ...inProject, pathRel: "notes/talk.md", terminal: null })).toEqual(["open-canvas"]);
+  });
+});
 
 describe("filesRowActions", () => {
-  const here = { pathRel: "src/index.ts", cwd: "/proj", terminal: { cwd: "/proj" } };
+  const here = { pathRel: "src/index.ts", cwd: "/proj", terminal: { cwd: "/proj" }, canvas: null };
 
   it("offers both paths when the tree and the terminal are the same directory", () => {
     expect(ids(here)).toEqual(["insert-relative", "insert-absolute"]);
@@ -35,7 +84,7 @@ describe("filesRowActions", () => {
   it("offers nothing without a root, and nothing for an empty path", () => {
     expect(ids({ ...here, cwd: null })).toEqual([]);
     expect(ids({ ...here, pathRel: "" })).toEqual([]);
-    expect(ids({ pathRel: "", cwd: null, terminal: null })).toEqual([]);
+    expect(ids({ pathRel: "", cwd: null, terminal: null, canvas: null })).toEqual([]);
   });
 
   // A directory is a path like any other, and gets no trailing slash: what the agent is being
@@ -54,7 +103,7 @@ describe("filesRowActions", () => {
   });
 
   it("joins a Windows root the way absoluteUnder does, and quotes the result", () => {
-    const win = { pathRel: "docs/x.md", cwd: "C:\\Users\\me", terminal: { cwd: "C:\\Users\\me" } };
+    const win = { pathRel: "docs/x.md", cwd: "C:\\Users\\me", terminal: { cwd: "C:\\Users\\me" }, canvas: null };
     expect(textOf("insert-absolute", win)).toBe("'C:\\Users\\me/docs/x.md' ");
   });
 

--- a/test/src/components/filesRowMenu.spec.ts
+++ b/test/src/components/filesRowMenu.spec.ts
@@ -29,7 +29,7 @@ function mockFs() {
   }) as unknown as typeof fetch;
 }
 
-type PaneProps = { cwd?: string | null; insertTarget?: boolean; insertTargetCwd?: string | null };
+type PaneProps = { cwd?: string | null; insertTarget?: boolean; insertTargetCwd?: string | null; canvasTarget?: boolean; workspace?: string | null };
 
 const mountPane = async (props: PaneProps = {}) => {
   const w = mount(FilesPane, {
@@ -79,6 +79,30 @@ describe("the files tree's row menu", () => {
     item("insert-absolute")?.click();
     await flushPromises();
     expect(w.emitted("insert-text")).toEqual([["/proj/src "]]);
+  });
+
+  // #1923: the row is where "show me this file" starts, so the entry that opens it in the Canvas
+  // rides the same emit as the pane's own Canvas button — and carries the RELATIVE path, which is
+  // what that button sends and what the receiver resolves against the pane's cwd.
+  it("opens a renderable file in the Canvas from the row, without opening it first", async () => {
+    const w = await mountPane({ canvasTarget: true, workspace: "/ws" });
+    rightClick(w.findAll('[data-testid="files-row"]')[0].element); // README.md
+    await flushPromises();
+
+    expect(labels()).toEqual(["Open in the Canvas", "Insert relative path", "Insert absolute path"]);
+    item("open-canvas")?.click();
+    await flushPromises();
+    expect(w.emitted("open-in-canvas")).toEqual([["README.md"]]);
+    expect(w.emitted("insert-text")).toBeUndefined();
+    expect(menu()).toBeNull();
+  });
+
+  // A directory is not something a plugin renders, so the row keeps the two inserts it had.
+  it("does not offer the Canvas on a row nothing can render", async () => {
+    const w = await mountPane({ canvasTarget: true, workspace: "/ws" });
+    rightClick(w.findAll('[data-testid="files-row"]')[1].element); // src/
+    await flushPromises();
+    expect(labels()).toEqual(["Insert relative path", "Insert absolute path"]);
   });
 
   // The full-screen view mounts the same pane with no terminal beside it. Swallowing the


### PR DESCRIPTION
## Summary

Files ペインの行メニュー（#1859）に **`Open in the Canvas`** を 1 項目足します。木に見えているファイルを、**エディタで開かずに**そのまま右ペインに出せます。

これまでの導線は #1374 の Canvas ボタンですが、**ペインのヘッダーにあり `openPath` に依存する**ので、まずファイルを開く一手が要りました。

| 変更 | 場所 |
|---|---|
| `FilesRowAction` を `id` で判別する union に（挿入は `text`、Canvas は `pathRel`） | `src/components/filesRowActions.ts` |
| Canvas の可否を `canvas: { workspace }` で受け取り、`canOpenInCanvas` に聞く | 同上 |
| `runRowAction` を分岐して既存の `open-in-canvas` emit に流す | `src/components/FilesPane.vue` |

**サーバ側の変更はゼロです。**

## Items to Confirm / Review

**1. 判定を自分で書いていません。** `canOpenInCanvas`（ヘッダーの Canvas ボタンと同じゲート）をそのまま呼びます。`canvasOpenFile.ts` の冒頭が「ここで拡張子判定を書くと、開けると言ったのに何も描かれない状態を作れる」と警告しているためです。結果として、**出るのは md / html と workspace の `artifacts/stories/*.json` だけ**です。

**2. リポジトリの中に置いた mulmoScript は出ません。** プラグインが絶対パスを拒否し、stories の根が起動時に 1 個へ固定されているためで、これは receptron/mulmoclaude#3014 で扱います。**この PR はそれを待たずに出せる分**で、#3014 が入れば `storyWirePath` の拡張だけでこのメニューに mulmoScript が並びます（メニュー側は無変更）。

**3. ゲートを `terminal` から独立させました。** `canvasTarget`（Canvas を置くセルがあるか）と `insertTarget`（挿入先のターミナルがあるか）は FilesPane で別 prop です（ペインがセルを trailing したときに割れるため）。なので早期 return を「root が無い / 空パス」だけにして、挿入 2 項目の手前で Canvas を積みます。全画面の Files ビューは両方 false なので、**メニュー自体が出ない現在の挙動は変わりません**（spec で pin）。

**4. 位置は挿入 2 項目の前、アイコンは `space_dashboard`。** 「見せる」が右クリックの動機として強く、キーボードで開いたとき最初にフォーカスが載るのも同じ理由です。挿入 2 つが `attach_file` を共用しているのは「同じ仕事を木から呼んでいる」からで、Canvas は別の仕事なので別アイコンにしました。ここは好みが分かれうるので見てください。

**5. 相対パスを載せています。** 既存の `open-in-canvas` emit（ヘッダーのボタン）が相対を渡し、受け側の `TerminalGrid.openFileInCanvas` が `absoluteUnder` で絶対にしています。メニューだけ絶対を渡すと二重解決になります。

## User Prompt

- header のメニューと MCP について。mulmocast を編集するケースで、MCP 経由で右ペインに編集/preview を出せるが毎回 LLM に頼む必要があって不便。できればリポジトリごとにボタンで出したい。ただし右を開けても「どの dir/file を開くか」は別問題で、どうするのがよいか
- （プレゼンの作り方）ベースのメモは txt か md でページごとに書いて `---` などで区切り、それを基に mulmocast deck を作る。問題があれば元のテキストを編集して調整し、デザインは LLM に指示して変える
- 1: files ペインでファイルエクスプローラーを開いた状態で該当ファイルを右クリックすると、mulmoScript なら mulmo を開けるようにする
- 2: 同じようにメニューに追加できるようにする。ただし複数ファイルがある場合を想定して `[run]` `[skill]` のようなプルダウンにする
- まずは mulmoScript とか、その他の右ペインで開くに対応できるか
- デッキはリポジトリ内に置き、その場所を設定ファイルに書いておけばファイルエクスプローラーでも認識できるようにする。なので plugin の変更から
- （着手順の選択肢に対して）a（= 何も決めずに今日出せる、右クリックの md / html 分）

## 検証

**ユニット。** `filesRowActions.spec.ts` に 6 件、`filesRowMenu.spec.ts` に 2 件追加。判定の分岐を無効化する mutation で **5 件が赤**になることを確認済み。`yarn format` / `lint` / `typecheck` / `build` 0、`yarn test` は **11802 passed / 50 skipped**。

**実機。** `SERVER_SOCKET` を `mt-verify1923` に隔離し、scratch HOME + 別ポート（34723）で実サーバを起動、system Chrome を Playwright で駆動しました。

| 見たこと | 結果 |
|---|---|
| メニューの項目 | `Open in the Canvas` / `Insert relative path` / `Insert absolute path` の 3 つ、この順 |
| クリック後 | **Canvas が開き、md が描画された**（`---` が区切り線として出る。PDF ボタンつき） |
| ディレクトリ行 | 挿入 2 つのまま |
| console error | 無し |

**最初の実機測定は嘘をつきました。** クライアントは `dist/` から配信されるので、`yarn build` 前は項目が出ず「実装が効いていない」ように見えました。ビルド後に出ています。ソースだけ直して実機を見るときの落とし穴として plan に残しました。

**シェルセルでも Canvas は開きました。** #1598 が指摘している「シェルセルは MCP グループを学習していないのでパネルが開かない」は、このクライアント側 seed 経路には当たりません（実測）。

設計判断の全記録は [`plans/feat-1923-row-menu-canvas.md`](plans/feat-1923-row-menu-canvas.md)。

Closes #1923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbtkBP7m9oq53qyYB3i8XX

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Open in the Canvas** option to file row context menus when supported.
  * Canvas actions appear before file insertion options and open the selected file using its relative path.
  * The option is available independently of terminal insertion support.

* **Bug Fixes**
  * Prevented Canvas actions from appearing for unsupported files or directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->