### PR TITLE
feat(collections): 誰がどのコレクションに触れるかをペインで示す

### DIFF
--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -343,9 +343,29 @@ function selfUpdateDeclared(declared: Declared): boolean {
   const { c, s } = declared;
   if (s === undefined || typeof c.statusField !== "string" || flagOn(s, "finalize")) return false;
   if (!windowOpen(s, declared.now)) return false;
-  const updates = asRecord(s.selfUpdate) ?? {};
-  const transitions = asRecord(s.selfTransitions) ?? {};
-  return Object.keys(updates).length > 0 || Object.keys(transitions).length > 0;
+  return editsSomeField(s) || movesSomeStatus(c, s);
+}
+
+/** A `selfUpdate` entry that actually names a field.
+ *
+ *  `selfWriteOk` asks `changed().hasOnly(selfUpdate[current])`, so an empty list passes only for a
+ *  write that changes nothing — which is not an edit, and reporting it as one puts `Edit own only`
+ *  on a row whose owner can change nothing at all. */
+function editsSomeField(submit: Record<string, unknown>): boolean {
+  return Object.values(asRecord(submit.selfUpdate) ?? {}).some((fields) => asStrings(fields).length > 0);
+}
+
+/** A `selfTransitions` entry with a target the state machine will actually accept.
+ *
+ *  Two ways it can name none: an empty target list, and a target the collection's own `transitions`
+ *  forbid — `updateWith` asks `transitionOk(c)` before it ever reaches `selfWriteOk`, so a move the
+ *  machine does not allow is refused however the submit block declares it. A target equal to the
+ *  status it moves from passes `transitionOk` and changes nothing, so it is not a move either. */
+function movesSomeStatus(c: Record<string, unknown>, submit: Record<string, unknown>): boolean {
+  const machine = asRecord(c.transitions);
+  return Object.entries(asRecord(submit.selfTransitions) ?? {}).some(([from, targets]) =>
+    asStrings(targets).some((to) => to !== from && (machine === undefined || asStrings(machine[from]).includes(to))),
+  );
 }
 
 function selfDeleteDeclared(declared: Declared): boolean {

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -364,6 +364,24 @@ function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): st
     caveats.push("A session gate has to be open, on the question the host is currently showing, before a submission is taken.");
   if (s !== undefined && s.idFrom === "field")
     caveats.push("The record id is a field, so the first submission for a value takes it and later ones are refused.");
+  // THE THREE THAT BIND A WRITER, and the reason they are here rather than in the table: each one
+  // is decided per RECORD, by the status that record is in or by another record entirely, and the
+  // `Owner / editor` row is one cell for the whole collection. Without them the row reads
+  // "Anything" about a collection where the owner cannot delete a closed topic.
+  if ("transitions" in c && typeof c.statusField === "string") {
+    caveats.push("A record's status may only move along the declared `transitions` — for everyone, the owner included.");
+  }
+  if (asStrings(c.sealed).length > 0) {
+    // DELETE only: a sealed record can still have its fields corrected. It is `deleteWith` that
+    // asks `sealedNow`, and saying "cannot be changed" here would be the panel being stricter than
+    // the rules, which is its own kind of wrong.
+    caveats.push("A record in a sealed state cannot be DELETED by anyone, the owner included — though its fields can still be corrected.");
+  }
+  if (isRecord(c.refIn)) {
+    caveats.push(
+      "A new record is refused unless the record it points at is in the state `refIn` requires, and that reference is frozen afterwards — the owner is bound too.",
+    );
+  }
   if (flagOn(c, "revealGated")) caveats.push("Everyone on the roster reads a row once its parent reveals it.");
   if (typeof c.assigneeField === "string") caveats.push("An assignee reads everything here and writes only the rows assigned to them.");
   if (typeof c.mirrorOf === "string") caveats.push("Anyone may repair this collection's `state` field to match the record it mirrors.");

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -222,6 +222,41 @@ function windowOpen(submit: Record<string, unknown>, now: number): boolean {
   return state !== "closed" && state !== "early";
 }
 
+/** The fields `validate` makes mandatory — `required` outright, and the `field` of each
+ *  `keyFields` entry, which the rules index into. */
+function validatedFields(submit: Record<string, unknown>): string[] {
+  const validate = asRecord(submit.validate);
+  if (validate === undefined) return [];
+  const keyed = Array.isArray(validate.keyFields) ? validate.keyFields : [];
+  return [...asStrings(validate.required), ...keyed.flatMap((entry) => (isRecord(entry) && typeof entry.field === "string" ? [entry.field] : []))];
+}
+
+/** Every field the rules REQUIRE a create to carry.
+ *
+ *  It matters because `submitCreate` also asks `hasOnly(s.createFields)`: a field the rules demand
+ *  and the list does not allow makes the two conjuncts contradict each other, and the collection
+ *  accepts nothing at all from anybody. `{ emailField: "email", createFields: ["title"] }` is the
+ *  shape — sending `email` fails `hasOnly`, omitting it fails the identity check — and this route
+ *  answers for declarations a publish would refuse, so the contradiction reaches the panel. */
+function requiredCreateFields(declared: Declared, stage: CollectionAccess["authStage"]): string[] {
+  const { c, s } = declared;
+  if (s === undefined) return [];
+  const need: string[] = [...validatedFields(s)];
+  // Only on the `verifiedEmail` stage: that is the branch of `authOk` that reads it.
+  if (stage === "verifiedEmail" && typeof s.emailField === "string") need.push(s.emailField);
+  // `uidOk` compares `.get(uidField, null)` against the uid, so an absent field simply loses.
+  if (typeof s.uidField === "string") need.push(s.uidField);
+  if (typeof s.idField === "string" && (s.idFrom === "auth.uid+field" || s.idFrom === "field" || s.idFrom === "slug")) need.push(s.idField);
+  if (typeof s.stampField === "string") need.push(s.stampField);
+  if (typeof c.statusField === "string" && s.initialStatus !== undefined) need.push(c.statusField);
+  const gate = asRecord(s.gateOn);
+  if (gate !== undefined && typeof gate.match === "string") need.push(gate.match);
+  // `refIn` builds the parent's path out of this field of the submission.
+  const refIn = asRecord(c.refIn);
+  if (refIn !== undefined && typeof refIn.ref === "string") need.push(refIn.ref);
+  return need;
+}
+
 /** The two ways a status DECLARATION refuses every create by itself — both fail closed in the
  *  rules, and both are shapes a half-finished manifest really has.
  *
@@ -239,10 +274,6 @@ function initialStatusOk(declared: Declared): boolean {
   // A non-string `initialStatus` can never equal the record's status field, which the rules compare
   // without coercing — so it refuses every create for the same reason and by the same rule.
   if (typeof initial !== "string" || typeof c.statusField !== "string") return false;
-  // And the submitter has to be ALLOWED to send it. `submitCreate` asks `hasOnly(createFields)` and
-  // then requires the status field to be present at the declared value, so a `createFields` that
-  // omits it makes those two conjuncts contradict each other and every create is refused.
-  if (!asStrings(s?.createFields).includes(c.statusField)) return false;
   const transitions = asRecord(c.transitions);
   if (transitions === undefined) return true;
   return asStrings(transitions.initial).includes(initial);
@@ -262,6 +293,8 @@ function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who
   // door on most of the apps there are.
   if (!ignoreWindow && !windowOpen(s, declared.now)) return false;
   if (!Array.isArray(s.createFields)) return false;
+  const allowed = asStrings(s.createFields);
+  if (!requiredCreateFields(declared, stage).every((field) => allowed.includes(field))) return false;
   if (!authOk(stage, who)) return false;
   if (!initialStatusOk(declared)) return false;
   // `audience: "participant"` is matched against the ROLE, so it shuts out viewers and editors as
@@ -291,7 +324,11 @@ function selfUpdateDeclared(declared: Declared): boolean {
 function selfDeleteDeclared(declared: Declared): boolean {
   const { c, s } = declared;
   if (s === undefined || typeof c.statusField !== "string") return false;
-  return asStrings(s.selfDelete).length > 0;
+  // MINUS the sealed states. `deleteWith` asks `!sealedNow(c)` before it reaches `selfDelete`, so a
+  // declaration whose every withdrawable status is also sealed grants no withdrawal at all — and
+  // `selfDelete: ["draft"]` beside `sealed: ["draft"]` is a shape a manifest really has.
+  const sealed = asStrings(c.sealed);
+  return asStrings(s.selfDelete).some((status) => !sealed.includes(status));
 }
 
 /** Whether this subject can hold a row here AT ALL — the binding reaching them is necessary and

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -274,11 +274,17 @@ function requiredCreateFields(declared: Declared, stage: CollectionAccess["authS
 function initialStatusOk(declared: Declared): boolean {
   const { c, s } = declared;
   const initial = s?.initialStatus;
-  if (initial === undefined) return true;
+  const transitions = asRecord(c.transitions);
+  if (initial === undefined) {
+    // `initialOk` only binds when BOTH are declared. When they are, the submitter has to supply a
+    // status the map lists under `initial` — so a map that lists none there (an empty list, or no
+    // `initial` key at all) can be satisfied by no value whatsoever.
+    if (transitions === undefined || typeof c.statusField !== "string") return true;
+    return asStrings(transitions.initial).length > 0;
+  }
   // A non-string `initialStatus` can never equal the record's status field, which the rules compare
   // without coercing — so it refuses every create for the same reason and by the same rule.
   if (typeof initial !== "string" || typeof c.statusField !== "string") return false;
-  const transitions = asRecord(c.transitions);
   if (transitions === undefined) return true;
   return asStrings(transitions.initial).includes(initial);
 }

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -271,6 +271,24 @@ function requiredCreateFields(declared: Declared, stage: CollectionAccess["authS
  *
  *  Modelled rather than caveated because the answer is decided by the declaration alone: nothing
  *  about the record or the caller can rescue it, which is exactly when the table can speak. */
+/** `initialOk(c)`, the half that binds EVERYBODY.
+ *
+ *  It sits above the branch group in `createWith`, so it is asked of a writer's create exactly as
+ *  it is asked of a visitor's. Only one shape of it is decidable from the declaration alone: with
+ *  `transitions` and `statusField` both declared, the create's status is looked up under
+ *  `transitions.initial` — and a map listing nothing there can be satisfied by no value at all,
+ *  from anyone. Which value a writer WOULD send is not knowable here, which is why the rest of
+ *  `initialOk` stays in the `transitions` caveat.
+ *
+ *  Deliberately not folded into `initialStatusOk`: that one also carries the `initialStatus`
+ *  comparison, which lives inside `submitCreate` and binds the public path only. Folding them
+ *  would apply a public-path condition to a writer, which is the mirror image of this bug. */
+function initialTransitionPossible(c: Record<string, unknown>): boolean {
+  const transitions = asRecord(c.transitions);
+  if (transitions === undefined || typeof c.statusField !== "string") return true;
+  return asStrings(transitions.initial).length > 0;
+}
+
 function initialStatusOk(declared: Declared): boolean {
   const { c, s } = declared;
   const initial = s?.initialStatus;
@@ -279,8 +297,7 @@ function initialStatusOk(declared: Declared): boolean {
     // `initialOk` only binds when BOTH are declared. When they are, the submitter has to supply a
     // status the map lists under `initial` — so a map that lists none there (an empty list, or no
     // `initial` key at all) can be satisfied by no value whatsoever.
-    if (transitions === undefined || typeof c.statusField !== "string") return true;
-    return asStrings(transitions.initial).length > 0;
+    return initialTransitionPossible(c);
   }
   // A non-string `initialStatus` can never equal the record's status field, which the rules compare
   // without coercing — so it refuses every create for the same reason and by the same rule.
@@ -384,7 +401,7 @@ function accessFor(declared: Declared, stage: CollectionAccess["authStage"], who
 
   // `createWith`: a writer creates unless the collection is `submitOnly`, and either way the
   // public submission path is open to them on the same terms as everybody else.
-  const create = (isWriter && !flagOn(c, "submitOnly")) || canCreate(declared, stage, who);
+  const create = (isWriter && !flagOn(c, "submitOnly") && initialTransitionPossible(c)) || canCreate(declared, stage, who);
 
   return {
     read,

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -222,6 +222,28 @@ function windowOpen(submit: Record<string, unknown>, now: number): boolean {
   return state !== "closed" && state !== "early";
 }
 
+/** The two ways a status DECLARATION refuses every create by itself — both fail closed in the
+ *  rules, and both are shapes a half-finished manifest really has.
+ *
+ *  `submitCreate` requires `statusField in c` before it will compare `initialStatus`, so a submit
+ *  block naming an initial status over a collection that declares no status field denies every
+ *  submission. And `initialOk` looks the create's status up under `transitions.initial`, defaulting
+ *  to the empty list — so an initial status the map does not list denies them too.
+ *
+ *  Modelled rather than caveated because the answer is decided by the declaration alone: nothing
+ *  about the record or the caller can rescue it, which is exactly when the table can speak. */
+function initialStatusOk(declared: Declared): boolean {
+  const { c, s } = declared;
+  const initial = s?.initialStatus;
+  if (initial === undefined) return true;
+  // A non-string `initialStatus` can never equal the record's status field, which the rules compare
+  // without coercing — so it refuses every create for the same reason and by the same rule.
+  if (typeof initial !== "string" || typeof c.statusField !== "string") return false;
+  const transitions = asRecord(c.transitions);
+  if (transitions === undefined) return true;
+  return asStrings(transitions.initial).includes(initial);
+}
+
 /** `submitCreate` minus the parts that depend on the record and the clock.
  *
  *  The first conjunct is the one #1926 was about and the one this whole panel is for: a
@@ -237,6 +259,7 @@ function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who
   if (!ignoreWindow && !windowOpen(s, declared.now)) return false;
   if (!Array.isArray(s.createFields)) return false;
   if (!authOk(stage, who)) return false;
+  if (!initialStatusOk(declared)) return false;
   // `audience: "participant"` is matched against the ROLE, so it shuts out viewers and editors as
   // firmly as it shuts out strangers.
   return s.audience !== "participant" || who.role === "participant";

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -291,7 +291,12 @@ function holdsRow(declared: Declared, stage: CollectionAccess["authStage"], who:
  *  openings, and `ownRow` last as the narrowest answer that is still an answer. */
 function readAccessFor(declared: Declared, who: Principal, isWriter: boolean, own: boolean): ReadAccess {
   if (isWriter || declared.publicRead) return "all";
-  if (who.listed && (declared.partRead || declared.c.peerVisibility === "public")) return "all";
+  // `revealGated` sits with the other two roster-wide openings, and it is CONDITIONAL: the row
+  // opens once its parent says so. There is no "some rows" state and this table would rather
+  // overstate an insider's reach than report `Nothing` about a row the rules hand them — the
+  // caveat below carries the condition. Roster-only, so no outsider row moves.
+  const rosterWide = declared.partRead || declared.c.peerVisibility === "public" || flagOn(declared.c, "revealGated");
+  if (who.listed && rosterWide) return "all";
   return own ? "own" : "none";
 }
 
@@ -382,7 +387,11 @@ function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): st
       "A new record is refused unless the record it points at is in the state `refIn` requires, and that reference is frozen afterwards — the owner is bound too.",
     );
   }
-  if (flagOn(c, "revealGated")) caveats.push("Everyone on the roster reads a row once its parent reveals it.");
+  if (flagOn(c, "revealGated")) {
+    // The condition the `All rows` above cannot carry: it is per record, and only after the parent
+    // says so.
+    caveats.push("Everyone on the roster reads a row ONCE ITS PARENT REVEALS IT, and not before — the roster rows above are the state after the reveal.");
+  }
   if (typeof c.assigneeField === "string") caveats.push("An assignee reads everything here and writes only the rows assigned to them.");
   if (typeof c.mirrorOf === "string") caveats.push("Anyone may repair this collection's `state` field to match the record it mirrors.");
   return caveats;

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -239,6 +239,10 @@ function initialStatusOk(declared: Declared): boolean {
   // A non-string `initialStatus` can never equal the record's status field, which the rules compare
   // without coercing — so it refuses every create for the same reason and by the same rule.
   if (typeof initial !== "string" || typeof c.statusField !== "string") return false;
+  // And the submitter has to be ALLOWED to send it. `submitCreate` asks `hasOnly(createFields)` and
+  // then requires the status field to be present at the declared value, so a `createFields` that
+  // omits it makes those two conjuncts contradict each other and every create is refused.
+  if (!asStrings(s?.createFields).includes(c.statusField)) return false;
   const transitions = asRecord(c.transitions);
   if (transitions === undefined) return true;
   return asStrings(transitions.initial).includes(initial);

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -1,0 +1,361 @@
+// WHO CAN SEE WHAT, per collection of a shared app — read off the two documents the Firestore
+// rules actually read, and nothing else.
+//
+// The question this answers is the author's, and it is asked about strangers: "the person who has
+// not signed in, and the person who signed in but was never invited — what of mine can they
+// reach?" That is not answerable from `app.json` by reading it, because the answer is spread over
+// `public.enabled`, `public.read`, `public.submit[cid].auth`, `participantRead`, `peerVisibility`
+// and the roster, and any two of them can disagree.
+//
+// So this is a TRANSCRIPTION of the rules, not a second opinion about them. Every branch below
+// names the predicate in `../../mulmoserver/firestore.rules` it mirrors, and the inputs are the
+// projected documents (`apps/{aid}` and its `public` block) rather than the authored manifest —
+// the same pair `app(aid)` hands every rule. A summary computed from the manifest would be a
+// third reading of the declaration, and the one that is wrong is always the one nobody deploys.
+//
+// It is a REPORT. Nothing here authorizes anything: the rules do, on the server, and an app whose
+// rules say otherwise is right and this is wrong. That is the point of stating it — a difference
+// between this panel and production is a bug worth finding, and it can only be found if the panel
+// commits to an answer.
+import { byCodeUnit } from "./byCodeUnit.js";
+import { isRecord } from "./isRecord.js";
+import { publicFaceOf, type PublicFace } from "./sharedAppPublicFace.js";
+
+/** The four people an author is deciding about. Two of them are the ones this panel exists for.
+ *
+ *  `visitor` is the person on the public page with no Google account. Firebase gives them an
+ *  ANONYMOUS session there, so `authed()` is true for them and `verified()` is not — which is what
+ *  makes them different from `stranger` rather than simply weaker, and why a `uidField` binding
+ *  reaches them while an `emailField` one cannot.
+ *
+ *  `stranger` is any Google account in the world that was never invited. The aid and the cid are
+ *  both readable from `config/public`, so "they would have to know the ids" is not a barrier and
+ *  is deliberately not modelled as one.
+ *
+ *  `participant` holds the literal `participant` role on the roster; `writer` holds `owner` or
+ *  `editor` on this collection. `viewer` and `assignee` are neither — they read like a writer and
+ *  write like nobody, which the census beside the table reports rather than the table. */
+export type AccessSubject = "visitor" | "stranger" | "participant" | "writer";
+
+export const ACCESS_SUBJECTS: readonly AccessSubject[] = ["visitor", "stranger", "participant", "writer"];
+
+/** How much of the collection this subject may READ. `own` is `ownRow` — the rows the subject
+ *  themselves submitted, reached through the declared identity binding and no other. */
+export type ReadAccess = "none" | "own" | "all";
+
+export interface SubjectAccess {
+  read: ReadAccess;
+  /** May bring a NEW record into this collection. */
+  create: boolean;
+  /** May change or withdraw the records that are theirs (`selfUpdate` / `selfTransitions` /
+   *  `selfDelete`), which is a different permission from `editAll` and never implies it. */
+  editOwn: boolean;
+  /** May change or delete ANY record here. */
+  editAll: boolean;
+}
+
+/** How many roster addresses hold each kind of role ON THIS COLLECTION.
+ *
+ *  Beside the table because the table's `participant` and `writer` columns describe a permission
+ *  that may belong to nobody: an app can declare `audience: "participant"` and have no
+ *  participants, and the column would then read as an exposure that does not exist. */
+export interface RoleCensus {
+  writers: number;
+  /** `viewer` and `assignee` — they read everything here and the table does not have a column for
+   *  them, so they are counted where they cannot be missed. */
+  readers: number;
+  participants: number;
+}
+
+export interface CollectionAccess {
+  cid: string;
+  /** Does this collection take submissions at all — `subOpen` in the rules. A collection with no
+   *  `public.submit` entry has no self-service path in or out for anybody, whatever the switch
+   *  says, and that is worth saying plainly rather than leaving as four empty cells. */
+  takesSubmissions: boolean;
+  /** The auth stage `public.submit[cid].auth` declares, or `none`. */
+  authStage: "none" | "anonymous" | "verifiedEmail";
+  census: RoleCensus;
+  /** Conditions this summary cannot answer, in the author's words — a submission window, a
+   *  session gate, a staged reveal. Each one can only NARROW what the table says. */
+  caveats: string[];
+  access: Record<AccessSubject, SubjectAccess>;
+}
+
+export interface SharedAppAccess {
+  publicFace: PublicFace;
+  collections: CollectionAccess[];
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined);
+const asStrings = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
+const flagOn = (block: Record<string, unknown>, key: string): boolean => block[key] === true;
+
+/** The role this address resolves to for this cid — `role(a, cid)` in the rules, including its
+ *  `'*'` fallback and its `null` for a member scoped elsewhere. */
+function roleFor(roles: Record<string, unknown>, cid: string): string | null {
+  const scoped = roles[cid];
+  if (typeof scoped === "string") return scoped;
+  const fallback = roles["*"];
+  return typeof fallback === "string" ? fallback : null;
+}
+
+function censusOf(members: Record<string, unknown>, cid: string): RoleCensus {
+  const census: RoleCensus = { writers: 0, readers: 0, participants: 0 };
+  for (const roles of Object.values(members)) {
+    if (!isRecord(roles)) continue;
+    const role = roleFor(roles, cid);
+    if (role === "owner" || role === "editor") census.writers += 1;
+    else if (role === "viewer" || role === "assignee") census.readers += 1;
+    else if (role === "participant") census.participants += 1;
+  }
+  return census;
+}
+
+/** What the subject brings to `request.auth`. `listed` is `listedIn(a)`; `role` is what `role(a,
+ *  cid)` would answer for them. */
+interface Principal {
+  verified: boolean;
+  listed: boolean;
+  role: "participant" | "writer" | null;
+}
+
+const PRINCIPALS: Record<AccessSubject, Principal> = {
+  // Anonymous session: authed, never verified. See the note on `AccessSubject`.
+  visitor: { verified: false, listed: false, role: null },
+  stranger: { verified: true, listed: false, role: null },
+  participant: { verified: true, listed: true, role: "participant" },
+  writer: { verified: true, listed: true, role: "writer" },
+};
+
+/** The two principals `caveatsOf` asks about — the same pair the panel colours. */
+const OUTSIDER_PRINCIPALS: readonly Principal[] = [PRINCIPALS.visitor, PRINCIPALS.stranger];
+
+/** One collection's declaration, read once so the four subjects cannot be answered from four
+ *  different readings of it. */
+interface Declared {
+  /** `col(a, cid)` — the collection's rule configuration on the app document. */
+  c: Record<string, unknown>;
+  /** `sub(a, cid)`, and `undefined` where `subOpen` is false. */
+  s: Record<string, unknown> | undefined;
+  publicOn: boolean;
+  publicRead: boolean;
+  partRead: boolean;
+  /** The clock `inWindow` is judged against — threaded in rather than read here so the summary
+   *  stays a pure function of its inputs and a spec can pin a closed window without waiting. */
+  now: number;
+}
+
+/** `ownRow` — can THIS subject be bound to a row here at all?
+ *
+ *  The bindings are the rules': the two `auth.uid` id strategies and `uidField` need only
+ *  `authed()`, so the anonymous visitor reaches them; `emailField` compares `email()` and so needs
+ *  `verified()`. Every one of them requires `subOpen` first, which is why a collection with no
+ *  submit declaration gives nobody an own row however they signed in. */
+function ownRowReachable(declared: Declared, who: Principal): boolean {
+  const { s } = declared;
+  if (s === undefined) return false;
+  const uidBound = s.idFrom === "auth.uid" || s.idFrom === "auth.uid+field" || typeof s.uidField === "string";
+  const emailBound = typeof s.emailField === "string";
+  return uidBound || (who.verified && emailBound);
+}
+
+/** `authOk(s)` for this subject. */
+function authOk(stage: CollectionAccess["authStage"], who: Principal): boolean {
+  if (stage === "verifiedEmail") return who.verified;
+  // Both `none` and `anonymous` are satisfied by the anonymous session every public page holds.
+  return true;
+}
+
+/** `inWindow(s, aid)`, evaluated against a clock.
+ *
+ *  Evaluated rather than merely mentioned, because a CLOSED window is how the sample apps seal a
+ *  board: `apps/roles` declares `window.until` in the year 2000 on all three of its collections, so
+ *  a summary that only said "there is a window" reported an open door on an app nobody can post to.
+ *  The rules compare `request.time`, so this is the same answer they give — at the moment it is
+ *  asked, which is what makes the panel worth re-opening rather than a fact about the file.
+ *
+ *  `perRecord` is the half that cannot be answered from here: `fromField` / `untilField` put the
+ *  bound on ANOTHER record. It is reported as its own state so the caveat can say so instead of
+ *  the table quietly picking one of the two answers. */
+function windowState(submit: Record<string, unknown>, now: number): "none" | "open" | "closed" | "early" | "perRecord" {
+  const window = asRecord(submit.window);
+  if (window === undefined) return "none";
+  if (typeof window.fromMs === "number" && now < window.fromMs) return "early";
+  if (typeof window.untilMs === "number" && now >= window.untilMs) return "closed";
+  if (window.fromField !== undefined || window.untilField !== undefined) return "perRecord";
+  return "open";
+}
+
+/** `submitCreate` minus the parts that depend on the record and the clock.
+ *
+ *  The first conjunct is the one #1926 was about and the one this whole panel is for: a
+ *  `public.submit` declaration is not a statement that the app is open, so the gate is the SWITCH
+ *  or the ROSTER, never the declaration's existence. */
+function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): boolean {
+  const { s } = declared;
+  if (s === undefined) return false;
+  if (!(declared.publicOn || who.listed)) return false;
+  // Only the two states that are DECIDED and shut. `none` is a collection with no window at all,
+  // and `perRecord` is a bound this summary cannot read — refusing on either would report a closed
+  // door on most of the apps there are.
+  const window = windowState(s, declared.now);
+  if (window === "closed" || window === "early") return false;
+  if (!Array.isArray(s.createFields)) return false;
+  if (!authOk(stage, who)) return false;
+  // `audience: "participant"` is matched against the ROLE, so it shuts out viewers and editors as
+  // firmly as it shuts out strangers.
+  return s.audience !== "participant" || who.role === "participant";
+}
+
+/** `selfWriteOk` / `selfDelete` — is there any self-service edit declared at all?
+ *
+ *  Both are keyed by the CURRENT STATUS, so a collection with no `statusField` can say neither and
+ *  the rules fail closed on it. That prerequisite is the declaration's, not a status machine's: a
+ *  single-status collection satisfies it. */
+function selfEditDeclared(declared: Declared): boolean {
+  const { c, s } = declared;
+  if (s === undefined || typeof c.statusField !== "string") return false;
+  if (flagOn(s, "finalize")) return false;
+  const updates = asRecord(s.selfUpdate) ?? {};
+  const transitions = asRecord(s.selfTransitions) ?? {};
+  return Object.keys(updates).length > 0 || Object.keys(transitions).length > 0 || asStrings(s.selfDelete).length > 0;
+}
+
+/** Whether this subject can hold a row here AT ALL — the binding reaching them is necessary and
+ *  not sufficient.
+ *
+ *  An `emailField` binding reaches every verified account in the world, so `ownRowReachable` alone
+ *  would report "own rows" for a stranger who has no way to create one, in the one panel whose
+ *  job is to say that strangers reach nothing. So the row has to have been creatable: by them, or
+ *  — for someone on the roster — by the desk on their behalf.
+ *
+ *  The case this closes over rather than models is a stranger who submitted while the app WAS open
+ *  and still owns that row after it closed. The rules do let them read and edit it, and nothing in
+ *  the working tree records that it happened; `caveatsOf` says so in words instead. */
+function ownRow(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): boolean {
+  return ownRowReachable(declared, who) && (who.listed || canCreate(declared, stage, who));
+}
+
+/** `readWith`, in its own order: a role first, then the public switch, then the two roster-wide
+ *  openings, and `ownRow` last as the narrowest answer that is still an answer. */
+function readAccessFor(declared: Declared, who: Principal, isWriter: boolean, own: boolean): ReadAccess {
+  if (isWriter || declared.publicRead) return "all";
+  if (who.listed && (declared.partRead || declared.c.peerVisibility === "public")) return "all";
+  return own ? "own" : "none";
+}
+
+function accessFor(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): SubjectAccess {
+  const { c } = declared;
+  const immutable = flagOn(c, "immutable");
+  const isWriter = who.role === "writer";
+  const own = ownRow(declared, stage, who);
+
+  const read = readAccessFor(declared, who, isWriter, own);
+
+  // `createWith`: a writer creates unless the collection is `submitOnly`, and either way the
+  // public submission path is open to them on the same terms as everybody else.
+  const create = (isWriter && !flagOn(c, "submitOnly")) || canCreate(declared, stage, who);
+
+  return { read, create, editOwn: own && !immutable && selfEditDeclared(declared), editAll: isWriter && !immutable };
+}
+
+/** The window's own sentence, in the four states `windowState` distinguishes. Split out of
+ *  `caveatsOf` because it is the only branch there with more than one outcome. */
+function windowCaveats(declared: Declared): string[] {
+  if (declared.s === undefined) return [];
+  const state = windowState(declared.s, declared.now);
+  if (state === "closed") {
+    return ["The submission window has CLOSED. Nobody reaches this collection through the public path now, whatever the rows above say about who could."];
+  }
+  if (state === "early") return ["The submission window has not opened yet."];
+  if (state === "open") return ["Submissions are only taken inside a declared window, and it is open right now."];
+  if (state === "perRecord") return ["Each record carries its own window bound, on another record — this summary cannot say whether any one of them is open."];
+  return [];
+}
+
+/** What the table cannot answer, said in the author's own declaration's terms.
+ *
+ *  Every one of these NARROWS the table — none of them opens anything — so a reader who ignores
+ *  the list is left with a summary that is too generous rather than too tight, which is the safe
+ *  direction for the one question this panel is asked. */
+function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): string[] {
+  const { c, s } = declared;
+  const caveats: string[] = [];
+  // The gap `ownRow` deliberately does not model — see its note. Reported only where it is
+  // possible: a binding that reaches an outsider, and a door that is now shut to them.
+  //
+  // "Closed to them" has to mean closed BY THE SWITCH, which is the only thing that moves. A
+  // collection scoped `audience: "participant"` refuses an outsider whatever `public.enabled`
+  // says, so it never had the open period this sentence describes — and printing the caveat
+  // there put a warning on `apps/ai-blogs`, whose strangers have never been able to submit.
+  const strandable = OUTSIDER_PRINCIPALS.some(
+    (who) => ownRowReachable(declared, who) && !canCreate(declared, stage, who) && canCreate({ ...declared, publicOn: true }, stage, who),
+  );
+  if (strandable) {
+    caveats.push("Anyone who submitted while this collection was open still reads and edits that row of theirs, whatever it says above.");
+  }
+  caveats.push(...windowCaveats(declared));
+  if (s !== undefined && s.gate !== undefined) caveats.push("A session gate has to be open before a submission is taken.");
+  if (s !== undefined && s.idFrom === "field")
+    caveats.push("The record id is a field, so the first submission for a value takes it and later ones are refused.");
+  if (flagOn(c, "revealGated")) caveats.push("Everyone on the roster reads a row once its parent reveals it.");
+  if (typeof c.assigneeField === "string") caveats.push("An assignee reads everything here and writes only the rows assigned to them.");
+  if (typeof c.mirrorOf === "string") caveats.push("Anyone may repair this collection's `state` field to match the record it mirrors.");
+  return caveats;
+}
+
+/** The summary, from the two documents `app(aid)` resolves to.
+ *
+ *  `cids` is the collections the app PUBLISHES, passed in rather than inferred from the keys
+ *  below: a collection that declares no rule configuration, no public read and no submit is
+ *  exactly the one whose absence from this table would be read as "it is not published". */
+export function sharedAppAccessOf(
+  app: Record<string, unknown>,
+  publicBlock: Record<string, unknown> | undefined,
+  cids: readonly string[],
+  now: number = Date.now(),
+): SharedAppAccess {
+  const publicOn = publicBlock?.enabled === true;
+  const readList = asStrings(publicBlock?.read);
+  const submit = asRecord(publicBlock?.submit) ?? {};
+  const configured = asRecord(app.collections) ?? {};
+  const participantRead = asStrings(app.participantRead);
+  const members = asRecord(app.members) ?? {};
+
+  const all = [...new Set([...cids, ...Object.keys(configured), ...Object.keys(submit), ...readList, ...participantRead])].sort(byCodeUnit);
+
+  return {
+    publicFace: publicFaceOf(publicBlock),
+    collections: all.map((cid): CollectionAccess => {
+      const s = asRecord(submit[cid]);
+      const declared: Declared = {
+        c: asRecord(configured[cid]) ?? {},
+        s,
+        publicOn,
+        publicRead: publicOn && readList.includes(cid),
+        partRead: participantRead.includes(cid),
+        now,
+      };
+      const stage = s?.auth === "anonymous" || s?.auth === "verifiedEmail" ? s.auth : "none";
+      return {
+        cid,
+        takesSubmissions: s !== undefined,
+        authStage: stage,
+        census: censusOf(members, cid),
+        caveats: caveatsOf(declared, stage),
+        access: {
+          visitor: accessFor(declared, stage, PRINCIPALS.visitor),
+          stranger: accessFor(declared, stage, PRINCIPALS.stranger),
+          participant: accessFor(declared, stage, PRINCIPALS.participant),
+          writer: accessFor(declared, stage, PRINCIPALS.writer),
+        },
+      };
+    }),
+  };
+}
+
+/** The wire shape of `GET /api/shared-app/access`, in the three states the pane distinguishes:
+ *  not a shared app at all, a manifest that could not be read, and the summary. */
+export type SharedAppAccessResponse =
+  { declared: false } | { declared: true; ok: false; problems: string[] } | { declared: true; ok: true; access: SharedAppAccess };

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -93,6 +93,13 @@ export interface CollectionAccess {
 export interface SharedAppAccess {
   publicFace: PublicFace;
   collections: CollectionAccess[];
+  /** Roster addresses the rules will never match, because they are not lower case — see
+   *  `unmatchable`. App-wide rather than per collection, because the roster is.
+   *
+   *  Reported rather than silently dropped from the census: an author whose `Owner / editor` count
+   *  reads `(0)` is owed the reason, and this one is invisible in a file that reads correctly to a
+   *  human. */
+  unmatchableRoster: string[];
 }
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined);
@@ -108,9 +115,21 @@ function roleFor(roles: Record<string, unknown>, cid: string): string | null {
   return typeof fallback === "string" ? fallback : null;
 }
 
+/** Roster keys the rules can never match, because of their case.
+ *
+ *  `email() in a.members` is an exact string comparison and rules have no `lower()`; Firebase puts
+ *  a lower-cased address in the token. So `Foo@Example.com` on the roster grants that person
+ *  nothing at all — the same defect `rosterCaseProblems` reports at publish time, and this route
+ *  deliberately answers even for a declaration a publish would refuse. */
+const unmatchable = (address: string): boolean => address !== address.toLowerCase();
+
 function censusOf(members: Record<string, unknown>, cid: string): RoleCensus {
   const census: RoleCensus = { writers: 0, readers: 0, participants: 0 };
-  for (const roles of Object.values(members)) {
+  for (const [address, roles] of Object.entries(members)) {
+    // NOT COUNTED, rather than counted with a warning beside them: the count is what the row says
+    // about who holds this permission, and a key the rules cannot match holds none of it. Counting
+    // it printed `Owner / editor (1)` over an app whose owner is locked out of their own roster.
+    if (unmatchable(address)) continue;
     if (!isRecord(roles)) continue;
     const role = roleFor(roles, cid);
     if (role === "owner" || role === "editor") census.writers += 1;
@@ -373,6 +392,7 @@ export function sharedAppAccessOf(
 
   return {
     publicFace: publicFaceOf(publicBlock),
+    unmatchableRoster: Object.keys(members).filter(unmatchable).sort(byCodeUnit),
     collections: all.map((cid): CollectionAccess => {
       const s = asRecord(submit[cid]);
       const declared: Declared = {

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -394,6 +394,12 @@ function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): st
   }
   if (typeof c.assigneeField === "string") caveats.push("An assignee reads everything here and writes only the rows assigned to them.");
   if (typeof c.mirrorOf === "string") caveats.push("Anyone may repair this collection's `state` field to match the record it mirrors.");
+  // The SUBMISSION side of the same pair (`mirrorClaimed` / `mirrorReleased`), which binds every
+  // create and every delete here — the writer branches included. Without it a create that looks
+  // allowed in the table is refused for a reason nothing on this panel names.
+  if (typeof s?.mirror === "string") {
+    caveats.push(`A record here cannot be created or deleted on its own: the same write has to move the slot it claims in \`${s.mirror}\`.`);
+  }
   return caveats;
 }
 

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -52,6 +52,14 @@ export interface SubjectAccess {
   editOwn: boolean;
   /** May change or delete ANY record here. */
   editAll: boolean;
+  /** `mirrorRepair` — this collection is the PUBLIC PROJECTION of records nobody outside may read
+   *  (`mirrorOf`), and the rules let ANYONE write its `state` field back to the truth. Not even
+   *  `authed()`: a stale grid repairing itself is the whole point of the rule.
+   *
+   *  A flag of its own rather than folded into `editAll`, because it is neither nothing nor a
+   *  general write — one field, to one value, that cannot be a lie. Its own flag is what stops the
+   *  table saying "Nothing" about a collection every visitor may write to. */
+  repairMirror: boolean;
 }
 
 /** How many roster addresses hold each kind of role ON THIS COLLECTION.
@@ -187,20 +195,27 @@ function windowState(submit: Record<string, unknown>, now: number): "none" | "op
   return "open";
 }
 
+/** Only the two states that are DECIDED and shut. `none` is a collection with no window at all,
+ *  and `perRecord` is a bound this summary cannot read — refusing on either would report a closed
+ *  door on most of the apps there are. */
+function windowOpen(submit: Record<string, unknown>, now: number): boolean {
+  const state = windowState(submit, now);
+  return state !== "closed" && state !== "early";
+}
+
 /** `submitCreate` minus the parts that depend on the record and the clock.
  *
  *  The first conjunct is the one #1926 was about and the one this whole panel is for: a
  *  `public.submit` declaration is not a statement that the app is open, so the gate is the SWITCH
  *  or the ROSTER, never the declaration's existence. */
-function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): boolean {
+function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who: Principal, ignoreWindow = false): boolean {
   const { s } = declared;
   if (s === undefined) return false;
   if (!(declared.publicOn || who.listed)) return false;
   // Only the two states that are DECIDED and shut. `none` is a collection with no window at all,
   // and `perRecord` is a bound this summary cannot read — refusing on either would report a closed
   // door on most of the apps there are.
-  const window = windowState(s, declared.now);
-  if (window === "closed" || window === "early") return false;
+  if (!ignoreWindow && !windowOpen(s, declared.now)) return false;
   if (!Array.isArray(s.createFields)) return false;
   if (!authOk(stage, who)) return false;
   // `audience: "participant"` is matched against the ROLE, so it shuts out viewers and editors as
@@ -208,33 +223,49 @@ function canCreate(declared: Declared, stage: CollectionAccess["authStage"], who
   return s.audience !== "participant" || who.role === "participant";
 }
 
-/** `selfWriteOk` / `selfDelete` — is there any self-service edit declared at all?
+/** `selfWriteOk` and `selfDelete`, kept APART — the rules gate them differently and the difference
+ *  shows up exactly when a window closes.
  *
  *  Both are keyed by the CURRENT STATUS, so a collection with no `statusField` can say neither and
- *  the rules fail closed on it. That prerequisite is the declaration's, not a status machine's: a
- *  single-status collection satisfies it. */
-function selfEditDeclared(declared: Declared): boolean {
+ *  the rules fail closed on it. That prerequisite is the declaration's, not a state machine's: a
+ *  single-status collection satisfies it.
+ *
+ *  The update half sits inside `updateWith`, which carries `inWindow`; the delete half is reached
+ *  through `deleteWith`, which does not. So after a window closes a submitter may still WITHDRAW
+ *  their row and may no longer EDIT it. */
+function selfUpdateDeclared(declared: Declared): boolean {
   const { c, s } = declared;
-  if (s === undefined || typeof c.statusField !== "string") return false;
-  if (flagOn(s, "finalize")) return false;
+  if (s === undefined || typeof c.statusField !== "string" || flagOn(s, "finalize")) return false;
+  if (!windowOpen(s, declared.now)) return false;
   const updates = asRecord(s.selfUpdate) ?? {};
   const transitions = asRecord(s.selfTransitions) ?? {};
-  return Object.keys(updates).length > 0 || Object.keys(transitions).length > 0 || asStrings(s.selfDelete).length > 0;
+  return Object.keys(updates).length > 0 || Object.keys(transitions).length > 0;
+}
+
+function selfDeleteDeclared(declared: Declared): boolean {
+  const { c, s } = declared;
+  if (s === undefined || typeof c.statusField !== "string") return false;
+  return asStrings(s.selfDelete).length > 0;
 }
 
 /** Whether this subject can hold a row here AT ALL — the binding reaching them is necessary and
  *  not sufficient.
  *
- *  An `emailField` binding reaches every verified account in the world, so `ownRowReachable` alone
- *  would report "own rows" for a stranger who has no way to create one, in the one panel whose
- *  job is to say that strangers reach nothing. So the row has to have been creatable: by them, or
- *  — for someone on the roster — by the desk on their behalf.
+ *  `emailField` reaches every verified account in the world, so `ownRowReachable` alone would
+ *  report "own rows" for a stranger who has no way to make one, in the one panel whose job is to
+ *  say that strangers reach nothing. So the row has to have been creatable: by them, or — for
+ *  someone on the roster — by the desk on their behalf.
  *
- *  The case this closes over rather than models is a stranger who submitted while the app WAS open
- *  and still owns that row after it closed. The rules do let them read and edit it, and nothing in
- *  the working tree records that it happened; `caveatsOf` says so in words instead. */
-function ownRow(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): boolean {
-  return ownRowReachable(declared, who) && (who.listed || canCreate(declared, stage, who));
+ *  THE WINDOW IS DELIBERATELY IGNORED HERE. `ownRow` in the rules asks for a submit binding and the
+ *  caller's identity and nothing else, so a visitor who submitted while the window was open goes on
+ *  reading that row after it closes. Asking `canCreate` in full would erase their row from this
+ *  table at the exact moment the panel is most likely to be consulted.
+ *
+ *  What it still closes over is a stranger who submitted while the SWITCH was on and the app was
+ *  closed afterwards. Nothing in the working tree records that it happened; `caveatsOf` says so in
+ *  words instead. */
+function holdsRow(declared: Declared, stage: CollectionAccess["authStage"], who: Principal): boolean {
+  return ownRowReachable(declared, who) && (who.listed || canCreate(declared, stage, who, true));
 }
 
 /** `readWith`, in its own order: a role first, then the public switch, then the two roster-wide
@@ -249,7 +280,7 @@ function accessFor(declared: Declared, stage: CollectionAccess["authStage"], who
   const { c } = declared;
   const immutable = flagOn(c, "immutable");
   const isWriter = who.role === "writer";
-  const own = ownRow(declared, stage, who);
+  const own = holdsRow(declared, stage, who);
 
   const read = readAccessFor(declared, who, isWriter, own);
 
@@ -257,7 +288,15 @@ function accessFor(declared: Declared, stage: CollectionAccess["authStage"], who
   // public submission path is open to them on the same terms as everybody else.
   const create = (isWriter && !flagOn(c, "submitOnly")) || canCreate(declared, stage, who);
 
-  return { read, create, editOwn: own && !immutable && selfEditDeclared(declared), editAll: isWriter && !immutable };
+  return {
+    read,
+    create,
+    editOwn: own && !immutable && (selfUpdateDeclared(declared) || selfDeleteDeclared(declared)),
+    editAll: isWriter && !immutable,
+    // Everybody's, and unconditionally: `mirrorRepair` is the FIRST branch of `updateWith` and asks
+    // nothing about the caller.
+    repairMirror: typeof c.mirrorOf === "string",
+  };
 }
 
 /** The window's own sentence, in the four states `windowState` distinguishes. Split out of
@@ -290,13 +329,17 @@ function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): st
   // says, so it never had the open period this sentence describes — and printing the caveat
   // there put a warning on `apps/ai-blogs`, whose strangers have never been able to submit.
   const strandable = OUTSIDER_PRINCIPALS.some(
-    (who) => ownRowReachable(declared, who) && !canCreate(declared, stage, who) && canCreate({ ...declared, publicOn: true }, stage, who),
+    (who) => ownRowReachable(declared, who) && !canCreate(declared, stage, who) && canCreate({ ...declared, publicOn: true }, stage, who, true),
   );
   if (strandable) {
-    caveats.push("Anyone who submitted while this collection was open still reads and edits that row of theirs, whatever it says above.");
+    caveats.push(
+      "Anyone who submitted while this collection was open still reads their own row, and may still withdraw it — the rules bind a row to its submitter without asking the switch or the window.",
+    );
   }
   caveats.push(...windowCaveats(declared));
-  if (s !== undefined && s.gate !== undefined) caveats.push("A session gate has to be open before a submission is taken.");
+  // `gateOn` — the projected key, and the one the rules read. `gate` is not produced by anything.
+  if (s !== undefined && s.gateOn !== undefined)
+    caveats.push("A session gate has to be open, on the question the host is currently showing, before a submission is taken.");
   if (s !== undefined && s.idFrom === "field")
     caveats.push("The record id is a field, so the first submission for a value takes it and later ones are refused.");
   if (flagOn(c, "revealGated")) caveats.push("Everyone on the roster reads a row once its parent reveals it.");

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -332,8 +332,11 @@ function caveatsOf(declared: Declared, stage: CollectionAccess["authStage"]): st
     (who) => ownRowReachable(declared, who) && !canCreate(declared, stage, who) && canCreate({ ...declared, publicOn: true }, stage, who, true),
   );
   if (strandable) {
+    // ONLY what is actually declared. `selfDelete` is what makes a withdrawal possible, and a
+    // caveat promising one where the declaration names none is the panel inventing a permission.
+    const andWithdraw = selfDeleteDeclared(declared) ? ", and may still withdraw it" : "";
     caveats.push(
-      "Anyone who submitted while this collection was open still reads their own row, and may still withdraw it — the rules bind a row to its submitter without asking the switch or the window.",
+      `Anyone who submitted while this collection was open still reads their own row${andWithdraw} — the rules bind a row to its submitter without asking the switch or the window.`,
     );
   }
   caveats.push(...windowCaveats(declared));

--- a/common/sharedAppAccess.ts
+++ b/common/sharedAppAccess.ts
@@ -248,7 +248,11 @@ function requiredCreateFields(declared: Declared, stage: CollectionAccess["authS
   if (typeof s.uidField === "string") need.push(s.uidField);
   if (typeof s.idField === "string" && (s.idFrom === "auth.uid+field" || s.idFrom === "field" || s.idFrom === "slug")) need.push(s.idField);
   if (typeof s.stampField === "string") need.push(s.stampField);
-  if (typeof c.statusField === "string" && s.initialStatus !== undefined) need.push(c.statusField);
+  // The status field is demanded by TWO different rules, and the second one has no `initialStatus`
+  // in it: `initialOk` refuses a create whose status is null whenever `transitions` and
+  // `statusField` are both declared, so the submitter must be able to send one either way. Which
+  // VALUE they send is not decidable from the declaration — the `transitions` caveat carries that.
+  if (typeof c.statusField === "string" && (s.initialStatus !== undefined || c.transitions !== undefined)) need.push(c.statusField);
   const gate = asRecord(s.gateOn);
   if (gate !== undefined && typeof gate.match === "string") need.push(gate.match);
   // `refIn` builds the parent's path out of this field of the submission.

--- a/server/backends/sharedApp/access.ts
+++ b/server/backends/sharedApp/access.ts
@@ -1,0 +1,47 @@
+// The access summary, for the pane that draws it.
+//
+// PURE, and that is the point of it having a file of its own next to `preview.ts`: `projectPublish`
+// takes no clock, no filesystem and no Firestore, so "who can see what" is answerable from the
+// working tree alone. The preview beside it needs a signed-in session because it READS the app's
+// records; this needs none, which is why it can be shown in a pane whose preview is switched off,
+// on a machine that has never connected.
+//
+// It projects rather than reading `app.json` directly. The rules evaluate `apps/{aid}` and its
+// `public` block, and the manifest is not those documents — `participantRead`, the roster and the
+// per-tier submit projections are all decided by the compiler. Reading the manifest here would be a
+// second implementation of the compiler, and the two would agree until the day they did not.
+import { projectPublish } from "@receptron/sharedapp";
+import { readAuthored, schemasOf, sharedCollections } from "./context.js";
+import { sharedAppAccessOf, type SharedAppAccess } from "../../../common/sharedAppAccess.js";
+
+/** The stamp `projectPublish` requires and this answer does not use.
+ *
+ *  Named rather than inlined so it is obvious that nothing below reads it: the stamp decides
+ *  `owner`, `publishedAt` and `publishedCommit`, and not one rule predicate about access consults
+ *  any of them. Passing the real one would mean resolving git and a Firebase session to compute
+ *  three fields that are then thrown away. */
+const UNUSED_STAMP = { uid: "", email: "", publishedAt: 0 };
+
+export type AccessResult = { ok: true; access: SharedAppAccess } | { ok: false; problems: string[] };
+
+/** What publishing this directory would grant, per collection.
+ *
+ *  A declaration with PROBLEMS is still answered. The author is looking at the panel while they
+ *  edit, and a summary that disappears whenever the manifest is momentarily wrong is a summary
+ *  nobody keeps open — the gate that refuses a bad publish is `publish`, not this. Only a manifest
+ *  that cannot be PARSED has no answer, because there is no declaration to summarize. */
+export async function sharedAppAccess(root: string): Promise<AccessResult> {
+  const authored = await readAuthored(root);
+  if (!authored.ok) return { ok: false, problems: authored.problems };
+
+  const collections = await sharedCollections(root);
+  const face = projectPublish(authored.app, schemasOf(collections), UNUSED_STAMP, null);
+  return {
+    ok: true,
+    access: sharedAppAccessOf(
+      face.app,
+      face.public,
+      collections.map((collection) => collection.slug),
+    ),
+  };
+}

--- a/server/backends/sharedApp/context.ts
+++ b/server/backends/sharedApp/context.ts
@@ -97,7 +97,7 @@ function byCid(left: { cid: string }, right: { cid: string }): number {
   return left.cid < right.cid ? -1 : 1;
 }
 
-async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp } | { ok: false; problems: string[] }> {
+export async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp } | { ok: false; problems: string[] }> {
   let raw: string;
   try {
     raw = await readFile(path.join(root, APP_MANIFEST_FILE), "utf-8");

--- a/server/backends/sharedAppPreviewRoutes.ts
+++ b/server/backends/sharedAppPreviewRoutes.ts
@@ -15,6 +15,7 @@ import { access } from "node:fs/promises";
 import path from "node:path";
 import { APP_MANIFEST_FILE } from "@mulmoclaude/core/collection/server";
 import { previewSharedApp } from "./sharedApp/preview.js";
+import { sharedAppAccess } from "./sharedApp/access.js";
 import { holdOpen, watchPreviewRecords } from "./sharedApp/previewWatch.js";
 import { undoPreviewSubmission, writePreviewSubmission } from "./sharedApp/previewWrite.js";
 import { performPreviewIntent } from "./sharedApp/previewIntent.js";
@@ -23,6 +24,7 @@ import { requestBody } from "../routes/requestBody.js";
 import { isRecord } from "../../common/isRecord.js";
 import { workspaceForRoute } from "../routes/routeParams.js";
 import type { PreviewIntent, PreviewSubmission, SharedAppPreview, SharedAppPreviewResponse } from "../../common/sharedAppPreview.js";
+import type { SharedAppAccessResponse } from "../../common/sharedAppAccess.js";
 
 const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
@@ -258,6 +260,58 @@ function mountRecordStream(app: Express): void {
   });
 }
 
+// WHO CAN SEE WHAT, per collection. A GET with no session behind it: the summary is a pure
+// projection of the working tree (see `sharedAppAccess`), so it answers on a machine that has
+// never connected to Firestore — which is the whole reason it can sit in a pane whose preview is
+// off, beside collections the author is editing.
+//
+// The same three-state answer shape as the preview route: `declared: false` for the ordinary
+// directory, a 200 carrying `problems` when the manifest cannot be read, and the summary
+// otherwise. Not because the shapes must match, but because the pane asks both and a second
+// convention for "this is not a shared app" is a second thing to get wrong.
+/** The two GETs that cost no Firestore session: "is there an app here?" and "who can reach it?".
+ *  Together because the pane asks them as one question and neither reads a record. */
+function mountAccessRoute(app: Express): void {
+  // "Is there anything to preview here?" — one `stat`, and its own route rather than a flag on the
+  // one below. The pane asks it for every directory a cell is open in, and computing a whole
+  // publish projection to answer "no" would put a Firestore session behind a question about a
+  // file's existence.
+  app.get("/api/shared-app/declared", (req, res) => {
+    void (async () => {
+      try {
+        const cwd = workspaceForRoute(req.query.cwd, res);
+        if (cwd === null) return;
+        res.json({ declared: await declaresAnApp(cwd) });
+      } catch (err) {
+        // `declaresAnApp` swallows its own failures, but the guard and the write can still throw,
+        // and an unhandled rejection here is a request that never gets an answer at all.
+        fail(res, err);
+      }
+    })();
+  });
+
+  app.get("/api/shared-app/access", (req, res) => {
+    void (async () => {
+      try {
+        const cwd = workspaceForRoute(req.query.cwd, res);
+        if (cwd === null) return;
+        if (!(await declaresAnApp(cwd))) {
+          res.json({ declared: false } satisfies SharedAppAccessResponse);
+          return;
+        }
+        const result = await sharedAppAccess(cwd);
+        res.json(
+          result.ok
+            ? ({ declared: true, ok: true, access: result.access } satisfies SharedAppAccessResponse)
+            : ({ declared: true, ok: false, problems: result.problems } satisfies SharedAppAccessResponse),
+        );
+      } catch (err) {
+        fail(res, err);
+      }
+    })();
+  });
+}
+
 export function mountSharedAppPreviewRoutes(app: Express): void {
   // The write the author accepted in the confirmation, performed as them.
   //
@@ -317,23 +371,7 @@ export function mountSharedAppPreviewRoutes(app: Express): void {
     })();
   });
 
-  // "Is there anything to preview here?" — one `stat`, and its own route rather than a flag on the
-  // one below. The pane asks it for every directory a cell is open in, and computing a whole
-  // publish projection to answer "no" would put a Firestore session behind a question about a
-  // file's existence.
-  app.get("/api/shared-app/declared", (req, res) => {
-    void (async () => {
-      try {
-        const cwd = workspaceForRoute(req.query.cwd, res);
-        if (cwd === null) return;
-        res.json({ declared: await declaresAnApp(cwd) });
-      } catch (err) {
-        // `declaresAnApp` swallows its own failures, but the guard and the write can still throw,
-        // and an unhandled rejection here is a request that never gets an answer at all.
-        fail(res, err);
-      }
-    })();
-  });
+  mountAccessRoute(app);
 
   mountRecordStream(app);
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -516,6 +516,20 @@ the cell open on this repository: the **Collections pane** → the **Previews** 
 so the pages are usually already there; turning it OFF is what shows the collections underneath
 them. Opening it reads only: nothing is written and no URL name is taken.
 
+**With that switch OFF there is an `Access` button beside it, and it answers the question neither
+preview can.** Both previews run as the AUTHOR, so they show what the author's own session may do;
+`Access` shows, per collection, what a person who never signed in and a person who signed in and was
+never invited may read and write. It is a transcription of `firestore.rules` off the two documents
+those rules read — the app document and its `public` block, projected from the working tree — so it
+needs no Firestore session and writes nothing, and it changes the moment you edit `app.json`.
+
+Read it before every `publish` of an app whose roster is the point, and **say what it shows in your
+own words** rather than only pointing at it: the row to read out is `Signed in, not invited`. A
+`public.submit` declaration is not a statement that the app is open — an invite-only app needs one so
+its own members' pages can write — and reading those two keys as one is what mulmoterminal#1926 was.
+The deployed rules decide; if that panel and the deployment ever disagree, the deployment is right
+and the disagreement is a bug worth reporting.
+
 **Accepting a submission there DOES write a real record**, as the signed-in author, into the live
 app — the pane says so at the button and lists what it made with an Undo beside it. So it is a
 real answer in the app's data, not a rehearsal: tell the user that before they press *Send it*,

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -18,6 +18,7 @@ import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 import { asSelfContainmentReport, type SelfContainmentReport, type SelfContainmentSeverity } from "../../common/collectionPortability";
 import type { ShortcutKind } from "../../common/shortcuts";
 import SharedAppPreview from "./SharedAppPreview.vue";
+import SharedAppAccessPanel from "./SharedAppAccessPanel.vue";
 import { isRecord } from "../../common/isRecord";
 
 const props = defineProps<{ cwd: string | null; expanded?: boolean }>();
@@ -37,6 +38,23 @@ const selectedId = ref<string | null>(null);
 const declaresApp = ref(false);
 const previewing = ref(false);
 
+// The pane's THIRD face: who, outside the roster, can reach these collections. It fills the body
+// like the preview does — the answer is a table per collection and there is no strip it fits in —
+// so the two are mutually exclusive, and each control turns the other off rather than leaving the
+// user to work out which one is winning.
+//
+// Not a checkbox beside `Previews`, because two independent-looking checkboxes over one slot is a
+// pair of controls that contradict each other on screen. A pressed button says "this is what you
+// are looking at", which is what it means.
+const showingAccess = ref(false);
+watch(previewing, (on) => {
+  if (on) showingAccess.value = false;
+});
+function toggleAccess(): void {
+  showingAccess.value = !showingAccess.value;
+  if (showingAccess.value) previewing.value = false;
+}
+
 // Whether anything has NAVIGATED since this directory was opened. The shared-app default below
 // only applies to a pane nobody has steered yet, and "still on the index" is not that test:
 // `gotoIndex("feed")` and a deliberate return to the collections index both leave `mode ===
@@ -50,6 +68,7 @@ let viewTouched = false;
 function navigated(next: PaneView, itemId: string | null): void {
   viewTouched = true;
   previewing.value = false;
+  showingAccess.value = false;
   selectedId.value = itemId;
   view.value = next;
 }
@@ -132,6 +151,7 @@ async function probeForApp(cwd: string | null): Promise<void> {
   const mine = ++probeGeneration;
   declaresApp.value = false;
   previewing.value = false;
+  showingAccess.value = false;
   if (cwd === null) return;
   try {
     const res = await fetchWithTimeout(`/api/shared-app/declared?cwd=${encodeURIComponent(cwd)}`);
@@ -279,6 +299,24 @@ useCollectionTeleportTarget(probe);
             <input v-model="previewing" data-testid="collections-preview-toggle" type="checkbox" class="h-3.5 w-3.5 cursor-pointer accent-accent" />
             Previews
           </label>
+          <!-- The THIRD face. A pressed button rather than a second checkbox beside `Previews`:
+               both fill the same slot, so a control that looks independent of the one next to it
+               would be a lie the first time you press it. It sits with `Previews` because it is
+               the same kind of question — about the APP rather than about the one collection on
+               screen — and it appears on the same condition, since a directory that declares no
+               app grants nobody anything and has no answer to give. -->
+          <button
+            v-if="declaresApp"
+            type="button"
+            data-testid="collections-access-btn"
+            class="shrink-0 cursor-pointer rounded-[5px] border px-1.5 py-[2px] text-[11px] hover:border-accent"
+            :class="showingAccess ? 'border-accent bg-input text-fg' : 'border-border bg-transparent text-dim'"
+            :aria-pressed="showingAccess"
+            title="Who can reach these collections — and which of them a stranger can read or write. Nothing is written."
+            @click="toggleAccess"
+          >
+            Access
+          </button>
           <!-- Where the preview's PAGE PICKER lands. It is the preview's control and its state
                lives there, so it is teleported in rather than lifted — but it belongs on this bar:
                a second strip of chrome directly beneath this one was two toolbars saying different
@@ -321,6 +359,9 @@ useCollectionTeleportTarget(probe);
     </div>
     <div v-else-if="previewing" class="min-h-0 flex-1">
       <SharedAppPreview :cwd="cwd" :picker-target="pickerSlot" />
+    </div>
+    <div v-else-if="showingAccess" class="min-h-0 flex-1">
+      <SharedAppAccessPanel :cwd="cwd" />
     </div>
     <template v-else>
       <div class="min-h-0 flex-1">

--- a/src/components/SharedAppAccessPanel.vue
+++ b/src/components/SharedAppAccessPanel.vue
@@ -22,6 +22,8 @@ const props = defineProps<{ cwd: string | null }>();
 const loading = ref(true);
 const problems = ref<string[]>([]);
 const failed = ref(false);
+/** The app.json went away under us — not a fault, and not something to draw a table about. */
+const notDeclared = ref(false);
 const access = ref<SharedAppAccess | null>(null);
 
 // A GENERATION token rather than a comparison of `cwd`, for the reason every other lookup in this
@@ -30,10 +32,35 @@ const access = ref<SharedAppAccess | null>(null);
 // which is the single worst thing a panel about permissions can do.
 let generation = 0;
 
+/** What the response MEANS, decided in one place and away from the refs it sets.
+ *
+ *  FOUR outcomes, and "none of them" is not one — a body that classifies as nothing left the panel
+ *  blank with no state at all, which reads as a rendering fault rather than an answer. So the two
+ *  shapes with nothing to say (`declared` absent, and a refusal carrying no reasons) both land on
+ *  `failed`, and only a directory that genuinely stopped declaring an app gets its own quiet line. */
+type Outcome = { kind: "notDeclared" } | { kind: "failed" } | { kind: "problems"; problems: string[] } | { kind: "access"; access: SharedAppAccess };
+
+function outcomeOf(body: unknown): Outcome {
+  if (!isRecord(body)) return { kind: "failed" };
+  // Reachable when the manifest is removed between the pane's `/declared` probe and this request.
+  if (body.declared === false) return { kind: "notDeclared" };
+  if (body.declared !== true) return { kind: "failed" };
+  if (body.ok === false) {
+    const listed = Array.isArray(body.problems) ? body.problems.filter((entry): entry is string => typeof entry === "string") : [];
+    return listed.length > 0 ? { kind: "problems", problems: listed } : { kind: "failed" };
+  }
+  // Narrowed rather than asserted, and a payload that does not narrow becomes the SAME failure a
+  // dead server is — see `asAccess`. A permission table drawn from something we could not read is
+  // the one thing worse than no table.
+  const parsed = asAccess(body.access);
+  return parsed === null ? { kind: "failed" } : { kind: "access", access: parsed };
+}
+
 async function load(cwd: string | null): Promise<void> {
   const mine = ++generation;
   loading.value = true;
   failed.value = false;
+  notDeclared.value = false;
   problems.value = [];
   access.value = null;
   if (cwd === null) {
@@ -45,17 +72,11 @@ async function load(cwd: string | null): Promise<void> {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body: unknown = await res.json();
     if (mine !== generation) return;
-    if (!isRecord(body) || body.declared !== true) return;
-    if (body.ok === false) {
-      problems.value = Array.isArray(body.problems) ? body.problems.filter((entry): entry is string => typeof entry === "string") : [];
-      return;
-    }
-    // Narrowed rather than asserted, and a payload that does not narrow becomes the SAME failure a
-    // dead server is — see `asAccess`. A permission table drawn from something we could not read is
-    // the one thing worse than no table.
-    const parsed = asAccess(body.access);
-    if (parsed === null) failed.value = true;
-    else access.value = parsed;
+    const outcome = outcomeOf(body);
+    if (outcome.kind === "notDeclared") notDeclared.value = true;
+    else if (outcome.kind === "failed") failed.value = true;
+    else if (outcome.kind === "problems") problems.value = outcome.problems;
+    else access.value = outcome.access;
   } catch {
     if (mine === generation) failed.value = true;
   } finally {
@@ -97,10 +118,18 @@ const READ_LABEL = { all: "All rows", own: "Own rows", none: "Nothing" } as cons
 function writeLabel(entry: SubjectAccess): string {
   if (entry.editAll) return entry.create ? "Anything" : "Edit any row";
   if (entry.create) return entry.editOwn ? "Submit, edit own" : "Submit only";
-  return entry.editOwn ? "Edit own only" : "Nothing";
+  if (entry.editOwn) return "Edit own only";
+  // LAST, and it is the only label that is not "Nothing" for somebody who may do almost nothing:
+  // a `mirrorOf` collection lets anyone at all write its `state` back to the truth, so the cell
+  // that would otherwise read "Nothing" would be contradicting the deployed rule.
+  return entry.repairMirror ? "Repair `state` only" : "Nothing";
 }
 
-const reaches = (entry: SubjectAccess): boolean => entry.read !== "none" || entry.create || entry.editOwn || entry.editAll;
+/** Any write at all — the test the write cell's colour uses. Not `writeLabel(...) !== "Nothing"`:
+ *  a colour decided by comparing rendered English breaks the moment a label is reworded. */
+const writes = (entry: SubjectAccess): boolean => entry.create || entry.editOwn || entry.editAll || entry.repairMirror;
+
+const reaches = (entry: SubjectAccess): boolean => entry.read !== "none" || entry.create || entry.editOwn || entry.editAll || entry.repairMirror;
 
 /** How many people the roster actually puts in this row. `null` for the two outsiders, who are not
  *  a group anyone is enrolled in — printing "0 people" beside a stranger would read as "nobody can
@@ -124,6 +153,7 @@ const shutToOutsiders = computed(
   <div class="flex h-full min-h-0 flex-col overflow-y-auto px-4 py-3 font-sans text-[11px]">
     <div v-if="loading" class="text-dim">Working out who can see what…</div>
     <div v-else-if="failed" class="text-err-text">Could not work out the access summary.</div>
+    <div v-else-if="notDeclared" class="text-dim">This directory no longer declares a shared app, so it grants nobody anything.</div>
     <div v-else-if="problems.length" class="flex flex-col gap-1">
       <span class="text-err-text">The declaration could not be read.</span>
       <span v-for="problem in problems" :key="problem" class="leading-[1.4] text-dim">{{ problem }}</span>
@@ -171,7 +201,7 @@ const shutToOutsiders = computed(
               <td class="py-1 pr-2" :class="OUTSIDERS.includes(subject) && collection.access[subject].read !== 'none' ? 'text-amber' : 'text-dim'">
                 {{ READ_LABEL[collection.access[subject].read] }}
               </td>
-              <td class="py-1" :class="OUTSIDERS.includes(subject) && writeLabel(collection.access[subject]) !== 'Nothing' ? 'text-amber' : 'text-dim'">
+              <td class="py-1" :class="OUTSIDERS.includes(subject) && writes(collection.access[subject]) ? 'text-amber' : 'text-dim'">
                 {{ writeLabel(collection.access[subject]) }}
               </td>
             </tr>

--- a/src/components/SharedAppAccessPanel.vue
+++ b/src/components/SharedAppAccessPanel.vue
@@ -115,14 +115,23 @@ const READ_LABEL = { all: "All rows", own: "Own rows", none: "Nothing" } as cons
 /** The write cell, from the three permissions rather than a fourth enum: they are independent in
  *  the rules (`submitOnly` takes creation off a writer and leaves editing; `immutable` does the
  *  reverse) and any enum of the combinations is a list somebody has to keep complete. */
-function writeLabel(entry: SubjectAccess): string {
-  if (entry.editAll) return entry.create ? "Anything" : "Edit any row";
+/** The label for the two ordinary permissions, before `mirrorRepair` is added to it. `""` is
+ *  "neither", which is a different answer from "Nothing" once a repair may still be possible. */
+function writeBase(entry: SubjectAccess): string {
   if (entry.create) return entry.editOwn ? "Submit, edit own" : "Submit only";
-  if (entry.editOwn) return "Edit own only";
-  // LAST, and it is the only label that is not "Nothing" for somebody who may do almost nothing:
-  // a `mirrorOf` collection lets anyone at all write its `state` back to the truth, so the cell
-  // that would otherwise read "Nothing" would be contradicting the deployed rule.
-  return entry.repairMirror ? "Repair `state` only" : "Nothing";
+  return entry.editOwn ? "Edit own only" : "";
+}
+
+function writeLabel(entry: SubjectAccess): string {
+  // A writer's `editAll` already covers the one field a repair touches, so it is the only branch
+  // that does not mention it.
+  if (entry.editAll) return entry.create ? "Anything" : "Edit any row";
+  const base = writeBase(entry);
+  // `mirrorRepair` is an ADDITION to whatever else this subject may do, not an alternative to it:
+  // a visitor who may submit here may also repair `state` on somebody else's row, and a label that
+  // named only the submission would be describing the smaller of the two permissions.
+  if (!entry.repairMirror) return base === "" ? "Nothing" : base;
+  return base === "" ? "Repair `state` only" : `${base}, repair \`state\``;
 }
 
 /** Any write at all — the test the write cell's colour uses. Not `writeLabel(...) !== "Nothing"`:

--- a/src/components/SharedAppAccessPanel.vue
+++ b/src/components/SharedAppAccessPanel.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+// WHO CAN SEE WHAT, drawn beside the collections themselves.
+//
+// The author's question here is not "what does my app do" — the preview answers that — it is "who
+// that I did not invite can reach this". That question is asked about the collections, while
+// looking at them, which is why this is a face of the collections pane and not a page of the
+// preview: with Previews on you are looking at the app; with Previews off you are looking at its
+// storage, and this says who else is.
+//
+// It reports; it authorizes nothing (see `common/sharedAppAccess.ts`). So the two rows that matter
+// are drawn first and are the only ones given a colour: an author scanning this is scanning for a
+// stranger's row that is not empty.
+import { computed, ref, watch } from "vue";
+import { fetchWithTimeout } from "../utils/fetchWithTimeout";
+import { ACCESS_SUBJECTS, type AccessSubject, type CollectionAccess, type SharedAppAccess, type SubjectAccess } from "../../common/sharedAppAccess";
+import type { PublicFace } from "../../common/sharedAppPublicFace";
+import { isRecord } from "../../common/isRecord";
+import { asAccess } from "../utils/sharedAppAccessPayload";
+
+const props = defineProps<{ cwd: string | null }>();
+
+const loading = ref(true);
+const problems = ref<string[]>([]);
+const failed = ref(false);
+const access = ref<SharedAppAccess | null>(null);
+
+// A GENERATION token rather than a comparison of `cwd`, for the reason every other lookup in this
+// pane has one: a cell moved between directories while a request is out, and the older answer
+// landing afterwards would label THIS directory's collections with the previous one's permissions —
+// which is the single worst thing a panel about permissions can do.
+let generation = 0;
+
+async function load(cwd: string | null): Promise<void> {
+  const mine = ++generation;
+  loading.value = true;
+  failed.value = false;
+  problems.value = [];
+  access.value = null;
+  if (cwd === null) {
+    loading.value = false;
+    return;
+  }
+  try {
+    const res = await fetchWithTimeout(`/api/shared-app/access?cwd=${encodeURIComponent(cwd)}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const body: unknown = await res.json();
+    if (mine !== generation) return;
+    if (!isRecord(body) || body.declared !== true) return;
+    if (body.ok === false) {
+      problems.value = Array.isArray(body.problems) ? body.problems.filter((entry): entry is string => typeof entry === "string") : [];
+      return;
+    }
+    // Narrowed rather than asserted, and a payload that does not narrow becomes the SAME failure a
+    // dead server is — see `asAccess`. A permission table drawn from something we could not read is
+    // the one thing worse than no table.
+    const parsed = asAccess(body.access);
+    if (parsed === null) failed.value = true;
+    else access.value = parsed;
+  } catch {
+    if (mine === generation) failed.value = true;
+  } finally {
+    if (mine === generation) loading.value = false;
+  }
+}
+
+watch(() => props.cwd, load, { immediate: true });
+
+const FACE_NOTE: Record<PublicFace, string> = {
+  open: "This app is OPEN. `public.enabled` is true, so anyone with the link reaches its public face.",
+  declared: "This app is CLOSED. It declares a public face, but `public.enabled` is off — only the roster gets in.",
+  none: "This app declares no public face. Nothing here is reachable without a role on the roster.",
+};
+
+const SUBJECT_LABEL: Record<AccessSubject, string> = {
+  visitor: "Not signed in",
+  stranger: "Signed in, not invited",
+  participant: "Participant",
+  writer: "Owner / editor",
+};
+
+const SUBJECT_NOTE: Record<AccessSubject, string> = {
+  visitor: "A visitor on the public page. Firebase gives them an anonymous session, so they have a uid and no verified address.",
+  stranger: "Any Google account in the world. The app id and the collection ids are world-readable, so knowing them is not a barrier.",
+  participant: "On the roster, holding the role `participant` here.",
+  writer: "On the roster, holding `owner` or `editor` here.",
+};
+
+/** The two rows this panel exists for. Kept as a list rather than an index comparison so the order
+ *  of `ACCESS_SUBJECTS` can change without quietly moving the emphasis onto the wrong people. */
+const OUTSIDERS: readonly AccessSubject[] = ["visitor", "stranger"];
+
+const READ_LABEL = { all: "All rows", own: "Own rows", none: "Nothing" } as const;
+
+/** The write cell, from the three permissions rather than a fourth enum: they are independent in
+ *  the rules (`submitOnly` takes creation off a writer and leaves editing; `immutable` does the
+ *  reverse) and any enum of the combinations is a list somebody has to keep complete. */
+function writeLabel(entry: SubjectAccess): string {
+  if (entry.editAll) return entry.create ? "Anything" : "Edit any row";
+  if (entry.create) return entry.editOwn ? "Submit, edit own" : "Submit only";
+  return entry.editOwn ? "Edit own only" : "Nothing";
+}
+
+const reaches = (entry: SubjectAccess): boolean => entry.read !== "none" || entry.create || entry.editOwn || entry.editAll;
+
+/** How many people the roster actually puts in this row. `null` for the two outsiders, who are not
+ *  a group anyone is enrolled in — printing "0 people" beside a stranger would read as "nobody can
+ *  do this", which is the opposite of what their row is for. */
+function headcount(collection: CollectionAccess, subject: AccessSubject): number | null {
+  if (subject === "participant") return collection.census.participants;
+  if (subject === "writer") return collection.census.writers;
+  return null;
+}
+
+const AUTH_LABEL = { none: "no sign-in required", anonymous: "any session", verifiedEmail: "verified email" } as const;
+
+/** Collections whose two outsider rows are both empty, counted for the summary line: an author
+ *  with fifteen collections wants to be told the number that are shut before reading the table. */
+const shutToOutsiders = computed(
+  () => (access.value?.collections ?? []).filter((collection) => OUTSIDERS.every((subject) => !reaches(collection.access[subject]))).length,
+);
+</script>
+
+<template>
+  <div class="flex h-full min-h-0 flex-col overflow-y-auto px-4 py-3 font-sans text-[11px]">
+    <div v-if="loading" class="text-dim">Working out who can see what…</div>
+    <div v-else-if="failed" class="text-err-text">Could not work out the access summary.</div>
+    <div v-else-if="problems.length" class="flex flex-col gap-1">
+      <span class="text-err-text">The declaration could not be read.</span>
+      <span v-for="problem in problems" :key="problem" class="leading-[1.4] text-dim">{{ problem }}</span>
+    </div>
+    <template v-else-if="access">
+      <!-- THE SWITCH, first and on its own. Every cell below is downstream of it: with
+           `public.enabled` off, a `public.submit` declaration grants a stranger nothing, and that
+           is exactly the pair an author reads the wrong way round (#1926). -->
+      <p class="m-0 leading-[1.45]" :class="access.publicFace === 'open' ? 'text-amber' : 'text-dim'" :data-testid="`access-face-${access.publicFace}`">
+        {{ FACE_NOTE[access.publicFace] }}
+      </p>
+      <p v-if="access.collections.length" class="m-0 mt-1 text-dim">
+        {{ shutToOutsiders }} of {{ access.collections.length }} collections are shut to everyone outside the roster.
+      </p>
+
+      <div v-if="!access.collections.length" class="mt-3 text-dim">This app publishes no collections yet.</div>
+
+      <section v-for="collection in access.collections" :key="collection.cid" class="mt-4" :data-testid="`access-collection-${collection.cid}`">
+        <div class="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5">
+          <span class="font-semibold text-fg">{{ collection.cid }}</span>
+          <span class="text-dim">
+            {{ collection.takesSubmissions ? `takes submissions — ${AUTH_LABEL[collection.authStage]}` : "no submission path declared" }}
+          </span>
+        </div>
+        <!-- Three columns, not four subjects across: this pane is a cell's side panel and is
+             routinely half a screen wide. Down the page the two outsiders stay side by side with
+             the people who were invited, which is the comparison being made. -->
+        <table class="mt-1 w-full border-collapse text-left">
+          <thead>
+            <tr class="text-dim">
+              <th scope="col" class="w-[46%] py-0.5 pr-2 font-normal">Who</th>
+              <th scope="col" class="py-0.5 pr-2 font-normal">Reads</th>
+              <th scope="col" class="py-0.5 font-normal">Writes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="subject in ACCESS_SUBJECTS" :key="subject" class="border-t border-border align-top" :data-testid="`access-${collection.cid}-${subject}`">
+              <th scope="row" class="py-1 pr-2 font-normal" :class="OUTSIDERS.includes(subject) ? 'text-fg' : 'text-dim'" :title="SUBJECT_NOTE[subject]">
+                {{ SUBJECT_LABEL[subject] }}<span v-if="headcount(collection, subject) !== null" class="text-dim"> ({{ headcount(collection, subject) }})</span>
+              </th>
+              <!-- COLOUR ONLY ON THE OUTSIDERS, and only where they reach something. A participant
+                   reading their own rows is the app working; a stranger doing it is the thing the
+                   author opened this panel to check, and a table where everything is highlighted
+                   highlights nothing. -->
+              <td class="py-1 pr-2" :class="OUTSIDERS.includes(subject) && collection.access[subject].read !== 'none' ? 'text-amber' : 'text-dim'">
+                {{ READ_LABEL[collection.access[subject].read] }}
+              </td>
+              <td class="py-1" :class="OUTSIDERS.includes(subject) && writeLabel(collection.access[subject]) !== 'Nothing' ? 'text-amber' : 'text-dim'">
+                {{ writeLabel(collection.access[subject]) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <!-- Each of these can only NARROW the table above it, never widen it — so an author who
+             stops reading here has an answer that is too generous rather than too tight. -->
+        <ul v-if="collection.caveats.length" class="mt-1 flex list-none flex-col gap-0.5 p-0 text-dim">
+          <li v-for="caveat in collection.caveats" :key="caveat" class="leading-[1.4]">{{ caveat }}</li>
+        </ul>
+        <p v-if="collection.census.readers" class="m-0 mt-1 text-dim">
+          {{ collection.census.readers }} more on the roster read every row here as `viewer` or `assignee`.
+        </p>
+      </section>
+
+      <p class="m-0 mt-4 leading-[1.45] text-dim">
+        Read off the two documents the Firestore rules read — the app document and its `public` block — as publishing this directory would write them. The
+        deployed rules are what actually decide; if they disagree with this table, they win and this is the bug.
+      </p>
+    </template>
+  </div>
+</template>

--- a/src/components/SharedAppAccessPanel.vue
+++ b/src/components/SharedAppAccessPanel.vue
@@ -178,6 +178,14 @@ const shutToOutsiders = computed(
         {{ shutToOutsiders }} of {{ access.collections.length }} collections are shut to everyone outside the roster.
       </p>
 
+      <!-- Coloured, because it is a permission the author believes they granted and did not. The
+           rules compare an address exactly, so a capital letter on the roster grants nothing and
+           the file still reads correctly to a human. -->
+      <p v-if="access.unmatchableRoster.length" class="m-0 mt-1 leading-[1.45] text-amber" data-testid="access-unmatchable-roster">
+        {{ access.unmatchableRoster.length }} roster {{ access.unmatchableRoster.length === 1 ? "address is" : "addresses are" }} written with capitals and
+        grant nothing — the rules compare an address exactly. Counted nowhere below: {{ access.unmatchableRoster.join(", ") }}
+      </p>
+
       <div v-if="!access.collections.length" class="mt-3 text-dim">This app publishes no collections yet.</div>
 
       <section v-for="collection in access.collections" :key="collection.cid" class="mt-4" :data-testid="`access-collection-${collection.cid}`">

--- a/src/utils/sharedAppAccessPayload.ts
+++ b/src/utils/sharedAppAccessPayload.ts
@@ -1,0 +1,68 @@
+// The access response, narrowed off the wire.
+//
+// STRICT, and deliberately unlike `asPayload` beside it. The preview fills a gap with a floor,
+// because half a preview is still worth drawing; half a permission table is not — a cell that says
+// "Nothing" because a field failed to parse is indistinguishable from one that says "Nothing"
+// because the rules refuse it, and the author reads both as reassurance. So anything unrecognised
+// makes the WHOLE answer null, and the panel says it could not work the summary out.
+import type { CollectionAccess, ReadAccess, SharedAppAccess, SubjectAccess } from "../../common/sharedAppAccess";
+import type { PublicFace } from "../../common/sharedAppPublicFace";
+import { isRecord } from "../../common/isRecord";
+
+/** The three closed vocabularies, as predicates rather than a shared `includes` helper: the helper
+ *  needed an assertion to hand the value back at its narrowed type, and an assertion is the one
+ *  thing this file is here to avoid. */
+const isFace = (value: unknown): value is PublicFace => value === "open" || value === "declared" || value === "none";
+const isRead = (value: unknown): value is ReadAccess => value === "none" || value === "own" || value === "all";
+const isStage = (value: unknown): value is CollectionAccess["authStage"] => value === "none" || value === "anonymous" || value === "verifiedEmail";
+
+const count = (value: unknown): number | null => (typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null);
+
+function asSubjectAccess(value: unknown): SubjectAccess | null {
+  if (!isRecord(value)) return null;
+  if (!isRead(value.read)) return null;
+  if (typeof value.create !== "boolean" || typeof value.editOwn !== "boolean" || typeof value.editAll !== "boolean") return null;
+  return { read: value.read, create: value.create, editOwn: value.editOwn, editAll: value.editAll };
+}
+
+function asCollectionAccess(value: unknown): CollectionAccess | null {
+  if (!isRecord(value) || typeof value.cid !== "string" || value.cid === "" || typeof value.takesSubmissions !== "boolean") return null;
+  if (!isStage(value.authStage) || !isRecord(value.census)) return null;
+  const writers = count(value.census.writers);
+  const readers = count(value.census.readers);
+  const participants = count(value.census.participants);
+  if (writers === null || readers === null || participants === null) return null;
+  if (!Array.isArray(value.caveats) || value.caveats.some((entry) => typeof entry !== "string")) return null;
+  if (!isRecord(value.access)) return null;
+
+  // Named one by one rather than accumulated in a loop, so the four rows the table draws are the
+  // four this file requires — a loop over `ACCESS_SUBJECTS` needs an assertion to hand the partial
+  // map back as a complete one, and that assertion is exactly the check being skipped.
+  const visitor = asSubjectAccess(value.access.visitor);
+  const stranger = asSubjectAccess(value.access.stranger);
+  const participant = asSubjectAccess(value.access.participant);
+  const writer = asSubjectAccess(value.access.writer);
+  // A MISSING SUBJECT is the case this refusal is for. Four rows are the answer; three of them plus
+  // a silently absent one is a table whose emptiest row is the one nobody was told about.
+  if (visitor === null || stranger === null || participant === null || writer === null) return null;
+  return {
+    cid: value.cid,
+    takesSubmissions: value.takesSubmissions,
+    authStage: value.authStage,
+    census: { writers, readers, participants },
+    caveats: value.caveats.filter((entry): entry is string => typeof entry === "string"),
+    access: { visitor, stranger, participant, writer },
+  };
+}
+
+export function asAccess(value: unknown): SharedAppAccess | null {
+  if (!isRecord(value)) return null;
+  if (!isFace(value.publicFace) || !Array.isArray(value.collections)) return null;
+  const collections: CollectionAccess[] = [];
+  for (const entry of value.collections) {
+    const parsed = asCollectionAccess(entry);
+    if (parsed === null) return null;
+    collections.push(parsed);
+  }
+  return { publicFace: value.publicFace, collections };
+}

--- a/src/utils/sharedAppAccessPayload.ts
+++ b/src/utils/sharedAppAccessPayload.ts
@@ -59,11 +59,16 @@ function asCollectionAccess(value: unknown): CollectionAccess | null {
 export function asAccess(value: unknown): SharedAppAccess | null {
   if (!isRecord(value)) return null;
   if (!isFace(value.publicFace) || !Array.isArray(value.collections)) return null;
+  if (!Array.isArray(value.unmatchableRoster) || value.unmatchableRoster.some((entry) => typeof entry !== "string")) return null;
   const collections: CollectionAccess[] = [];
   for (const entry of value.collections) {
     const parsed = asCollectionAccess(entry);
     if (parsed === null) return null;
     collections.push(parsed);
   }
-  return { publicFace: value.publicFace, collections };
+  return {
+    publicFace: value.publicFace,
+    collections,
+    unmatchableRoster: value.unmatchableRoster.filter((entry): entry is string => typeof entry === "string"),
+  };
 }

--- a/src/utils/sharedAppAccessPayload.ts
+++ b/src/utils/sharedAppAccessPayload.ts
@@ -21,8 +21,9 @@ const count = (value: unknown): number | null => (typeof value === "number" && N
 function asSubjectAccess(value: unknown): SubjectAccess | null {
   if (!isRecord(value)) return null;
   if (!isRead(value.read)) return null;
-  if (typeof value.create !== "boolean" || typeof value.editOwn !== "boolean" || typeof value.editAll !== "boolean") return null;
-  return { read: value.read, create: value.create, editOwn: value.editOwn, editAll: value.editAll };
+  if (typeof value.create !== "boolean" || typeof value.editOwn !== "boolean" || typeof value.editAll !== "boolean" || typeof value.repairMirror !== "boolean")
+    return null;
+  return { read: value.read, create: value.create, editOwn: value.editOwn, editAll: value.editAll, repairMirror: value.repairMirror };
 }
 
 function asCollectionAccess(value: unknown): CollectionAccess | null {

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -277,6 +277,37 @@ describe("a createFields list that cannot carry what the rules demand", () => {
   });
 });
 
+describe("a self-edit declaration that names nothing reachable", () => {
+  const shape = (collection: Record<string, unknown>, self: Record<string, unknown>) =>
+    sharedAppAccessOf(
+      { members: {}, collections: { drafts: { statusField: "status", ...collection } } },
+      { enabled: true, submit: { drafts: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "draft", ...self } } },
+      ["drafts"],
+    );
+
+  it("refuses a `selfTransitions` entry with no target", () => {
+    // `selfWriteOk` asks `selfTransitions[current].hasAny([next])` — an empty list matches nothing.
+    expect(only(shape({}, { selfTransitions: { draft: [] } }), "drafts").access.visitor.editOwn).toBe(false);
+  });
+
+  it("refuses a target the collection's own `transitions` forbid", () => {
+    // `updateWith` asks `transitionOk(c)` before it ever reaches `selfWriteOk`.
+    const c = { transitions: { initial: ["draft"], draft: ["sent"] } };
+    expect(only(shape(c, { selfTransitions: { draft: ["cancelled"] } }), "drafts").access.visitor.editOwn).toBe(false);
+    expect(only(shape(c, { selfTransitions: { draft: ["sent"] } }), "drafts").access.visitor.editOwn).toBe(true);
+  });
+
+  it("refuses a move to the status it moves from, which changes nothing", () => {
+    expect(only(shape({}, { selfTransitions: { draft: ["draft"] } }), "drafts").access.visitor.editOwn).toBe(false);
+  });
+
+  it("refuses a `selfUpdate` entry that names no field", () => {
+    // `changed().hasOnly([])` passes only for a write that changes nothing, which is not an edit.
+    expect(only(shape({}, { selfUpdate: { draft: [] } }), "drafts").access.visitor.editOwn).toBe(false);
+    expect(only(shape({}, { selfUpdate: { draft: ["uid"] } }), "drafts").access.visitor.editOwn).toBe(true);
+  });
+});
+
 describe("a withdrawal every sealed state takes back", () => {
   // `deleteWith` asks `!sealedNow(c)` before it reaches `selfDelete`, so a declaration whose every
   // withdrawable status is also sealed grants no withdrawal at all.

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -48,7 +48,7 @@ describe("an INVITE-ONLY app — the #1926 shape", () => {
   it("gives a signed-in STRANGER nothing at all", () => {
     // The whole point. The aid and the cid are world-readable, so a summary that let this cell
     // read as anything but empty would be describing the hole #1926's fix closed.
-    expect(only(access, "records").access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false });
+    expect(only(access, "records").access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false, repairMirror: false });
     expect(reaches(access, "records", "stranger")).toBe(false);
   });
 
@@ -57,11 +57,11 @@ describe("an INVITE-ONLY app — the #1926 shape", () => {
   });
 
   it("lets a participant read the collection and edit their own row", () => {
-    expect(only(access, "records").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false });
+    expect(only(access, "records").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false, repairMirror: false });
   });
 
   it("lets an owner do anything", () => {
-    expect(only(access, "records").access.writer).toEqual({ read: "all", create: true, editOwn: true, editAll: true });
+    expect(only(access, "records").access.writer).toEqual({ read: "all", create: true, editOwn: true, editAll: true, repairMirror: false });
   });
 
   it("counts the people the roster actually puts in each row", () => {
@@ -79,7 +79,7 @@ describe("an app whose switch is ON", () => {
   const access = sharedAppAccessOf(app, block, ["answers"]);
 
   it("takes an anonymous visitor's submission, since `anonymous` is satisfied by the session the public page holds", () => {
-    expect(only(access, "answers").access.visitor).toEqual({ read: "own", create: true, editOwn: false, editAll: false });
+    expect(only(access, "answers").access.visitor).toEqual({ read: "own", create: true, editOwn: false, editAll: false, repairMirror: false });
   });
 
   it("keeps everyone else's rows out of sight — nothing is in `public.read`", () => {
@@ -124,12 +124,12 @@ describe("a BLOG — the writer edits their own article forever", () => {
   const access = sharedAppAccessOf(app, block, ["articles"]);
 
   it("lets the world read the articles and write nothing", () => {
-    expect(only(access, "articles").access.visitor).toEqual({ read: "all", create: false, editOwn: false, editAll: false });
-    expect(only(access, "articles").access.stranger).toEqual({ read: "all", create: false, editOwn: false, editAll: false });
+    expect(only(access, "articles").access.visitor).toEqual({ read: "all", create: false, editOwn: false, editAll: false, repairMirror: false });
+    expect(only(access, "articles").access.stranger).toEqual({ read: "all", create: false, editOwn: false, editAll: false, repairMirror: false });
   });
 
   it("lets a participant publish and go on editing what they published", () => {
-    expect(only(access, "articles").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false });
+    expect(only(access, "articles").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false, repairMirror: false });
   });
 
   it('shuts a writer out of `audience: "participant"` and out of creating at all, because the collection is submitOnly', () => {
@@ -140,10 +140,11 @@ describe("a BLOG — the writer edits their own article forever", () => {
 
 describe("the submission window, evaluated rather than mentioned", () => {
   const app = { members: {}, collections: { topics: { statusField: "status" } } };
+  // No `read` list on purpose: with the collection world-readable every cell would answer "all"
+  // and the own-row assertion below could not tell the two apart.
   const block = (window: Record<string, unknown>) => ({
     enabled: true,
-    read: ["topics"],
-    submit: { topics: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "open", window } },
+    submit: { topics: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "open", window, selfUpdate: { open: ["uid"] } } },
   });
   const NOW = Date.UTC(2026, 8, 1);
 
@@ -152,26 +153,80 @@ describe("the submission window, evaluated rather than mentioned", () => {
     // summary that only said "there is a window" reported an open board nobody can post to.
     const access = sharedAppAccessOf(app, block({ untilMs: Date.UTC(2000, 0, 1) }), ["topics"], NOW);
     expect(only(access, "topics").access.visitor.create).toBe(false);
-    expect(only(access, "topics").caveats[0]).toContain("has CLOSED");
+    expect(only(access, "topics").caveats.join(" ")).toContain("has CLOSED");
+    // AND the row they already submitted is still theirs. `ownRow` in the rules never asks about
+    // the window, so erasing this cell when the window shuts is false reassurance at exactly the
+    // moment the panel is most likely to be read.
+    expect(only(access, "topics").access.visitor.read).toBe("own");
   });
 
   it("shuts it on a window that has not opened", () => {
     const access = sharedAppAccessOf(app, block({ fromMs: Date.UTC(2030, 0, 1) }), ["topics"], NOW);
     expect(only(access, "topics").access.visitor.create).toBe(false);
-    expect(only(access, "topics").caveats[0]).toContain("not opened yet");
+    expect(only(access, "topics").caveats.join(" ")).toContain("not opened yet");
   });
 
   it("leaves it open inside the window, and says the window is there", () => {
     const access = sharedAppAccessOf(app, block({ fromMs: Date.UTC(2020, 0, 1), untilMs: Date.UTC(2030, 0, 1) }), ["topics"], NOW);
     expect(only(access, "topics").access.visitor.create).toBe(true);
-    expect(only(access, "topics").caveats[0]).toContain("open right now");
+    expect(only(access, "topics").caveats.join(" ")).toContain("open right now");
   });
 
   it("refuses to guess when the bound lives on another record", () => {
     const access = sharedAppAccessOf(app, block({ fromField: { collection: "classes", ref: "classId", field: "opensAt" } }), ["topics"], NOW);
     // Neither answer is available, so the table keeps the wider one and the caveat says why.
     expect(only(access, "topics").access.visitor.create).toBe(true);
-    expect(only(access, "topics").caveats[0]).toContain("cannot say whether any one of them is open");
+    expect(only(access, "topics").caveats.join(" ")).toContain("cannot say whether any one of them is open");
+  });
+});
+
+describe("the two write paths a closed window separates", () => {
+  // `updateWith` carries `inWindow`; `deleteWith` does not. So after a window closes a submitter
+  // may still WITHDRAW their row and may no longer EDIT it, and a summary that folded the two
+  // together had to be wrong about one of them.
+  const app = { members: {}, collections: { rsvps: { statusField: "status" } } };
+  const shape = (window: Record<string, unknown>, self: Record<string, unknown>) => ({
+    enabled: true,
+    submit: { rsvps: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "in", window, ...self } },
+  });
+  const CLOSED = { untilMs: Date.UTC(2000, 0, 1) };
+  const NOW = Date.UTC(2026, 8, 1);
+
+  it("keeps the withdrawal a closed window does not take away", () => {
+    const access = sharedAppAccessOf(app, shape(CLOSED, { selfDelete: ["in"] }), ["rsvps"], NOW);
+    expect(only(access, "rsvps").access.visitor).toEqual({ read: "own", create: false, editOwn: true, editAll: false, repairMirror: false });
+  });
+
+  it("takes away the edit it does", () => {
+    const access = sharedAppAccessOf(app, shape(CLOSED, { selfUpdate: { in: ["uid"] } }), ["rsvps"], NOW);
+    expect(only(access, "rsvps").access.visitor).toEqual({ read: "own", create: false, editOwn: false, editAll: false, repairMirror: false });
+  });
+});
+
+describe("a mirror is writable by everyone, and the table has to say so", () => {
+  // `mirrorRepair` is the FIRST branch of `updateWith` and asks nothing about the caller — not even
+  // `authed()`. A stale grid repairing itself is the whole point of the rule.
+  const access = sharedAppAccessOf({ members: {}, collections: { slots: { mirrorOf: "bookings" } } }, undefined, ["slots"]);
+
+  it("gives every subject the repair, whatever else they may not do", () => {
+    expect(only(access, "slots").access.visitor).toEqual({ read: "none", create: false, editOwn: false, editAll: false, repairMirror: true });
+    expect(only(access, "slots").access.stranger.repairMirror).toBe(true);
+  });
+
+  it("says in words what the one field is", () => {
+    expect(only(access, "slots").caveats.join(" ")).toContain("`state`");
+  });
+});
+
+describe("a session gate", () => {
+  it("is read under the key the rules read, which is `gateOn`", () => {
+    // `gate` is produced by nothing. Checking it meant the caveat never appeared on any real app.
+    const access = sharedAppAccessOf(
+      { members: {}, collections: { answers: {} } },
+      { enabled: true, submit: { answers: { auth: "anonymous", createFields: ["a"], gateOn: { phase: "answering", match: "questionId" } } } },
+      ["answers"],
+    );
+    expect(only(access, "answers").caveats.join(" ")).toContain("session gate");
   });
 });
 
@@ -197,9 +252,7 @@ describe("what the summary refuses to overstate", () => {
     // exists to answer exactly this question.
     const access = sharedAppAccessOf({ members: {} }, { submit: { records: { auth: "verifiedEmail", emailField: "by", createFields: ["by"] } } }, ["records"]);
     expect(only(access, "records").access.stranger.read).toBe("none");
-    expect(only(access, "records").caveats).toContain(
-      "Anyone who submitted while this collection was open still reads and edits that row of theirs, whatever it says above.",
-    );
+    expect(only(access, "records").caveats.join(" ")).toContain("still reads their own row, and may still withdraw it");
   });
 
   it("does not hand an emailField row to the visitor, who has a uid and no verified address", () => {
@@ -210,8 +263,8 @@ describe("what the summary refuses to overstate", () => {
       { enabled: true, submit: { rsvps: { auth: "none", emailField: "by", createFields: ["by", "status"], initialStatus: "in", selfUpdate: { in: ["by"] } } } },
       ["rsvps"],
     );
-    expect(only(access, "rsvps").access.visitor).toEqual({ read: "none", create: true, editOwn: false, editAll: false });
-    expect(only(access, "rsvps").access.stranger).toEqual({ read: "own", create: true, editOwn: true, editAll: false });
+    expect(only(access, "rsvps").access.visitor).toEqual({ read: "none", create: true, editOwn: false, editAll: false, repairMirror: false });
+    expect(only(access, "rsvps").access.stranger).toEqual({ read: "own", create: true, editOwn: true, editAll: false, repairMirror: false });
   });
 
   it("says nobody may edit anything when the collection is immutable", () => {

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -184,12 +184,10 @@ describe("a status declaration that refuses every create by itself", () => {
   // Both fail CLOSED in the rules, and both are shapes a half-finished manifest really has. They
   // are modelled rather than caveated because the declaration alone decides them: nothing about
   // the record or the caller can rescue the create, which is exactly when the table may speak.
-  const open = (c: Record<string, unknown>, initialStatus: string) =>
-    sharedAppAccessOf(
-      { members: {}, collections: { answers: c } },
-      { enabled: true, submit: { answers: { auth: "none", createFields: ["a", "status"], initialStatus } } },
-      ["answers"],
-    );
+  const open = (c: Record<string, unknown>, initialStatus: string, createFields: string[] = ["a", "status"]) =>
+    sharedAppAccessOf({ members: {}, collections: { answers: c } }, { enabled: true, submit: { answers: { auth: "none", createFields, initialStatus } } }, [
+      "answers",
+    ]);
 
   it("refuses when the submit names an initial status and the collection names no status field", () => {
     expect(only(open({}, "new"), "answers").access.visitor.create).toBe(false);
@@ -201,6 +199,12 @@ describe("a status declaration that refuses every create by itself", () => {
 
   it("allows it when the map lists it", () => {
     expect(only(open({ statusField: "status", transitions: { initial: ["new"], new: ["done"] } }, "new"), "answers").access.visitor.create).toBe(true);
+  });
+
+  it("refuses when `createFields` does not let the submitter send the status at all", () => {
+    // `hasOnly(createFields)` and "the status field must be present at the declared value" are
+    // then two conjuncts that contradict each other.
+    expect(only(open({ statusField: "status" }, "new", ["a"]), "answers").access.visitor.create).toBe(false);
   });
 
   it("leaves a collection with no `transitions` alone", () => {

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -197,6 +197,18 @@ describe("the two write paths a closed window separates", () => {
     expect(only(access, "rsvps").access.visitor).toEqual({ read: "own", create: false, editOwn: true, editAll: false, repairMirror: false });
   });
 
+  it("does not promise a withdrawal the declaration never named", () => {
+    const access = sharedAppAccessOf(app, shape(CLOSED, { selfUpdate: { in: ["uid"] } }), ["rsvps"], NOW);
+    const said = only(access, "rsvps").caveats.join(" ");
+    expect(said).toContain("still reads their own row");
+    expect(said).not.toContain("withdraw");
+  });
+
+  it("promises it where `selfDelete` names one", () => {
+    const access = sharedAppAccessOf(app, shape(CLOSED, { selfDelete: ["in"] }), ["rsvps"], NOW);
+    expect(only(access, "rsvps").caveats.join(" ")).toContain("may still withdraw it");
+  });
+
   it("takes away the edit it does", () => {
     const access = sharedAppAccessOf(app, shape(CLOSED, { selfUpdate: { in: ["uid"] } }), ["rsvps"], NOW);
     expect(only(access, "rsvps").access.visitor).toEqual({ read: "own", create: false, editOwn: false, editAll: false, repairMirror: false });
@@ -252,7 +264,7 @@ describe("what the summary refuses to overstate", () => {
     // exists to answer exactly this question.
     const access = sharedAppAccessOf({ members: {} }, { submit: { records: { auth: "verifiedEmail", emailField: "by", createFields: ["by"] } } }, ["records"]);
     expect(only(access, "records").access.stranger.read).toBe("none");
-    expect(only(access, "records").caveats.join(" ")).toContain("still reads their own row, and may still withdraw it");
+    expect(only(access, "records").caveats.join(" ")).toContain("still reads their own row");
   });
 
   it("does not hand an emailField row to the visitor, who has a uid and no verified address", () => {

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -197,6 +197,17 @@ describe("a status declaration that refuses every create by itself", () => {
     expect(only(open({ statusField: "status", transitions: { open: ["closed"] } }, "new"), "answers").access.visitor.create).toBe(false);
   });
 
+  it("refuses when `transitions` lists nothing under `initial` and the submit names no status", () => {
+    // Nothing the submitter can send satisfies `initialOk`: it looks the value up under `initial`
+    // and that list is empty.
+    const empty = sharedAppAccessOf(
+      { members: {}, collections: { answers: { statusField: "status", transitions: { initial: [], open: ["closed"] } } } },
+      { enabled: true, submit: { answers: { auth: "none", createFields: ["a", "status"] } } },
+      ["answers"],
+    );
+    expect(only(empty, "answers").access.visitor.create).toBe(false);
+  });
+
   it("allows it when the map lists it", () => {
     expect(only(open({ statusField: "status", transitions: { initial: ["new"], new: ["done"] } }, "new"), "answers").access.visitor.create).toBe(true);
   });

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -206,6 +206,19 @@ describe("a status declaration that refuses every create by itself", () => {
       ["answers"],
     );
     expect(only(empty, "answers").access.visitor.create).toBe(false);
+    // AND the owner. `initialOk` sits above the branch group in `createWith`, so it is asked of a
+    // writer's create exactly as it is asked of a visitor's.
+    expect(only(empty, "answers").access.writer.create).toBe(false);
+    expect(only(empty, "answers").access.writer.editAll).toBe(true);
+  });
+
+  it("leaves the owner alone when the map does list an initial status", () => {
+    const fine = sharedAppAccessOf(
+      { members: { "owner@example.com": { "*": "owner" } }, collections: { answers: { statusField: "status", transitions: { initial: ["new"] } } } },
+      undefined,
+      ["answers"],
+    );
+    expect(only(fine, "answers").access.writer.create).toBe(true);
   });
 
   it("allows it when the map lists it", () => {

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -307,6 +307,18 @@ describe("a mirror is writable by everyone, and the table has to say so", () => 
     expect(only(access, "slots").access.stranger.repairMirror).toBe(true);
   });
 
+  it("names the paired write on the submission side too", () => {
+    // `mirrorClaimed` / `mirrorReleased` bind every create and delete, the writer branches
+    // included. Without this a create that looks allowed in the table is refused for a reason
+    // nothing on the panel names.
+    const paired = sharedAppAccessOf(
+      { members: {}, collections: { bookings: {} } },
+      { enabled: true, submit: { bookings: { auth: "anonymous", uidField: "uid", createFields: ["uid"], mirror: "slots" } } },
+      ["bookings"],
+    );
+    expect(only(paired, "bookings").caveats.join(" ")).toContain("move the slot it claims in `slots`");
+  });
+
   it("says in words what the one field is", () => {
     expect(only(access, "slots").caveats.join(" ")).toContain("`state`");
   });

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -180,6 +180,30 @@ describe("the submission window, evaluated rather than mentioned", () => {
   });
 });
 
+describe("a reveal-gated collection", () => {
+  // `readWith` opens a gated row to every listed member once its parent reveals it. Reporting
+  // `Nothing` for the participant row contradicted the deployed read rule; there is no "some rows"
+  // state, so the table takes the wider answer and the caveat carries the condition.
+  const access = sharedAppAccessOf(
+    { members: { "guest@example.com": { "*": "participant" } }, collections: { answers: { revealGated: true, gatedFrom: "questions", revealBy: "revealed" } } },
+    undefined,
+    ["answers"],
+  );
+
+  it("lets the roster read it", () => {
+    expect(only(access, "answers").access.participant.read).toBe("all");
+  });
+
+  it("leaves the outsiders where they were — the opening is roster-only", () => {
+    expect(only(access, "answers").access.visitor.read).toBe("none");
+    expect(only(access, "answers").access.stranger.read).toBe("none");
+  });
+
+  it("says the read only happens after the parent reveals it", () => {
+    expect(only(access, "answers").caveats.join(" ")).toContain("ONCE ITS PARENT REVEALS IT");
+  });
+});
+
 describe("what still binds an owner", () => {
   // The `Owner / editor` row is one cell for the whole collection, and these three are decided per
   // RECORD — by the status it is in, or by another record entirely. Without them the row reads

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import { sharedAppAccessOf, type AccessSubject, type CollectionAccess, type SharedAppAccess } from "../../common/sharedAppAccess";
+
+// The panel is a transcription of `firestore.rules`, so these cases are the SHAPES the matrix in
+// mulmoserver's `test/rules/rules_matrix.ts` measures against the emulator: an invite-only app, an
+// anonymous survey, a blog. What is pinned here is that the summary says the same thing the rules
+// answer — a table that disagrees with the deployment is worse than no table.
+
+/** The one collection under test, or a failure that names it — a `find` returning undefined would
+ *  otherwise surface as "cannot read property access of undefined" three assertions later. */
+function only(access: SharedAppAccess, cid: string): CollectionAccess {
+  const found = access.collections.find((entry) => entry.cid === cid);
+  if (found === undefined) throw new Error(`no collection ${cid} in the summary`);
+  return found;
+}
+const reaches = (access: SharedAppAccess, cid: string, subject: AccessSubject): boolean => {
+  const entry = only(access, cid).access[subject];
+  return entry.read !== "none" || entry.create || entry.editOwn || entry.editAll;
+};
+
+const ROSTER = {
+  members: {
+    "owner@example.com": { "*": "owner" },
+    "member@example.com": { "*": "participant" },
+  },
+};
+
+describe("an INVITE-ONLY app — the #1926 shape", () => {
+  // `public.submit` is declared and `public.enabled` is not. That is the NORMAL invite-only app:
+  // the roster's own pages have no other way to write a record. It is not an app half-way to being
+  // opened, and the panel must not read it as one.
+  const app = {
+    ...ROSTER,
+    collections: { records: { statusField: "status" } },
+    participantRead: ["records"],
+  };
+  const block = {
+    submit: {
+      records: { auth: "verifiedEmail", emailField: "by", createFields: ["by", "note", "status"], initialStatus: "new", selfUpdate: { new: ["note"] } },
+    },
+  };
+  const access = sharedAppAccessOf(app, block, ["records"]);
+
+  it("calls the app closed even though it declares a public submit", () => {
+    expect(access.publicFace).toBe("declared");
+  });
+
+  it("gives a signed-in STRANGER nothing at all", () => {
+    // The whole point. The aid and the cid are world-readable, so a summary that let this cell
+    // read as anything but empty would be describing the hole #1926's fix closed.
+    expect(only(access, "records").access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false });
+    expect(reaches(access, "records", "stranger")).toBe(false);
+  });
+
+  it("gives a visitor with no account nothing either", () => {
+    expect(reaches(access, "records", "visitor")).toBe(false);
+  });
+
+  it("lets a participant read the collection and edit their own row", () => {
+    expect(only(access, "records").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false });
+  });
+
+  it("lets an owner do anything", () => {
+    expect(only(access, "records").access.writer).toEqual({ read: "all", create: true, editOwn: true, editAll: true });
+  });
+
+  it("counts the people the roster actually puts in each row", () => {
+    expect(only(access, "records").census).toEqual({ writers: 1, readers: 0, participants: 1 });
+  });
+});
+
+describe("an app whose switch is ON", () => {
+  const app = { ...ROSTER, collections: { answers: { statusField: "status" } } };
+  const block = {
+    enabled: true,
+    read: [],
+    submit: { answers: { auth: "anonymous", uidField: "uid", createFields: ["uid", "answer", "status"], initialStatus: "in" } },
+  };
+  const access = sharedAppAccessOf(app, block, ["answers"]);
+
+  it("takes an anonymous visitor's submission, since `anonymous` is satisfied by the session the public page holds", () => {
+    expect(only(access, "answers").access.visitor).toEqual({ read: "own", create: true, editOwn: false, editAll: false });
+  });
+
+  it("keeps everyone else's rows out of sight — nothing is in `public.read`", () => {
+    expect(only(access, "answers").access.stranger.read).toBe("own");
+    expect(access.publicFace).toBe("open");
+  });
+
+  it("opens the whole collection once it is named in `public.read`", () => {
+    const opened = sharedAppAccessOf(app, { ...block, read: ["answers"] }, ["answers"]);
+    expect(only(opened, "answers").access.visitor.read).toBe("all");
+  });
+
+  it("refuses a visitor who has no verified address when the stage asks for one", () => {
+    const strict = sharedAppAccessOf(app, { ...block, submit: { answers: { ...block.submit.answers, auth: "verifiedEmail" } } }, ["answers"]);
+    expect(only(strict, "answers").access.visitor.create).toBe(false);
+    expect(only(strict, "answers").access.stranger.create).toBe(true);
+  });
+});
+
+describe("a BLOG — the writer edits their own article forever", () => {
+  // Modelled on `apps/ai-blogs`: a single status, no transitions, `audience: "participant"`, and
+  // `submitOnly` so even an editor writes through the same path everybody else does.
+  const app = {
+    members: { "owner@example.com": { "*": "owner", articles: "participant" }, "writer@example.com": { "*": "participant" } },
+    collections: { articles: { statusField: "status", submitOnly: true } },
+  };
+  const block = {
+    enabled: true,
+    read: ["articles"],
+    submit: {
+      articles: {
+        auth: "verifiedEmail",
+        audience: "participant",
+        emailField: "by",
+        createFields: ["by", "body", "status"],
+        initialStatus: "published",
+        selfUpdate: { published: ["body"] },
+        selfDelete: ["published"],
+      },
+    },
+  };
+  const access = sharedAppAccessOf(app, block, ["articles"]);
+
+  it("lets the world read the articles and write nothing", () => {
+    expect(only(access, "articles").access.visitor).toEqual({ read: "all", create: false, editOwn: false, editAll: false });
+    expect(only(access, "articles").access.stranger).toEqual({ read: "all", create: false, editOwn: false, editAll: false });
+  });
+
+  it("lets a participant publish and go on editing what they published", () => {
+    expect(only(access, "articles").access.participant).toEqual({ read: "all", create: true, editOwn: true, editAll: false });
+  });
+
+  it('shuts a writer out of `audience: "participant"` and out of creating at all, because the collection is submitOnly', () => {
+    expect(only(access, "articles").access.writer.create).toBe(false);
+    expect(only(access, "articles").access.writer.editAll).toBe(true);
+  });
+});
+
+describe("the submission window, evaluated rather than mentioned", () => {
+  const app = { members: {}, collections: { topics: { statusField: "status" } } };
+  const block = (window: Record<string, unknown>) => ({
+    enabled: true,
+    read: ["topics"],
+    submit: { topics: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "open", window } },
+  });
+  const NOW = Date.UTC(2026, 8, 1);
+
+  it("shuts the door on a window that has closed", () => {
+    // `apps/roles` seals all three of its collections with `window.until` in the year 2000. A
+    // summary that only said "there is a window" reported an open board nobody can post to.
+    const access = sharedAppAccessOf(app, block({ untilMs: Date.UTC(2000, 0, 1) }), ["topics"], NOW);
+    expect(only(access, "topics").access.visitor.create).toBe(false);
+    expect(only(access, "topics").caveats[0]).toContain("has CLOSED");
+  });
+
+  it("shuts it on a window that has not opened", () => {
+    const access = sharedAppAccessOf(app, block({ fromMs: Date.UTC(2030, 0, 1) }), ["topics"], NOW);
+    expect(only(access, "topics").access.visitor.create).toBe(false);
+    expect(only(access, "topics").caveats[0]).toContain("not opened yet");
+  });
+
+  it("leaves it open inside the window, and says the window is there", () => {
+    const access = sharedAppAccessOf(app, block({ fromMs: Date.UTC(2020, 0, 1), untilMs: Date.UTC(2030, 0, 1) }), ["topics"], NOW);
+    expect(only(access, "topics").access.visitor.create).toBe(true);
+    expect(only(access, "topics").caveats[0]).toContain("open right now");
+  });
+
+  it("refuses to guess when the bound lives on another record", () => {
+    const access = sharedAppAccessOf(app, block({ fromField: { collection: "classes", ref: "classId", field: "opensAt" } }), ["topics"], NOW);
+    // Neither answer is available, so the table keeps the wider one and the caveat says why.
+    expect(only(access, "topics").access.visitor.create).toBe(true);
+    expect(only(access, "topics").caveats[0]).toContain("cannot say whether any one of them is open");
+  });
+});
+
+describe("what the summary refuses to overstate", () => {
+  it("keeps the stranded-row caveat off a collection the switch could never have opened", () => {
+    // `audience: "participant"` refuses an outsider whatever `public.enabled` says, so there was no
+    // open period for anyone to have submitted in. The caveat fired here against `apps/ai-blogs`.
+    const access = sharedAppAccessOf(
+      { members: {}, collections: { articles: { statusField: "status" } } },
+      {
+        enabled: true,
+        read: ["articles"],
+        submit: { articles: { auth: "verifiedEmail", audience: "participant", emailField: "by", createFields: ["by", "status"] } },
+      },
+      ["articles"],
+    );
+    expect(only(access, "articles").caveats).toEqual([]);
+  });
+
+  it("does not claim an own row for someone who could never create one", () => {
+    // `emailField` reaches every verified account in the world. Without the creatability gate this
+    // cell reads "own rows" for a stranger who has no way to make one — an alarm in the panel that
+    // exists to answer exactly this question.
+    const access = sharedAppAccessOf({ members: {} }, { submit: { records: { auth: "verifiedEmail", emailField: "by", createFields: ["by"] } } }, ["records"]);
+    expect(only(access, "records").access.stranger.read).toBe("none");
+    expect(only(access, "records").caveats).toContain(
+      "Anyone who submitted while this collection was open still reads and edits that row of theirs, whatever it says above.",
+    );
+  });
+
+  it("does not hand an emailField row to the visitor, who has a uid and no verified address", () => {
+    // `auth: "none"` lets them submit, so the creatability gate is open; what stops them reaching
+    // the row afterwards is `ownRow`'s `verified()` on the `emailField` branch, and nothing else.
+    const access = sharedAppAccessOf(
+      { members: {}, collections: { rsvps: { statusField: "status" } } },
+      { enabled: true, submit: { rsvps: { auth: "none", emailField: "by", createFields: ["by", "status"], initialStatus: "in", selfUpdate: { in: ["by"] } } } },
+      ["rsvps"],
+    );
+    expect(only(access, "rsvps").access.visitor).toEqual({ read: "none", create: true, editOwn: false, editAll: false });
+    expect(only(access, "rsvps").access.stranger).toEqual({ read: "own", create: true, editOwn: true, editAll: false });
+  });
+
+  it("says nobody may edit anything when the collection is immutable", () => {
+    const access = sharedAppAccessOf(
+      { members: ROSTER.members, collections: { log: { statusField: "status", immutable: true } } },
+      { enabled: true, read: ["log"], submit: { log: { auth: "none", uidField: "uid", createFields: ["uid", "status"], selfUpdate: { new: ["uid"] } } } },
+      ["log"],
+    );
+    expect(only(access, "log").access.writer.editAll).toBe(false);
+    expect(only(access, "log").access.visitor.editOwn).toBe(false);
+  });
+
+  it("grants no self-edit without a statusField, which is what the rules fail closed on", () => {
+    const access = sharedAppAccessOf(
+      { members: ROSTER.members },
+      { enabled: true, submit: { notes: { auth: "none", uidField: "uid", createFields: ["uid"], selfUpdate: { "*": ["uid"] } } } },
+      ["notes"],
+    );
+    expect(only(access, "notes").access.visitor.editOwn).toBe(false);
+  });
+
+  it("opens a collection to the whole roster through participantRead and peerVisibility", () => {
+    const access = sharedAppAccessOf({ members: ROSTER.members, collections: { votes: { peerVisibility: "public" } }, participantRead: ["notes"] }, undefined, [
+      "votes",
+      "notes",
+    ]);
+    expect(only(access, "votes").access.participant.read).toBe("all");
+    expect(only(access, "votes").access.stranger.read).toBe("none");
+    expect(only(access, "notes").access.participant.read).toBe("all");
+    expect(access.publicFace).toBe("none");
+  });
+
+  it("lists a collection that declares nothing at all, rather than leaving it out", () => {
+    // A collection with no rule configuration, no public read and no submit is precisely the one
+    // whose absence would be read as "not published".
+    const access = sharedAppAccessOf({ members: ROSTER.members }, undefined, ["quiet"]);
+    expect(only(access, "quiet").takesSubmissions).toBe(false);
+    expect(reaches(access, "quiet", "stranger")).toBe(false);
+    expect(only(access, "quiet").access.writer.read).toBe("all");
+  });
+});

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -180,6 +180,45 @@ describe("the submission window, evaluated rather than mentioned", () => {
   });
 });
 
+describe("what still binds an owner", () => {
+  // The `Owner / editor` row is one cell for the whole collection, and these three are decided per
+  // RECORD — by the status it is in, or by another record entirely. Without them the row reads
+  // "Anything" about a collection whose owner cannot delete a closed topic.
+  const access = sharedAppAccessOf(
+    {
+      members: { "owner@example.com": { "*": "owner" } },
+      collections: {
+        topics: {
+          statusField: "status",
+          transitions: { open: ["closed"] },
+          sealed: ["closed"],
+        },
+        messages: { refIn: { collection: "topics", ref: "topicId", where: { field: "status", equals: "open" } } },
+      },
+    },
+    undefined,
+    ["topics", "messages"],
+  );
+
+  it("still calls the owner's write unrestricted in the table", () => {
+    // The table cannot say "unless the record is closed" — that is what the caveats are for.
+    expect(only(access, "topics").access.writer.editAll).toBe(true);
+  });
+
+  it("names the transitions and the seal", () => {
+    const said = only(access, "topics").caveats.join(" ");
+    expect(said).toContain("declared `transitions`");
+    // DELETE only. `sealedNow` is asked by `deleteWith` and by nothing else, so "cannot be changed"
+    // would make the panel stricter than the rules.
+    expect(said).toContain("cannot be DELETED by anyone, the owner included");
+    expect(said).toContain("fields can still be corrected");
+  });
+
+  it("names the parent a create has to match", () => {
+    expect(only(access, "messages").caveats.join(" ")).toContain("`refIn` requires");
+  });
+});
+
 describe("a roster key the rules can never match", () => {
   // `email() in a.members` is exact and Firebase lower-cases the token, so `Foo@Example.com`
   // grants that person nothing — and the file reads correctly to a human. Counting it printed

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -232,6 +232,16 @@ describe("a createFields list that cannot carry what the rules demand", () => {
     expect(only(with_(submit, collection), "answers").access.visitor.create).toBe(false);
   });
 
+  it("demands the status field even with no `initialStatus`, when `transitions` is declared", () => {
+    // `initialOk` refuses a create whose status is null whenever `transitions` and `statusField`
+    // are both declared, so the submitter has to be able to send one either way.
+    const c = { statusField: "status", transitions: { initial: ["new"] } };
+    expect(only(with_({ createFields: ["title"] }, c), "answers").access.visitor.create).toBe(false);
+    // With the field allowed the create is possible; WHICH value passes is not decidable from the
+    // declaration, and the `transitions` caveat is what carries that.
+    expect(only(with_({ createFields: ["title", "status"] }, c), "answers").access.visitor.create).toBe(true);
+  });
+
   it("allows the create once the list carries them", () => {
     expect(only(with_({ uidField: "uid", stampField: "at", createFields: ["title", "uid", "at"] }), "answers").access.visitor.create).toBe(true);
   });

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -180,6 +180,34 @@ describe("the submission window, evaluated rather than mentioned", () => {
   });
 });
 
+describe("a status declaration that refuses every create by itself", () => {
+  // Both fail CLOSED in the rules, and both are shapes a half-finished manifest really has. They
+  // are modelled rather than caveated because the declaration alone decides them: nothing about
+  // the record or the caller can rescue the create, which is exactly when the table may speak.
+  const open = (c: Record<string, unknown>, initialStatus: string) =>
+    sharedAppAccessOf(
+      { members: {}, collections: { answers: c } },
+      { enabled: true, submit: { answers: { auth: "none", createFields: ["a", "status"], initialStatus } } },
+      ["answers"],
+    );
+
+  it("refuses when the submit names an initial status and the collection names no status field", () => {
+    expect(only(open({}, "new"), "answers").access.visitor.create).toBe(false);
+  });
+
+  it("refuses when `transitions` does not list that status under `initial`", () => {
+    expect(only(open({ statusField: "status", transitions: { open: ["closed"] } }, "new"), "answers").access.visitor.create).toBe(false);
+  });
+
+  it("allows it when the map lists it", () => {
+    expect(only(open({ statusField: "status", transitions: { initial: ["new"], new: ["done"] } }, "new"), "answers").access.visitor.create).toBe(true);
+  });
+
+  it("leaves a collection with no `transitions` alone", () => {
+    expect(only(open({ statusField: "status" }, "new"), "answers").access.visitor.create).toBe(true);
+  });
+});
+
 describe("a reveal-gated collection", () => {
   // `readWith` opens a gated row to every listed member once its parent reveals it. Reporting
   // `Nothing` for the participant row contradicted the deployed read rule; there is no "some rows"

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -180,6 +180,25 @@ describe("the submission window, evaluated rather than mentioned", () => {
   });
 });
 
+describe("a roster key the rules can never match", () => {
+  // `email() in a.members` is exact and Firebase lower-cases the token, so `Foo@Example.com`
+  // grants that person nothing — and the file reads correctly to a human. Counting it printed
+  // `Owner / editor (1)` over an app whose owner is locked out of their own roster.
+  const access = sharedAppAccessOf(
+    { members: { "Owner@Example.com": { "*": "owner" }, "guest@example.com": { "*": "participant" } }, collections: { records: {} } },
+    undefined,
+    ["records"],
+  );
+
+  it("is left out of the census", () => {
+    expect(only(access, "records").census).toEqual({ writers: 0, readers: 0, participants: 1 });
+  });
+
+  it("is named, so the missing count has a reason", () => {
+    expect(access.unmatchableRoster).toEqual(["Owner@Example.com"]);
+  });
+});
+
 describe("the two write paths a closed window separates", () => {
   // `updateWith` carries `inWindow`; `deleteWith` does not. So after a window closes a submitter
   // may still WITHDRAW their row and may no longer EDIT it, and a summary that folded the two

--- a/test/common/sharedAppAccess.spec.ts
+++ b/test/common/sharedAppAccess.spec.ts
@@ -212,6 +212,60 @@ describe("a status declaration that refuses every create by itself", () => {
   });
 });
 
+describe("a createFields list that cannot carry what the rules demand", () => {
+  // `submitCreate` asks `hasOnly(createFields)` AND requires certain fields to be present. A field
+  // the rules demand and the list does not allow makes those two contradict each other, and the
+  // collection accepts nothing from anybody.
+  const with_ = (submit: Record<string, unknown>, collection: Record<string, unknown> = {}) =>
+    sharedAppAccessOf({ members: {}, collections: { answers: collection } }, { enabled: true, submit: { answers: { auth: "none", ...submit } } }, ["answers"]);
+
+  it.each([
+    ["the verified address it checks the submitter against", { auth: "verifiedEmail", emailField: "email", createFields: ["title"] }, {}],
+    ["the uid field it binds the row by", { uidField: "uid", createFields: ["title"] }, {}],
+    ["the field the document id is built from", { idFrom: "field", idField: "slot", createFields: ["title"] }, {}],
+    ["the server-stamped field", { stampField: "at", createFields: ["title"] }, {}],
+    ["the field a session gate matches on", { gateOn: { phase: "answering", match: "questionId" }, createFields: ["title"] }, {}],
+    ["a field `validate.required` names", { validate: { required: ["title"] }, createFields: ["body"] }, {}],
+    ["the field a `keyFields` entry indexes", { validate: { keyFields: [{ field: "kind", values: ["a"] }] }, createFields: ["title"] }, {}],
+    ["the reference `refIn` builds the parent path from", { createFields: ["title"] }, { refIn: { collection: "topics", ref: "topicId" } }],
+  ])("refuses every create when the list omits %s", (_name, submit, collection) => {
+    expect(only(with_(submit, collection), "answers").access.visitor.create).toBe(false);
+  });
+
+  it("allows the create once the list carries them", () => {
+    expect(only(with_({ uidField: "uid", stampField: "at", createFields: ["title", "uid", "at"] }), "answers").access.visitor.create).toBe(true);
+  });
+
+  it("does not demand an emailField the auth stage never reads", () => {
+    // `authOk` reads it on the `verifiedEmail` branch and nowhere else; `ownRow` reads it on a
+    // READ, which is not this question.
+    expect(only(with_({ auth: "anonymous", emailField: "email", createFields: ["title"] }), "answers").access.visitor.create).toBe(true);
+  });
+});
+
+describe("a withdrawal every sealed state takes back", () => {
+  // `deleteWith` asks `!sealedNow(c)` before it reaches `selfDelete`, so a declaration whose every
+  // withdrawable status is also sealed grants no withdrawal at all.
+  const shape = (sealed: string[]) =>
+    sharedAppAccessOf(
+      { members: {}, collections: { drafts: { statusField: "status", sealed } } },
+      {
+        enabled: true,
+        submit: { drafts: { auth: "anonymous", uidField: "uid", createFields: ["uid", "status"], initialStatus: "draft", selfDelete: ["draft"] } },
+      },
+      ["drafts"],
+    );
+
+  it("grants nothing when the sealed list covers every withdrawable status", () => {
+    expect(only(shape(["draft"]), "drafts").access.visitor.editOwn).toBe(false);
+    expect(only(shape(["draft"]), "drafts").caveats.join(" ")).not.toContain("withdraw");
+  });
+
+  it("grants it when one status is left", () => {
+    expect(only(shape(["published"]), "drafts").access.visitor.editOwn).toBe(true);
+  });
+});
+
 describe("a reveal-gated collection", () => {
   // `readWith` opens a gated row to every listed member once its parent reveals it. Reporting
   // `Nothing` for the participant row contradicted the deployed read rule; there is no "some rows"

--- a/test/server/backends/sharedAppAccess.spec.ts
+++ b/test/server/backends/sharedAppAccess.spec.ts
@@ -73,7 +73,7 @@ describe("the shared-app access summary", () => {
     if (!result.ok) return;
     expect(result.access.publicFace).toBe("declared");
     expect(result.access.collections.map((entry) => entry.cid)).toEqual(["records"]);
-    expect(result.access.collections[0].access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false });
+    expect(result.access.collections[0].access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false, repairMirror: false });
     expect(result.access.collections[0].census).toEqual({ writers: 1, readers: 0, participants: 1 });
   });
 
@@ -92,7 +92,7 @@ describe("the shared-app access summary", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.access.publicFace).toBe("open");
-    expect(result.access.collections[0].access.visitor).toEqual({ read: "all", create: true, editOwn: false, editAll: false });
+    expect(result.access.collections[0].access.visitor).toEqual({ read: "all", create: true, editOwn: false, editAll: false, repairMirror: false });
   });
 
   it("still answers for a declaration a publish would refuse", async () => {

--- a/test/server/backends/sharedAppAccess.spec.ts
+++ b/test/server/backends/sharedAppAccess.spec.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+//
+// The access summary is answered from the WORKING TREE and nothing else.
+//
+// That is the property worth a spec of its own rather than a detail of one: the preview beside it
+// needs a signed-in Firestore session because it reads the app's records, and if this grew the same
+// requirement the panel would go blank on the machine of every author who has not connected — which
+// is most of them, most of the time, and exactly when "who can reach this?" is being asked.
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setFirestoreAccessor, setSharedCollectionsSupport } from "@mulmoclaude/core/collection/server";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { sharedAppAccess } from "../../../server/backends/sharedApp/access.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const AID = "11111111-2222-3333-4444-555555555555";
+
+const withCollection = (root: string, slug: string): void => {
+  const dir = path.join(root, ".claude", "skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(dir + "/SKILL.md", `---\nname: ${slug}\ndescription: ${slug}\n---\n`);
+  writeFileSync(
+    path.join(dir, "schema.json"),
+    JSON.stringify({
+      title: slug,
+      icon: "list",
+      primaryKey: "id",
+      storage: { type: "firestore" },
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        note: { type: "string", label: "Note" },
+        status: { type: "string", label: "Status" },
+      },
+    }),
+  );
+};
+
+/** The #1926 shape: a `public.submit` declaration with the switch OFF. */
+const inviteOnly = (root: string): void => {
+  writeFileSync(
+    path.join(root, "app.json"),
+    JSON.stringify({
+      aid: AID,
+      name: "Invite only",
+      members: { "owner@example.com": { "*": "owner" }, "guest@example.com": { "*": "participant" } },
+      collections: { records: { statusField: "status" } },
+      participantRead: ["records"],
+      public: { submit: { records: { auth: "verifiedEmail", emailField: "note", createFields: ["note", "status"], initialStatus: "new" } } },
+    }),
+  );
+};
+
+describe("the shared-app access summary", () => {
+  let root: string;
+
+  beforeAll(() => {
+    initCollectionsBackend({ workspace: makeTempDir("mt-shared-app-access-ws-") });
+    setSharedCollectionsSupport(true);
+  });
+
+  beforeEach(() => {
+    root = makeTempDir("mt-shared-app-access-");
+    // SIGNED OUT, and every test here leaves it that way. See the header.
+    setFirestoreAccessor(null);
+    withCollection(root, "records");
+  });
+
+  it("answers with no Firestore session at all", async () => {
+    inviteOnly(root);
+    const result = await sharedAppAccess(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.access.publicFace).toBe("declared");
+    expect(result.access.collections.map((entry) => entry.cid)).toEqual(["records"]);
+    expect(result.access.collections[0].access.stranger).toEqual({ read: "none", create: false, editOwn: false, editAll: false });
+    expect(result.access.collections[0].census).toEqual({ writers: 1, readers: 0, participants: 1 });
+  });
+
+  it("opens the same collection once the switch and the read list say so", async () => {
+    writeFileSync(
+      path.join(root, "app.json"),
+      JSON.stringify({
+        aid: AID,
+        name: "Open",
+        members: { "owner@example.com": { "*": "owner" } },
+        collections: { records: { statusField: "status" } },
+        public: { enabled: true, read: ["records"], submit: { records: { auth: "none", createFields: ["note", "status"], initialStatus: "new" } } },
+      }),
+    );
+    const result = await sharedAppAccess(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.access.publicFace).toBe("open");
+    expect(result.access.collections[0].access.visitor).toEqual({ read: "all", create: true, editOwn: false, editAll: false });
+  });
+
+  it("still answers for a declaration a publish would refuse", async () => {
+    // The author is editing while the panel is open. A summary that vanishes on every half-typed
+    // manifest is a summary nobody keeps open; `publish` is the gate, not this.
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: AID, name: "No owner", members: {}, collections: { records: {} } }));
+    const result = await sharedAppAccess(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.access.collections[0].access.stranger.read).toBe("none");
+  });
+
+  it("reports a manifest that cannot be parsed rather than pretending it grants nothing", async () => {
+    writeFileSync(path.join(root, "app.json"), "{ not json");
+    const result = await sharedAppAccess(root);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.problems.join(" ")).not.toBe("");
+  });
+
+  it("lists a collection the declaration never mentions", async () => {
+    withCollection(root, "quiet");
+    inviteOnly(root);
+    const result = await sharedAppAccess(root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Leaving it out would read as "this one is not published", which is the opposite of true.
+    expect(result.access.collections.map((entry) => entry.cid)).toEqual(["quiet", "records"]);
+    expect(result.access.collections[0].takesSubmissions).toBe(false);
+  });
+});

--- a/test/src/components/CollectionsPaneAccess.spec.ts
+++ b/test/src/components/CollectionsPaneAccess.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// Same stubs as the sibling shared-app spec, for the same reason: what is under test is which face
+// of the pane is up, not what the plugin or the panel render inside it.
+vi.mock("@mulmoclaude/collection-plugin/vue", () => ({
+  CollectionsIndexView: { name: "CollectionsIndexView", template: "<div>index</div>" },
+  CollectionView: { name: "CollectionView", template: "<div>collection</div>" },
+  FeedsView: { name: "FeedsView", template: "<div>feeds</div>" },
+  configureCollectionUi: () => {},
+}));
+vi.mock("../../../src/components/PluginFrame.vue", () => ({ default: { name: "PluginFrame", template: "<div><slot /></div>" } }));
+vi.mock("../../../src/components/SharedAppPreview.vue", () => ({
+  default: { name: "SharedAppPreview", props: ["cwd", "pickerTarget"], template: "<div>the preview</div>" },
+}));
+vi.mock("../../../src/components/SharedAppAccessPanel.vue", () => ({
+  default: { name: "SharedAppAccessPanel", props: ["cwd"], template: "<div>who can see what</div>" },
+}));
+
+vi.mock("../../../src/composables/collectionProject", () => ({
+  projectIdForCwd: async (cwd: string | null) => (cwd === null ? null : "p1"),
+}));
+
+const CollectionsPane = (await import("../../../src/components/CollectionsPane.vue")).default;
+const { activeCollectionNavSurface } = await import("../../../src/composables/collectionSurface");
+
+function mockDeclared(declared: boolean) {
+  globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ declared }) }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const PREVIEWS = '[data-testid="collections-preview-toggle"]';
+const ACCESS = '[data-testid="collections-access-btn"]';
+
+describe("the collections pane's access face", () => {
+  it("is offered only where a directory declares a shared app", async () => {
+    mockDeclared(false);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/plain" } });
+    await flushPromises();
+    // No app: nobody is granted anything, so there is no question to put a button on.
+    expect(w.find(ACCESS).exists()).toBe(false);
+  });
+
+  it("replaces the preview when pressed, rather than sharing the slot with it", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("the preview");
+
+    await w.find(ACCESS).trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("who can see what");
+    expect(w.text()).not.toContain("the preview");
+    // The two controls report the one state between them: the box that says "you are looking at
+    // the pages" must not stay ticked while you are looking at something else.
+    expect((w.find(PREVIEWS).element as HTMLInputElement).checked).toBe(false);
+    expect(w.find(ACCESS).attributes("aria-pressed")).toBe("true");
+  });
+
+  it("gives the slot back when the preview is switched on again", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    await w.find(ACCESS).trigger("click");
+    await flushPromises();
+
+    await w.find(PREVIEWS).setValue(true);
+    await flushPromises();
+    expect(w.text()).toContain("the preview");
+    expect(w.find(ACCESS).attributes("aria-pressed")).toBe("false");
+  });
+
+  it("closes when a navigation asks for a collection", async () => {
+    // The same contract the preview keeps: a click on a collection link is a request FOR that
+    // collection, and honouring it behind this panel makes the click look like it did nothing.
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    await w.find(ACCESS).trigger("click");
+    await flushPromises();
+
+    activeCollectionNavSurface()?.navigateToRecord("notes", "r1");
+    await flushPromises();
+    expect(w.text()).not.toContain("who can see what");
+    expect(w.text()).toContain("collection");
+  });
+
+  it("does not carry one directory's answer into the next", async () => {
+    mockDeclared(true);
+    const w = mount(CollectionsPane, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    await w.find(ACCESS).trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("who can see what");
+
+    await w.setProps({ cwd: "/srv/app2" });
+    await flushPromises();
+    // A panel about permissions is the last thing that may survive the directory it describes.
+    expect(w.text()).not.toContain("who can see what");
+  });
+});

--- a/test/src/components/SharedAppAccessPanel.spec.ts
+++ b/test/src/components/SharedAppAccessPanel.spec.ts
@@ -4,7 +4,7 @@ import type { SharedAppAccess } from "../../../common/sharedAppAccess";
 
 const Panel = (await import("../../../src/components/SharedAppAccessPanel.vue")).default;
 
-const shut = { read: "none", create: false, editOwn: false, editAll: false } as const;
+const shut = { read: "none", create: false, editOwn: false, editAll: false, repairMirror: false } as const;
 
 function answer(access: SharedAppAccess) {
   globalThis.fetch = vi.fn(
@@ -24,8 +24,8 @@ const CLOSED: SharedAppAccess = {
       access: {
         visitor: shut,
         stranger: shut,
-        participant: { read: "all", create: true, editOwn: true, editAll: false },
-        writer: { read: "all", create: true, editOwn: true, editAll: true },
+        participant: { read: "all", create: true, editOwn: true, editAll: false, repairMirror: false },
+        writer: { read: "all", create: true, editOwn: true, editAll: true, repairMirror: false },
       },
     },
   ],
@@ -54,7 +54,10 @@ describe("the access panel", () => {
       ...CLOSED,
       publicFace: "open",
       collections: [
-        { ...CLOSED.collections[0], access: { ...CLOSED.collections[0].access, stranger: { read: "all", create: true, editOwn: false, editAll: false } } },
+        {
+          ...CLOSED.collections[0],
+          access: { ...CLOSED.collections[0].access, stranger: { read: "all", create: true, editOwn: false, editAll: false, repairMirror: false } },
+        },
       ],
     });
     const open = mount(Panel, { props: { cwd: "/srv/app" } });
@@ -84,6 +87,39 @@ describe("the access panel", () => {
     expect(w.find('[data-testid="access-records-stranger"]').text()).not.toContain("(");
   });
 
+  it("labels the one field a mirror lets anyone write, rather than calling it Nothing", async () => {
+    answer({
+      ...CLOSED,
+      collections: [{ ...CLOSED.collections[0], access: { ...CLOSED.collections[0].access, visitor: { ...shut, repairMirror: true } } }],
+    });
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    const row = w.find('[data-testid="access-records-visitor"]');
+    expect(row.text()).toContain("Repair `state` only");
+    // And it counts as reaching something, so the row is coloured and the collection is not
+    // counted among those shut to outsiders.
+    expect(row.html()).toContain("text-amber");
+    expect(w.text()).toContain("0 of 1 collections are shut");
+  });
+
+  it("says the app.json went away rather than drawing nothing at all", async () => {
+    // Reachable when the manifest is removed between the pane's `/declared` probe and this
+    // request. Returning silently left a blank panel with no state.
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: true, status: 200, json: async () => ({ declared: false }) }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("no longer declares a shared app");
+  });
+
+  it("treats an answer that carries no `declared` at all as a failure", async () => {
+    globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ some: "thing" }) }) as unknown as Response) as unknown as typeof fetch;
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("Could not work out the access summary.");
+  });
+
   it("reports a manifest it could not read instead of an empty table", async () => {
     globalThis.fetch = vi.fn(
       async () => ({ ok: true, status: 200, json: async () => ({ declared: true, ok: false, problems: ["app.json is not JSON"] }) }) as unknown as Response,
@@ -92,6 +128,16 @@ describe("the access panel", () => {
     await flushPromises();
     expect(w.text()).toContain("app.json is not JSON");
     expect(w.text()).not.toContain("collections are shut");
+  });
+
+  it("does not print an empty list of reasons", async () => {
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: true, status: 200, json: async () => ({ declared: true, ok: false, problems: [] }) }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("Could not work out the access summary.");
+    expect(w.text()).not.toContain("The declaration could not be read.");
   });
 
   it("says so when the summary could not be computed at all", async () => {

--- a/test/src/components/SharedAppAccessPanel.spec.ts
+++ b/test/src/components/SharedAppAccessPanel.spec.ts
@@ -14,6 +14,7 @@ function answer(access: SharedAppAccess) {
 
 const CLOSED: SharedAppAccess = {
   publicFace: "declared",
+  unmatchableRoster: [],
   collections: [
     {
       cid: "records",
@@ -112,6 +113,16 @@ describe("the access panel", () => {
     const w = mount(Panel, { props: { cwd: "/srv/app" } });
     await flushPromises();
     expect(w.find('[data-testid="access-records-visitor"]').text()).toContain("Submit only, repair `state`");
+  });
+
+  it("names the roster addresses the rules can never match", async () => {
+    answer({ ...CLOSED, unmatchableRoster: ["Foo@Example.com"] });
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    const line = w.find('[data-testid="access-unmatchable-roster"]');
+    expect(line.text()).toContain("Foo@Example.com");
+    // Coloured: it is a permission the author believes they granted and did not.
+    expect(line.html()).toContain("text-amber");
   });
 
   it("says the app.json went away rather than drawing nothing at all", async () => {

--- a/test/src/components/SharedAppAccessPanel.spec.ts
+++ b/test/src/components/SharedAppAccessPanel.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import type { SharedAppAccess } from "../../../common/sharedAppAccess";
+
+const Panel = (await import("../../../src/components/SharedAppAccessPanel.vue")).default;
+
+const shut = { read: "none", create: false, editOwn: false, editAll: false } as const;
+
+function answer(access: SharedAppAccess) {
+  globalThis.fetch = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ declared: true, ok: true, access }) }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+const CLOSED: SharedAppAccess = {
+  publicFace: "declared",
+  collections: [
+    {
+      cid: "records",
+      takesSubmissions: true,
+      authStage: "verifiedEmail",
+      census: { writers: 1, readers: 0, participants: 4 },
+      caveats: [],
+      access: {
+        visitor: shut,
+        stranger: shut,
+        participant: { read: "all", create: true, editOwn: true, editAll: false },
+        writer: { read: "all", create: true, editOwn: true, editAll: true },
+      },
+    },
+  ],
+};
+
+describe("the access panel", () => {
+  it("leads with the switch, because every cell under it is downstream of that one field", async () => {
+    answer(CLOSED);
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.find('[data-testid="access-face-declared"]').text()).toContain("This app is CLOSED");
+    expect(w.text()).toContain("1 of 1 collections are shut to everyone outside the roster.");
+  });
+
+  it("colours an outsider's cell only where the outsider reaches something", async () => {
+    answer(CLOSED);
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    const stranger = w.find('[data-testid="access-records-stranger"]');
+    expect(stranger.text()).toContain("Nothing");
+    expect(stranger.html()).not.toContain("text-amber");
+
+    // The same table with the app opened: now the stranger reads every row, and that is the line
+    // the author opened this panel to find.
+    answer({
+      ...CLOSED,
+      publicFace: "open",
+      collections: [
+        { ...CLOSED.collections[0], access: { ...CLOSED.collections[0].access, stranger: { read: "all", create: true, editOwn: false, editAll: false } } },
+      ],
+    });
+    const open = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    const row = open.find('[data-testid="access-records-stranger"]');
+    expect(row.text()).toContain("All rows");
+    expect(row.text()).toContain("Submit only");
+    expect(row.html()).toContain("text-amber");
+  });
+
+  it("does not colour a participant who reaches the same thing", async () => {
+    // A participant reading their own rows is the app working. A table where every filled cell is
+    // highlighted highlights nothing.
+    answer(CLOSED);
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.find('[data-testid="access-records-participant"]').html()).not.toContain("text-amber");
+  });
+
+  it("counts the roster into the rows that describe it, and nowhere else", async () => {
+    answer(CLOSED);
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.find('[data-testid="access-records-participant"]').text()).toContain("(4)");
+    // "Signed in, not invited (0)" would read as "nobody can do this", which is the opposite of
+    // what that row is for.
+    expect(w.find('[data-testid="access-records-stranger"]').text()).not.toContain("(");
+  });
+
+  it("reports a manifest it could not read instead of an empty table", async () => {
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: true, status: 200, json: async () => ({ declared: true, ok: false, problems: ["app.json is not JSON"] }) }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("app.json is not JSON");
+    expect(w.text()).not.toContain("collections are shut");
+  });
+
+  it("says so when the summary could not be computed at all", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.text()).toContain("Could not work out the access summary.");
+  });
+});

--- a/test/src/components/SharedAppAccessPanel.spec.ts
+++ b/test/src/components/SharedAppAccessPanel.spec.ts
@@ -102,6 +102,18 @@ describe("the access panel", () => {
     expect(w.text()).toContain("0 of 1 collections are shut");
   });
 
+  it("adds the repair to a subject who may already do something else", async () => {
+    // The repair is an ADDITION, not an alternative: a visitor who may submit here may also write
+    // `state` on somebody else's row, and naming only the submission describes the smaller half.
+    answer({
+      ...CLOSED,
+      collections: [{ ...CLOSED.collections[0], access: { ...CLOSED.collections[0].access, visitor: { ...shut, create: true, repairMirror: true } } }],
+    });
+    const w = mount(Panel, { props: { cwd: "/srv/app" } });
+    await flushPromises();
+    expect(w.find('[data-testid="access-records-visitor"]').text()).toContain("Submit only, repair `state`");
+  });
+
   it("says the app.json went away rather than drawing nothing at all", async () => {
     // Reachable when the manifest is removed between the pane's `/declared` probe and this
     // request. Returning silently left a blank panel with no state.

--- a/test/src/utils/sharedAppAccessPayload.spec.ts
+++ b/test/src/utils/sharedAppAccessPayload.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { asAccess } from "../../../src/utils/sharedAppAccessPayload";
+import { ACCESS_SUBJECTS } from "../../../common/sharedAppAccess";
+
+const entry = { read: "none", create: false, editOwn: false, editAll: false };
+
+/** The server's summary, optionally with one subject's row left out — built from
+ *  `ACCESS_SUBJECTS` so a fifth subject joins these cases by existing. */
+const payload = (omit?: string) => ({
+  publicFace: "declared",
+  collections: [
+    {
+      cid: "records",
+      takesSubmissions: true,
+      authStage: "verifiedEmail",
+      census: { writers: 1, readers: 0, participants: 2 },
+      caveats: [] as string[],
+      access: Object.fromEntries(ACCESS_SUBJECTS.filter((subject) => subject !== omit).map((subject) => [subject, { ...entry }])),
+    },
+  ],
+});
+
+describe("narrowing the access response", () => {
+  it("accepts the summary the server sends", () => {
+    expect(asAccess(payload())?.collections[0].census.participants).toBe(2);
+  });
+
+  // The narrower names its four subjects one by one (it cannot loop without an assertion), so this
+  // is what stops a FIFTH subject being added to the table and silently never checked.
+  // The narrower names its four subjects one by one (it cannot loop without an assertion), so this
+  // is what stops a FIFTH subject being added to the table and silently never checked.
+  it.each([...ACCESS_SUBJECTS])("refuses a summary missing the %s row", (subject) => {
+    expect(asAccess(payload(subject))).toBeNull();
+  });
+
+  it.each([
+    ["an unknown public face", { publicFace: "maybe" }],
+    ["collections that are not a list", { collections: {} }],
+  ])("refuses %s", (_name, patch) => {
+    expect(asAccess({ ...payload(), ...patch })).toBeNull();
+  });
+
+  it("refuses a read verdict it does not recognise, rather than falling back to Nothing", () => {
+    // Falling back would print "Nothing" in a cell whose real answer we could not read — the one
+    // failure mode this whole file exists to prevent.
+    const body = payload();
+    body.collections[0].access.stranger = { ...entry, read: "some" };
+    expect(asAccess(body)).toBeNull();
+  });
+
+  it("refuses a census that is not a count", () => {
+    const body = payload();
+    body.collections[0].census.writers = -1;
+    expect(asAccess(body)).toBeNull();
+  });
+});

--- a/test/src/utils/sharedAppAccessPayload.spec.ts
+++ b/test/src/utils/sharedAppAccessPayload.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { asAccess } from "../../../src/utils/sharedAppAccessPayload";
 import { ACCESS_SUBJECTS } from "../../../common/sharedAppAccess";
 
-const entry = { read: "none", create: false, editOwn: false, editAll: false };
+const entry = { read: "none", create: false, editOwn: false, editAll: false, repairMirror: false };
 
 /** The server's summary, optionally with one subject's row left out — built from
  *  `ACCESS_SUBJECTS` so a fifth subject joins these cases by existing. */

--- a/test/src/utils/sharedAppAccessPayload.spec.ts
+++ b/test/src/utils/sharedAppAccessPayload.spec.ts
@@ -8,6 +8,7 @@ const entry = { read: "none", create: false, editOwn: false, editAll: false, rep
  *  `ACCESS_SUBJECTS` so a fifth subject joins these cases by existing. */
 const payload = (omit?: string) => ({
   publicFace: "declared",
+  unmatchableRoster: [] as string[],
   collections: [
     {
       cid: "records",
@@ -36,6 +37,7 @@ describe("narrowing the access response", () => {
   it.each([
     ["an unknown public face", { publicFace: "maybe" }],
     ["collections that are not a list", { collections: {} }],
+    ["a roster list that is not a list of strings", { unmatchableRoster: [1] }],
   ])("refuses %s", (_name, patch) => {
     expect(asAccess({ ...payload(), ...patch })).toBeNull();
   });


### PR DESCRIPTION
共有アプリを Collections ペインで見たとき（Previews OFF）、**コレクションごとに「誰が何を読めて何を書けるか」**を表で示す。特に見たいのは 2 行 —— **サインインしていない人**と、**サインインしただけで招待されていない人**。

## なぜ

Previews はヘッドレスもペインも **著者のセッション**で動く。だから「著者に何ができるか」しか見えず、SKILL.md 自身が `Neither preview can tell you what the rules would say to a visitor or a participant` と書いている。一方で答えは静的に出せる —— 認可を決めているのは `firestore.rules` で、そのルールが読む文書は 2 つ（アプリ文書と、その `public` ブロック）だけだからだ。

この 2 つは `projectPublish` が作業ツリーから**純粋に**射影する。よって Firestore のセッションは要らず、何も書かず、`app.json` を直した瞬間に変わる。

## 何を出すか

`Previews` の隣に `Access` ボタン（排他の第 3 面）。コレクションごとに 4 行 × 2 列:

| Who | Reads | Writes |
|---|---|---|
| Not signed in | Nothing | Nothing |
| Signed in, not invited | Nothing | Nothing |
| Participant (4) | All rows | Submit, edit own |
| Owner / editor (1) | All rows | Anything |

- 色が付くのは**外部の 2 行が何かに届いているときだけ**。全部光る表は何も光っていないのと同じ。
- 名簿の実数を括弧で出す（`audience: "participant"` を宣言していて participant が 0 人、は表からは読めない）。
- `viewer` / `assignee` は列を持たないので、表の下に人数で出す。

## 表に出さないこと

判定できないものを表のセルにすると嘘になるので、**必ず表を狭める向きの注記**として文で出す:

- 投稿の窓 —— 「宣言がある」ではなく**今開いているか**まで解く。`apps/roles` は 3 コレクションとも `window.until` が 2000 年で閉じており、宣言の有無だけを見ると「誰でも投稿できる板」と報告してしまう（実地で確認・修正済み）。`fromField` / `untilField` は別レコードに境界があるので「判断できない」と言う。
- セッションゲート / `idFrom: "field"` の先着 / `revealGated` / `assignee` / `mirrorOf`。

## `emailField` の穴

`ownRow` の `emailField` 分岐は**世界中の verified アカウントに届く**。素直に書くと、行を作る手段が一切ない赤の他人のセルが `Own rows` になり、「他人は何にも触れない」ことを言うための表が逆のことを言う。なので **行を作れるか**でゲートした。作れない人は行を持てない。

ただし「開いていた時期に投稿して、閉じた後も自分の行を読み書きできる人」は本当に居て、作業ツリーには記録がない。これは表では言えないので caveat の文にした。しかもその文は**スイッチで閉じた場合にだけ**出す —— `audience: "participant"` は `public.enabled` が何であれ外部を拒むので、開いていた時期が存在しない（`apps/ai-blogs` に誤って警告が出ていたのを直した）。

## 実地確認

`~/git/ai/apps` の実アプリに対して射影を回して読み合わせた: `ai-blogs`（世界が読む・9 人の participant だけが書く・各自が自分の記事を直す）、`roles`（窓が閉じている）、`gym`（`bookings` は匿名には見えない / レコードごとの窓）、`live`（`votes` は自分の票だけ）、`survey`、`todos`。

## テスト

- `test/common/sharedAppAccess.spec.ts` 24 本 —— 形は mulmoserver の `test/rules/rules_matrix.ts` が emulator で測っている形（招待制 = #1926 の形・無記名アンケート・ブログ）に合わせてある。ミューテーションで感度を確認済み: `(publicOn || listedIn)` のゲートを外すと招待制の他人セルが落ち、`emailField` の `verified()` を外すと匿名訪問者のセルが落ちる。
- `test/server/backends/sharedAppAccess.spec.ts` —— **Firestore セッション無し**で答えること自体を pin する（`setFirestoreAccessor(null)`）。
- ペインの面の切り替え、コンポーネント、ワイヤの narrow それぞれに spec。

## 権威について

これは**報告**であって、何も認可しない。認可を持つのは deploy 済みのルールだけで、パネルと本番が食い違ったら本番が正しく、食い違いのほうがバグ。パネルの末尾にもそう書いてある。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Access panel for shared apps showing read and write permissions by collection and access level.
  * Added permission details, roster counts, submission status, authentication requirements, mirror-repair access, and relevant caveats.
  * Access summaries are calculated from the working tree without requiring a Firestore session.
  * Added warnings for unmatched roster addresses and clear handling for unavailable or malformed access information.
  * Access and preview views now switch cleanly and reset when navigating between collections or apps.

* **Documentation**
  * Documented how to use the Access panel before publishing shared apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->