### PR TITLE
chore: @mulmoclaude/mulmoscript-plugin 4.5.1 — 起動時の誤った警告が消える

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
-    "@mulmoclaude/mulmoscript-plugin": "^4.5.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.5.1",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,10 +1924,10 @@
     js-yaml "^5.4.1"
     marked "^18.0.11"
 
-"@mulmoclaude/mulmoscript-plugin@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-4.5.0.tgz#754a5f866764fe20c12e3d024ae60ec9b3bc011f"
-  integrity sha512-APZasqYO+rJcKcO/+aG8tu6jZugfJ5UJ+tFtxJKJlkahyHnphuXEEokJoL7OMoT3VelcroEO7lnFajUwrtkoXw==
+"@mulmoclaude/mulmoscript-plugin@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-4.5.1.tgz#8b0c4d462cabd70c206a996e8203a7350e6212c1"
+  integrity sha512-RnUKWSDRg23lPsc5CEpOLy9dkKSGc6MK/pVmColgpiRnPozLYCoQHOh9Cu64c2TUZ5qJ3P04aZbGJcMbsUKP5A==
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 


### PR DESCRIPTION
## Summary

`@mulmoclaude/mulmoscript-plugin` を **4.5.1** に上げます。

4.5.0 は、**`artifactsFor` を渡しているホストにも**毎起動でこう言っていました:

```
[mulmo-script] extra stories roots registered — reads, uploads and generation work;
save/update still land in the DEFAULT root until this host passes `artifactsFor` (#3019)
```

条件が root の**数**だけを見ていて `backend.artifactsFor` を判定していなかったためで、**コードの逆**を言っていました。#1934 で名前付き root を登録するようになったこのホストは、まさにその対象です。receptron/mulmoclaude#3022 として報告し、#3023 で修正・publish されました。

## 検証

**クリーン install で検証しています。** 依存が動く PR は warm な `node_modules` の上で試しても意味がない（推移的依存の欠落を見逃す）ため:

```
rm -rf node_modules && yarn install --frozen-lockfile
```

そのうえで**実機の起動ログ**で確認しました（隔離サーバ: scratch HOME・ポート 34727・tmux ソケット `mt-verify451`、ワークスペース配下にデッキを置いた状態）:

| 見たこと | 結果 |
|---|---|
| 4.5.1 での起動ログ | **`mulmo-script` の行が 1 つも出ない** |
| 同じサーバでデッキを reopen | `ok: true` / `root: 73537714d0bfe6dd` —— 機能は従来どおり |
| **対照**: `rootScopedGenerationState` を外して起動 | **それだけ**を名指しする警告が出る |

対照を取ったのは、**沈黙が「直った」なのか「ログ経路が壊れた」なのかを区別する**ためです。片方を外すと出る、両方揃うと出ない —— これで沈黙の意味が確定します。

`yarn format` / `lint` / `typecheck` / `build` 0、`yarn test` **11927 passed / 50 skipped**（クリーン install 後）。

## User Prompt

- npm │ @mulmoclaude/mulmoscript-plugin@4.5.1（latest=4.5.1）　でた

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbtkBP7m9oq53qyYB3i8XX

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MulmoScript plugin to the latest patch release for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->