### PR TITLE
feat(collections): 「チャットを開始」ダイアログに起動エージェントのピッカーを出す (#1945)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^3.0.0",
     "@mulmoclaude/chart-plugin": "^3.0.0",
-    "@mulmoclaude/collection-plugin": "^4.4.0",
+    "@mulmoclaude/collection-plugin": "^4.6.0",
     "@mulmoclaude/core": "^4.5.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",

--- a/plans/feat-1945-fill-chat-modal-slot.md
+++ b/plans/feat-1945-fill-chat-modal-slot.md
@@ -1,0 +1,64 @@
+# 「チャットを開始」ダイアログに起動エージェントのピッカーを出す (#1945)
+
+## 問題
+
+#1938 / PR #1940 で、コレクション発チャットの起動エージェントをオーバーレイ・セル内ペイン・
+Settings の 3 面で見せて変えられるようにした。残った穴が 1 つ:
+
+plugin の `CollectionChatModal` は `fixed inset-0` + `backdrop-blur-sm` で画面全体を覆うので、
+**押すまさにその瞬間だけ**ヘッダのピッカーがぼかされて見えない。本来いちばん置きたい場所だが、
+この modal は `@mulmoclaude/collection-plugin` のものだった。
+
+plugin 側に slot を開ける依頼（receptron/mulmoclaude#3026 / PR #3027）は完了し、
+**`@mulmoclaude/collection-plugin@4.6.0`** として公開済み。こちらで埋める。
+
+## 変更
+
+1. 依存を `^4.6.0` へ。
+2. `<CollectionView>` を描く 2 箇所 — `CollectionsBrowseOverlay.vue` と `CollectionsPane.vue` —
+   に `#chat-modal-options` を渡す。
+3. `src/components/ChatModalAgentPicker.vue`（新規）を差し込む。
+
+## なぜ `LaunchAgentPicker` を再利用しないのか
+
+**slot の中身は plugin の shadow root で描かれる。** そこに注入されるのは plugin の Tailwind
+シートだけ（`src/collectionShadowCss.ts`）で、**クラス規則は shadow 境界を貫通しない**。
+出荷されているシートを実測したところ、MulmoTerminal のテーマ utility は 1 つも入っていない:
+
+| class | plugin のシートにあるか |
+|---|---|
+| `bg-input` / `text-fg` / `border-border` / `text-dim` | **無い** |
+| `text-slate-600` / `border-slate-200` / `bg-white` / `h-8` / `text-xs` … | ある |
+
+つまり `LaunchAgentPicker` をそのまま置くと、白いカードの上に**素の `<select>`** が出る。型は
+何も言わないし、markup はどちらでも正しいので、component テストでも捕まらない。
+
+そこで modal 自身の light card の語彙で描く。これは「使える唯一の選択肢」であると同時に
+**正しい選択**でもある: あのカードは MulmoTerminal がどのテーマを着ていても白いので、
+ピッカーは背後のアプリではなくカードに属する。
+
+## 常時表示にする
+
+ペインのチップは `nonDefaultOnly`（驚きのある答えだけ印を付ける）。この modal は**起動そのものが
+主題**なので、Settings の `SkillLaunchConfirm` と同じく常に出す。「Claude です」も読む価値のある
+答えになる。
+
+## 覆わない範囲
+
+Canvas のコレクションカード（`CollectionCardView.vue`）。`GuiPanel.vue` が常に
+`sendTextMessage` を渡す埋め込み経路なので、**plugin 側が slot を withhold する** —
+チャットは今動いているセッションに入り、`launchAgent` は関与しない。
+
+## 検証
+
+- `test/src/components/ChatModalAgentPicker.spec.ts` — 挙動（値が届く／既定でも出る／選択肢）。
+- `test/scripts/chat-modal-picker-shadow-css.spec.ts` — **この変更の本丸の guard**。
+  component の template が使うクラスを、出荷済み plugin シートに突き合わせる。`node:fs` が要る
+  ので node 型のプロジェクト側に置く（`test/src/**` は DOM プログラムで node 型を持たない —
+  `test/config/**` が同じ理由でそちらにいる）。`tailwind-font-mono.spec.ts` が同じ形の検査。
+  **guard が噛むことを確認済み**: `text-dim` を入れると赤、戻すと緑。
+- **実機**（build 成功 ≠ 動作する。リスクの本体が shadow 境界をまたぐ CSS なので、green な
+  テストは何も証明しない）: 隔離した `HOME` と別ポートで `yarn dev` を起動し、Playwright で
+  オーバーレイ経路とペイン経路の両方から modal を開いて確認。console error は 0。
+  計測した computed style: `bg #fff` / `color oklch(0.446 …)=slate-600` / `border slate-200 1px` /
+  `height 32px` / `radius 4px` / `font-size 12px` / `cursor pointer` — すべて意図どおり適用。

--- a/src/components/ChatModalAgentPicker.vue
+++ b/src/components/ChatModalAgentPicker.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// The launch-agent picker for the collection plugin's "Start chat" modal (#1945).
+//
+// Why this is not `LaunchAgentPicker` with a prop: it renders INSIDE the plugin's shadow root,
+// where MulmoTerminal's own utilities do not exist. `src/collectionShadowCss.ts` injects the
+// PLUGIN's Tailwind sheet, and a class rule does not pierce a shadow boundary — so `bg-input`,
+// `text-fg`, `border-border` and `text-dim` resolve to nothing in here and the control would come
+// out as a bare `<select>` on a white card. (Verified against the shipped sheet: none of those
+// four appear in it.) The duplication is exactly the part that has to differ.
+//
+// It speaks the modal's own language instead, which is also the right answer rather than merely
+// the available one: that card is white whatever theme MulmoTerminal is wearing, so the picker
+// belongs to the card, not to the app behind it. Every class below is one the plugin's sheet
+// already ships — a `slate-*` the modal's own Cancel button uses.
+//
+// ALWAYS shown, unlike the same choice in a Collections pane. The pane marks only a surprising
+// answer; here the launch IS the subject, so "it will be Claude" is worth reading — the same call
+// SkillLaunchConfirm makes.
+import { launchAgent } from "../composables/useChatLauncher";
+import { BUILTIN_AGENT_OPTIONS } from "./agentPicker";
+</script>
+
+<template>
+  <!-- A <label> wrapper so the visible words name the control, and are a second hit target for it. -->
+  <label class="flex shrink-0 items-center gap-2" data-testid="chat-modal-agent-picker" title="Agent this chat will start as">
+    <span class="text-xs font-bold uppercase tracking-wide text-slate-400">Launch with</span>
+    <select v-model="launchAgent" class="h-8 cursor-pointer rounded border border-slate-200 bg-white px-2 text-xs font-bold text-slate-600 transition-colors">
+      <option v-for="o in BUILTIN_AGENT_OPTIONS" :key="o.agent" :value="o.agent">{{ o.label }}</option>
+    </select>
+  </label>
+</template>

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -25,6 +25,7 @@ import {
 import { useShortcuts } from "../composables/useShortcuts";
 import type { Shortcut } from "../../common/shortcuts";
 import LaunchAgentPicker from "./LaunchAgentPicker.vue";
+import ChatModalAgentPicker from "./ChatModalAgentPicker.vue";
 
 // Navigation is the toolbar's job (the Chat tab closes this; Collections / favorite
 // tabs switch what it shows), so the overlay itself carries no chrome — it just fills
@@ -144,7 +145,14 @@ useEscapeToClose(isOpen, close);
                render none of them. -->
           <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" :key="projectKey" />
           <CollectionsIndexView v-else-if="view.mode === 'index'" :key="projectKey" />
-          <CollectionView v-else-if="view.mode === 'detail'" :key="projectKey" />
+          <!-- The plugin's "Start chat" modal covers the whole page (`fixed inset-0` +
+               `backdrop-blur-sm`), so the toolbar picker above is blurred out at exactly the
+               moment the button is pressed — which is why the plugin grew a footer slot for us
+               (#1945, @mulmoclaude/collection-plugin 4.6.0). The plugin withholds it on the
+               embedded path, where the seed goes into a session that is already running. -->
+          <CollectionView v-else-if="view.mode === 'detail'" :key="projectKey">
+            <template #chat-modal-options><ChatModalAgentPicker /></template>
+          </CollectionView>
         </div>
       </PluginFrame>
     </div>

--- a/src/components/CollectionsPane.vue
+++ b/src/components/CollectionsPane.vue
@@ -19,6 +19,7 @@ import { asSelfContainmentReport, type SelfContainmentReport, type SelfContainme
 import type { ShortcutKind } from "../../common/shortcuts";
 import SharedAppPreview from "./SharedAppPreview.vue";
 import LaunchAgentPicker from "./LaunchAgentPicker.vue";
+import ChatModalAgentPicker from "./ChatModalAgentPicker.vue";
 import SharedAppAccessPanel from "./SharedAppAccessPanel.vue";
 import { isRecord } from "../../common/isRecord";
 
@@ -379,7 +380,14 @@ useCollectionTeleportTarget(probe);
           <div ref="probe" style="height: 100%">
             <FeedsView v-if="view.mode === 'index' && view.kind === 'feed'" />
             <CollectionsIndexView v-else-if="view.mode === 'index'" />
-            <CollectionView v-else />
+            <!-- Same slot as the overlay: the plugin's "Start chat" modal covers the whole page,
+                 so the header chip beside `Collections` above is blurred out at the one moment it
+                 would be read (#1945). Here the picker is always shown, unlike that chip — the
+                 modal exists to start a chat, so what it starts as is the subject rather than a
+                 surprise worth flagging. -->
+            <CollectionView v-else>
+              <template #chat-modal-options><ChatModalAgentPicker /></template>
+            </CollectionView>
           </div>
         </PluginFrame>
       </div>

--- a/test/scripts/chat-modal-picker-shadow-css.spec.ts
+++ b/test/scripts/chat-modal-picker-shadow-css.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `ChatModalAgentPicker` renders inside the collection plugin's SHADOW ROOT, and a class rule does
+// not pierce a shadow boundary. What is injected there is the PLUGIN's Tailwind sheet
+// (src/collectionShadowCss.ts) — so a MulmoTerminal utility written into that component paints
+// nothing, and the control comes out as a bare `<select>` on a white card.
+//
+// Nothing in the type system says so, and no component test can: the markup is correct either
+// way, and the failure is only visible to an eye looking at the real modal. This is the guard.
+//
+// It lives here rather than beside the component's own spec because it needs `node:fs`, and
+// `test/src/**` is type-checked by the DOM program (tsconfig.test.json) which has no node types —
+// the same reason `test/config/**` sits in the node-typed project. `tailwind-font-mono.spec.ts`
+// next door is the same shape of check: our source against a stylesheet it cannot import.
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const componentFile = path.join(repoRoot, "src", "components", "ChatModalAgentPicker.vue");
+const pluginSheet = path.join(repoRoot, "node_modules", "@mulmoclaude", "collection-plugin", "dist", "style.css");
+
+/** Every class the component's template puts on an element. */
+function classesUsed(): string[] {
+  const template = readFileSync(componentFile, "utf8").split("<template>")[1] ?? "";
+  const found = new Set<string>();
+  for (const match of template.matchAll(/\sclass="([^"]*)"/g)) {
+    (match[1] ?? "")
+      .split(/\s+/)
+      .filter(Boolean)
+      .forEach((c) => found.add(c));
+  }
+  return [...found];
+}
+
+/** Tailwind escapes `.` `:` `/` `[` `]` in the selector it emits (`.px-2\.5`, `.hover\:x`). */
+function sheetHas(css: string, className: string): boolean {
+  const escaped = className.replace(/[.:/[\]]/g, (ch) => `\\${ch}`);
+  return new RegExp(`\\.${escaped}(?=[\\s,{:.\\\\])`).test(css);
+}
+
+describe("ChatModalAgentPicker styling survives the plugin's shadow root", () => {
+  it("uses only classes the plugin's shipped stylesheet defines", () => {
+    const css = readFileSync(pluginSheet, "utf8");
+    // Read, not assumed: an empty or moved sheet would make every class below "present" and the
+    // check would pass while proving nothing.
+    expect(css.length).toBeGreaterThan(1000);
+
+    const used = classesUsed();
+    expect(used.length).toBeGreaterThan(5);
+
+    const missing = used.filter((c) => !sheetHas(css, c));
+    expect(missing, `absent from the plugin sheet, so they paint nothing inside its shadow root: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  // The trap this guard exists for, stated as a fact rather than as prose: MulmoTerminal's own
+  // theme utilities really are missing from that sheet.
+  it("confirms MulmoTerminal's theme utilities are the ones that would silently vanish", () => {
+    const css = readFileSync(pluginSheet, "utf8");
+    ["bg-input", "text-fg", "border-border", "text-dim"].forEach((c) => expect(sheetHas(css, c), `${c} unexpectedly present`).toBe(false));
+  });
+});

--- a/test/src/components/ChatModalAgentPicker.spec.ts
+++ b/test/src/components/ChatModalAgentPicker.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import ChatModalAgentPicker from "../../../src/components/ChatModalAgentPicker.vue";
+import { launchAgent } from "../../../src/composables/useChatLauncher";
+
+// A module singleton with a localStorage watcher behind it. Restored here rather than at the end
+// of each test: an assertion that throws would otherwise leave the next one running as muse.
+afterEach(() => {
+  launchAgent.value = "claude";
+});
+
+const PICKER = '[data-testid="chat-modal-agent-picker"]';
+
+describe("ChatModalAgentPicker", () => {
+  it("writes the choice through to the shared value and to localStorage", async () => {
+    const w = mount(ChatModalAgentPicker);
+    await w.get("select").setValue("muse");
+    await flushPromises();
+    expect(launchAgent.value).toBe("muse");
+    expect(localStorage.getItem("mt-launch-agent")).toBe("muse");
+  });
+
+  // Unlike the pane's chip, which marks only a surprising answer. The modal exists to start a
+  // chat, so what it starts as is the subject — the call SkillLaunchConfirm makes.
+  it("shows itself even when the agent is the default", () => {
+    const w = mount(ChatModalAgentPicker);
+    expect(w.find(PICKER).exists()).toBe(true);
+    expect((w.get("select").element as HTMLSelectElement).value).toBe("claude");
+  });
+
+  it("offers every agent a seeded chat can run, and no shell", () => {
+    const w = mount(ChatModalAgentPicker);
+    expect(w.findAll("option").map((o) => o.attributes("value"))).toEqual(["claude", "codex", "antigravity", "grok", "muse"]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,13 +1846,13 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-3.0.0.tgz#adadc685f2bcc4ce3fb662a4750f2bcdf32b6c07"
   integrity sha512-787wJuE4Hr4UGDujUgjzdX2+dj2WiyMZ0Z1UaHX3L8jdnQyONnGDK6HrA2sARYGfwrNVsHgK3Ku3ZbfCZxndPA==
 
-"@mulmoclaude/collection-plugin@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-4.4.0.tgz#b1af320d0b542238a6683c8a813b5cdc94421380"
-  integrity sha512-lnUiphvuKUOF31snwKK4ZfkiQCinnyHvTIrPJyddHFjva7IQPDI92ZaP2EkkekVQv7c9Hh7++OPvmZjyPA+Zxw==
+"@mulmoclaude/collection-plugin@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-4.6.0.tgz#a9a75504cbc198575f785a64381c4c833fac61e0"
+  integrity sha512-8x88d1a/SwnmG6xp4fgjItFsh1IEoQMQjYHzgj3wAyN49Ucw4WHc/YY0onfXn0cJxt1q5n0eNLqEn7fQCf1y8g==
   dependencies:
     vuedraggable "^4.1.0"
-    zod "^4.4.3"
+    zod "^4.5.2"
 
 "@mulmoclaude/common@^1.1.2", "@mulmoclaude/common@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
## Summary

plugin の `CollectionChatModal` は `fixed inset-0` + `backdrop-blur-sm` で画面全体を覆う。#1940 でオーバーレイとペインのヘッダに出したピッカーは、**押すまさにその瞬間だけ**ぼかされて見えない。plugin 側がそのために開けたフッターの slot（receptron/mulmoclaude#3026 / PR #3027、`@mulmoclaude/collection-plugin@4.6.0`）を、こちらで埋める。

Closes #1945

| ファイル | 変更 |
|---|---|
| `package.json` / `yarn.lock` | `@mulmoclaude/collection-plugin` を `^4.6.0` へ |
| `src/components/ChatModalAgentPicker.vue` | **新規**。modal 専用のピッカー |
| `CollectionsBrowseOverlay.vue` / `CollectionsPane.vue` | `<CollectionView>` に `#chat-modal-options` を渡す |
| `test/src/components/ChatModalAgentPicker.spec.ts` | **新規**。挙動 |
| `test/scripts/chat-modal-picker-shadow-css.spec.ts` | **新規**。この変更の本丸の guard |
| `plans/feat-1945-fill-chat-modal-slot.md` | 設計メモ |

## Items to Confirm / Review

- **`LaunchAgentPicker` を再利用していない**のが、この PR でいちばん判断が要るところ。理由は下の「実装方針」に測定値付きで書いた。DRY を破っているように見えるが、破っているのは**まさに違わねばならない部分**（クラス語彙）だけで、`launchAgent` と `BUILTIN_AGENT_OPTIONS` は共有している
- **modal では常時表示**にした（ペインのチップは `nonDefaultOnly`）。`SkillLaunchConfirm` と同じ判断だが、オーバーレイのツールバーには既に常設のピッカーがあるので、そこだけ二重に見えないか目視してほしい。実機では modal がツールバーを覆うので重複には見えなかった
- **`slate-*` 語彙で描いている**。アプリのテーマに追従しないが、あのカードは MulmoTerminal がどのテーマを着ていても白いので、カード側に合わせるのが正しいと判断した。異論があれば shadow root に utility を注入する道もある（`collectionShadowCss.ts` が `.material-icons` で既にやっていること）
- **Canvas のコレクションカードは対象外**。plugin 側が `sendTextMessage` のある埋め込み経路で slot を withhold する、というのが第一の理由。
  
  **訂正（自分のレビューで発見、ボットの指摘ではない）**: 当初ここに「`sendTextMessage` を渡さなくなったら何も起きないピッカーが Canvas カードに出る」と書いたが、**それは起こり得ない**。Canvas カードは plugin の `ChatView` を描き、`ChatView` は `<CollectionView>` に**slot を一切転送していない**（`chat/View.vue`）。こちらが渡した内容はその mount に届きようがなく、渡していない内容が出ることもない。gate は二重にかかっている。

## 実装方針と主な判断

### slot の中身は plugin の shadow root で描かれる

そこに注入されるのは plugin の Tailwind シートだけ（`src/collectionShadowCss.ts`）で、**クラス規則は shadow 境界を貫通しない**。出荷シート（`dist/style.css`, 63KB）を実測した:

| class | plugin のシートにあるか |
|---|---|
| `bg-input` / `text-fg` / `border-border` / `text-dim` | **無い** |
| `text-slate-600` / `border-slate-200` / `bg-white` / `h-8` / `text-xs` / `rounded` … | ある |

つまり `LaunchAgentPicker` をそのまま置けば、白いカードの上に**素の `<select>`** が出る。**型は何も言わないし、markup はどちらでも正しいので component テストでも捕まらない。** 実際の modal を見た目でしか分からない。

だから modal 自身の light card の語彙で描く。これは使える唯一の選択肢であると同時に正しい選択でもある — あのカードは MulmoTerminal がどのテーマを着ていても白い。

### その罠を捕まえる guard

`test/scripts/chat-modal-picker-shadow-css.spec.ts` が、component の template が使うクラスを出荷済み plugin シートに突き合わせる。`node:fs` が要るので node 型のプロジェクト側に置いた（`test/src/**` は DOM プログラムで node 型を持たない。`test/config/**` が同じ理由でそちらにいる）。`tailwind-font-mono.spec.ts` が同じ形の検査。

**guard が空振りしないことを確認した**: `text-slate-400` を `text-dim` に変えると赤（`absent from the plugin sheet, so they paint nothing inside its shadow root: text-dim`）、戻すと緑。シート自体が空でないことも spec 内で assert している（`?inline` / `?raw` はどちらも vitest では空文字を返すため — それに気づかず書いていたら、この検査はあらゆるクラスに対して通っていた）。

## 検証

`yarn format` → `lint` → `typecheck` → `build` → `test`（**11948 passed / 50 skipped**）すべて緑。

**実機確認**（build 成功 ≠ 動作する。リスクの本体が shadow 境界をまたぐ CSS なので、green なテストは何も証明しない）。隔離した `HOME` と別ポート（backend 34572 / vite 6872）で `yarn dev` を起動し、Playwright で **2 つの配線経路の両方**から modal を開いた。console error は両方 0。

- **オーバーレイ経路** — ピッカーが出る、値 `muse`
- **ペイン経路** — ピッカーが出る、値 `grok`
- 実測した computed style: `background rgb(255,255,255)` / `color oklch(0.446 0.043 257.281)`（slate-600）/ `border oklch(0.929 …) 1px`（slate-200）/ `height 32px` / `border-radius 4px` / `font-size 12px` / `cursor pointer` — すべて意図どおり適用され、`Cancel` / `Start chat` の位置は動いていない

## User Prompt

- MulmoTerminal のコレクションからチャットを始めると Claude ではなく Meta Muse が立ち上がる、という報告の原因を調べてほしい。
- ドロップダウンの見えない画面でも分かるようにしたい。あわせて、そこで変更もできるようにしておくと良い。
- （plugin の「チャットを開始」ダイアログを指して）ここでは選べないのか。
- receptron/mulmoclaude 側の issue を立てて、その実装をしてほしい。
- MulmoTerminal 側で slot を埋めてほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxdCdUWcAikvCU6fkhMP7p

work in mulmoterminal4

