### PR TITLE
test(server): seeded spawn が各エージェントに渡す文字列を固定する (#1939 は再現せず)

### DIFF
--- a/plans/test-1939-seeded-spawn-prompt.md
+++ b/plans/test-1939-seeded-spawn-prompt.md
@@ -1,0 +1,49 @@
+# #1939 は再現しなかった — 代わりに、再現しない理由を固定する
+
+## 報告した内容と、実際
+
+#1939 はこう書いた: `GridView.vue` の Settings skill ボタンが `skillSeed(skill, "claude")` と
+決め打ちしているので、Launch with が Muse のとき Muse に `/mulmoterminal-theme` という
+スラッシュコマンドがそのまま届く、と。
+
+**再現しない。** サーバ側が既に正規化している。`server/routes/plugin-routes.ts` の
+`spawnSeededSession` は spawner に渡す前に `codexifySkillSeed(message)` をかけ、その結果を
+claude 以外の全分岐に渡す。実行して確認した:
+
+| 入力 | 出力 |
+|---|---|
+| `/mulmoterminal-theme` | `Use the "mulmoterminal-theme" skill.` |
+| `/mulmoterminal-theme make it warm` | `Use the "mulmoterminal-theme" skill.\n\nmake it warm` |
+| `just a sentence` | `just a sentence` |
+
+issue を書いたときクライアント側だけを追い、サーバの変換を見落としていた。`GridView` の
+決め打ちは、この正規化があるおかげで無害。
+
+## それでも入れるもの
+
+**その正規化はテストで固定されていなかった。** `spawnSeededSession` は 5 分岐のファンアウトで、
+claude 以外の各分岐が `initialPrompt`（変換後）を渡すことに依存している。新しいエージェントを
+`message`（生）で足せば、#1939 の不具合がそのまま現実になる — どのテストも通らない経路で、
+静かに。
+
+`test/server/routes/seeded-spawn-prompt.spec.ts` が、実際にルートを叩いて各 spawner が
+受け取った文字列を捕まえる。
+
+- claude は `/slug` を**そのまま**受け取る（スラッシュコマンドを持つ唯一のエージェント）
+- それ以外は変換後を受け取る。エージェント一覧は `TERMINAL_AGENTS` から引くので、**Agent Picker
+  に足したエージェントはこの spec を落とすまで出荷できない**
+- 非スラッシュのプロンプト（コレクションアクションの自然文）は全エージェントで無変更
+- claude の draft は生のまま、実行されずに入力欄へ
+
+## 検証
+
+**guard が空振りしないことを確認済み**: muse 分岐を `initialPrompt: message` に変えると赤
+（`rewrites the slash command for muse`）、戻すと緑。これを確かめないと、引数の拾い方を
+間違えた spec が「常に緑」で通ってしまう。
+
+`format` → `lint` → `typecheck` → `build` → `test`（11955 passed / 50 skipped）すべて緑。
+
+## コードは変えない
+
+`GridView.vue` の `skillSeed(skill, "claude")` はそのまま。動いているものを、動く理由が
+テストで固定された今、書き換える理由がない。

--- a/test/server/routes/seeded-spawn-prompt.spec.ts
+++ b/test/server/routes/seeded-spawn-prompt.spec.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+// Which text each agent actually receives when a seeded chat is spawned.
+//
+// This is the invariant that keeps a reported bug from being real (#1939). The Settings skill
+// buttons build a CLAUDE-shaped seed — `skillSeed(skill, "claude")` in GridView, literally
+// `/mulmoterminal-theme` — while the spawn follows the user's "Launch with" toggle, which may be
+// muse. Read from the client alone that looks like a slash command being handed to an agent that
+// has no slash commands. It is not, because `spawnSeededSession` codexifies the seed for every
+// NON-claude branch before it reaches the spawner.
+//
+// Nothing pinned that. `spawnSeededSession` is a five-branch fan-out and each non-claude branch
+// has to pass `initialPrompt` (the rewritten text) rather than `message` (the raw one) — a new
+// agent added without it re-creates exactly the bug, silently, in a path no test walks. So the
+// route is driven for real, once per agent, and the string each spawner is handed is captured.
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import { routeCall, jsonPost } from "../../helpers/routeCall";
+import { TERMINAL_AGENTS } from "../../../common/sessionAgent";
+
+// Same reason as worker-failure-wiring.spec.ts: process.env is shared across a vitest worker, so
+// pointing HOME at a temp dir reaches unrelated specs. What is under test is the in-memory
+// decision, and persistence has its own spec.
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async () => ""),
+    appendFile: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  const realpathSync = Object.assign(
+    vi.fn((p: string) => p),
+    { native: vi.fn((p: string) => p) },
+  );
+  return { promises, realpathSync, default: { promises, realpathSync } };
+});
+
+const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");
+
+/** What one spawner was handed: the auto-run text, or the draft typed into the input box. */
+interface Seen {
+  initialPrompt?: string | undefined;
+  draft?: string | undefined;
+}
+const seen = new Map<string, Seen>();
+const record =
+  (agent: string, read: (args: unknown[]) => Seen) =>
+  (...args: unknown[]) => {
+    seen.set(agent, read(args));
+    return {};
+  };
+
+/** claude's options are its 4th argument; the others take theirs 5th (codex) or 5th (agy/grok/muse). */
+const lastOption = (args: unknown[]): Seen => {
+  const opts = args.find((a, i) => i > 2 && a !== null && typeof a === "object");
+  const o = (opts ?? {}) as Seen;
+  return { initialPrompt: o.initialPrompt, draft: o.draft };
+};
+
+const app = express();
+app.use(express.json());
+mountPluginRoutes(app, {
+  spawnClaudePty: record("claude", lastOption) as never,
+  spawnCodexPty: record("codex", lastOption) as never,
+  spawnAntigravityPty: record("antigravity", lastOption) as never,
+  spawnGrokPty: record("grok", lastOption) as never,
+  spawnMusePty: record("muse", lastOption) as never,
+  registerBackgroundSession: () => {},
+});
+const call = routeCall(app);
+
+const SKILL_SEED = "/mulmoterminal-theme";
+const CODEXIFIED = 'Use the "mulmoterminal-theme" skill.';
+
+async function spawn(agent: string, message = SKILL_SEED, draft = false): Promise<Seen> {
+  seen.delete(agent);
+  await call("/api/plugin/spawnBackgroundChat", jsonPost({ message, agent, draft }));
+  const got = seen.get(agent);
+  if (!got) throw new Error(`the ${agent} spawner was never called`);
+  return got;
+}
+
+describe("the seed each agent is handed", () => {
+  // Claude is the one that HAS slash commands, so its seed must arrive untouched. Rewriting it
+  // would turn a working `/slug` into prose for the only agent that wanted the command.
+  it("hands claude the slash command unchanged", async () => {
+    expect((await spawn("claude")).initialPrompt).toBe(SKILL_SEED);
+  });
+
+  // Everything else. Written from TERMINAL_AGENTS rather than a second list of names, so an agent
+  // added to the picker fails HERE — with "the <agent> spawner was never called" or a raw `/slug`
+  // — rather than shipping as a session that is told to run a command it cannot parse.
+  it.each(TERMINAL_AGENTS.filter((a) => a !== "claude"))("rewrites the slash command for %s", async (agent) => {
+    expect((await spawn(agent)).initialPrompt).toBe(CODEXIFIED);
+  });
+
+  // The rewrite is for SKILL seeds only: a collection action's prompt is already prose and must
+  // reach the agent as written.
+  it("leaves an ordinary prompt alone for every agent", async () => {
+    const prose = "Repair the rows that lost their cover image.";
+    for (const agent of TERMINAL_AGENTS) {
+      expect((await spawn(agent, prose)).initialPrompt, agent).toBe(prose);
+    }
+  });
+
+  // A claude DRAFT is typed into the input box for review instead of run, and it is the raw seed
+  // for the same reason the claude run is.
+  it("keeps a claude draft as the slash command, unrun", async () => {
+    const got = await spawn("claude", SKILL_SEED, true);
+    expect(got.draft).toBe(SKILL_SEED);
+    expect(got.initialPrompt).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

**#1939 は再現しませんでした。** 実装に入る前に再現を取ろうとして、前提が誤りだと分かったので、修正は書いていません。代わりに**再現しない理由**をテストで固定します。

#1939 の主張は「`GridView.vue` が `skillSeed(skill, "claude")` と決め打ちしているので、Launch with が Muse のとき Muse に `/mulmoterminal-theme` がそのまま届く」でした。実際には `server/routes/plugin-routes.ts` の `spawnSeededSession` が spawner に渡す前に `codexifySkillSeed(message)` をかけ、その結果を claude 以外の全分岐に渡しています。`codexifySkillSeed` を実行して確認:

| 入力 | 出力 |
|---|---|
| `/mulmoterminal-theme` | `Use the "mulmoterminal-theme" skill.` |
| `/mulmoterminal-theme make it warm` | `Use the "mulmoterminal-theme" skill.\n\nmake it warm` |
| `just a sentence` | `just a sentence`（非スラッシュはそのまま） |

issue を書いたときクライアント側だけを追い、サーバの変換を見落としていました。`GridView` の決め打ちは、この正規化があるおかげで無害です。

**ただしその正規化はテストで固定されていませんでした。** `spawnSeededSession` は 5 分岐のファンアウトで、claude 以外の各分岐が `initialPrompt`（変換後）を渡すことに依存しています。新しいエージェントを `message`（生）で足せば #1939 の不具合がそのまま現実になる — どのテストも通らない経路で、静かに。

Refs #1939（`Closes` にしていません。直すものが無いので、issue は not-a-bug としてクローズします）

| ファイル | 変更 |
|---|---|
| `test/server/routes/seeded-spawn-prompt.spec.ts` | **新規**。実際にルートを叩き、各 spawner が受け取った文字列を捕まえる |
| `plans/test-1939-seeded-spawn-prompt.md` | 調査の記録 |

**コードは 1 行も変えていません。** 動いているものを、動く理由が固定された今、書き換える理由がありません。

## Items to Confirm / Review

- **`GridView.vue:648` の `skillSeed(skill, "claude")` をそのままにした判断**。クライアントが claude 用の形を作り、サーバが直す、という分業は一見ちぐはぐです。エージェントを渡すよう直すこともできますが、そのためには `startCollectionChat` の内側（agent が確定した後）に seed の組み立てを移す必要があり、動作の変わらない書き換えになります。今回は spec で固定するだけに留めました
- **spec がルート経由の統合テストであること**。`spawnSeededSession` は module-private なので、export して単体で叩く手もありました。ルートを叩くほうが「実際に spawner が受け取るもの」を見られるので、そちらを採っています
- **エージェント一覧を `TERMINAL_AGENTS` から引いている**ので、Agent Picker に足した瞬間この spec が落ちます（「the &lt;agent&gt; spawner was never called」または生の `/slug`）。意図的ですが、新エージェント追加時に一手間増えることは明記しておきます

## 検証

- `format` → `lint` → `typecheck` → `build` → `test`（**11955 passed / 50 skipped**）すべて緑
- **guard が空振りしないことを確認**: muse 分岐を `initialPrompt: message` に変えると赤（`rewrites the slash command for muse`）、戻すと緑。これを確かめないと、引数の拾い方を間違えた spec が「常に緑」で通ってしまいます
- `codexifySkillSeed` の入出力は上の表のとおり、**実行して**確認したものです（コードを読んだだけではありません）

## User Prompt

- MulmoTerminal のコレクションからチャットを始めると Claude ではなく Meta Muse が立ち上がる、という報告の原因を調べてほしい。
- ドロップダウンの見えない画面でも分かるようにしたい。あわせて、そこで変更もできるようにしておくと良い。
- （調査中に見つけた seed 決め打ちについて）バグは別 issue にすること。
- #1939 も進めてほしい。
- （再現しないという報告に対して）そのとおりに進めてほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxdCdUWcAikvCU6fkhMP7p

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for seeded prompt handling across supported terminal agents.
  - Verified that Claude receives slash-command seeds unchanged, while other agents receive the appropriate converted prompt.
  - Confirmed that regular text prompts remain unchanged for all agents.
  - Ensured Claude draft prompts retain the original slash command without executing it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->