### PR TITLE
fix(theme): 設定到着後に xterm のパレットを塗り直す (#1943)

### DIFF
--- a/plans/fix-1943-xterm-theme-after-config.md
+++ b/plans/fix-1943-xterm-theme-after-config.md
@@ -1,0 +1,89 @@
+# fix(theme): 設定到着後に xterm のパレットを塗り直す (#1943)
+
+## 症状
+
+カスタムテーマ（`config.json` の `themes`）を選んだ状態でタブを再読み込みすると、パネルやヘッダーは
+カスタムテーマの色になるのに、xterm の背景だけがビルトイン既定の Midnight (`#1a1a2e`) のまま残る。
+Settings で別のテーマを選び直すと直るが、再読み込みのたびに再発する。
+
+## 原因
+
+`Terminal.vue` の xterm パレット用 watch が、パレットの入力を**列挙**していて、そのうち一つを取り
+こぼしていた。
+
+```ts
+watch([themeId, () => dirConfig.value.theme, () => dirConfig.value.colors], () => {
+  conn.setTheme(slotKey, effectiveTermTheme());
+});
+```
+
+再読み込み時の順序は次のとおり。
+
+1. `localStorage` の `theme` はカスタム id。`isThemeIdLike` を通るので `themeId` にその id が入る。
+2. `/api/config` はまだ届いていないので `customThemes` は空。`applyTheme` の `findCustomTheme` が
+   null を返し、`data-theme` は既定の `midnight` になる。
+3. この間に Terminal が mount され、`termThemeFor(id)` も空振りして `THEMES[0].term`（Midnight）で
+   xterm が確定する。
+4. `/api/config` 到着 → `useAppConfig` が `setCustomThemes(c.themes)` → `refreshTheme()`。これは
+   `:root` の CSS 変数だけを塗り直すのでクロームは正しくなる。
+5. **xterm には誰も通知しない。** `themeId` の値は再読み込みの前後で変わらないので上の watch は
+   発火せず、canvas だけ Midnight のまま残る。
+
+`dirConfig` にカスタムテーマを pin したセル（`termThemeFor(theme)` 経路）も同じ理由で取り残される。
+
+すぐ下のフォント用 watch は同種のレースを既に踏んでいて、`globalFontFamily`（同じく `/api/config`
+由来）を watch に入れて解決してある。テーマ側だけその「設定到着」ソースが欠けていた。
+
+## 修正方針
+
+入力の列挙をやめ、**解決済みのパレットそのもの**を watch する。
+
+```ts
+const termTheme = computed<ITheme>(() => effectiveTermTheme());
+watch(
+  () => JSON.stringify(termTheme.value),
+  () => conn.setTheme(slotKey, termTheme.value),
+);
+```
+
+- `effectiveTermTheme()` が読む reactive な値（`themeId` / `customThemes` / `dirConfig.theme` /
+  `dirConfig.colors`）を computed が自動的に追跡するので、入力を一つ書き忘れる余地がなくなる。
+  今回のバグはまさに「列挙し忘れ」なので、列挙そのものを消すのが再発防止になる。
+- 直接 `termTheme` を watch せずシリアライズしたキーを見るのは、`setCustomThemes` が毎回新しい配列を
+  代入するため。色が同じでも identity が変わり、カスタムテーマを使っていない大多数のユーザーの全セルに
+  無意味な repaint を押し付けてしまう。「ディレクトリが何も pin していないときは app-wide の値に触らない」
+  という既存 spec と同じ姿勢。
+
+`attach()` に渡す初期値は `effectiveTermTheme()` のままで変えない。
+
+## テスト
+
+`test/src/components/TerminalDirFontApply.spec.ts` に describe を追加する（`useTerminalConnections`
+を差し替えて `setTheme` の呼び出しを捕まえる seam が既にあるため、新ファイルにすると mock を丸ごと
+複製することになる）。
+
+1. カスタムテーマ id を選択済み・`themes` 未到着の状態で mount → `attach` は Midnight。その後
+   `setCustomThemes([...])` を呼ぶと `setTheme` にカスタムテーマの色が届く。
+2. カスタムテーマを使っていない場合、`setCustomThemes` の到着だけでは `setTheme` を呼ばない
+   （空配列でも identity が変わる、という上記の懸念を固定する）。
+
+## 影響範囲
+
+`conn.setTheme` の呼び出し元は `Terminal.vue` のこの 1 箇所だけ。
+
+## 実機確認
+
+`dist` をビルドして、スクラッチ HOME（`themes` に `washi` を登録、実設定には触れない）でサーバーを
+起動し、Shell セルを開く → `theme` を `washi` にしてタブを再読み込み、という報告どおりの手順を
+Playwright で実行した。
+
+- **修正なし**: クローム（ヘッダー・セルヘッダー）は washi のクリーム色になるのに、ターミナル領域だけ
+  Midnight の濃紺のまま。報告と一致。
+- **修正あり**: 再読み込み直後からターミナル背景も `#ece7dc`。
+- `extends: "daylight"` + 一部キーのみのテーマでも同じく正しく塗られることを確認（ビルトインを
+  base にした導出パスも通る）。
+
+備考: 検証中、借用した Playwright の Chromium が 112 で `AbortSignal.any` を持たず、
+`fetchWithTimeout` がリクエスト発行前に throw して `/api/config` が一度も飛ばない、という
+偽の症状を踏んだ。アプリ側の問題ではないが、この repo を古いブラウザで検証すると設定が
+まったく読まれない状態を「テーマのバグ」と見誤るので記録しておく。

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -7,7 +7,7 @@ import { dragCarriesFiles, dropTextFromUriList, toInsertText } from "./dropPaths
 import { dropUploadErrorMessage, uploadDropBatch } from "./dropUpload";
 import { createImagePasteHandler } from "../composables/usePasteImage";
 import { translateUiSentence } from "../utils/translateUi";
-import { useTheme, currentTermTheme, termThemeFor } from "../composables/useTheme";
+import { currentTermTheme, termThemeFor } from "../composables/useTheme";
 import { useDirConfig } from "../composables/useDirConfig";
 import { useTerminalFontSize } from "../composables/useTerminalFontSize";
 import { globalFontFamily } from "../composables/terminalFontFamily";
@@ -199,7 +199,6 @@ function onSkill(slug: string): void {
 const gitCwd = computed(() => (props.devTerminal ? null : serverCwd.value));
 const { status: gitStatus } = useGitStatus(gitCwd);
 const dragOver = ref(false);
-const { themeId } = useTheme();
 const { fontSize } = useTerminalFontSize();
 
 // A dir-pinned theme wins over the app-wide selection for this terminal's canvas,
@@ -322,12 +321,26 @@ onDeactivated(() => pushView(false));
 onActivated(() => pushView(viewActive.value));
 onUnmounted(() => pushView(false));
 
-// xterm can't read CSS variables, so repaint its canvas palette when the theme
-// changes (keeps an already-open terminal in sync with the rest of the app). A
-// dir-pinned theme ignores the app-wide change; a change to the pin itself repaints.
-watch([themeId, () => dirConfig.value.theme, () => dirConfig.value.colors], () => {
-  conn.setTheme(slotKey, effectiveTermTheme());
-});
+// xterm can't read CSS variables, so repaint its canvas palette when the theme changes (keeps an
+// already-open terminal in sync with the rest of the app). A dir-pinned theme ignores the app-wide
+// change; a change to the pin itself repaints.
+//
+// Watched as the RESOLVED palette, not as a list of the inputs it is derived from. That list used
+// to name themeId and the two dir keys, and missed the user's own themes: those arrive from
+// /api/config AFTER the terminal is built, and the selected id does not change when they land — so
+// a custom theme's terminals kept the built-in default until the user re-picked a theme (#1943).
+// A computed cannot miss an input the way a hand-written list can.
+//
+// Compared as a serialized key because the themes array is REBUILT on every config read: watching
+// the object itself would fire on identity alone and push a redundant repaint at every terminal of
+// every user, including the ones who defined no themes at all.
+const termTheme = computed<ITheme>(() => effectiveTermTheme());
+watch(
+  () => JSON.stringify(termTheme.value),
+  () => {
+    conn.setTheme(slotKey, termTheme.value);
+  },
+);
 
 // The font, unlike the palette, changes the cell metrics — conn.setFont re-fits and pushes the
 // new cols/rows to the PTY, so the ResizeObserver above is not what reacts here (the host element

--- a/test/src/components/TerminalDirFontApply.spec.ts
+++ b/test/src/components/TerminalDirFontApply.spec.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { nextTick } from "vue";
 import { mount, flushPromises } from "@vue/test-utils";
 import type { TerminalFont } from "../../../src/composables/useTerminalConnections";
 import { TERMINAL_FONT_FAMILY_DEFAULT } from "../../../common/terminalFontFamily";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../../../common/terminalFontSize";
+import { THEME_VAR_KEYS, type ThemeVars } from "../../../common/themeVars";
+import { setCustomThemes } from "../../../src/composables/customThemes";
+import { useTheme } from "../../../src/composables/useTheme";
 
 vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
@@ -51,10 +55,16 @@ function serveDirConfig(dirConfig: Record<string, unknown>) {
   }) as unknown as typeof fetch;
 }
 
+// The theme selection and the user's themes are module-level singletons, so a spec that changes
+// either has to put them back or the next one starts on someone else's palette.
+const { setTheme } = useTheme();
+
 beforeEach(() => {
   attached.length = 0;
   setFontCalls.length = 0;
   setThemeCalls.length = 0;
+  setCustomThemes([]);
+  setTheme("midnight");
   globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
 });
 
@@ -122,5 +132,66 @@ describe("Terminal.vue falls back to the dirCwd hint when it has no cwd", () => 
 
     expect(setFontCalls.at(-1)).toEqual({ size: 18, family: "Cica, monospace" });
     w.unmount();
+  });
+});
+
+// A custom theme naming every variable, which is what makes it resolvable with no built-in base:
+// jsdom loads no stylesheet, so `readBuiltinVars` finds nothing and `extends` would resolve to
+// nothing either. The three keys spelled out are the ones the xterm palette is derived from.
+const WASHI_BG = "#ece7dc";
+const WASHI_FG = "#33302b";
+const washiColors = (): Partial<ThemeVars> => {
+  const filled: Partial<ThemeVars> = {};
+  THEME_VAR_KEYS.forEach((key) => {
+    filled[key] = "#808080";
+  });
+  return { ...filled, "--bg-base": WASHI_BG, "--term-fg": WASHI_FG, "--term-selection": "#d8cfbb" };
+};
+const washi = () => ({ id: "washi", label: "Washi", colors: washiColors() });
+
+describe("Terminal.vue repaints its canvas once the user's own themes arrive", () => {
+  // #1943. On a reload the selected id is read from localStorage and resolves to nothing until
+  // /api/config lands, so the terminal is BUILT on the built-in default — and the id never changes
+  // when the themes arrive. Watching the inputs by name missed this one, and the canvas kept the
+  // dark default under a light chrome until the user re-picked a theme in Settings.
+  it("applies a custom theme selected before its definition was known", async () => {
+    serveDirConfig({});
+    setTheme("washi"); // selected while `themes` is still empty, exactly as a reload leaves it
+    await mountTerminal("late-theme");
+    await flushPromises();
+
+    expect(attached).toHaveLength(1);
+    expect(setThemeCalls).toHaveLength(0);
+
+    setCustomThemes([washi()]);
+    await nextTick();
+
+    expect(setThemeCalls.at(-1)).toMatchObject({ background: WASHI_BG, foreground: WASHI_FG });
+  });
+
+  // The themes array is rebuilt on every config read, so an identity-only watch would repaint the
+  // canvas of every terminal of every user on every load. Only a real colour change may.
+  it("leaves the canvas alone when the arriving themes are not the selected one", async () => {
+    serveDirConfig({});
+    await mountTerminal("builtin-theme");
+    await flushPromises();
+
+    setCustomThemes([washi()]);
+    await nextTick();
+
+    expect(setThemeCalls).toHaveLength(0);
+  });
+
+  // A directory pinning a custom theme resolves through the same lookup, and was stranded the same
+  // way — the pin arrives from /api/dir-config, the definition from /api/config, in either order.
+  it("applies a custom theme a directory pins, whichever config lands first", async () => {
+    serveDirConfig({ theme: "washi" });
+    await mountTerminal("pinned-custom");
+    await flushPromises();
+
+    setCustomThemes([washi()]);
+    await nextTick();
+
+    expect(setThemeCalls.at(-1)).toMatchObject({ background: WASHI_BG, foreground: WASHI_FG });
   });
 });


### PR DESCRIPTION
## Summary

カスタムテーマを選んだ状態でタブを再読み込みすると、ヘッダーやパネルはカスタムテーマの色になるのに **xterm の背景だけ Midnight の濃紺のまま残る** 不具合を直します (#1943)。

原因は `Terminal.vue` の xterm パレット用 watch が、パレットの**入力を列挙**していて、そのうち一つを取りこぼしていたことです。

```ts
watch([themeId, () => dirConfig.value.theme, () => dirConfig.value.colors], () => { ... });
```

再読み込み時の順序:

1. `localStorage` の `theme` はカスタム id。`isThemeIdLike` を通るので `themeId` にその id が入る。
2. `/api/config` はまだ届かず `customThemes` は空 → `findCustomTheme` が null → `data-theme` は既定の `midnight`。
3. この間に Terminal が mount され、`termThemeFor(id)` も空振りして `THEMES[0].term`（Midnight）で xterm が確定する。
4. `/api/config` 到着 → `setCustomThemes` → `refreshTheme()`。これは `:root` の CSS 変数だけを塗り直すのでクロームは正しくなる。
5. **xterm には誰も通知しない。** `themeId` は再読み込みの前後で変わらないので watch が発火せず、canvas だけ Midnight が残る。

修正は、入力の列挙をやめて**解決済みのパレットそのもの**を watch する形にしました。`effectiveTermTheme()` が読む reactive な値を computed が自動的に追跡するので、「入力を一つ書き忘れる」という今回の原因ごと無くなります。

```ts
const termTheme = computed<ITheme>(() => effectiveTermTheme());
watch(
  () => JSON.stringify(termTheme.value),
  () => { conn.setTheme(slotKey, termTheme.value); },
);
```

同じファイルのフォント用 watch は、同種のレースを既に `globalFontFamily`（同じく `/api/config` 由来）を列挙に加えて解決してあります。テーマ側だけその「設定到着」ソースが欠けていました。

## Items to Confirm / Review

- **`JSON.stringify` をキーにした比較**。直接 `termTheme` を watch しなかったのは、`setCustomThemes` が毎回新しい配列を代入するためです。色が同じでも identity が変わるので、カスタムテーマを使っていない大多数のユーザーの全セルに無意味な repaint を押し付けてしまいます。「ディレクトリが何も pin していないときは app-wide の値に触らない」という既存 spec と同じ姿勢で揃えました。もっと素直な書き方があればご指摘ください。
- **`useTheme()` の destructure を削除しました**。`themeId` の唯一の読み手がこの watch だったためで、`currentTermTheme()` が同じ module-level ref を読むので reactive なソースは変わっていません。
- `attach()` に渡す初期値は `effectiveTermTheme()` のままです（変更なし）。

## 検証

- 追加した 3 本の spec は、**修正を外すと 2 本が赤**（`#1a1a2e` Midnight のまま）になることを確認済み。残り 1 本は「選択中でないテーマが届いただけでは repaint しない」ガードです。
- `yarn format` / `lint` / `typecheck` / `build` / `test`（803 files, 11967 tests）すべて green。
- **実機確認**: `dist` をビルドし、スクラッチ HOME（`themes` に `washi` を登録）でサーバーを起動 → Shell セルを開く → `theme` を `washi` にして再読み込み、という報告どおりの手順を Playwright で実行しました。

| | 修正なし | 修正あり |
|---|---|---|
| クローム | washi のクリーム色 | washi のクリーム色 |
| ターミナル背景 | **Midnight の濃紺（バグ）** | `#ece7dc`（正） |

`extends: "daylight"` + 一部キーのみのテーマでも正しく塗られること（ビルトインを base にした導出パス）も確認しました。

> 検証中の余談: 借用した Playwright の Chromium が 112 で `AbortSignal.any` を持たず、`fetchWithTimeout` がリクエスト発行前に throw して `/api/config` が一度も飛ばない、という偽の症状を踏みました。アプリ側の問題ではありませんが、古いブラウザで検証すると設定がまったく読まれないので plans に記録しています。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1943 を示して「これわかる？」と確認を求められた。
- 分析が正しいことを報告したのち、「直そう」と修正を指示された。

Closes #1943

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5dt9VDJH3rprhRRohyc6W


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terminal colors could remain on the default theme after configuration loaded or a tab was reloaded.
  * Custom themes now apply correctly regardless of when configuration becomes available.
  * Prevented unnecessary terminal repaints when unrelated theme settings change.

* **Tests**
  * Added coverage for delayed custom-theme loading, unrelated theme updates, and directory-specific themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->