### PR TITLE
fix(test): Windows CI で落ちる config-lock の経過時間予算を、retry の有無に置き換える (#1953)

### DIFF
--- a/plans/fix-1953-config-lock-elapsed-budget.md
+++ b/plans/fix-1953-config-lock-elapsed-budget.md
@@ -6,7 +6,7 @@ Issue: #1953 / 失敗した run: https://github.com/receptron/mulmoterminal/acti
 
 Windows (PR) の `test_windows` だけが落ちた。
 
-```
+```text
 FAIL  test/server/config/config-lock.spec.ts > withConfigLock > creates the config directory rather than reading a missing one as contention
 AssertionError: expected 1539 to be less than 1000
 ```

--- a/plans/fix-1953-config-lock-elapsed-budget.md
+++ b/plans/fix-1953-config-lock-elapsed-budget.md
@@ -1,0 +1,64 @@
+# fix(test): config-lock の「待たされていない」判定を経過時間から retry の有無へ
+
+Issue: #1953 / 失敗した run: https://github.com/receptron/mulmoterminal/actions/runs/33616594519/job/100203738814
+
+## 何が起きたか
+
+Windows (PR) の `test_windows` だけが落ちた。
+
+```
+FAIL  test/server/config/config-lock.spec.ts > withConfigLock > creates the config directory rather than reading a missing one as contention
+AssertionError: expected 1539 to be less than 1000
+```
+
+落ちた PR (#1949) は `package.json` / `yarn.lock` しか触っていない。つまり PR の内容ではなく、
+テストの判定方法がランナーの負荷に依存している。
+
+## なぜ経過時間では判定できないか
+
+このテストが確かめたいのは「`~/.mulmoterminal` が無い初回書き込みを contention と誤読して
+`LOCK_WAIT_MS` を待ち切っていないこと」。ところが assert しているのは経過時間で、その区間の
+実測値はほぼ全部ファイルシステムである。
+
+- `mkdtempSync` → `mkdirSync -p` → `openSync` (ENOENT) → `openSync` → `writeSync` → `closeSync`
+  → `writeFileSync` → `readFileSync`
+- スキャナの入った Windows ランナーでは、この一連が 1539ms かかりうる。製品コードは fast path を
+  意図どおり通っている。
+
+実 I/O に「必ずこの時間で終わる」値は無いので、閾値を伸ばしても先送りにしかならない (#816 と同じ)。
+
+加えて 1000ms という予算は**緩すぎもする**: `LOCK_RETRY_MS` は 15ms なので、66 回リトライしてから
+成功する退行を「1000ms 未満」として見逃す。速すぎる予算と遅すぎる予算を同時にやっている。
+
+## 直し方
+
+待ちの正体は `sleep()` = `setTimeout` なので、時計ではなく**リトライがスケジュールされたか**を見る。
+
+```ts
+const scheduled = vi.spyOn(globalThis, "setTimeout");
+...
+await withConfigLock(nested, () => writeFileSync(nested, '["made it"]'));
+expect(JSON.parse(readFileSync(nested, "utf8"))).toEqual(["made it"]);
+expect(scheduled).not.toHaveBeenCalled();
+```
+
+`vi.spyOn` は実装をそのまま残すので、実際のタイマー挙動は変わらない (フェイクタイマーだと、
+退行時に promise が永久に settle せずハングし、vitest のタイムアウトという分かりにくい失敗になる)。
+負荷では動かない判定になり、リトライ 1 回でも捕まえられる。
+
+## 差分検証 (実行済み)
+
+| 製品コードの変異 | 旧 assert (経過時間 < 1000ms) | 新 assert (setTimeout 未呼び出し) |
+|---|---|---|
+| ENOENT を `return false` (当時のバグそのもの) | 捕まえる (6s 待って ConfigLockTimeout) | 捕まえる (同上) |
+| ENOENT で mkdir はするが `return false` (retry 1 回で成功) | **見逃す** (実測 23ms) | **捕まえる** (`Number of calls: 1`) |
+| 変異なし | pass (12/12) | pass (12/12) |
+
+変異は検証後に pristine copy から戻し、`git diff` が spec 1 ファイルだけであることを確認した。
+
+## 触らないもの
+
+- `server/config/config-lock.ts` は正常。変更しない。
+- `test/helpers/waitHelpers.spec.ts:66` も経過時間を見ているが、60ms の deadline に対して 2000ms
+  (33 倍) で、測っている `untilTrue` は I/O を含まないタイマー演算のみ。壊れていないので触らない。
+  横断調査の全表は #1953 にある。

--- a/test/server/config/config-lock.spec.ts
+++ b/test/server/config/config-lock.spec.ts
@@ -8,7 +8,7 @@
 // A saved directory is not cosmetic here: the list is what decides which projects the server
 // serves collections for. So the read-modify-write is claimed with a lock, and this is what says
 // the lock is real rather than decorative.
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, utimesSync } from "node:fs";
 import { hostname } from "node:os";
 import { tmpdir } from "node:os";
@@ -189,13 +189,19 @@ describe("withConfigLock", () => {
   // save anything at all.
   it("creates the config directory rather than reading a missing one as contention", async () => {
     const { dir, cleanup } = tmp();
+    // "It did not wait anything out" is asked of the RETRY, not of the clock. An elapsed-time
+    // budget measures the runner's filesystem — mkdir plus four opens, under a Windows scanner —
+    // and 1539ms of that went red against a 1000ms budget on a loaded runner while this code took
+    // the fast path exactly as intended. Waiting is `sleep` between claims, so the thing to assert
+    // is that no such sleep was ever scheduled; that answer does not move with the load.
+    const scheduled = vi.spyOn(globalThis, "setTimeout");
     try {
       const nested = path.join(dir, "never-created", "config.json");
-      const started = Date.now();
       await withConfigLock(nested, () => writeFileSync(nested, '["made it"]'));
       expect(JSON.parse(readFileSync(nested, "utf8"))).toEqual(["made it"]);
-      expect(Date.now() - started).toBeLessThan(1_000); // i.e. it did not wait anything out
+      expect(scheduled).not.toHaveBeenCalled();
     } finally {
+      scheduled.mockRestore();
       cleanup();
     }
   });


### PR DESCRIPTION
## Summary

Windows (PR) の `test_windows` が `config-lock.spec.ts` の 1 件だけで落ちていた
([該当 job](https://github.com/receptron/mulmoterminal/actions/runs/33616594519/job/100203738814))。

```
AssertionError: expected 1539 to be less than 1000
 ❯ test/server/config/config-lock.spec.ts:197:36
```

落ちた PR (#1949) は `package.json` / `yarn.lock` しか触っていないので、PR の内容ではなく
テストの判定方法がランナーの負荷に依存していた。**製品コード (`server/config/config-lock.ts`)
は変更していない**。正常で、意図どおり fast path を通っている。

確かめたいのは「`~/.mulmoterminal` が無い初回書き込みを contention と誤読して timeout を
待ち切っていないこと」だが、assert していたのは経過時間だった。その区間の実測値はほぼ全部
ファイルシステムで、`mkdtempSync` → `mkdirSync -p` → `openSync` 4 回 → `writeFileSync` →
`readFileSync` をスキャナ入りの Windows ランナーで走らせると 1539ms かかりうる。
実 I/O に「必ずこの時間で終わる」値は無いので、閾値を伸ばしても先送りにしかならない (#816 と同じ構図)。

しかも 1000ms は**緩すぎもする**: `LOCK_RETRY_MS` は 15ms なので、66 回リトライしてから成功する
退行を見逃していた。速すぎる予算と遅すぎる予算を同時にやっていたことになる。

待ちの正体は `sleep()` = `setTimeout` なので、時計ではなく**リトライがスケジュールされたか**を見る:

```ts
const scheduled = vi.spyOn(globalThis, "setTimeout");
...
expect(scheduled).not.toHaveBeenCalled();
```

## Items to Confirm / Review

- **`vi.spyOn` であってフェイクタイマーではない点**。`vi.spyOn` は実装をそのまま残すので実際の
  タイマー挙動は変わらない。`vi.useFakeTimers()` にすると、退行時に retry の promise が永久に
  settle せずハングし、「vitest のタイムアウト」という原因の分からない失敗になる。ここは意図的な選択。
- **`globalThis.setTimeout` へのスパイが `config-lock.ts` の `sleep` を捉えること**は、下の変異 2 で
  実測確認済み (`Number of calls: 1` と 15ms の引数が出る)。同じ tick で他に `setTimeout` を呼ぶ
  ものが無いことに依存しているので、このテストに他の非同期待ちを足すときは注意。
- **横断調査の結論**: 経過時間そのものを予算にしている assert のうち壊れているのは本件のみ
  (全表は #1953)。`test/helpers/waitHelpers.spec.ts:66` も経過時間を見ているが、60ms の deadline に
  対して 2000ms (33 倍) で、測っている `untilTrue` は I/O を含まないタイマー演算のみなので触っていない。
  ここは判断が入っているので、一緒に直すべきという意見があれば従う。

## 差分検証 (実行済み)

「同じ挙動」ではなく「同じ退行を捕まえるか」を確かめるため、製品コードを変異させて両方の assert を走らせた。

| 製品コードの変異 | 旧 assert (経過時間 < 1000ms) | 新 assert (setTimeout 未呼び出し) |
|---|---|---|
| ENOENT を `return false` (当時のバグそのもの) | 捕まえる (6s 待って `ConfigLockTimeout`) | 捕まえる (同上) |
| ENOENT で mkdir はするが `return false` (retry 1 回で成功) | **見逃す** (実測 23ms) | **捕まえる** (`Number of calls: 1`) |
| 変異なし | pass (12/12) | pass (12/12) |

変異は pristine copy から戻し、`git diff` が spec 1 ファイルだけであることを確認した。

## ローカルで通したもの

`yarn format` / `yarn lint` / `yarn typecheck` / `npx vitest run test/server/config/` (40 files, 699 tests) は green。
`yarn build` の `vite build` 部分は、`src/` が無変更で load average が 16 だったため回していない
(`vue-tsc -b` は `yarn typecheck` として実行済み)。**Windows での再現確認は CI が ground truth** で、
手元は macOS なので元の失敗自体は再現できない。

## User Prompt

- fix https://github.com/receptron/mulmoterminal/actions/runs/33616594519/job/100203738814?pr=1949

Closes #1953

work in mulmoterminal4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STx3obgDKfcMvg7kZQGTPb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration-lock handling verification to reliably distinguish missing configuration directories from active lock contention.
  - Prevented false failures caused by variable filesystem performance on slower or heavily loaded systems.

- **Tests**
  - Updated coverage to verify that no retry delay is scheduled when configuration access is uncontended.
  - Replaced timing-dependent assertions with deterministic behavior checks for more stable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->