### PR TITLE
fix(collections): staged なカスタムビューを、このサーバ自身のワークスペースでも読む (#1925)

### DIFF
--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -133,11 +133,20 @@ project, which is what keeps `~`-scoped collections unreachable from a project a
 | Host path | Answers the real path for | Otherwise |
 |---|---|---|
 | `userSkillsDir(root)` | the managed mulmoclaude workspace (`~/mulmoclaude`) | `null` |
-| `skillsStagingDir(root)` | any workspace — `~/mulmoclaude` **or** the one this server serves (`CLAUDE_CWD`) | `null` |
+| `skillsStagingDir(root)` | `~/mulmoclaude`, **or** the workspace this server serves (`CLAUDE_CWD`) once `data/skills` is actually there | `null` |
 
-`skillsStagingDir` takes both because a staged collection's `views/*.html` exists only in
-`data/skills/<slug>/`, and the two roots are the same path only by coincidence: asking about
+`skillsStagingDir` takes the second root because a staged collection's `views/*.html` exists only
+in `data/skills/<slug>/`, and the two roots are the same path only by coincidence: asking about
 `~/mulmoclaude` alone 404'd every custom view in a workspace launched from anywhere else (#1925).
+It asks for the directory to exist because `CLAUDE_CWD` is often somebody's git repository — one
+with no staging tree answers exactly as it did before, so nothing grows a second copy of a skill
+definition there.
+
+`stagedSkillAuthoring` (the `manageCollection` binding, `server/infra/collection-tool.ts`) is
+**derived from the same function**, `skillsStagingDirFor` in `server/backends/stagedSkills.ts`.
+Core requires the two to agree, and the failure when they do not is silent: a root that reads
+staging first while telling the agent to author directly serves a stale staged view instead of
+the one just written.
 
 ---
 

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -125,6 +125,20 @@ wire the engine against the shared `workspaceRoot` using the **same path layout*
 | `archiveDir` | `archive` |
 | `isPresetSlug(slug)` | `slug.startsWith("mc-") && slug.length > 3` |
 
+Two of those are **conditional here and unconditional in MulmoClaude**, because MulmoClaude serves one
+root and this app serves several (`server/infra/project-root.ts`). Both answer `null` for a saved
+project, which is what keeps `~`-scoped collections unreachable from a project and stops a stray
+`data/skills` file shadowing the skill a repo commits:
+
+| Host path | Answers the real path for | Otherwise |
+|---|---|---|
+| `userSkillsDir(root)` | the managed mulmoclaude workspace (`~/mulmoclaude`) | `null` |
+| `skillsStagingDir(root)` | any workspace — `~/mulmoclaude` **or** the one this server serves (`CLAUDE_CWD`) | `null` |
+
+`skillsStagingDir` takes both because a staged collection's `views/*.html` exists only in
+`data/skills/<slug>/`, and the two roots are the same path only by coincidence: asking about
+`~/mulmoclaude` alone 404'd every custom view in a workspace launched from anywhere else (#1925).
+
 ---
 
 ## Gap analysis (updated for `0.5.1`)

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -133,14 +133,16 @@ project, which is what keeps `~`-scoped collections unreachable from a project a
 | Host path | Answers the real path for | Otherwise |
 |---|---|---|
 | `userSkillsDir(root)` | the managed mulmoclaude workspace (`~/mulmoclaude`) | `null` |
-| `skillsStagingDir(root)` | `~/mulmoclaude`, **or** the workspace this server serves (`CLAUDE_CWD`) once `data/skills` is actually there | `null` |
+| `skillsStagingDir(root)` | `~/mulmoclaude`, **or** the workspace this server serves (`CLAUDE_CWD`) once a staged collection (`data/skills/<slug>/schema.json`) is actually there | `null` |
 
 `skillsStagingDir` takes the second root because a staged collection's `views/*.html` exists only
 in `data/skills/<slug>/`, and the two roots are the same path only by coincidence: asking about
 `~/mulmoclaude` alone 404'd every custom view in a workspace launched from anywhere else (#1925).
-It asks for the directory to exist because `CLAUDE_CWD` is often somebody's git repository — one
-with no staging tree answers exactly as it did before, so nothing grows a second copy of a skill
-definition there.
+It asks for a staged collection to be there because `CLAUDE_CWD` is often somebody's git
+repository — one with none answers exactly as it did before, so nothing grows a second copy of a
+skill definition there. The evidence is the `<slug>/schema.json`, not the directory: `data/skills`
+is a name a repo can own for its own reasons, and core's own `canonicalBase` looks for the same
+file before it treats a staging tree as authoritative.
 
 `stagedSkillAuthoring` (the `manageCollection` binding, `server/infra/collection-tool.ts`) is
 **derived from the same function**, `skillsStagingDirFor` in `server/backends/stagedSkills.ts`.

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -144,11 +144,13 @@ skill definition there. The evidence is the `<slug>/schema.json`, not the direct
 is a name a repo can own for its own reasons, and core's own `canonicalBase` looks for the same
 file before it treats a staging tree as authoritative.
 
-`stagedSkillAuthoring` (the `manageCollection` binding, `server/infra/collection-tool.ts`) is
-**derived from the same function**, `skillsStagingDirFor` in `server/backends/stagedSkills.ts`.
-Core requires the two to agree, and the failure when they do not is silent: a root that reads
-staging first while telling the agent to author directly serves a stale staged view instead of
-the one just written.
+`stagedSkillAuthoring` (a `manageCollection` factory dep) is **deliberately not passed at all**.
+Core's `authoringTarget` falls through to `skillsStagingDir` unless the host hands it a literal
+`false`, so where the agent is told to author follows from the binding above rather than from a
+second decision. That matters because the binding's answer MOVES — a workspace gains its first
+staged collection the moment MulmoClaude writes one — while a factory dep is frozen when the tool
+instance is built. A frozen `false` beside a live staging path is the silent failure: the agent
+authors into `.claude/skills` while the read prefers staging, so its edit never appears.
 
 ---
 

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -68,25 +68,31 @@ MulmoClaude が置いた古い staging のコピーが勝つ**（＝編集が黙
 export function skillsStagingDirFor(root: string): string | null {
   const staging = path.join(root, "data", "skills");
   if (isManagedWorkspace(root)) return staging;
-  return isWorkspaceRoot(root) && existsSync(staging) ? staging : null;
+  return isWorkspaceRoot(root) && holdsStagedCollection(staging) ? staging : null;
 }
 ```
 
-- **managed workspace (`~/mulmoclaude`)** — 無条件。今日と同じ。`data/skills` が生成される前でも
-  返す必要がある（最初の `putSchema` がそれを作る）
-- **このサーバが serve しているワークスペース (`CLAUDE_CWD`)** — `data/skills` が**実在するときだけ**
+- **managed workspace (`~/mulmoclaude`)** — 無条件。今日と同じ。中身が空でも返す必要がある
+  （最初の `putSchema` がそれを埋める）
+- **このサーバが serve しているワークスペース (`CLAUDE_CWD`)** — **staged なコレクションが実在
+  するときだけ**（`data/skills/<slug>/schema.json`）
 
-`existsSync` の一手間が、この変更を「#1925 の人」だけに届かせる:
+証拠を「ディレクトリの存在」ではなく「`<slug>/schema.json`」にしているのが要点。`data/skills`
+という**名前**は repo が自分の都合で持ちうるので、それを根拠にエージェントの書き先を変えるのは
+名前を信じているだけになる。`<slug>/schema.json` は staged なコレクションが実際に持つ形で、
+core 自身も `canonicalBase` で同じ証拠を見ている。
 
 | root | 判定 | 意味 |
 |---|---|---|
 | `~/mulmoclaude` | staged（無条件） | 今日と同じ |
-| `CLAUDE_CWD` に `data/skills` がある | staged | MulmoClaude が staged にした本物のワークスペース → **#1925 が直る** |
-| `CLAUDE_CWD` に `data/skills` が無い（＝git repo でランチャを起動しただけ） | direct | **今日と 1 ビットも変わらない**。repo に `data/skills` が生えることもない |
+| `CLAUDE_CWD` に staged なコレクションがある | staged | 何かが staged にした本物のワークスペース → **#1925 が直る** |
+| `CLAUDE_CWD` に無い（＝git repo でランチャを起動しただけ。`data/skills` が別用途であっても） | direct | **今日と 1 ビットも変わらない**。repo に `data/skills` が生えることもない |
 | 保存済みプロジェクト | direct | 今日と同じ。野良ファイルが commit 済み skill を shadow しない |
 
-キャッシュしない。ワークスペースは MulmoClaude が初めて書いた瞬間に staging tree を得るので、
-「無い」を覚えるとサーバが生きている限りそれに気づけなくなる。
+キャッシュしない。ワークスペースは MulmoClaude が最初の 1 件を書いた瞬間に staged になるので、
+「無い」を覚えるとサーバが生きている限りそれに気づけなくなる。`manageCollectionHandlerFor` の
+インスタンスキャッシュも同じ理由で **root + variant** を鍵にした（root だけだと、変わった後も
+古い authoring guide を出し続ける）。
 
 ### D3: `userSkillsDir` は触らない
 
@@ -138,9 +144,9 @@ export function skillsStagingDirFor(root: string): string | null {
 3. **両方にコピーがある**とき staging が勝ち、**かつ authoring guide も staged** — D1 の両端
 4. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
 
-**`collectionStagingUnstagedWorkspace.spec.ts`** — `data/skills` の無い git repo をワークスペースに
-した場合。commit 済みの view が出ること、**authoring guide が direct のままである**ことの 2 つで、
-「この人たちには何も変わらない」を留める。
+**`collectionStagingUnstagedWorkspace.spec.ts`** — git repo をワークスペースにした場合。
+**コレクションを含まない `data/skills` を置いた状態で**、commit 済みの view が出ること、
+**authoring guide が direct のままである**ことの 2 つで、「この人たちには何も変わらない」を留める。
 
 **`canonical-path.spec.ts`** — D4 の抽出で確かめた性質（trailing separator / `.` / `..` /
 大文字小文字 / symlink の両向き / 存在しない leaf）。

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -45,42 +45,50 @@ root = それ以外のワークスペース       → detail: project / view-fil
 
 ## 決定
 
-### D1: staging の可否は「このサーバが serve しているワークスペースか」で決める
+### D1: staging の可否は 1 つの述語にまとめ、read と authoring の両方をそこから導く
 
-`skillsStagingDir` の述語を **`isManagedWorkspace(root) || isWorkspaceRoot(root)`** にする。
-`isWorkspaceRoot` は `initProjectRoots({ workspace })` が束縛した root — つまり `CLAUDE_CWD` —
-との同一判定。`~/mulmoclaude` 判定は**残したまま足す**ので、今動いているものは何も止まらない。
+`server/backends/stagedSkills.ts` に `skillsStagingDirFor(root)` を置き、
 
-`CLAUDE_CWD === ~/mulmoclaude`（通常のケース）では union は今日とビット単位で同じ答えを返す。
-差が出るのは、今まさに 404 になっている「ワークスペースが `~/mulmoclaude` でない」場合だけ。
+- `skillsStagingDir`（読み。view / schema をどこから読むか）
+- `stagedSkillAuthoring`（書き。どの authoring guide を出し、`putSchema` がどこに書くか）
 
-### D2: `stagedSkillAuthoring` は触らない（読みだけ広げる）
+の**両方をそこから導く**。core が言うとおり、この 2 つは合っていなければならない：
 
-`server/infra/collection-tool.ts` の `stagedSkillAuthoring` は `isManagedWorkspace` のまま。
-core の `authoringTarget` は
+> ONE predicate on purpose. … a host that says `stagedSkillAuthoring: false` while still returning
+> a staging path would have the agent told to write `.claude/skills/<slug>/` while `putSchema`
+> wrote `data/skills/` …
 
-```js
-const stagingDir = deps.stagedSkillAuthoring === false ? null : stagingSkillDir(resolveBase(deps), slug);
+読みだけ広げて書きを据え置くと、**エージェントが `.claude/skills` に書いた view より、
+MulmoClaude が置いた古い staging のコピーが勝つ**（＝編集が黙って反映されない）。
+#1955 の codex レビューの指摘どおり。
+
+### D2: staging を返す root は 2 つ。第 2 の root だけ「証拠」を要求する
+
+```ts
+export function skillsStagingDirFor(root: string): string | null {
+  const staging = path.join(root, "data", "skills");
+  if (isManagedWorkspace(root)) return staging;
+  return isWorkspaceRoot(root) && existsSync(staging) ? staging : null;
+}
 ```
 
-なので `false` が勝ち、**エージェントに出す authoring guide も `putSchema` の書き先も今日のまま**
-（`.claude/skills/<slug>/`）。「読めるようにする」以上のことをしない。
+- **managed workspace (`~/mulmoclaude`)** — 無条件。今日と同じ。`data/skills` が生成される前でも
+  返す必要がある（最初の `putSchema` がそれを作る）
+- **このサーバが serve しているワークスペース (`CLAUDE_CWD`)** — `data/skills` が**実在するときだけ**
 
-これは core が "Staged requires BOTH to agree; anything else is direct" と書いている、定義済みの
-組み合わせ。書き込み先を変えるのは別の判断（このワークスペースで MulmoTerminal が staged に
-authoring すべきか）なので、この PR には含めない。
+`existsSync` の一手間が、この変更を「#1925 の人」だけに届かせる:
 
-### D2b: そのぶん残る非対称は、テストで優先順位を明示して #1956 に送る
+| root | 判定 | 意味 |
+|---|---|---|
+| `~/mulmoclaude` | staged（無条件） | 今日と同じ |
+| `CLAUDE_CWD` に `data/skills` がある | staged | MulmoClaude が staged にした本物のワークスペース → **#1925 が直る** |
+| `CLAUDE_CWD` に `data/skills` が無い（＝git repo でランチャを起動しただけ） | direct | **今日と 1 ビットも変わらない**。repo に `data/skills` が生えることもない |
+| 保存済みプロジェクト | direct | 今日と同じ。野良ファイルが commit 済み skill を shadow しない |
 
-D2 の結果、`~/mulmoclaude` でないワークスペースでは **authoring は `.claude/skills` なのに読みは
-staging 優先** になる。両方にコピーがあると、MulmoClaude が置いた staging 側が勝つ。
+キャッシュしない。ワークスペースは MulmoClaude が初めて書いた瞬間に staging tree を得るので、
+「無い」を覚えるとサーバが生きている限りそれに気づけなくなる。
 
-書き側を広げれば揃うが、それは「ランチャを起動したディレクトリに `data/skills` が生える」＝
-副作用。どちらが正しいかは #1956 に切り出し、**現在の優先順位はテストで留める**
-（"prefers the workspace's staging copy when the mirror holds one too"）。ワークスペースでは
-staging が正本で `.claude/skills` はミラーなので、`~/mulmoclaude` が昔から返してきた答えと同じ。
-
-### D3: `userSkillsDir` も触らない
+### D3: `userSkillsDir` は触らない
 
 同じ `isManagedWorkspace` で分岐しているが、こちらを広げると **どのコレクションが見えるか** が
 変わる（`~/.claude/skills` 配下がワークスペースの一覧と slug 解決に入る）。副作用なので触らない。
@@ -97,7 +105,7 @@ staging が正本で `.claude/skills` はミラーなので、`~/mulmoclaude` �
 | 呼び出し元 | 影響 |
 |---|---|
 | `readSourceAwareFile`（view / i18n） | **これが目的**。staging を先に試し、無ければ従来どおり `skillDir` |
-| `authoringTarget`（`putSchema` / `schemaDocs`） | 変化なし（D2 の `stagedSkillAuthoring: false` が勝つ） |
+| `authoringTarget`（`putSchema` / `schemaDocs`） | **読みと同じ答え**になる（D1）。staged なワークスペースでのみ staged |
 | `writeArchive` | `staging !== null && await pathExists(staging)` で存在ガード済み |
 | `canonicalBase` / `schemaWriteTargets`（view 削除） | `fileExists(<staging>/schema.json)` で存在ガード済み |
 | `deleteTargets` | 封じ込めチェックの対象が増えるだけ |
@@ -112,16 +120,27 @@ staging が正本で `.claude/skills` はミラーなので、`~/mulmoclaude` �
 | `isSameRealPath` を足す | `server/infra/canonical-path.ts` |
 | 2 段判定をそれに置き換える | `server/backends/workspaceSetup.ts` |
 | `isWorkspaceRoot` を足す | `server/infra/project-root.ts` |
-| `skillsStagingDir` の述語を union にする | `server/backends/collections.ts` |
-| 回帰テスト | `test/server/backends/collectionStagingServerWorkspace.spec.ts` |
+| `skillsStagingDirFor` / `usesStagedSkillAuthoring` を置く | `server/backends/stagedSkills.ts`（新規） |
+| 束縛をそれに差し替える | `server/backends/collections.ts` |
+| `stagedSkillAuthoring` をそれから導く | `server/infra/collection-tool.ts` |
+| 条件付きの 2 エントリを表に書く | `docs/collection-plugin-integration.md` |
+| 回帰テスト | `test/server/backends/collectionStagingServerWorkspace.spec.ts`, `collectionStagingUnstagedWorkspace.spec.ts`, `test/server/infra/canonical-path.spec.ts` |
 
 ## テスト
 
-新規 spec は 4 つを留める（`configureCollectionHost` は 1 ファイル 1 束縛なので root を変えて確認。
-ケースごとに別 slug を使い、テストの実行順に依存しない）:
+`configureCollectionHost` は 1 プロセス 1 束縛なので、ワークスペースの状態ごとにファイルを分ける。
+
+**`collectionStagingServerWorkspace.spec.ts`** — staging tree のある root（ケースごとに別 slug を
+使い、実行順に依存しない）:
 
 1. **サーバ自身のワークスペース**（`~/mulmoclaude` ではない）で staged view が読める — 修正前は `null`
-2. **`~/mulmoclaude`** も引き続き読める — union であって置き換えではない
-3. **ワークスペースで両方にコピーがある**とき staging が勝つ — D2b の優先順位を明示
+2. **`~/mulmoclaude`** も引き続き読める — 置き換えではない
+3. **両方にコピーがある**とき staging が勝ち、**かつ authoring guide も staged** — D1 の両端
 4. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
-   — 今日の保証がそのまま残っている
+
+**`collectionStagingUnstagedWorkspace.spec.ts`** — `data/skills` の無い git repo をワークスペースに
+した場合。commit 済みの view が出ること、**authoring guide が direct のままである**ことの 2 つで、
+「この人たちには何も変わらない」を留める。
+
+**`canonical-path.spec.ts`** — D4 の抽出で確かめた性質（trailing separator / `.` / `..` /
+大文字小文字 / symlink の両向き / 存在しない leaf）。

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -99,6 +99,19 @@ core 自身も `canonicalBase` で同じ証拠を見ている。
 同じ `isManagedWorkspace` で分岐しているが、こちらを広げると **どのコレクションが見えるか** が
 変わる（`~/.claude/skills` 配下がワークスペースの一覧と slug 解決に入る）。副作用なので触らない。
 
+### D3b: staging の先読みが root 単位である件は core の設計。#1957 に切り出す
+
+core の `readSourceAwareFile` は `<staging>/<slug>` を**その slug が staged かを見ずに** base へ
+入れる。なので staged なワークスペースでは、staging schema を持たないコレクションでも古い
+`data/skills/<slug>/views/*.html` が commit 済みの view に勝つ。
+
+**この PR が持ち込んだものではない** —— `~/mulmoclaude`（触っていない側）で実測して同じ挙動を
+確認済み。かつホストの束縛は `skillsStagingDir(workspaceRoot) => string | null` で slug を
+受け取らないので、**このリポジトリからは per-slug を表現できない**。直す場所は core
+（削除側の `canonicalBase` は既に per-slug の証拠を見ている）。#1957。
+
+現在の挙動は「両 root で同じ答えになる」形でテストに留めてある。
+
 ### D4: 「同じディレクトリか」の 2 段判定を 1 か所にする
 
 `isManagedWorkspace` は lexical → realpath の 2 段で比較している。`isWorkspaceRoot` も同じ規則が
@@ -142,7 +155,9 @@ core 自身も `canonicalBase` で同じ証拠を見ている。
 1. **サーバ自身のワークスペース**（`~/mulmoclaude` ではない）で staged view が読める — 修正前は `null`
 2. **`~/mulmoclaude`** も引き続き読める — 置き換えではない
 3. **両方にコピーがある**とき staging が勝ち、**かつ authoring guide も staged** — D1 の両端
-4. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
+4. **staging の先読みは root 単位**（D3b の既知の制約）。`managed` と `workspace` の**両方**で
+   同じ答えになることを assert し、core のルールであってこの PR の新ルールではないことを示す
+5. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
 
 **`collectionStagingUnstagedWorkspace.spec.ts`** — git repo をワークスペースにした場合。
 **コレクションを含まない `data/skills` を置いた状態で**、commit 済みの view が出ること、

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -1,0 +1,115 @@
+# fix(#1925): staged なカスタムビューを、このサーバ自身のワークスペースでも読む
+
+## 症状
+
+grid セルの Canvas でコレクションのカスタムビューを開くと `HTTP 404`。同じワークスペース・同じ
+`schema.json`・同じレコードを、単体の MulmoClaude で開くと描画される。
+
+`detail` は 200 で `"source":"project"` を返すのに、`view-file` だけが 404 という署名。
+
+## 原因
+
+`readCustomViewHtml` → `readSourceAwareFile`（`@mulmoclaude/core`）は、project スコープの
+コレクションについて staging を先に、`skillDir` を後に読む:
+
+```js
+const staging = collection.source === "project" ? stagingSkillDir(workspaceRoot, safeSlug) : null;
+const bases = staging === null ? [collection.skillDir] : [staging, collection.skillDir];
+```
+
+staged authoring では `views/*.html` は **staging(`data/skills/<slug>/`) にしか無い**
+（`.claude/skills/<slug>/` へは SKILL.md / schema.json / templates だけがミラーされる）。
+だからホストの `skillsStagingDir` が `null` を返すと、base から staging が丸ごと落ちて 404 になる。
+
+2 つのホストの束縛が非対称だった:
+
+| | `skillsStagingDir` |
+|---|---|
+| MulmoClaude (`server/workspace/collections/configure.ts:25`) | `path.join(root, WORKSPACE_DIRS.skillsStaging)` — 無条件 |
+| MulmoTerminal (`server/backends/collections.ts`) | `isManagedWorkspace(root) ? … : null` |
+
+そして `isManagedWorkspace` が聞いているのは「**このパスは `~/mulmoclaude` か**」
+(`MULMOCLAUDE_WORKSPACE_PATH || path.join(os.homedir(), "mulmoclaude")`)。
+一方 MulmoTerminal 自身のワークスペースは `CLAUDE_CWD` = **ランチャを起動したディレクトリ**
+(`bin/cli-args.js` の `chooseCwd` → `serverSpawnEnv` が必ず注入する)。**この 2 つは同じ質問ではない。**
+
+両者がずれると、MulmoClaude が staged レイアウトで書いた「このサーバ自身のワークスペース」を、
+MulmoTerminal が「managed ではない」と判定して staging を読まない。これが 404 の正体。
+
+手元で署名まで再現済み（同じレイアウトを 2 つの root に置いて比較）:
+
+```
+root = 管理下 (~/mulmoclaude 相当)   → detail: project / view-file: 200
+root = それ以外のワークスペース       → detail: project / view-file: 404 (null)
+```
+
+## 決定
+
+### D1: staging の可否は「このサーバが serve しているワークスペースか」で決める
+
+`skillsStagingDir` の述語を **`isManagedWorkspace(root) || isWorkspaceRoot(root)`** にする。
+`isWorkspaceRoot` は `initProjectRoots({ workspace })` が束縛した root — つまり `CLAUDE_CWD` —
+との同一判定。`~/mulmoclaude` 判定は**残したまま足す**ので、今動いているものは何も止まらない。
+
+`CLAUDE_CWD === ~/mulmoclaude`（通常のケース）では union は今日とビット単位で同じ答えを返す。
+差が出るのは、今まさに 404 になっている「ワークスペースが `~/mulmoclaude` でない」場合だけ。
+
+### D2: `stagedSkillAuthoring` は触らない（読みだけ広げる）
+
+`server/infra/collection-tool.ts` の `stagedSkillAuthoring` は `isManagedWorkspace` のまま。
+core の `authoringTarget` は
+
+```js
+const stagingDir = deps.stagedSkillAuthoring === false ? null : stagingSkillDir(resolveBase(deps), slug);
+```
+
+なので `false` が勝ち、**エージェントに出す authoring guide も `putSchema` の書き先も今日のまま**
+（`.claude/skills/<slug>/`）。「読めるようにする」以上のことをしない。
+
+これは core が "Staged requires BOTH to agree; anything else is direct" と書いている、定義済みの
+組み合わせ。書き込み先を変えるのは別の判断（このワークスペースで MulmoTerminal が staged に
+authoring すべきか）なので、この PR には含めない。
+
+### D3: `userSkillsDir` も触らない
+
+同じ `isManagedWorkspace` で分岐しているが、こちらを広げると **どのコレクションが見えるか** が
+変わる（`~/.claude/skills` 配下がワークスペースの一覧と slug 解決に入る）。副作用なので触らない。
+
+### D4: 「同じディレクトリか」の 2 段判定を 1 か所にする
+
+`isManagedWorkspace` は lexical → realpath の 2 段で比較している。`isWorkspaceRoot` も同じ規則が
+要る（root は保存済み preset のスペルで来る）。2 か所に書き写さず `isSameRealPath` として
+`server/infra/canonical-path.ts` に出し、両方がそれを呼ぶ。抽出は 1:1（分岐なし）で、既存の
+`collectionStaging.spec.ts` が symlink 経路を含めて `isManagedWorkspace` を留めている。
+
+## 広がった root で何が変わるか（core 側の `stagingSkillDir` 呼び出し全数）
+
+| 呼び出し元 | 影響 |
+|---|---|
+| `readSourceAwareFile`（view / i18n） | **これが目的**。staging を先に試し、無ければ従来どおり `skillDir` |
+| `authoringTarget`（`putSchema` / `schemaDocs`） | 変化なし（D2 の `stagedSkillAuthoring: false` が勝つ） |
+| `writeArchive` | `staging !== null && await pathExists(staging)` で存在ガード済み |
+| `canonicalBase` / `schemaWriteTargets`（view 削除） | `fileExists(<staging>/schema.json)` で存在ガード済み |
+| `deleteTargets` | 封じ込めチェックの対象が増えるだけ |
+| `removeLocations` | `rm -rf` に `force: true`。無ければ no-op、有れば消すのが正しい |
+
+`data/skills` を持たないディレクトリでは、増える仕事は ENOENT の probe 1 回だけ。
+
+## 変更
+
+| 変更 | 場所 |
+|---|---|
+| `isSameRealPath` を足す | `server/infra/canonical-path.ts` |
+| 2 段判定をそれに置き換える | `server/backends/workspaceSetup.ts` |
+| `isWorkspaceRoot` を足す | `server/infra/project-root.ts` |
+| `skillsStagingDir` の述語を union にする | `server/backends/collections.ts` |
+| 回帰テスト | `test/server/backends/collectionStagingServerWorkspace.spec.ts` |
+
+## テスト
+
+新規 spec は 3 つを留める（`configureCollectionHost` は 1 ファイル 1 束縛なので root を変えて確認）:
+
+1. **サーバ自身のワークスペース**（`~/mulmoclaude` ではない）で staged view が読める — 修正前は `null`
+2. **`~/mulmoclaude`** も引き続き読める — union であって置き換えではない
+3. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
+   — 今日の保証がそのまま残っている

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -47,20 +47,26 @@ root = それ以外のワークスペース       → detail: project / view-fil
 
 ### D1: staging の可否は 1 つの述語にまとめ、read と authoring の両方をそこから導く
 
-`server/backends/stagedSkills.ts` に `skillsStagingDirFor(root)` を置き、
+`server/backends/stagedSkills.ts` に `skillsStagingDirFor(root)` を置き、**それだけを答えにする**。
 
-- `skillsStagingDir`（読み。view / schema をどこから読むか）
+- `skillsStagingDir`（読み。view / schema をどこから読むか）← この関数
 - `stagedSkillAuthoring`（書き。どの authoring guide を出し、`putSchema` がどこに書くか）
+  ← **何も渡さない**
 
-の**両方をそこから導く**。core が言うとおり、この 2 つは合っていなければならない：
+core の `authoringTarget` は
 
-> ONE predicate on purpose. … a host that says `stagedSkillAuthoring: false` while still returning
-> a staging path would have the agent told to write `.claude/skills/<slug>/` while `putSchema`
-> wrote `data/skills/` …
+```js
+const stagingDir = deps.stagedSkillAuthoring === false ? null : stagingSkillDir(resolveBase(deps), slug);
+```
 
-読みだけ広げて書きを据え置くと、**エージェントが `.claude/skills` に書いた view より、
-MulmoClaude が置いた古い staging のコピーが勝つ**（＝編集が黙って反映されない）。
-#1955 の codex レビューの指摘どおり。
+なので、**渡さなければ読みと同じ経路に落ちる**。boolean を渡すと 2 つ目の真実の源ができ、
+しかもそれは factory dep として**インスタンス生成時に固定される**一方、path binding は
+オペレーションごとに再評価される。固定された `false` と生きた staging path の組み合わせが、
+まさにこの変更が防ごうとしている状態 ——**エージェントが `.claude/skills` に書いた view より
+古い staging のコピーが勝つ**（編集が黙って反映されない）。
+
+読みだけ広げて書きを据え置いた iter-1 は codex に、boolean を snapshot して渡していた iter-2〜5 は
+CodeRabbit に指摘された。答えを 1 つにするのが結論。
 
 ### D2: staging を返す root は 2 つ。第 2 の root だけ「証拠」を要求する
 

--- a/plans/fix-1925-staged-view-in-server-workspace.md
+++ b/plans/fix-1925-staged-view-in-server-workspace.md
@@ -38,7 +38,7 @@ MulmoTerminal が「managed ではない」と判定して staging を読まな�
 
 手元で署名まで再現済み（同じレイアウトを 2 つの root に置いて比較）:
 
-```
+```text
 root = 管理下 (~/mulmoclaude 相当)   → detail: project / view-file: 200
 root = それ以外のワークスペース       → detail: project / view-file: 404 (null)
 ```
@@ -69,6 +69,16 @@ const stagingDir = deps.stagedSkillAuthoring === false ? null : stagingSkillDir(
 これは core が "Staged requires BOTH to agree; anything else is direct" と書いている、定義済みの
 組み合わせ。書き込み先を変えるのは別の判断（このワークスペースで MulmoTerminal が staged に
 authoring すべきか）なので、この PR には含めない。
+
+### D2b: そのぶん残る非対称は、テストで優先順位を明示して #1956 に送る
+
+D2 の結果、`~/mulmoclaude` でないワークスペースでは **authoring は `.claude/skills` なのに読みは
+staging 優先** になる。両方にコピーがあると、MulmoClaude が置いた staging 側が勝つ。
+
+書き側を広げれば揃うが、それは「ランチャを起動したディレクトリに `data/skills` が生える」＝
+副作用。どちらが正しいかは #1956 に切り出し、**現在の優先順位はテストで留める**
+（"prefers the workspace's staging copy when the mirror holds one too"）。ワークスペースでは
+staging が正本で `.claude/skills` はミラーなので、`~/mulmoclaude` が昔から返してきた答えと同じ。
 
 ### D3: `userSkillsDir` も触らない
 
@@ -107,9 +117,11 @@ authoring すべきか）なので、この PR には含めない。
 
 ## テスト
 
-新規 spec は 3 つを留める（`configureCollectionHost` は 1 ファイル 1 束縛なので root を変えて確認）:
+新規 spec は 4 つを留める（`configureCollectionHost` は 1 ファイル 1 束縛なので root を変えて確認。
+ケースごとに別 slug を使い、テストの実行順に依存しない）:
 
 1. **サーバ自身のワークスペース**（`~/mulmoclaude` ではない）で staged view が読める — 修正前は `null`
 2. **`~/mulmoclaude`** も引き続き読める — union であって置き換えではない
-3. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
+3. **ワークスペースで両方にコピーがある**とき staging が勝つ — D2b の優先順位を明示
+4. **保存済みプロジェクト**では `data/skills` の野良ファイルが commit 済みの view を shadow しない
    — 今日の保証がそのまま残っている

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -73,10 +73,10 @@ import { manageCollectionHandlerFor } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
 import { getCwdPresets } from "../config/config-routes.js";
 import { isManagedWorkspace } from "./workspaceSetup.js";
+import { skillsStagingDirFor } from "./stagedSkills.js";
 import {
   errorStatus,
   initProjectRoots,
-  isWorkspaceRoot,
   projectId,
   projectRootKey,
   projectRootsConfigured,
@@ -145,43 +145,13 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       projectSkillsDir,
       // <root>/feeds — feed registry root.
       feedsRoot: (root) => path.join(root, "feeds"),
-      // <root>/data/skills — project-skills staging, and ONLY for a WORKSPACE.
-      //
-      // Staging exists to route around the `.claude/` permission gate: the agent writes drafts
-      // to a plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`.
-      // A project folder has no such gate and MulmoTerminal runs no bridge, so a staging tree
-      // there is not merely unused — the engine reads it FIRST for a project-scope collection,
-      // so a stray file would shadow the committed skill, and it is a second copy of the
-      // definition in a repo that is supposed to be self-contained.
-      //
-      // `null` is what core 3.1.0 added for exactly this: the engine then skips the staging
-      // base rather than being handed a path that must never match.
-      //
-      // TWO roots are a workspace, and asking only the first one 404'd every staged custom view
-      // (#1925). `isManagedWorkspace` answers "is this path `~/mulmoclaude`", which is what
-      // MulmoClaude's workspace always is — but OURS is `CLAUDE_CWD`, the directory the launcher
-      // was started in (bin/cli-args.js `chooseCwd` → `serverSpawnEnv`). When those differ, a
-      // collection MulmoClaude staged into that directory has its `views/*.html` in `data/skills`
-      // and NOTHING in `.claude/skills` (only SKILL.md / schema.json / templates are mirrored), so
-      // dropping the staging base left the read with a base that never holds the file.
-      //
-      // A UNION, not a replacement: where the two roots are the same path — the ordinary setup —
-      // this answers exactly what it answered before, and `~/mulmoclaude` keeps its staging even
-      // when it is merely one of the saved projects. A saved project that is neither still gets
-      // `null`, so the shadowing guarantee above is untouched.
-      //
-      // Reads only. `stagedSkillAuthoring` (server/infra/collection-tool.ts) stays on
-      // `isManagedWorkspace`, so the guide the agent is served and the directory `putSchema`
-      // writes to are unchanged — core's `authoringTarget` lets `false` win over a staging path,
-      // which is the "anything else is direct" combination it documents.
-      //
-      // What that leaves, deliberately: in a workspace that is not `~/mulmoclaude` the agent
-      // authors into `.claude/skills` while the read prefers staging, so a staging copy of the
-      // SAME view — one MulmoClaude left there — wins over a later one written here. That needs
-      // both copies to exist, and widening the write side instead would grow a `data/skills` tree
-      // in whatever directory the launcher was started in. Which of the two is right is #1956;
-      // the precedence as it stands is pinned in collectionStagingServerWorkspace.spec.ts.
-      skillsStagingDir: (root) => (isManagedWorkspace(root) || isWorkspaceRoot(root) ? path.join(root, "data", "skills") : null),
+      // <root>/data/skills — project-skills staging, and ONLY for a root that keeps its skills
+      // there. `null` is what core 3.1.0 added for exactly this: the engine skips the staging
+      // base rather than being handed a path that must never match. Which roots qualify, and why
+      // a saved project must not, is `skillsStagingDirFor` — the SAME function `stagedSkillAuthoring`
+      // is derived from (server/infra/collection-tool.ts), because a root that reads from staging
+      // while authoring directly reads a stale view instead of the one it just wrote.
+      skillsStagingDir: skillsStagingDirFor,
       // Workspace-relative archive dir (removed collections move here).
       archiveDir: "archive",
       // <root>/config/collections-registries.json — extra Discover registries

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -148,9 +148,12 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       // <root>/data/skills — project-skills staging, and ONLY for a root that keeps its skills
       // there. `null` is what core 3.1.0 added for exactly this: the engine skips the staging
       // base rather than being handed a path that must never match. Which roots qualify, and why
-      // a saved project must not, is `skillsStagingDirFor` — the SAME function `stagedSkillAuthoring`
-      // is derived from (server/infra/collection-tool.ts), because a root that reads from staging
-      // while authoring directly reads a stale view instead of the one it just wrote.
+      // a saved project must not, is `skillsStagingDirFor`.
+      //
+      // This is also the ONLY place the answer is given. Where the agent is told to AUTHOR follows
+      // from it inside core (`authoringTarget`), because MulmoTerminal passes no
+      // `stagedSkillAuthoring` — a root that read from staging while authoring directly would
+      // serve a stale view instead of the one it just wrote (server/infra/collection-tool.ts).
       skillsStagingDir: skillsStagingDirFor,
       // Workspace-relative archive dir (removed collections move here).
       archiveDir: "archive",

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -76,6 +76,7 @@ import { isManagedWorkspace } from "./workspaceSetup.js";
 import {
   errorStatus,
   initProjectRoots,
+  isWorkspaceRoot,
   projectId,
   projectRootKey,
   projectRootsConfigured,
@@ -144,7 +145,7 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       projectSkillsDir,
       // <root>/feeds — feed registry root.
       feedsRoot: (root) => path.join(root, "feeds"),
-      // <root>/data/skills — project-skills staging, and ONLY for the managed workspace.
+      // <root>/data/skills — project-skills staging, and ONLY for a WORKSPACE.
       //
       // Staging exists to route around the `.claude/` permission gate: the agent writes drafts
       // to a plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`.
@@ -155,7 +156,25 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       //
       // `null` is what core 3.1.0 added for exactly this: the engine then skips the staging
       // base rather than being handed a path that must never match.
-      skillsStagingDir: (root) => (isManagedWorkspace(root) ? path.join(root, "data", "skills") : null),
+      //
+      // TWO roots are a workspace, and asking only the first one 404'd every staged custom view
+      // (#1925). `isManagedWorkspace` answers "is this path `~/mulmoclaude`", which is what
+      // MulmoClaude's workspace always is — but OURS is `CLAUDE_CWD`, the directory the launcher
+      // was started in (bin/cli-args.js `chooseCwd` → `serverSpawnEnv`). When those differ, a
+      // collection MulmoClaude staged into that directory has its `views/*.html` in `data/skills`
+      // and NOTHING in `.claude/skills` (only SKILL.md / schema.json / templates are mirrored), so
+      // dropping the staging base left the read with a base that never holds the file.
+      //
+      // A UNION, not a replacement: where the two roots are the same path — the ordinary setup —
+      // this answers exactly what it answered before, and `~/mulmoclaude` keeps its staging even
+      // when it is merely one of the saved projects. A saved project that is neither still gets
+      // `null`, so the shadowing guarantee above is untouched.
+      //
+      // Reads only. `stagedSkillAuthoring` (server/infra/collection-tool.ts) stays on
+      // `isManagedWorkspace`, so the guide the agent is served and the directory `putSchema`
+      // writes to are unchanged — core's `authoringTarget` lets `false` win over a staging path,
+      // which is the "anything else is direct" combination it documents.
+      skillsStagingDir: (root) => (isManagedWorkspace(root) || isWorkspaceRoot(root) ? path.join(root, "data", "skills") : null),
       // Workspace-relative archive dir (removed collections move here).
       archiveDir: "archive",
       // <root>/config/collections-registries.json — extra Discover registries

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -174,6 +174,13 @@ export function initCollectionsBackend(deps: { workspace: string; knownProjects?
       // `isManagedWorkspace`, so the guide the agent is served and the directory `putSchema`
       // writes to are unchanged — core's `authoringTarget` lets `false` win over a staging path,
       // which is the "anything else is direct" combination it documents.
+      //
+      // What that leaves, deliberately: in a workspace that is not `~/mulmoclaude` the agent
+      // authors into `.claude/skills` while the read prefers staging, so a staging copy of the
+      // SAME view — one MulmoClaude left there — wins over a later one written here. That needs
+      // both copies to exist, and widening the write side instead would grow a `data/skills` tree
+      // in whatever directory the launcher was started in. Which of the two is right is #1956;
+      // the precedence as it stands is pinned in collectionStagingServerWorkspace.spec.ts.
       skillsStagingDir: (root) => (isManagedWorkspace(root) || isWorkspaceRoot(root) ? path.join(root, "data", "skills") : null),
       // Workspace-relative archive dir (removed collections move here).
       archiveDir: "archive",

--- a/server/backends/stagedSkills.ts
+++ b/server/backends/stagedSkills.ts
@@ -1,10 +1,13 @@
 // Does this root keep its collection skills in a `data/skills` staging tree?
 //
-// ONE predicate, because the engine reads the answer through two knobs that must agree — the
-// host's `skillsStagingDir` (where views and schemas are READ from) and its
-// `stagedSkillAuthoring` (which guide the agent is served, and where `putSchema` WRITES). Core
-// spells the consequence out: a root told "author directly" while still handed a staging path
-// reads a stale staged view instead of the one it just wrote, silently.
+// ONE answer, for two things that must agree: where views and schemas are READ from
+// (`skillsStagingDir`) and where the agent is told to AUTHOR them (`schemaDocs` / `putSchema`).
+// The second is not a second binding — core's `authoringTarget` falls through to this same path
+// unless the host hands it a `stagedSkillAuthoring: false`, so MulmoTerminal hands it nothing and
+// there is only ever one thing to keep right (server/infra/collection-tool.ts says why).
+//
+// Core spells the consequence of getting it wrong out: a root told "author directly" while still
+// handed a staging path reads a stale staged view instead of the one it just wrote, silently.
 //
 // Staging exists to route around the `.claude/` permission gate: the agent writes drafts to a
 // plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`. Only
@@ -65,10 +68,4 @@ export function skillsStagingDirFor(root: string): string | null {
   const staging = path.join(root, ...STAGING_DIR);
   if (isManagedWorkspace(root)) return staging;
   return isWorkspaceRoot(root) && holdsStagedCollection(staging) ? staging : null;
-}
-
-/** The same answer as the authoring knob wants it. Derived rather than decided again, so the two
- *  cannot drift apart. */
-export function usesStagedSkillAuthoring(root: string): boolean {
-  return skillsStagingDirFor(root) !== null;
 }

--- a/server/backends/stagedSkills.ts
+++ b/server/backends/stagedSkills.ts
@@ -1,0 +1,53 @@
+// Does this root keep its collection skills in a `data/skills` staging tree?
+//
+// ONE predicate, because the engine reads the answer through two knobs that must agree — the
+// host's `skillsStagingDir` (where views and schemas are READ from) and its
+// `stagedSkillAuthoring` (which guide the agent is served, and where `putSchema` WRITES). Core
+// spells the consequence out: a root told "author directly" while still handed a staging path
+// reads a stale staged view instead of the one it just wrote, silently.
+//
+// Staging exists to route around the `.claude/` permission gate: the agent writes drafts to a
+// plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`. Only
+// `views/*.html` never crosses — a staged collection's view HTML exists ONLY under
+// `data/skills/<slug>/`, which is why a root that skips this base 404s every custom view (#1925).
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { isWorkspaceRoot } from "../infra/project-root.js";
+import { isManagedWorkspace } from "./workspaceSetup.js";
+
+const STAGING_DIR = ["data", "skills"];
+
+/** `<root>/data/skills` when this root keeps its collection skills there, else `null` — the
+ *  shape the engine's `skillsStagingDir` binding takes, where `null` means "skip the staging
+ *  base entirely" (core 3.1.0).
+ *
+ *  Two roots qualify, and they are different questions:
+ *
+ *  - **The managed mulmoclaude workspace** (`~/mulmoclaude`). Unconditional, because it is what
+ *    MulmoClaude stages into and what this app stages into when it runs there — including before
+ *    the tree exists, since the first `putSchema` is what creates it.
+ *  - **The workspace THIS server serves** (`CLAUDE_CWD`, the directory the launcher was started
+ *    in) — but only on evidence, `data/skills` actually being there. The two roots are the same
+ *    path only by coincidence, and when they differ a collection MulmoClaude staged into the
+ *    directory we serve was unreadable here (#1925). The evidence check is what keeps that from
+ *    reaching a launch directory that is somebody's git repository: a repo with no staging tree
+ *    answers `null` exactly as it did before, so nothing starts writing a second copy of a skill
+ *    definition into it. A directory that HAS one was staged by something, and reads and writes
+ *    there agree with each other and with MulmoClaude.
+ *
+ *  A SAVED PROJECT is neither, and gets `null`. The engine reads staging first, so a stray
+ *  `data/skills` file there would shadow the skill the repo commits.
+ *
+ *  Not cached: a workspace gains its staging tree the first time MulmoClaude writes to it, and a
+ *  remembered "no" would keep this server blind to that for as long as it runs. */
+export function skillsStagingDirFor(root: string): string | null {
+  const staging = path.join(root, ...STAGING_DIR);
+  if (isManagedWorkspace(root)) return staging;
+  return isWorkspaceRoot(root) && existsSync(staging) ? staging : null;
+}
+
+/** The same answer as the authoring knob wants it. Derived rather than decided again, so the two
+ *  cannot drift apart. */
+export function usesStagedSkillAuthoring(root: string): boolean {
+  return skillsStagingDirFor(root) !== null;
+}

--- a/server/backends/stagedSkills.ts
+++ b/server/backends/stagedSkills.ts
@@ -10,12 +10,34 @@
 // plain data dir and a bridge mirrors the allowlisted files into `.claude/skills`. Only
 // `views/*.html` never crosses — a staged collection's view HTML exists ONLY under
 // `data/skills/<slug>/`, which is why a root that skips this base 404s every custom view (#1925).
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { isWorkspaceRoot } from "../infra/project-root.js";
 import { isManagedWorkspace } from "./workspaceSetup.js";
 
 const STAGING_DIR = ["data", "skills"];
+const SCHEMA_FILE = "schema.json";
+
+/** Does this staging tree hold a staged COLLECTION — some `<slug>/schema.json`?
+ *
+ *  The directory merely existing is a weaker claim than it looks. `data/skills` is a
+ *  generic-looking path a repository could own for its own reasons, and answering "staged" for
+ *  one would redirect where the agent authors on the strength of a name. A `<slug>/schema.json`
+ *  under it is the layout a staged collection actually has — the same evidence core's own
+ *  `canonicalBase` looks for before it treats the staging tree as authoritative.
+ *
+ *  Every entry is probed rather than only the directories, so a symlinked collection counts. The
+ *  scan stops at the first hit and walks one directory of collection slugs.
+ */
+function holdsStagedCollection(staging: string): boolean {
+  let entries: string[];
+  try {
+    entries = readdirSync(staging);
+  } catch {
+    return false; // absent, unreadable, or not a directory
+  }
+  return entries.some((entry) => existsSync(path.join(staging, entry, SCHEMA_FILE)));
+}
 
 /** `<root>/data/skills` when this root keeps its collection skills there, else `null` — the
  *  shape the engine's `skillsStagingDir` binding takes, where `null` means "skip the staging
@@ -24,26 +46,25 @@ const STAGING_DIR = ["data", "skills"];
  *  Two roots qualify, and they are different questions:
  *
  *  - **The managed mulmoclaude workspace** (`~/mulmoclaude`). Unconditional, because it is what
- *    MulmoClaude stages into and what this app stages into when it runs there — including before
- *    the tree exists, since the first `putSchema` is what creates it.
+ *    MulmoClaude stages into and what this app stages into when it runs there — including while
+ *    the tree is still empty, since the first `putSchema` is what fills it.
  *  - **The workspace THIS server serves** (`CLAUDE_CWD`, the directory the launcher was started
- *    in) — but only on evidence, `data/skills` actually being there. The two roots are the same
- *    path only by coincidence, and when they differ a collection MulmoClaude staged into the
- *    directory we serve was unreadable here (#1925). The evidence check is what keeps that from
- *    reaching a launch directory that is somebody's git repository: a repo with no staging tree
- *    answers `null` exactly as it did before, so nothing starts writing a second copy of a skill
- *    definition into it. A directory that HAS one was staged by something, and reads and writes
- *    there agree with each other and with MulmoClaude.
+ *    in) — but only when a staged collection is actually sitting there. The two roots are the
+ *    same path only by coincidence, and when they differ a collection MulmoClaude staged into
+ *    the directory we serve was unreadable here (#1925). The evidence is what keeps that from
+ *    reaching a launch directory that is somebody's git repository: no staged collection, and
+ *    the root answers exactly as it did before, so nothing starts writing a second copy of a
+ *    skill definition into it.
  *
- *  A SAVED PROJECT is neither, and gets `null`. The engine reads staging first, so a stray
- *  `data/skills` file there would shadow the skill the repo commits.
+ *  A SAVED PROJECT is neither, and gets `null` whatever it holds. The engine reads staging first,
+ *  so a stray `data/skills` file there would shadow the skill the repo commits.
  *
- *  Not cached: a workspace gains its staging tree the first time MulmoClaude writes to it, and a
- *  remembered "no" would keep this server blind to that for as long as it runs. */
+ *  Not cached: a workspace gains its first staged collection the moment MulmoClaude writes one,
+ *  and a remembered "no" would keep this server blind to that for as long as it runs. */
 export function skillsStagingDirFor(root: string): string | null {
   const staging = path.join(root, ...STAGING_DIR);
   if (isManagedWorkspace(root)) return staging;
-  return isWorkspaceRoot(root) && existsSync(staging) ? staging : null;
+  return isWorkspaceRoot(root) && holdsStagedCollection(staging) ? staging : null;
 }
 
 /** The same answer as the authoring knob wants it. Derived rather than decided again, so the two

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -19,8 +19,7 @@ import os from "node:os";
 import { mkdirSync } from "node:fs";
 import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { syncCodexSkills, codexSkillsRoot } from "../agents/codex-skills.js";
-import { isSamePath } from "../infra/path-within.js";
-import { canonicalPath } from "../infra/canonical-path.js";
+import { isSameRealPath } from "../infra/canonical-path.js";
 
 // Console-backed logger, matching the prefix style other backends use.
 const log = {
@@ -39,16 +38,10 @@ function managedWorkspacePath(): string {
  *  is confined to it so launching the terminal in an arbitrary project dir never
  *  writes mulmoclaude presets/helps there. */
 export function isManagedWorkspace(workspace: string): boolean {
-  // isSamePath, not `===`: the workspace arrives from the launcher's --cwd, so on Windows it
-  // can name the managed directory in a different casing than os.homedir() spells it, and a
-  // raw compare would silently skip seeding.
-  const managed = managedWorkspacePath();
-  // Lexical first, so an answer that already matched keeps matching byte for byte. Then through
-  // REALPATH, because `isSamePath` resolves `.`/`..` and casing but not symlinks: a managed
-  // workspace that is a symlink, launched by its physical target (or the reverse), read as "not
-  // the workspace" — which since core 3.1.0 means no staging dir and the project-style authoring
-  // guide, i.e. the workspace quietly losing its staged views and being told to write elsewhere.
-  return isSamePath(workspace, managed) || isSamePath(canonicalPath(workspace), canonicalPath(managed));
+  // `isSameRealPath`, not `===`: the workspace arrives from the launcher's --cwd, so on Windows it
+  // can name the managed directory in a different casing than os.homedir() spells it, and it is
+  // often reached through a symlink — a raw compare would silently skip seeding.
+  return isSameRealPath(workspace, managedWorkspacePath());
 }
 
 // Run one seeding step in isolation: a filesystem edge case (EACCES/ENOSPC/path

--- a/server/infra/canonical-path.ts
+++ b/server/infra/canonical-path.ts
@@ -5,6 +5,7 @@
 // two import each other.
 import { realpathSync } from "node:fs";
 import path from "node:path";
+import { isSamePath } from "./path-within.js";
 
 // realpathSync.native, not the JS one: on Windows only the native call expands an 8.3 short
 // component (C:\Users\RUNNER~1 → …\runneradmin) to the long form that `git worktree list`
@@ -33,4 +34,18 @@ export function canonicalPath(p: string): string {
       cur = parent;
     }
   }
+}
+
+/** Do these name the same directory, THROUGH symlinks?
+ *
+ * The lexical answer first, so a pair that already matched keeps matching byte for byte, then
+ * the canonical one — `isSamePath` resolves `.`/`..` and Windows casing but not symlinks, and a
+ * directory reached by a link (or by its physical target, or one of each) is the same directory.
+ *
+ * Its own function because two callers ask it of the same value: `isManagedWorkspace` compares a
+ * root against `~/mulmoclaude`, `isWorkspaceRoot` against the workspace this server serves, and a
+ * root that arrives from a saved preset may spell either differently.
+ */
+export function isSameRealPath(a: string, b: string): boolean {
+  return isSamePath(a, b) || isSamePath(canonicalPath(a), canonicalPath(b));
 }

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -21,7 +21,6 @@ import type { ToolDefinition } from "gui-chat-protocol";
 import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { workspaceScope } from "./project-root.js";
-import { usesStagedSkillAuthoring } from "../backends/stagedSkills.js";
 // A successful `putSchema` carries back whether the collection would survive a clone — the agent
 // is the one that chose the storage kind or dropped the primaryKey, and it is holding the file
 // open at the moment that is cheapest to fix.
@@ -49,16 +48,10 @@ export const manageCollectionHandler = withGeneratedAid(
   () => workspaceScope().workspaceRoot,
 );
 
-// One tool instance per root AND per authoring variant. `makeManageCollectionTool` takes both in
-// the FACTORY deps, not per call, so a request-scoped operation needs its own instance; they are
-// cached because a custom view's dashboard can issue these in a loop. Bounded by the number of
-// projects the user has, which is the same list `resolveProjectRoot` resolves against.
-//
-// The variant is part of the KEY because it can change while the server runs: a workspace gains
-// its first staged collection the moment MulmoClaude writes one, and the read side
-// (`skillsStagingDir`) picks that up immediately. Caching on the root alone would leave a handler
-// built before that still serving the direct authoring guide — the two knobs drifting apart
-// exactly as they must not, and only a restart putting them back.
+// One tool instance per root. `makeManageCollectionTool` takes its root in the FACTORY deps,
+// not per call, so a request-scoped operation needs its own instance; they are cached because
+// a custom view's dashboard can issue these in a loop. Bounded by the number of projects the
+// user has, which is the same list `resolveProjectRoot` resolves against.
 const byRoot = new Map<string, typeof tool.handler>();
 
 /** The handler bound to ONE project root — what a request-scoped route must use.
@@ -68,36 +61,32 @@ const byRoot = new Map<string, typeof tool.handler>();
  *  receive another's rows for a shared slug. The token check and the query have to agree on
  *  the root, and this is how the query learns it. */
 export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
-  const staged = usesStagedSkillAuthoring(workspaceRoot);
-  const key = `${workspaceRoot}\u0000${staged}`;
-  const cached = byRoot.get(key);
+  const cached = byRoot.get(workspaceRoot);
   if (cached) return cached;
   const handler = withGeneratedAid(
     withPortabilityNote(
       makeManageCollectionTool({
         bundledHelpsDir: helpsAssetDir,
         workspaceRoot,
-        // Which authoring guide `schemaDocs` serves. Staged authoring (`data/skills/<slug>/`,
-        // mirrored by a bridge) is a WORKSPACE mechanism; told that in a project folder, the agent
-        // writes a draft nothing mirrors and nothing discovers — it does as instructed and produces
-        // a collection that does not exist, with no error anywhere.
+        // `stagedSkillAuthoring` is deliberately NOT passed — here or on the module-level tool
+        // above. Which authoring guide `schemaDocs` serves, and where `putSchema` writes, is the
+        // same question as where views are READ from, and core already answers it from one place:
+        // `authoringTarget` falls through to `skillsStagingDir` unless the flag is literally
+        // `false`. Handing it a boolean as well makes a SECOND source of truth that can only ever
+        // drift from the first.
         //
-        // The engine also derives the variant from `skillsStagingDir` returning null, so this
-        // agrees with the host binding rather than overriding it. Passed anyway: two levers that
-        // must agree are worth stating at both ends, and this one says WHY the root has no staging
-        // rather than leaving it to be inferred from a path that came back empty.
-        //
-        // DERIVED from the same function the path binding is (`skillsStagingDirFor`), not decided
-        // again here. Deciding twice is how they drift, and the drift is silent: a root that reads
-        // staging first while authoring directly serves the agent a stale view instead of the one
-        // it just wrote, with nothing anywhere saying so.
-        stagedSkillAuthoring: staged,
+        // It would drift, too, and silently. The flag is a factory dep, frozen when the instance
+        // is built, while the host binding is re-read per operation — and the binding's answer
+        // moves: a workspace gains its first staged collection the moment MulmoClaude writes one
+        // (server/backends/stagedSkills.ts). A frozen `false` beside a live staging path is
+        // exactly the state this change exists to prevent: the agent authors into
+        // `.claude/skills` while the read prefers staging, so its edit never appears.
       }).handler,
       () => workspaceRoot,
     ),
     () => workspaceRoot,
   );
-  byRoot.set(key, handler);
+  byRoot.set(workspaceRoot, handler);
   return handler;
 }
 

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -21,7 +21,7 @@ import type { ToolDefinition } from "gui-chat-protocol";
 import { makeManageCollectionTool } from "@mulmoclaude/core/collection/server";
 import { helpsAssetDir } from "@mulmoclaude/core/workspace-setup";
 import { workspaceScope } from "./project-root.js";
-import { isManagedWorkspace } from "../backends/workspaceSetup.js";
+import { usesStagedSkillAuthoring } from "../backends/stagedSkills.js";
 // A successful `putSchema` carries back whether the collection would survive a clone — the agent
 // is the one that chose the storage kind or dropped the primaryKey, and it is holding the file
 // open at the moment that is cheapest to fix.
@@ -78,7 +78,12 @@ export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.h
         // agrees with the host binding rather than overriding it. Passed anyway: two levers that
         // must agree are worth stating at both ends, and this one says WHY the root has no staging
         // rather than leaving it to be inferred from a path that came back empty.
-        stagedSkillAuthoring: isManagedWorkspace(workspaceRoot),
+        //
+        // DERIVED from the same function the path binding is (`skillsStagingDirFor`), not decided
+        // again here. Deciding twice is how they drift, and the drift is silent: a root that reads
+        // staging first while authoring directly serves the agent a stale view instead of the one
+        // it just wrote, with nothing anywhere saying so.
+        stagedSkillAuthoring: usesStagedSkillAuthoring(workspaceRoot),
       }).handler,
       () => workspaceRoot,
     ),

--- a/server/infra/collection-tool.ts
+++ b/server/infra/collection-tool.ts
@@ -49,10 +49,16 @@ export const manageCollectionHandler = withGeneratedAid(
   () => workspaceScope().workspaceRoot,
 );
 
-// One tool instance per root. `makeManageCollectionTool` takes its root in the FACTORY deps,
-// not per call, so a request-scoped operation needs its own instance; they are cached because
-// a custom view's dashboard can issue these in a loop. Bounded by the number of projects the
-// user has, which is the same list `resolveProjectRoot` resolves against.
+// One tool instance per root AND per authoring variant. `makeManageCollectionTool` takes both in
+// the FACTORY deps, not per call, so a request-scoped operation needs its own instance; they are
+// cached because a custom view's dashboard can issue these in a loop. Bounded by the number of
+// projects the user has, which is the same list `resolveProjectRoot` resolves against.
+//
+// The variant is part of the KEY because it can change while the server runs: a workspace gains
+// its first staged collection the moment MulmoClaude writes one, and the read side
+// (`skillsStagingDir`) picks that up immediately. Caching on the root alone would leave a handler
+// built before that still serving the direct authoring guide — the two knobs drifting apart
+// exactly as they must not, and only a restart putting them back.
 const byRoot = new Map<string, typeof tool.handler>();
 
 /** The handler bound to ONE project root — what a request-scoped route must use.
@@ -62,7 +68,9 @@ const byRoot = new Map<string, typeof tool.handler>();
  *  receive another's rows for a shared slug. The token check and the query have to agree on
  *  the root, and this is how the query learns it. */
 export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.handler {
-  const cached = byRoot.get(workspaceRoot);
+  const staged = usesStagedSkillAuthoring(workspaceRoot);
+  const key = `${workspaceRoot}\u0000${staged}`;
+  const cached = byRoot.get(key);
   if (cached) return cached;
   const handler = withGeneratedAid(
     withPortabilityNote(
@@ -83,13 +91,13 @@ export function manageCollectionHandlerFor(workspaceRoot: string): typeof tool.h
         // again here. Deciding twice is how they drift, and the drift is silent: a root that reads
         // staging first while authoring directly serves the agent a stale view instead of the one
         // it just wrote, with nothing anywhere saying so.
-        stagedSkillAuthoring: usesStagedSkillAuthoring(workspaceRoot),
+        stagedSkillAuthoring: staged,
       }).handler,
       () => workspaceRoot,
     ),
     () => workspaceRoot,
   );
-  byRoot.set(workspaceRoot, handler);
+  byRoot.set(key, handler);
   return handler;
 }
 

--- a/server/infra/project-root.ts
+++ b/server/infra/project-root.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 import type { Request } from "express";
 import { describeValue } from "../../common/readString.js";
 import { lastSegment } from "../../common/pathSegments.js";
+import { isSameRealPath } from "./canonical-path.js";
 
 /** A root, in the shape the collection engine's options already take, so it can be passed
  *  straight through as `opts` rather than unpacked at every call site. */
@@ -90,6 +91,20 @@ function requireWorkspace(): string {
     throw new Error("project roots are not configured — call initProjectRoots({ workspace }) at boot");
   }
   return workspace;
+}
+
+/** Is this root the workspace this server serves, rather than one of the saved projects?
+ *
+ *  A separate question from `isManagedWorkspace`, which asks whether a path IS `~/mulmoclaude`.
+ *  The workspace is `CLAUDE_CWD` — the directory the launcher was started in — and the two are
+ *  only the same path by coincidence, so a caller that means "the workspace" must ask this one.
+ *
+ *  `isSameRealPath` because the root arrives from a saved preset, which may spell the same
+ *  directory with different casing, a trailing separator, or through a symlink. False when
+ *  nothing is bound yet: with no workspace, no root is it.
+ */
+export function isWorkspaceRoot(root: string): boolean {
+  return workspace !== null && isSameRealPath(root, workspace);
 }
 
 /** The opaque id for a root. A truncated digest: stable across restarts (nothing is stored),

--- a/test/server/backends/collectionStagingServerWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingServerWorkspace.spec.ts
@@ -92,6 +92,15 @@ describe("staged custom views are readable from every workspace, and from no pro
     writeSkillDir(workspace, "mirrored", "<body>workspace mirror copy</body>");
     writeStagingDir(workspace, "mirrored", "<body>workspace staged copy</body>");
 
+    // A collection that is NOT staged — committed direct — with a stale staging view left beside
+    // it and no staging schema of its own. Built in BOTH workspaces, because the point of the
+    // assertion below is that they answer the same.
+    for (const root of [managed, workspace]) {
+      writeSkillDir(root, "unstaged", "<body>committed direct view</body>");
+      mkdirSync(path.join(root, "data", "skills", "unstaged", "views"), { recursive: true });
+      writeFileSync(path.join(root, "data", "skills", "unstaged", "views", "v1.html"), "<body>STALE STAGED</body>");
+    }
+
     // The project holds the layout a repo commits — plus a stray staging copy.
     writeSkillDir(project, "tasks", "<body>committed view</body>");
     writeStagingDir(project, "tasks", "<body>STRAY</body>");
@@ -135,6 +144,24 @@ describe("staged custom views are readable from every workspace, and from no pro
     const docs = await manageCollectionHandlerFor(workspace)({ action: "schemaDocs", topic: "Anatomy of a collection skill" });
     expect(docs).toContain("Author under `data/skills/<slug>/`");
     expect(docs).not.toContain("Author under `.claude/skills/<slug>/`");
+  });
+
+  // KNOWN LIMITATION, pinned so it is discoverable rather than folklore — see #1957.
+  //
+  // Core prepends the staging base PER ROOT: `readSourceAwareFile` builds `<staging>/<slug>` for
+  // every project-scope collection without checking that THAT slug is staged. So in a staged
+  // workspace, a stale `data/skills/<slug>/views/*.html` wins over the committed one even for a
+  // collection with no staged schema of its own.
+  //
+  // Asserted on BOTH roots on purpose. `~/mulmoclaude` is untouched by #1925's fix and answers
+  // the same, which is what says this is core's rule rather than a second one introduced for the
+  // workspace this server serves. It cannot be fixed from this repo: the host binding is
+  // `skillsStagingDir(workspaceRoot) => string | null` and never sees the slug, so the per-slug
+  // decision has to move into core's read (its delete path already makes it, in `canonicalBase`).
+  it("prepends staging per root, not per slug — the same in either workspace (#1957)", async () => {
+    for (const root of [managed, workspace]) {
+      expect(await readView(root, "unstaged")).toContain("STALE STAGED");
+    }
   });
 
   // The guarantee that must survive the widening. A saved project is not a workspace: it has no

--- a/test/server/backends/collectionStagingServerWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingServerWorkspace.spec.ts
@@ -11,6 +11,10 @@
 // a SAVED PROJECT must still get none, because there a stray `data/skills` file would shadow the
 // skill the repo actually commits.
 //
+// The workspace here HAS a staging tree. A launch directory that has none keeps answering exactly
+// as it did before — that half is collectionStagingUnstagedWorkspace.spec.ts, which needs its own
+// file because `configureCollectionHost` binds one workspace per process.
+//
 // Each case gets its own slug rather than writing fixtures inside a test, so no assertion here
 // depends on the order the others ran in.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
@@ -19,6 +23,7 @@ import path from "node:path";
 import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection/server";
 
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { manageCollectionHandlerFor } from "../../../server/infra/collection-tool.js";
 import { makeTempDir } from "../../support/tempDir";
 
 const schemaFor = (slug: string) => ({
@@ -115,15 +120,21 @@ describe("staged custom views are readable from every workspace, and from no pro
     expect(await readView(managed, "tasks")).toContain("managed staged view");
   });
 
-  // The precedence, stated deliberately rather than left to whichever file happens to exist.
-  // In a WORKSPACE the staging copy is the canonical one and `.claude/skills` is the mirror a
-  // bridge writes, so staging winning is the same answer `~/mulmoclaude` has always given
-  // (collectionStaging.spec.ts, "still prefers the workspace's staging copy") — this pins that
-  // the workspace this server serves is not a second, quieter rule.
-  it("prefers the workspace's staging copy when the mirror holds one too", async () => {
+  // The precedence, and the reason it is safe: reads and writes name the SAME directory. A root
+  // that preferred staging while telling the agent to author directly would serve a stale staged
+  // view instead of the one just written to `.claude/skills`, silently — so the two knobs are
+  // derived from one predicate (`skillsStagingDirFor`), and this asserts both ends of it rather
+  // than the read alone.
+  it("reads and authors in the same place — staging — when the mirror holds a copy too", async () => {
     const html = await readView(workspace, "mirrored");
     expect(html).toContain("workspace staged copy");
     expect(html).not.toContain("workspace mirror copy");
+
+    // Asserted on the INSTRUCTION, not the string: the direct variant still says the words
+    // "data/skills" — in the sentence telling the agent never to write there.
+    const docs = await manageCollectionHandlerFor(workspace)({ action: "schemaDocs", topic: "Anatomy of a collection skill" });
+    expect(docs).toContain("Author under `data/skills/<slug>/`");
+    expect(docs).not.toContain("Author under `.claude/skills/<slug>/`");
   });
 
   // The guarantee that must survive the widening. A saved project is not a workspace: it has no

--- a/test/server/backends/collectionStagingServerWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingServerWorkspace.spec.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+//
+// A staged collection's `views/*.html` lives ONLY in `data/skills/<slug>/` — the mirror into
+// `.claude/skills/<slug>/` carries SKILL.md, schema.json and templates and nothing else. So the
+// engine's staging base is not an optimisation there: drop it and the read is left with a
+// directory that never holds the file, which is a 404 on every custom view (#1925).
+//
+// Which roots get that base is what this file pins. MulmoClaude's workspace is always
+// `~/mulmoclaude`; ours is `CLAUDE_CWD`, the directory the launcher was started in, and the two
+// are the same path only by coincidence. Both are a workspace and both must read staging — while
+// a SAVED PROJECT must still get none, because there a stray `data/skills` file would shadow the
+// skill the repo actually commits.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection/server";
+
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const SCHEMA = {
+  title: "Tasks",
+  icon: "star",
+  dataPath: "data/tasks/items",
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+};
+
+/** Write the skill dir discovery anchors on, with `viewBody` only when the caller wants the view
+ *  file beside it — a staged collection has no `views/` there at all. */
+function writeSkillDir(root: string, viewBody: string | null): void {
+  const skillDir = path.join(root, ".claude", "skills", "tasks");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), "# tasks");
+  writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(SCHEMA));
+  if (viewBody !== null) {
+    mkdirSync(path.join(skillDir, "views"), { recursive: true });
+    writeFileSync(path.join(skillDir, "views", "v1.html"), viewBody);
+  }
+  mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
+}
+
+/** The staging tree a staged-authoring host produces: the schema AND the view HTML. */
+function writeStagingDir(root: string, viewBody: string): void {
+  const staging = path.join(root, "data", "skills", "tasks");
+  mkdirSync(path.join(staging, "views"), { recursive: true });
+  writeFileSync(path.join(staging, "schema.json"), JSON.stringify(SCHEMA));
+  writeFileSync(path.join(staging, "views", "v1.html"), viewBody);
+}
+
+async function readView(root: string): Promise<string | null> {
+  const collection = await loadCollection("tasks", { workspaceRoot: root });
+  if (!collection) throw new Error(`fixture collection did not load for ${root}`);
+  // The signature the issue reported: `detail` resolves the collection fine, and only the view
+  // file 404s. Asserted here so a failure below cannot be read as "the fixture never loaded".
+  expect(collection.source).toBe("project");
+  return readCustomViewHtml(collection, "views/v1.html", { workspaceRoot: root });
+}
+
+describe("staged custom views are readable from every workspace, and from no project", () => {
+  const savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  // `~/mulmoclaude` — the root MulmoClaude serves, which this server may not be running in.
+  let managed = "";
+  // CLAUDE_CWD — the directory THIS server was launched in, and the workspace it serves.
+  let workspace = "";
+  let project = "";
+
+  // ONE binding for the file: `configureCollectionHost` refuses a second call with a different
+  // host, deliberately — silently redirecting later filesystem work to another workspace would be
+  // a bug, not a feature. So the roots are built once and each test only reads.
+  beforeAll(() => {
+    managed = makeTempDir("mt-staged-managed-");
+    workspace = makeTempDir("mt-staged-workspace-");
+    project = makeTempDir("mt-staged-project-");
+
+    // Both workspaces hold the staged layout: no `views/` in the skill dir, the HTML in staging.
+    writeSkillDir(managed, null);
+    writeStagingDir(managed, "<body>managed staged view</body>");
+    writeSkillDir(workspace, null);
+    writeStagingDir(workspace, "<body>workspace staged view</body>");
+
+    // The project holds the layout a repo commits — plus a stray staging copy.
+    writeSkillDir(project, "<body>committed view</body>");
+    writeStagingDir(project, "<body>STRAY</body>");
+
+    // `isManagedWorkspace` compares against this, so a temp dir can stand in for ~/mulmoclaude.
+    // Deliberately NOT the workspace below: that divergence is the whole bug.
+    process.env.MULMOCLAUDE_WORKSPACE_PATH = managed;
+    initCollectionsBackend({ workspace, knownProjects: () => [{ label: "project", path: project }] });
+  });
+
+  afterAll(() => {
+    if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+    else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
+  });
+
+  // The regression. Before #1925 the staging base was handed out only for `~/mulmoclaude`, so a
+  // server launched anywhere else could not read the views in the workspace it was serving —
+  // while MulmoClaude, pointed at the same directory, rendered them.
+  it("reads the staged view from the workspace this server serves", async () => {
+    expect(await readView(workspace)).toContain("workspace staged view");
+  });
+
+  // A union, not a replacement: `~/mulmoclaude` keeps its staging even when this server is
+  // running somewhere else and merely knows it as another root.
+  it("still reads the staged view from the managed mulmoclaude workspace", async () => {
+    expect(await readView(managed)).toContain("managed staged view");
+  });
+
+  // The guarantee that must survive the widening. A saved project is not a workspace: it has no
+  // bridge and no permission gate to route around, so its `data/skills` is not a source — and the
+  // engine reads staging FIRST, so handing one out here would let a stray file win over the skill
+  // the repo commits.
+  it("does not let a stray data/skills view shadow a project's committed one", async () => {
+    const html = await readView(project);
+    expect(html).toContain("committed view");
+    expect(html).not.toContain("STRAY");
+  });
+});

--- a/test/server/backends/collectionStagingServerWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingServerWorkspace.spec.ts
@@ -10,6 +10,9 @@
 // are the same path only by coincidence. Both are a workspace and both must read staging — while
 // a SAVED PROJECT must still get none, because there a stray `data/skills` file would shadow the
 // skill the repo actually commits.
+//
+// Each case gets its own slug rather than writing fixtures inside a test, so no assertion here
+// depends on the order the others ran in.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -18,40 +21,40 @@ import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection
 import { initCollectionsBackend } from "../../../server/backends/collections.js";
 import { makeTempDir } from "../../support/tempDir";
 
-const SCHEMA = {
-  title: "Tasks",
+const schemaFor = (slug: string) => ({
+  title: slug,
   icon: "star",
-  dataPath: "data/tasks/items",
+  dataPath: `data/${slug}/items`,
   primaryKey: "id",
   fields: { id: { type: "string", label: "ID", primary: true, required: true } },
   views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
-};
+});
 
-/** Write the skill dir discovery anchors on, with `viewBody` only when the caller wants the view
- *  file beside it — a staged collection has no `views/` there at all. */
-function writeSkillDir(root: string, viewBody: string | null): void {
-  const skillDir = path.join(root, ".claude", "skills", "tasks");
+/** The skill dir discovery anchors on. `viewBody` is null for a staged collection — nothing
+ *  mirrors `views/` there, which is the whole reason the staging base has to be reachable. */
+function writeSkillDir(root: string, slug: string, viewBody: string | null): void {
+  const skillDir = path.join(root, ".claude", "skills", slug);
   mkdirSync(skillDir, { recursive: true });
-  writeFileSync(path.join(skillDir, "SKILL.md"), "# tasks");
-  writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(SCHEMA));
+  writeFileSync(path.join(skillDir, "SKILL.md"), `# ${slug}`);
+  writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(schemaFor(slug)));
   if (viewBody !== null) {
     mkdirSync(path.join(skillDir, "views"), { recursive: true });
     writeFileSync(path.join(skillDir, "views", "v1.html"), viewBody);
   }
-  mkdirSync(path.join(root, "data", "tasks", "items"), { recursive: true });
+  mkdirSync(path.join(root, "data", slug, "items"), { recursive: true });
 }
 
 /** The staging tree a staged-authoring host produces: the schema AND the view HTML. */
-function writeStagingDir(root: string, viewBody: string): void {
-  const staging = path.join(root, "data", "skills", "tasks");
+function writeStagingDir(root: string, slug: string, viewBody: string): void {
+  const staging = path.join(root, "data", "skills", slug);
   mkdirSync(path.join(staging, "views"), { recursive: true });
-  writeFileSync(path.join(staging, "schema.json"), JSON.stringify(SCHEMA));
+  writeFileSync(path.join(staging, "schema.json"), JSON.stringify(schemaFor(slug)));
   writeFileSync(path.join(staging, "views", "v1.html"), viewBody);
 }
 
-async function readView(root: string): Promise<string | null> {
-  const collection = await loadCollection("tasks", { workspaceRoot: root });
-  if (!collection) throw new Error(`fixture collection did not load for ${root}`);
+async function readView(root: string, slug: string): Promise<string | null> {
+  const collection = await loadCollection(slug, { workspaceRoot: root });
+  if (!collection) throw new Error(`fixture collection '${slug}' did not load for ${root}`);
   // The signature the issue reported: `detail` resolves the collection fine, and only the view
   // file 404s. Asserted here so a failure below cannot be read as "the fixture never loaded".
   expect(collection.source).toBe("project");
@@ -75,14 +78,18 @@ describe("staged custom views are readable from every workspace, and from no pro
     project = makeTempDir("mt-staged-project-");
 
     // Both workspaces hold the staged layout: no `views/` in the skill dir, the HTML in staging.
-    writeSkillDir(managed, null);
-    writeStagingDir(managed, "<body>managed staged view</body>");
-    writeSkillDir(workspace, null);
-    writeStagingDir(workspace, "<body>workspace staged view</body>");
+    writeSkillDir(managed, "tasks", null);
+    writeStagingDir(managed, "tasks", "<body>managed staged view</body>");
+    writeSkillDir(workspace, "tasks", null);
+    writeStagingDir(workspace, "tasks", "<body>workspace staged view</body>");
+
+    // A second collection in the workspace, this one with a copy in BOTH places.
+    writeSkillDir(workspace, "mirrored", "<body>workspace mirror copy</body>");
+    writeStagingDir(workspace, "mirrored", "<body>workspace staged copy</body>");
 
     // The project holds the layout a repo commits — plus a stray staging copy.
-    writeSkillDir(project, "<body>committed view</body>");
-    writeStagingDir(project, "<body>STRAY</body>");
+    writeSkillDir(project, "tasks", "<body>committed view</body>");
+    writeStagingDir(project, "tasks", "<body>STRAY</body>");
 
     // `isManagedWorkspace` compares against this, so a temp dir can stand in for ~/mulmoclaude.
     // Deliberately NOT the workspace below: that divergence is the whole bug.
@@ -99,13 +106,24 @@ describe("staged custom views are readable from every workspace, and from no pro
   // server launched anywhere else could not read the views in the workspace it was serving —
   // while MulmoClaude, pointed at the same directory, rendered them.
   it("reads the staged view from the workspace this server serves", async () => {
-    expect(await readView(workspace)).toContain("workspace staged view");
+    expect(await readView(workspace, "tasks")).toContain("workspace staged view");
   });
 
   // A union, not a replacement: `~/mulmoclaude` keeps its staging even when this server is
   // running somewhere else and merely knows it as another root.
   it("still reads the staged view from the managed mulmoclaude workspace", async () => {
-    expect(await readView(managed)).toContain("managed staged view");
+    expect(await readView(managed, "tasks")).toContain("managed staged view");
+  });
+
+  // The precedence, stated deliberately rather than left to whichever file happens to exist.
+  // In a WORKSPACE the staging copy is the canonical one and `.claude/skills` is the mirror a
+  // bridge writes, so staging winning is the same answer `~/mulmoclaude` has always given
+  // (collectionStaging.spec.ts, "still prefers the workspace's staging copy") — this pins that
+  // the workspace this server serves is not a second, quieter rule.
+  it("prefers the workspace's staging copy when the mirror holds one too", async () => {
+    const html = await readView(workspace, "mirrored");
+    expect(html).toContain("workspace staged copy");
+    expect(html).not.toContain("workspace mirror copy");
   });
 
   // The guarantee that must survive the widening. A saved project is not a workspace: it has no
@@ -113,7 +131,7 @@ describe("staged custom views are readable from every workspace, and from no pro
   // engine reads staging FIRST, so handing one out here would let a stray file win over the skill
   // the repo commits.
   it("does not let a stray data/skills view shadow a project's committed one", async () => {
-    const html = await readView(project);
+    const html = await readView(project, "tasks");
     expect(html).toContain("committed view");
     expect(html).not.toContain("STRAY");
   });

--- a/test/server/backends/collectionStagingUnstagedWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingUnstagedWorkspace.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+//
+// The other half of collectionStagingServerWorkspace.spec.ts, and the one that keeps #1925's fix
+// from reaching people it was never about.
+//
+// `npx mulmoterminal` run inside a git repository makes that repo `CLAUDE_CWD` — the workspace
+// this server serves — and it is emphatically not a staged-authoring workspace: nothing stages
+// into it, and growing a second copy of every skill definition under `data/skills/` there would
+// be a change nobody asked for. So the staging base is offered to the server's own workspace only
+// on EVIDENCE, `data/skills` actually being present, and a repo without one answers exactly as it
+// did before this fix — in BOTH knobs, the read and the authoring guide.
+//
+// Its own file because `configureCollectionHost` binds one workspace per process, and this one
+// has to be a workspace that starts with no staging tree.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readCustomViewHtml, loadCollection } from "@mulmoclaude/core/collection/server";
+
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { manageCollectionHandlerFor } from "../../../server/infra/collection-tool.js";
+import { makeTempDir } from "../../support/tempDir";
+
+const SCHEMA = {
+  title: "Tasks",
+  icon: "star",
+  dataPath: "data/tasks/items",
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+};
+
+async function readView(root: string): Promise<string | null> {
+  const collection = await loadCollection("tasks", { workspaceRoot: root });
+  if (!collection) throw new Error("fixture collection did not load");
+  return readCustomViewHtml(collection, "views/v1.html", { workspaceRoot: root });
+}
+
+const authoringGuide = (root: string) => manageCollectionHandlerFor(root)({ action: "schemaDocs", topic: "Anatomy of a collection skill" });
+
+describe("a launch directory with no staging tree is not a staged workspace", () => {
+  const savedWorkspaceEnv = process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  let managed = "";
+  // A git repository somebody ran the launcher inside: the committed layout, no `data/skills`.
+  let repo = "";
+
+  beforeAll(() => {
+    managed = makeTempDir("mt-unstaged-managed-");
+    repo = makeTempDir("mt-unstaged-repo-");
+
+    const skillDir = path.join(repo, ".claude", "skills", "tasks");
+    mkdirSync(path.join(skillDir, "views"), { recursive: true });
+    writeFileSync(path.join(skillDir, "SKILL.md"), "# tasks");
+    writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(SCHEMA));
+    writeFileSync(path.join(skillDir, "views", "v1.html"), "<body>committed view</body>");
+    mkdirSync(path.join(repo, "data", "tasks", "items"), { recursive: true });
+
+    // The managed workspace is somewhere else entirely and is not otherwise used here — it only
+    // has to not be `repo`, so `isManagedWorkspace` cannot be what answers for it.
+    process.env.MULMOCLAUDE_WORKSPACE_PATH = managed;
+    initCollectionsBackend({ workspace: repo, knownProjects: () => [] });
+  });
+
+  afterAll(() => {
+    if (savedWorkspaceEnv === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+    else process.env.MULMOCLAUDE_WORKSPACE_PATH = savedWorkspaceEnv;
+  });
+
+  it("serves the view the repo commits", async () => {
+    expect(await readView(repo)).toContain("committed view");
+  });
+
+  // The half that would otherwise change silently: the agent must still be told to author in the
+  // skill dir, so nothing starts writing a `data/skills` tree into somebody's repository.
+  // Asserted on the INSTRUCTION, not the string — the direct variant still says the words
+  // "data/skills", in the sentence telling the agent never to write there.
+  it("still serves the direct authoring guide", async () => {
+    const docs = await authoringGuide(repo);
+    expect(docs).toContain("Author under `.claude/skills/<slug>/`");
+    expect(docs).not.toContain("Author under `data/skills/<slug>/`");
+  });
+});

--- a/test/server/backends/collectionStagingUnstagedWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingUnstagedWorkspace.spec.ts
@@ -7,8 +7,13 @@
 // this server serves — and it is emphatically not a staged-authoring workspace: nothing stages
 // into it, and growing a second copy of every skill definition under `data/skills/` there would
 // be a change nobody asked for. So the staging base is offered to the server's own workspace only
-// on EVIDENCE, `data/skills` actually being present, and a repo without one answers exactly as it
-// did before this fix — in BOTH knobs, the read and the authoring guide.
+// on EVIDENCE — a `data/skills/<slug>/schema.json`, the layout a staged collection actually has —
+// and a repo without one answers exactly as it did before this fix, in BOTH knobs: the read and
+// the authoring guide.
+//
+// `data/skills` merely existing is deliberately NOT the evidence. It is a generic-looking path a
+// repository can own for its own reasons, and treating the name as proof would redirect where the
+// agent authors on the strength of a directory that means nothing.
 //
 // Its own file because `configureCollectionHost` binds one workspace per process, and this one
 // has to be a workspace that starts with no staging tree.
@@ -54,6 +59,11 @@ describe("a launch directory with no staging tree is not a staged workspace", ()
     writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(SCHEMA));
     writeFileSync(path.join(skillDir, "views", "v1.html"), "<body>committed view</body>");
     mkdirSync(path.join(repo, "data", "tasks", "items"), { recursive: true });
+
+    // A `data/skills` that holds no collection — the case a bare existence check would have got
+    // wrong, flipping the repo to staged authoring on the strength of a directory name.
+    mkdirSync(path.join(repo, "data", "skills", "notes"), { recursive: true });
+    writeFileSync(path.join(repo, "data", "skills", "README.md"), "not a collection");
 
     // The managed workspace is somewhere else entirely and is not otherwise used here — it only
     // has to not be `repo`, so `isManagedWorkspace` cannot be what answers for it.

--- a/test/server/infra/canonical-path.spec.ts
+++ b/test/server/infra/canonical-path.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+//
+// The properties `isSameRealPath` has to hold, harvested from the differential run that proved
+// the extraction out of `isManagedWorkspace` preserved its behaviour (324 generated spellings,
+// 0 mismatches). The harness could not survive — half of it was the code it replaced — so what
+// it established lives here instead.
+//
+// Why any of it matters: two callers decide "is this root a workspace" with this, and a false
+// answer is silent. It costs `isManagedWorkspace` the seeding step, and it costs the collection
+// engine its staging base — which is a 404 on every staged custom view (#1925), with the file
+// sitting right there on disk.
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdirSync, symlinkSync } from "node:fs";
+import path from "node:path";
+import { isSameRealPath } from "../../../server/infra/canonical-path";
+import { makeTempDir } from "../../support/tempDir";
+
+describe("isSameRealPath", () => {
+  let home = "";
+  let workspace = "";
+  let sibling = "";
+  let link = "";
+
+  beforeAll(() => {
+    home = makeTempDir("mt-realpath-");
+    workspace = path.join(home, "mulmoclaude");
+    sibling = path.join(home, "elsewhere");
+    mkdirSync(path.join(workspace, "data", "skills"), { recursive: true });
+    mkdirSync(sibling, { recursive: true });
+    link = path.join(home, "link-to-workspace");
+    symlinkSync(workspace, link, "dir");
+  });
+
+  it("matches a directory against itself, however it is spelled", () => {
+    expect(isSameRealPath(workspace, workspace)).toBe(true);
+    expect(isSameRealPath(workspace, `${workspace}${path.sep}`)).toBe(true);
+    expect(isSameRealPath(workspace, path.join(workspace, "."))).toBe(true);
+    expect(isSameRealPath(workspace, path.join(workspace, "data", ".."))).toBe(true);
+  });
+
+  // The reason the canonical pass exists at all: `~/mulmoclaude` is a symlink on plenty of
+  // machines, and the launcher may name it by either end.
+  it("sees through a symlink, in both directions", () => {
+    expect(isSameRealPath(link, workspace)).toBe(true);
+    expect(isSameRealPath(workspace, link)).toBe(true);
+    expect(isSameRealPath(link, link)).toBe(true);
+  });
+
+  it("separates distinct directories, including a child and its parent", () => {
+    expect(isSameRealPath(workspace, sibling)).toBe(false);
+    expect(isSameRealPath(workspace, path.join(workspace, "data"))).toBe(false);
+    expect(isSameRealPath(workspace, home)).toBe(false);
+  });
+
+  // A root can name a directory that is not there — a workspace the server creates on boot, a
+  // preset saved for a folder since deleted. `canonicalPath` re-attaches the missing leaves, so
+  // the answer stays about the paths rather than throwing.
+  it("answers for a path that does not exist yet", () => {
+    const missing = path.join(home, "not-created-yet");
+    expect(isSameRealPath(missing, missing)).toBe(true);
+    expect(isSameRealPath(missing, path.join(link, "..", "not-created-yet"))).toBe(true);
+    expect(isSameRealPath(missing, workspace)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Canvas でコレクションのカスタムビューが `HTTP 404` になる (#1925) のを直す。

`readCustomViewHtml` → `readSourceAwareFile`（`@mulmoclaude/core`）は project スコープの
コレクションについて staging を先に、`skillDir` を後に読む。staged authoring では
`views/*.html` は **staging (`data/skills/<slug>/`) にしか無い**（`.claude/skills/<slug>/` へは
SKILL.md / schema.json / templates だけがミラーされる）ので、ホストの `skillsStagingDir` が
`null` を返すと base から staging が丸ごと落ちて 404 になる。

その述語 `isManagedWorkspace` が聞いていたのは「**このパスは `~/mulmoclaude` か**」
(`MULMOCLAUDE_WORKSPACE_PATH || path.join(os.homedir(), "mulmoclaude")`)。MulmoClaude の
ワークスペースは常にそれで、しかも `skillsStagingDir` は無条件
(`../mulmoclaude/server/workspace/collections/configure.ts:25`)。一方 **MulmoTerminal 自身の
ワークスペースは `CLAUDE_CWD`** —— ランチャを起動したディレクトリ (`bin/cli-args.js` の
`chooseCwd` → `serverSpawnEnv` が必ず注入する) —— で、2 つが同じパスなのは偶然でしかない。

ずれると、MulmoClaude が staged レイアウトで書いた「このサーバ自身のワークスペース」を
MulmoTerminal が「managed ではない」と判定して staging を読まない。これが
「同じワークスペース・同じファイルなのに MulmoClaude だけ描画される」の正体。

## 変更

**述語を 1 つにまとめ、読みと authoring の両方をそこから導く。**
`server/backends/stagedSkills.ts`:

```ts
export function skillsStagingDirFor(root: string): string | null {
  const staging = path.join(root, "data", "skills");
  if (isManagedWorkspace(root)) return staging;                       // 今日と同じ、無条件
  return isWorkspaceRoot(root) && holdsStagedCollection(staging) ? staging : null;
}
export const usesStagedSkillAuthoring = (root: string) => skillsStagingDirFor(root) !== null;
```

`holdsStagedCollection` は `data/skills/<slug>/schema.json` の実在を見る。**ディレクトリの
名前ではなく、staged なコレクションが実際に持つ形**を証拠にする（core 自身も `canonicalBase`
で同じファイルを見てから staging を正本として扱う）。

| root | 判定 | 意味 |
|---|---|---|
| `~/mulmoclaude` | staged（無条件） | 今日と同じ。中身が空でも返す必要がある（最初の `putSchema` が埋める） |
| `CLAUDE_CWD` に staged なコレクションがある | staged | 何かが staged にした本物のワークスペース → **#1925 が直る** |
| `CLAUDE_CWD` に無い（git repo でランチャを起動しただけ。別用途の `data/skills` があっても） | direct | **今日と 1 ビットも変わらない**。repo に `data/skills` が生えることもない |
| 保存済みプロジェクト | direct | 今日と同じ。野良ファイルが commit 済み skill を shadow しない |

| 変更 | 場所 |
|---|---|
| `skillsStagingDirFor` / `usesStagedSkillAuthoring` | `server/backends/stagedSkills.ts`（新規） |
| 束縛をそれに差し替え | `server/backends/collections.ts` |
| `stagedSkillAuthoring` をそれから導く＋インスタンスキャッシュの鍵を root + variant に | `server/infra/collection-tool.ts` |
| `isWorkspaceRoot`（束縛された workspace との同一判定） | `server/infra/project-root.ts` |
| `isSameRealPath`（lexical → realpath の 2 段判定）を出す | `server/infra/canonical-path.ts` |
| 2 段判定をそれに置き換え | `server/backends/workspaceSetup.ts` |
| 条件付きの束縛を表に書く | `docs/collection-plugin-integration.md` |
| 回帰テスト | `collectionStagingServerWorkspace.spec.ts`, `collectionStagingUnstagedWorkspace.spec.ts`, `canonical-path.spec.ts` |

## Items to Confirm / Review

**1. 「副作用が無い」の根拠**

`CLAUDE_CWD === ~/mulmoclaude`（通常の構成）では、述語は第 1 項で返るので今日とビット単位で
同じ。差が出るのは「ワークスペースが `~/mulmoclaude` でなく、かつそこに staged なコレクションが
実在する」場合だけ ——つまり今まさに 404 になっている人だけ。保存済みプロジェクトは
`isWorkspaceRoot` が false なので従来どおり `null`（野良 `data/skills` の shadow ガードは無傷）。

**2. 読みと書きを 1 つの述語から導いている**

core が要求している点（"ONE predicate on purpose"）。片方だけ広げると、エージェントが
`.claude/skills` に書いた view より古い staging のコピーが勝つ ——**編集が黙って反映されない**
—— 状態になる。iter-1 でそれをやってしまい、codex の指摘で iter-2 に直しました。

あわせて `manageCollectionHandlerFor` のキャッシュ鍵を root → **root + variant** に。
`stagedSkillAuthoring` はハンドラ生成時に固定される値なので、ワークスペースが最初の staged
コレクションを得た後も古い authoring guide を出し続けていた（読み側は即座に切り替わる）。

**3. 意図的にやっていないこと**

- **`userSkillsDir` は触らない。** 同じ `isManagedWorkspace` で分岐しているが、広げると
  `~/.claude/skills` 配下がワークスペースの一覧と slug 解決に入る＝**どのコレクションが
  見えるかが変わる**。
- **core の per-root な staging 先読みは直せない → #1957。** `readSourceAwareFile` は
  `<staging>/<slug>` を無条件に base に入れ、その slug が staged かは見ない。ホストの束縛は
  `(root) => string | null` で slug を受け取らないので、このリポジトリからは表現できない。
  **`~/mulmoclaude`（この PR が触っていない側）で既に同じ挙動**であることを実測して #1957 に
  切り出した。直すなら core 側（削除側の `canonicalBase` と同じ per-slug の証拠を読み側も見る）。

**4. `isSameRealPath` の抽出は 1:1 であることを差分実行で確認**

旧式をそのままコピーしたハーネスで、生成したパスの綴り（trailing separator / `.` / `..` /
大文字小文字 / symlink の両向き / 存在しない leaf）の **324 ペアを比較して不一致 0**。
ハーネスは片側が消えたコードなので残せないため、性質を `canonical-path.spec.ts` に恒久テストとして残した。

**5. 報告者の環境で `isManagedWorkspace` が false になった具体的な値は未確定**

Windows の当該マシンでしか取れないため。ただし **どの経路で false になっても** この修正で
staging は読める（`os.homedir()` や `MULMOCLAUDE_WORKSPACE_PATH` が 2 プロセス間で一致すること
に依存しなくなる）。false のときは起動ログに必ず 1 行出る:
`[workspace-setup] skipping seed — not the managed mulmoclaude workspace { workspace: … }`

## 検証

**実サーバに対する差分**（`CLAUDE_CWD` も `HOME` も一時ディレクトリに向けて起動。
報告と同じ `?project=<hash>` 付きのリクエスト）

| | `GET /detail` | `GET /view-file` |
|---|---|---|
| 修正前 | `200` / `"source":"project"` | **`404`** `view file 'views/v1.html' not found` |
| 修正後 | `200` / `"source":"project"` | **`200`** `<body>STAGED VIEW OVER HTTP</body>` |

報告の署名（detail は通るのに view-file だけ 404）がそのまま再現し、修正後に解消。起動ログにも
`skipping seed — not the managed mulmoclaude workspace` が出ており、狙った条件で走っている。

**同じ実サーバで、変わらないことの確認**

| root | `GET /view-file` |
|---|---|
| 保存済みプロジェクト（野良 staging コピーあり） | `200` commit 済み copy |
| repo workspace、`data/skills` 無し | `200` commit 済み copy、`data/skills` は生えず |
| repo workspace、**無関係な `data/skills` あり** | `200` commit 済み copy |

**コマンド**: `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` すべて exit 0、
`yarn test` は **810 files / 12013 passed**（skip 50）。CI は Windows を含め全 green。
新 spec は修正を戻すと落ちることも確認済み。

## User Prompt

- receptron/mulmoterminal#1925（Canvas でコレクションのカスタムビューが HTTP 404）について
  「原因わかる？」と調査を依頼。
- 原因の説明後、「副作用無くなおして。」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZqpsdPygLwesjp2a6GHvs

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom collection views returning HTTP 404 when working from a workspace outside the managed MulmoClaude directory.
  * Ensured staged collections are read from and written to the same location across supported workspaces.
  * Prevented stray staging files from overriding committed skills in saved projects.
  * Improved workspace recognition for equivalent paths, including symlinks and alternate path formats.

* **Documentation**
  * Clarified collection staging behavior and workspace-specific requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->