### PR TITLE
chore(deps): @mulmoclaude/core 4.6.0 — staged view の判定が slug 単位になる (#1957)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@mulmoclaude/accounting-plugin": "^3.0.0",
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.6.0",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",

--- a/plans/chore-1957-core-4.6.0.md
+++ b/plans/chore-1957-core-4.6.0.md
@@ -1,0 +1,59 @@
+# chore(#1957): `@mulmoclaude/core` を 4.6.0 に上げ、staged view の per-slug 判定を取り込む
+
+## 何のための bump か
+
+#1955 で `skillsStagingDir` が staging を返す **root** を直したが、core 側には
+「その root の中の**どの slug** が staged か」を見ない問題が残っていた（#1957）。
+
+`readSourceAwareFile` は `<staging>/<slug>` を無条件に base へ入れるので、staged な
+ワークスペースに同居する **imported / direct commit のコレクション**でも、古い
+`data/skills/<slug>/views/*.html` が commit 済みの view に勝っていた。
+
+ホストの束縛は `skillsStagingDir: (workspaceRoot: string) => string | null` で slug を
+受け取らないため、**このリポジトリからは表現できない**。core 側で直した
+（receptron/mulmoclaude#3031 / PR #3032 → `@mulmoclaude/core@4.6.0`）。
+
+core 4.6.0 は読みと削除が `stagedSkillDir(root, safeSlug)` を共有し、`<staging>/<slug>/schema.json`
+の実在（`lstat`。symlink は証拠にせず、`ENOENT`/`ENOTDIR` 以外は再送出）を証拠にする。
+
+## この PR がやること
+
+1. `@mulmoclaude/core` を `^4.5.0` → `^4.6.0`（`yarn add`。lockfile も更新）
+2. core 4.6.0 で**期待値が反転するテスト**を更新する
+3. core 4.6.0 が正しく無視するようになった**薄い fixture** を、実際の authoring レイアウトに直す
+
+## 2 — 反転するテスト
+
+`test/server/backends/collectionStagingServerWorkspace.spec.ts` の
+
+> `"prepends staging per root, not per slug — the same in either workspace (#1957)"`
+
+は #1955 の時点の挙動（両 root で `STALE STAGED` が勝つ）を、**既知の制約として意図的に**
+留めていたもの。core 4.6.0 でその制約が消えるので、アサーションを反転させる:
+
+> `"prefers the committed view for a slug with no staged schema — in either workspace (#1957)"`
+
+両 root で assert し続けるのは変えない —— ルールは core のものなので、`~/mulmoclaude` と
+このサーバが serve するワークスペースが同じ答えを返すべき、という点は 4.6.0 でも同じ。
+
+## 3 — 薄い fixture
+
+`test/server/backends/collections.spec.ts` は staging に `views/*.html` を置きながら
+`data/skills/<slug>/schema.json` を置いていなかった。実際の authoring レイアウトは
+`putSchema` が schema.json を書くので、**fixture が実物より薄い**（＝ 4.6.0 が区別したい
+2 つの形を区別していない）。`testcol` と `viewactcol` に staged schema.json を足して実物に
+合わせる。fixture を緩めたのではなく、実物に寄せている。
+
+mulmoclaude 側でも同じ性質の fixture 2 系統を同時に直している（PR #3032）。
+
+## 検証
+
+依存を動かす PR なので、**ground truth は committed lockfile からのクリーン解決**であって
+手元の warm な `node_modules` ではない。ローカルのゲートは通したうえで、クリーン install の
+検証は CI に委ねる（`uptime` が 13.9 と高く、ここでフル再インストールを足すと今動いている
+作業の方が代償を払うため）。CI は `actions/setup-node` のキャッシュから
+`yarn install --frozen-lockfile` 相当を回すので、そこが検証になる。
+
+## これで閉じるもの
+
+#1957。

--- a/test/server/backends/collectionStagingServerWorkspace.spec.ts
+++ b/test/server/backends/collectionStagingServerWorkspace.spec.ts
@@ -146,21 +146,23 @@ describe("staged custom views are readable from every workspace, and from no pro
     expect(docs).not.toContain("Author under `.claude/skills/<slug>/`");
   });
 
-  // KNOWN LIMITATION, pinned so it is discoverable rather than folklore — see #1957.
+  // Staging is decided per SLUG, not per root — fixed in `@mulmoclaude/core@4.6.0` (#1957,
+  // receptron/mulmoclaude#3031).
   //
-  // Core prepends the staging base PER ROOT: `readSourceAwareFile` builds `<staging>/<slug>` for
-  // every project-scope collection without checking that THAT slug is staged. So in a staged
-  // workspace, a stale `data/skills/<slug>/views/*.html` wins over the committed one even for a
-  // collection with no staged schema of its own.
+  // A staged workspace also holds imported and directly-committed collections. Core used to build
+  // `<staging>/<slug>` for every project-scope collection without checking that THAT slug was
+  // staged, so a stale `data/skills/<slug>/views/*.html` beside one of them won on every read.
+  // It now requires the slug's own `schema.json` there, the same evidence its delete path
+  // (`canonicalBase`) has always used.
   //
-  // Asserted on BOTH roots on purpose. `~/mulmoclaude` is untouched by #1925's fix and answers
-  // the same, which is what says this is core's rule rather than a second one introduced for the
-  // workspace this server serves. It cannot be fixed from this repo: the host binding is
-  // `skillsStagingDir(workspaceRoot) => string | null` and never sees the slug, so the per-slug
-  // decision has to move into core's read (its delete path already makes it, in `canonicalBase`).
-  it("prepends staging per root, not per slug — the same in either workspace (#1957)", async () => {
+  // Asserted on BOTH roots on purpose: the rule is core's, so `~/mulmoclaude` and the workspace
+  // this server serves must answer identically. This assertion is INVERTED from what it pinned
+  // before core 4.6.0 — it read `STALE STAGED` then, which is exactly the bug.
+  it("prefers the committed view for a slug with no staged schema — in either workspace (#1957)", async () => {
     for (const root of [managed, workspace]) {
-      expect(await readView(root, "unstaged")).toContain("STALE STAGED");
+      const html = await readView(root, "unstaged");
+      expect(html).toContain("committed direct view");
+      expect(html).not.toContain("STALE STAGED");
     }
   });
 

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -42,9 +42,16 @@ vi.mock("@mulmoclaude/core/collection/server", async (importOriginal) => {
 // A minimal project-scope collection skill + one record + one read-only custom
 // view, laid out exactly where the engine's discovery looks (matching the shared
 // path layout initCollectionsBackend configures):
-//   <ws>/.claude/skills/testcol/schema.json   — the collection schema
+//   <ws>/.claude/skills/testcol/schema.json   — the collection schema (discovery anchor)
 //   <ws>/data/testcol/items/item1.json        — one record (dataPath)
+//   <ws>/data/skills/testcol/schema.json      — the staged copy: what makes this slug STAGED
 //   <ws>/data/skills/testcol/views/v1.html    — the custom view (project staging)
+//
+// The staged schema.json is not decoration. Since `@mulmoclaude/core@4.6.0` the staging base is
+// offered per SLUG rather than per root (#1957), and the slug's own schema.json there is the
+// evidence — the same evidence core's delete path has always used. A fixture that stages views
+// without it is not the authoring layout; it is the stale-leftover layout, whose views are
+// deliberately ignored in favour of the committed copy.
 const SCHEMA = {
   title: "Test Collection",
   icon: "star",
@@ -80,6 +87,7 @@ beforeAll(async () => {
   mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
   writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
   mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v2.html"), "<head></head><body>editable</body>");
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "phone.html"), "<head></head><body>phone-view</body>");
@@ -115,6 +123,7 @@ beforeAll(async () => {
   writeFileSync(path.join(ws, "data", "viewactcol", "items", "a1.json"), JSON.stringify({ id: "a1", status: "open" }));
   writeFileSync(path.join(ws, "data", "viewactcol", "items", "a2.json"), JSON.stringify({ id: "a2", status: "closed" }));
   mkdirSync(path.join(ws, "data", "skills", "viewactcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "viewactcol", "schema.json"), JSON.stringify(VIEW_ACTION_SCHEMA));
   writeFileSync(path.join(ws, "data", "skills", "viewactcol", "views", "board.html"), "<head></head><body>board</body>");
 
   // A singleton collection with a write-capable view, to prove PUT /view-data

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,10 +1859,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/common/-/common-1.2.0.tgz#ad2d696a6a06ea47c078e45d8d7f6f41b53d4aeb"
   integrity sha512-Y459jz/3fGY+QPSOtRUpq+JA1v839qlhaKmuz6LohoJp0nneP9Eot+gsn7Yl8RKhEGqxhfmJaCDa28bWK7RhCA==
 
-"@mulmoclaude/core@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-4.5.0.tgz#8ff9fdbeff518ceb45f0f896ae75489ef5b98c57"
-  integrity sha512-bk98EfjZvigg+hOhG9h5IfKMGjOWV1U5Wl2eO17FTVLgLLFkprBRSQpdetCYRsFLL5OB/1mw6cwVJI8eEpL2Iw==
+"@mulmoclaude/core@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-4.6.0.tgz#eec1aa7ed5fe1ce2a2e2b8d5e58021bfc257c991"
+  integrity sha512-+uNhn72F5nPx+EauJj0oQmgM9KuJdWXpQZ3/C9/eEuho1gICZsdj66iuFQrqRRdsLjt+soR5L9AOvr46+YMHOg==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.2.0"
@@ -1872,7 +1872,7 @@
     google-auth-library "^10.9.1"
     iconv-lite "^0.7.3"
     js-yaml "^5.4.1"
-    zod "^4.5.2"
+    zod "^4.5.4"
 
 "@mulmoclaude/form-plugin@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` を `^4.5.0` → `^4.6.0` に上げ、**#1957 を閉じます**。

#1955 で `skillsStagingDir` が staging を返す **root** は直しましたが、core 側に
「その root の中の**どの slug** が staged か」を見ない問題が残っていました。
`readSourceAwareFile` は `<staging>/<slug>` を無条件に base へ入れるので、staged な
ワークスペースに同居する **imported / direct commit のコレクション**でも、古い
`data/skills/<slug>/views/*.html` が commit 済みの view に勝っていました。

ホストの束縛は `skillsStagingDir: (workspaceRoot: string) => string | null` で slug を
受け取らないため、**このリポジトリからは表現できません**。core 側で直しました:

- receptron/mulmoclaude#3031 / PR receptron/mulmoclaude#3032
- [`@mulmoclaude/core@4.6.0`](https://www.npmjs.com/package/@mulmoclaude/core/v/4.6.0)

4.6.0 は読みと削除が `stagedSkillDir(root, safeSlug)` を共有し、`<staging>/<slug>/schema.json`
の実在を証拠にします（`lstat` なので symlink は証拠にならず、`ENOENT`/`ENOTDIR` 以外の
エラーは再送出）。

## 変更

| 変更 | 場所 |
|---|---|
| `@mulmoclaude/core` を `^4.6.0` へ（`yarn add`、lockfile も更新） | `package.json` / `yarn.lock` |
| #1957 のテストのアサーションを**反転** | `test/server/backends/collectionStagingServerWorkspace.spec.ts` |
| staged fixture に `data/skills/<slug>/schema.json` を追加 | `test/server/backends/collections.spec.ts` |
| 設計メモ | `plans/chore-1957-core-4.6.0.md` |

## Items to Confirm / Review

**1. #1957 のテストは「意図的に反転」させています**

`"prepends staging per root, not per slug — the same in either workspace (#1957)"` は、
#1955 の時点で **既知の制約を意図的に留める**ために置いたテストでした（両 root で
`STALE STAGED` が勝つ）。core 4.6.0 でその制約が消えるので、期待値を反転しています:

```
"prefers the committed view for a slug with no staged schema — in either workspace (#1957)"
```

**両 root で assert し続ける点は変えていません** —— ルールは core のものなので、
`~/mulmoclaude` とこのサーバが serve するワークスペースが同じ答えを返すべき、という
主張は 4.6.0 でも同じです。

**2. `collections.spec.ts` の fixture は「緩めた」のではなく「実物に寄せた」**

staging に `views/*.html` を置きながら `data/skills/<slug>/schema.json` を置いていませんでした。
実際の authoring レイアウトは `putSchema` が schema.json を書くので、**fixture が実物より
薄かった**（＝ 4.6.0 が区別したい 2 つの形を区別していなかった）。`testcol` と `viewactcol` に
staged schema.json を足しています。core 側でも同じ性質の fixture 2 系統を同時に直しました
（receptron/mulmoclaude#3032）。

これを足さないと 4 件落ちます:
`serves view-file HTML with sandbox + nosniff hardening` /
`GET /:slug/remote-view builds a mobile view into a sandboxed srcdoc` /
`custom-view i18n` ×2。

**3. クリーン install の検証は CI に委ねています**

依存を動かす PR の ground truth は **committed lockfile からのクリーン解決**であって、
手元の warm な `node_modules` ではありません。ローカルのゲートは全部通していますが、
`uptime` が **load average 13.9** と高く、ここでフル再インストールを足すと今動いている
作業の方が代償を払うため、クリーン install の検証は CI に任せます。

## 検証

ローカル（warm）:

| gate | 結果 |
|---|---|
| `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` | すべて exit 0 |
| `yarn test` | **811 files / 12029 passed**（skip 50）、fail 0 |

`@mulmoclaude/core` が 4.6.0 に解決されていることも確認済み
（`node_modules/@mulmoclaude/core/package.json` → `4.6.0`）。

## User Prompt

- receptron/mulmoterminal#1925 の調査 →「副作用無くなおして」→ #1955。
- 「#1957 も並行して直して」→ core 側を receptron/mulmoclaude#3032 で修正。
- 「publish」→ `@mulmoclaude/core@4.6.0` を公開。
- 本 PR はそれをこのリポジトリに取り込み、#1957 を閉じるもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZqpsdPygLwesjp2a6GHvs

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection view resolution when staged content is present, ensuring committed views are used unless the corresponding staged schema confirms an active staged version.
  - Prevented stale staged views from overriding committed views in managed and workspace collections.

- **Chores**
  - Updated the core platform dependency to version 4.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->