### PR TITLE
docs(skills): tool group の登録コマンドを skill に書き、ランチャー任せをやめる (#1931)

### DIFF
--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1327,9 +1327,18 @@ tool-group switch does exactly this, and in a Claude Code cell you can do it fro
 in the folder the cell is open in:
 
 ```bash
-claude mcp remove mulmoterminal-data -s local   # ignore its failure: it means nothing was registered
+claude mcp remove mulmoterminal-data -s local   # usually fails with "No MCP server named …" — that is fine
 claude mcp add -s local --transport http mulmoterminal-data 'http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/data/${MULMOTERMINAL_SESSION_ID}'
 ```
+
+**Say what you are registering before you run it.** It writes into the user's own Claude Code
+config, and it is theirs to know about — one sentence naming the group and the folder. It is
+undone by the `remove` line alone, so this is a note, not a confirmation gate: stopping to ask is
+what this section exists to remove.
+
+**If the `add` refuses with "Server already exists", the `remove` failed for a real reason** —
+a different scope, or a config it could not write. Read what the remove actually said instead of
+running the pair again; a second attempt fails the same way and the OLD url stays in force.
 
 **Single quotes are load-bearing.** `${MULMOTERMINAL_PORT}` and `${MULMOTERMINAL_SESSION_ID}` are
 stored as LITERAL text: Claude Code expands them when it CONNECTS to the server, and MulmoTerminal
@@ -1344,8 +1353,15 @@ does nothing for the session you are in. Say so, and ask them to close and reope
 start again from `init`.
 
 This is the `data` group because that is where both tools live, along with the collection store
-they act on. If a cell needs the Canvas as well, the same two lines with `mulmoterminal-render` do
-that group.
+they act on. If a cell needs the Canvas as well, that is a SECOND group and **the group name
+appears twice** — in the server id and in the url path:
+
+```bash
+claude mcp add -s local --transport http mulmoterminal-render 'http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}'
+```
+
+Changing only the id would register a server called `mulmoterminal-render` against the **data**
+endpoint, and the cell would get the data tools again under a name that promises otherwise.
 
 ## Two refusals that are NOT your cue to start editing
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1357,8 +1357,13 @@ they act on. If a cell needs the Canvas as well, that is a SECOND group and **th
 appears twice** — in the server id and in the url path:
 
 ```bash
+claude mcp remove mulmoterminal-render -s local
 claude mcp add -s local --transport http mulmoterminal-render 'http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}'
 ```
+
+**Both lines, for the reason the `data` pair has both**: a folder that registered Canvas before
+already holds that id, so an `add` on its own is refused and the OLD url stays in force — which is
+the failure this whole section exists to prevent, arriving through the fix for it.
 
 Changing only the id would register a server called `mulmoterminal-render` against the **data**
 endpoint, and the cell would get the data tools again under a name that promises otherwise.

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1318,10 +1318,34 @@ after they have watched you build it.
 ## If the tools are not here
 
 `manageSharedApp` and `manageCollection` are only offered in a cell whose directory has the
-workspace-data tool group. If they are not in your tool list, **stop and say so**: a shared app
+workspace-data tool group. If they are not in your tool list, **do not carry on**: a shared app
 cannot be published from here, and writing `app.json` and a schema by hand produces files nothing
-can act on. Point the user at the launcher's tool-group switch for this folder rather than
-carrying on.
+can act on.
+
+**Register the group yourself rather than handing the user a UI to find.** The launcher's
+tool-group switch does exactly this, and in a Claude Code cell you can do it from here — run this
+in the folder the cell is open in:
+
+```bash
+claude mcp remove mulmoterminal-data -s local   # ignore its failure: it means nothing was registered
+claude mcp add -s local --transport http mulmoterminal-data 'http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/data/${MULMOTERMINAL_SESSION_ID}'
+```
+
+**Single quotes are load-bearing.** `${MULMOTERMINAL_PORT}` and `${MULMOTERMINAL_SESSION_ID}` are
+stored as LITERAL text: Claude Code expands them when it CONNECTS to the server, and MulmoTerminal
+puts both in the environment of every claude cell. A shell that expanded them here would freeze one
+session's port and id into a permanent registration, and every later session would point at a
+server that is gone. Remove-then-add is what the launcher's switch itself does — the remove repairs
+a registration written against an older URL, and its failure is the normal case.
+
+**Then the user has one thing left to do, and you must ask for it:** the registration is
+per-folder, written into Claude Code's own config, and a session reads it **when it starts**. It
+does nothing for the session you are in. Say so, and ask them to close and reopen this cell — then
+start again from `init`.
+
+This is the `data` group because that is where both tools live, along with the collection store
+they act on. If a cell needs the Canvas as well, the same two lines with `mulmoterminal-render` do
+that group.
 
 ## Two refusals that are NOT your cue to start editing
 

--- a/server/skills/mulmoterminal-shared-app/SKILL.md
+++ b/server/skills/mulmoterminal-shared-app/SKILL.md
@@ -1317,8 +1317,8 @@ after they have watched you build it.
 
 ## If the tools are not here
 
-`manageSharedApp` and `manageCollection` are only offered in a cell whose directory has the
-workspace-data tool group. If they are not in your tool list, **do not carry on**: a shared app
+`manageSharedApp` and `manageCollection` are only offered in a cell whose directory has the `data`
+tool group — the launcher's switch calls it **Workspace data**. If they are not in your tool list, **do not carry on**: a shared app
 cannot be published from here, and writing `app.json` and a schema by hand produces files nothing
 can act on.
 


### PR DESCRIPTION
## Summary

`mulmoterminal-shared-app` の「If the tools are not here」節が、ランチャーの tool-group スイッチをユーザーに差し戻していました。そのスイッチを見たことがない人には見つけられず、**「共有アプリを作って」がソースの調べ物に変わる**（#1931 の実例）。

スイッチの実体は `claude mcp add` なので、**Claude Code のセルならエージェント自身が実行できます**。その形を skill に書きました。ユーザーに残る操作は「セルを開き直す」だけです。

| 変更 | 場所 |
|---|---|
| 登録コマンド（remove → add）と、リテラル `${...}` の理由、開き直しの依頼 | `server/skills/mulmoterminal-shared-app/SKILL.md`「If the tools are not here」 |

## Items to Confirm / Review

**1. コマンドは実装からの写しで、composeしていません。** CLAUDE.md の「API/ツールの文書は実装を確認してから書く」に従い、3 つとも確認しました:

| 書いたもの | 出どころ |
|---|---|
| `mulmoterminal-data` | `toolGroupServerId("data")`（`common/toolGroups.ts:138`） |
| URL | `guiMcpUrlTemplate("data")`（`server/infra/gui-mcp-registration.ts:23`） |
| remove → add の順 | `registerGuiMcpGroup`（同 `:45`–`:46`）がそうしている |
| `data` グループでよいこと | `manageSharedApp` / `manageCollection` がどちらも `data`（`common/toolGroups.ts:99`, `:91`） |

**2. 実際に走らせて確認しました。** `CLAUDE_CONFIG_DIR` をスクラッチに向けて実行（本物の `~/.claude.json` は触っていません）:

- `remove` は `No MCP server named "mulmoterminal-data" in local scope` で失敗 → 「失敗は正常」と書いたとおり
- `add` は**プロジェクト（フォルダ）単位**のエントリとして書かれる
- `${MULMOTERMINAL_PORT}` / `${MULMOTERMINAL_SESSION_ID}` は**リテラルのまま保存**される

3 つ目が「シングルクォートが効いている」という注意書きの根拠です。シェルが展開してしまうと、1 セッション分の port と id が恒久的な登録に焼き付き、以後のセッションは消えたサーバを指します。

**3. 展開のタイミングは実装のコメントに合わせました。** 最初「セル起動時に展開」と書きましたが、`mcp-config.ts:66` は「Claude Code expands `${VAR}` in an MCP url **at connect time**」です。環境変数側は `guiMcpEnv` が claude の全 spawn に入れています。文言はこちらに直しました。

**4. issue の ②（Tools ペインの空状態に導線を出す）は入れていません。** issue 自身が「独立した任意の follow-up」としているためです。必要なら別 issue に切ります。

## User Prompt

- 次これ https://github.com/receptron/mulmoterminal/issues/1931

## 検証

`yarn format` / `lint` 0、`yarn test` **12028 passed / 50 skipped**。コマンド自体はスクラッチの `CLAUDE_CONFIG_DIR` に対して実行し、書き込まれた JSON を読み返して確認しています（上記 2）。

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated setup guidance for missing tools with clearer remove-and-readd instructions for required MCP groups.
  - Clarified that registration is folder-specific and that the development cell must be closed and reopened before restarting from initialization.
  - Preserved environment-variable expansion in registration commands.
  - Documented equivalent setup steps for rendering tools, including why adding without removal may retain an existing URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->