### PR TITLE
feat(tools): Tools ペインの空状態に、ツールグループの有効化手段を書く (#1966)

### DIFF
--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -103,9 +103,14 @@ async function loadAvailableTools(sessionId: string | null) {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body = await jsonBody(res);
     if (overtaken()) return;
-    availableTools.value = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : [];
+    // A missing or non-array `tools` is UNREADABLE, not empty: every success path of the route
+    // sends the array (`tool-routes.ts:159`), and `jsonBody` answers `{}` for a body it could not
+    // parse — so a proxy's error page arriving as a 200 would otherwise read as a confirmed empty
+    // configuration and send the reader off to fix a folder that is fine (Codex on #1966).
+    const listed = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : null;
+    availableTools.value = listed ?? [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
-    toolsUnknown.value = false;
+    toolsUnknown.value = listed === null;
   } catch {
     if (overtaken()) return;
     availableTools.value = [];

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -112,10 +112,16 @@ async function loadAvailableTools(sessionId: string | null) {
     // sends the array (`tool-routes.ts:159`), and `jsonBody` answers `{}` for a body it could not
     // parse — so a proxy's error page arriving as a 200 would otherwise read as a confirmed empty
     // configuration and send the reader off to fix a folder that is fine (Codex on #1966).
-    const listed = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : null;
+    const raw = isUnknownArray(body.tools) ? body.tools : null;
+    const listed = raw === null ? null : raw.filter(isAvailableTool);
+    // Readable means the body survived parsing, not merely that it arrived. An array that is
+    // non-empty and yet yields nothing is a body we could not read: the route sends well-formed
+    // summaries, so entries this rejects came from a proxy or a version skew, and calling that
+    // "no tools are enabled" sends the reader to fix a folder that is fine (Codex on #1966).
+    const readable = listed !== null && raw !== null && (raw.length === 0 || listed.length > 0);
     availableTools.value = listed ?? [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
-    toolsState.value = listed === null ? "unknown" : "known";
+    toolsState.value = readable ? "known" : "unknown";
   } catch {
     if (overtaken()) return;
     availableTools.value = [];

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -90,6 +90,9 @@ const expandedCalls = ref<Set<string>>(new Set());
 // would restore the empty list this pane exists to get rid of. Only the newest may apply, which
 // is the same rule and the same counter useSessionFeed keeps (#620).
 let latestToolsLoad = 0;
+/** The last request FAILED, so an empty list means "we could not ask", not "there are none". */
+const toolsUnknown = ref(false);
+
 async function loadAvailableTools(sessionId: string | null) {
   const loadId = ++latestToolsLoad;
   const url = sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools";
@@ -102,12 +105,18 @@ async function loadAvailableTools(sessionId: string | null) {
     if (overtaken()) return;
     availableTools.value = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
+    toolsUnknown.value = false;
   } catch {
     if (overtaken()) return;
     availableTools.value = [];
     // Unknown, so claim nothing: a note that appears on a failed request would be a statement
     // about a history we could not ask about.
     guiOnlyHistory.value = false;
+    // The same reasoning one field over, and it is why the empty state has two forms: an empty
+    // list from a FAILED request is not evidence that no group is registered, and telling the
+    // reader to go and enable one would send them to fix a folder that may be configured fine
+    // (CodeRabbit on #1966).
+    toolsUnknown.value = true;
   }
 }
 watch(() => props.sessionId, loadAvailableTools, { immediate: true });
@@ -232,7 +241,10 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
              switch is on an empty cell's LAUNCH FORM, so it is not on screen while this session
              runs, and the registration is read when a session STARTS. Naming one without the other
              sends the reader hunting for a control that is not there. -->
-        <div v-if="availableTools.length === 0" data-testid="tools-empty" class="text-[12px] leading-relaxed text-dim">
+        <div v-if="availableTools.length === 0 && toolsUnknown" data-testid="tools-unknown" class="text-[12px] leading-relaxed text-dim">
+          Could not ask this server which tools are enabled. The list below is empty because the request failed, not because nothing is registered.
+        </div>
+        <div v-else-if="availableTools.length === 0" data-testid="tools-empty" class="text-[12px] leading-relaxed text-dim">
           No GUI plugin tools enabled. They come from the tool groups registered for this folder — the switches are on an empty cell's launch form (<span
             class="text-secondary"
             >Workspace data</span

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -90,11 +90,12 @@ const expandedCalls = ref<Set<string>>(new Set());
 // would restore the empty list this pane exists to get rid of. Only the newest may apply, which
 // is the same rule and the same counter useSessionFeed keeps (#620).
 let latestToolsLoad = 0;
-/** What an EMPTY `availableTools` means right now, which is three different things and was one.
+/** What an EMPTY `availableTools` means right now — three different things, and it used to be one.
  *
- *  `loading` is the initial value and not a formality: the pane mounts before the first response,
- *  so a two-state flag renders "nothing is enabled" as a confirmed result for every session while
- *  it is still being asked (Codex on #1966, the third door into this). */
+ *  Only `known` may show the guidance below, because that guidance tells the reader to go and
+ *  change their configuration. `loading` is not a formality: the pane mounts before the first
+ *  response and is re-asked on every cell change, so without it every session is told "nothing is
+ *  enabled" while it is still being asked (#1966). */
 const toolsState = ref<"loading" | "unknown" | "known">("loading");
 
 async function loadAvailableTools(sessionId: string | null) {
@@ -108,16 +109,14 @@ async function loadAvailableTools(sessionId: string | null) {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body = await jsonBody(res);
     if (overtaken()) return;
-    // A missing or non-array `tools` is UNREADABLE, not empty: every success path of the route
-    // sends the array (`tool-routes.ts:159`), and `jsonBody` answers `{}` for a body it could not
-    // parse — so a proxy's error page arriving as a 200 would otherwise read as a confirmed empty
-    // configuration and send the reader off to fix a folder that is fine (Codex on #1966).
+    // READABLE means the body survived parsing, not that it arrived. `jsonBody` answers `{}` for a
+    // body it could not parse, and every success path of the route sends the array of well-formed
+    // summaries (`tool-routes.ts:159`) — so a missing `tools`, and equally an array that yields
+    // nothing, is a proxy or a version skew rather than a session with no tools. The distinction
+    // is the whole point of the empty state below: "none are enabled" sends the reader off to
+    // configure a folder that may be fine (#1966).
     const raw = isUnknownArray(body.tools) ? body.tools : null;
     const listed = raw === null ? null : raw.filter(isAvailableTool);
-    // Readable means the body survived parsing, not merely that it arrived. An array that is
-    // non-empty and yet yields nothing is a body we could not read: the route sends well-formed
-    // summaries, so entries this rejects came from a proxy or a version skew, and calling that
-    // "no tools are enabled" sends the reader to fix a folder that is fine (Codex on #1966).
     const readable = listed !== null && raw !== null && (raw.length === 0 || listed.length > 0);
     availableTools.value = listed ?? [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
@@ -128,10 +127,7 @@ async function loadAvailableTools(sessionId: string | null) {
     // Unknown, so claim nothing: a note that appears on a failed request would be a statement
     // about a history we could not ask about.
     guiOnlyHistory.value = false;
-    // The same reasoning one field over, and it is why the empty state has two forms: an empty
-    // list from a FAILED request is not evidence that no group is registered, and telling the
-    // reader to go and enable one would send them to fix a folder that may be configured fine
-    // (CodeRabbit on #1966).
+    // The same rule as the success path: an empty list we could not fill is not an answer.
     toolsState.value = "unknown";
   }
 }

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -90,14 +90,19 @@ const expandedCalls = ref<Set<string>>(new Set());
 // would restore the empty list this pane exists to get rid of. Only the newest may apply, which
 // is the same rule and the same counter useSessionFeed keeps (#620).
 let latestToolsLoad = 0;
-/** The last request FAILED, so an empty list means "we could not ask", not "there are none". */
-const toolsUnknown = ref(false);
+/** What an EMPTY `availableTools` means right now, which is three different things and was one.
+ *
+ *  `loading` is the initial value and not a formality: the pane mounts before the first response,
+ *  so a two-state flag renders "nothing is enabled" as a confirmed result for every session while
+ *  it is still being asked (Codex on #1966, the third door into this). */
+const toolsState = ref<"loading" | "unknown" | "known">("loading");
 
 async function loadAvailableTools(sessionId: string | null) {
   const loadId = ++latestToolsLoad;
   const url = sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools";
   // Overtaken: a load for another session (we switched away), or a newer load for this one.
   const overtaken = () => sessionId !== props.sessionId || loadId !== latestToolsLoad;
+  toolsState.value = "loading";
   try {
     const res = await fetchWithTimeout(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -110,7 +115,7 @@ async function loadAvailableTools(sessionId: string | null) {
     const listed = isUnknownArray(body.tools) ? body.tools.filter(isAvailableTool) : null;
     availableTools.value = listed ?? [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
-    toolsUnknown.value = listed === null;
+    toolsState.value = listed === null ? "unknown" : "known";
   } catch {
     if (overtaken()) return;
     availableTools.value = [];
@@ -121,7 +126,7 @@ async function loadAvailableTools(sessionId: string | null) {
     // list from a FAILED request is not evidence that no group is registered, and telling the
     // reader to go and enable one would send them to fix a folder that may be configured fine
     // (CodeRabbit on #1966).
-    toolsUnknown.value = true;
+    toolsState.value = "unknown";
   }
 }
 watch(() => props.sessionId, loadAvailableTools, { immediate: true });
@@ -246,7 +251,8 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
              switch is on an empty cell's LAUNCH FORM, so it is not on screen while this session
              runs, and the registration is read when a session STARTS. Naming one without the other
              sends the reader hunting for a control that is not there. -->
-        <div v-if="availableTools.length === 0 && toolsUnknown" data-testid="tools-unknown" class="text-[12px] leading-relaxed text-dim">
+        <div v-if="availableTools.length === 0 && toolsState === 'loading'" data-testid="tools-loading" class="text-[12px] text-dim">Checking…</div>
+        <div v-else-if="availableTools.length === 0 && toolsState === 'unknown'" data-testid="tools-unknown" class="text-[12px] leading-relaxed text-dim">
           Could not ask this server which tools are enabled. The list below is empty because the request failed, not because nothing is registered.
         </div>
         <div v-else-if="availableTools.length === 0" data-testid="tools-empty" class="text-[12px] leading-relaxed text-dim">

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -227,7 +227,18 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
       <!-- Available tools -->
       <div class="border-b border-border px-3 py-2.5">
         <div class="mb-2 text-[11px] font-bold uppercase tracking-[0.04em] text-dim">Available Tools</div>
-        <div v-if="availableTools.length === 0" class="text-[12px] text-dim">No GUI plugin tools enabled.</div>
+        <!-- Not just "there are none": someone reading this pane is here BECAUSE they expected a
+             tool, and the empty state used to end the trail (#1966). Both halves are needed — the
+             switch is on an empty cell's LAUNCH FORM, so it is not on screen while this session
+             runs, and the registration is read when a session STARTS. Naming one without the other
+             sends the reader hunting for a control that is not there. -->
+        <div v-if="availableTools.length === 0" data-testid="tools-empty" class="text-[12px] leading-relaxed text-dim">
+          No GUI plugin tools enabled. They come from the tool groups registered for this folder — the switches are on an empty cell's launch form (<span
+            class="text-secondary"
+            >Workspace data</span
+          >, <span class="text-secondary">Canvas</span>, <span class="text-secondary">External accounts</span>), and a session reads the registration when it
+          starts, so turn one on before launching.
+        </div>
         <div v-for="tool in availableTools" :key="tool.toolName" class="[&+&]:mt-1">
           <button
             class="flex w-full cursor-pointer items-center justify-between gap-2 border-0 bg-transparent px-0 py-1 text-left text-inherit"

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -140,6 +140,17 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
   });
 
+  // A 200 whose body is not the shape the route promises — a proxy's error page, a truncated
+  // response — reaches here as `{}` from `jsonBody`. Every success path of `/api/tools` sends the
+  // array, so its absence is "unreadable", not "none" (Codex on #1966).
+  it("treats a 200 with no tools array as unreadable, not as an empty configuration", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? {} : { toolCalls: [] })));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-unknown"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+  });
+
   // …and the guidance comes back once a request succeeds with nothing in it, so a transient
   // failure does not leave the pane stuck on "could not ask".
   it("returns to the guidance after a failed request is followed by an empty one", async () => {

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -128,6 +128,38 @@ describe("ToolsPane", () => {
     ["Workspace data", "Canvas", "External accounts"].forEach((heading) => expect(empty).toContain(heading));
   });
 
+  // The pane mounts BEFORE the first response, and it is re-asked whenever the cell changes — so
+  // "empty" has to mean "still asking" until an answer arrives, or the pane reports the PREVIOUS
+  // session's answer as this one's (Codex on #1966, the third door into "an empty list is not
+  // evidence").
+  //
+  // The second load is what this asserts, deliberately. `immediate: true` makes the watcher assign
+  // "loading" before anything can observe the ref's initial value, so a test that only covers the
+  // first request passes whatever that initial value is — which is how the first version of this
+  // test could not fail.
+  it("does not claim anything while a request is in flight", async () => {
+    let release: ((value: unknown) => void) | null = null;
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<Response>((resolve) => (release = resolve as (value: unknown) => void)) : Promise.resolve(jsonRes({ tools: [] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true); // answered: none
+
+    // Another cell. Until IT answers, the previous answer must not stand in for it.
+    pend = true;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+
+    release?.(jsonRes({ tools: [] }));
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true);
+  });
+
   // An empty list from a FAILED request is not evidence that nothing is registered, and the
   // guidance above would send the reader to fix a folder that may be configured fine. The file
   // already reasons this way one field over — `guiOnlyHistory` resets on failure with "Unknown, so

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -184,6 +184,26 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
   });
 
+  // An array that arrives and yields nothing is the same class one layer down: the route sends
+  // well-formed summaries, so entries this rejects came from a proxy or a version skew. Saying
+  // "none are enabled" there sends the reader to fix a folder that is fine (Codex on #1966).
+  it("treats a tools array whose entries are all unusable as unreadable", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: [{}, { nope: 1 }] } : { toolCalls: [] })));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-unknown"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+  });
+
+  // …but a genuinely empty array is still the answer it looks like, or the guidance could never
+  // appear at all.
+  it("keeps an empty array as a real answer", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: [] } : { toolCalls: [] })));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true);
+  });
+
   // …and the guidance comes back once a request succeeds with nothing in it, so a transient
   // failure does not leave the pane stuck on "could not ask".
   it("returns to the guidance after a failed request is followed by an empty one", async () => {

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -138,11 +138,11 @@ describe("ToolsPane", () => {
   // first request passes whatever that initial value is — which is how the first version of this
   // test could not fail.
   it("does not claim anything while a request is in flight", async () => {
-    let release: ((value: unknown) => void) | null = null;
+    const held: Array<(value: unknown) => void> = [];
     let pend = false;
     mockFetch((url) => {
       if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
-      return pend ? new Promise<Response>((resolve) => (release = resolve as (value: unknown) => void)) : Promise.resolve(jsonRes({ tools: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [] }));
     });
     const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
     await flushPromises();
@@ -155,7 +155,8 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
 
-    release?.(jsonRes({ tools: [] }));
+    expect(held).toHaveLength(1); // the second request IS in flight, so the gap under test is real
+    held.forEach((resolve) => resolve(jsonRes({ tools: [] })));
     await flushPromises();
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true);
   });

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -128,6 +128,37 @@ describe("ToolsPane", () => {
     ["Workspace data", "Canvas", "External accounts"].forEach((heading) => expect(empty).toContain(heading));
   });
 
+  // An empty list from a FAILED request is not evidence that nothing is registered, and the
+  // guidance above would send the reader to fix a folder that may be configured fine. The file
+  // already reasons this way one field over — `guiOnlyHistory` resets on failure with "Unknown, so
+  // claim nothing" (CodeRabbit on #1966).
+  it("says it could not ask, rather than blaming the config, when the request fails", async () => {
+    mockFetch((url) => (url.startsWith("/api/tools") ? Promise.reject(new Error("offline")) : Promise.resolve(jsonRes({ toolCalls: [] }))));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-unknown"]').text()).toContain("Could not ask this server");
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+  });
+
+  // …and the guidance comes back once a request succeeds with nothing in it, so a transient
+  // failure does not leave the pane stuck on "could not ask".
+  it("returns to the guidance after a failed request is followed by an empty one", async () => {
+    let fail = true;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return fail ? Promise.reject(new Error("offline")) : Promise.resolve(jsonRes({ tools: [] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-unknown"]').exists()).toBe(true);
+
+    fail = false;
+    capturedGroups?.({ sessionId: "a", groups: ["render"] });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="tools-unknown"]').exists()).toBe(false);
+  });
+
   // The pane asks what tools a session has while the agent is still starting, so the first answer
   // is "none" — and it used to stand there until something remounted the pane. That is the
   // "No GUI plugin tools enabled." a freshly launched session showed until it was redrawn.

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -113,6 +113,21 @@ describe("ToolsPane", () => {
     expect(wrapper.text()).not.toContain("OldTool");
   });
 
+  // The empty state is where someone who expected a tool ends up, so it has to say where tools come
+  // from — and BOTH halves of that, because the switch is on an empty cell's launch form (not on
+  // screen while this session runs) and the registration is read when a session starts. Naming one
+  // without the other sends the reader hunting for a control that is not there (#1966).
+  it("tells the reader where tools come from when there are none", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: [] } : { toolCalls: [] })));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    const empty = wrapper.find('[data-testid="tools-empty"]').text();
+    expect(empty).toContain("launch form");
+    expect(empty).toContain("when it starts");
+    // The switches' own labels, so the sentence and the control agree on what to look for.
+    ["Workspace data", "Canvas", "External accounts"].forEach((heading) => expect(empty).toContain(heading));
+  });
+
   // The pane asks what tools a session has while the agent is still starting, so the first answer
   // is "none" — and it used to stand there until something remounted the pane. That is the
   // "No GUI plugin tools enabled." a freshly launched session showed until it was redrawn.


### PR DESCRIPTION
## Summary

Tools ペインが空のとき、いまは `No GUI plugin tools enabled.` と出るだけで、**どうすれば有効になるのかが書かれていません**。#1931 の実例が示したのは、そこで詰まった人の探索がソースに向かうということでした。#1960 は skill 側（エージェントが自分で登録する）で、こちらは **skill を通らない、UI を見ている人**の経路です。

| 変更 | 場所 |
|---|---|
| 空状態に、ツールの出どころと有効化の手順を 1 文 | `src/components/ToolsPane.vue` |
| その 2 点が消えないよう固定 | `test/src/components/ToolsPane.spec.ts` |
| **空リストの意味を 3 状態に**（loading / unknown / known）—— レビューで判明した必須の付随変更 | `src/components/ToolsPane.vue` |

出る文言:

> No GUI plugin tools enabled. They come from the tool groups registered for this folder — the switches are on an empty cell's launch form (**Workspace data**, **Canvas**, **External accounts**), and a session reads the registration when it starts, so turn one on before launching.

## Items to Confirm / Review

**0. 文言だけでは足りませんでした（レビューで判明、本文を更新）。** 当初は空状態の文言 1 つを足す PR でしたが、`availableTools` が空になるのは 4 通りあり、そのうち 3 つは「設定が無い」ではありません —— リクエスト失敗、読めない 200、まだ応答が無い、配列は来たが中身が 1 件も使えない。**具体的で行動を促す文言にしたこと自体が、それらを「誤った断定」に変えました**（元の曖昧な 1 行なら無視されて済んでいた）。なので空リストの意味を `loading` / `unknown` / `known` の 3 状態にし、**`known` のときだけ**この案内を出します。規則は 1 か所（`readable`）に書いてあります。

**1. 2 つの事実が両方要る、というのがこの変更の主張です。** 片方だけだと元の失敗を繰り返します:

- **スイッチは空セルの「起動フォーム」にある**（`CellLaunchForm.vue:803`）。**セッション実行中は画面に出ません。** これを言わずに「ランチャーのスイッチで」と書くと、いま見えていないコントロールを探させることになります —— #1931 そのものです
- **登録はセッションが起動時に読む**。だから今のセルには効かず、「入れてから起動する」が必要です

**2. グループ名はランチャー自身の見出しを使いました**（`TOOL_GROUP_HEADINGS`、`common/toolGroups.ts:61`）。文言とコントロールが同じ語を使っていないと照合できないためです。なお `render` と `media` は見出しを共有する（どちらも **Canvas**）ので、3 つだけ挙げています。

**3. CLI 形（`claude mcp add …`）は載せていません。** #1960 で skill には入りましたが、ここを読んでいるのは UI の人で、起動フォームのトグルのほうが近道です。必要なら足せます。

**4. i18n は使っていません（意図的）。** `src/i18n` は「Settings モーダルのみ、他は段階移行中（#1566）」と明記されており、`ToolsPane` は未移行です。周囲に合わせてハードコード英語のままにしました。

## User Prompt

- #1931 の ②（Tools ペインの空状態に、登録手段への導線を出す）

## 検証

**実機。** 隔離サーバ（scratch HOME / ポート 34765 / 専用 tmux ソケット、復元済み）で、**空状態が出る条件**（ワークスペースの外のディレクトリ）にセルを開き、拡大して Tools ペインを開きました。

- 文言が出ることを DOM から確認
- **描画も確認**（スクリーンショット）: 折り返しが崩れず、スイッチ名が dim な本文から浮き上がって読める

**テストは「戻すと赤くなる」ことを確認済み**です（元の 1 文に戻すと、`launch form` / `when it starts` / 3 つの見出しの表明が落ちる）。

`yarn format` / `lint` / `typecheck` / `build` 0、`yarn test` **12029 passed / 50 skipped**。

Closes #1966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Available Tools empty state to distinguish failed or unreadable server responses from successful responses with no enabled tools.
  * Restored the appropriate guidance after a temporary request failure is followed by a successful empty response.

* **Tests**
  * Added coverage for tool availability guidance, unreadable responses, launch-form settings, session-start registration, and recovery from transient request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
