### PR TITLE
fix(tools): セル切り替え中に前のセッションのツール一覧が出たままになるのを直す (#1968)

### DIFF
--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onUnmounted } from "vue";
+import { ref, computed, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
 import { isRecord, optionalString } from "../../common/isRecord";
@@ -52,7 +52,15 @@ const emit = defineEmits<{ close: []; toggleExpand: [] }>();
 // (server/mcp/gui-call-history.ts).
 const guiOnlyHistory = ref(false);
 
-const availableTools = ref<AvailableTool[]>([]);
+/** The list AND the session it describes, because a list alone cannot say whose it is. Switching
+ *  cells re-asks, and until the answer lands the previous session's tools were being shown as this
+ *  session's — the `loading` state below could not cover it, being about an EMPTY list (#1968).
+ *
+ *  Paired rather than cleared on switch: clearing would also blank the pane on the re-ask a
+ *  session makes when the server announces its groups, which is a good answer we already have.
+ *  Pairing makes the stale state unrepresentable instead of short. */
+const loadedTools = ref<{ sessionId: string | null; tools: AvailableTool[] } | null>(null);
+const availableTools = computed<AvailableTool[]>(() => (loadedTools.value?.sessionId === props.sessionId ? loadedTools.value.tools : []));
 const toolCalls = ref<ToolCall[]>([]);
 
 // One call off the live channel. `toolName`, `status` and `at` are what every row renders from;
@@ -118,12 +126,12 @@ async function loadAvailableTools(sessionId: string | null) {
     const raw = isUnknownArray(body.tools) ? body.tools : null;
     const listed = raw === null ? null : raw.filter(isAvailableTool);
     const readable = listed !== null && raw !== null && (raw.length === 0 || listed.length > 0);
-    availableTools.value = listed ?? [];
+    loadedTools.value = { sessionId, tools: listed ?? [] };
     guiOnlyHistory.value = body.guiOnlyHistory === true;
     toolsState.value = readable ? "known" : "unknown";
   } catch {
     if (overtaken()) return;
-    availableTools.value = [];
+    loadedTools.value = { sessionId, tools: [] };
     // Unknown, so claim nothing: a note that appears on a failed request would be a statement
     // about a history we could not ask about.
     guiOnlyHistory.value = false;

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -50,7 +50,6 @@ const emit = defineEmits<{ close: []; toggleExpand: [] }>();
 // The SERVER decides it, and the client cannot: a codex launcher chip runs the user's own command
 // through the login shell, so nothing the browser holds about that cell names an agent at all
 // (server/mcp/gui-call-history.ts).
-const guiOnlyHistory = ref(false);
 
 /** The list AND the session it describes, because a list alone cannot say whose it is. Switching
  *  cells re-asks, and until the answer lands the previous session's tools were being shown as this
@@ -59,8 +58,13 @@ const guiOnlyHistory = ref(false);
  *  Paired rather than cleared on switch: clearing would also blank the pane on the re-ask a
  *  session makes when the server announces its groups, which is a good answer we already have.
  *  Pairing makes the stale state unrepresentable instead of short. */
-const loadedTools = ref<{ sessionId: string | null; tools: AvailableTool[] } | null>(null);
-const availableTools = computed<AvailableTool[]>(() => (loadedTools.value?.sessionId === props.sessionId ? loadedTools.value.tools : []));
+const loadedTools = ref<{ sessionId: string | null; tools: AvailableTool[]; guiOnlyHistory: boolean } | null>(null);
+/** The whole response, or nothing — one gate, so no field of it can go stale on its own. */
+const forThisSession = computed(() => (loadedTools.value?.sessionId === props.sessionId ? loadedTools.value : null));
+const availableTools = computed<AvailableTool[]>(() => forThisSession.value?.tools ?? []);
+// Same gate: this note describes the AGENT whose history is shown, so carrying it across a switch
+// would describe the wrong one.
+const guiOnlyHistory = computed(() => forThisSession.value?.guiOnlyHistory ?? false);
 const toolCalls = ref<ToolCall[]>([]);
 
 // One call off the live channel. `toolName`, `status` and `at` are what every row renders from;
@@ -126,15 +130,13 @@ async function loadAvailableTools(sessionId: string | null) {
     const raw = isUnknownArray(body.tools) ? body.tools : null;
     const listed = raw === null ? null : raw.filter(isAvailableTool);
     const readable = listed !== null && raw !== null && (raw.length === 0 || listed.length > 0);
-    loadedTools.value = { sessionId, tools: listed ?? [] };
-    guiOnlyHistory.value = body.guiOnlyHistory === true;
+    loadedTools.value = { sessionId, tools: listed ?? [], guiOnlyHistory: body.guiOnlyHistory === true };
     toolsState.value = readable ? "known" : "unknown";
   } catch {
     if (overtaken()) return;
-    loadedTools.value = { sessionId, tools: [] };
     // Unknown, so claim nothing: a note that appears on a failed request would be a statement
     // about a history we could not ask about.
-    guiOnlyHistory.value = false;
+    loadedTools.value = { sessionId, tools: [], guiOnlyHistory: false };
     // The same rule as the success path: an empty list we could not fill is not an answer.
     toolsState.value = "unknown";
   }

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -110,12 +110,23 @@ let latestToolsLoad = 0;
  *  enabled" while it is still being asked (#1966). */
 const toolsState = ref<"loading" | "unknown" | "known">("loading");
 
-async function loadAvailableTools(sessionId: string | null) {
+/** WHY the pane is asking, because the two callers mean different things and the answer decides
+ *  what may stay on screen.
+ *
+ *  `selected` — the cell changed. Whatever is held describes a session the user has moved away
+ *  from, or an earlier visit to this one, so it is dropped and the pane says it is asking.
+ *  `refreshed` — the SAME session announced its groups and we are confirming an answer we already
+ *  have. Dropping there blanks a good list every time an agent's MCP client connects (Codex on
+ *  #1969, which is right that the session tag alone cannot tell these apart). */
+type LoadReason = "selected" | "refreshed";
+
+async function loadAvailableTools(sessionId: string | null, reason: LoadReason = "selected") {
   const loadId = ++latestToolsLoad;
   const url = sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools";
   // Overtaken: a load for another session (we switched away), or a newer load for this one.
   const overtaken = () => sessionId !== props.sessionId || loadId !== latestToolsLoad;
   toolsState.value = "loading";
+  if (reason === "selected") loadedTools.value = null;
   try {
     const res = await fetchWithTimeout(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -141,7 +152,11 @@ async function loadAvailableTools(sessionId: string | null) {
     toolsState.value = "unknown";
   }
 }
-watch(() => props.sessionId, loadAvailableTools, { immediate: true });
+watch(
+  () => props.sessionId,
+  (sessionId) => void loadAvailableTools(sessionId, "selected"),
+  { immediate: true },
+);
 
 // The question above is normally asked BEFORE it can be answered: the browser is handed a session
 // id while the agent is still being spawned, so its MCP client has not connected and the server
@@ -154,7 +169,7 @@ watch(() => props.sessionId, loadAvailableTools, { immediate: true });
 // does not, and the announcement for a single-view session carries no groups at all (see
 // mcp-routes.ts).
 onToolGroupsAnnounced((announcement) => {
-  if (announcement.sessionId === props.sessionId) void loadAvailableTools(props.sessionId);
+  if (announcement.sessionId === props.sessionId) void loadAvailableTools(props.sessionId, "refreshed");
 });
 
 function callKey(c: ToolCall, i: number): string {

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -231,10 +231,31 @@ describe("ToolsPane", () => {
     await wrapper.setProps({ sessionId: "a" }); // back before either answered
     await flushPromises();
 
-    // A's own earlier answer is what the gate lets through — and it is empty, so the guidance is
-    // NOT what shows. The pane says it is asking, which is true.
     expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+  });
+
+  // The same reselect with a NON-empty earlier answer. The session tag alone cannot tell "the user
+  // came back to this cell" from "this session announced its groups", and the two want opposite
+  // things — so the CALLER says which, and a selection drops what it held (#1969).
+  it("does not resurrect a NON-empty earlier answer when the same session is selected again", async () => {
+    const held: Array<(value: unknown) => void> = [];
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [{ toolName: "presentDocument" }] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    pend = true;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    await wrapper.setProps({ sessionId: "a" }); // back before either answered
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
   });
 
   // The other half of the pairing, and the reason it is a pairing rather than a clear-on-switch:

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -161,6 +161,56 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true);
   });
 
+  // Switching cells re-asks, and until the answer lands the pane was still showing the PREVIOUS
+  // session's tools — as this session's. The `loading` state cannot cover it: that branch is
+  // guarded on an empty list, and this list is not empty (#1968).
+  it("does not show the previous session's tools while the new one is still being asked", async () => {
+    const held: Array<(value: unknown) => void> = [];
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [{ toolName: "presentDocument" }] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    pend = true;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
+
+    held.forEach((resolve) => resolve(jsonRes({ tools: [{ toolName: "presentChart" }] })));
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentChart");
+  });
+
+  // The other half of the pairing, and the reason it is a pairing rather than a clear-on-switch:
+  // a session re-asks when the server announces its groups, and blanking the pane for that would
+  // throw away a good answer we already have (#1968).
+  it("keeps the tools it has while the SAME session is re-asked", async () => {
+    const held: Array<(value: unknown) => void> = [];
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [{ toolName: "presentDocument" }] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    // The server announces this session's groups, which re-asks for the SAME session.
+    pend = true;
+    capturedGroups?.({ sessionId: "a", groups: ["render"] });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    held.forEach((resolve) => resolve(jsonRes({ tools: [{ toolName: "presentChart" }] })));
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentChart");
+  });
+
   // An empty list from a FAILED request is not evidence that nothing is registered, and the
   // guidance above would send the reader to fix a folder that may be configured fine. The file
   // already reasons this way one field over — `guiOnlyHistory` resets on failure with "Unknown, so

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -210,6 +210,33 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(false);
   });
 
+  // A -> B -> A, with A's earlier answer EMPTY. Codex read the session gate as re-showing A's
+  // prior response while the fresh A request is in flight; what matters is whether that response
+  // can be the misleading one, and it cannot: an empty list falls through to the loading branch,
+  // which is ordered first (#1969).
+  it("does not resurrect an EMPTY earlier answer when the same session is selected again", async () => {
+    const held: Array<(value: unknown) => void> = [];
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [] }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(true); // A answered: none
+
+    pend = true;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    await wrapper.setProps({ sessionId: "a" }); // back before either answered
+    await flushPromises();
+
+    // A's own earlier answer is what the gate lets through — and it is empty, so the guidance is
+    // NOT what shows. The pane says it is asking, which is true.
+    expect(wrapper.find('[data-testid="tools-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="tools-empty"]').exists()).toBe(false);
+  });
+
   // The other half of the pairing, and the reason it is a pairing rather than a clear-on-switch:
   // a session re-asks when the server announces its groups, and blanking the pane for that would
   // throw away a good answer we already have (#1968).

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -186,6 +186,30 @@ describe("ToolsPane", () => {
     expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentChart");
   });
 
+  // The same gate, one field over: `guiOnlyHistory` draws a note about the AGENT whose history is
+  // shown ("reports no hooks…"). Carried across a switch it describes the wrong agent, which is
+  // the stale-list bug wearing a different hat (#1968).
+  it("does not describe the previous session's agent while the new one is still being asked", async () => {
+    const held: Array<(value: unknown) => void> = [];
+    let pend = false;
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      return pend ? new Promise<unknown>((resolve) => held.push(resolve)) : Promise.resolve(jsonRes({ tools: [], guiOnlyHistory: true }));
+    });
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(true);
+
+    pend = true;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(false);
+
+    held.forEach((resolve) => resolve(jsonRes({ tools: [], guiOnlyHistory: false })));
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(false);
+  });
+
   // The other half of the pairing, and the reason it is a pairing rather than a clear-on-switch:
   // a session re-asks when the server announces its groups, and blanking the pane for that would
   // throw away a good answer we already have (#1968).


### PR DESCRIPTION
## Summary

セルを切り替えると、新しいセッションの応答が届くまで **Tools ペインが前のセッションのツール一覧を出したまま**でした（#1968）。しかも「読み込み中」とも言いません —— #1967 で入れた `loading` 表示は **空リスト**を条件にしているので、前のセルにツールがあった場合は出ないからです。

| 変更 | 場所 |
|---|---|
| 一覧を「どのセッションのものか」と対にする | `src/components/ToolsPane.vue` |
| 両方向の固定（切り替え中は出さない／同一セッションの再取得では消さない） | `test/src/components/ToolsPane.spec.ts` |

```ts
const loadedTools = ref<{ sessionId: string | null; tools: AvailableTool[] } | null>(null);
const availableTools = computed(() => (loadedTools.value?.sessionId === props.sessionId ? loadedTools.value.tools : []));
```

## Items to Confirm / Review

**1. 先にバグを再現させてから直しました。** 回帰テストは修正前の挙動に対して赤くなることを確認済みです（`expected true to be false`）。

**2. 「切り替え時にクリア」ではなく「対にする」を選びました。** クリアは自明な直し方ですが、こちらのほうが悪くなります —— **サーバがグループを通知すると同一セッションで再取得が走る**ので、クリアすると既に持っている正しい答えを毎回一瞬捨てることになります。対にすれば、古い状態が**そもそも表現できなく**なります（#1942 の Canvas 再オープンのガードと同じ形）。

**この判断はテストで固定してあります**: セッション判定を外すとバグが戻り、代わりに「切り替え時クリア」にすると**同一セッション再取得のテストが赤**になります。つまり採用案と却下案の両方が pin されています。

**3. `availableTools` を ref から computed に変えています。** 書き込み箇所は 2 つとも `loadedTools` 経由に置き換え済みで、typecheck が代入漏れを拾います。

**4. 実機で通常経路（空でない側）も確認しました。** ワークスペースのセルで 13 個のツールが並び、空状態・不明・読み込み中はいずれも出ず、console error なし。computed 化で普通の表示が壊れていないことの確認です。

## User Prompt

- #1968（#1967 のレビュー中に範囲外として切り出した欠陥）

## 検証

- 回帰テスト 2 本（切り替え中は前の一覧を出さない／同一セッション再取得では保持する）。**変異で両方向とも赤**
- `typecheck` / `lint` / `build` / 全テスト —— すべて**終了コードで確認**（このセッションでパイプの終了コードを見て赤を見逃した経緯があるため）
- 実機スモーク（隔離サーバ、ポート 34769、専用 tmux ソケット、復元済み）

Closes #1968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented tools and GUI-only history information from a previous session from appearing after switching sessions.
  * Preserved the current tool list while refreshing tools within the same session.
  * Prevented outdated empty responses from reappearing when revisiting a session.

* **Tests**
  * Added coverage for session changes, history metadata, and same-session tool-list refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->