### PR TITLE
fix: restore alternate-screen/mouse modes on reattach without tmux

### DIFF
--- a/server/session/output-relay.ts
+++ b/server/session/output-relay.ts
@@ -6,6 +6,7 @@
 // from 118k to 655k in one measurement (#1506). One frame each would move the cost we just
 // removed from appendBoundedOutput onto JSON.stringify and the socket.
 import { growOutputTail } from "./terminal-replay.js";
+import { TerminalModeTracker } from "./terminal-mode-tracker.js";
 import { sendFrame } from "./ws-frames.js";
 import type { PtyEntry } from "./types.js";
 
@@ -79,8 +80,14 @@ export function createOutputRelay(entry: PtyEntry, limit: number): OutputRelay {
 export function wireBufferedOutput(entry: PtyEntry, limit: number, tap?: (data: string) => void): OutputRelay {
   const relay = createOutputRelay(entry, limit);
   entry.output = relay;
+  // On a non-tmux session, track DECSET/DECRST modes from the byte stream so reattachPty can
+  // restore alternate-screen and mouse modes without querying tmux (#1972).
+  if (!entry.tmux) {
+    entry.modeTracker = new TerminalModeTracker();
+  }
   entry.term.onData((data) => {
     relay.push(data);
+    entry.modeTracker?.scan(data);
     tap?.(data);
   });
   return relay;

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -112,9 +112,12 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
     if (ws.readyState === ws.OPEN) {
       // The replay is a bounded TAIL, and the modes an app sets once at startup — the alternate
       // buffer above all — fell off its front long ago. Restore them first, or the browser draws
-      // this into the normal buffer and the wheel stops reaching the app (#1073). Only a tmux
-      // session can be asked; anything else replays as before.
-      const prefix = entry.tmux ? terminalModePrefix(deps.terminalModesOf(sessionId)) : "";
+      // this into the normal buffer and the wheel stops reaching the app (#1073).
+      // A tmux session asks tmux; a non-tmux session uses modes tracked from the byte stream
+      // (#1972) — without this, the browser replays into the normal buffer and the same output
+      // is drawn multiple times with garbled interleaving.
+      const modes = entry.tmux ? deps.terminalModesOf(sessionId) : (entry.modeTracker?.modes() ?? []);
+      const prefix = terminalModePrefix(modes);
       // Cut to the bound BEFORE stripping: the buffer runs over it (PtyEntry.buffer), and the
       // strip is five regex passes that would otherwise sweep the overrun as well.
       // Stripping keeps xterm from re-answering the replayed queries as stray input (e.g. a DA

--- a/server/session/terminal-mode-tracker.ts
+++ b/server/session/terminal-mode-tracker.ts
@@ -18,6 +18,32 @@ const ESC = "\x1b";
 // everything else in the stream is skipped as fast as possible.
 const TRACKED_MODES = new Set([1049, 1000, 1002, 1003, 1005, 1006]);
 
+// A real DECSET/DECRST sequence is at most `ESC[?1049;1000;1002;1003;1005;1006h` — well under
+// 64 bytes. A partial candidate longer than this is malformed PTY output; retaining it would
+// grow without bound and rescan on every chunk.
+const MAX_PARTIAL_BYTES = 64;
+
+const isDigit = (code: number) => code >= 0x30 && code <= 0x39;
+
+/** Find the end of a CSI `?` parameter run (digits and semicolons). Returns the index of the
+ *  first character past the run, or -1 when the run reaches `end` (split sequence). */
+function scanParams(input: string, start: number, end: number): number {
+  let j = start;
+  while (j < end && (isDigit(input.charCodeAt(j)) || input[j] === ";")) j++;
+  return j < end ? j : -1;
+}
+
+/** Apply tracked modes from a parsed `CSI ? <params> h/l` sequence. */
+function applyModes(params: string, enable: boolean, active: Set<number>): void {
+  for (const token of params.split(";")) {
+    const mode = Number(token);
+    if (TRACKED_MODES.has(mode)) {
+      if (enable) active.add(mode);
+      else active.delete(mode);
+    }
+  }
+}
+
 export class TerminalModeTracker {
   private active = new Set<number>();
   private partial = "";
@@ -32,49 +58,53 @@ export class TerminalModeTracker {
       const escIdx = input.indexOf(ESC, i);
       if (escIdx === -1) break;
 
-      // Need at least ESC [ ? to continue — carry forward if the chunk ends here.
-      if (escIdx + 2 >= input.length) {
-        this.partial = input.slice(escIdx);
-        return;
-      }
-
-      if (input[escIdx + 1] !== "[" || input[escIdx + 2] !== "?") {
-        i = escIdx + 1;
-        continue;
-      }
-
-      // ESC [ ? found — read digits and semicolons until the final byte.
-      let j = escIdx + 3;
-      while (j < input.length && ((input.charCodeAt(j) >= 0x30 && input.charCodeAt(j) <= 0x39) || input[j] === ";")) {
-        j++;
-      }
-
-      if (j >= input.length) {
-        // The sequence is split: params started but no final byte yet.
-        this.partial = input.slice(escIdx);
-        return;
-      }
-
-      const finalByte = input[j];
-      if (finalByte === "h" || finalByte === "l") {
-        const params = input.slice(escIdx + 3, j);
-        if (params.length > 0) {
-          for (const token of params.split(";")) {
-            const mode = Number(token);
-            if (TRACKED_MODES.has(mode)) {
-              if (finalByte === "h") this.active.add(mode);
-              else this.active.delete(mode);
-            }
-          }
-        }
-      }
-
-      i = j + 1;
+      const after = this.handleEscape(input, escIdx);
+      if (after === -1) return; // partial carried forward
+      i = after;
     }
+  }
+
+  /** Dispatch a single ESC sequence starting at `escIdx`. Returns the index to resume scanning
+   *  from, or -1 when a partial was retained (caller should return). */
+  private handleEscape(input: string, escIdx: number): number {
+    // RIS (full reset) clears every mode the terminal had set.
+    if (input[escIdx + 1] === "c") {
+      this.active.clear();
+      return escIdx + 2;
+    }
+
+    // Need at least ESC [ ? to continue — carry forward if the chunk ends here.
+    if (escIdx + 2 >= input.length) {
+      this.retainPartial(input, escIdx);
+      return -1;
+    }
+
+    if (input[escIdx + 1] !== "[" || input[escIdx + 2] !== "?") return escIdx + 1;
+
+    const paramEnd = scanParams(input, escIdx + 3, input.length);
+    if (paramEnd === -1) {
+      this.retainPartial(input, escIdx);
+      return -1;
+    }
+
+    const finalByte = input[paramEnd];
+    if (finalByte === "h" || finalByte === "l") {
+      const params = input.slice(escIdx + 3, paramEnd);
+      if (params.length > 0) applyModes(params, finalByte === "h", this.active);
+    }
+
+    return paramEnd + 1;
   }
 
   /** The modes currently on, in the same shape terminalModesOf returns. */
   modes(): readonly number[] {
     return [...this.active];
+  }
+
+  /** Carry an incomplete sequence forward, bounded to prevent unbounded growth from malformed
+   *  PTY output that never delivers a final byte. */
+  private retainPartial(input: string, from: number): void {
+    const candidate = input.slice(from);
+    this.partial = candidate.length <= MAX_PARTIAL_BYTES ? candidate : "";
   }
 }

--- a/server/session/terminal-mode-tracker.ts
+++ b/server/session/terminal-mode-tracker.ts
@@ -93,7 +93,9 @@ export class TerminalModeTracker {
       if (params.length > 0) applyModes(params, finalByte === "h", this.active);
     }
 
-    return paramEnd + 1;
+    // When a CSI is aborted by another ESC (e.g. `ESC[?ESC[?1049h`), the "final byte" is
+    // ESC itself. Return to it so the scanner picks up the new sequence instead of skipping it.
+    return finalByte === ESC ? paramEnd : paramEnd + 1;
   }
 
   /** The modes currently on, in the same shape terminalModesOf returns. */

--- a/server/session/terminal-mode-tracker.ts
+++ b/server/session/terminal-mode-tracker.ts
@@ -1,0 +1,80 @@
+// Track DECSET/DECRST terminal modes directly from the PTY byte stream.
+//
+// On a tmux-backed session, tmux is queried for the current modes at reattach time. On a host
+// with no tmux, that query has no answer, and the reattach replays into a browser that never
+// learns it should be in the alternate screen — producing the garbled-scrollback corruption
+// described in #1773 / #1972.
+//
+// This tracker is the fallback: it scans every chunk the PTY emits for the same mode sequences
+// tmux would report (DECSET `CSI ? <modes> h` and DECRST `CSI ? <modes> l`), and answers the
+// same question reattachPty asks of tmux.
+//
+// Handles a CSI sequence split across two consecutive chunks by carrying the partial tail
+// forward — the concern infra/tmux.ts avoided by querying tmux instead of the byte stream.
+
+const ESC = "\x1b";
+
+// The same modes tmux reports via TERMINAL_MODE_FLAGS (infra/tmux.ts). Only these are tracked;
+// everything else in the stream is skipped as fast as possible.
+const TRACKED_MODES = new Set([1049, 1000, 1002, 1003, 1005, 1006]);
+
+export class TerminalModeTracker {
+  private active = new Set<number>();
+  private partial = "";
+
+  /** Scan a chunk of PTY output and update the tracked mode set. */
+  scan(data: string): void {
+    const input = this.partial + data;
+    this.partial = "";
+
+    let i = 0;
+    while (i < input.length) {
+      const escIdx = input.indexOf(ESC, i);
+      if (escIdx === -1) break;
+
+      // Need at least ESC [ ? to continue — carry forward if the chunk ends here.
+      if (escIdx + 2 >= input.length) {
+        this.partial = input.slice(escIdx);
+        return;
+      }
+
+      if (input[escIdx + 1] !== "[" || input[escIdx + 2] !== "?") {
+        i = escIdx + 1;
+        continue;
+      }
+
+      // ESC [ ? found — read digits and semicolons until the final byte.
+      let j = escIdx + 3;
+      while (j < input.length && ((input.charCodeAt(j) >= 0x30 && input.charCodeAt(j) <= 0x39) || input[j] === ";")) {
+        j++;
+      }
+
+      if (j >= input.length) {
+        // The sequence is split: params started but no final byte yet.
+        this.partial = input.slice(escIdx);
+        return;
+      }
+
+      const finalByte = input[j];
+      if (finalByte === "h" || finalByte === "l") {
+        const params = input.slice(escIdx + 3, j);
+        if (params.length > 0) {
+          for (const token of params.split(";")) {
+            const mode = Number(token);
+            if (TRACKED_MODES.has(mode)) {
+              if (finalByte === "h") this.active.add(mode);
+              else this.active.delete(mode);
+            }
+          }
+        }
+      }
+
+      i = j + 1;
+    }
+  }
+
+  /** The modes currently on, in the same shape terminalModesOf returns. */
+  modes(): readonly number[] {
+    return [...this.active];
+  }
+}

--- a/server/session/terminal-mode-tracker.ts
+++ b/server/session/terminal-mode-tracker.ts
@@ -14,9 +14,10 @@
 
 const ESC = "\x1b";
 
-// The same modes tmux reports via TERMINAL_MODE_FLAGS (infra/tmux.ts). Only these are tracked;
-// everything else in the stream is skipped as fast as possible.
-const TRACKED_MODES = new Set([1049, 1000, 1002, 1003, 1005, 1006]);
+// The modes to track. Includes the six modes tmux reports via TERMINAL_MODE_FLAGS
+// (infra/tmux.ts) plus the two legacy alternate-screen modes (47, 1047) that tmux
+// has no flag for but a non-tmux application may still use.
+const TRACKED_MODES = new Set([47, 1047, 1049, 1000, 1002, 1003, 1005, 1006]);
 
 // A real DECSET/DECRST sequence is at most `ESC[?1049;1000;1002;1003;1005;1006h` — well under
 // 64 bytes. A partial candidate longer than this is malformed PTY output; retaining it would

--- a/server/session/terminal-mode-tracker.ts
+++ b/server/session/terminal-mode-tracker.ts
@@ -15,9 +15,10 @@
 const ESC = "\x1b";
 
 // The modes to track. Includes the six modes tmux reports via TERMINAL_MODE_FLAGS
-// (infra/tmux.ts) plus the two legacy alternate-screen modes (47, 1047) that tmux
-// has no flag for but a non-tmux application may still use.
-const TRACKED_MODES = new Set([47, 1047, 1049, 1000, 1002, 1003, 1005, 1006]);
+// (infra/tmux.ts), the two legacy alternate-screen modes (47, 1047) that tmux has no
+// flag for but a non-tmux application may still use, and bracketed paste (2004) which
+// an app enables once at startup and expects to survive a reattach.
+const TRACKED_MODES = new Set([47, 1047, 1049, 1000, 1002, 1003, 1005, 1006, 2004]);
 
 // A real DECSET/DECRST sequence is at most `ESC[?1049;1000;1002;1003;1005;1006h` — well under
 // 64 bytes. A partial candidate longer than this is malformed PTY output; retaining it would

--- a/server/session/types.ts
+++ b/server/session/types.ts
@@ -6,6 +6,7 @@ import type { WebSocket } from "ws";
 import type { WorkerStatus } from "../../common/workerStatus.js";
 import type { SessionAgent } from "../../common/sessionAgent.js";
 import type { OutputRelay } from "./output-relay.js";
+import type { TerminalModeTracker } from "./terminal-mode-tracker.js";
 
 export interface Activity {
   working?: boolean;
@@ -39,6 +40,9 @@ export interface PtyEntry {
   // (see tmuxRedrawClient). Cleared by the first resize frame after the reattach — waiting for it
   // is the point, since that frame is where the client tells us the size it actually settled at.
   redrawPending?: boolean;
+  // DECSET/DECRST modes tracked from the PTY byte stream, for hosts with no tmux (#1972).
+  // tmux-backed sessions query tmux instead (terminalModesOf); this is the non-tmux fallback.
+  modeTracker?: TerminalModeTracker;
   // What is running in this PTY. Recorded at spawn because nothing else can recover it
   // later, and the phone needs it to offer input that suits the session (mulmoserver#84).
   agent: SessionAgent;

--- a/test/server/session/output-relay.spec.ts
+++ b/test/server/session/output-relay.spec.ts
@@ -180,4 +180,24 @@ describe("wireBufferedOutput", () => {
     pty.feed("c");
     expect(seen).toEqual(["a", "b", "c"]); // b and c are still queued for the browser
   });
+
+  it("creates a mode tracker for non-tmux entries and feeds PTY output through it (#1972)", () => {
+    const pty = fakePty();
+    const entry = entryFor(pty, fakeSocket().socket);
+    wireBufferedOutput(entry, LIMIT);
+    expect(entry.modeTracker).toBeDefined();
+    pty.feed("\x1b[?1049h\x1b[?1006h");
+    const tracker = entry.modeTracker;
+    expect(tracker).toBeDefined();
+    if (!tracker) return; // type guard — the assertion above catches the real failure
+    const modes = [...tracker.modes()].sort();
+    expect(modes).toEqual([1006, 1049]);
+  });
+
+  it("does not create a mode tracker for tmux entries", () => {
+    const pty = fakePty();
+    const entry = { ...entryFor(pty, fakeSocket().socket), tmux: true } as unknown as PtyEntry;
+    wireBufferedOutput(entry, LIMIT);
+    expect(entry.modeTracker).toBeUndefined();
+  });
 });

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { createConnectionHandlers, handleCommandFrame } from "../../../server/session/pty-connection.js";
 import type { PtyEntry } from "../../../server/session/types.js";
+import { TerminalModeTracker } from "../../../server/session/terminal-mode-tracker.js";
 import { otherWriteCount, stopWatchingOtherWrites, watchOtherWrites } from "../../../server/session/write-to-session";
 
 const OPEN = 1;
@@ -432,6 +433,25 @@ describe("reattachPty", () => {
     reattachPty(entryWith({ ws: null, buffer: "sandboxed output" }), s.ws as never, SESSION);
     expect(calls).toEqual([`cancelReap:${SESSION}`]);
     expect(s.parsed()).toEqual([{ type: "output", data: "sandboxed output" }]);
+  });
+
+  it("restores tracked modes on a non-tmux reattach (#1972)", () => {
+    // End-to-end: a non-tmux entry whose modeTracker has seen DECSET sequences gets the
+    // mode prefix prepended to its replay, just as a tmux entry would via terminalModesOf.
+    const { reattachPty, calls } = setup();
+    const s = fakeSocket();
+    const tracker = new TerminalModeTracker();
+    tracker.scan("\x1b[?1049h\x1b[?1006h");
+    const entry = entryWith({ ws: null, buffer: "app output", modeTracker: tracker });
+    reattachPty(entry, s.ws as never, SESSION);
+    // terminalModesOf must NOT be called — the tracker is the source.
+    expect(calls).toEqual([`cancelReap:${SESSION}`]);
+    const frames = s.parsed();
+    expect(frames).toHaveLength(1);
+    const data = frames[0].data as string;
+    expect(data).toContain("\x1b[?1049h");
+    expect(data).toContain("\x1b[?1006h");
+    expect(data).toContain("app output");
   });
 
   it("leaves a pane with nothing sticky set replaying exactly as before", () => {

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { createConnectionHandlers, handleCommandFrame } from "../../../server/session/pty-connection.js";
 import type { PtyEntry } from "../../../server/session/types.js";
 import { TerminalModeTracker } from "../../../server/session/terminal-mode-tracker.js";
+import { wireBufferedOutput } from "../../../server/session/output-relay.js";
 import { otherWriteCount, stopWatchingOtherWrites, watchOtherWrites } from "../../../server/session/write-to-session";
 
 const OPEN = 1;
@@ -445,6 +446,29 @@ describe("reattachPty", () => {
     const entry = entryWith({ ws: null, buffer: "app output", modeTracker: tracker });
     reattachPty(entry, s.ws as never, SESSION);
     // terminalModesOf must NOT be called — the tracker is the source.
+    expect(calls).toEqual([`cancelReap:${SESSION}`]);
+    const frames = s.parsed();
+    expect(frames).toHaveLength(1);
+    const data = frames[0].data as string;
+    const outputIndex = data.indexOf("app output");
+    expect(data.indexOf("\x1b[?1049h")).toBeLessThan(outputIndex);
+    expect(data.indexOf("\x1b[?1006h")).toBeLessThan(outputIndex);
+  });
+
+  it("restores modes wired through wireBufferedOutput on non-tmux reattach (#1972 e2e)", () => {
+    // Full path: wireBufferedOutput creates the tracker, PTY output feeds through it,
+    // and reattachPty reads the tracked modes into the replay prefix.
+    const { reattachPty, calls } = setup();
+    let emit: ((data: string) => void) | undefined;
+    const term = { pid: 9999, onData: (fn: (data: string) => void) => (emit = fn) };
+    const entry = { term, ws: null, buffer: "", cwd: "/e2e", active: false, agent: "claude" } as unknown as PtyEntry;
+    wireBufferedOutput(entry, OUTPUT_BUFFER_LIMIT);
+    // Simulate PTY emitting DECSET sequences (as Claude Code does at startup).
+    emit?.("\x1b[?1049h\x1b[?1006happ output");
+    // Detach the relay socket so reattach replays from the buffer.
+    entry.ws = null;
+    const s = fakeSocket();
+    reattachPty(entry, s.ws as never, SESSION);
     expect(calls).toEqual([`cancelReap:${SESSION}`]);
     const frames = s.parsed();
     expect(frames).toHaveLength(1);

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -449,9 +449,9 @@ describe("reattachPty", () => {
     const frames = s.parsed();
     expect(frames).toHaveLength(1);
     const data = frames[0].data as string;
-    expect(data).toContain("\x1b[?1049h");
-    expect(data).toContain("\x1b[?1006h");
-    expect(data).toContain("app output");
+    const outputIndex = data.indexOf("app output");
+    expect(data.indexOf("\x1b[?1049h")).toBeLessThan(outputIndex);
+    expect(data.indexOf("\x1b[?1006h")).toBeLessThan(outputIndex);
   });
 
   it("leaves a pane with nothing sticky set replaying exactly as before", () => {

--- a/test/server/session/terminal-mode-tracker.spec.ts
+++ b/test/server/session/terminal-mode-tracker.spec.ts
@@ -80,4 +80,22 @@ describe("TerminalModeTracker", () => {
     t.scan(`${ESC}[31m${ESC}[?1049h${ESC}[0m`);
     expect(t.modes()).toEqual([1049]);
   });
+
+  it("clears all modes on RIS (ESC c)", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?1049h${ESC}[?1000h${ESC}[?1006h`);
+    expect(t.modes().length).toBe(3);
+    t.scan(`${ESC}c`);
+    expect(t.modes()).toEqual([]);
+  });
+
+  it("discards an overlong partial candidate (malformed PTY)", () => {
+    const t = new TerminalModeTracker();
+    // A partial that exceeds the bound is dropped rather than retained.
+    const longDigits = "1".repeat(100);
+    t.scan(`${ESC}[?${longDigits}`);
+    // Next chunk should not see the stale partial.
+    t.scan(`${ESC}[?1049h`);
+    expect(t.modes()).toEqual([1049]);
+  });
 });

--- a/test/server/session/terminal-mode-tracker.spec.ts
+++ b/test/server/session/terminal-mode-tracker.spec.ts
@@ -84,9 +84,16 @@ describe("TerminalModeTracker", () => {
   it("clears all modes on RIS (ESC c)", () => {
     const t = new TerminalModeTracker();
     t.scan(`${ESC}[?1049h${ESC}[?1000h${ESC}[?1006h`);
-    expect(t.modes().length).toBe(3);
+    expect(t.modes()).toHaveLength(3);
     t.scan(`${ESC}c`);
     expect(t.modes()).toEqual([]);
+  });
+
+  it("tracks a mode after an ESC-aborted CSI sequence", () => {
+    const t = new TerminalModeTracker();
+    // ESC[? with no final byte, immediately followed by a valid DECSET
+    t.scan(`${ESC}[?${ESC}[?1049h`);
+    expect(t.modes()).toEqual([1049]);
   });
 
   it("discards an overlong partial candidate (malformed PTY)", () => {

--- a/test/server/session/terminal-mode-tracker.spec.ts
+++ b/test/server/session/terminal-mode-tracker.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { TerminalModeTracker } from "../../../server/session/terminal-mode-tracker.js";
+
+const ESC = "\x1b";
+
+describe("TerminalModeTracker", () => {
+  it("tracks a single DECSET mode", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?1049h`);
+    expect(t.modes()).toEqual([1049]);
+  });
+
+  it("tracks multiple modes in one sequence", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?1049;1000;1006h`);
+    const modes = [...t.modes()].sort();
+    expect(modes).toEqual([1000, 1006, 1049]);
+  });
+
+  it("removes modes on DECRST", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?1049h${ESC}[?1000h`);
+    expect(t.modes()).toContain(1049);
+    expect(t.modes()).toContain(1000);
+    t.scan(`${ESC}[?1049l`);
+    expect(t.modes()).not.toContain(1049);
+    expect(t.modes()).toContain(1000);
+  });
+
+  it("ignores untracked modes", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?25h`); // cursor visibility — not tracked
+    expect(t.modes()).toEqual([]);
+  });
+
+  it("handles modes embedded in other output", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`hello${ESC}[?1049hworld${ESC}[?1006h`);
+    const modes = [...t.modes()].sort();
+    expect(modes).toEqual([1006, 1049]);
+  });
+
+  it("handles a sequence split across two chunks — ESC at end", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`output${ESC}`);
+    t.scan(`[?1049h`);
+    expect(t.modes()).toEqual([1049]);
+  });
+
+  it("handles a sequence split across two chunks — ESC[ at end", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`output${ESC}[`);
+    t.scan(`?1049h`);
+    expect(t.modes()).toEqual([1049]);
+  });
+
+  it("handles a sequence split across two chunks — params split", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?10`);
+    t.scan(`49h`);
+    expect(t.modes()).toEqual([1049]);
+  });
+
+  it("handles a sequence split after semicolon", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?1049;`);
+    t.scan(`1006h`);
+    const modes = [...t.modes()].sort();
+    expect(modes).toEqual([1006, 1049]);
+  });
+
+  it("returns empty for a fresh tracker", () => {
+    const t = new TerminalModeTracker();
+    expect(t.modes()).toEqual([]);
+  });
+
+  it("survives non-DECSET CSI sequences without tracking them", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[31m${ESC}[?1049h${ESC}[0m`);
+    expect(t.modes()).toEqual([1049]);
+  });
+});

--- a/test/server/session/terminal-mode-tracker.spec.ts
+++ b/test/server/session/terminal-mode-tracker.spec.ts
@@ -28,6 +28,15 @@ describe("TerminalModeTracker", () => {
     expect(t.modes()).toContain(1000);
   });
 
+  it("tracks legacy alternate-screen modes 47 and 1047", () => {
+    const t = new TerminalModeTracker();
+    t.scan(`${ESC}[?47h`);
+    expect(t.modes()).toEqual([47]);
+    t.scan(`${ESC}[?1047h`);
+    const modes = [...t.modes()].sort((a, b) => a - b);
+    expect(modes).toEqual([47, 1047]);
+  });
+
   it("ignores untracked modes", () => {
     const t = new TerminalModeTracker();
     t.scan(`${ESC}[?25h`); // cursor visibility — not tracked


### PR DESCRIPTION
## Summary

- On a host with no tmux, `reattachPty()` sent an empty mode-restoration prefix because `terminalModePrefix` was gated on `entry.tmux`. The browser replayed the buffered tail into the normal buffer, producing duplicated blocks with garbled interleaving (#1972, #1773).
- Added `TerminalModeTracker` that scans the PTY byte stream for DECSET/DECRST sequences and records which modes are currently on, handling sequences split across consecutive chunks.
- For non-tmux sessions, `wireBufferedOutput` creates a tracker; `reattachPty` uses the tracked modes as fallback so the browser enters the alternate screen before the replay data arrives.

## Items to Confirm / Review

- The tracker only scans for the six modes tmux reports (`TERMINAL_MODE_FLAGS`): 1049, 1000, 1002, 1003, 1005, 1006. This matches what `terminalModePrefix` sends. Confirm this covers all modes needed for correct reattach.
- Non-tmux sessions do not get `redrawPending = true` because there is no tmux to repaint. The app redraws on the resize frame the browser sends after reattach. Confirm this is sufficient.
- The chunk-split handling carries partial sequences forward via a `partial` string field. The test covers ESC-at-end, ESC[-at-end, and params-split cases.

## User Prompt

issue #1972 の修正: tmux の無いホストで Claude セルの同じ応答が何度も描画される問題を修正する。

Closes #1972

work in mulmoterminal2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session reattachment so terminal modes are preserved more reliably, including for non-tmux sessions.
  * Prevented alternate-screen display issues when reconnecting, including legacy terminal modes.
  * Improved handling of terminal control sequences split across output chunks and recovery from interrupted sequences.
  * Added safeguards for malformed or incomplete sequences to prevent excessive processing.

* **Tests**
  * Added coverage for tracking, updating, and restoring terminal modes across varied terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->