### PR TITLE
fix: IME composition box follows the active theme

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -168,6 +168,15 @@
   --err-hover-bg: #f6d4d7;
 }
 
+/* xterm.css hard-codes .composition-view to white-on-black, which shows up as a
+   black box on light themes. Override with theme tokens so the IME pre-edit
+   string follows the active palette (#1973). */
+.xterm .composition-view {
+  color: var(--term-fg);
+  background: var(--bg-selected);
+  outline: 1px solid var(--accent);
+}
+
 /* These global defaults live in @layer base so Tailwind utilities (@layer
    utilities, declared last in tailwind.css) can override them. Unlayered they
    would WIN over every utility: the universal reset silently killed every

--- a/src/style.css
+++ b/src/style.css
@@ -170,8 +170,10 @@
 
 /* xterm.css hard-codes .composition-view to white-on-black, which shows up as a
    black box on light themes. Override with theme tokens so the IME pre-edit
-   string follows the active palette (#1973). */
-.xterm .composition-view {
+   string follows the active palette (#1973). `:root` raises specificity above
+   the identically-qualified xterm.css rule that loads later (via
+   useTerminalConnections.ts), so import order cannot win back. */
+:root .xterm .composition-view {
   color: var(--term-fg);
   background: var(--bg-selected);
   outline: 1px solid var(--accent);


### PR DESCRIPTION
## Summary

- Override xterm.css's hard-coded white-on-black `.xterm .composition-view` with theme tokens (`--term-fg`, `--bg-selected`, `--accent`) so the IME pre-edit string follows the active palette
- One CSS rule added to `src/style.css`, no JS change

## Items to Confirm / Review

- The override uses `--bg-selected` (not `--term-selection`) to distinguish pre-edit text from mouse selections — matches the issue's proposal
- Dark themes see minimal visual change (their `--bg-selected` is a dark blue, close to the original black)

## User Prompt

Fix #1973: IME composition box ignores the theme (black box on light themes)

Closes #1973

work in mulmoterminal3