### PR TITLE
feat(plugins): 3D の presentShapeScript を render グループに追加する

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -84,6 +84,7 @@ const GROUP_BY_TOOL = new Map<string, ToolGroup>([
   ["presentForm", "render"],
   ["presentChart", "render"],
   ["presentHtml", "render"],
+  ["presentShapeScript", "render"],
 
   // presentCollection RENDERS, but it renders collection data and only makes sense next to
   // manageCollection — a cell offered the view without the store gets a tool it cannot fill.
@@ -175,8 +176,10 @@ export const LEGACY_GUI_SERVER_IDS: readonly string[] = ["mulmoterminal-gui"];
 // model spend money silently under a switch the UI presents as "let the agent draw", so it
 // keeps Claude Code's prompt (answer it once per project and the prompt stops).
 //
-// The three below save an artifact and draw it, and call nothing external.
-export const AUTO_ALLOWED_TOOLS: readonly string[] = ["presentForm", "presentChart", "presentHtml"];
+// The four below save an artifact and draw it, and call nothing external.
+// `presentShapeScript` does not even save one — the ShapeScript source travels in
+// the result and is rendered client-side — so it clears the bar the others meet.
+export const AUTO_ALLOWED_TOOLS: readonly string[] = ["presentForm", "presentChart", "presentHtml", "presentShapeScript"];
 
 /** Tools that must keep the agent's permission prompt on EVERY claude session, including the
  *  workspace.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
+    "@mulmoclaude/shapescript-plugin": "^1.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -7,7 +7,8 @@
     "@mulmoclaude/core/collection",
     "@mulmoclaude/html-plugin",
     "@mulmoclaude/google-plugin",
-    "@mulmoclaude/mulmoscript-plugin"
+    "@mulmoclaude/mulmoscript-plugin",
+    "@mulmoclaude/shapescript-plugin"
   ],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -228,6 +228,7 @@ const TOOL_HINTS = new Map<string, string>([
   ["presentForm", "a form to fill in and send back"],
   ["presentChart", "a chart from a set of data"],
   ["presentHtml", "a self-contained web page"],
+  ["presentShapeScript", "a 3D model you can rotate and zoom, written as ShapeScript"],
 
   ["presentCollection", "a collection from this workspace, laid out to browse"],
   ["manageCollection", "reads and writes those collections and their schemas"],

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -13,6 +13,7 @@ import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
 import { plugin as htmlPlugin } from "@mulmoclaude/html-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { plugin as mulmoScriptPlugin, MULMOSCRIPT_HOST_ADAPTER_KEY, type MulmoScriptHostAdapter } from "@mulmoclaude/mulmoscript-plugin/vue";
+import { plugin as shapeScriptPlugin } from "@mulmoclaude/shapescript-plugin/vue";
 import { AccountingView } from "@mulmoclaude/accounting-plugin/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
@@ -27,6 +28,7 @@ import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
 import htmlCss from "@mulmoclaude/html-plugin/style.css?inline";
 import mulmoScriptCss from "@mulmoclaude/mulmoscript-plugin/style.css?inline";
+import shapeScriptCss from "@mulmoclaude/shapescript-plugin/style.css?inline";
 import { collectionShadowCss } from "./collectionShadowCss";
 // The accounting package ships its own self-contained Tailwind in style.css (its
 // content scan can't reach node_modules), imported as a STRING for shadow-DOM
@@ -167,6 +169,19 @@ const PACKAGES: Record<string, Registration> = {
     // ?? "en"), so it renders standalone. Its style.css is self-contained Tailwind.
     viewComponent: viewOf("@mulmoclaude/chart-plugin", chartPlugin.viewComponent),
     css: chartCss,
+  },
+  "@mulmoclaude/shapescript-plugin": {
+    toolName: shapeScriptPlugin.toolDefinition.name,
+    // No runtime wrap: the View reads the ShapeScript source out of
+    // selectedResult.data and renders it with its own Three.js canvas, and its
+    // only injected dependency is the locale its 8-locale bundle falls back to
+    // English without. Its style.css is self-contained.
+    viewComponent: viewOf("@mulmoclaude/shapescript-plugin", shapeScriptPlugin.viewComponent),
+    css: shapeScriptCss,
+    // The WebGL viewport lays out with an internal h-full chain rather than
+    // flowing at content height, so it needs the measured card height — same as
+    // the other canvas-filling views.
+    height: CANVAS_CARD_HEIGHT,
   },
   "@mulmoclaude/mulmoscript-plugin": {
     toolName: mulmoScriptPlugin.toolDefinition.name,

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -95,7 +95,7 @@ describe("tool groups", () => {
   // its execute resolves image placeholders through the image backend, a PAID call. Auto-
   // allowing it would let a model spend money under a switch labelled "let the agent draw".
   it("auto-allows only tools that call nothing external", () => {
-    expect(AUTO_ALLOWED_TOOLS).toEqual(["presentForm", "presentChart", "presentHtml"]);
+    expect(AUTO_ALLOWED_TOOLS).toEqual(["presentForm", "presentChart", "presentHtml", "presentShapeScript"]);
     expect(AUTO_ALLOWED_TOOLS).not.toContain("presentDocument");
   });
 

--- a/test/scripts/mulmoclaudePeerRanges.spec.ts
+++ b/test/scripts/mulmoclaudePeerRanges.spec.ts
@@ -56,6 +56,7 @@ const PLUGINS: string[] = Object.keys(manifestAt(root).dependencies ?? {})
  *  added here on purpose. */
 const NO_CORE: Record<string, string> = {
   "@mulmoclaude/form-plugin": "the form card is self-contained; it names core in neither list",
+  "@mulmoclaude/shapescript-plugin": "parses and renders the script client-side; it touches no host service, so it peers only on gui-chat-protocol and vue",
   "@mulmoclaude/x-plugin": "no peer dependencies at all",
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,15 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
+"@mulmoclaude/shapescript-plugin@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-1.0.0.tgz#f60870816daa56247b37412b36c19defeeb0c61a"
+  integrity sha512-4MpY5QiZ5yTFQfBbrynwhsU9rPdTiAmQq2n8WojzajwDh4Mg8W/4UTo7Ezepgr5n9Y7zctr+H2tUQ7p1V8q+DQ==
+  dependencies:
+    three "^0.185.1"
+    three-bvh-csg "^0.0.18"
+    three-mesh-bvh "0.9.13"
+
 "@mulmoclaude/x-plugin@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/x-plugin/-/x-plugin-1.0.3.tgz#14f437a3fbe95952fa8f4347f62619ed51c34b57"
@@ -7577,6 +7586,21 @@ text-decoder@^1.1.0:
   integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
   dependencies:
     b4a "^1.6.4"
+
+three-bvh-csg@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/three-bvh-csg/-/three-bvh-csg-0.0.18.tgz#c2801788f35c3d830800194cf414dcdbd2a84924"
+  integrity sha512-M3GCZMmGFgASGuDf+YMamM83nVlD/vdwzVHcYbFxgW+g1S7/nKPiuY00YVHOMbjmJPh8mLevGZL65ItHUuGt2w==
+
+three-mesh-bvh@0.9.13:
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.9.13.tgz#706db5d6ad138ef6db155d90cc2807d8c72fe114"
+  integrity sha512-2zRh4iTFDmiTISanSVFofIw6J92DxFSqWn2qsQTtKp2ko5Ebk/JaI/wpMqNaBJ3F0qx7/NuP9GPK4jGDX99J2Q==
+
+three@^0.185.1:
+  version "0.185.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.185.1.tgz#63e9e241a17b101e211965121a017b4b4d8054ae"
+  integrity sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==
 
 tiny-inflate@^1.0.0, tiny-inflate@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
MulmoClaude で作った [`@mulmoclaude/shapescript-plugin@1.0.0`](https://www.npmjs.com/package/@mulmoclaude/shapescript-plugin) を npm から取り込み、既存の GUI プラグインと同じ扱いで `render` グループに登録します。ShapeScript のソースを結果に載せてクライアント側で Three.js が描画するので、**ホスト側のバックエンドは要りません**。

## サーバ側は追加コードなし

`loadPackage` が `pluginCore` から定義と execute を拾う形なので、`plugins/plugins.json` の `packages` に 1 行足すだけで既存の loader に乗ります。`test/server/infra/plugins-registry.spec.ts` の「plugins.json の全パッケージが読める・ツール名重複なし」がそのまま検証になっています。

## フロント側

`src/plugins-registry.ts` に View と `style.css?inline` を登録。**runtime wrap なし** — View は `selectedResult.data` からソースを読んで自前の canvas に描くだけで、注入に頼るのは 8 言語バンドルのロケールだけ（未注入なら英語にフォールバック）です。WebGL の viewport は内部 `h-full` 前提なので、他のキャンバス全面ビューと同じく `CANVAS_CARD_HEIGHT` を渡しています。

## グループと自動許可

`common/toolGroups.ts` で `render` に入れました（描画してそこで終わり、パネルの外に副作用なし）。

**`AUTO_ALLOWED_TOOLS` にも入れています。** この一覧の基準はコメントに書かれているとおり「アーティファクトを保存して描くだけで、外部を呼ばない」で、`presentShapeScript` は保存すらしません（ソースは結果に載って渡るだけ）。除外されている `presentDocument` の理由 — `fillImages` が課金される画像生成を呼ぶ — にも当たりません。判断が違えばここは外せます。

## レジストリの追随

テストが要求してきた 2 箇所も更新しました。どちらも「一覧を揃えるための既存の仕組み」です:

- `GuiPanel.vue` の `TOOL_HINTS` — 空状態で何が得られるかを説明する行
- `mulmoclaudePeerRanges.spec.ts` の `NO_CORE` — このプラグインが `@mulmoclaude/core` を名指ししないことの**記録**（「見ていない」と「本当に使っていない」を区別するための表）

## 確認

`yarn typecheck` / `yarn lint` / `yarn test`（**12069 件 pass**）/ `yarn build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6qxpiuuHpYZBWQNCQqdKM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rendering interactive 3D models written in ShapeScript.
  - ShapeScript results can be rotated and zoomed directly in the Canvas pane.
  - ShapeScript rendering is available without an additional permission prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->