### PR TITLE
fix: pin docs/facts.json to package.json so its version stops drifting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,9 @@ a slower way to do what the UI already does is not pressed.
 
 ## Publishing a release
 
-`/publish` drives the mechanics (bump, tag, npm, GitHub release). Two things are this repo's
-own, and both are easy to skip because the release still "works" without them:
+`/publish` drives the mechanics (bump, tag, npm, GitHub release). Three things are this repo's own.
+The first two are easy to skip because the release still "works" without them; the third is the one
+a spec will stop you on:
 
 **1. `docs/ChangeLog.md`** — English, newest-first, the same per-PR detail as the GitHub release.
 It records **what changed and why**.
@@ -292,6 +293,13 @@ procedure: open this file, paste this, restart what, how to tell it worked, what
   - **Never guess where a terminal link is.** Hover across the row and take the x range where the
     computed `cursor` becomes `pointer`; a coordinate estimated from the image is off by enough to
     click nothing (and a click that silently misses looks exactly like a broken feature).
+
+**3. `docs/facts.json`** — the machine-readable copy of what this package is, read by tools rather
+than people, so a stale field is a wrong answer nobody can see is wrong. Unlike 1 and 2 this one is
+**enforced**: a spec pins its `version` and `requires.node` to `package.json`, so the bump belongs
+in the same commit and `yarn test` goes red until it is there. Leave `updated` alone — it means
+"when a human last read this file against reality", not "when it was last touched". Nothing checked
+any of it until #1988, and the version had sat on 4.4.0 for twelve releases.
 
 ## Filing issues
 - Before filing a **bug / "broken" / "weird behaviour"** issue about MulmoTerminal, run the

--- a/docs/facts.json
+++ b/docs/facts.json
@@ -7,7 +7,7 @@
   "documentation": "https://receptron.github.io/mulmoterminal/",
   "license": "MIT",
   "openSource": true,
-  "version": "4.4.0",
+  "version": "4.16.1",
   "install": "npx mulmoterminal@latest",
   "requires": {
     "node": ">=22.12",

--- a/plans/fix-facts-json-version.md
+++ b/plans/fix-facts-json-version.md
@@ -1,0 +1,36 @@
+# facts.json の version ドリフトを止める (#1988)
+
+## 何が起きていたか
+
+`docs/facts.json` は公開している機械可読な事実ファイル。その `version` が `4.4.0` のまま、
+実際の公開版は 4.16.1 だった（12 リリース分）。`docs/facts.schema.json` には
+`"Must match the version in package.json."` と**書いてある**のに、確かめるものが 1 つも無かった。
+
+#1986（`engines.node` が 22.12 なのに doctor と docs が 22.9）と同じ形。真因も同じで、
+**両側がそれぞれ自己整合**なので、どちらのテストも緑のまま食い違える。
+
+## やること
+
+1. `version` を 4.16.1 に更新
+2. `test/scripts/factsJson.spec.ts` を追加し、`package.json` と一致させるべき値を固定する:
+   - `facts.version` == `package.json.version`
+   - `facts.requires.node` == `package.json.engines.node`（#1986 と同じ穴がこのファイルにもある）
+3. `CLAUDE.md` の "Publishing a release" に 3 つめとして記載。1 / 2 と違い spec で止まることを明記
+
+置き場所は `test/scripts/`。`tsconfig.test-server.json` が `test/scripts/**/*.ts` を含んでいるので
+typecheck に載る。同じ性質の「マニフェスト同士の整合」チェックである
+`mulmoclaudePeerRanges.spec.ts` の隣。
+
+## 触らないもの
+
+- **`updated`（2026-08-04）**。スキーマ上の意味は "When a human last checked this file against
+  reality" —— 人が中身を実物と突き合わせた日であって、ファイルの最終更新日ではない。
+  `version` を直すついでに today に書き換えると、このフィールドの意味が壊れる。
+  棚卸しを実際にやったときに動かす。
+- `facts.json` のそれ以外のフィールド。今回の issue の範囲外で、内容の正しさは別途確認が要る。
+
+## 確認方法
+
+pin した 2 値をそれぞれ**元の古い値に戻して赤くなること**を確認する
+（`version` → 4.4.0、`requires.node` → `>=22.9`）。実際に起きた 2 つのドリフトそのものなので、
+このテストが「起きたことを捕まえられる」ことの直接の証拠になる。

--- a/test/scripts/factsJson.spec.ts
+++ b/test/scripts/factsJson.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `docs/facts.json` is the machine-readable copy of what this package is, served from the docs
+// site and read by tools rather than people — so a stale field is not a typo someone spots, it is
+// a wrong answer nobody can see is wrong. Two of its values are restatements of `package.json`,
+// and `facts.schema.json` already says so in prose ("Must match the version in package.json").
+// Nothing enforced it: the file sat on 4.4.0 for twelve releases (#1988), the same way the Node
+// floor sat on 22.9 (#1986) — each side self-consistent, with nothing comparing them.
+
+const readJson = (...parts: string[]): unknown => JSON.parse(readFileSync(join(process.cwd(), ...parts), "utf8"));
+
+const hasVersion = (value: unknown): value is { version: string } =>
+  typeof value === "object" && value !== null && "version" in value && typeof value.version === "string";
+
+const hasNodeRequirement = (value: unknown): value is { requires: { node: string } } => {
+  if (typeof value !== "object" || value === null || !("requires" in value)) return false;
+  const { requires } = value;
+  if (typeof requires !== "object" || requires === null || !("node" in requires)) return false;
+  return typeof requires.node === "string";
+};
+
+const hasNodeEngine = (value: unknown): value is { engines: { node: string } } => {
+  if (typeof value !== "object" || value === null || !("engines" in value)) return false;
+  const { engines } = value;
+  if (typeof engines !== "object" || engines === null || !("node" in engines)) return false;
+  return typeof engines.node === "string";
+};
+
+describe("docs/facts.json restates package.json", () => {
+  const facts = readJson("docs", "facts.json");
+  const manifest = readJson("package.json");
+
+  it("names the version being shipped", () => {
+    expect(hasVersion(facts) && hasVersion(manifest)).toBe(true);
+    if (!hasVersion(facts) || !hasVersion(manifest)) return;
+    expect(facts.version).toBe(manifest.version);
+  });
+
+  it("names the Node requirement npm enforces", () => {
+    expect(hasNodeRequirement(facts) && hasNodeEngine(manifest)).toBe(true);
+    if (!hasNodeRequirement(facts) || !hasNodeEngine(manifest)) return;
+    expect(facts.requires.node).toBe(manifest.engines.node);
+  });
+});

--- a/test/scripts/factsJson.spec.ts
+++ b/test/scripts/factsJson.spec.ts
@@ -34,14 +34,17 @@ describe("docs/facts.json restates package.json", () => {
   const manifest = readJson("package.json");
 
   it("names the version being shipped", () => {
-    expect(hasVersion(facts) && hasVersion(manifest)).toBe(true);
+    expect(hasVersion(facts), "docs/facts.json has no string `version`").toBe(true);
+    expect(hasVersion(manifest), "package.json has no string `version`").toBe(true);
     if (!hasVersion(facts) || !hasVersion(manifest)) return;
-    expect(facts.version).toBe(manifest.version);
+    // Failing here means the release commit bumped package.json and left facts.json behind.
+    expect(facts.version, "docs/facts.json is behind the version being released").toBe(manifest.version);
   });
 
   it("names the Node requirement npm enforces", () => {
-    expect(hasNodeRequirement(facts) && hasNodeEngine(manifest)).toBe(true);
+    expect(hasNodeRequirement(facts), "docs/facts.json has no string `requires.node`").toBe(true);
+    expect(hasNodeEngine(manifest), "package.json has no string `engines.node`").toBe(true);
     if (!hasNodeRequirement(facts) || !hasNodeEngine(manifest)) return;
-    expect(facts.requires.node).toBe(manifest.engines.node);
+    expect(facts.requires.node, "docs/facts.json states a Node floor npm does not enforce").toBe(manifest.engines.node);
   });
 });


### PR DESCRIPTION
## Summary

`docs/facts.json` is the machine-readable statement of what this package is, served at [`/facts.json`](https://receptron.github.io/mulmoterminal/facts.json) and read by tools rather than people. Its `version` said **`4.4.0`** while **4.16.1** was on npm — twelve releases of a file answering wrong to readers who cannot tell it is wrong.

`docs/facts.schema.json` already stated the rule in prose:

> `"description": "Must match the version in package.json."`

Nothing enforced it. `git log -- docs/facts.json` shows `version` last moved in the `mulmoterminal@4.4.0` release commit; no release commit since has touched the file.

- `docs/facts.json` — `version` → `4.16.1`
- `test/scripts/factsJson.spec.ts` (new) — pins the two values that restate the manifest: `version` against `package.json.version`, and `requires.node` against `package.json.engines.node`
- `CLAUDE.md` — `docs/facts.json` added to *Publishing a release* as item 3, marked as the one a spec stops you on rather than one you can forget

### Why `requires.node` is in the same spec

It is the identical hole, one file over. #1987 fixed `requires.node` by hand three hours ago; nothing stopped it going stale again on the next engine bump. Same class, same commit, one spec.

### Verified by inverting, not by asserting

Both pins were re-broken to the exact values that actually shipped, and both go red:

| inverted to | result |
| --- | --- |
| `version: "4.4.0"` | `AssertionError: expected '4.4.0' to be '4.16.1'` |
| `requires.node: ">=22.9"` | `AssertionError: expected '>=22.9' to be '>=22.12'` |

Restored, `2 passed`. So the test catches the two drifts that happened, not two that were imagined.

## Items to Confirm / Review

- **`updated` (`2026-08-04`) is deliberately untouched.** The schema defines it as *"When a human last checked this file against reality"* — not a last-modified stamp. Bumping it while mechanically fixing one field would assert a review that did not happen. It should move when someone actually re-reads the file; **that re-read is worth scheduling and is not in this PR** — the other fields (`features`, `agents`, `os`, `notFor`) have had no audit and I have not verified them
- **This adds a step to every release**: the version bump commit must now include `docs/facts.json`, and `yarn test` is red until it does. That is the intent, but it is a real cost on a path that runs often — say if you would rather generate the field at docs-build time instead
- Spec placed in `test/scripts/` beside `mulmoclaudePeerRanges.spec.ts`, the other manifest-consistency check; `tsconfig.test-server.json` already includes `test/scripts/**/*.ts`, so it is type-checked
- No `as` casts — the manifest reads go through type guards, per CLAUDE.md

## Verification

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green. `yarn test` — **813 files, 12,072 tests passed**, 50 skipped (2 new).

## User Prompt

- publish しよう
- （リリース後、`docs/facts.json` の `version` が 4.4.0 のままである件について）はい → issue を立てる
- なおして

Closes #1988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2ziujUbL8WEN7DzQ2bpMn

work in mulmoterminal3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the package’s machine-readable release information to version 4.16.1.
  - Added validation to keep release metadata synchronized with the published package version and supported Node.js requirement.

- **Documentation**
  - Clarified release publishing guidance, including required updates to machine-readable package information.
  - Documented that the metadata’s update date reflects the last human review.
  - Added guidance for maintaining release metadata alongside package version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->