### PR TITLE
fix: Canvas card の identity を「ワイヤの綴り」から「ファイル」にする (#1976 PR 1/2)

### DIFF
--- a/common/dirPathKey.ts
+++ b/common/dirPathKey.ts
@@ -43,3 +43,8 @@ export function dirPathKey(path: string): string {
 
 /** Whether two paths name the same directory, as far as spelling can tell. */
 export const isSameDirPath = (a: string | null | undefined, b: string | null | undefined): boolean => !!a && !!b && dirPathKey(a) === dirPathKey(b);
+
+/** Whether `path` names a place from a root — POSIX `/…`, a Windows drive root, a UNC share —
+ *  rather than one relative to a directory the spelling does not name. The same three spellings
+ *  `dirPathKey` keeps, so a caller cannot disagree with it about what "absolute" means. */
+export const isRootedPath = (path: string): boolean => rootOf(path.trim()) !== "";

--- a/common/dirPathKey.ts
+++ b/common/dirPathKey.ts
@@ -44,7 +44,21 @@ export function dirPathKey(path: string): string {
 /** Whether two paths name the same directory, as far as spelling can tell. */
 export const isSameDirPath = (a: string | null | undefined, b: string | null | undefined): boolean => !!a && !!b && dirPathKey(a) === dirPathKey(b);
 
-/** Whether `path` names a place from a root — POSIX `/…`, a Windows drive root, a UNC share —
- *  rather than one relative to a directory the spelling does not name. The same three spellings
- *  `dirPathKey` keeps, so a caller cannot disagree with it about what "absolute" means. */
-export const isRootedPath = (path: string): boolean => rootOf(path.trim()) !== "";
+/**
+ * Whether `path` names one file on its own — POSIX `/…`, a Windows drive root, a UNC share.
+ *
+ * NARROWER than `rootOf` on purpose, in the one place the two could disagree: a SINGLE leading
+ * backslash. `rootOf` keys `\deck.json` as `/deck.json`, which is right for its job (comparing two
+ * spellings of a directory lexically) and wrong for this one — on Windows that path is rooted on
+ * the process's CURRENT DRIVE, which the spelling does not carry and a browser cannot infer. Keying
+ * it would give `\deck.json` and `C:\deck.json` two identities for one file while conflating the
+ * first with a POSIX `/deck.json` (Codex P2 on #1976). A caller that needs a decision here gets
+ * "no", and whatever it falls back to is at worst what it did before.
+ *
+ * The same distinction `rootOf` already draws for `C:foo` and `\server\share`: a spelling that
+ * means something else must not borrow a rooted one's key.
+ */
+export const isRootedPath = (path: string): boolean => {
+  const trimmed = path.trim();
+  return /^[a-zA-Z]:[/\\]/.test(trimmed) || /^[/\\]{2}/.test(trimmed) || trimmed.startsWith("/");
+};

--- a/plans/fix-1976-canonical-card-identity.md
+++ b/plans/fix-1976-canonical-card-identity.md
@@ -20,7 +20,7 @@ card identity は `src/utils/canvasIdentity.ts` の `filePathIdentity` が決め
 
 **(B) preset を 1 つ足して再起動すると、同じファイルの identity が変わる**
 
-```
+```text
 file = /Users/me/w/proj/decks/x.json
 workspace のみ登録        → "W\0stories/proj/decks/x.json"
 /Users/me/w/proj も登録   → "P\0stories/decks/x.json"
@@ -30,7 +30,7 @@ preset 追加の前後に作られたカードは 1 つのデッキで 2 枚に�
 
 **(C) default root のカードにはパス成分が無い**
 
-```
+```text
 /Users/me/w1/artifacts/stories/x.json → "stories/x.json"
 /Users/me/w2/artifacts/stories/x.json → "stories/x.json"   ← 別ファイルが同一 identity
 ```

--- a/plans/fix-1976-canonical-card-identity.md
+++ b/plans/fix-1976-canonical-card-identity.md
@@ -1,0 +1,99 @@
+# #1976 PR 1 — card identity を「ファイル」にする（ボタンはまだ出さない）
+
+#1976 は「Files ペインの Canvas ボタンが stories ルート外の絶対パスのデッキに出ない」。
+本体は **2 PR に切る**。これは 1 本目で、**identity だけ**を直す。issue はここでは閉じない。
+
+- **PR 1（これ）** — card identity を正規化。`storyWirePath` のゲートは触らない
+- **PR 2** — ゲートを緩めて root 外の絶対パスにも ref を mint する。**issue はそちらで閉じる**
+
+順番が逆にできない理由: ボタンを先に出すと、1 つのデッキに 2 枚のカードが生まれる。
+toolResults は `~/.mulmoterminal/toolresults` に永続する（`server/session/tool-store.ts`）ので、
+割れたカードは履歴として残り、あとから identity を変えても
+「設計上の互換性」ではなく「実際に割れて保存された履歴」が移行対象になる。
+しかも割れた 2 枚は別々の綴りしか持たないので、あとから畳める保証がない。
+
+## 直した欠陥（#1976 とは独立に、今日踏める）
+
+card identity は `src/utils/canvasIdentity.ts` の `filePathIdentity` が決めていて、
+**ワイヤの綴りそのもの**（`root\0filePath`）だった。ワイヤの綴りはファイルの性質ではなく
+**「このサーバが何を登録しているか」の関数**なので、次の 2 つが起きる。純関数で再現を取った実測値:
+
+**(B) preset を 1 つ足して再起動すると、同じファイルの identity が変わる**
+
+```
+file = /Users/me/w/proj/decks/x.json
+workspace のみ登録        → "W\0stories/proj/decks/x.json"
+/Users/me/w/proj も登録   → "P\0stories/decks/x.json"
+```
+
+preset 追加の前後に作られたカードは 1 つのデッキで 2 枚になり、新しい方が古い方を supersede しない。
+
+**(C) default root のカードにはパス成分が無い**
+
+```
+/Users/me/w1/artifacts/stories/x.json → "stories/x.json"
+/Users/me/w2/artifacts/stories/x.json → "stories/x.json"   ← 別ファイルが同一 identity
+```
+
+#1933 が named root について入れた守り（2 つの root の同名デッキを混ぜない）が、
+default root には効いていなかった。
+
+## 方針
+
+**カードが持つ情報から canonical 絶対パスを組み立て、それを identity にする。**
+
+`stories/<tail>` + root id は、root の canonical ディレクトリと繋げば絶対パスになる。
+上の (B) はどちらの綴りも `/Users/me/w/proj/decks/x.json` に解決する。
+これは **PR 2 で絶対パス指定で開いたときにサーバが返す綴り**でもあるので、
+2 つの経路のカードが 1 枚に畳まれる — マイグレーションも二重キーも要らない。
+
+解決できないカード（未登録の root、config 到着前、stories 以外の相対パス）は
+**旧来の文字列にフォールバック**する。挙動は現状と同じなので後退しない。
+
+## 変更点
+
+- `server/backends/mulmoscript.ts` — `/api/config` の `storiesRoots[]` に **`canonical` を明示**。
+  `paths` には canonical も入っているが**どれがそれかは印が無く**、位置も
+  （symlink preset がマージされる経路で）一定しない。ブラウザは realpath できないので、
+  どの綴りが解決済みかは**サーバしか言えない**。1 つの root を 2 つの綴りで解決すれば
+  1 つのデッキが 2 枚になるため、推測ではなくラベルにする。
+- `src/utils/canvasCardPath.ts`（新規・純関数）— ワイヤの綴り → 絶対パス。
+  `dirPathKey` で正規化（`.` / `..` / 区切り / Windows）。
+- `src/utils/canvasIdentity.ts` — `filePathIdentity(result, storyRoots)`。解決できなければ旧文字列。
+- `src/plugins-registry.ts` / `src/components/GuiPanel.vue` — `identityOf` に root 表を渡す。
+  `computed` なので config 到着で**再 collapse** される（カードの再送は不要）。
+- `common/dirPathKey.ts` — `isRootedPath` を export（`rootOf` の重複定義を作らないため）。
+
+## 限界
+
+ブラウザは realpath できないので、**誰も解決していない綴りの中の symlink は畳めない**:
+
+- root より下の symlink（`/root/link/x.json` と `/root/real/x.json` は別 identity のまま）
+- **絶対パスの `filePath`**。プラグインは絶対パスを**呼び出し側が綴ったまま返す**
+  （core の `locate` が `byPath` にその文字列をそのまま渡す。`resolveAbsoluteStory` は
+  realpath を内部で使うが、返す card payload には載らない）。
+
+root **の綴り**は解決できる。サーバが boot 時に realpath 済みで、それを `canonical` として
+返すようにしたのがこの PR。実際に綴りが割れるのは主にそこ（launcher で打った綴り /
+`git worktree list` の綴り）。
+
+逃げ道は「正確な版」: `resolveStory` の realpath 済み `absolutePath` を card payload に載せて返す。
+両側とも手元に値はある（こちらの `wirePathMismatch` も計算している）。今は入れない。
+
+## 検証
+
+- (B)(C) を**現行コードに対して**再現させてから直した（上の実測値）。
+- 回帰テストは Files ペインの実チェーン（`storyWirePath` → card → `filePathIdentity`）を通す。
+  片側だけでは欠陥が見えないため。
+- 解決を無効化して**全部赤になること**を確認済み（identity 10 本、パネル 2 本）。
+- **実サーバで確認**（`PORT=8899`、workspace を symlink 経由で起動、preset に `ws/proj`）:
+  - `/api/config` が `canonical` を返し、それは `paths[0]`（launcher で打った symlink 綴り）ではない
+    — 位置で拾う案が誤りだったことの実測。
+  - プラグインの実レスポンス 4 通り（default root / root+tail / 絶対パス canonical / 絶対パス symlink）を
+    identity にかけると、`root+tail` と `絶対パス canonical` が **1 つに畳まれる**。
+    symlink 綴りだけ別 — 上記「限界」のとおり。
+  - preset 追加前後の 2 つのワイヤ綴りが同じ identity に解決される（(B) の実機再現）。
+  - 実際に保存された 2 枚の toolResult（`/api/agent/toolResults/:id` の中身）を実 config で解決 → 1 identity。
+  - ビルド済みアプリをブラウザで読み込み: 描画される / uncaught console error なし。
+  - Canvas ペインを実ブラウザで開くところまでは自動化できなかった（シェルセルの UI 操作が不安定）。
+    表示の畳み込み自体は GuiPanel を**実コンポーネントとしてマウントする** spec で固定してある。

--- a/plans/fix-1976-canonical-card-identity.md
+++ b/plans/fix-1976-canonical-card-identity.md
@@ -80,6 +80,27 @@ root **の綴り**は解決できる。サーバが boot 時に realpath 済み�
 逃げ道は「正確な版」: `resolveStory` の realpath 済み `absolutePath` を card payload に載せて返す。
 両側とも手元に値はある（こちらの `wirePathMismatch` も計算している）。今は入れない。
 
+## 綴りの規則（レビュー 3 往復で固まった部分）
+
+identity は「そのファイルを *名指しできる* 綴りか」で決める。**どの host かは、サーバが自分の
+登録 root をどう綴っているか**から読む（`navigator` は見ない —— この画面はスマホで開かれ得る）。
+
+| card path | POSIX 綴りのサーバ | Windows 綴りのサーバ |
+|---|---|---|
+| `/a/x.json` | `/a/x.json` | **null**（現在ドライブ依存） |
+| `//a/x.json` | `/a/x.json`（先頭の連続スラッシュは 1 つの root。`realpath` で実測） | 共有（別の場所） |
+| `//server/share/x.json` | `/server/share/x.json` | `//server/share/x.json` |
+| `C:\a\x.json` | **null**（そこでは何も名指さない） | `C:/a/x.json` |
+| `\a\x.json` | **null** | **null** |
+
+null は「旧来の文字列 identity に落ちる」＝この PR 以前の挙動。**ルート相対のカードも同じ規則で
+キーを取る**（`dirPathKey` を直接呼ばない）: workspace が `/` のとき base が `//artifacts/stories`
+になり、UNC root として読まれて絶対パスのカードと畳めなくなる。
+
+**この family で残すもの**: 誰も解決していない symlink と、**case-insensitive ボリューム上の
+大文字小文字違い**。ブラウザには判定できず、case-sensitive なボリュームで畳むと**別のファイルが
+1 枚になる**（より悪い誤り）。どれも「サーバが解決済み絶対パスを card payload に載せる」で閉じる。
+
 ## 検証
 
 - (B)(C) を**現行コードに対して**再現させてから直した（上の実測値）。

--- a/server/backends/mulmoscript.ts
+++ b/server/backends/mulmoscript.ts
@@ -52,13 +52,19 @@ interface PubSubLike {
 
 let ops: MulmoScriptServerOps | null = null;
 /** The named stories root this server actually registered with the plugin, or null before boot. */
-let registeredRoots: Array<{ id: string; paths: string[] }> = [];
+let registeredRoots: Array<{ id: string; canonical: string; paths: string[] }> = [];
 
-/** What the browser is told about the named stories root: the id a Canvas card must carry, and
- *  every spelling of the workspace it may compare a file against. The REGISTERED value, never
- *  re-derived — see initMulmoScriptBackend. Null until the backend is initialised, which reads as
- *  "no named root" and is exactly the behaviour before #1933. */
-export const registeredStoriesRoots = (): ReadonlyArray<{ id: string; paths: readonly string[] }> => registeredRoots;
+/** What the browser is told about the named stories root: the id a Canvas card must carry, every
+ *  spelling of the workspace it may compare a file against, and which of those spellings is the
+ *  RESOLVED one. The REGISTERED value, never re-derived — see initMulmoScriptBackend. Empty until
+ *  the backend is initialised, which reads as "no named root" and is exactly the behaviour before
+ *  #1933.
+ *
+ *  `canonical` is labelled rather than left to be picked out of `paths`, because only this side can
+ *  tell which spelling that is: the browser cannot realpath, and it builds a Canvas card's identity
+ *  by resolving the card's wire path against this directory (#1976). Two cards resolved against two
+ *  different spellings of one root are two cards for one deck. */
+export const registeredStoriesRoots = (): ReadonlyArray<{ id: string; canonical: string; paths: readonly string[] }> => registeredRoots;
 let dispatchHandler: MulmoScriptDispatchHandler | null = null;
 
 // undefined = probe not finished yet; the ops treat that as "assume available"
@@ -127,7 +133,7 @@ export function initMulmoScriptBackend(deps: {
   //
   // Merging them is also the right answer for the browser: the spellings become one root's `paths`,
   // which is exactly what the workspace's own two spellings already are.
-  const byCanonical = new Map<string, { id: string; paths: string[] }>();
+  const byCanonical = new Map<string, { id: string; canonical: string; paths: string[] }>();
   for (const dir of uniqueRootPaths([deps.workspace, ...(deps.extraRoots ?? [])])) {
     const canonical = canonicalPath(dir);
     const seen = byCanonical.get(canonical);
@@ -135,7 +141,7 @@ export function initMulmoScriptBackend(deps: {
       if (!seen.paths.includes(dir)) seen.paths.push(dir);
       continue;
     }
-    byCanonical.set(canonical, { id: storiesRootId(canonical), paths: [...new Set([dir, canonical])] });
+    byCanonical.set(canonical, { id: storiesRootId(canonical), canonical, paths: [...new Set([dir, canonical])] });
   }
   const dirForId = new Map([...byCanonical].map(([canonical, root]) => [root.id, canonical]));
   // BOTH spellings travel to the browser: the one the user launched with reaches the Files pane

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -7,6 +7,8 @@ import PluginFrame from "./PluginFrame.vue";
 import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups";
 import { reconcileCollectionCard } from "../../common/collectionSeed";
 import { collapseByIdentity } from "../utils/canvasCollapse";
+import { storyRootDirsFrom } from "../utils/canvasCardPath";
+import { useAppConfig } from "../composables/useAppConfig";
 import { useCanvasCardHeight } from "../composables/useCanvasCardHeight";
 import { isRecord } from "../../common/isRecord";
 import { isUnknownArray } from "../../common/isUnknownArray";
@@ -133,11 +135,19 @@ async function onUpdateResult(existing: ToolResult, update: Partial<ToolResult>)
 
 const hasContent = computed(() => results.value.length > 0);
 
+// The directories a card's wire path is read against, so `stories/<tail>` + a root id names a FILE
+// rather than a spelling that moves when the user registers another directory (#1976). A singleton
+// ref filled in by the shell's `loadConfig`, the way Terminal.vue and MulmoMenu.vue read it — and
+// reactive on purpose: cards drawn before the config lands keep the old identity, and re-collapse
+// against the file the moment it arrives.
+const { storiesRoots } = useAppConfig();
+const storyRoots = computed(() => storyRootDirsFrom(storiesRoots.value));
+
 // What a result IS, for the purpose of "this is the same thing you already drew". The plugin
 // decides (Registration.identityOf); the toolName prefix is added here so two plugins returning
 // the same string — a collection slug that happens to read like a path — stay separate.
 function cardIdentity(result: ToolResult): string | null {
-  const identity = getPlugin(result.toolName)?.identityOf?.(result) ?? null;
+  const identity = getPlugin(result.toolName)?.identityOf?.(result, storyRoots.value) ?? null;
   return identity === null ? null : `${result.toolName}:${identity}`;
 }
 

--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -20,6 +20,9 @@ import { TOOL_NAME as DOCUMENT_TOOL, isDocumentPath } from "@mulmoclaude/markdow
 import { TOOL_NAME as HTML_TOOL, isPresentableHtmlPath, isHtmlArtifactPath, htmlArtifactPreviewUrl, htmlFileUrl } from "@mulmoclaude/html-plugin";
 import { TOOL_NAME as STORY_TOOL } from "@mulmoclaude/mulmoscript-plugin";
 import { dirPathKey } from "../../common/dirPathKey";
+// The wire spelling is minted here and parsed back into a path there — one pair of constants, so a
+// card's identity cannot come to disagree with the ref that opened it.
+import { STORY_DIR, STORY_WIRE_PREFIX } from "../utils/canvasCardPath";
 import { isRecord } from "../../common/isRecord";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 
@@ -37,10 +40,6 @@ export interface CanvasCard {
  *  `none` stays silent on purpose: nothing offers the action for such a file, so it cannot be
  *  clicked. `refused` carries what the server said, which is already a sentence about what to do. */
 export type CanvasCardResult = { kind: "card"; card: CanvasCard } | { kind: "refused"; reason: string } | { kind: "none" };
-
-/** Where mulmoScript keeps its stories, under the workspace. Both halves are fixed by the plugin:
- *  the artifacts area is its only file capability, and `stories/` is its wire prefix. */
-const STORY_DIR = "artifacts/stories";
 
 /** One directory the plugin serves stories from, as this server registered it.
  *
@@ -183,7 +182,7 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
   // `stories/artifacts/stories/x.json` — and the two spellings are two identities, hence two cards
   // for one deck. Deciding the narrower one first means only one spelling is ever minted.
   const inDefault = underAny(workspaces, (workspace) => joinPath(workspace, STORY_DIR));
-  if (inDefault) return { filePath: `stories/${inDefault}` };
+  if (inDefault) return { filePath: `${STORY_WIRE_PREFIX}${inDefault}` };
   // Otherwise the most SPECIFIC registered root that contains it. Roots nest — a saved project
   // under the workspace is both — and the longest prefix is the only choice that does not depend
   // on the order the server happened to list them in, which would make one file's card identity
@@ -193,7 +192,7 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
     const tail = underAny(root.paths, (dir) => dir);
     if (tail !== null && (best === null || tail.length < best.tail.length)) best = { root: root.id, tail };
   }
-  return best === null ? null : { filePath: `stories/${best.tail}`, root: best.root };
+  return best === null ? null : { filePath: `${STORY_WIRE_PREFIX}${best.tail}`, root: best.root };
 }
 
 /**

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -90,7 +90,7 @@ const worktreesRoot = ref<string | null>(null);
 // carries, and the CANONICAL path to compare a file against. Read, never derived — an id the
 // browser re-computed could drift from the one the server registered, and a non-canonical path
 // would stop matching the moment the workspace was reached through a symlink.
-const storiesRoots = ref<Array<{ id: string; paths: string[] }>>([]);
+const storiesRoots = ref<StoriesRootConfig[]>([]);
 
 // The initial /api/config while it is still in flight, so a launch that lands first can wait for
 // the root rather than decide without it (Codex on #1543). Null when nothing is loading — then
@@ -171,21 +171,33 @@ function readLegacyRecents(): string[] {
 const listOf = <T>(value: unknown, isEntry: (entry: unknown) => entry is T): T[] => (isUnknownArray(value) ? value.filter(isEntry) : []);
 
 const stringsOf = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []);
+/** A stories root as `/api/config` reports it. `canonical` is the server's RESOLVED spelling of the
+ *  same directory — optional because a server older than #1976 does not send it, and a card whose
+ *  root has none keeps the identity it had before that change. */
+export interface StoriesRootConfig {
+  id: string;
+  canonical?: string;
+  paths: string[];
+}
+
 /** The named stories root off the wire: an id plus EVERY spelling of the workspace (the launched
  *  one and the resolved one). Both travel because both reach the Files pane, and the browser's
  *  containment check is lexical (#1934). Anything malformed reads as "no named root". */
-function readStoriesRoot(value: unknown): { id: string; paths: string[] } | null {
+function readStoriesRoot(value: unknown): StoriesRootConfig | null {
   if (!isRecord(value) || typeof value.id !== "string" || !Array.isArray(value.paths)) return null;
   const paths = value.paths.filter((path): path is string => typeof path === "string");
-  return paths.length > 0 ? { id: value.id, paths } : null;
+  if (paths.length === 0) return null;
+  // Omitted rather than set to undefined: exactOptionalPropertyTypes is on. A blank one is dropped
+  // for the same reason a blank path is — it names no directory to resolve a card against.
+  return { id: value.id, ...(typeof value.canonical === "string" && value.canonical !== "" ? { canonical: value.canonical } : {}), paths };
 }
 
 /** Every directory the server serves stories from (#1951). The WORKSPACE is the first entry — the
  *  server registers it first and the browser's default-stories rule needs to know which one it is,
  *  so the order is part of the contract rather than a coincidence. */
-function readStoriesRoots(value: unknown): Array<{ id: string; paths: string[] }> {
+function readStoriesRoots(value: unknown): StoriesRootConfig[] {
   if (!Array.isArray(value)) return [];
-  return value.map(readStoriesRoot).filter((root): root is { id: string; paths: string[] } => root !== null);
+  return value.map(readStoriesRoot).filter((root): root is StoriesRootConfig => root !== null);
 }
 
 const isCwdPreset = (value: unknown): value is CwdPreset => isRecord(value) && typeof value.label === "string" && typeof value.path === "string";

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -17,6 +17,7 @@ import { AccountingView } from "@mulmoclaude/accounting-plugin/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
 import { documentIdentity, filePathIdentity, collectionIdentity } from "./utils/canvasIdentity";
+import type { StoryRootDirs } from "./utils/canvasCardPath";
 import { CANVAS_CARD_HEIGHT_VAR } from "./composables/useCanvasCardHeight";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
@@ -109,8 +110,12 @@ interface Registration {
    *
    * The value is namespaced by toolName at the call site, so two plugins may return the same
    * string without colliding.
+   *
+   * `storyRoots` is passed to every accessor and used by the file-backed ones: a card's wire path
+   * only names a file once it is read against the directories this server registered (#1976, see
+   * utils/canvasCardPath.ts). An accessor that does not need it simply declares one parameter.
    */
-  identityOf?: (result: unknown) => string | null;
+  identityOf?: (result: unknown, storyRoots: StoryRootDirs) => string | null;
   // Optional fixed frame height for views that rely on an internal h-full layout
   // (vs flowing at natural content height). See PluginFrame's `height` prop.
   height?: string;

--- a/src/utils/canvasCardPath.ts
+++ b/src/utils/canvasCardPath.ts
@@ -18,9 +18,15 @@
 // resolved: below a root, or inside an absolute `filePath`, which the plugin echoes as the CALLER
 // spelled it (`locate` in the package's core hands `byPath` the path it was given). Those stay two
 // identities. So is a path rooted on a Windows drive the spelling does not carry (`\deck.json`, or
-// `/deck.json` on a Windows host) — see `windowsSpelled` below. Closing all of it means putting the
-// server's own resolved path on the card payload — both sides already compute one — and it is
-// deliberately not in this change.
+// `/deck.json` on a Windows host), and so is one that differs only in CASE on a case-insensitive
+// volume — a browser cannot know that either, and folding case where the volume is case-sensitive
+// would merge two real files, which is the worse error. Every one of them closes the same way:
+// the server putting its own resolved path on the card payload, which both sides already compute.
+// Deliberately not in this change.
+//
+// What IS decided here is the spelling arithmetic that does not need the disk — the syntax the
+// server's own roots are written in says which of two rooted forms names a file at all, and
+// `absoluteOnThisServer` below is that one rule.
 import { dirPathKey, isRootedPath } from "../../common/dirPathKey";
 
 /** The plugin's wire prefix for a story. Minted by `storyWirePath`, parsed here — one constant, so
@@ -63,23 +69,30 @@ export const storyRootDirsFrom = (registered: ReadonlyArray<{ id: string; canoni
 const DRIVE_OR_SHARE = /^([a-zA-Z]:[/\\]|[/\\]{2})/;
 
 /**
- * Whether `filePath` names one file ON THIS SERVER — the rule the two Windows findings on #1976
- * are both instances of, stated once rather than enumerated.
+ * The absolute path `filePath` names ON THIS SERVER, or null when this spelling names no one file
+ * there — the rule every Windows/POSIX finding on #1976 is an instance of, stated once rather than
+ * enumerated.
  *
- * Rooted is not enough on Windows: `\deck.json` AND `/deck.json` are both rooted on the process's
- * CURRENT DRIVE, which the spelling does not carry, so neither can be reconciled with the same
- * file spelled `C:\deck.json`. Only a drive or a share qualifies there. On every other host a
- * leading `/` is the whole of it.
+ * Which host it is comes from the way the SERVER spells its own registered roots — never from
+ * `navigator`, because this page can be open on a phone while the files live on Windows. No roots
+ * yet reads as POSIX, the syntax every host but one uses.
  *
- * Which host that is comes from the way the SERVER spells its own registered roots — the same test,
- * applied to a directory it resolved — and never from `navigator`: this page can be open on a phone
- * while the files live on Windows. No roots yet reads as POSIX, the spelling every other host uses.
+ * The two syntaxes disagree about the SAME two spellings, in opposite directions:
+ *
+ *   - `\deck.json` and `/deck.json` are rooted on Windows' CURRENT DRIVE, which the spelling does
+ *     not carry, so neither can be reconciled with `C:\deck.json`. Only a drive or a share names a
+ *     file there.
+ *   - A leading RUN of slashes is one root on POSIX: `//tmp/x.json` and `/tmp/x.json` are the same
+ *     file (measured — `realpath` agrees), while `dirPathKey` reads the first as a UNC share. So the
+ *     run is collapsed before keying, and a Windows spelling (`C:/…`, `\\srv\share`) names nothing.
  */
-const namesOneFileOnThisServer = (filePath: string, dirs: StoryRootDirs): boolean => {
-  if (!isRootedPath(filePath)) return false;
+const absoluteOnThisServer = (filePath: string, dirs: StoryRootDirs): string | null => {
+  const spelling = filePath.trim();
   const serverDir = dirs.workspace ?? Object.values(dirs.byId)[0];
-  const windowsSpelled = serverDir !== undefined && DRIVE_OR_SHARE.test(serverDir);
-  return !windowsSpelled || DRIVE_OR_SHARE.test(filePath.trim());
+  if (serverDir !== undefined && DRIVE_OR_SHARE.test(serverDir)) {
+    return DRIVE_OR_SHARE.test(spelling) ? dirPathKey(spelling) : null;
+  }
+  return spelling.startsWith("/") ? dirPathKey(spelling.replace(/^\/+/, "/")) : null;
 };
 
 /** No join helper: `dirPathKey` folds a doubled separator, so a root directory (`/`, `C:/`) that
@@ -96,14 +109,24 @@ const defaultStoriesDir = (workspace: string | null): string | null => (workspac
 export function canonicalCardPath(filePath: string, root: string | null, dirs: StoryRootDirs): string | null {
   // Already the answer, whoever minted it. Keyed all the same, so `/w/./x.json` and `/w/x.json` are
   // one card.
-  // A spelling that leans on the server's current drive answers nothing and keeps its legacy
-  // identity — better than being keyed into something the drive-qualified card cannot match. What
-  // closes that case properly is the server putting its own resolved path on the card; see header.
-  if (isRootedPath(filePath)) return namesOneFileOnThisServer(filePath, dirs) ? dirPathKey(filePath) : null;
+  const absolute = absoluteOnThisServer(filePath, dirs);
+  if (absolute !== null) return absolute;
+  // Rooted, but in a syntax that names no file HERE — a drive-less path on Windows, a Windows one
+  // on a POSIX server. It keeps its legacy identity rather than being keyed into something the
+  // fully-qualified card cannot match, and it is never read as a wire path either: `stories/…` is
+  // relative, and a rooted path that looked like one would name a file in the wrong place. What
+  // closes these properly is the server putting its own resolved path on the card; see the header.
+  if (isRootedPath(filePath)) return null;
   if (!filePath.startsWith(STORY_WIRE_PREFIX)) return null;
   const tail = filePath.slice(STORY_WIRE_PREFIX.length);
   const base = root === null ? defaultStoriesDir(dirs.workspace) : (dirs.byId[root] ?? null);
   // A bare `stories/` names the directory, not a card in it.
   if (base === null || tail === "") return null;
-  return dirPathKey(`${base}/${tail}`);
+  // Keyed by the SAME rule as an absolute card, not by `dirPathKey` directly — the two have to
+  // agree or the whole point is lost. It is not cosmetic: a workspace at `/` builds
+  // `//artifacts/stories/x.json`, which `dirPathKey` reads as a UNC root, so that card would not
+  // collapse with the absolute one for the same file. (Observed reading this back, not flagged by
+  // a review bot. A workspace at a filesystem root is a case this file already handles — Codex P1
+  // on #1934.)
+  return absoluteOnThisServer(`${base}/${tail}`, dirs);
 }

--- a/src/utils/canvasCardPath.ts
+++ b/src/utils/canvasCardPath.ts
@@ -17,8 +17,10 @@
 // boot, and says which one that is. What it cannot see through is a symlink in a path nobody
 // resolved: below a root, or inside an absolute `filePath`, which the plugin echoes as the CALLER
 // spelled it (`locate` in the package's core hands `byPath` the path it was given). Those stay two
-// identities. Closing that gap means putting the server's realpath on the card payload — both sides
-// already compute one — and it is deliberately not in this change.
+// identities. So is a path rooted on a Windows drive the spelling does not carry (`\deck.json`, or
+// `/deck.json` on a Windows host) — see `windowsSpelled` below. Closing all of it means putting the
+// server's own resolved path on the card payload — both sides already compute one — and it is
+// deliberately not in this change.
 import { dirPathKey, isRootedPath } from "../../common/dirPathKey";
 
 /** The plugin's wire prefix for a story. Minted by `storyWirePath`, parsed here — one constant, so
@@ -56,6 +58,22 @@ export const storyRootDirsFrom = (registered: ReadonlyArray<{ id: string; canoni
   byId: Object.fromEntries(registered.flatMap((root) => (root.canonical ? [[root.id, root.canonical] as const] : []))),
 });
 
+/** Drive-qualified or a UNC share: the two spellings that name a file on a WINDOWS host without
+ *  depending on which drive the process happens to be on. */
+const DRIVE_OR_SHARE = /^([a-zA-Z]:[/\\]|[/\\]{2})/;
+
+/**
+ * Whether this SERVER spells its own directories with a drive letter.
+ *
+ * Read off the roots it registered, never off `navigator`: the page can be open on a phone while
+ * the files live on a Windows machine, so the browser's own platform says nothing about theirs.
+ * Unknown (no roots yet) reads as POSIX, which is the spelling every other host uses.
+ */
+const windowsSpelled = (dirs: StoryRootDirs): boolean => {
+  const dir = dirs.workspace ?? Object.values(dirs.byId)[0];
+  return dir !== undefined && /^[a-zA-Z]:[/\\]/.test(dir);
+};
+
 /** No join helper: `dirPathKey` folds a doubled separator, so a root directory (`/`, `C:/`) that
  *  already ends in one costs nothing. */
 const defaultStoriesDir = (workspace: string | null): string | null => (workspace === null ? null : `${workspace}/${STORY_DIR}`);
@@ -70,7 +88,14 @@ const defaultStoriesDir = (workspace: string | null): string | null => (workspac
 export function canonicalCardPath(filePath: string, root: string | null, dirs: StoryRootDirs): string | null {
   // Already the answer, whoever minted it. Keyed all the same, so `/w/./x.json` and `/w/x.json` are
   // one card.
-  if (isRootedPath(filePath)) return dirPathKey(filePath);
+  //
+  // Except on a Windows host, where `/deck.json` means what `\deck.json` does — rooted on the
+  // process's CURRENT DRIVE, which the spelling does not carry (Codex P2 on #1976). `isRootedPath`
+  // cannot refuse that form, since on every other host it is THE absolute spelling; only the
+  // server's own roots say which host this is. Refused there, the card keeps its legacy identity
+  // rather than being keyed into something `C:\deck.json` cannot match. What closes it properly is
+  // the server putting its resolved path on the card — see the header.
+  if (isRootedPath(filePath)) return windowsSpelled(dirs) && !DRIVE_OR_SHARE.test(filePath.trim()) ? null : dirPathKey(filePath);
   if (!filePath.startsWith(STORY_WIRE_PREFIX)) return null;
   const tail = filePath.slice(STORY_WIRE_PREFIX.length);
   const base = root === null ? defaultStoriesDir(dirs.workspace) : (dirs.byId[root] ?? null);

--- a/src/utils/canvasCardPath.ts
+++ b/src/utils/canvasCardPath.ts
@@ -58,20 +58,28 @@ export const storyRootDirsFrom = (registered: ReadonlyArray<{ id: string; canoni
   byId: Object.fromEntries(registered.flatMap((root) => (root.canonical ? [[root.id, root.canonical] as const] : []))),
 });
 
-/** Drive-qualified or a UNC share: the two spellings that name a file on a WINDOWS host without
- *  depending on which drive the process happens to be on. */
+/** Drive-qualified (`C:\…`) or a UNC share (`\\server\share\…`) — the two spellings Windows uses
+ *  to name a place without leaning on which drive a process happens to be on. */
 const DRIVE_OR_SHARE = /^([a-zA-Z]:[/\\]|[/\\]{2})/;
 
 /**
- * Whether this SERVER spells its own directories with a drive letter.
+ * Whether `filePath` names one file ON THIS SERVER — the rule the two Windows findings on #1976
+ * are both instances of, stated once rather than enumerated.
  *
- * Read off the roots it registered, never off `navigator`: the page can be open on a phone while
- * the files live on a Windows machine, so the browser's own platform says nothing about theirs.
- * Unknown (no roots yet) reads as POSIX, which is the spelling every other host uses.
+ * Rooted is not enough on Windows: `\deck.json` AND `/deck.json` are both rooted on the process's
+ * CURRENT DRIVE, which the spelling does not carry, so neither can be reconciled with the same
+ * file spelled `C:\deck.json`. Only a drive or a share qualifies there. On every other host a
+ * leading `/` is the whole of it.
+ *
+ * Which host that is comes from the way the SERVER spells its own registered roots — the same test,
+ * applied to a directory it resolved — and never from `navigator`: this page can be open on a phone
+ * while the files live on Windows. No roots yet reads as POSIX, the spelling every other host uses.
  */
-const windowsSpelled = (dirs: StoryRootDirs): boolean => {
-  const dir = dirs.workspace ?? Object.values(dirs.byId)[0];
-  return dir !== undefined && /^[a-zA-Z]:[/\\]/.test(dir);
+const namesOneFileOnThisServer = (filePath: string, dirs: StoryRootDirs): boolean => {
+  if (!isRootedPath(filePath)) return false;
+  const serverDir = dirs.workspace ?? Object.values(dirs.byId)[0];
+  const windowsSpelled = serverDir !== undefined && DRIVE_OR_SHARE.test(serverDir);
+  return !windowsSpelled || DRIVE_OR_SHARE.test(filePath.trim());
 };
 
 /** No join helper: `dirPathKey` folds a doubled separator, so a root directory (`/`, `C:/`) that
@@ -88,14 +96,10 @@ const defaultStoriesDir = (workspace: string | null): string | null => (workspac
 export function canonicalCardPath(filePath: string, root: string | null, dirs: StoryRootDirs): string | null {
   // Already the answer, whoever minted it. Keyed all the same, so `/w/./x.json` and `/w/x.json` are
   // one card.
-  //
-  // Except on a Windows host, where `/deck.json` means what `\deck.json` does — rooted on the
-  // process's CURRENT DRIVE, which the spelling does not carry (Codex P2 on #1976). `isRootedPath`
-  // cannot refuse that form, since on every other host it is THE absolute spelling; only the
-  // server's own roots say which host this is. Refused there, the card keeps its legacy identity
-  // rather than being keyed into something `C:\deck.json` cannot match. What closes it properly is
-  // the server putting its resolved path on the card — see the header.
-  if (isRootedPath(filePath)) return windowsSpelled(dirs) && !DRIVE_OR_SHARE.test(filePath.trim()) ? null : dirPathKey(filePath);
+  // A spelling that leans on the server's current drive answers nothing and keeps its legacy
+  // identity — better than being keyed into something the drive-qualified card cannot match. What
+  // closes that case properly is the server putting its own resolved path on the card; see header.
+  if (isRootedPath(filePath)) return namesOneFileOnThisServer(filePath, dirs) ? dirPathKey(filePath) : null;
   if (!filePath.startsWith(STORY_WIRE_PREFIX)) return null;
   const tail = filePath.slice(STORY_WIRE_PREFIX.length);
   const base = root === null ? defaultStoriesDir(dirs.workspace) : (dirs.byId[root] ?? null);

--- a/src/utils/canvasCardPath.ts
+++ b/src/utils/canvasCardPath.ts
@@ -1,0 +1,80 @@
+// The FILE a Canvas card is about, as one absolute path — the string card identity is built from.
+//
+// A deck reaches the Canvas under more than one spelling. The plugin addresses it on the wire as
+// `stories/<tail>` plus a root id, and which root answers depends on what this server happened to
+// register: with only the workspace registered a deck is `W\0stories/proj/decks/x.json`, and
+// registering `…/proj` as a preset makes the SAME file `P\0stories/decks/x.json`. Identity built
+// from the wire spelling therefore moves when the user adds a directory and restarts — one deck,
+// two cards, and the second one supersedes nothing (#1976).
+//
+// So the spelling is resolved back to the file before anything is compared. Everything needed is
+// already on the card and in `/api/config`: a root id names a canonical directory, and the tail is
+// the same relative path either way, so both spellings above resolve to
+// `/Users/me/w/proj/decks/x.json` — the same string a card built from that absolute path carries.
+//
+// LEXICAL, like the gate in canvasOpenFile.ts and for the same reason: a browser cannot realpath.
+// What it sees through is the several spellings of a ROOT — the server resolved those once, at
+// boot, and says which one that is. What it cannot see through is a symlink in a path nobody
+// resolved: below a root, or inside an absolute `filePath`, which the plugin echoes as the CALLER
+// spelled it (`locate` in the package's core hands `byPath` the path it was given). Those stay two
+// identities. Closing that gap means putting the server's realpath on the card payload — both sides
+// already compute one — and it is deliberately not in this change.
+import { dirPathKey, isRootedPath } from "../../common/dirPathKey";
+
+/** The plugin's wire prefix for a story. Minted by `storyWirePath`, parsed here — one constant, so
+ *  the two cannot drift into disagreeing about what a story path looks like. */
+export const STORY_WIRE_PREFIX = "stories/";
+
+/** Where the DEFAULT root's stories live, under the workspace. Both halves are fixed by the
+ *  plugin: the artifacts area is its only file capability, and `stories/` is its wire prefix. */
+export const STORY_DIR = "artifacts/stories";
+
+/** The directories a card's wire path is resolved against, as this server registered them. */
+export interface StoryRootDirs {
+  /** The workspace, canonically spelled: the base of the root addressed WITHOUT an id. Null until
+   *  `/api/config` lands — which reads as "cannot resolve", never as "the workspace is `/`". */
+  workspace: string | null;
+  /** Canonical directory per registered root id. A card naming an id that is absent — a root from
+   *  another machine, or one whose preset was removed — resolves to nothing rather than to a guess. */
+  byId: Readonly<Record<string, string>>;
+}
+
+/** What the browser knows before the config arrives: nothing resolves, so every card keeps the
+ *  identity it had before this rule existed. */
+export const NO_STORY_ROOTS: StoryRootDirs = { workspace: null, byId: {} };
+
+/**
+ * The resolution table, from what `/api/config` reports.
+ *
+ * The FIRST entry is the workspace — the server registers it first, and that is the contract
+ * `storiesRootsFrom` already reads the same array by (#1951). `canonical` is the server's own
+ * realpathed spelling, never re-derived here: a browser cannot realpath, and a rule that guessed
+ * which of a root's spellings was the resolved one would resolve one card differently from the next.
+ */
+export const storyRootDirsFrom = (registered: ReadonlyArray<{ id: string; canonical?: string }>): StoryRootDirs => ({
+  workspace: registered[0]?.canonical ?? null,
+  byId: Object.fromEntries(registered.flatMap((root) => (root.canonical ? [[root.id, root.canonical] as const] : []))),
+});
+
+/** No join helper: `dirPathKey` folds a doubled separator, so a root directory (`/`, `C:/`) that
+ *  already ends in one costs nothing. */
+const defaultStoriesDir = (workspace: string | null): string | null => (workspace === null ? null : `${workspace}/${STORY_DIR}`);
+
+/**
+ * The absolute path `filePath` names, or null when this browser cannot say.
+ *
+ * Null is the important answer: an unregistered root, a config that has not arrived, a relative
+ * path belonging to some other tool's addressing. The caller keeps its old identity for those, so
+ * nothing that used to fold apart starts folding together on a guess.
+ */
+export function canonicalCardPath(filePath: string, root: string | null, dirs: StoryRootDirs): string | null {
+  // Already the answer, whoever minted it. Keyed all the same, so `/w/./x.json` and `/w/x.json` are
+  // one card.
+  if (isRootedPath(filePath)) return dirPathKey(filePath);
+  if (!filePath.startsWith(STORY_WIRE_PREFIX)) return null;
+  const tail = filePath.slice(STORY_WIRE_PREFIX.length);
+  const base = root === null ? defaultStoriesDir(dirs.workspace) : (dirs.byId[root] ?? null);
+  // A bare `stories/` names the directory, not a card in it.
+  if (base === null || tail === "") return null;
+  return dirPathKey(`${base}/${tail}`);
+}

--- a/src/utils/canvasIdentity.ts
+++ b/src/utils/canvasIdentity.ts
@@ -11,6 +11,7 @@
 import { documentPathOf, type MarkdownToolData } from "@mulmoclaude/markdown-plugin/vue";
 import { isRecord } from "../../common/isRecord";
 import { collectionSlugOf } from "../../common/collectionSeed";
+import { canonicalCardPath, NO_STORY_ROOTS, type StoryRootDirs } from "./canvasCardPath";
 
 // A tool result's payload travels in `data` and `jsonData` both. Read through both because a
 // partial update (a view persisting its state) may carry only one — the same lookup, for the same
@@ -60,14 +61,26 @@ export function documentIdentity(result: unknown): string | null {
  * story's path is the wire form every mulmoScript endpoint keys on), and each tool's CREATE path
  * writes a FRESH path — so this collapses re-presentations of one artifact without ever merging
  * two distinct ones.
+ *
+ * Resolved to the file it names before comparing, because ONE deck has several wire spellings and
+ * which one a card carries depends on what this server registered. `storyRoots` is what resolves
+ * them; its default is "nothing registered", under which every card keeps the identity it had
+ * before this existed — which is also what the browser has until `/api/config` lands.
  */
-export function filePathIdentity(result: unknown): string | null {
+export function filePathIdentity(result: unknown, storyRoots: StoryRootDirs = NO_STORY_ROOTS): string | null {
   const filePath = payloadString(result, "filePath");
   if (filePath === null) return null;
-  // The PAIR, not the path: since the workspace subtree is a named stories root (#1933), two decks
-  // in different roots can share `stories/deck.json`, and collapsing on the path alone would merge
-  // two files into one card. `presentHtml` payloads carry no `root` and fold as they always did.
   const root = payloadString(result, "root");
+  // The FILE, whichever spelling this card carries — see canvasCardPath.ts. The wire spelling moves
+  // when the user registers another directory, so identity built from it splits one deck into two
+  // cards on a restart (#1976).
+  const resolved = canonicalCardPath(filePath, root, storyRoots);
+  if (resolved !== null) return resolved;
+  // Nothing here can say where that path is: a root this server never registered, a config that has
+  // not arrived, a relative path with no root to read it against. Then the wire spelling itself,
+  // exactly as before — the PAIR, not the path, because since the workspace subtree became a named
+  // stories root (#1933) two decks in different roots can share `stories/deck.json`, and collapsing
+  // on the path alone merges two files into one card.
   return root === null ? filePath : `${root}\u0000${filePath}`;
 }
 

--- a/test/common/dirPathKey.spec.ts
+++ b/test/common/dirPathKey.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { dirPathKey, isSameDirPath } from "../../common/dirPathKey";
+import { dirPathKey, isRootedPath, isSameDirPath } from "../../common/dirPathKey";
 
 // Raised by Codex on #1208: the launcher compared a path the user typed against one git reported
 // with `===`, so `/wt/foo/` and `/repo/../wt/foo` read as different directories and the control
@@ -61,5 +61,45 @@ describe("dirPathKey", () => {
     expect(isSameDirPath(null, null)).toBe(false);
     expect(isSameDirPath("/wt/foo", undefined)).toBe(false);
     expect(isSameDirPath("  ", "")).toBe(false);
+  });
+});
+
+// Whether a spelling names one file BY ITSELF — what a Canvas card's identity is built from
+// (src/utils/canvasCardPath.ts). Narrower than the key above in exactly one place, and that is the
+// point of testing it separately.
+describe("isRootedPath", () => {
+  it("accepts the three rooted spellings", () => {
+    expect(isRootedPath("/work/deck.json")).toBe(true);
+    expect(isRootedPath("C:\\work\\deck.json")).toBe(true);
+    expect(isRootedPath("c:/work/deck.json")).toBe(true);
+    expect(isRootedPath("//server/share/deck.json")).toBe(true);
+    expect(isRootedPath("\\\\server\\share\\deck.json")).toBe(true);
+  });
+
+  it("refuses a relative path", () => {
+    expect(isRootedPath("deck.json")).toBe(false);
+    expect(isRootedPath("../deck.json")).toBe(false);
+    expect(isRootedPath("")).toBe(false);
+  });
+
+  // The Windows boundary this exists for. `\deck.json` is rooted on the process's CURRENT DRIVE —
+  // a drive the spelling does not carry and a browser cannot infer — so it names no one file.
+  // `dirPathKey` still keys it as `/deck.json`, which is right for comparing directories and wrong
+  // for identity: it would split `\deck.json` from `C:\deck.json` while conflating it with a POSIX
+  // `/deck.json` (Codex P2 on #1976).
+  it("refuses a single leading backslash, whose drive is unknown", () => {
+    expect(isRootedPath("\\deck.json")).toBe(false);
+    expect(isRootedPath("\\work\\deck.json")).toBe(false);
+    expect(dirPathKey("\\deck.json")).toBe("/deck.json"); // …while the KEY still folds it, deliberately
+  });
+
+  // The other spelling `rootOf` already refuses to fold: relative to the current directory ON that
+  // drive, which is not the drive root.
+  it("refuses a drive-relative path", () => {
+    expect(isRootedPath("C:deck.json")).toBe(false);
+  });
+
+  it("ignores surrounding whitespace, as the key does", () => {
+    expect(isRootedPath("  /work/deck.json  ")).toBe(true);
   });
 });

--- a/test/server/config/stories-root-response.spec.ts
+++ b/test/server/config/stories-root-response.spec.ts
@@ -88,6 +88,26 @@ describe("the registered stories root", () => {
     expect(roots[0]?.paths).toContain(ws);
   });
 
+  // WHICH of the spellings is the resolved one, labelled rather than left to be picked out of the
+  // list. The browser cannot realpath, and it resolves a Canvas card's wire path against this
+  // directory to decide what the card is about (#1976) — two cards resolved against two spellings
+  // of one root would be two cards for one deck.
+  it("says which spelling is the resolved one", () => {
+    const real = path.join(base, "real-ws");
+    const link = path.join(base, "ws-link");
+    mkdirSync(real);
+    symlinkSync(real, link);
+    initArtifactsBackend({ workspace: link });
+    initMulmoScriptBackend({ workspace: link, pubsub: null });
+    const root = registeredStoriesRoots()[0];
+    expect(root?.canonical).toBeDefined();
+    expect(root?.canonical).not.toBe(link);
+    expect(root?.paths).toContain(root?.canonical);
+    // The same value the id was derived from, so a card naming this id resolves against the
+    // directory the plugin actually serves.
+    expect(root?.id).toBe(storiesRootId(String(root?.canonical)));
+  });
+
   it("does not follow a symlink retargeted after boot", () => {
     const first = path.join(base, "first");
     const second = path.join(base, "second");

--- a/test/src/canvasIdentity.spec.ts
+++ b/test/src/canvasIdentity.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { collectionIdentity, documentIdentity, filePathIdentity, payloadString } from "../../src/utils/canvasIdentity";
+import { storyWirePath } from "../../src/composables/canvasOpenFile";
+import { storyRootDirsFrom } from "../../src/utils/canvasCardPath";
 
 // What each tool calls "the same thing". These decide whether a card on screen is REPLACED, so
 // the cases that must return null (nothing durable behind the result, an unrecognised shape) are
@@ -64,6 +66,76 @@ describe("filePathIdentity", () => {
     const one = filePathIdentity({ data: { filePath: "artifacts/html/a.html" } });
     const two = filePathIdentity({ data: { filePath: "artifacts/html/b.html" } });
     expect(one).not.toBe(two);
+  });
+});
+
+// The wire spelling a card carries is not a property of the FILE — it is a property of what this
+// server registered when the card was made. These drive the real chain (the Files pane's
+// `storyWirePath` mints the ref, the card carries it, this reads it back), because the defect is in
+// how the two fit together and neither half shows it alone (#1976).
+describe("filePathIdentity — one deck, whatever spelling reached it", () => {
+  const WS = "/Users/me/w";
+  const FILE = `${WS}/proj/decks/x.json`;
+  /** What the server registers with only the workspace opened, and after `…/proj` is added as a
+   *  preset — both as `/api/config` reports them. */
+  const workspaceOnly = [{ id: "W", canonical: WS, paths: [WS] }];
+  const withPreset = [...workspaceOnly, { id: "P", canonical: `${WS}/proj`, paths: [`${WS}/proj`] }];
+  const gate = (registered: typeof workspaceOnly) => ({ workspaces: registered[0]?.paths ?? [], roots: registered });
+
+  /** The identity the Canvas gives the card the Files pane would seed for `absolutePath`. */
+  const identityFor = (absolutePath: string, registered: typeof workspaceOnly): string | null => {
+    const ref = storyWirePath(absolutePath, gate(registered));
+    return ref === null ? null : filePathIdentity({ data: { ...ref, script: {} } }, storyRootDirsFrom(registered));
+  };
+
+  // (B) Registering another directory re-spells every deck beneath it — `W\0stories/proj/decks/x.json`
+  // became `P\0stories/decks/x.json`, measured on the pure functions. A card stored before the
+  // preset and one made after it are then two cards for one file, and the older one supersedes
+  // nothing.
+  it("does not change when the user registers another directory", () => {
+    expect(identityFor(FILE, workspaceOnly)).toBe(identityFor(FILE, withPreset));
+    expect(identityFor(FILE, withPreset)).toBe(FILE);
+  });
+
+  // (C) A card in the workspace's own stories directory carried NO path component at all — every
+  // workspace's `stories/x.json` was one identity, so the guard named roots got in #1933 did not
+  // apply to the default root.
+  it("tells two workspaces' default-root decks apart", () => {
+    const one = identityFor("/Users/me/w1/artifacts/stories/x.json", [{ id: "W1", canonical: "/Users/me/w1", paths: ["/Users/me/w1"] }]);
+    const two = identityFor("/Users/me/w2/artifacts/stories/x.json", [{ id: "W2", canonical: "/Users/me/w2", paths: ["/Users/me/w2"] }]);
+    expect(one).toBe("/Users/me/w1/artifacts/stories/x.json");
+    expect(two).not.toBe(one);
+  });
+
+  // What the gate in canvasOpenFile.ts is waiting for: once a deck outside every root can be opened
+  // by absolute path, its card must be the SAME card as the one reached through a root. Both sides
+  // are lexical — the plugin echoes an absolute `filePath` as the caller spelled it — so this holds
+  // for a spelling that names the root the way the server resolved it, and a cell reached through a
+  // symlink is the limit stated in canvasCardPath.ts.
+  it("folds the absolute spelling onto the deck opened through a root", () => {
+    const throughRoot = filePathIdentity({ data: { filePath: "stories/decks/x.json", root: "P", script: {} } }, storyRootDirsFrom(withPreset));
+    const byPath = filePathIdentity({ data: { filePath: FILE, script: {} } }, storyRootDirsFrom(withPreset));
+    expect(throughRoot).toBe(byPath);
+  });
+
+  it("still tells two roots' identically-named decks apart", () => {
+    const inPreset = filePathIdentity({ data: { filePath: "stories/deck.json", root: "P", script: {} } }, storyRootDirsFrom(withPreset));
+    const inWorkspace = filePathIdentity({ data: { filePath: "stories/deck.json", root: "W", script: {} } }, storyRootDirsFrom(withPreset));
+    expect(inPreset).toBe(`${WS}/proj/deck.json`);
+    expect(inWorkspace).toBe(`${WS}/deck.json`);
+  });
+
+  // A card made on another machine, or under a preset since removed. Resolving it would need a
+  // directory nothing here knows, so it keeps the identity it has always had rather than folding
+  // onto a guess.
+  it("keeps the old identity for a root this server never registered", () => {
+    expect(filePathIdentity({ data: { filePath: "stories/x.json", root: "gone" } }, storyRootDirsFrom(withPreset))).toBe("gone\u0000stories/x.json");
+  });
+
+  // The state the panel is in for the first moments after it opens.
+  it("keeps the old identity until the config arrives", () => {
+    expect(filePathIdentity({ data: { filePath: "stories/x.json", root: "W" } })).toBe("W\u0000stories/x.json");
+    expect(filePathIdentity({ data: { filePath: "artifacts/html/a.html" } })).toBe("artifacts/html/a.html");
   });
 });
 

--- a/test/src/canvasIdentity.spec.ts
+++ b/test/src/canvasIdentity.spec.ts
@@ -132,6 +132,13 @@ describe("filePathIdentity — one deck, whatever spelling reached it", () => {
     expect(filePathIdentity({ data: { filePath: "stories/x.json", root: "gone" } }, storyRootDirsFrom(withPreset))).toBe("gone\u0000stories/x.json");
   });
 
+  // Not every absolute-looking spelling names a file: a Windows path rooted on the current drive
+  // does not carry the drive. Keeping the old identity is what stops it merging with a POSIX card
+  // of the same tail (Codex P2 on #1976).
+  it("keeps the old identity for a path whose drive is unknown", () => {
+    expect(filePathIdentity({ data: { filePath: "\\decks\\x.json" } }, storyRootDirsFrom(withPreset))).toBe("\\decks\\x.json");
+  });
+
   // The state the panel is in for the first moments after it opens.
   it("keeps the old identity until the config arrives", () => {
     expect(filePathIdentity({ data: { filePath: "stories/x.json", root: "W" } })).toBe("W\u0000stories/x.json");

--- a/test/src/components/GuiPanelCollapse.spec.ts
+++ b/test/src/components/GuiPanelCollapse.spec.ts
@@ -33,17 +33,23 @@ const StubView = defineComponent({
   },
 });
 
-// A registry with just the two tools this file needs: one that collapses (by a `data.key`) and one
-// that does not, so the opt-out default is exercised alongside the new behaviour.
-vi.mock("../../../src/plugins-registry", () => ({
-  getPlugin: (toolName: string) => {
-    if (toolName === "collapsing") {
-      return { toolName, viewComponent: StubView, identityOf: (r: { data?: { key?: string } }) => r.data?.key ?? null };
-    }
-    if (toolName === "plain") return { toolName, viewComponent: StubView };
-    return undefined;
-  },
-}));
+// A registry with just the three tools this file needs: one that collapses (by a `data.key`), one
+// that does not — so the opt-out default is exercised alongside the new behaviour — and one that
+// uses the REAL file-path accessor, which is the only way to see that the panel hands it the
+// registered stories roots (#1976).
+vi.mock("../../../src/plugins-registry", async () => {
+  const { filePathIdentity } = await import("../../../src/utils/canvasIdentity");
+  return {
+    getPlugin: (toolName: string) => {
+      if (toolName === "collapsing") {
+        return { toolName, viewComponent: StubView, identityOf: (r: { data?: { key?: string } }) => r.data?.key ?? null };
+      }
+      if (toolName === "story") return { toolName, viewComponent: StubView, identityOf: filePathIdentity };
+      if (toolName === "plain") return { toolName, viewComponent: StubView };
+      return undefined;
+    },
+  };
+});
 
 // PluginFrame puts each view in a Shadow DOM, which hides it from the queries below and has
 // nothing to do with what is being tested.
@@ -58,6 +64,7 @@ vi.mock("../../../src/components/PluginFrame.vue", () => ({
 }));
 
 const { activeCollectionProjectId } = await import("../../../src/composables/collectionSurface");
+const { useAppConfig } = await import("../../../src/composables/useAppConfig");
 const GuiPanel = (await import("../../../src/components/GuiPanel.vue")).default;
 
 function mountPanel() {
@@ -107,6 +114,8 @@ function stubScrollMetrics(element: Element, { scrollHeight = 1000, clientHeight
 beforeEach(() => {
   handlers.clear();
   viewMounts = 0;
+  // A module-level singleton, so a root left behind here would decide the next file's cards too.
+  useAppConfig().storiesRoots.value = [];
 });
 
 describe("GuiPanel — collapsing repeated cards", () => {
@@ -252,5 +261,52 @@ describe("GuiPanel — following the newest card", () => {
     await push({ uuid: "p1", toolName: "plain", data: {}, viewState: { typed: "x" } });
     await nextTick();
     expect(scroller.element.scrollTop).toBe(250);
+  });
+});
+
+// The panel is where a card's wire path meets the directories it has to be read against: the
+// accessor is pure and the roots are a singleton ref, so nothing but a mounted panel shows that the
+// two were actually joined up.
+describe("GuiPanel — one deck, whichever spelling reached it", () => {
+  const WS = "/Users/me/w";
+  const throughRoot = (uuid: string) => ({ uuid, toolName: "story", data: { filePath: "stories/decks/x.json", root: "W", script: {} } });
+  const byAbsolutePath = (uuid: string) => ({ uuid, toolName: "story", data: { filePath: `${WS}/decks/x.json`, script: {} } });
+
+  it("collapses the two spellings of one deck", async () => {
+    useAppConfig().storiesRoots.value = [{ id: "W", canonical: WS, paths: [WS] }];
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(throughRoot("s1"));
+    await push(byAbsolutePath("s2"));
+    expect(rendered(wrapper)).toEqual(["s2"]);
+  });
+
+  // The panel opens before `/api/config` lands, and cards can arrive in that window. Until the
+  // roots are known the wire path names no file, so the two stand apart — and the moment the config
+  // arrives they collapse, without the cards being re-sent.
+  it("re-collapses when the config arrives", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(throughRoot("s1"));
+    await push(byAbsolutePath("s2"));
+    expect(rendered(wrapper)).toEqual(["s1", "s2"]);
+
+    useAppConfig().storiesRoots.value = [{ id: "W", canonical: WS, paths: [WS] }];
+    await nextTick();
+    expect(rendered(wrapper)).toEqual(["s2"]);
+  });
+
+  // Two decks that merely share a wire tail under different roots are still two cards — the guard
+  // #1933 added, now held by the paths the roots resolve to.
+  it("keeps two roots' identically-named decks apart", async () => {
+    useAppConfig().storiesRoots.value = [
+      { id: "W", canonical: WS, paths: [WS] },
+      { id: "P", canonical: `${WS}/proj`, paths: [`${WS}/proj`] },
+    ];
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push({ uuid: "w1", toolName: "story", data: { filePath: "stories/deck.json", root: "W", script: {} } });
+    await push({ uuid: "p1", toolName: "story", data: { filePath: "stories/deck.json", root: "P", script: {} } });
+    expect(rendered(wrapper)).toEqual(["w1", "p1"]);
   });
 });

--- a/test/src/composables/useAppConfig.spec.ts
+++ b/test/src/composables/useAppConfig.spec.ts
@@ -57,6 +57,37 @@ beforeEach(() => {
   mockConfigFetch();
 });
 
+// What the browser keeps of `/api/config`'s stories roots. `canonical` is the spelling the server
+// RESOLVED, and the Canvas reads a card's wire path against it to decide what the card is about
+// (#1976) — dropping it here would quietly put one deck back on two cards.
+describe("useAppConfig — the stories roots off the wire", () => {
+  it("keeps the resolved spelling alongside the ones the file is compared against", async () => {
+    mockServer([], { get: { storiesRoots: [{ id: "W", canonical: "/private/w", paths: ["/w", "/private/w"] }] } });
+    const { storiesRoots, loadConfig } = useAppConfig();
+    await loadConfig();
+    expect(storiesRoots.value).toEqual([{ id: "W", canonical: "/private/w", paths: ["/w", "/private/w"] }]);
+  });
+
+  // A server older than #1976 sends no `canonical`. The root still gates the Files pane's Canvas
+  // entry; only the identity resolution stands down, which is the behaviour before that change.
+  it("keeps a root that names no resolved spelling", async () => {
+    mockServer([], {
+      get: {
+        storiesRoots: [
+          { id: "W", paths: ["/w"] },
+          { id: "bad", canonical: 7, paths: ["/x"] },
+        ],
+      },
+    });
+    const { storiesRoots, loadConfig } = useAppConfig();
+    await loadConfig();
+    expect(storiesRoots.value).toEqual([
+      { id: "W", paths: ["/w"] },
+      { id: "bad", paths: ["/x"] },
+    ]);
+  });
+});
+
 describe("useAppConfig — auto preset recording", () => {
   it("recordPreset prepends a new dir with a basename label", async () => {
     const { presets, recordPreset } = useAppConfig();

--- a/test/src/utils/canvasCardPath.spec.ts
+++ b/test/src/utils/canvasCardPath.spec.ts
@@ -61,8 +61,12 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("/Users/me//w/./decks/x.json", null, dirs)).toBe("/Users/me/w/decks/x.json");
   });
 
+  // On a WINDOWS server, where such a path names a file. Both separators fold, so the mixed
+  // spelling `absoluteUnder` produces there keys the same as the backslashed one.
   it("keys a Windows path onto the separator the rest of the app compares with", () => {
-    expect(canonicalCardPath("C:\\Users\\me\\decks\\x.json", null, dirs)).toBe("C:/Users/me/decks/x.json");
+    const onWindows: StoryRootDirs = { workspace: "C:/Users/me/w", byId: {} };
+    expect(canonicalCardPath("C:\\Users\\me\\decks\\x.json", null, onWindows)).toBe("C:/Users/me/decks/x.json");
+    expect(canonicalCardPath("C:\\Users\\me/decks/x.json", null, onWindows)).toBe("C:/Users/me/decks/x.json");
   });
 
   // Folded rather than refused: this value opens nothing (the server resolves and realpath-checks
@@ -90,8 +94,12 @@ describe("canonicalCardPath", () => {
   // spelling and the browser cannot infer it — so it is left to the caller's legacy identity
   // rather than keyed into something a drive-qualified card would not match (Codex P2 on #1976).
   it("says nothing for a path whose drive is unknown", () => {
+    const onWindows: StoryRootDirs = { workspace: "C:/Users/me/w", byId: {} };
+    expect(canonicalCardPath("\\decks\\x.json", null, onWindows)).toBeNull();
+    expect(canonicalCardPath("C:\\decks\\x.json", null, onWindows)).toBe("C:/decks/x.json");
+    // …and on a POSIX server neither spelling names anything at all.
     expect(canonicalCardPath("\\decks\\x.json", null, dirs)).toBeNull();
-    expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBe("C:/decks/x.json");
+    expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBeNull();
   });
 
   // The rule both Windows findings on #1976 are instances of: a path that leans on the server's
@@ -122,6 +130,39 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("//server/share/project/decks/x.json", null, onShare)).toBe("//server/share/project/decks/x.json");
     expect(canonicalCardPath("C:\\decks\\x.json", null, onShare)).toBe("C:/decks/x.json");
     expect(canonicalCardPath("stories/decks/x.json", "W", onShare)).toBe("//server/share/project/decks/x.json");
+  });
+
+  // A leading RUN of slashes is one root on POSIX — measured: `realpath("//tmp/x")` is `/tmp/x` —
+  // while `dirPathKey` reads the first as a UNC share, which would give one file two cards
+  // (Codex, re-review of the same head). Collapsed here rather than in the key: on a Windows host
+  // `//server/share` really is a different place.
+  it("folds a POSIX path's leading slash run, which names one file", () => {
+    expect(canonicalCardPath("//Users/me/decks/x.json", null, dirs)).toBe("/Users/me/decks/x.json");
+    expect(canonicalCardPath("///Users/me/decks/x.json", null, dirs)).toBe("/Users/me/decks/x.json");
+    expect(canonicalCardPath("//Users/me/decks/x.json", null, dirs)).toBe(canonicalCardPath("/Users/me/decks/x.json", null, dirs));
+  });
+
+  // …and the same spelling on a Windows host is a share, which is a place of its own.
+  it("keeps a UNC share as a share on a Windows host", () => {
+    const onWindows: StoryRootDirs = { workspace: "C:/Users/me/w", byId: { W: "C:/Users/me/w" } };
+    expect(canonicalCardPath("//server/share/x.json", null, onWindows)).toBe("//server/share/x.json");
+  });
+
+  // The mirror of the drive-less case: a Windows spelling names no file on a POSIX server, so it
+  // keeps its legacy identity instead of being keyed as though it did.
+  it("says nothing for a Windows spelling when the server is a POSIX one", () => {
+    expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBeNull();
+    expect(canonicalCardPath("\\\\server\\share\\x.json", null, dirs)).toBeNull();
+  });
+
+  // A workspace AT a filesystem root builds `//artifacts/stories/…` when the default root's base is
+  // joined — a doubled leading slash, which `dirPathKey` reads as a UNC share. Both branches key by
+  // one rule so that card is the same card as the absolute one for the same file.
+  it("resolves the default root under a workspace that is the filesystem root", () => {
+    const atRoot: StoryRootDirs = { workspace: "/", byId: { W: "/" } };
+    expect(canonicalCardPath("stories/x.json", null, atRoot)).toBe("/artifacts/stories/x.json");
+    expect(canonicalCardPath("stories/x.json", null, atRoot)).toBe(canonicalCardPath("/artifacts/stories/x.json", null, atRoot));
+    expect(canonicalCardPath("stories/decks/x.json", "W", atRoot)).toBe("/decks/x.json");
   });
 
   // The server's spelling is read from whichever root is there — a card can arrive before the

--- a/test/src/utils/canvasCardPath.spec.ts
+++ b/test/src/utils/canvasCardPath.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { canonicalCardPath, storyRootDirsFrom, NO_STORY_ROOTS, type StoryRootDirs } from "../../../src/utils/canvasCardPath";
+
+// The file a card is ABOUT, from the spelling the card happens to carry. Identity is built on this,
+// so a wrong answer merges two decks into one card and a missing one splits one deck into two.
+
+const dirs: StoryRootDirs = { workspace: "/Users/me/w", byId: { W: "/Users/me/w", P: "/Users/me/w/proj" } };
+
+describe("storyRootDirsFrom", () => {
+  it("takes the workspace from the FIRST entry, which is the contract the server registers by", () => {
+    expect(
+      storyRootDirsFrom([
+        { id: "W", canonical: "/w" },
+        { id: "P", canonical: "/w/proj" },
+      ]).workspace,
+    ).toBe("/w");
+  });
+
+  it("maps every root that named its resolved spelling", () => {
+    expect(
+      storyRootDirsFrom([
+        { id: "W", canonical: "/w" },
+        { id: "P", canonical: "/w/proj" },
+      ]).byId,
+    ).toEqual({ W: "/w", P: "/w/proj" });
+  });
+
+  // A server older than #1976 sends `paths` and no `canonical`. Nothing may be guessed from the
+  // spellings — the browser cannot tell which of them the server resolved — so the root resolves
+  // nothing and its cards keep the identity they had before.
+  it("drops a root that carries no resolved spelling", () => {
+    const dirsFromOldServer = storyRootDirsFrom([{ id: "W" }, { id: "P", canonical: "/w/proj" }]);
+    expect(dirsFromOldServer.workspace).toBeNull();
+    expect(dirsFromOldServer.byId).toEqual({ P: "/w/proj" });
+  });
+
+  it("answers nothing-registered for an empty list", () => {
+    expect(storyRootDirsFrom([])).toEqual(NO_STORY_ROOTS);
+  });
+});
+
+describe("canonicalCardPath", () => {
+  it("resolves a story under a named root", () => {
+    expect(canonicalCardPath("stories/decks/x.json", "P", dirs)).toBe("/Users/me/w/proj/decks/x.json");
+  });
+
+  // The same file addressed through the workspace root instead — one deck, two wire spellings.
+  it("resolves the same file the same way through a root further up", () => {
+    expect(canonicalCardPath("stories/proj/decks/x.json", "W", dirs)).toBe("/Users/me/w/proj/decks/x.json");
+  });
+
+  it("resolves a rootless story under the workspace's own stories directory", () => {
+    expect(canonicalCardPath("stories/x.json", null, dirs)).toBe("/Users/me/w/artifacts/stories/x.json");
+  });
+
+  it("takes an absolute path as the answer it already is", () => {
+    expect(canonicalCardPath("/Users/me/decks/keynote.json", null, dirs)).toBe("/Users/me/decks/keynote.json");
+  });
+
+  it("keys an absolute path, so two spellings of one file are one card", () => {
+    expect(canonicalCardPath("/Users/me//w/./decks/x.json", null, dirs)).toBe("/Users/me/w/decks/x.json");
+  });
+
+  it("keys a Windows path onto the separator the rest of the app compares with", () => {
+    expect(canonicalCardPath("C:\\Users\\me\\decks\\x.json", null, dirs)).toBe("C:/Users/me/decks/x.json");
+  });
+
+  // Folded rather than refused: this value opens nothing (the server resolves and realpath-checks
+  // the file itself), and folding is what keeps two spellings of one file on one card.
+  it("folds a traversal instead of treating it as its own file", () => {
+    expect(canonicalCardPath("stories/decks/../x.json", "P", dirs)).toBe("/Users/me/w/proj/x.json");
+  });
+
+  it("says nothing for a root this server never registered", () => {
+    expect(canonicalCardPath("stories/x.json", "from-another-machine", dirs)).toBeNull();
+  });
+
+  it("says nothing before the config arrives", () => {
+    expect(canonicalCardPath("stories/x.json", null, NO_STORY_ROOTS)).toBeNull();
+    expect(canonicalCardPath("stories/x.json", "W", NO_STORY_ROOTS)).toBeNull();
+  });
+
+  // presentHtml addresses its pages relative to the workspace, not through a stories root. Nothing
+  // here knows how to read that, and a guess would fold two tools' paths together.
+  it("says nothing for a relative path that is not a story", () => {
+    expect(canonicalCardPath("artifacts/html/report.html", null, dirs)).toBeNull();
+  });
+
+  it("says nothing for the stories directory itself", () => {
+    expect(canonicalCardPath("stories/", null, dirs)).toBeNull();
+  });
+});

--- a/test/src/utils/canvasCardPath.spec.ts
+++ b/test/src/utils/canvasCardPath.spec.ts
@@ -94,10 +94,10 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBe("C:/decks/x.json");
   });
 
-  // The forward-slash half of the same Windows boundary. `/decks/x.json` is the POSIX absolute
-  // form — refusing it everywhere would disable identity on every other host — so it is refused
-  // only where the SERVER's own roots are drive-qualified, which is the one signal a browser has
-  // (it may itself be a phone). Codex P2 on #1976, second half.
+  // The rule both Windows findings on #1976 are instances of: a path that leans on the server's
+  // CURRENT DRIVE names no one file, and which host that is comes from how the server spells its
+  // own roots — the one signal a browser has (the page may be open on a phone). `/decks/x.json` is
+  // the POSIX absolute form, so refusing it everywhere would disable identity on every other host.
   it("says nothing for a drive-less path when the server's roots are Windows ones", () => {
     const onWindows: StoryRootDirs = { workspace: "C:/Users/me/w", byId: { W: "C:/Users/me/w" } };
     expect(canonicalCardPath("/decks/x.json", null, onWindows)).toBeNull();
@@ -109,6 +109,26 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("stories/decks/x.json", "W", onWindows)).toBe("C:/Users/me/w/decks/x.json");
     // And on a POSIX server the same spelling is the answer it always was.
     expect(canonicalCardPath("/decks/x.json", null, dirs)).toBe("/decks/x.json");
+  });
+
+  // A Windows server whose workspace is a UNC share rather than a drive: `canonicalPath` keeps that
+  // spelling, and a drive-less card path is just as unreconcilable there (Codex P2, third round).
+  // The host test is the same one applied to the server's own root, so this case is closed by the
+  // rule rather than by another branch.
+  it("reads a UNC-rooted server as a Windows one too", () => {
+    const onShare: StoryRootDirs = { workspace: "//server/share/project", byId: { W: "//server/share/project" } };
+    expect(canonicalCardPath("/decks/x.json", null, onShare)).toBeNull();
+    expect(canonicalCardPath("\\decks\\x.json", null, onShare)).toBeNull();
+    expect(canonicalCardPath("//server/share/project/decks/x.json", null, onShare)).toBe("//server/share/project/decks/x.json");
+    expect(canonicalCardPath("C:\\decks\\x.json", null, onShare)).toBe("C:/decks/x.json");
+    expect(canonicalCardPath("stories/decks/x.json", "W", onShare)).toBe("//server/share/project/decks/x.json");
+  });
+
+  // The server's spelling is read from whichever root is there — a card can arrive before the
+  // workspace entry does, and the map is what `storyRootDirsFrom` fills either way.
+  it("reads the host's spelling from a named root when there is no workspace", () => {
+    expect(canonicalCardPath("/decks/x.json", null, { workspace: null, byId: { P: "C:/Users/me/w/proj" } })).toBeNull();
+    expect(canonicalCardPath("/decks/x.json", null, { workspace: null, byId: { P: "/Users/me/w/proj" } })).toBe("/decks/x.json");
   });
 
   it("says nothing for the stories directory itself", () => {

--- a/test/src/utils/canvasCardPath.spec.ts
+++ b/test/src/utils/canvasCardPath.spec.ts
@@ -94,6 +94,23 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBe("C:/decks/x.json");
   });
 
+  // The forward-slash half of the same Windows boundary. `/decks/x.json` is the POSIX absolute
+  // form — refusing it everywhere would disable identity on every other host — so it is refused
+  // only where the SERVER's own roots are drive-qualified, which is the one signal a browser has
+  // (it may itself be a phone). Codex P2 on #1976, second half.
+  it("says nothing for a drive-less path when the server's roots are Windows ones", () => {
+    const onWindows: StoryRootDirs = { workspace: "C:/Users/me/w", byId: { W: "C:/Users/me/w" } };
+    expect(canonicalCardPath("/decks/x.json", null, onWindows)).toBeNull();
+    expect(canonicalCardPath("\\decks\\x.json", null, onWindows)).toBeNull();
+    // …while the two spellings that DO name a file on that host still resolve.
+    expect(canonicalCardPath("C:\\decks\\x.json", null, onWindows)).toBe("C:/decks/x.json");
+    expect(canonicalCardPath("//server/share/x.json", null, onWindows)).toBe("//server/share/x.json");
+    // A root-relative card is unaffected: its base is the root's own drive-qualified spelling.
+    expect(canonicalCardPath("stories/decks/x.json", "W", onWindows)).toBe("C:/Users/me/w/decks/x.json");
+    // And on a POSIX server the same spelling is the answer it always was.
+    expect(canonicalCardPath("/decks/x.json", null, dirs)).toBe("/decks/x.json");
+  });
+
   it("says nothing for the stories directory itself", () => {
     expect(canonicalCardPath("stories/", null, dirs)).toBeNull();
   });

--- a/test/src/utils/canvasCardPath.spec.ts
+++ b/test/src/utils/canvasCardPath.spec.ts
@@ -86,6 +86,14 @@ describe("canonicalCardPath", () => {
     expect(canonicalCardPath("artifacts/html/report.html", null, dirs)).toBeNull();
   });
 
+  // A Windows path rooted on the CURRENT DRIVE names no one file — the drive is not in the
+  // spelling and the browser cannot infer it — so it is left to the caller's legacy identity
+  // rather than keyed into something a drive-qualified card would not match (Codex P2 on #1976).
+  it("says nothing for a path whose drive is unknown", () => {
+    expect(canonicalCardPath("\\decks\\x.json", null, dirs)).toBeNull();
+    expect(canonicalCardPath("C:\\decks\\x.json", null, dirs)).toBe("C:/decks/x.json");
+  });
+
   it("says nothing for the stories directory itself", () => {
     expect(canonicalCardPath("stories/", null, dirs)).toBeNull();
   });


### PR DESCRIPTION
## Summary

#1976 の**1 本目**。issue のコメントで決めた「軽い版」の PR 1 — **card identity だけ**を直す。
`storyWirePath` のゲート（＝ボタンが出る条件）は触らないので、**この PR では issue を閉じない**。

card identity は `filePathIdentity` が決めていて、**ワイヤの綴りそのもの**（`root\0filePath`）だった。
ワイヤの綴りはファイルの性質ではなく「**このサーバが何を登録しているか**」の関数なので、
#1976 とは独立に今日踏める欠陥が 2 つある（どちらも純関数で再現を取ってから直した）:

- **(B) preset を 1 つ足して再起動すると、同じファイルの identity が変わる**
  `file = /Users/me/w/proj/decks/x.json` は、workspace だけ登録なら `W\0stories/proj/decks/x.json`、
  `…/proj` も登録すると `P\0stories/decks/x.json`。前後に作られたカードは 1 つのデッキで 2 枚になり、
  新しい方が古い方を supersede しない。
- **(C) default root のカードにはパス成分が無い**
  `/w1/artifacts/stories/x.json` も `/w2/artifacts/stories/x.json` も identity は `stories/x.json`。
  #1933 が named root について入れた守りが、default root には効いていなかった。

**直し方**: カードが持つ情報から canonical 絶対パスを組み立て、それを identity にする。
root id → canonical ディレクトリ、tail はどちらの綴りでも同じなので、上の 2 つの綴りは
どちらも `/Users/me/w/proj/decks/x.json` に解決する。絶対パスの `filePath` も同じ規則で読むので、
**「root 経由で開いたカード」と「絶対パスで開いたカード」が 1 枚に畳まれる** — これが PR 2
（ゲートを緩めてボタンを出す）の前提。解決できないカードは**旧来の文字列にフォールバック**するので、
マイグレーションも二重キーも要らない。

順番を逆にできない理由: ボタンを先に出すと割れたカードが生まれ、それが永続 store
（`~/.mulmoterminal/toolresults`）に残る。あとから identity を変えるとき、移行対象が
「設計上の互換性」ではなく「実際に割れて保存された履歴」になる。

設計メモ: [`plans/fix-1976-canonical-card-identity.md`](plans/fix-1976-canonical-card-identity.md)

## Items to Confirm / Review

1. **`/api/config` に `canonical` を足した**（`storiesRoots[].canonical`）。issue のコメントは
   「`paths` に canonical も入っているから使える」としていたが、**どれが canonical かの印が無く、
   位置も一定しない**（symlink preset がマージされる経路で順序が変わる）。実サーバで確認した実測:
   symlink 経由で起動すると `paths[0]` は **launcher で打った symlink 綴り**で、canonical は 2 番目。
   ブラウザは realpath できないので、どの綴りが解決済みかはサーバしか言えない。
   → **ラベルにする判断でよいか**（位置の規約にする案もあった）。
2. **`identityOf` の signature を `(result, storyRoots)` に変えた**。root 表は mulmoScript 固有だが
   全 accessor に渡している（引数 1 つだけ宣言している accessor はそのままで assignable）。
   `IdentityContext` のような箱を噛ませるほどではない、という判断。
3. **限界（今回入れていないこと）**: プラグインは**絶対パスの `filePath` を呼び出し側が綴ったまま返す**
   （core の `locate` が `byPath` にその文字列を渡す）。なので **symlink 経由の綴りで開いた絶対パスは
   畳めない** — 実サーバで再現も確認済み。塞ぐには `resolveStory` の realpath 済み `absolutePath` を
   card payload に載せる「正確な版」が要る。両側とも値は手元にあるが、この PR には入れていない。
4. **html の絶対パスも `dirPathKey` で正規化されるようになった**（`/a/./b.html` と `/a/b.html` が 1 枚）。
   意図した副作用。別ファイルが混ざることはないが、想定どおりか。

5. **レビューで足した規則（Windows）**: card path が「サーバの *現在のドライブ* に依存する綴り」の
   ときは identity を作らず、旧来の文字列に落ちる。`\deck.json` はどの host でもそう扱い、
   `/deck.json` は **サーバが自分の root をドライブ付き / UNC で綴っている場合だけ**そう扱う
   （POSIX ではそれが唯一の絶対形なので、一律に拒めば機能が死ぬ）。host の判定は `navigator` では
   なく **サーバが登録した root の綴り**から取る — この画面はスマホで開かれていることがある。

## 検証

- **(B)(C) を現行コードに対して再現させてから**直した。回帰テストは Files ペインの実チェーン
  （`storyWirePath` → card → `filePathIdentity`）を通す（片側だけでは欠陥が見えないため）。
- 解決を無効化して**全部赤になること**を確認（identity 10 本 + パネル 2 本）。
- `yarn format` / `lint` / `typecheck` / `build` / `test`（12099 passed）ローカル green。
- **実サーバで確認**（workspace を symlink 経由で起動、preset に `ws/proj` を登録）:
  - `/api/config` の `canonical` が resolved 綴りで、`paths[0]` ではない。
  - プラグインの実レスポンス 4 通り（default root / root+tail / 絶対パス canonical / 絶対パス symlink）を
    identity にかけると、`root+tail` と `絶対パス canonical` が 1 つに畳まれる。symlink 綴りだけ別（上記 3）。
  - preset 追加前後の 2 つのワイヤ綴りが同じ identity に解決される（(B) の実機再現）。
  - 実際に保存された 2 枚の toolResult を実 config で解決 → 1 identity。
  - ビルド済みアプリをブラウザで読み込み: 描画される / uncaught console error なし。
  - **やっていないこと**: Canvas ペインを実ブラウザで開いてカードを目視するところまでは自動化できなかった
    （シェルセルの UI 操作が不安定）。表示の畳み込み自体は **GuiPanel を実コンポーネントとしてマウントする**
    spec で固定してある（config 到着で再 collapse されることも含む）。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1976 のコメントを確認して、その方法で進める

Refs #1976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD523v7QBEqiYymHgLYbVT

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Card identity now consistently uses canonical absolute paths, preventing duplicates from different path spellings.
  - Decks with identical names in different story roots remain distinct.
  - POSIX, Windows, and UNC rooted paths are recognized consistently; single-leading-backslash paths are not treated as rooted.
  - Compatibility is preserved when story-root configuration is unavailable or incomplete.
  - Story-root configuration now retains resolved canonical paths.

- **Tests**
  - Added coverage for canonical paths, multiple roots, symlinks, cross-platform paths, and delayed configuration loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
