### PR TITLE
fix: 共有 shortcuts.json から MulmoClaude の color を消さない (#1993)

### DIFF
--- a/common/shortcuts.ts
+++ b/common/shortcuts.ts
@@ -19,6 +19,14 @@ export interface Shortcut {
   title: string;
   /** Cached material-symbols glyph — refreshed on reconcile. */
   icon: string;
+  /** Cached accent colour name — MulmoClaude's, and only MulmoClaude draws it (#1993).
+   *
+   *  Carried rather than understood: this app has no accent palette, so it keeps whatever string
+   *  the file holds and hands it back unchanged. Deliberately NOT validated here — deciding which
+   *  colours are legal is the job of the app that draws them, and a check that drifted from theirs
+   *  would silently delete a colour they consider valid, which is the bug this field exists to fix.
+   *  Absent when the collection names none. */
+  color?: string;
 }
 
 /** True when two shortcuts target the same thing (the dedupe key). */

--- a/plans/fix-1993-shortcut-color.md
+++ b/plans/fix-1993-shortcut-color.md
@@ -1,0 +1,42 @@
+# fix: 共有 shortcuts.json から MulmoClaude の `color` が消える (#1993)
+
+## 問題
+
+`<workspace>/config/shortcuts.json` は MulmoClaude と共有している。MulmoClaude はピンに
+`color`（アクセント色）を持たせて保存し、`PluginLauncher.vue` / `ShortcutReorderPopover.vue` で
+実際に描いている。
+
+MulmoTerminal 側の `normalizeShortcuts`（`server/backends/shortcuts.ts`）は、読み込んだレコードを
+`{kind, slug, title, icon}` の**新しいオブジェクトに組み立て直す**ので、`color` が落ちる。
+読み（GET で配信する前）と書き（PUT でディスクに書く前）の両方に効くため、
+**MulmoTerminal でピン留めを 1 回でも操作すると、全エントリの色が消える**。
+
+意図ではなくドリフト: `common/shortcuts.ts` の冒頭に「Keep this type in sync with MulmoClaude's」と
+書いてある。
+
+影響は見た目のみで、MulmoClaude 側の `reconcile` が index を開いたときに貼り直すので自己修復もする。
+それでも「MulmoTerminal を触るたびに色が飛ぶ」往復は残る。
+
+## 決めたこと
+
+| 論点 | 決定 | 理由 |
+|---|---|---|
+| 直し方 | `common/shortcuts.ts` の `Shortcut` に **`color?: string`** を足し、`normalizeShortcuts` で通す | 共有ファイルの契約は「MulmoClaude の型と同期」。相手の型をそのまま持つのが最小で、最も素直 |
+| 値の検証 | **しない**（文字列であることだけ見る） | パレットを持っているのは MulmoClaude 側（`isAccentColor`）。こちらが妥当性を判断すると、**判断がずれた瞬間に同じ「黙って消える」が再発する**。描かない側が捨てる理由がない |
+| 未知キー全部を保持する案 | **採らない**（PR に follow-up として書く） | 片側だけ直しても、MulmoClaude の `toShortcut` も同様に組み立て直すので、こちらが足したキーは向こうで落ちる。両リポジトリにまたがる変更で、この issue の範囲ではない |
+| UI | 触らない | MulmoTerminal は色を描かない。持って返すだけ |
+
+## 実装
+
+- `common/shortcuts.ts` — `color?: string` を追加（なぜ検証しないかをコメントに残す）。
+- `server/backends/shortcuts.ts` — `normalizeShortcuts` が `color` を拾う。空文字は付けない
+  （`color: undefined` を JSON に出さないための条件付き追加。MulmoClaude 側と同じ扱い）。
+- `test/server/backends/shortcuts.spec.ts` — 以下を固定する:
+  - `normalizeShortcuts` が `color` を残す / 文字列でない `color` は落とす。
+  - **ファイル往復**: `color` 付きのファイルを置いて GET → そのまま PUT → ディスクの `color` が残る
+    （これが実際に壊れていた経路）。
+
+## 確認すること
+
+- MulmoClaude 側で色付きのピンを作り、MulmoTerminal で別のものをピン留め／解除しても色が残ること。
+- MulmoTerminal 自身は色を読まないので、UI の変化が無いこと。

--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -24,26 +24,40 @@ const KINDS = new Set<string>(SHORTCUT_KINDS);
 // entry below can be built without asserting the kind it just checked.
 const isShortcutKind = (value: string): value is ShortcutKind => KINDS.has(value);
 
-/** Coerce arbitrary JSON into a clean `Shortcut[]`: drop malformed entries (bad
- *  kind / empty slug / non-string fields), default title→slug and icon→"bookmark",
- *  and dedupe on (kind, slug) keeping the first. Pure — exported for tests. */
+/** What ONE stored record has to be to survive: a known kind and a non-empty slug, with the label
+ *  and glyph defaulted. Split out of the loop below so each concern reads on its own — the same
+ *  split, and the same name, MulmoClaude gives it in `shortcuts-io.ts`.
+ *
+ *  It REBUILDS the record, which is why every field the file may carry has to be listed here: one
+ *  left out is not passed through, it is deleted — from the copy served to the browser AND from the
+ *  file the next write puts back. `color` was missing for exactly that reason (#1993), so every
+ *  pin/unpin in this app wiped the colours MulmoClaude had stored in the shared file. */
+function toShortcut(raw: unknown): Shortcut | null {
+  if (!isRecord(raw)) return null;
+  const { kind, slug, title, icon, color } = raw;
+  if (typeof kind !== "string" || !isShortcutKind(kind)) return null;
+  if (typeof slug !== "string" || slug.length === 0) return null;
+  return {
+    kind,
+    slug,
+    title: typeof title === "string" ? title : slug,
+    icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",
+    // Added conditionally, the way MulmoClaude adds it: an explicit `color: undefined` serialises
+    // as `null`, which is a value the other app would then have to know to ignore.
+    ...(typeof color === "string" && color.length > 0 ? { color } : {}),
+  };
+}
+
+/** Coerce arbitrary JSON into a clean `Shortcut[]`: drop malformed entries and dedupe on
+ *  (kind, slug), keeping the first. Pure — exported for tests. */
 export function normalizeShortcuts(input: unknown): Shortcut[] {
   if (!Array.isArray(input)) return [];
   const out: Shortcut[] = [];
-  for (const raw of input) {
-    if (!isRecord(raw)) continue;
-    const { kind, slug, title, icon } = raw;
-    if (typeof kind !== "string" || !isShortcutKind(kind)) continue;
-    if (typeof slug !== "string" || slug.length === 0) continue;
-    const entry: Shortcut = {
-      kind,
-      slug,
-      title: typeof title === "string" ? title : slug,
-      icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",
-    };
-    if (out.some((existing) => sameShortcut(existing, entry))) continue;
+  input.forEach((raw) => {
+    const entry = toShortcut(raw);
+    if (!entry || out.some((existing) => sameShortcut(existing, entry))) return;
     out.push(entry);
-  }
+  });
   return out;
 }
 

--- a/test/server/backends/shortcuts.spec.ts
+++ b/test/server/backends/shortcuts.spec.ts
@@ -27,6 +27,26 @@ describe("normalizeShortcuts", () => {
     expect(normalizeShortcuts(undefined)).toEqual([]);
     expect(normalizeShortcuts({ shortcuts: [] })).toEqual([]);
   });
+
+  // #1993: this rebuilds every record, so a field it does not list is DELETED rather than passed
+  // through. `color` is MulmoClaude's — it stores it in this shared file and draws it — and leaving
+  // it out wiped the colours from every entry each time this app wrote the file.
+  it("keeps the colour MulmoClaude stores, whatever the palette says", () => {
+    expect(normalizeShortcuts([{ kind: "collection", slug: "a", title: "A", icon: "star", color: "violet" }])).toEqual([
+      { kind: "collection", slug: "a", title: "A", icon: "star", color: "violet" },
+    ]);
+    // Not validated against a palette this app does not have: a check that drifted from theirs
+    // would delete a colour they consider valid, which is the bug itself.
+    expect(normalizeShortcuts([{ kind: "collection", slug: "a", color: "not-a-palette-name" }])[0].color).toBe("not-a-palette-name");
+  });
+
+  // Absent rather than null: `color: undefined` serialises as `null`, a value the other app would
+  // then have to know to ignore.
+  it("leaves the key out when there is no colour to carry", () => {
+    const [entry] = normalizeShortcuts([{ kind: "feed", slug: "b", color: 7 }]);
+    expect(entry).toEqual({ kind: "feed", slug: "b", title: "b", icon: "bookmark" });
+    expect("color" in entry).toBe(false);
+  });
 });
 
 describe("/api/shortcuts routes", () => {
@@ -105,6 +125,28 @@ describe("/api/shortcuts routes", () => {
     const onDisk = JSON.parse(readFileSync(path.join(ws, "config", "shortcuts.json"), "utf8"));
     expect(Array.isArray(onDisk.shortcuts)).toBe(true);
     expect(onDisk.shortcuts).toHaveLength(1);
+  });
+
+  // The path that actually broke (#1993): MulmoClaude writes a colour, this app reads the file and
+  // writes it back — a pin/unpin here is exactly that — and the colour has to survive the round
+  // trip, on the wire AND on disk.
+  it("does not strip MulmoClaude's colour when it rewrites the file", async () => {
+    const file = path.join(ws, "config", "shortcuts.json");
+    mkdirSync(path.dirname(file), { recursive: true });
+    const stored = [{ kind: "collection", slug: "lens", title: "カメラのレンズ", icon: "photo_camera", color: "amber" }];
+    writeFileSync(file, JSON.stringify({ shortcuts: stored }));
+
+    const served = await (await request("/api/shortcuts")).json();
+    expect(served).toEqual({ shortcuts: stored });
+
+    // ...and putting back what was served — what pinning one more thing does — keeps it on disk.
+    const put = await request("/api/shortcuts", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ shortcuts: [...stored, { kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] }),
+    });
+    expect(put.status).toBe(200);
+    expect(JSON.parse(readFileSync(file, "utf8")).shortcuts[0]).toEqual(stored[0]);
   });
 
   it("reads an existing MulmoClaude-written file (wrapper format)", async () => {


### PR DESCRIPTION
## Summary

`<workspace>/config/shortcuts.json` は MulmoClaude と共有しているのに、MulmoTerminal の
`normalizeShortcuts` がレコードを `{kind, slug, title, icon}` で**組み立て直して**いたため、
MulmoClaude が保存した `color`（アクセント色）が落ちていました。読み（GET で配信する前）と
書き（PUT でディスクに書く前）の両方に効くので、**MulmoTerminal でピン留めを 1 回操作するだけで
全エントリの色が消えます**。

- `common/shortcuts.ts` に `color?: string` を追加。ファイル冒頭に「Keep this type in sync with
  MulmoClaude's」と書いてあるとおり、これは仕様ではなく**ドリフト**です。
- 1 レコード分の組み立てを `toShortcut` に切り出しました（MulmoClaude 側と**同じ分け方・同じ名前**）。

Closes #1993

## Items to Confirm / Review

1. **色を検証しない判断**。MulmoTerminal は色を描かず、パレットも持っていません（持っているのは
   MulmoClaude の `isAccentColor`）。ここで妥当性を判断すると、判断がずれた瞬間に**同じ「黙って消える」が
   再発**します。なので「文字列で、空でなければ運ぶ」だけにしています。
2. **未知キーを一般に保持する案は採っていません**。グローバル config は `serializableAppConfig` で
   未知のトップレベルキーを保持しています（#966）。同じことを共有ファイルでもやる手はありますが、
   MulmoClaude の `toShortcut` も同様に組み立て直すので**片側だけ直しても向こうで落ちます**。
   両リポジトリにまたがる変更なので、この issue の範囲外としました。必要なら follow-up にします。
3. **MulmoTerminal からピン留めしたとき、色は付きません**（`PinToggle` は plugin binding から
   `{kind, slug, title, icon}` しか受け取らないため）。MulmoClaude 側の `reconcile` が index を
   開いた時点で貼り直すので実害は小さいと判断しましたが、ここも follow-up の候補です。
4. **`toShortcut` への切り出し**は、`sonarjs/cognitive-complexity` が 18 > 15 で止まったのが直接の
   きっかけです（抑制はしていません）。結果として MulmoClaude と同じ形になりました。

## 検証

- `yarn format` → `lint` → `typecheck` → `build` → `test` すべて green（**816 files**）。
- 新規テスト 3 本 + 実際に壊れていた経路の往復テスト:
  - `normalizeShortcuts` が色を残す / **パレット外の文字列でも残す**（検証しない、の固定）。
  - 色が無ければ `color` キー自体を出さない（`color: undefined` は JSON で `null` になり、
    相手側が無視の仕方を知らないといけなくなるため）。
  - **MulmoClaude が書いたファイルを読んで書き戻す**（＝こちらでピン留めを 1 つ足す動作）と、
    ディスクの色が残る。
- 修正を外すと前者 2 本が落ちることを確認しています。

## User Prompt

- 「1993 すすめて」— PR #1991 の作業中に見つけて起票した issue #1993（MulmoTerminal がピンを
  書き込むと、共有 shortcuts.json から MulmoClaude の `color` が消える）を実装まで進めてほしい。

## やっていないこと

- MulmoClaude 側は触っていません（あちらは既に `color` を保存・描画しています）。
- 未知キー一般の保持（上記 2）と、MulmoTerminal からのピン留め時に色を付けること（上記 3）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhpBoaAvZsCqPmkLYFvCyy

work in mulmoterminal2
