### PR TITLE
fix(shapescript): take shapescript-plugin 1.1.1, where a stray `}` no longer hangs the server

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -21,6 +21,16 @@ Entries here are folded into the next release's heading when it ships.
   (100,000 objects, 5,000,000 vertices, a 30-second wall clock), which is what lets a genuinely
   large procedural model through: the old object cap refused a 150×150 grid of cubes while using
   barely a quarter of its vertex budget.
+- **[#2006](https://github.com/receptron/mulmoterminal/pull/2006)** — and then a model with one
+  brace too many took the whole server down. `presentShapeScript` on a script whose braces do not
+  balance never returned: the plugin's top-level parse loop spun on the unmatched `}` forever, and
+  because that parse is synchronous and runs inside this server, it did not fail one tool call — it
+  pinned the process. Still listening on its port, 100% CPU, accepting nothing, every `/api/*`
+  request and websocket timing out until it was restarted. An agent writing a 130-line model is
+  exactly who trips this. Fixed upstream in
+  [mulmoclaude#3058](https://github.com/receptron/mulmoclaude/pull/3058) and taken here as
+  shapescript-plugin **1.1.1**: an unmatched brace is now a parse error naming its line and column,
+  like every other diagnostic the tool returns.
 
 ## mulmoterminal@4.17.0 — 2026-09-08
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^1.1.0",
+    "@mulmoclaude/shapescript-plugin": "^1.1.1",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/test/scripts/shapescriptParserFix.spec.ts
+++ b/test/scripts/shapescriptParserFix.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+// The ShapeScript build this host runs on must be one where an unmatched brace is a
+// PARSE ERROR, not a hang.
+//
+// Until shapescript-plugin 1.1.1, `parseShapeScript` spun forever on a `}` with no block
+// open: `parseNode()` answers `null` there so a BLOCK's loop can stop, and at the top level
+// nothing consumed the token, so the loop never advanced. The parse is SYNCHRONOUS and runs
+// in this process, so it did not fail one tool call — it pinned the server. A 4394-character
+// agent-written model with one extra `}` on its last line left MulmoTerminal LISTENing on its
+// port at 100% CPU, accepting nothing, every `/api/*` request and websocket timing out until
+// it was restarted (mulmoclaude#3058).
+//
+// Why this asserts the VERSION rather than feeding the parser the bad input: the failure is a
+// synchronous infinite loop, and `testTimeout` cannot interrupt one — a regression would hang
+// the vitest worker rather than fail it, which is the same outage in CI. The behavioural test
+// belongs upstream, where it runs against the parser's own source, and it is there. What this
+// host can usefully pin is that no build WITHOUT that fix can be the one installed here.
+//
+// Reads what is INSTALLED as well as what is declared, for the reason mulmoclaudePeerRanges
+// gives: a range resolves to one version, and that version is the one that runs.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const PKG = "@mulmoclaude/shapescript-plugin";
+/** The first build where an unmatched brace throws instead of looping (mulmoclaude#3058). */
+const FLOOR = [1, 1, 1] as const;
+
+const parts = (version: string): number[] =>
+  version
+    .replace(/^[^\d]*/, "")
+    .split(".")
+    .map(Number)
+    .slice(0, 3);
+
+/** True when `version` is at or above FLOOR. Enough for a floor check on one package's own
+ *  release line — no prerelease or range algebra, which is why semver is not pulled in. */
+const atLeastFloor = (version: string): boolean => {
+  const got = parts(version);
+  for (let i = 0; i < FLOOR.length; i++) {
+    if ((got[i] ?? 0) !== FLOOR[i]) return (got[i] ?? 0) > FLOOR[i];
+  }
+  return true;
+};
+
+describe("the ShapeScript parser this host runs on", () => {
+  it("is installed at 1.1.1 or later, where a stray `}` cannot hang the server", () => {
+    const installed = JSON.parse(readFileSync(join(root, "node_modules", PKG, "package.json"), "utf8")) as { version: string };
+    expect(atLeastFloor(installed.version), `${PKG} ${installed.version} is installed; 1.1.1+ is required`).toBe(true);
+  });
+
+  it("cannot be RE-installed below it — our declared range's floor is 1.1.1 too", () => {
+    // A passing test above with a `^1.1.0` range would be luck: the next fresh install is free
+    // to resolve 1.1.0 again.
+    const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as { dependencies?: Record<string, string> };
+    const range = manifest.dependencies?.[PKG];
+    expect(range, `${PKG} is not a dependency of this package`).toBeTruthy();
+    expect(atLeastFloor(range ?? ""), `the declared range ${range ?? ""} admits a build older than 1.1.1`).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,10 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/shapescript-plugin@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-1.1.0.tgz#abf10a281c1f47205599e12a7baeb1af8e1a0017"
-  integrity sha512-O0E+D5ogexfT4nZ4wTOvW6kvsWfWXUDS4U+JljBZWbqmU75R7wdpccrV+fjGINzhzxId1KskITYNOx67dwkPww==
+"@mulmoclaude/shapescript-plugin@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-1.1.1.tgz#cb38ac9f375865f68d57b5528c52903abc0cf5c8"
+  integrity sha512-H0n9ztH6gNo7zcQDSbbCCNFh7id/AeSOplLZWR4JG8Xv1Tsq+F98sldJFIaneduK2SkNglyythP6SIHToJOqsQ==
   dependencies:
     three "^0.185.1"
     three-bvh-csg "^0.0.18"


### PR DESCRIPTION
## What this fixes

After #2000 shipped, MulmoTerminal's server stopped answering anything — every `/api/*` call and every websocket through the Vite proxy failed with `AggregateError [ETIMEDOUT]`. `ETIMEDOUT` rather than `ECONNREFUSED` was the tell: the process was alive, still `LISTEN`ing on 34567, at 100% CPU, accepting no connections.

Pausing the wedged process over the inspector put the top JS frame in shapescript-plugin's parser, and the frozen call's own arguments read off the stack frame were `presentShapeScript({ title: "Empire State Building", script: <4394 chars> })` — a model with **41 `}` to 40 `{`**, one stray closing brace on its last line, written by an agent.

The plugin's `parseNode()` answers `null` at a `}` so a BLOCK's loop can stop there. At the top level nothing consumes that token, the position never moves, and the parse loop spins on it forever. Being synchronous and in-process, it took the whole server with it rather than failing one tool call.

Fixed upstream in [mulmoclaude#3058](https://github.com/receptron/mulmoclaude/pull/3058), published as **1.1.1**. This is the bump.

## Verification

The exact script that hung the server, against the installed 1.1.1 build:

```
Parse error at line 131, column 1: Unexpected token: RBRACE
```

`yarn typecheck`, `yarn lint`, `yarn test` (12201 passed, 50 skipped) all clean.

The range moves `^1.1.0` → `^1.1.1` rather than resting on the caret, so it says which build carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tVmyinjLa4mFiR5tyL4fg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unbalanced braces in ShapeScript now return a clear parse error with line and column details instead of causing the parser to hang and block the server.
  - Updated the ShapeScript plugin to version 1.1.1 or later to ensure the parsing fix is applied.

- **Documentation**
  - Added an Unreleased changelog entry describing the ShapeScript plugin update and parsing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->