### PR TITLE
fix: park ボタンを session terminal だけに出す (#2007)

### DIFF
--- a/plans/fix-2007-park-button-non-session-cells.md
+++ b/plans/fix-2007-park-button-non-session-cells.md
@@ -1,0 +1,49 @@
+# fix: launcher / command セルに死んだ park ボタンが出る
+
+Issue: #2007
+
+## User Prompt
+
+> https://github.com/receptron/mulmoterminal/issues/2007 なおせる？
+
+## 原因
+
+`CellChromeButtons.vue` の park ボタンは `v-if="parked !== undefined"` で出し分けていた。
+Vue は **宣言されていない boolean prop を `false` にキャストする**ので `parked === undefined` は
+決して真にならず、ガードは常に真 = 全セル種別でボタンが描画されていた。
+
+`LauncherCell` / `CommandCell` は `CellShell` → `cellChromeBinding` 経由でこのボタンを使い、その
+イベント表は意図的に `toggle-park` を持たない（"minus the ones a cell binds itself"）。よって
+emit は誰にも届かず、押しても何も起きない。park 機能が入った #992 (`a9b5268b`, 2026-07-31) から
+一度も意図どおりに動いていない。
+
+## 実機での確認（before / after）
+
+隔離 `HOME`（launcher chip 1 つ）+ port 34611 の実サーバ、Playwright（Chromium）で
+「terminal セル + launcher セル」のグリッドを描画して比較した。
+
+- **before**: launcher セルのヘッダに park ボタンあり。クリックしても `aria-pressed` は `false` のまま、
+  localStorage の grid 状態も `awake` のまま、console error も無し（= issue の報告どおり死んでいる）。
+- **after**: launcher セルに park ボタンは出ない。terminal セルは従来どおりボタンを持ち、押すと
+  `aria-pressed` が `true`、title が "Wake this terminal" になり、grid 状態が `parked` で永続化される。
+
+## 修正
+
+- `CellChromeButtons` に `canPark?: boolean` を追加し、ボタンのガードを `v-if="canPark"` にした。
+  `parked` は押下状態（pressed / title / 配色）専用に残す。**「渡さないことで opt out する」は
+  boolean prop では表現できない**ため、権限を表す prop を別に立てるのが最小の修正。
+- `TerminalCell` の 2 か所（cockpit ヘッダ / 通常ヘッダ）だけが `:can-park="true"` を渡す。
+  `CellShell` 経由の launcher / command セルは渡さない = ボタンが出ない。
+
+## テスト
+
+- `CellChromeButtons.spec.ts`: prop 未指定で非表示（`canPark: false` ではなく **未指定** を先に見る。
+  false は壊れていた版の値そのものなので、それだけでは回帰を捕まえられない）、`parked` だけ来ても
+  出ない、`canPark` で出る、押下状態、emit、close の直前という並び。
+- `LauncherCell.spec.ts` / `CommandCell.spec.ts`: 実コンポーネントを mount して park ボタンが無いこと。
+  issue が「observed」としたのは launcher 側だけで command 側は推測だったが、両方 mount して確認した。
+
+## 同じ罠の掃き出し
+
+`v-if` で `!== undefined` を見ている箇所は他に `FilterChip.vue` の `count` のみ。こちらは
+`count?: number` で、Vue が数値 prop を勝手にキャストすることは無いため問題なし。

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -29,11 +29,16 @@ const props = defineProps<{
   // manageCollection is served under. False REMOVES the button, where canvasAvailable only
   // disables its own: a pane the agent cannot act on is not worth a control to explain.
   collectionsAvailable?: boolean;
-  // Whether this cell is set aside (#992). Present ONLY on a cell that can be parked — a session
-  // terminal. Left undefined, the button is not rendered at all, which is how the command and
-  // launcher cells opt out without declaring anything: an ephemeral run and an empty launch slot
-  // have nothing to come back to.
-  parked?: boolean | undefined;
+  // Whether this cell can be set aside at all (#992) — only a session terminal can, and it is the
+  // only caller that passes this. It is a prop of its own rather than the absence of `parked`
+  // below, because Vue casts an ABSENT boolean prop to `false`: `parked === undefined` is never
+  // true, so a guard written that way rendered the button on every cell type, including the
+  // command and launcher cells, whose event binding deliberately omits `toggle-park` — so it
+  // clicked and did nothing (#2007).
+  canPark?: boolean;
+  // Whether this cell is currently set aside, i.e. the button's pressed state. Only read where
+  // `canPark` is true.
+  parked?: boolean;
 }>();
 const emit = defineEmits<{
   (
@@ -200,11 +205,11 @@ const parkTitle = computed(() => (props.parked ? "Wake this terminal" : "Set asi
   <!-- Before close on purpose: the two are the choice the user is making — set it aside, or end
        it — and the reversible one should not sit past the one that tears a session down. -->
   <button
-    v-if="parked !== undefined"
+    v-if="canPark"
     data-testid="cell-park-btn"
     class="cell-btn"
     :class="parkClass"
-    :aria-pressed="parked"
+    :aria-pressed="!!parked"
     :title="parkTitle"
     :aria-label="parkTitle"
     @click="emit('toggle-park')"

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1348,7 +1348,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           @click="onHeaderClick"
         >
           <span class="cell-actions" :class="CELL_ACTIONS">
-            <CellChromeButtons v-bind="chromeProps" :parked="parked" v-on="chromeEvents" @toggle-park="togglePark" />
+            <CellChromeButtons v-bind="chromeProps" :can-park="true" :parked="parked" v-on="chromeEvents" @toggle-park="togglePark" />
           </span>
         </CockpitHeader>
         <!-- Row 1 — the CELL (normal grid / expanded): what it is (dir + git + model/token + what
@@ -1506,7 +1506,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">
               <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
             </button>
-            <CellChromeButtons v-bind="chromeProps" :parked="parked" v-on="chromeEvents" @toggle-park="togglePark" />
+            <CellChromeButtons v-bind="chromeProps" :can-park="true" :parked="parked" v-on="chromeEvents" @toggle-park="togglePark" />
           </span>
         </div>
         <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -4,6 +4,7 @@ import CellChromeButtons from "../../../src/components/CellChromeButtons.vue";
 import { CELL_BTN, CELL_CLOSE_BTN } from "../../../src/components/cellChromeClasses";
 
 const mountButtons = (expanded = false) => mount(CellChromeButtons, { props: { expanded } });
+const PARK = '[data-testid="cell-park-btn"]';
 
 describe("CellChromeButtons", () => {
   // Both buttons must carry their styling as utilities. As scoped CSS it reached neither: this
@@ -213,5 +214,57 @@ describe("the open pane's button, seen", () => {
   it("swaps the idle fill out rather than layering over it", () => {
     expect(button({ rightPane: "tools" }, TOOLS).classes()).not.toContain("bg-transparent");
     expect(button({ rightPane: "files" }, TOOLS).classes()).toContain("bg-transparent");
+  });
+});
+
+// #2007. The button belongs to a session terminal — the only cell that can be set aside — and the
+// command and launcher cells reach these buttons through a binding that deliberately has no
+// `toggle-park` key, so one rendered there clicks and does nothing.
+//
+// It was guarded on `parked !== undefined`, which cannot express "opt out by not passing it": Vue
+// casts an ABSENT boolean prop to `false`, so the guard was true on every cell and the button
+// shipped on all three from the day parking landed. Hence a prop of its own, and hence the first
+// test here mounts with the prop MISSING rather than with `canPark: false` — false is what the
+// broken version already had.
+describe("the park button", () => {
+  const parkButton = (props: Record<string, unknown>) => mount(CellChromeButtons, { props: { expanded: true, ...props } }).find(PARK);
+
+  it("is absent when the caller says nothing about parking", () => {
+    expect(parkButton({}).exists()).toBe(false);
+    expect(parkButton({ canPark: false }).exists()).toBe(false);
+  });
+
+  // `parked` is the pressed state, not the permission: a cell that cannot park is not given the
+  // button by being handed one.
+  it("stays absent even if a parked flag arrives without it", () => {
+    expect(parkButton({ parked: true }).exists()).toBe(false);
+  });
+
+  it("is there for a session terminal, on a tile as well as enlarged", () => {
+    for (const expanded of [false, true]) expect(parkButton({ expanded, canPark: true }).exists()).toBe(true);
+  });
+
+  it("reads as pressed, and offers the way back, while the cell is set aside", () => {
+    const awake = parkButton({ canPark: true, parked: false });
+    expect(awake.attributes("aria-pressed")).toBe("false");
+    expect(awake.attributes("title")).toBe("Set aside (stays open, keeps its history)");
+
+    const asleep = parkButton({ canPark: true, parked: true });
+    expect(asleep.attributes("aria-pressed")).toBe("true");
+    expect(asleep.attributes("title")).toBe("Wake this terminal");
+  });
+
+  it("emits the intent and never acts on it, like its neighbours", async () => {
+    const w = mount(CellChromeButtons, { props: { expanded: true, canPark: true } });
+    await w.find(PARK).trigger("click");
+    expect(w.emitted("toggle-park")).toHaveLength(1);
+    expect(w.emitted("close")).toBeUndefined();
+  });
+
+  // Set aside, or end it — the reversible one must not sit past the one that tears a session down.
+  it("sits immediately before close", () => {
+    const buttons = mount(CellChromeButtons, { props: { expanded: true, canPark: true } }).findAll(".cell-btn");
+    expect(buttons[buttons.length - 2].attributes("data-testid")).toBe("cell-park-btn");
+    expect(buttons[buttons.length - 1].attributes("aria-label")).toBe("Close terminal");
   });
 });

--- a/test/src/components/CommandCell.spec.ts
+++ b/test/src/components/CommandCell.spec.ts
@@ -222,4 +222,10 @@ describe("CommandCell summarize", () => {
     await w.find('[aria-label="Dismiss summary"]').trigger("click");
     expect(w.find('[data-testid="cell-summary"]').exists()).toBe(false);
   });
+
+  // #2007, the other half: the command cell reaches the shared chrome the same way the launcher
+  // does and binds no `toggle-park` either, so the button was equally dead here.
+  it("offers no park button: an ephemeral run has nothing to come back to", () => {
+    expect(mountCell().find('[data-testid="cell-park-btn"]').exists()).toBe(false);
+  });
 });

--- a/test/src/components/LauncherCell.spec.ts
+++ b/test/src/components/LauncherCell.spec.ts
@@ -63,4 +63,14 @@ describe("LauncherCell header zoom", () => {
     await w.find(".cell-header").trigger("click");
     expect(w.emitted("toggle-expand")).toBeUndefined();
   });
+
+  // #2007. A launcher cell has no `toggle-park` in its event binding (cellShellEvents), so a park
+  // button here is one that clicks and does nothing. It shipped that way for eleven releases: the
+  // guard in CellChromeButtons asked whether `parked` was undefined, and Vue casts an absent
+  // boolean prop to `false`. Mounted here rather than only on the buttons because this — a cell
+  // the user actually opens — is where it was visible.
+  it("offers no park button: a launched program is not a session to set aside", () => {
+    expect(mountCell().find('[data-testid="cell-park-btn"]').exists()).toBe(false);
+    expect(mountCell({ expanded: true }).find('[data-testid="cell-park-btn"]').exists()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

`CellChromeButtons` の park ボタン（🌙）が **launcher セル / command セル** にも出ていて、押しても何も起きなかった問題 (#2007) を直す。

- 原因: ガードが `v-if="parked !== undefined"` だった。Vue は **未指定の boolean prop を `false` にキャスト**するので `parked === undefined` は決して真にならず、「prop を渡さないことで opt out する」という設計意図が成立していなかった。`LauncherCell` / `CommandCell` は `CellShell` → `cellChromeBinding` 経由で、そのイベント表は意図的に `toggle-park` を持たない。よって emit は誰にも届かない = 死んだボタン。park 機能が入った #992 (`a9b5268b`) 以来ずっとこの状態。
- 修正: 表示権限を `canPark?: boolean` という別 prop に分け、`TerminalCell` の 2 か所（cockpit ヘッダ / 通常ヘッダ）だけが `:can-park="true"` を渡す。`parked` は押下状態（`aria-pressed` / title / 配色）専用として残す。
- 設計選択: issue が挙げた 2 案のうち「positive flag を 1 つの caller だけが渡す」を採った。`parked` は押下状態そのものなので、権限と状態を 1 つの prop に兼ねさせたのが今回のバグの根であり、分けるのが最小かつ再発しない形。

## Items to Confirm / Review

- **`TerminalCell` は空（セッション未起動）の状態でも `can-park` を渡す** = 従来どおりボタンが出る。旧コメントの「an empty launch slot は opt out」は `LauncherCell` のことを指していたと解釈し、**TerminalCell 側の挙動は一切変えていない**（変えると issue の範囲を越えるため）。ここを「空セルでは park させない」に寄せたい場合は別 issue で。
- `:aria-pressed="parked"` → `!!parked` にした（`canPark` だけ渡して `parked` を省略した場合に `aria-pressed` が空にならないように）。現状の唯一の caller は常に両方渡す。
- 同種の罠の掃き出し: `v-if` で `!== undefined` を見ているのは他に `FilterChip.vue` の `count` のみ。こちらは `count?: number` で、Vue が数値 prop をキャストすることは無いので**問題なし**（確認済み）。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/2007 なおせる？

## 実機で before / after を確認した（build が通った、ではなく）

隔離 `HOME`（launcher chip を 1 つだけ持つ config）+ port 34611 で実サーバを起動し、Playwright(Chromium) で
「terminal セル + launcher セル」のグリッドを描画して、**同じスクリプトを修正前の bundle と修正後の bundle に対して**流した。

| | terminal セル | launcher セル |
|---|---|---|
| **before** | park ボタンあり / 動く | park ボタン**あり**・押しても `aria-pressed` は `false` のまま、grid 状態も `awake` のまま、console error 無し |
| **after** | park ボタンあり / 押すと `aria-pressed=true`・title が "Wake this terminal"・localStorage の grid 状態が `parked` で永続化 | park ボタン**無し** |

issue が「observed」としていたのは launcher 側だけで command セルは推測だったが、こちらもコンポーネントを mount して同じく再現・修正を確認した。

## テスト

- `CellChromeButtons.spec.ts` — park ボタンの describe を追加。**prop 未指定で非表示**（`canPark: false` ではなく *未指定* から見る: `false` は壊れていた版が実際に受け取っていた値そのものなので、それだけでは回帰を捕まえられない）、`parked` だけ来ても出ない、`canPark` で出る、押下状態と title、emit、close の直前という並び。
- `LauncherCell.spec.ts` / `CommandCell.spec.ts` — 実コンポーネントを mount して park ボタンが無いことを固定。ユーザーが実際に開く単位で見るためのもの。
- 手元で `yarn format` / `lint` / `typecheck` / `build` / `test`（12211 passed）まで通した。

設計と再現手順の詳細は `plans/fix-2007-park-button-non-session-cells.md`。

Closes #2007

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Utp5td1zFtxtLkqDwuaEN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the inactive park button from launcher and command cells.
  - Park controls now appear only where the action is supported.
  - Preserved park functionality for terminal cells, including thumbnails and standard cell views.
  - Improved the parked-state accessibility labeling for supported controls.

- **Tests**
  - Added coverage verifying park button visibility, ordering, click behavior, and state labeling.
  - Added regression tests confirming launcher and command cells do not display the park button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->