### PR TITLE
fix: codex の user ターン record 型変更にプロンプト履歴とハンドオフを追従させる (#2011)

### DIFF
--- a/plans/fix-2011-codex-user-turn-shape.md
+++ b/plans/fix-2011-codex-user-turn-shape.md
@@ -1,0 +1,102 @@
+# fix #2011 — codex の user ターン record 型変更に prompt-history / last-turn が追従していない
+
+## 症状（実測、HTTP ルート経由）
+
+| ルート | 新形式 rollout (2026-09) | 旧形式 rollout (2026-08 前半) |
+| --- | --- | --- |
+| `GET /api/transcript/prompts` | `{"prompts":[],"truncated":false}` | プロンプトが並ぶ |
+| `GET /api/transcript/last-turn` | `prompt: null` / reply あり | prompt・reply とも あり |
+
+同一サーバ・同一設定での対照なので、差は rollout の record 型だけ。
+ハンドオフのテキストは `--- their prompt ---` ブロックごと落ち、受け取った側は
+「返答だけで質問が無い」ものを読むことになる。
+
+## 原因
+
+#1962 と同じ根。codex はユーザーターンを
+
+- 旧: `type: "event_msg"` / `payload.type: "user_message"`（`payload.message` が本文）
+- 新: `type: "response_item"` / `payload.type: "message"` / `role: "user"`（`payload.content[].text`）
+
+へ移した。#2009 で `server/agents/codex-sessions.ts` は両形式を読むようにしたが、
+**同じ record を読む残り 2 箇所**が旧形式のまま:
+
+- `server/session/prompt-history.ts:142`
+- `server/session/last-turn.ts:88`
+
+`~/.codex/sessions` 6,334 rollout の実測で、2026-09 は 171/171、2026-08 は 1,945/5,715 が
+旧 record を持たない = 履歴ペインが空になる。2026-07 以前は 0 件。
+
+## 修正
+
+規則が 3 箇所に散らないよう、**判定を 1 本にして 3 箇所から使う**。
+
+新規 `server/agents/codex-user-turn.ts`（純関数のみ）:
+
+```ts
+codexUserPrompt(doc: Record<string, unknown>): string | null
+```
+
+- 両形式の user ターンからテキスト part 群を取り出す
+- codex 自身の合成前置きは **メッセージ単位で捨てる**（`<environment_context>` /
+  `<recommended_plugins>` / `<user_action>` / `<turn_aborted>`。タグを持たない
+  `# AGENTS.md instructions for …` part が同じメッセージに同居するため part 単位では落とせない）
+- 残った最初のテキストを返す。無ければ null
+
+### 途中で見つかったこと: 旧 rollout はプロンプトを **2 回** 書いている
+
+両形式を読むようにした最初の版を差分テストにかけたら、**旧形式 762 件のうち 748 件で
+プロンプトが 2 倍**になった。実測すると codex は 1 年ほどの間、1 つのプロンプトを
+
+1. `response_item`（モデルへ送る側）
+2. **その直後の record** で `event_msg`（同じテキスト）
+
+の 2 回書いていた。サンプル 1,095 rollout で **924 組すべてがこの順序・record 間隔 1** で、
+両者のテキストが食い違う例は 0 件。
+
+したがって「両方読む」だけでは全プロンプトを収集する読み手（履歴ペイン）が二重計上する。
+一方で **28 件のプロンプトは `event_msg` にしか存在しない**（2026-07 の 14 rollout）ので、
+旧 record を捨てるだけでも駄目。
+
+規則: **直前の record が同じテキストの `response_item` だったときに限り `event_msg` を捨てる**。
+形と隣接の両方を見るので、人が同じ文言を 2 回送った場合（同じ形・間に応答がある）は collapse しない。
+落とす側を `event_msg` にしたのは、上記 28 件を残すため。
+
+`last-turn.ts` と `codex-sessions.ts` は最初の 1 件しか取らないので、この重複は無関係。
+よって dedupe は `prompt-history.ts` の fold 側に置き、ペアの事実（`isDoubleWrite`）だけを
+共有モジュールに置く。
+
+呼び出し側:
+
+- `codex-sessions.ts` — 自前の private コピーを削除して import（**振る舞いは不変**）
+- `prompt-history.ts` の `foldCodexPrompt` — `codexUserPrompt` に差し替え。
+  時刻は現状どおり `epochMs(record.timestamp)`（新形式 `response_item` も同じトップレベルに
+  ISO の `timestamp` を持つことを確認済み）
+- `last-turn.ts` の `codexPromptForTurn` — `eventPayload(doc, "user_message")` を差し替え。
+  `task_started` / `task_complete` は現行 rollout にも残っているので、ターンの位置スパンの
+  取り方は変えない
+
+## 検証（「同じ挙動」は走らせて示す）
+
+1. **抽出の振る舞い保存**: `codex-sessions.ts` は純粋な抽出なので、#2009 で使った
+   codex 自身の `threads.first_user_message` との差分テストを全 rollout で再実行し、
+   一致数が変わらないことを示す。
+2. **旧形式で不変・新形式で回復**: 修正前後の `codexPrompts` / `lastTurnFromCodexRollout` を
+   1,096 rollout（2026-08 以外は全件、2026-08 は 12 件に 1 件）に対して走らせて比較した結果:
+
+   | | rollout | 結果 |
+   | --- | --- | --- |
+   | 旧 record あり | 762 | **変化 0 件**（prompts / last-turn の prompt・reply すべて一致） |
+   | 旧 record なし | 334 | **333 件が 0 → 回復**、残り 1 件は本当にプロンプトが無い（`<turn_aborted>` だけの中断セッション） |
+
+   last-turn の prompt が付かない新形式 4 件は、いずれも `task_complete` が無い未完了ターン
+   （「実行中のターンは飛ばす」という既存の仕様どおり）。
+3. **実機**: サーバを起動して 2 つのルートを新旧両方の rollout に対して叩き、
+   ハンドオフ本文に prompt ブロックが戻ることを確認する。
+4. ミューテーションで新テストが赤くなることを確認する。
+
+## この PR に入れないもの
+
+- `codex-activity-track.ts` は `task_started` / `task_complete` を見ており、これらは現行 rollout にも
+  残っているので壊れていない。触らない。
+- transcript ビュー（`transcript-view-read.ts`）は codex のログを読んでいない。対象外。

--- a/server/agents/codex-sessions.ts
+++ b/server/agents/codex-sessions.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import { cleanTitle, parseJsonRecord, readFirstLine, readTranscriptHead } from "./transcript-head.js";
 import { codexHomeOf, readThreadNames } from "./codex-thread-names.js";
+import { codexUserPrompt } from "./codex-user-turn.js";
 import { byCodeUnit } from "../../common/byCodeUnit.js";
 import { mapConcurrent } from "../infra/mapConcurrent.js";
 
@@ -55,50 +56,6 @@ export interface RolloutMeta {
 const isSessionMeta = (d: Record<string, unknown>): boolean =>
   d.type === "session_meta" && isRecord(d.payload) && typeof d.payload.id === "string" && UUID_RE.test(d.payload.id);
 
-// A user's turn, in EITHER shape codex has recorded it in. Older rollouts write an `event_msg`
-// whose payload type is `user_message`; since 2026-08 the same turn is a `response_item` `message`
-// with `role: "user"`. Measured on this machine: 899 of the 2,840 rollouts written in August 2026
-// carry the old record and NONE of the 160 written in September do — which is why every recent row
-// read "Codex session" (#1962). Both are read because the store holds both.
-function userTurnTexts(d: Record<string, unknown>): string[] | null {
-  const { payload } = d;
-  if (!isRecord(payload)) return null;
-  if (d.type === "event_msg" && payload.type === "user_message") return typeof payload.message === "string" ? [payload.message] : null;
-  if (d.type !== "response_item" || payload.type !== "message" || payload.role !== "user") return null;
-  const { content } = payload;
-  if (typeof content === "string") return [content];
-  return Array.isArray(content) ? content.flatMap((part) => (isRecord(part) && typeof part.text === "string" ? [part.text] : [])) : null;
-}
-
-// The blocks codex writes INTO a user turn rather than the person writing them. Every leading tag
-// in the 6,325 rollouts on this machine is one of these four — environment_context 6,315,
-// recommended_plugins 4,521, user_action 14, turn_aborted 8 — and none of them is a prompt.
-//
-// Named rather than "anything that opens with a tag", because a person's prompt may perfectly well
-// open with `<div>` or `<task>`, and treating that as codex's own would drop the one row it titles.
-// If codex adds a fifth wrapper the cost is a visibly wrong title rather than a missing session,
-// and the bundle below still catches it whenever it travels with one of these.
-const CODEX_WRAPPER_TAGS: ReadonlySet<string> = new Set(["environment_context", "recommended_plugins", "user_action", "turn_aborted"]);
-const LEADING_TAG_RE = /^<([a-zA-Z_][\w.:-]*)[\s>/]/;
-
-// codex bundles its preamble into ONE message with several content parts: the plugin list, the
-// repo's AGENTS.md and the environment context together. The person's prompt is the next message.
-//
-// So the test is per MESSAGE, not per part. The AGENTS.md part carries no tag of its own, and a
-// part-level skip would make it the title of every session in a repo that has one.
-const isSyntheticTurn = (texts: readonly string[]): boolean =>
-  texts.some((t) => {
-    const tag = LEADING_TAG_RE.exec(t)?.[1];
-    return tag !== undefined && CODEX_WRAPPER_TAGS.has(tag);
-  });
-
-// A user turn's prompt, or null when the record is not one, or is codex talking to itself.
-function userPrompt(d: Record<string, unknown>): string | null {
-  const texts = (userTurnTexts(d) ?? []).map((t) => t.trim()).filter((t) => t !== "");
-  if (texts.length === 0 || isSyntheticTurn(texts)) return null;
-  return texts[0] ?? null;
-}
-
 function stringField(doc: Record<string, unknown> | undefined, key: string): string | null {
   const payload = doc?.payload;
   return isRecord(payload) && typeof payload[key] === "string" ? payload[key] : null;
@@ -114,7 +71,7 @@ export function parseCodexRolloutHead(head: string): RolloutHead | null {
   const meta = docs.find(isSessionMeta);
   const id = stringField(meta, "id");
   if (!id) return null;
-  const prompt = docs.map(userPrompt).find((t): t is string => t !== null) ?? null;
+  const prompt = docs.map(codexUserPrompt).find((t): t is string => t !== null) ?? null;
   return { id, cwd: stringField(meta, "cwd"), title: cleanTitle(prompt, DEFAULT_TITLE) };
 }
 

--- a/server/agents/codex-user-turn.ts
+++ b/server/agents/codex-user-turn.ts
@@ -1,0 +1,86 @@
+// What the PERSON typed at a codex session, as opposed to what codex wrote into their turn.
+//
+// One rule, three readers: the resume list's title (codex-sessions.ts), the prompt history pane
+// (prompt-history.ts) and the handoff's last exchange (last-turn.ts). It lives on its own because
+// the rule has changed under all three at once and only one of them was taught (#1962 → #2011):
+// a copy per reader is a copy per reader to find next time.
+import { isRecord } from "../../common/isRecord.js";
+
+/** Which record carried the turn. Only a reader collecting EVERY prompt needs to know — see
+ *  `isDoubleWrite` below. */
+export type CodexTurnShape = "event_msg" | "response_item";
+
+export interface CodexUserTurn {
+  text: string;
+  shape: CodexTurnShape;
+}
+
+// A user's turn, in EITHER shape codex has recorded it in. Older rollouts write an `event_msg`
+// whose payload type is `user_message`; since 2026-08 the same turn is a `response_item` `message`
+// with `role: "user"`. Measured across the 6,334 rollouts on this machine: every one written in
+// September 2026 carries only the new record, 1,945 of August's 5,715 already did, and 14 from
+// July carry only the old one — so neither shape alone reads the store.
+function userTurnTexts(d: Record<string, unknown>): { texts: string[]; shape: CodexTurnShape } | null {
+  const { payload } = d;
+  if (!isRecord(payload)) return null;
+  if (d.type === "event_msg" && payload.type === "user_message") {
+    return typeof payload.message === "string" ? { texts: [payload.message], shape: "event_msg" } : null;
+  }
+  if (d.type !== "response_item" || payload.type !== "message" || payload.role !== "user") return null;
+  const { content } = payload;
+  if (typeof content === "string") return { texts: [content], shape: "response_item" };
+  if (!Array.isArray(content)) return null;
+  return { texts: content.flatMap((part) => (isRecord(part) && typeof part.text === "string" ? [part.text] : [])), shape: "response_item" };
+}
+
+// The blocks codex writes INTO a user turn rather than the person writing them. Every leading tag
+// in the 6,334 rollouts on this machine is one of these four — environment_context 6,315,
+// recommended_plugins 4,521, user_action 14, turn_aborted 8 — and none of them is a prompt.
+//
+// Named rather than "anything that opens with a tag", because a person's prompt may perfectly well
+// open with `<div>` or `<task>`, and treating that as codex's own would drop the one turn it
+// speaks for. If codex adds a fifth wrapper the cost is a visibly wrong prompt rather than a
+// missing one, and the bundle below still catches it whenever it travels with one of these.
+const CODEX_WRAPPER_TAGS: ReadonlySet<string> = new Set(["environment_context", "recommended_plugins", "user_action", "turn_aborted"]);
+const LEADING_TAG_RE = /^<([a-zA-Z_][\w.:-]*)[\s>/]/;
+
+// codex bundles its preamble into ONE message with several content parts: the plugin list, the
+// repo's AGENTS.md and the environment context together. The person's prompt is the next message.
+//
+// So the test is per MESSAGE, not per part. The AGENTS.md part carries no tag of its own, and a
+// part-level skip would hand every reader that text as the prompt in any repo that has one.
+const isSyntheticTurn = (texts: readonly string[]): boolean =>
+  texts.some((t) => {
+    const tag = LEADING_TAG_RE.exec(t)?.[1];
+    return tag !== undefined && CODEX_WRAPPER_TAGS.has(tag);
+  });
+
+/** A rollout record's user turn, or null when it is not one — or is codex talking to itself.
+ *  Trimmed; the callers cap and clean it for their own surface. */
+export function codexUserTurn(d: Record<string, unknown>): CodexUserTurn | null {
+  const read = userTurnTexts(d);
+  const texts = (read?.texts ?? []).map((t) => t.trim()).filter((t) => t !== "");
+  if (read === null || texts.length === 0 || isSyntheticTurn(texts)) return null;
+  const text = texts[0];
+  return text === undefined ? null : { text, shape: read.shape };
+}
+
+/** The same turn's text, for a reader that only wants ONE prompt and so cannot meet the pair
+ *  below: the resume list's title and the handoff's last exchange both take the first match. */
+export const codexUserPrompt = (d: Record<string, unknown>): string | null => codexUserTurn(d)?.text ?? null;
+
+/** Is this turn the second half of codex writing one prompt TWICE?
+ *
+ *  For a year codex recorded a prompt as a `response_item` and then, as the VERY NEXT record, an
+ *  `event_msg` carrying the identical text — 924 such pairs in the sampled store, every one of them
+ *  adjacent and in that order, and not a single case of the two shapes disagreeing. Reading both
+ *  shapes is what makes rollouts written since 2026-08 readable at all, so a reader collecting
+ *  every prompt has to drop one half or report each prompt twice.
+ *
+ *  The `event_msg` half is the one dropped, because 28 prompts in the store exist ONLY in that
+ *  shape and dropping the other half would lose them. `previous` is the turn from the record
+ *  IMMEDIATELY before this one — null for any other record — which is what keeps a person who
+ *  really did send the same text twice from being collapsed: their two turns are the same shape
+ *  and have a whole reply between them. */
+export const isDoubleWrite = (turn: CodexUserTurn, previous: CodexUserTurn | null): boolean =>
+  turn.shape === "event_msg" && previous !== null && previous.shape === "response_item" && previous.text === turn.text;

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -6,6 +6,7 @@
 
 import { conversationTurnsFromParsed, parseJsonl } from "./transcript.js";
 import { codexEventPayload as eventPayload } from "../agents/codex-events.js";
+import { codexUserPrompt } from "../agents/codex-user-turn.js";
 
 export interface LastTurn {
   prompt: string | null;
@@ -62,10 +63,12 @@ export function currentTurnReplyFromClaudeParsed(records: Record<string, unknown
 }
 
 // codex tags only its turn BOUNDARIES with a turn_id (task_started / turn_context /
-// task_complete) — the user_message and agent_message rows in between carry none. So a
-// turn is the positional span between a task_started and its matching task_complete,
-// and the id serves to pair those two rather than to group the contents. Each of those
-// rows is reached through `eventPayload` above, which is shared with the badge reader.
+// task_complete) — the prompt and reply rows in between carry none. So a turn is the
+// positional span between a task_started and its matching task_complete, and the id
+// serves to pair those two rather than to group the contents. The boundaries are reached
+// through `eventPayload` above, which is shared with the badge reader; the prompt inside
+// them is not, because codex has written it in two different record shapes and that
+// question belongs to `codexUserPrompt` (#2011).
 const trimmedString = (value: unknown): string | null => (typeof value === "string" && value.trim() ? value.trim() : null);
 
 // Walk back to the task_started that opened this turn, then forward to the first
@@ -85,11 +88,8 @@ function codexPromptForTurn(docs: Record<string, unknown>[], completeIndex: numb
   if (start < 0) return null;
   for (let i = start + 1; i < completeIndex; i++) {
     const doc = docs[i];
-    const message = doc === undefined ? null : eventPayload(doc, "user_message");
-    if (message) {
-      const text = trimmedString(message.message);
-      if (text) return text;
-    }
+    const text = doc === undefined ? null : codexUserPrompt(doc);
+    if (text) return text;
   }
   return null;
 }

--- a/server/session/prompt-history.ts
+++ b/server/session/prompt-history.ts
@@ -13,7 +13,7 @@
 import { isRecord } from "../../common/isRecord.js";
 import { readString } from "../../common/readString.js";
 import type { PromptEntry, PromptWindow } from "../../common/promptHistory.js";
-import { codexEventPayload } from "../agents/codex-events.js";
+import { codexUserTurn, isDoubleWrite, type CodexUserTurn } from "../agents/codex-user-turn.js";
 import { userPromptText } from "./transcript.js";
 
 /** Enough to recognise a prompt again, which is what this is for. Deliberately far above
@@ -133,14 +133,23 @@ export function foldClaudePrompt(scan: ClaudePromptScan, record: Record<string, 
   keepNewest(scan, read && scan.wanted.has(read.sessionId) && afterFloor(read.prompt, scan.since) ? read.prompt : null);
 }
 
+/** A codex scan also carries the turn the PREVIOUS record held, which is what lets the fold
+ *  recognise codex's double-write (see `isDoubleWrite`). It is the previous RECORD's turn, not the
+ *  previous prompt's: any other record in between resets it to null, which is the whole point. */
+export interface CodexPromptScan extends PromptScan {
+  previousTurn: CodexUserTurn | null;
+}
+
 /** The codex equivalent. A rollout is one file per conversation, so it needs no session filter —
  *  but it still has to be STREAMED: three of the 2,586 rollouts on this machine are past the 4 MB
  *  tail window, and the largest would have shown 5 of its 9 prompts (#1749). */
-export const codexPromptScan = (limit: number = PROMPT_HISTORY_MAX): PromptScan => ({ limit, found: [] });
+export const codexPromptScan = (limit: number = PROMPT_HISTORY_MAX): CodexPromptScan => ({ limit, found: [], previousTurn: null });
 
-export function foldCodexPrompt(scan: PromptScan, record: Record<string, unknown>): void {
-  const payload = codexEventPayload(record, "user_message");
-  keepNewest(scan, payload ? entry(epochMs(record.timestamp), payload.message) : null);
+export function foldCodexPrompt(scan: CodexPromptScan, record: Record<string, unknown>): void {
+  const turn = codexUserTurn(record);
+  const duplicate = turn !== null && isDoubleWrite(turn, scan.previousTurn);
+  scan.previousTurn = turn;
+  keepNewest(scan, turn === null || duplicate ? null : entry(epochMs(record.timestamp), turn.text));
 }
 
 /** These ids' prompts, oldest first, capped to the newest `limit`. Several ids are ONE session
@@ -176,9 +185,11 @@ export function claudePromptsFor(
  *  kept, since there is then nothing it could be on the wrong side of. */
 const afterFloor = (prompt: PromptEntry, since: number | undefined): boolean => since === undefined || (prompt.at !== null && prompt.at >= since);
 
-/** codex has no history file and no hooks, so its rollout is the only record of a prompt. The
- *  `user_message` events are the ones a person sent: measured over 40 real rollouts, none of them
- *  carried injected text (codex files its environment context under other payload types).
+/** codex has no history file and no hooks, so its rollout is the only record of a prompt. Which
+ *  records those are is `codexUserPrompt`'s job, and it is shared with the resume list and the
+ *  handoff: codex moved the user's turn to a `response_item` during 2026-08 AND started filing its
+ *  own injected blocks under that same record, so "the user's turn" stopped being a record type
+ *  and became a record type minus a preamble (#2011).
  *
  *  Through the same fold the server streams, so what a test drives is what production runs. */
 export function codexPrompts(records: Record<string, unknown>[], limit: number = PROMPT_HISTORY_MAX): PromptEntry[] {

--- a/server/session/prompt-history.ts
+++ b/server/session/prompt-history.ts
@@ -145,6 +145,12 @@ export interface CodexPromptScan extends PromptScan {
  *  tail window, and the largest would have shown 5 of its 9 prompts (#1749). */
 export const codexPromptScan = (limit: number = PROMPT_HISTORY_MAX): CodexPromptScan => ({ limit, found: [], previousTurn: null });
 
+/** Fold one rollout record into the scan, through the same rule the array reader below uses.
+ *
+ *  `previousTurn` is assigned on EVERY record, not only on the ones that are turns — that is the
+ *  mechanism, not bookkeeping. Moving the assignment inside the `turn !== null` branch would let a
+ *  reply sit between the two halves of a pair and still collapse them, and would collapse a person
+ *  who really did send the same text twice. */
 export function foldCodexPrompt(scan: CodexPromptScan, record: Record<string, unknown>): void {
   const turn = codexUserTurn(record);
   const duplicate = turn !== null && isDoubleWrite(turn, scan.previousTurn);

--- a/test/server/agents/codex-user-turn.spec.ts
+++ b/test/server/agents/codex-user-turn.spec.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { codexUserTurn, codexUserPrompt, isDoubleWrite } from "../../../server/agents/codex-user-turn.js";
+
+const eventMsg = (message: string): Record<string, unknown> => ({ type: "event_msg", payload: { type: "user_message", message } });
+const responseItem = (...texts: string[]): Record<string, unknown> => ({
+  type: "response_item",
+  payload: { type: "message", role: "user", content: texts.map((text) => ({ type: "input_text", text })) },
+});
+// codex's preamble: ONE message carrying the plugin list, the repo's AGENTS.md and the environment
+// context together. The AGENTS.md part has no tag of its own, so it only stays out if the whole
+// message is skipped.
+const preamble = (): Record<string, unknown> =>
+  responseItem(
+    "<recommended_plugins>\nAirtable (airtable@openai-curated-remote)\n</recommended_plugins>",
+    "# AGENTS.md instructions for /work\n\n<INSTRUCTIONS>\nbe nice\n</INSTRUCTIONS>",
+    "<environment_context>\n  <cwd>/work</cwd>\n</environment_context>",
+  );
+
+describe("codexUserTurn", () => {
+  it("reads the shape codex wrote until 2026-08", () => {
+    expect(codexUserTurn(eventMsg("fix the login bug"))).toEqual({ text: "fix the login bug", shape: "event_msg" });
+  });
+  it("reads the shape codex writes now", () => {
+    expect(codexUserTurn(responseItem("fix the login bug"))).toEqual({ text: "fix the login bug", shape: "response_item" });
+  });
+  it("accepts a message whose content is a bare string", () => {
+    const doc = { type: "response_item", payload: { type: "message", role: "user", content: "plain string content" } };
+    expect(codexUserTurn(doc)?.text).toBe("plain string content");
+  });
+  it("trims", () => {
+    expect(codexUserTurn(responseItem("  spaced  "))?.text).toBe("spaced");
+  });
+
+  it("skips the whole synthetic preamble, including its untagged AGENTS.md part", () => {
+    expect(codexUserTurn(preamble())).toBeNull();
+  });
+  it.each(["environment_context", "recommended_plugins", "user_action", "turn_aborted"])("skips codex's own <%s> block", (tag) => {
+    expect(codexUserTurn(responseItem(`<${tag}>\n  something\n</${tag}>`))).toBeNull();
+  });
+  // A person's prompt may open with markup, and treating that as codex's own would drop the turn.
+  it.each(["<div>fix the login bug</div>", "<task> explain this file", "<foo/> and then some"])("keeps a real prompt that opens with markup: %s", (text) => {
+    expect(codexUserTurn(responseItem(text))?.text).toBe(text);
+  });
+  it("keeps a multi-part prompt whose second part opens with an unknown tag", () => {
+    expect(codexUserTurn(responseItem("explain this", "<foo>bar</foo>"))?.text).toBe("explain this");
+  });
+
+  it.each([
+    ["an assistant message", { type: "response_item", payload: { type: "message", role: "assistant", content: [{ text: "hi" }] } }],
+    ["a developer message", { type: "response_item", payload: { type: "message", role: "developer", content: [{ text: "<skills_instructions>x" }] } }],
+    ["a reasoning item", { type: "response_item", payload: { type: "reasoning", content: [{ text: "thinking" }] } }],
+    ["a user_message payload that is not an event_msg", { type: "response_item", payload: { type: "user_message", message: "no" } }],
+    ["an event_msg of another type", { type: "event_msg", payload: { type: "agent_message", message: "no" } }],
+    ["a message with no text parts", { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_image" }] } }],
+    ["a message whose parts are all blank", { type: "response_item", payload: { type: "message", role: "user", content: [{ text: "   " }] } }],
+    ["a payload that is not an object", { type: "response_item", payload: "x" }],
+    ["a record with no payload", { type: "response_item" }],
+    ["an empty record", {}],
+  ])("returns null for %s", (_label, doc) => {
+    expect(codexUserTurn(doc as Record<string, unknown>)).toBeNull();
+  });
+});
+
+describe("codexUserPrompt", () => {
+  it("is the turn's text", () => {
+    expect(codexUserPrompt(responseItem("hello"))).toBe("hello");
+  });
+  it("is null when there is no turn", () => {
+    expect(codexUserPrompt(preamble())).toBeNull();
+  });
+});
+
+describe("isDoubleWrite", () => {
+  // 924 pairs measured in the store, every one of them a response_item followed IMMEDIATELY by an
+  // event_msg carrying the identical text.
+  const asTurn = (doc: Record<string, unknown>) => {
+    const turn = codexUserTurn(doc);
+    if (turn === null) throw new Error("fixture is not a user turn");
+    return turn;
+  };
+  it("recognises the event_msg half of a pair", () => {
+    expect(isDoubleWrite(asTurn(eventMsg("same text")), asTurn(responseItem("same text")))).toBe(true);
+  });
+  it("does not drop the response_item half", () => {
+    expect(isDoubleWrite(asTurn(responseItem("same text")), asTurn(eventMsg("same text")))).toBe(false);
+  });
+  // 28 prompts in the store exist ONLY as an event_msg; dropping those would lose them.
+  it("keeps an event_msg with no response_item before it", () => {
+    expect(isDoubleWrite(asTurn(eventMsg("only shape")), null)).toBe(false);
+  });
+  it("keeps an event_msg whose predecessor said something else", () => {
+    expect(isDoubleWrite(asTurn(eventMsg("second")), asTurn(responseItem("first")))).toBe(false);
+  });
+  // A person who really did send the same text twice sends it in ONE shape both times.
+  it("keeps a repeated prompt in the same shape", () => {
+    expect(isDoubleWrite(asTurn(responseItem("続けて")), asTurn(responseItem("続けて")))).toBe(false);
+  });
+});

--- a/test/server/session/last-turn.spec.ts
+++ b/test/server/session/last-turn.spec.ts
@@ -25,6 +25,15 @@ const toolUse = (name: string) => line({ type: "assistant", message: { stop_reas
 const started = (turnId: string) => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
 const turnContext = (turnId: string) => line({ type: "turn_context", payload: { turn_id: turnId, cwd: "/w" } });
 const userMessage = (message: string) => line({ type: "event_msg", payload: { type: "user_message", message } });
+// The shape codex writes since 2026-08 (#2011), and the preamble it puts in front of the prompt.
+const userItem = (...texts: string[]) =>
+  line({ type: "response_item", payload: { type: "message", role: "user", content: texts.map((text) => ({ type: "input_text", text })) } });
+const preamble = () =>
+  userItem(
+    "<recommended_plugins>\nAirtable\n</recommended_plugins>",
+    "# AGENTS.md instructions for /w\n\nbe nice",
+    "<environment_context>\n  <cwd>/w</cwd>\n</environment_context>",
+  );
 const agentMessage = (message: string) => line({ type: "event_msg", payload: { type: "agent_message", message } });
 const complete = (turnId: string, lastAgentMessage: string) =>
   line({ type: "event_msg", payload: { type: "task_complete", turn_id: turnId, last_agent_message: lastAgentMessage } });
@@ -139,6 +148,26 @@ describe("lastTurnFromCodexRollout", () => {
       complete("t2", "second answer\nwith a second line"),
     ].join("\n");
     expect(lastTurnFromCodexRollout(raw)).toEqual({ prompt: "second", reply: "second answer\nwith a second line" });
+  });
+
+  // #2011: codex moved the user's turn to a response_item during 2026-08, and the handoff's prompt
+  // half went null for every session started since — the receiving cell got an answer with no
+  // question in it.
+  it("takes a prompt written in the response_item shape codex uses now", () => {
+    const raw = [started("t1"), turnContext("t1"), preamble(), userItem("review the branch"), complete("t1", "reviewed it")].join("\n");
+    expect(lastTurnFromCodexRollout(raw)).toEqual({ prompt: "review the branch", reply: "reviewed it" });
+  });
+
+  it("does not hand over codex's own preamble as the prompt", () => {
+    const raw = [started("t1"), preamble(), complete("t1", "answered anyway")].join("\n");
+    expect(lastTurnFromCodexRollout(raw)).toEqual({ prompt: null, reply: "answered anyway" });
+  });
+
+  // The older rollouts on disk carry the prompt in BOTH shapes, back to back. Either half is the
+  // same text, so the turn reads the same whichever one it meets first.
+  it("reads a turn codex wrote in both shapes", () => {
+    const raw = [started("t1"), userItem("review the branch"), userMessage("review the branch"), complete("t1", "reviewed it")].join("\n");
+    expect(lastTurnFromCodexRollout(raw)).toEqual({ prompt: "review the branch", reply: "reviewed it" });
   });
 
   it("falls back to the previous turn while the newest one is still running", () => {

--- a/test/server/session/prompt-history.spec.ts
+++ b/test/server/session/prompt-history.spec.ts
@@ -23,12 +23,19 @@ const historyLine = (over: Record<string, unknown> = {}): Record<string, unknown
   ...over,
 });
 
-// A codex rollout row: the payload type is what identifies it, and the outer type must be
-// event_msg — a response_item carrying the same payload type is a different record.
+// A codex rollout row in the shape codex wrote until 2026-08: the payload type identifies it and
+// the outer type must be event_msg — a response_item carrying the same payload type is a
+// different record.
 const codexLine = (message: unknown, ts = "2026-08-16T02:31:02.318Z"): Record<string, unknown> => ({
   type: "event_msg",
   timestamp: ts,
   payload: { type: "user_message", message },
+});
+// The shape codex writes now (#2011): a response_item message with role "user".
+const codexItemLine = (text: string, ts = "2026-08-16T02:31:02.318Z"): Record<string, unknown> => ({
+  type: "response_item",
+  timestamp: ts,
+  payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
 });
 
 describe("claudeHistoryPrompt", () => {
@@ -191,6 +198,51 @@ describe("codexPrompts", () => {
     const notAnEvent = { type: "response_item", timestamp: "2026-08-16T02:31:02.318Z", payload: { type: "user_message", message: "no" } };
     const otherEvent = { type: "event_msg", payload: { type: "agent_message", message: "no" } };
     expect(codexPrompts([notAnEvent, otherEvent, {}, { payload: null }])).toEqual([]);
+  });
+
+  // #2011: codex moved the user's turn to a response_item during 2026-08. Reading only the old
+  // record left the pane empty for every session started since — 171 of 171 September rollouts on
+  // the maintainer's machine.
+  it("reads the response_item shape codex writes now", () => {
+    expect(codexPrompts([codexItemLine("review the branch")])).toEqual([{ at: Date.parse("2026-08-16T02:31:02.318Z"), text: "review the branch" }]);
+  });
+
+  it("skips codex's own preamble rather than listing it as a prompt", () => {
+    const preamble = {
+      type: "response_item",
+      timestamp: "2026-08-16T02:31:02.318Z",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "<recommended_plugins>\nAirtable\n</recommended_plugins>" },
+          { type: "input_text", text: "# AGENTS.md instructions for /work\n\nbe nice" },
+          { type: "input_text", text: "<environment_context>\n  <cwd>/work</cwd>\n</environment_context>" },
+        ],
+      },
+    };
+    expect(codexPrompts([preamble, codexItemLine("the real prompt")]).map((p) => p.text)).toEqual(["the real prompt"]);
+  });
+
+  // codex wrote each prompt TWICE for a year — the response_item, then the very next record an
+  // event_msg with the identical text (924 such pairs measured, every one adjacent and in that
+  // order). Reading both shapes is what makes recent rollouts readable, so the pair has to collapse
+  // or every prompt in the 748 older rollouts is listed twice.
+  it("lists a prompt once when codex wrote it in both shapes back to back", () => {
+    const records = [codexItemLine("review the branch"), codexLine("review the branch")];
+    expect(codexPrompts(records).map((p) => p.text)).toEqual(["review the branch"]);
+  });
+
+  // 28 prompts in the store exist ONLY as an event_msg, so the pair is recognised by adjacency and
+  // shape — never by dropping the old record wholesale.
+  it("keeps an event_msg prompt that no response_item precedes", () => {
+    const records = [codexItemLine("first"), { type: "event_msg", payload: { type: "agent_message", message: "x" } }, codexLine("second")];
+    expect(codexPrompts(records).map((p) => p.text)).toEqual(["first", "second"]);
+  });
+
+  it("keeps a prompt a person really did send twice", () => {
+    const records = [codexItemLine("続けて"), { type: "response_item", payload: { type: "reasoning" } }, codexItemLine("続けて")];
+    expect(codexPrompts(records).map((p) => p.text)).toEqual(["続けて", "続けて"]);
   });
 
   it("drops a message that is blank or not a string, and keeps the newest within the limit", () => {


### PR DESCRIPTION
## Summary

#1962 / #2009 の続き。codex はユーザーターンを `event_msg/user_message` から
`response_item/message (role: user)` へ移したが、#2009 で直したのは resume 一覧のタイトルだけで、
**同じ record を読む残り 2 箇所**が旧型のままだった。

- `server/session/prompt-history.ts` — codex セルのプロンプト履歴ペイン（`/api/transcript/prompts`）
- `server/session/last-turn.ts` — ハンドオフの直前 1 ターン（`/api/transcript/last-turn`、#550）

実測（`~/.codex/sessions` 6,334 rollout）: **2026-09 は 171/171、2026-08 は 1,945/5,715** が
履歴ペイン空・ハンドオフの `prompt` が `null`。ハンドオフは「返答だけで質問が無い」テキストを
相手のセルに渡していた。

判定を `server/agents/codex-user-turn.ts` に **1 本化**し、3 箇所（resume タイトル / 履歴ペイン /
ハンドオフ）から使う。`codex-sessions.ts` からは private コピーを削除しただけで振る舞いは不変。

### 途中で見つかったこと: 旧 rollout はプロンプトを 2 回書いている

両形式を読む最初の版を差分テストにかけたら、**旧形式 762 件のうち 748 件でプロンプトが 2 倍**に
なった。codex は 1 年ほどの間、1 つのプロンプトを

1. `response_item`（モデルへ送る側）
2. **その直後の record** で `event_msg`（同じテキスト）

の 2 回書いていた。サンプル 1,095 rollout で **924 組すべてがこの順序・record 間隔 1**、
両者のテキストが食い違う例は **0 件**。

一方で **28 件のプロンプトは `event_msg` にしか存在しない**（2026-07 の 14 rollout）ので、
旧 record を捨てる方向では直せない。規則は
**「直前の record が同じテキストの `response_item` だったときだけ `event_msg` を捨てる」**。
形と隣接の両方を見るので、人が同じ文言を 2 回送った場合（同じ形・間に応答がある）は collapse しない。

`last-turn.ts` と `codex-sessions.ts` は最初の 1 件しか取らないのでこの重複は無関係。よって
dedupe は `prompt-history.ts` の fold 側に置き、ペアの事実（`isDoubleWrite`）だけを共有モジュールに
置いた。

## Items to Confirm / Review

- **dedupe の置き場所**: 「ペアであるという事実」は `codex-user-turn.ts`、「直前 record を覚える」
  状態は `prompt-history.ts` の `CodexPromptScan` に分けた。全プロンプトを集める読み手が他にも
  増えるなら、fold ごと共有モジュールへ寄せる判断もあり得る。
- **落とす側を `event_msg` にした根拠**は「その形にしか存在しないプロンプトが 28 件ある」という
  実測 1 点。将来 codex が逆向きに書いたら壊れるが、そのときは履歴が二重に出るので気付ける。
- **合成前置きのタグ集合**は #2009 で決めた 4 つ（`environment_context` / `recommended_plugins` /
  `user_action` / `turn_aborted`）をそのまま共有。
- `prompt-history.ts` の「codex は environment context を別の payload type に書く」という
  ファイル冒頭コメントは**もう偽**なので書き換えた。

## 検証

**差分テスト（修正前後を同じ 1,096 rollout に対して実行）** — 2026-08 以外は全件、2026-08 は 12 件に 1 件:

| | rollout | 結果 |
| --- | --- | --- |
| 旧 record あり | 762 | **変化 0 件**（prompts / last-turn の prompt・reply すべて一致） |
| 旧 record なし | 334 | **333 件が 0 → 回復**、残り 1 件は本当にプロンプトが無い（`<turn_aborted>` だけの中断セッション） |

新形式で last-turn の prompt が付かない 4 件は、いずれも `task_complete` が無い未完了ターン
（「実行中のターンは飛ばす」という既存仕様どおり）。

**ミューテーション（新テストが本当に赤くなるか）** — 6 種すべて赤、復元後にファイルは pristine と一致:

| 変更 | 落ちたテスト |
| --- | --- |
| 旧 record shape だけを user ターンにする | 30 |
| 新 record shape だけを user ターンにする | 34 |
| 二重書きの dedupe を外す | 1 |
| dedupe で `response_item` 側を落とす | 3 |
| dedupe をテキストのみで判定（形を見ない） | 2 |
| 前置きを message 単位でなく part 単位で捨てる | 12 |

**実機（build が通る ≠ 動く）** — `server/index.ts` を起動して実 store に対して両ルートを叩いた:

- 新形式セッション: `prompts` 1 件、`last-turn.prompt` あり、ハンドオフ本文に
  `--- their prompt ---` ブロックが復活（修正前は `prompts: []` / `prompt: null` でブロックごと欠落）
- 旧形式セッション: 修正前と同じ
- **二重書きの実 rollout**（プロンプト 2 件がディスク上は 4 record）: `prompts` は **2 件**

**ゲート**: `yarn format` / `lint` / `typecheck` / `build` / `test`（**821 files, 12,294 passed**）すべて green。

## この PR に入れていないもの

- `codex-activity-track.ts` は `task_started` / `task_complete` を見ており、これらは現行 rollout にも
  残っているのでターン境界は壊れていない。触っていない。
- transcript ビュー（`transcript-view-read.ts`）は codex のログを読んでいないので対象外。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1962 原因わかる？なおせる？
- 同じ根で壊れているのは別 PR。いまのがおわったらやろう。
- 別 PR（prompt-history.ts / last-turn.ts）

Closes #2011

work in mulmoterminal4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYKq3mwvoRtRHmg9DcUJAR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex prompt detection across legacy and current message formats.
  - Prevented Codex-generated setup text and synthetic wrappers from appearing as user prompts.
  - Removed duplicate prompts created when the same turn is recorded in multiple formats.
  - Preserved genuinely repeated prompts and support for multipart message content.
  - Improved prompt retrieval in session history and last-turn views.

- **Tests**
  - Added coverage for message formats, filtering, duplicate handling, and repeated prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->