### PR TITLE
fix: /clear した会話を --resume で復活させない (#2013)

### DIFF
--- a/plans/fix-2013-cleared-transcript-resume.md
+++ b/plans/fix-2013-cleared-transcript-resume.md
@@ -1,0 +1,61 @@
+# fix: `/clear` した会話が、次の接続で `--resume` されて復活する (#2013)
+
+## 症状（報告 → 実機で再現）
+
+`/clear` したセルが、PC 再起動後に開き直すとクリア前の会話ごと復活する。入力するとその会話が
+丸ごと再送されるので、実害はトークン（報告では 1 ターン 478,237 tokens）と、同じ transcript が
+再起動のたびに積み上がること（報告では 11 日ぶん 9.7MB / 合計 175MB）。
+
+**この手元でも再現した**（tmux あり・Windows 以外でも成立する）:
+
+1. 使い捨て `HOME` に、凍結された transcript（`~/.claude/projects/<enc>/<id>.jsonl`）と
+   `~/.mulmoterminal/cleared-transcripts/<id>.json`（`{cwd,size}` が現在サイズと一致）を置く
+2. サーバ起動（`hydrateClearedTranscripts` が印を復元する）
+3. `ws://…/ws?session=<id>&cwd=<ws>` で接続
+4. → `[ws] client connected (resume <id>)` / `[pty] started claude … — resume <id>`
+
+## 原因（コードを辿って確認）
+
+```
+/ws 接続 → resolveClaudeSession()            server/routes/ws-routes.ts:119
+        → facts { hasLivePty, tmuxAlive, onDisk }   ← onDisk は sessionExistsOnDisk() だけ
+        → resolveSession()                    server/session/session-resolve.ts:29
+        → resume = requested （onDisk なので）
+        → spawnClaudePty(sessionId, resume)   server/session/spawn-claude.ts:206
+        → canResume = sessionExistsOnDisk()   → `--resume <id>`
+```
+
+`/clear` は claude 側に新しい session id を発行させ、こちらのキーの `<id>.jsonl` は**凍結**される。
+その事実は `clearedTranscripts`（#1085、`~/.mulmoterminal/cleared-transcripts/` に永続化され boot で
+hydrate される）が持っているのに、**resume の判定はそれを見ていない**。読んでいるのは、サマリー /
+タイトル / transcript ビュー / プロンプトペインだけ（`grep clearedTranscripts`）。
+
+`cleared-transcripts.ts` の冒頭は、印を永続化する理由を「tmux がプロセスを生かしたままサーバだけ
+再起動する窓」と説明している。tmux の無いホストでは、その窓は「PC 再起動から次に開くまで」という
+もっと長いものになる — 印は正しく残っているのに、その窓でだけ参照されない。
+
+## 直し方
+
+**事実を直す。** 「ディスクに transcript がある」ではなく「**resume してよい** transcript がある」を
+`resolveSession` に渡す。判定はすでに純関数で切り出されているので、そこに `cleared` を足す。
+
+| | 決定 | 理由 |
+|---|---|---|
+| どこで弾くか | `resolveSession`（純関数）に `cleared` を足す | `canResume`（spawn-claude）だけ直すと、`resolveSession` はキーを再利用したまま `--session-id <id>` で起動し、**claude が "Session ID is already in use" で落ちる**（同ファイルのコメントが警告している通り）。id を振り直すところまで含めて 1 つの決定 |
+| tmux が生きている場合 | **従来どおり resume を渡す** | tmux が生きているなら attach されるのは*クリア後*の claude で、resume 引数は「その tmux が死んでいた場合」のフォールバックとしてしか効かない。そこで resume を外すと `--session-id` になり、上記の "already in use" で落ちる（同コメントが直した回帰そのもの） |
+| tmux が無い / 死んでいる場合 | resume しない → `sessionId` は新しい id | 報告のケース。素の状態で立ち上がる |
+| 凍結 transcript | **消さない** | 消すのは別の話。#1085 のサマリー等はこの印と凍結ファイルを読んでいる |
+
+```ts
+// session-resolve.ts
+const frozen = facts.cleared && !facts.tmuxAlive;
+const resume = !reattachId && requested && facts.onDisk && !frozen ? requested : null;
+```
+
+呼び出し側（ws-routes）は `cleared: clearedTranscripts.has(requested)` を足すだけ。
+
+## やらないこと
+
+- **クリア後の会話（claude 側の新しい id）を代わりに resume する**こと。印は `claudeId` を持って
+  いるので技術的には可能だが、セルが担う会話が変わるうえフックの id 対応にも触れる。別の提案。
+- 凍結 transcript の掃除（報告者はスクリプトで退避している）。サイズの問題は本質的には別 issue。

--- a/plans/fix-2013-cleared-transcript-resume.md
+++ b/plans/fix-2013-cleared-transcript-resume.md
@@ -16,7 +16,7 @@
 
 ## 原因（コードを辿って確認）
 
-```
+```text
 /ws 接続 → resolveClaudeSession()            server/routes/ws-routes.ts:119
         → facts { hasLivePty, tmuxAlive, onDisk }   ← onDisk は sessionExistsOnDisk() だけ
         → resolveSession()                    server/session/session-resolve.ts:29
@@ -42,14 +42,13 @@ hydrate される）が持っているのに、**resume の判定はそれを見
 | | 決定 | 理由 |
 |---|---|---|
 | どこで弾くか | `resolveSession`（純関数）に `cleared` を足す | `canResume`（spawn-claude）だけ直すと、`resolveSession` はキーを再利用したまま `--session-id <id>` で起動し、**claude が "Session ID is already in use" で落ちる**（同ファイルのコメントが警告している通り）。id を振り直すところまで含めて 1 つの決定 |
-| tmux が生きている場合 | **従来どおり resume を渡す** | tmux が生きているなら attach されるのは*クリア後*の claude で、resume 引数は「その tmux が死んでいた場合」のフォールバックとしてしか効かない。そこで resume を外すと `--session-id` になり、上記の "already in use" で落ちる（同コメントが直した回帰そのもの） |
+| tmux が生きている場合 | **id は維持するが resume は渡さない**（改訂: Codex #2014） | 当初は「従来どおり resume」にしていたが、`tmuxAlive` は probe でしかない。spawn までにその tmux が死ぬと `tmux new-session -A` がコマンドを実行し、そこで `--resume` は**凍結された会話を黙って復活させる** — この PR が止めようとしているものそのもの。`--session-id` で claude が拒否して落ちる方を選ぶ: 次の接続では tmux が無いので新しい id になり、素の状態で立ち上がる |
 | tmux が無い / 死んでいる場合 | resume しない → `sessionId` は新しい id | 報告のケース。素の状態で立ち上がる |
 | 凍結 transcript | **消さない** | 消すのは別の話。#1085 のサマリー等はこの印と凍結ファイルを読んでいる |
 
 ```ts
 // session-resolve.ts
-const frozen = facts.cleared && !facts.tmuxAlive;
-const resume = !reattachId && requested && facts.onDisk && !frozen ? requested : null;
+const resume = !reattachId && requested && facts.onDisk && !facts.cleared ? requested : null;
 ```
 
 呼び出し側（ws-routes）は `cleared: clearedTranscripts.has(requested)` を足すだけ。

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -49,6 +49,7 @@ import { handleCommandFrame } from "../session/pty-connection.js";
 import { closeWithError } from "../session/ws-frames.js";
 import { ProviderRefusedError } from "../session/provider-env.js";
 import { sessionExistsOnDisk } from "../session/session-reads.js";
+import { clearedTranscripts } from "../session/cleared-transcripts.js";
 import { canStartLauncher, isContinuingSession, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
 import type { PtyEntry } from "../session/types.js";
 import type {
@@ -119,7 +120,10 @@ function resolveClaudeSession(requested: string | null, cwd: string): SessionRes
   const hasLivePty = !!requested && ptys.has(requested);
   const tmuxAlive = !hasLivePty && !!requested && tmuxHasSession(requested);
   const onDisk = !hasLivePty && !!requested && sessionExistsOnDisk(requested, cwd);
-  return resolveSession(requested, { hasLivePty, tmuxAlive, onDisk }, randomUUID);
+  // Whether that transcript is the frozen pre-`/clear` one. The mark is hydrated from disk at boot,
+  // so it answers across the restart this decision is usually made after (#2013).
+  const cleared = !hasLivePty && !!requested && clearedTranscripts.has(requested);
+  return resolveSession(requested, { hasLivePty, tmuxAlive, onDisk, cleared }, randomUUID);
 }
 
 // The params every terminal WebSocket reads: the request URL, the validated

--- a/server/session/session-resolve.ts
+++ b/server/session/session-resolve.ts
@@ -10,6 +10,10 @@ export interface SessionFacts {
   // An on-disk transcript exists in the target workspace (claude writes it after the
   // first prompt) — the only id claude will `--resume`.
   onDisk: boolean;
+  // That transcript is FROZEN: the user ran `/clear`, so claude minted itself a new id and this
+  // file is the conversation they ended (`cleared-transcripts.ts`, #1085). Resuming it brings the
+  // cleared conversation back — and puts it in the next turn's request (#2013).
+  cleared: boolean;
 }
 
 export interface SessionResolution {
@@ -28,7 +32,14 @@ export interface SessionResolution {
 // (the old behavior) left that window fatal.
 export function resolveSession(requested: string | null, facts: SessionFacts, mintId: () => string): SessionResolution {
   const reattachId = requested && facts.hasLivePty ? requested : null;
-  const resume = !reattachId && requested && facts.onDisk ? requested : null;
+  // A cleared transcript is not something to resume — it is the conversation the user ended. Only
+  // when tmux is NOT holding this session, though: with a live tmux session the claude that
+  // attaches is the POST-clear one, and `resume` there is only the fallback for the window the
+  // paragraph above describes. Dropping it in that window would spawn `--session-id <id>` against
+  // an id that IS on disk, which claude refuses outright — the regression that paragraph exists to
+  // prevent, traded for a bug it does not have (#2013).
+  const frozen = facts.cleared && !facts.tmuxAlive;
+  const resume = !reattachId && requested && facts.onDisk && !frozen ? requested : null;
   // Reuse the requested id when we can actually serve it (reattach, a live tmux
   // session, or an on-disk transcript to resume); otherwise it can't be reused —
   // mint a fresh one.

--- a/server/session/session-resolve.ts
+++ b/server/session/session-resolve.ts
@@ -32,14 +32,17 @@ export interface SessionResolution {
 // (the old behavior) left that window fatal.
 export function resolveSession(requested: string | null, facts: SessionFacts, mintId: () => string): SessionResolution {
   const reattachId = requested && facts.hasLivePty ? requested : null;
-  // A cleared transcript is not something to resume — it is the conversation the user ended. Only
-  // when tmux is NOT holding this session, though: with a live tmux session the claude that
-  // attaches is the POST-clear one, and `resume` there is only the fallback for the window the
-  // paragraph above describes. Dropping it in that window would spawn `--session-id <id>` against
-  // an id that IS on disk, which claude refuses outright — the regression that paragraph exists to
-  // prevent, traded for a bug it does not have (#2013).
-  const frozen = facts.cleared && !facts.tmuxAlive;
-  const resume = !reattachId && requested && facts.onDisk && !frozen ? requested : null;
+  // A cleared transcript is never resumed — it is the conversation the user ENDED, and `--resume`
+  // brings it back into the next turn's request (#2013).
+  //
+  // Including while tmux says it is holding the session, which costs something and is still right.
+  // `tmuxAlive` is a probe: if that session dies before the spawn, `tmux new-session -A` runs the
+  // command, and there `--session-id <id>` against an id that is on disk makes claude refuse
+  // outright ("Session ID is already in use"). Keeping `--resume` for that window would instead
+  // resurrect the frozen conversation silently — the exact thing this decision exists to stop
+  // (Codex, PR #2014). A spawn that fails loudly is the better half of that trade: the next
+  // connect finds no tmux session, and mints a fresh id.
+  const resume = !reattachId && requested && facts.onDisk && !facts.cleared ? requested : null;
   // Reuse the requested id when we can actually serve it (reattach, a live tmux
   // session, or an on-disk transcript to resume); otherwise it can't be reused —
   // mint a fresh one.

--- a/test/server/session/session-resolve.spec.ts
+++ b/test/server/session/session-resolve.spec.ts
@@ -4,7 +4,7 @@ import { resolveSession, type SessionFacts, resolveReattachableId, canStartLaunc
 
 const FIXED = "fresh-minted-id";
 const mint = () => FIXED;
-const facts = (over: Partial<SessionFacts> = {}): SessionFacts => ({ hasLivePty: false, tmuxAlive: false, onDisk: false, ...over });
+const facts = (over: Partial<SessionFacts> = {}): SessionFacts => ({ hasLivePty: false, tmuxAlive: false, onDisk: false, cleared: false, ...over });
 
 describe("resolveSession", () => {
   it("mints a fresh id when nothing is requested", () => {
@@ -23,6 +23,34 @@ describe("resolveSession", () => {
 
   it("resumes an on-disk transcript", () => {
     expect(resolveSession("s1", facts({ onDisk: true }), mint)).toEqual({ reattachId: null, resume: "s1", sessionId: "s1" });
+  });
+
+  // `/clear` leaves OUR key's transcript holding the conversation the user ended (claude took a new
+  // id for itself). Resuming it brings that conversation back — and into the next turn's request,
+  // which is what made a reboot cost 478k tokens on the first prompt (#2013).
+  it("does not resume a transcript the user cleared — it starts fresh", () => {
+    expect(resolveSession("s1", facts({ onDisk: true, cleared: true }), mint)).toEqual({ reattachId: null, resume: null, sessionId: FIXED });
+  });
+
+  // With tmux holding the session, the claude that attaches is the POST-clear one and the resume
+  // arg only covers the window where that tmux session died since we looked. Dropping it there
+  // would spawn `--session-id` against an id that is on disk, which claude refuses outright.
+  it("still resumes a cleared transcript while tmux is holding the session", () => {
+    expect(resolveSession("s1", facts({ onDisk: true, cleared: true, tmuxAlive: true }), mint)).toEqual({
+      reattachId: null,
+      resume: "s1",
+      sessionId: "s1",
+    });
+  });
+
+  // The mark says nothing about a session this process is already running: that pty IS the
+  // post-clear conversation, and reattaching it reads no transcript at all.
+  it("reattaches a live pty whether or not the transcript was cleared", () => {
+    expect(resolveSession("s1", facts({ hasLivePty: true, onDisk: true, cleared: true }), mint)).toEqual({
+      reattachId: "s1",
+      resume: null,
+      sessionId: "s1",
+    });
   });
 
   it("reuses the id for a live tmux session with no transcript yet (idle, --session-id attaches)", () => {

--- a/test/server/session/session-resolve.spec.ts
+++ b/test/server/session/session-resolve.spec.ts
@@ -32,13 +32,14 @@ describe("resolveSession", () => {
     expect(resolveSession("s1", facts({ onDisk: true, cleared: true }), mint)).toEqual({ reattachId: null, resume: null, sessionId: FIXED });
   });
 
-  // With tmux holding the session, the claude that attaches is the POST-clear one and the resume
-  // arg only covers the window where that tmux session died since we looked. Dropping it there
-  // would spawn `--session-id` against an id that is on disk, which claude refuses outright.
-  it("still resumes a cleared transcript while tmux is holding the session", () => {
+  // Not even while tmux says it is holding the session. The id is kept — tmux attaches the running
+  // (post-clear) claude — but the fallback command carries no `--resume`, so the window where that
+  // tmux session died since the probe fails loudly instead of resurrecting the frozen conversation
+  // (Codex, PR #2014).
+  it("keeps the id but refuses to resume a cleared transcript, tmux or not", () => {
     expect(resolveSession("s1", facts({ onDisk: true, cleared: true, tmuxAlive: true }), mint)).toEqual({
       reattachId: null,
-      resume: "s1",
+      resume: null,
       sessionId: "s1",
     });
   });


### PR DESCRIPTION
## Summary

`/clear` したセッションが、次の接続で `--resume` されてクリア前の会話ごと復活していました
（#2013）。tmux の無いホストでは PC 再起動のたびに起き、**入力するとその会話が丸ごと再送**され
ます（報告では 1 ターン 478,237 tokens、同じ transcript が 11 日で 9.7MB）。

原因は resume の判定が **`clearedTranscripts` を見ていない**ことでした。`/clear` は claude 側に
新しい id を振らせ、こちらのキーの `<id>.jsonl` は「ユーザが終わらせた会話」として凍結されます。
その事実は #1085 で導入された印が持ち、`~/.mulmoterminal/cleared-transcripts/` に永続化されて
boot で hydrate されるのに、読んでいるのはサマリー / タイトル / transcript ビュー /
プロンプトペインだけで、**spawn / resume の経路には出てきません**でした。

Closes #2013

## Items to Confirm / Review

1. **直したのは「事実」の側です。** `resolveSession` に `cleared` を足し、「ディスクに transcript が
   ある」ではなく「**resume してよい** transcript がある」を渡します。`canResume`
   （`spawn-claude.ts`）だけを直すと、`resolveSession` はキーを再利用したまま
   `--session-id <on-disk id>` で起動し、**claude が "Session ID is already in use" で拒否**します
   — 同ファイルのコメントが警告している、まさにその回帰です。id を振り直すところまで含めて 1 つの
   決定なので、判定を 1 か所に置きました。
2. **tmux が生きている場合は従来どおり resume を渡します。** attach されるのは*クリア後*の claude で、
   resume 引数は「チェックの後にその tmux セッションが死んでいた場合」のフォールバックとしてしか
   効きません。そこで外すと上記の "already in use" で落ちるため、報告のケース（tmux 無し / 死亡）
   だけを対象にしています。**ここは判断が要るところなので、特に見てほしい点です。**
3. **凍結 transcript は消していません。** #1085 のサマリー・タイトル・プロンプトペインがその印と
   ファイルを読んでいます。ディスク使用量（報告では 175MB）は別の話として残ります。
4. **クリア後の会話を代わりに resume する**選択肢（印は `claudeId` を持っているので技術的には可能）は
   採っていません。セルが担う会話が変わり、フックの id 対応にも触れるためです。別提案にしたいです。

## 検証

`resolveSession` は純関数なのでユニットで両方向を固定しました（クリア済み → 新しい id /
tmux 生存時はそのまま resume / live pty は無関係に reattach）。

加えて **実機で再現 → 修正を確認**しました。使い捨ての `HOME` に、凍結 transcript
（`~/.claude/projects/<enc>/<id>.jsonl`）と印（`{cwd,size}` が現在サイズと一致）を置き、サーバを
起動して `/ws?session=<id>&cwd=…` で接続:

| | 修正前 | 修正後 |
|---|---|---|
| `/clear` 済みの id | `[ws] client connected (resume 1111…)` | **`(new 5d24…)`**、クライアントには新しい id が返る |
| クリアしていない id（対照） | `resume 9999…` | `resume 9999…`（変わらず） |

`yarn format` → `lint` → `typecheck` → `build` → `test` すべて green。

## User Prompt

- 「https://github.com/receptron/mulmoterminal/issues/2013 原因わかる？なおせる？」

## やっていないこと

- 凍結 transcript の掃除（報告者はスクリプトで退避中）。
- クリア後の会話への自動 resume（上の 4 番）。
- Windows 実機での確認。手元は macOS で、tmux を持たないホストと同じ経路
  （`tmuxAlive: false`）を印つきで再現しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhpBoaAvZsCqPmkLYFvCyy

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where conversations cleared with `/clear` could reappear after reconnecting or restarting the app.
  - Prevented cleared transcripts from being unintentionally resumed, including when a session is still held by tmux.
  - Preserved reconnection to active sessions while ensuring cleared conversations receive a fresh session instead of being resurrected.

- **Tests**
  - Added regression coverage for cleared conversations, reconnect behavior, and active session reattachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->