### PR TITLE
fix: canvas renderer を terminal より先に dispose する（#2021 — 固まったセルの修復が connect を飛ばしていた）

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -239,6 +239,16 @@ forced rather than chosen. What to know before that day:
 | Settle first | The WebGL **context limit** — browsers cap concurrent contexts and evict the oldest (order of ten; not measured here, so measure before relying on a number). This app is unusually exposed: a persisted slot **deliberately keeps its connection alive** when its view goes away (`Terminal.vue` calls `detach`, not `release` — that IS the persistence), so live terminals accumulate across tabs rather than tracking what is on screen. #965's reporter ran 22 cells. Needs `onContextLoss` handling and a decision about disposing off-screen terminals. |
 | Also | WebGL is unavailable on GPU blocklists / GPU-less VMs / some remote desktops. Keep the same best-effort load + DOM fallback this site already has. |
 
+**Disposal order (#2021).** The addon must be disposed BEFORE its terminal, and
+`src/composables/terminalRenderer.ts` is the only place that does either. On dispose the addon
+restores the DOM renderer through the core's `_createRenderer()`, which xterm 6 builds out of
+`this.linkifier` — a `MutableDisposable` the terminal's own dispose has already cleared, so the DOM
+renderer subscribes to `undefined` and throws
+(`Cannot read properties of undefined (reading 'onShowLinkUnderline')`). Measured in a real browser
+on the shipped pair: terminal-first throws 10/10, addon-first 0/10. It is not cosmetic — the throw
+escapes `dispose()`, and in the #846 rebuild path it skipped the `connect()` that gives the
+replacement terminal its socket, so the repair for a frozen cell left the cell dead.
+
 **Debugging note:** the canvas renderer
 paints to `<canvas>`, so terminal text and link decorations are **not in the DOM** — headless
 inspection (`.xterm-rows`, `elementFromPoint`) sees nothing. To debug links/selection headlessly,

--- a/plans/fix-2021-canvas-renderer-dispose-order.md
+++ b/plans/fix-2021-canvas-renderer-dispose-order.md
@@ -1,0 +1,73 @@
+# fix: canvas renderer を先に dispose する（#2021）
+
+## 問題
+
+ターミナルを破棄すると xterm が
+`TypeError: Cannot read properties of undefined (reading 'onShowLinkUnderline')` を投げる。
+検証中にコンソールで 4 回観測（コレクションペインの dock 切り替え / スプリッタ最大）。
+当初は「大きなリサイズで間欠的に出るコンソールノイズ」に見えていた。
+
+## 原因（コードで追った経路）
+
+1. `@xterm/addon-canvas@0.7.0` は dispose されるとき、DOM renderer に戻すために
+   `(terminal as any)._core._createRenderer()` を呼ぶ
+   （`node_modules/@xterm/addon-canvas/src/CanvasAddon.ts:61-66`）。
+2. xterm 6 の `_createRenderer()` は `this.linkifier!` を渡す
+   （`CoreBrowserTerminal.ts:583-585`）。`linkifier` は `MutableDisposable` で
+   （同 72-73 行）、**terminal 自身の dispose がすでに value を捨てている**。
+3. `DomRenderer` のコンストラクタは `this._linkifier2.onShowLinkUnderline(...)` を購読する
+   （`renderer/dom/DomRenderer.ts:89`）→ `undefined` を購読して throw。
+
+つまり「**addon より先に terminal を dispose すると必ず落ちる**」という順序のバグ。
+リサイズは引き金ではなく、リサイズ由来の `rebuildTerminal`（#846 の修復）が
+`deadTerm.dispose()` を呼んでいたのが実体。
+
+## これがコンソールノイズで済まない理由
+
+`rebuildTerminal` は dispose を try/catch していなかったので、throw が抜けて**後続が実行されない**:
+
+```ts
+deadTerm.dispose();   // ← throw
+connect(c);           // ← 実行されない = 新しい端末にソケットが無い
+fitAndSyncSize(c);
+if (hadFocus) term.focus();
+```
+
+「固まったセルを直す」ための修復が、**セルを恒久的に無反応にする**。
+`release()` 側は try/catch があるので握り潰されていたが、terminal の dispose は
+addon の disposable で止まるため、その後ろの後始末は走っていない。
+
+## 測定（実ブラウザ・このアプリが積んでいるバージョンで）
+
+esbuild で最小ページを作り、`@xterm/xterm@6.0.0` + `@xterm/addon-canvas@0.7.0` で 10 回ずつ:
+
+| | throw |
+|---|---|
+| terminal を先に dispose（従来） | **10 / 10** |
+| addon を先に dispose（本 PR） | **0 / 10** |
+
+間欠的に見えていたのは引き金（rebuild）のほうで、順序さえ踏めば 100% 再現する。
+
+## 直し方
+
+`src/composables/terminalRenderer.ts` に canvas renderer の**ライフサイクル一式**を集約:
+
+- `loadCanvasRenderer(term)` — 従来 `buildTerminal` にあった best-effort な読み込み。
+- `disposeTerminal(term, renderer)` — **renderer を先に**、どちらが throw しても
+  呼び出し側には投げない。呼び出し側には後始末（`connect`）が残っているため。
+
+`Conn` が addon を保持するようにし、`rebuildTerminal` と `release` の両方をこの関数経由にした。
+
+## 検証
+
+- ユニット: `test/src/composables/terminalRenderer.spec.ts`（順序・両方向の throw・null renderer・二重 dispose なし）。
+- 実ブラウザ: 上の 10 回 × 2 の測定（`disposeTerminal` は**リポジトリから import した実物**）。
+- 実アプリ（専用 HOME / ポート 34599、ビルド済み dist）:
+  - shell セルを作る → 出力 → **閉じる**（release 経路）→ 端末 0・エラー 0 → もう 1 枚作って動作。
+  - コレクションペインで chat 起動 → dock 切り替え → スプリッタ Home/End → **入力が通る**（画面が変化）、pageerror 無し。
+
+## やらないこと
+
+- `@xterm/addon-webgl` への移行（`docs/terminal-notes.md` の Renderer 節の検討事項。WebGL の
+  コンテキスト上限と `onContextLoss` の設計が先）。この PR は順序の是正だけ。
+- `guardBufferHealth` / `bufferIsShort` の閾値の見直し（リサイズ直後の判定が妥当かは別の問題）。

--- a/src/composables/terminalRenderer.ts
+++ b/src/composables/terminalRenderer.ts
@@ -1,0 +1,67 @@
+import { CanvasAddon } from "@xterm/addon-canvas";
+import type { Terminal } from "@xterm/xterm";
+
+// The canvas renderer's whole lifecycle: how a terminal gets one, and the order the two have to be
+// taken apart in.
+//
+// WHY CANVAS AT ALL — it renders each glyph in its own cell, instead of the DOM renderer's inline
+// runs: a full-width CJK glyph that isn't exactly 2x the Latin cell lets a long Japanese line drift
+// right and spill its tail past the terminal's edge (the reason this was added, b12cc48). A
+// fixed-grid renderer makes that structurally impossible.
+//
+// CAVEAT — version mismatch: @xterm/addon-canvas is xterm-5 era (its peerDependency is
+// `@xterm/xterm@^5`, and there is no xterm-6 build — even 0.8.0-beta still peers ^5), but the app
+// runs @xterm/xterm@6. It renders, and it was once named the suspected cause of #782 (selection
+// auto-scroll + scrollbar) and #783 (OSC 8 links); measurement disproved both. What the mismatch
+// DOES mean is that a future xterm bump cannot be repaired by bumping this addon, because no such
+// release exists — see the Renderer section of docs/terminal-notes.md for what to move to on the
+// day it breaks, and what to settle before moving.
+//
+// DISPOSAL ORDER is the other thing the pairing gets wrong (#2021). On dispose the addon restores
+// the DOM renderer by calling the core's `_createRenderer()`, and xterm 6 builds that renderer out
+// of `this.linkifier` — a `MutableDisposable` the terminal's own dispose has already cleared by the
+// time it reaches its addons. The DOM renderer then subscribes to `undefined`:
+//
+//     TypeError: Cannot read properties of undefined (reading 'onShowLinkUnderline')
+//
+// Measured in a real browser against the versions this app ships: disposing the terminal with the
+// addon still loaded throws EVERY time; disposing the addon first, while the terminal is still
+// whole, never does. So the order is the fix, and the try/catch is for what neither of us can see
+// coming.
+//
+// It matters beyond a console line, because the throw escapes `dispose()` and whatever the caller
+// meant to do next does not run. In the #846 rebuild path that is `connect()` — the repair for a
+// frozen cell would leave the replacement terminal attached to no socket at all.
+
+/** The canvas renderer, or null where it could not initialise — xterm keeps its own DOM renderer
+ *  then, and there is nothing of ours to dispose first. */
+export function loadCanvasRenderer(term: Terminal): CanvasAddon | null {
+  try {
+    const canvas = new CanvasAddon();
+    term.loadAddon(canvas);
+    return canvas;
+  } catch (err) {
+    console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
+    return null;
+  }
+}
+
+/** Just the part of a terminal / addon the teardown needs. Structural so a spec can drive it with
+ *  fakes — the real pairing needs a canvas, which jsdom does not have. */
+export interface Disposes {
+  dispose(): void;
+}
+
+/** Dispose a terminal and its renderer addon, renderer FIRST, and never throw at the caller. */
+export function disposeTerminal(term: Disposes, renderer: Disposes | null): void {
+  try {
+    renderer?.dispose();
+  } catch (err) {
+    console.warn("[terminal] the canvas renderer would not let go — disposing the terminal anyway", err);
+  }
+  try {
+    term.dispose();
+  } catch (err) {
+    console.warn("[terminal] dispose threw; the slot is being torn down regardless", err);
+  }
+}

--- a/src/composables/terminalRenderer.ts
+++ b/src/composables/terminalRenderer.ts
@@ -33,35 +33,55 @@ import type { Terminal } from "@xterm/xterm";
 // meant to do next does not run. In the #846 rebuild path that is `connect()` — the repair for a
 // frozen cell would leave the replacement terminal attached to no socket at all.
 
-/** The canvas renderer, or null where it could not initialise — xterm keeps its own DOM renderer
- *  then, and there is nothing of ours to dispose first. */
-export function loadCanvasRenderer(term: Terminal): CanvasAddon | null {
-  try {
-    const canvas = new CanvasAddon();
-    term.loadAddon(canvas);
-    return canvas;
-  } catch (err) {
-    console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
-    return null;
-  }
-}
-
-/** Just the part of a terminal / addon the teardown needs. Structural so a spec can drive it with
+/** Just the part of a terminal / addon this file needs. Structural so a spec can drive it with
  *  fakes — the real pairing needs a canvas, which jsdom does not have. */
 export interface Disposes {
   dispose(): void;
 }
 
+/** Dispose without letting the failure travel: everything here is called by someone with cleanup
+ *  still to do. */
+function disposeQuietly(target: Disposes | null, whatFailed: string): void {
+  try {
+    target?.dispose();
+  } catch (err) {
+    console.warn(`[terminal] ${whatFailed}`, err);
+  }
+}
+
+/** Load a renderer addon onto a terminal, and clean up after a load that fails HALFWAY.
+ *
+ *  `loadAddon` registers the addon before it activates it
+ *  (`@xterm/xterm/src/common/public/AddonManager.ts:29-31`), so a throw out of `activate()` leaves
+ *  it in xterm's addon list — where the terminal's own dispose would reach it at exactly the moment
+ *  this file exists to avoid. Disposing it here happens while the terminal is still whole, which is
+ *  the safe side of that rule (CodeRabbit, PR #2026).
+ *
+ *  Generic and structural so a spec can fail the load on purpose. */
+export function attachRenderer<T extends Disposes>(term: { loadAddon: (addon: T) => void }, renderer: T): T | null {
+  try {
+    term.loadAddon(renderer);
+    return renderer;
+  } catch (err) {
+    console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
+    disposeQuietly(renderer, "the half-loaded canvas renderer would not let go either");
+    return null;
+  }
+}
+
+/** The canvas renderer, or null where it could not initialise — xterm keeps its own DOM renderer
+ *  then, and there is nothing of ours to dispose first. */
+export function loadCanvasRenderer(term: Terminal): CanvasAddon | null {
+  try {
+    return attachRenderer(term, new CanvasAddon());
+  } catch (err) {
+    console.warn("[terminal] canvas renderer could not be constructed — using the DOM renderer", err);
+    return null;
+  }
+}
+
 /** Dispose a terminal and its renderer addon, renderer FIRST, and never throw at the caller. */
 export function disposeTerminal(term: Disposes, renderer: Disposes | null): void {
-  try {
-    renderer?.dispose();
-  } catch (err) {
-    console.warn("[terminal] the canvas renderer would not let go — disposing the terminal anyway", err);
-  }
-  try {
-    term.dispose();
-  } catch (err) {
-    console.warn("[terminal] dispose threw; the slot is being torn down regardless", err);
-  }
+  disposeQuietly(renderer, "the canvas renderer would not let go — disposing the terminal anyway");
+  disposeQuietly(term, "dispose threw; the slot is being torn down regardless");
 }

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -36,8 +36,9 @@ import { getTerminalScrollSpeed } from "./useTerminalScrollSpeed";
 import { scrollsToBottomOnSubmit } from "./useScrollToBottomOnSubmit";
 import { isTypedInput } from "./terminalUserInput";
 import { bufferIsShort, readBufferShape } from "./terminalBufferHealth";
+import { disposeTerminal, loadCanvasRenderer } from "./terminalRenderer";
 import { initialFitGate, reportOnScreen, requestFit, type FitGate } from "./terminalFitGate";
-import { CanvasAddon } from "@xterm/addon-canvas";
+import type { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
 import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
 import { connectionWillReturn, reconnectDelayMs, shouldReconnect } from "./reconnectPolicy";
@@ -143,6 +144,9 @@ interface Conn {
   key: string;
   term: Terminal;
   fitAddon: FitAddon;
+  // The canvas renderer, kept so it can be disposed BEFORE its terminal — see terminalTeardown.ts.
+  // Null where it could not initialise, which is the DOM-renderer fallback below.
+  canvas: CanvasAddon | null;
   host: HTMLDivElement; // term.open()'d into this ONCE; re-parented on attach/detach
   ws: WebSocket | null;
   knownSessionId: string | null;
@@ -440,6 +444,7 @@ function registerFilePathLinks(term: Terminal, c: Conn): void {
 interface TerminalRuntime {
   term: Terminal;
   fitAddon: FitAddon;
+  canvas: CanvasAddon | null;
   host: HTMLDivElement;
   wheel: WheelScrollControl;
 }
@@ -490,29 +495,7 @@ function buildTerminal(swallowedMouseModes: Set<number>, font: TerminalFont): Te
   guardMouseClicks(term, swallowedMouseModes);
   // After open(), so the helper textarea the clipboard fallback looks for exists in `host`.
   wireCopyOnSelect(term, host);
-  // Render each glyph in its own cell (canvas) instead of the default DOM renderer, which flows text
-  // as inline runs: a full-width CJK glyph that isn't exactly 2× the Latin cell lets a long Japanese
-  // line drift right and spill its tail past the terminal's edge (the reason this was added, b12cc48).
-  // A fixed-grid renderer makes that structurally impossible.
-  //
-  // CAVEAT — version mismatch: @xterm/addon-canvas is xterm-5 era (its peerDependency is
-  // `@xterm/xterm@^5`, and there is no xterm-6 build — even 0.8.0-beta still peers ^5), but the app
-  // runs @xterm/xterm@6. It renders, and it is NOT known to break anything: an earlier version of
-  // this comment named it the suspected cause of #782 (selection auto-scroll + scrollbar) and #783
-  // (OSC 8 links), and measurement disproved both. #782 is tmux owning the scrollback — the outer
-  // xterm only ever receives the visible screen — and reproduced identically with the addon off.
-  // #783 was tmux stripping hyperlinks (fixed in #785). Neither is a reason to change renderer.
-  //
-  // What the mismatch DOES mean is that a future xterm bump cannot be repaired by bumping this
-  // addon, because no such release exists — see the Renderer section of docs/terminal-notes.md for
-  // what to move to on the day it breaks, and what to settle before moving.
-  // Best-effort: if the canvas renderer can't initialise, xterm keeps the DOM renderer.
-  try {
-    term.loadAddon(new CanvasAddon());
-  } catch (err) {
-    console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
-  }
-  return { term, fitAddon, host, wheel };
+  return { term, fitAddon, canvas: loadCanvasRenderer(term), host, wheel };
 }
 
 // The wiring that needs the connection itself, so it is re-applied to every terminal a slot owns.
@@ -529,11 +512,12 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
     return existing;
   }
   const swallowedMouseModes = new Set<number>();
-  const { term, fitAddon, host, wheel } = buildTerminal(swallowedMouseModes, font);
+  const { term, fitAddon, canvas, host, wheel } = buildTerminal(swallowedMouseModes, font);
   const c: Conn = {
     key,
     term,
     fitAddon,
+    canvas,
     host,
     ws: null,
     knownSessionId: target.sessionId,
@@ -569,12 +553,14 @@ function ensure(key: string, target: ConnTarget, font: TerminalFont): Conn {
 // into the fresh terminal, so the user sees the cell blink rather than a dead panel.
 function rebuildTerminal(c: Conn): void {
   const deadTerm = c.term;
+  const deadCanvas = c.canvas;
   const deadHost = c.host;
   const hadFocus = deadHost.contains(document.activeElement);
   console.warn(`[terminal] slot ${c.key}: xterm buffer corrupted (xtermjs/xterm.js#6063) — rebuilding the terminal and re-attaching`);
-  const { term, fitAddon, host, wheel } = buildTerminal(c.swallowedMouseModes, c.font);
+  const { term, fitAddon, canvas, host, wheel } = buildTerminal(c.swallowedMouseModes, c.font);
   c.term = term;
   c.fitAddon = fitAddon;
+  c.canvas = canvas;
   c.host = host;
   c.wheel = wheel;
   c.lastRebuildMs = Date.now();
@@ -582,7 +568,10 @@ function rebuildTerminal(c: Conn): void {
   watchOnScreen(c);
   c.attachedEl?.appendChild(host);
   deadHost.remove();
-  deadTerm.dispose();
+  // Renderer first, and never throwing: the lines below are the half that makes the new terminal
+  // usable, and disposing in the other order threw right here — leaving the replacement attached
+  // to nothing (#2021).
+  disposeTerminal(deadTerm, deadCanvas);
   connect(c);
   fitAndSyncSize(c);
   if (hadFocus) term.focus();
@@ -820,11 +809,8 @@ export function release(key: string) {
   } catch {
     // not in the DOM
   }
-  try {
-    c.term.dispose();
-  } catch {
-    // already disposed
-  }
+  disposeTerminal(c.term, c.canvas);
+  c.canvas = null;
   conns.delete(key);
   connView.delete(key);
 }

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -144,7 +144,7 @@ interface Conn {
   key: string;
   term: Terminal;
   fitAddon: FitAddon;
-  // The canvas renderer, kept so it can be disposed BEFORE its terminal — see terminalTeardown.ts.
+  // The canvas renderer, kept so it can be disposed BEFORE its terminal — see terminalRenderer.ts.
   // Null where it could not initialise, which is the DOM-renderer fallback below.
   canvas: CanvasAddon | null;
   host: HTMLDivElement; // term.open()'d into this ONCE; re-parented on attach/detach

--- a/test/src/composables/terminalRenderer.spec.ts
+++ b/test/src/composables/terminalRenderer.spec.ts
@@ -1,7 +1,7 @@
 // The disposal order xterm 6 + the xterm-5-era canvas addon require, and the promise that neither
 // side can stop the caller (#2021).
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { disposeTerminal, type Disposes } from "../../../src/composables/terminalRenderer";
+import { attachRenderer, disposeTerminal, type Disposes } from "../../../src/composables/terminalRenderer";
 
 const recorder = () => {
   const order: string[] = [];
@@ -64,5 +64,48 @@ describe("disposeTerminal", () => {
     disposeTerminal(term, renderer);
     expect(term.dispose).toHaveBeenCalledTimes(1);
     expect(renderer.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("attachRenderer", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("hands back the renderer it loaded", () => {
+    const renderer = { dispose: vi.fn() };
+    const term = { loadAddon: vi.fn() };
+    expect(attachRenderer(term, renderer)).toBe(renderer);
+    expect(term.loadAddon).toHaveBeenCalledWith(renderer);
+    expect(renderer.dispose).not.toHaveBeenCalled();
+  });
+
+  // xterm registers an addon BEFORE it activates it, so a throw out of activate() leaves it in the
+  // addon list — where the terminal's own dispose would reach it at the moment this module exists
+  // to avoid (CodeRabbit, PR #2026).
+  it("disposes a renderer whose activation threw, while the terminal is still whole", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const renderer = { dispose: vi.fn() };
+    const term = {
+      loadAddon: () => {
+        throw new Error("no 2d context");
+      },
+    };
+    expect(attachRenderer(term, renderer)).toBeNull();
+    expect(renderer.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a half-loaded renderer that will not let go either", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const renderer: Disposes = {
+      dispose: () => {
+        throw new Error("half-built");
+      },
+    };
+    const term = {
+      loadAddon: () => {
+        throw new Error("no 2d context");
+      },
+    };
+    expect(() => attachRenderer(term, renderer)).not.toThrow();
+    expect(attachRenderer(term, renderer)).toBeNull();
   });
 });

--- a/test/src/composables/terminalRenderer.spec.ts
+++ b/test/src/composables/terminalRenderer.spec.ts
@@ -1,0 +1,68 @@
+// The disposal order xterm 6 + the xterm-5-era canvas addon require, and the promise that neither
+// side can stop the caller (#2021).
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { disposeTerminal, type Disposes } from "../../../src/composables/terminalRenderer";
+
+const recorder = () => {
+  const order: string[] = [];
+  const make = (name: string, throws = false): Disposes => ({
+    dispose: () => {
+      order.push(name);
+      if (throws) throw new Error(`${name} refused`);
+    },
+  });
+  return { order, make };
+};
+
+describe("disposeTerminal", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // The whole point. On dispose the addon asks the core for a DOM renderer, and the core builds it
+  // out of a linkifier the terminal's own dispose has already cleared — so the addon has to go
+  // while the terminal is still whole.
+  it("disposes the renderer before the terminal", () => {
+    const { order, make } = recorder();
+    disposeTerminal(make("term"), make("renderer"));
+    expect(order).toEqual(["renderer", "term"]);
+  });
+
+  it("disposes the terminal even when the renderer throws", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { order, make } = recorder();
+    expect(() => disposeTerminal(make("term"), make("renderer", true))).not.toThrow();
+    expect(order).toEqual(["renderer", "term"]);
+  });
+
+  // The caller has work left after this — the rebuild path reconnects the replacement terminal —
+  // so a throw here is what turns "the cell blinked" into "the cell is dead".
+  it("does not throw at the caller when the terminal throws", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { order, make } = recorder();
+    expect(() => disposeTerminal(make("term", true), make("renderer"))).not.toThrow();
+    expect(order).toEqual(["renderer", "term"]);
+  });
+
+  it("says which side refused, rather than swallowing it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { make } = recorder();
+    disposeTerminal(make("term"), make("renderer", true));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("canvas renderer");
+  });
+
+  // The canvas addon is best-effort: where it cannot initialise, xterm keeps its own DOM renderer
+  // and there is nothing of ours to dispose first.
+  it("disposes the terminal alone when there is no renderer addon", () => {
+    const { order, make } = recorder();
+    disposeTerminal(make("term"), null);
+    expect(order).toEqual(["term"]);
+  });
+
+  it("disposes each side exactly once", () => {
+    const term = { dispose: vi.fn() };
+    const renderer = { dispose: vi.fn() };
+    disposeTerminal(term, renderer);
+    expect(term.dispose).toHaveBeenCalledTimes(1);
+    expect(renderer.dispose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

#2021 の `Cannot read properties of undefined (reading 'onShowLinkUnderline')` を直します。
**コンソールノイズではありませんでした。**

原因は dispose の順序です。`@xterm/addon-canvas@0.7.0` は dispose されるとき DOM renderer に戻す
ために core の `_createRenderer()` を呼びますが（`CanvasAddon.ts:61-66`）、xterm 6 のそれは
`this.linkifier!` を渡します（`CoreBrowserTerminal.ts:583-585`）。`linkifier` は `MutableDisposable`
で、**terminal 自身の dispose がすでに value を捨てている**ため、`DomRenderer` が `undefined` を
購読して落ちます（`renderer/dom/DomRenderer.ts:89`）。

そして `rebuildTerminal`（#846 の修復）は dispose を try/catch していませんでした:

```ts
deadTerm.dispose();   // ← ここで throw
connect(c);           // ← 実行されない = 新しい端末にソケットが無い
fitAndSyncSize(c);
if (hadFocus) term.focus();
```

つまり「**固まったセルを直す**」経路が、**セルを恒久的に無反応にしていた**ことになります。

直し方: `src/composables/terminalRenderer.ts` に canvas renderer のライフサイクルを集約し
（`loadCanvasRenderer` / `disposeTerminal`）、**renderer を先に** dispose し、どちらが throw しても
呼び出し側には投げないようにしました。`Conn` が addon を保持し、`rebuildTerminal` と `release` の
両方がこれを通ります。

Closes #2021

## Items to Confirm / Review

1. **「間欠的」ではありませんでした。** issue には「リサイズで間欠的に出る」と書きましたが、
   間欠的なのは**引き金**（リサイズ → `guardBufferHealth` → `rebuildTerminal`）のほうで、
   順序さえ踏めば 100% 落ちます。実ブラウザで 10 回ずつ測定:

   | | throw |
   |---|---|
   | terminal を先に dispose（従来） | **10 / 10** |
   | addon を先に dispose（本 PR） | **0 / 10** |

   計測は esbuild の最小ページで、`disposeTerminal` は**このリポジトリから import した実物**です。
2. **`release()` の try/catch を関数側に移しました**（`disposeTerminal` が投げない）。従来は
   release 側だけ握り潰されており、rebuild 側が無防備でした。順序の是正が本体で、try/catch は
   「どちらも見えていないもの」への保険です。
3. **`loadCanvasRenderer` の抽出は行きがかり**です（`useTerminalConnections.ts` が
   `max-lines` 600 の上限に当たったため、canvas のライフサイクルを 1 ファイルに集めました）。
   挙動は同じ — best-effort な読み込みで、失敗したら DOM renderer のままです。
4. **`guardBufferHealth` / `bufferIsShort` の妥当性はこの PR では触っていません**。
   「リサイズ直後の buffer を短いと読んで rebuild してよいのか」は別の問題として残しています。
5. `@xterm/addon-webgl` への移行も**やっていません**（`docs/terminal-notes.md` の Renderer 節どおり、
   WebGL のコンテキスト上限と `onContextLoss` の設計が先）。

## 検証

- ユニット: `test/src/composables/terminalRenderer.spec.ts` — 順序、renderer が throw しても
  terminal は dispose される、terminal が throw しても呼び出し側には届かない、renderer が
  null（canvas を読み込めなかった環境）、二重 dispose なし。
- 実ブラウザ: 上記 10 回 × 2。
- **実アプリ**（専用 HOME / ワークスペース / ポート 34599、ビルド済み dist）:
  - shell セル作成 → 出力 → **クローズ**（release 経路）→ 端末 0・console エラー 0 →
    もう 1 枚作って動作（前のセルの後始末が何も壊していない）。
  - コレクションペインで chat 起動 → dock 切り替え → スプリッタ Home/End →
    **入力が通る**（画面が変化）、pageerror 無し。
- `yarn format` → `lint` → `typecheck` → `build` → `test`（836 files / 12426 tests）すべて green。

## User Prompt

- 「https://github.com/receptron/mulmoterminal/issues/2021 すすめて」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhpBoaAvZsCqPmkLYFvCyy

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed terminal rebuild and shutdown errors that could occur when using the canvas renderer.
  - Improved cleanup reliability by releasing the renderer before the terminal.
  - Canvas initialization now falls back safely to standard DOM rendering when needed.
  - Cleanup failures no longer interrupt subsequent terminal connections, resizing, or focus behavior.
  - Added safeguards to ensure renderer and terminal resources are disposed once.

- **Documentation**
  - Added guidance on correct terminal and renderer disposal order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->