### PR TITLE
fix: scheduler spec の残り2箇所が本物の ~/.mulmoterminal に書いている

### DIFF
--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -265,6 +265,7 @@ describe("initUserTaskScheduler", () => {
       workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, prompt: "go" }]),
       spawnChat: spawnOk,
       systemTasks: [sysTask("system:feed-refresh")],
+      home,
     });
 
     expect(startMock).toHaveBeenCalledTimes(1); // already ticking, with the adapter still going
@@ -282,6 +283,7 @@ describe("initUserTaskScheduler", () => {
       workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, prompt: "go" }]),
       spawnChat: spawnOk,
       systemTasks: [sysTask("system:feed-refresh")],
+      home,
     });
 
     expect(startMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

`test/server/backends/scheduler.spec.ts` の 9 つの `initUserTaskScheduler` 呼び出しのうち **2 つが
使い捨ての `home` を渡していない**。そのため `hostStateRoot` が tmpdir ワークスペースに対して
本物の `~/.mulmoterminal` にフォールバックし、**スイートを走らせた人のホームにゴミを残す**。

その 11 行上にある、このスペック自身のコメントが逆のことを書いている:

> Every call gets a disposable home: state and logs now hang off the HOST STATE ROOT, so a spec
> that let it default would file them in the home of whoever runs the suite.

## Items to Confirm / Review

- **テストは両方の状態で緑**（書き込めるホームがあれば通る）ので、失敗から読み取ったのではなく
  **実測**した。この機械の `~/.mulmoterminal/workspaces/` には、存在しない temp パスの名前を持つ
  ディレクトリが **39 個**あり、いくつかは数分前のもの — このファイルを1回走らせるごとに1個増える。
- **逆向きにも検証済み**: 片方だけ元に戻すとファイル1回の実行でそのディレクトリが1個増える
  （34 → 35）。両方直すと1回走らせても増えない（35 → 35）。`yarn test` 全体でも増えない。
- 9 箇所すべてが `home` を渡すようになったので、上記のコメントがようやく本当になる。
- **既存の 39 個のゴミディレクトリはそのまま**にしてある。人のホームから物を消すのはこの PR の
  仕事ではない。中身は空の `config/` だけなので、消すのは任意。

## User Prompt

- （直接の依頼ではなく)#2027 の `/codex-cross-review` 中に Codex が発見。#2027 は #2024 を merge して
  このファイルを取り込んでいたため、そちらで直しかけたが、**単独で revert できるものは別 PR**という
  リポジトリのルールに従って切り出した（Codex も round 5 の checkpoint で同じことを指摘）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUReodhMZjZ1DDK92LtxgC

work in mulmoterminal4
