### PR TITLE
chore: @mulmoclaude/shapescript-plugin 2.0.0 — upstream ShapeScript semantics

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,23 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+### ShapeScript follows the upstream language now — `@mulmoclaude/shapescript-plugin@2.0.0`
+
+- `presentShapeScript`, `renderShapeScript` and `exportShapeScriptUsdz` now read a script the way
+  the upstream [ShapeScript](https://shapescript.info/mac/) app does: `size` is the **diameter** of
+  a sphere, cylinder, cone, circle or polygon; `orientation` (alias `rotation`) and `rotate` take
+  **half-turns** as `roll yaw pitch` (0.5 = 90°); path `point` / `curve` coordinates are
+  **absolute** in the path's frame, with `curve` a Bézier control point; a `path` may carry its own
+  `position` / `orientation` / `size`; `seed N` reseeds `rnd` for its block; and function arguments
+  may be space-separated (`max(0 (j - 1))`) as upstream writes them, with `.first` … `.last` ordinal
+  members. A script written against the upstream docs renders the same here, and a script written
+  here opens in the upstream app.
+- **Breaking for `.shape` files saved under the old conventions** (radius sizes, radian rotations,
+  relative path points). They still parse but render at half size or rotated wrong — convert them:
+  sphere/cylinder sizes ×2, `rotation X Y Z` radians → `orientation` in half-turns with the sign
+  flipped, path deltas → absolute points. MulmoClaude shares these files, so both hosts moved to
+  2.0.0 together (mulmoclaude#3069).
+
 ### Take a 3D model out of the chat as a USDZ file
 
 - A ShapeScript model can now leave MulmoTerminal as a **USDZ** file — Apple's AR format: AR

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -21,9 +21,14 @@ Entries here are folded into the next release's heading when it ships.
   here opens in the upstream app.
 - **Breaking for `.shape` files saved under the old conventions** (radius sizes, radian rotations,
   relative path points). They still parse but render at half size or rotated wrong — convert them:
-  sphere/cylinder sizes ×2, `rotation X Y Z` radians → `orientation` in half-turns with the sign
-  flipped, path deltas → absolute points. MulmoClaude shares these files, so both hosts moved to
-  2.0.0 together (mulmoclaude#3069).
+  the `size` of every `sphere`, `cylinder`, `cone`, `circle`, `polygon` and `torus` ×2 (the first
+  component for a cylinder or cone, all of them for a sphere); a `rotation X Y Z` property in
+  radians → `orientation roll yaw pitch` in half-turns, each axis negated and divided by pi (the old
+  X value becomes the new third component, the old Z the first); a `rotate` command in full turns →
+  half-turns, negated and doubled; path `point` / `curve` deltas → absolute points, and the old
+  four-argument `curve x y cx cy` → a `curve cx cy` control point between two `point`s; `tau` → `2 * pi`
+  if the file must also open in the upstream app. MulmoClaude shares these files, so both hosts
+  moved to 2.0.0 together (mulmoclaude#3069).
 
 ### Take a 3D model out of the chat as a USDZ file
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^1.4.0",
+    "@mulmoclaude/shapescript-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,10 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/shapescript-plugin@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-1.4.0.tgz#3cd3a3c20bdcdddb3241aa4b8cc481cc9ab82d75"
-  integrity sha512-uqqbKsHC87yTaWJsb3o6onvE4Kb6fnBThn7/j9trDDrr9UqCKy/fa5WoUD+xrpTX80byDP1o/N0i3ru7d0OaKg==
+"@mulmoclaude/shapescript-plugin@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-2.0.0.tgz#2c3838d29d35ec734d2c3faf8a46e6357e731259"
+  integrity sha512-5xkhig0S5fXRJB+Gp5rX6SnLKjUn6ydx8gLQtMELt0NgLNyjD2uhjL6UZW6funRxk/gofCUEolDNb47dusasww==
   dependencies:
     three "^0.185.1"
     three-bvh-csg "^0.0.18"


### PR DESCRIPTION
## What

Bumps `@mulmoclaude/shapescript-plugin` from `^1.4.0` to `^2.0.0` (published today) and records the change in the changelog. No host code changes.

## Why

2.0.0 makes the plugin read a script the way the upstream [ShapeScript](https://shapescript.info/mac/) app does, so a model the agent writes from the upstream docs renders correctly, and a model written here opens in the upstream app. Landed in MulmoClaude as receptron/mulmoclaude#3069:

| Feature | Before (present3D dialect) | Now (upstream) |
|---|---|---|
| `sphere` / `cylinder` / `cone` / `circle` / `polygon` `size` | radius | **diameter** |
| `orientation` / `rotation`, `rotate` | radians XYZ / full turns | **half-turns** as `roll yaw pitch`, clockwise positive |
| path `point` / `curve` | relative steps, 4-arg curve | **absolute**, `curve` is a Bézier control point |
| `path { position … orientation … }` | not parsed | accepted (how a loft section is placed) |
| `seed N` | none | scoped reseed, upstream's generator |
| call arguments | `max(0, 1)` only | also `max(0 1)`; `.first` … `.last` members |

## Why both hosts at once

MulmoTerminal and MulmoClaude share the workspace's `artifacts/shapes/*.shape` files. With one host on 1.4.0 and the other on 2.0.0 the same file would render at two different sizes and rotations, which is the cross-app data skew the shared-package rule exists to prevent.

## Breaking

`.shape` files saved under the old conventions still parse but render wrong (half size, wrong rotation, collapsed paths). The changelog entry gives the conversion rules; three real models were converted and verified mesh-for-mesh during the MulmoClaude work.

## Host surface checked

- `server/backends/shapescript.ts`, `server/infra/shapescript-render-tool.ts`, `server/infra/shapescript-usdz-tool.ts`, `server/infra/plugins-registry.ts`: consume `executePresentShapeScript`, `renderShapeScriptSheet`, `executeExportShapeScriptUsdz` and the tool definitions. All signatures unchanged in 2.0.0.
- `test/scripts/shapescriptParserFix.spec.ts` pins a `>= 1.1.1` floor; 2.0.0 satisfies it.
- Nothing in `server/`, `common/` or `src/` calls the parser or converter directly, so there is no engine port to make.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build` all green locally with 2.0.0 installed.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the Unreleased changelog with detailed conversion guidance for `.shape` files using older ShapeScript conventions.
  - Clarified updates for shape sizes, rotations and orientations, path coordinates and curves, and `tau` values.
  - Documented compatibility considerations when opening legacy files in the upstream application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->