### PR TITLE
docs: slotLabel のコメントが uid について偽の説明をしていた (#2005)

### DIFF
--- a/src/composables/useHandoff.ts
+++ b/src/composables/useHandoff.ts
@@ -28,8 +28,9 @@ export interface HandoffSource {
   agent: TerminalAgent;
 }
 
-// Slot keys are `cell-<uid>`; the uid is what the user sees on the cell, so a menu
-// entry reads the same way the grid does.
+// Slot keys are `cell-<uid>`, and the uid is an ARRAY POSITION — renumbered on every grid parse
+// (useTerminalConnections.ts, `attach`) and shown on no cell. `#3` therefore names nothing the
+// reader can point at, and two terminals in one directory differ here by that number alone (#2005).
 export const slotLabel = (slot: SlotInfo, home: string | null): string => {
   const cell = slot.key.startsWith("cell-") ? `#${slot.key.slice("cell-".length)}` : slot.key;
   return slot.cwd ? `${cell} · ${slot.agent} · ${formatCwd(slot.cwd, home, 24)}` : `${cell} · ${slot.agent}`;


### PR DESCRIPTION
## Summary

`src/composables/useHandoff.ts` の `slotLabel` に付いていたコメントが、事実と逆のことを書いていました。

```diff
-// Slot keys are `cell-<uid>`; the uid is what the user sees on the cell, so a menu
-// entry reads the same way the grid does.
+// Slot keys are `cell-<uid>`, and the uid is an ARRAY POSITION — renumbered on every grid parse
+// (useTerminalConnections.ts, `attach`) and shown on no cell. `#3` therefore names nothing the
+// reader can point at, and two terminals in one directory differ here by that number alone (#2005).
```

uid は**配列の位置**です。`useTerminalConnections.ts:709` に、この skill が書いたのではなく元から
こう書いてあります:

> Slot keys are positional (`cell-<uid>`, **renumbered from array position on every grid parse**)

そしてテンプレート中で uid が使われているのは `persist-key` と round table の `self-label` だけで、
**どのセルにも表示されていません**（`grep` で確認）。

この偽の前提のせいで、`#3 · claude · ~/mulmoclaude` というラベルで十分だと判断されていました。
実際には同じフォルダで複数開くと、番号以外が完全に同じ行が並びます（#2005 の報告）。

## Items to Confirm / Review

1. **挙動は変えていません。** コメントのみの変更です。
2. **#2005 自体は minor として close 済み**で、これは直していません。直すならユーザーに見える値
   （セルのメモ/要約）を `SlotInfo` に載せる配線が要ります — 経緯と根拠は #2005 のコメントにあります。
3. コメントを 3 行に抑えました。当初はもっと長く書きましたが、CLAUDE.md の「1 行が原則、現在の
   タスクへの言及はしない」に照らして、読み手に必要な事実（配列位置であること・表示されていないこと・
   結果として何が起きるか）だけに削っています。イシュー番号は、このリポジトリの既存コメントの慣行に
   合わせて 1 つだけ残しました。

## 検証

`yarn format` → `lint` → `typecheck` → `build` すべて green。コメントのみの変更なので
`test` は CI に任せます。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/2005 マイナーな機能なのでそこまで対応不要
- コメントしてcloseかな
- useHandoff.ts の偽コメントも直して

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGUaJzDbjksQeXhnUyZTi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified internal slot-label documentation to accurately describe how grid cell identifiers are generated and interpreted.
  - Corrected misleading wording about whether these identifiers are visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->