### PR TITLE
fix(canvas): リポジトリ内のデッキを絶対パスで開き、編集が届くようにする (#1970)

### DIFF
--- a/plans/fix-1970-canvas-repo-deck-root.md
+++ b/plans/fix-1970-canvas-repo-deck-root.md
@@ -51,8 +51,14 @@ movieStatus / pdfStatus / pendingGenerations / save → { filePath }
 ## 影響しないこと
 
 - **開けるファイルの範囲**: `canOpenInCanvas` のゲートは変わらない。任意の `.json` は #1976 以降すでに対象。
-- **カードの同一視**: `canonicalCardPath` が絶対・相対+root の**どちらも同じ絶対パスに正規化**するので、
-  エージェントが作った `stories/…` のカードと 1 枚に畳まれる（実装を読んで確認）。
+- **カードの同一視（登録済み root 配下）**: 綴りは **その root の canonical**（サーバが realpath した綴り）
+  で mint する。`canonicalCardPath` が `stories/…`+root を解決する先と同じ綴りなので、エージェントが
+  作ったカードと 1 枚に畳まれる。ブラウザは realpath できないので、**canonical を使わずペインの綴りを
+  そのまま出すと symlink 経由の workspace で 2 枚に割れる**（Codex round 1 の P2。実測して修正済み、
+  `test/src/composables/canvasOpenFile.spec.ts` の「a deck reached two ways is one card」）。
+- **どの root にも属さないデッキ**: canonical が無いのでペインの綴りをそのまま出す。同じファイルを
+  別綴り（symlink）で開けば 2 枚になる — #1976 以前と同じで、この修正は改善も悪化もさせない。
+  閉じられるのはサーバが解決済みパスをカードに載せたときだけ。
 - **既定 stories 配下**: 相対のまま。root 無しの dispatch でも正しく解決でき、
   ワークスペース subtree との二重綴りを避けるため先に判定する必要がある。
 
@@ -76,4 +82,6 @@ root 付き相対を残したが、**実測すると相対入力は全ケース�
 - 既存 spec のうち 9 件は旧規則（root 相対を優先）を固定しているので、新規則に書き直す。
   **既定 stories 配下の難所**（ワークスペースが `/`、末尾が空白、symlink の両綴り）は
   そのまま残すことが肝。動くのは root 配下の綴りだけ。
+- **新規則を break-verify する**: canonical 綴りの mint を元（ペインの綴り）に戻すと 2 件、
+  最長 tail 優先に反転すると 1 件が赤になることを実測する（mutation の前後で pristine 一致を確認）。
 - `yarn format` → `lint` → `typecheck` → `build` → `test`。

--- a/plans/fix-1970-canvas-repo-deck-root.md
+++ b/plans/fix-1970-canvas-repo-deck-root.md
@@ -1,0 +1,79 @@
+# fix #1970 — リポジトリ内のデッキが Canvas で編集できない
+
+## 症状
+
+`<workspace>/<repo>/decks/launch.json` を Files ペインから Canvas で開くと、開くところまでは通るが
+
+- Media タブ: 各ビートに `File not found: stories/<repo>/decks/launch.json`
+- Edit タブ: 保存しても変わらない。コンソールに `deck save failed: File not found: …`
+
+`<workspace>/artifacts/stories/` に置いたデッキでは起きない。
+
+## 原因
+
+`storyWirePath()` が **登録済み root 配下のデッキだけ `stories/<tail>` + `root` という綴り**を返していた。
+カードは `root` を持ち、reopen は `root` を受け取るので**開くのは通る**。
+
+ところがプラグインの View が出す後続の dispatch は `filePath` をそのまま流し、**`root` を送らない**
+（`@mulmoclaude/mulmoscript-plugin` 4.6.0 の `dist/vue.js` を読んで確認）:
+
+```
+updateScript → { filePath, script, origin }
+updateBeat   → { filePath, beatIndex, beat }
+beatMovie    → { filePath, beatIndex }
+movieStatus / pdfStatus / pendingGenerations / save → { filePath }
+```
+
+`root` の無い相対パスをサーバは既定 root（`artifacts/stories/`）として解決するので、
+実際の置き場所と食い違って `File not found` になる。
+
+**実測（実サーバ、修正前）:**
+
+```
+相対 + root なし → {"ok":false,"code":"not_found","error":"File not found: stories/acme-docs/decks/launch.json"}
+絶対 + root なし → {"ok":true}   ファイルが実際に書き変わる
+```
+
+## 直し方
+
+`storyWirePath()` から**登録済み root の分岐を削除**し、既定 stories 配下以外は
+**そのファイル自身の絶対パス**を返す。**絶対パスは root を持たないので、root を落とす dispatch でも壊れない。**
+
+これは新機能ではない。プラグイン 4.6.0 の `byPath` 形式で、このホストは既に opt-in 済み
+（`server/backends/mulmoscript.ts`）、かつ **どの root にも属さないデッキは #1976 で既にこの形**だった。
+今回は「登録済み root だけを例外扱いするのをやめる」だけ。
+
+### 併せて直す偽コメント（#1970 の原因そのもの）
+
+`canvasOpenFile.ts` の冒頭が **「mulmoScript は絶対パスを一切受け付けない」** と書いていた。
+4.5.2 までは真、4.6.0 で偽。この前提が残っていたために root 配下だけ相対形式のままだった。
+
+## 影響しないこと
+
+- **開けるファイルの範囲**: `canOpenInCanvas` のゲートは変わらない。任意の `.json` は #1976 以降すでに対象。
+- **カードの同一視**: `canonicalCardPath` が絶対・相対+root の**どちらも同じ絶対パスに正規化**するので、
+  エージェントが作った `stories/…` のカードと 1 枚に畳まれる（実装を読んで確認）。
+- **既定 stories 配下**: 相対のまま。root 無しの dispatch でも正しく解決でき、
+  ワークスペース subtree との二重綴りを避けるため先に判定する必要がある。
+
+## 削った到達不能コード
+
+当初は「絶対パスが無いとき（ペインに cwd が無く相対パスで来るとき）の最後の手段」として
+root 付き相対を残したが、**実測すると相対入力は全ケースで `null`** を返す
+（root の prefix 照合が相対キーに一致しない）。起きない場合を説明するコメント付きの
+死んだ分岐だったので削除した。
+
+## 範囲外（上流 mulmoclaude 側）
+
+- View の dispatch に `root` を載せる（mulmoclaude#3014）。入れば相対形式でも通るようになるが、
+  この修正はそれを待たない。
+- 保存失敗が Edit タブに出ずコンソールだけな点。入力欄に値が残るので保存されたように見える。
+
+## 検証
+
+- **実サーバで修正前後を測る**。修正前に `File not found` だった `updateScript` / `beatImage` が
+  `ok: true` になり、ファイルの中身が実際に変わることまで確認する。
+- 既存 spec のうち 9 件は旧規則（root 相対を優先）を固定しているので、新規則に書き直す。
+  **既定 stories 配下の難所**（ワークスペースが `/`、末尾が空白、symlink の両綴り）は
+  そのまま残すことが肝。動くのは root 配下の綴りだけ。
+- `yarn format` → `lint` → `typecheck` → `build` → `test`。

--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -59,6 +59,12 @@ export interface StoriesRoot {
    *  Only a GATE: the server re-checks containment with a realpath when the card is built, so a
    *  spelling accepted here that names something else still opens nothing. */
   paths: readonly string[];
+  /** The server's own realpathed spelling of this root, never re-derived here — a browser cannot
+   *  realpath. It is what an absolute `filePath` is rewritten onto, so a file reached through a
+   *  symlinked spelling and through the real one mint ONE path and therefore one card. Absent
+   *  where the server did not say (an older server, or a root it could not resolve), and then the
+   *  spelling the pane showed travels as-is. */
+  canonical?: string;
 }
 
 /** Where stories can live, as this server serves them.
@@ -78,9 +84,11 @@ export interface StoriesRoots {
  *  registers it first — and its own `artifacts/stories` is the one place addressed without a root.
  *  One derivation, so the Files pane, the Mulmo menu and the grid cannot disagree about which
  *  directory that is (#1951). */
-export const storiesRootsFrom = (registered: ReadonlyArray<{ id: string; paths: readonly string[] }>): StoriesRoots => ({
+export const storiesRootsFrom = (registered: ReadonlyArray<{ id: string; paths: readonly string[]; canonical?: string }>): StoriesRoots => ({
   workspaces: registered[0]?.paths ?? [],
-  roots: registered.map((root) => ({ id: root.id, paths: root.paths })),
+  // Spread rather than assigned: `exactOptionalPropertyTypes` makes an explicit `undefined`
+  // different from an absent key, and a root the server could not resolve has no canonical at all.
+  roots: registered.map((root) => ({ id: root.id, paths: root.paths, ...(root.canonical ? { canonical: root.canonical } : {}) })),
 });
 
 /** A story as the wire addresses it: the path, plus which root it is relative to (absent = the
@@ -155,9 +163,11 @@ export function absoluteUnder(cwd: string | null, relative: string): string {
  * FIRST because the default stories directory sits inside the workspace's own subtree — one file
  * reachable both ways must mint one spelling, not two.
  *
- * Identity is unharmed by any of this: `canonicalCardPath` resolves all three to the same absolute
- * path (utils/canvasCardPath.ts), so an agent's `stories/…` card and a pane-minted one collapse
- * onto one card.
+ * Identity holds UNDER A ROOT THE SERVER NAMED: case 2 mints that root's canonical spelling, which
+ * is what `canonicalCardPath` resolves an agent's `stories/…`-plus-root card to as well
+ * (utils/canvasCardPath.ts), so the two collapse onto one card. Outside every registered root there
+ * is no canonical to mint and the pane's own spelling is all there is — a symlinked second spelling
+ * of that file is a second card, as it was before #1976, and only the server can close that.
  *
  * Until #1976 the absolute case answered null, and a deck outside every root had no Canvas entry at
  * all: the plugin would have opened it, but the card's identity was the wire string, so the same
@@ -175,7 +185,7 @@ export function absoluteUnder(cwd: string | null, relative: string): string {
  * lets through still yields no card.
  */
 export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryRef | null {
-  const { workspaces } = roots;
+  const { workspaces, roots: named } = roots;
   const key = dirPathKey(absolutePath);
   if (!key.endsWith(".json")) return null;
   // ONE rule for what "under this directory" means, because two goes wrong twice: `dirPathKey`
@@ -217,19 +227,40 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
   //
   // An absolute path cannot lose a root because it does not have one, so it survives a dispatch
   // that forgets to carry it. That is the same reason the deck-outside-every-root case already used
-  // it (#1976); this only stops treating a registered root as the exception. Identity is unharmed —
-  // `canonicalCardPath` resolves both spellings to the same absolute path, so an agent's
-  // `stories/…` card and this one still collapse into one.
+  // it (#1976); this only stops treating a registered root as the exception. Identity survives the
+  // change because the spelling minted here is the root's CANONICAL one, which is what
+  // `canonicalCardPath` resolves an agent's `stories/…`-plus-root card to — see below for the
+  // symlink case that makes the choice of spelling load-bearing.
   //
   // As the pane spelled it rather than as `key`: `dirPathKey` TRIMS, so a name ending in a space
   // would name a different file, and the server is handed this same string as `expectPath` to
   // compare its realpath against. A `.` or `..` segment the plugin refuses is the one thing the key
   // would have folded, and neither the tree's rows nor a cell's cwd produces one.
-  // Not a path this server can place: the pane falls back to the row's RELATIVE spelling when it
-  // has no cwd (`absoluteUnder`), and a relative `filePath` is not "the file over there" — it is
-  // the default stories root's own `design.json`. Measured: every relative input answers null here,
-  // through the default-stories branch above as well, so there is no reachable case left in which a
-  // registered root could offer a spelling this does not.
+  // Spelled CANONICALLY where the server told us what canonical is. A workspace reached through a
+  // symlink has two spellings, the pane shows whichever the cell was launched with, and identity is
+  // resolved LEXICALLY — a browser cannot realpath. So without this, one file opened through
+  // `/tmp/ws-link/…` and through `/srv/real-ws/…` mints two paths, two identities, two cards for
+  // one deck. Measured: `/tmp/ws-link/decks/talk.json` and `/srv/real-ws/decks/talk.json` resolved
+  // to two different identities, and neither matched a card minted before this change.
+  //
+  // The MOST SPECIFIC root wins, as it did when this branch minted a root id. Usually every root
+  // containing the file rebuilds the same absolute path, so the choice does not matter — but a
+  // nested root that is ITSELF a symlink has a canonical outside its parent, and then it does. The
+  // shortest tail is the only pick that does not depend on the order the server listed them in
+  // (#1951).
+  const best = named.reduce<{ canonical: string; tail: string } | null>((shortest, root) => {
+    const tail = root.canonical === undefined ? null : underAny(root.paths, (dir) => dir);
+    if (tail === null || root.canonical === undefined) return shortest;
+    return shortest !== null && shortest.tail.length <= tail.length ? shortest : { canonical: root.canonical, tail };
+  }, null);
+  if (best !== null) return { filePath: joinPath(best.canonical, best.tail) };
+  // Under no root the server named, or a server that reported no canonical: the spelling the pane
+  // showed, which is all there is (#1976).
+  //
+  // Not a path this server can place at all: the pane falls back to the row's RELATIVE spelling
+  // when it has no cwd (`absoluteUnder`), and a relative `filePath` is not "the file over there" —
+  // it is the default stories root's own `design.json`. Measured: every relative input answers null
+  // here, through the default-stories branch above as well.
   return isRootedPath(absolutePath) ? { filePath: absolutePath } : null;
 }
 

--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -13,9 +13,12 @@
 //   markdown, html   a lexical guard their executors already run (`isDocumentPath` refuses a
 //                    prefixed traversal; `isPresentableHtmlPath` refuses a dotfile the iframe
 //                    mount would deny). The card carries a path and the View self-fetches.
-//   mulmoScript      no absolute path is accepted at all, and the card needs the parsed script
-//                    rather than a path — so the question is WHERE the file is, and the card
-//                    comes from the plugin's own reopen. See storyWirePath / reopenStory.
+//   mulmoScript      the card needs the parsed script rather than a path, so the card comes from
+//                    the plugin's own reopen. See storyWirePath / reopenStory. (Absolute paths
+//                    WERE refused outright, through plugin 4.5.2; 4.6.0 added the `byPath` form
+//                    and this host opts into it — server/backends/mulmoscript.ts. Reading the old
+//                    sentence as still true is what kept a repository deck on the rooted wire
+//                    path, which is #1970.)
 import { TOOL_NAME as DOCUMENT_TOOL, isDocumentPath } from "@mulmoclaude/markdown-plugin/vue";
 import { TOOL_NAME as HTML_TOOL, isPresentableHtmlPath, isHtmlArtifactPath, htmlArtifactPreviewUrl, htmlFileUrl } from "@mulmoclaude/html-plugin";
 import { TOOL_NAME as STORY_TOOL } from "@mulmoclaude/mulmoscript-plugin";
@@ -134,15 +137,27 @@ export function absoluteUnder(cwd: string | null, relative: string): string {
  * The wire path a mulmoScript card carries for `absolutePath`, or null when it is not a `.json`.
  *
  * Where markdown and html are asked "can you render this file", this asks WHERE the file is, and
- * answers with the spelling the plugin wants for that place: a deck under a registered root
- * travels as `stories/<tail>` plus the root's id, and a deck anywhere else travels as its own
- * absolute path (the form the plugin has taken since 4.6.0, which this host opts into with
- * `byPath` — see server/backends/mulmoscript.ts).
+ * answers with the spelling the plugin wants for that place. Two cases, in this order:
  *
- * The root-relative forms are decided FIRST, and that order is the whole rule: one deck reachable
- * both ways must mint one spelling, not two. It stopped being load-bearing in #1976 — identity is
- * now the resolved path either way (utils/canvasCardPath.ts), so the two forms collapse onto one
- * card — but minting the narrower form keeps a card readable and keeps the root a card names true.
+ *   1. under the workspace's own `artifacts/stories/` — `stories/<tail>`, no root. That IS the
+ *      plugin's default root, so a dispatch carrying no root still resolves it.
+ *   2. anywhere else — the file's own absolute path (the `byPath` form the plugin has taken since
+ *      4.6.0, which this host opts into; see server/backends/mulmoscript.ts).
+ *
+ * A REGISTERED ROOT used to be its own case between those two, answering `stories/<tail>` plus the
+ * root's id, and that was #1970. The reopen carries a root, so the deck OPENED — but the View's own
+ * dispatches (`updateScript`, `updateBeat`, `beatImage`, the movie/PDF polls) pass `filePath`
+ * through and send no root, so every one of them resolved the tail against the DEFAULT root and
+ * answered `File not found`. A deck kept in a repository showed a red error on each beat and failed
+ * to save in silence. An absolute path cannot lose a root, because it has none.
+ *
+ * Case 1 stays relative because it is already right under a root-less dispatch, and it is decided
+ * FIRST because the default stories directory sits inside the workspace's own subtree — one file
+ * reachable both ways must mint one spelling, not two.
+ *
+ * Identity is unharmed by any of this: `canonicalCardPath` resolves all three to the same absolute
+ * path (utils/canvasCardPath.ts), so an agent's `stories/…` card and a pane-minted one collapse
+ * onto one card.
  *
  * Until #1976 the absolute case answered null, and a deck outside every root had no Canvas entry at
  * all: the plugin would have opened it, but the card's identity was the wire string, so the same
@@ -160,7 +175,7 @@ export function absoluteUnder(cwd: string | null, relative: string): string {
  * lets through still yields no card.
  */
 export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryRef | null {
-  const { workspaces, roots: named } = roots;
+  const { workspaces } = roots;
   const key = dirPathKey(absolutePath);
   if (!key.endsWith(".json")) return null;
   // ONE rule for what "under this directory" means, because two goes wrong twice: `dirPathKey`
@@ -190,25 +205,32 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
   // for one deck. Deciding the narrower one first means only one spelling is ever minted.
   const inDefault = underAny(workspaces, (workspace) => joinPath(workspace, STORY_DIR));
   if (inDefault) return { filePath: `${STORY_WIRE_PREFIX}${inDefault}` };
-  // Otherwise the most SPECIFIC registered root that contains it. Roots nest — a saved project
-  // under the workspace is both — and the longest prefix is the only choice that does not depend
-  // on the order the server happened to list them in, which would make one file's card identity
-  // vary between two servers serving the same disk (#1951).
-  let best: { root: string; tail: string } | null = null;
-  for (const root of named) {
-    const tail = underAny(root.paths, (dir) => dir);
-    if (tail !== null && (best === null || tail.length < best.tail.length)) best = { root: root.id, tail };
-  }
-  if (best !== null) return { filePath: `${STORY_WIRE_PREFIX}${best.tail}`, root: best.root };
-  // Outside every registered root: the file's own absolute path — but ONLY if it is one. The pane
-  // falls back to the row's RELATIVE path when it has no cwd (`absoluteUnder`), and a relative
-  // `filePath` is not "the file over there", it is the default stories root's own `design.json`.
-  if (!isRootedPath(absolutePath)) return null;
+  // ANYWHERE ELSE: the file's own absolute path, whether or not a registered root contains it.
+  //
+  // A registered root used to answer `stories/<tail>` plus the root's id here, and that is what
+  // #1970 was: opening worked, because the reopen carries the root — but the View's own dispatches
+  // (`updateScript`, `updateBeat`, `beatImage`, the movie/PDF status polls) pass `filePath` through
+  // and send NO root, so every one of them resolved the tail against the DEFAULT stories root and
+  // answered `File not found`. A deck in a repository opened, showed a red error on every beat, and
+  // silently failed to save. Measured against a running server: the wire form 404s on
+  // `updateScript` where the absolute form writes the file.
+  //
+  // An absolute path cannot lose a root because it does not have one, so it survives a dispatch
+  // that forgets to carry it. That is the same reason the deck-outside-every-root case already used
+  // it (#1976); this only stops treating a registered root as the exception. Identity is unharmed —
+  // `canonicalCardPath` resolves both spellings to the same absolute path, so an agent's
+  // `stories/…` card and this one still collapse into one.
+  //
   // As the pane spelled it rather than as `key`: `dirPathKey` TRIMS, so a name ending in a space
   // would name a different file, and the server is handed this same string as `expectPath` to
   // compare its realpath against. A `.` or `..` segment the plugin refuses is the one thing the key
   // would have folded, and neither the tree's rows nor a cell's cwd produces one.
-  return { filePath: absolutePath };
+  // Not a path this server can place: the pane falls back to the row's RELATIVE spelling when it
+  // has no cwd (`absoluteUnder`), and a relative `filePath` is not "the file over there" — it is
+  // the default stories root's own `design.json`. Measured: every relative input answers null here,
+  // through the default-stories branch above as well, so there is no reachable case left in which a
+  // registered root could offer a spelling this does not.
+  return isRootedPath(absolutePath) ? { filePath: absolutePath } : null;
 }
 
 /**

--- a/src/composables/canvasOpenFile.ts
+++ b/src/composables/canvasOpenFile.ts
@@ -215,39 +215,19 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
   // for one deck. Deciding the narrower one first means only one spelling is ever minted.
   const inDefault = underAny(workspaces, (workspace) => joinPath(workspace, STORY_DIR));
   if (inDefault) return { filePath: `${STORY_WIRE_PREFIX}${inDefault}` };
-  // ANYWHERE ELSE: the file's own absolute path, whether or not a registered root contains it.
+  // ANYWHERE ELSE: an absolute path, which cannot lose a root because it has none — the whole of
+  // #1970, argued in the header above.
   //
-  // A registered root used to answer `stories/<tail>` plus the root's id here, and that is what
-  // #1970 was: opening worked, because the reopen carries the root — but the View's own dispatches
-  // (`updateScript`, `updateBeat`, `beatImage`, the movie/PDF status polls) pass `filePath` through
-  // and send NO root, so every one of them resolved the tail against the DEFAULT stories root and
-  // answered `File not found`. A deck in a repository opened, showed a red error on every beat, and
-  // silently failed to save. Measured against a running server: the wire form 404s on
-  // `updateScript` where the absolute form writes the file.
-  //
-  // An absolute path cannot lose a root because it does not have one, so it survives a dispatch
-  // that forgets to carry it. That is the same reason the deck-outside-every-root case already used
-  // it (#1976); this only stops treating a registered root as the exception. Identity survives the
-  // change because the spelling minted here is the root's CANONICAL one, which is what
-  // `canonicalCardPath` resolves an agent's `stories/…`-plus-root card to — see below for the
-  // symlink case that makes the choice of spelling load-bearing.
-  //
-  // As the pane spelled it rather than as `key`: `dirPathKey` TRIMS, so a name ending in a space
-  // would name a different file, and the server is handed this same string as `expectPath` to
-  // compare its realpath against. A `.` or `..` segment the plugin refuses is the one thing the key
-  // would have folded, and neither the tree's rows nor a cell's cwd produces one.
-  // Spelled CANONICALLY where the server told us what canonical is. A workspace reached through a
-  // symlink has two spellings, the pane shows whichever the cell was launched with, and identity is
-  // resolved LEXICALLY — a browser cannot realpath. So without this, one file opened through
-  // `/tmp/ws-link/…` and through `/srv/real-ws/…` mints two paths, two identities, two cards for
-  // one deck. Measured: `/tmp/ws-link/decks/talk.json` and `/srv/real-ws/decks/talk.json` resolved
-  // to two different identities, and neither matched a card minted before this change.
+  // Built on the root's CANONICAL prefix rather than the pane's spelling. A workspace reached
+  // through a symlink has two spellings, the pane shows whichever the cell was launched with, and
+  // card identity is resolved LEXICALLY, because a browser cannot realpath. So the pane's spelling
+  // would mint two paths for one deck — and neither would match a card minted before this change,
+  // which resolves through the same canonical (Codex P2; measured both ways).
   //
   // The MOST SPECIFIC root wins, as it did when this branch minted a root id. Usually every root
-  // containing the file rebuilds the same absolute path, so the choice does not matter — but a
-  // nested root that is ITSELF a symlink has a canonical outside its parent, and then it does. The
-  // shortest tail is the only pick that does not depend on the order the server listed them in
-  // (#1951).
+  // containing the file rebuilds the same absolute path — but a nested root that is ITSELF a
+  // symlink has a canonical outside its parent, and then the pick shows. The shortest tail is the
+  // only one that does not depend on the order the server listed the roots in (#1951).
   const best = named.reduce<{ canonical: string; tail: string } | null>((shortest, root) => {
     const tail = root.canonical === undefined ? null : underAny(root.paths, (dir) => dir);
     if (tail === null || root.canonical === undefined) return shortest;
@@ -255,7 +235,9 @@ export function storyWirePath(absolutePath: string, roots: StoriesRoots): StoryR
   }, null);
   if (best !== null) return { filePath: joinPath(best.canonical, best.tail) };
   // Under no root the server named, or a server that reported no canonical: the spelling the pane
-  // showed, which is all there is (#1976).
+  // showed, which is all there is (#1976). Verbatim rather than keyed — `dirPathKey` TRIMS, so a
+  // name ending in a space would name a different file, and this same string is handed to the
+  // server as `expectPath` to realpath against.
   //
   // Not a path this server can place at all: the pane falls back to the row's RELATIVE spelling
   // when it has no cwd (`absoluteUnder`), and a relative `filePath` is not "the file over there" —

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -122,7 +122,9 @@ describe("the button's gate and the card's gate agree on the same path", () => {
 // `(root, stories/<rel>)` — which is what makes "put the deck in the repository" work at all.
 describe("storyWirePath — the workspace subtree", () => {
   const WS = "/work/ws";
-  const ROOTS = { workspaces: [WS], roots: [{ id: "abc123", paths: [WS] }] };
+  // `canonical` is present because a real root always has one — `registeredStoriesRoots()` types it
+  // as required. A fixture without it measures the fallback, not the branch the server takes.
+  const ROOTS = { workspaces: [WS], roots: [{ id: "abc123", paths: [WS], canonical: WS }] };
 
   // By its own absolute path, NOT `stories/<tail>` + the root's id. #1970: the rooted spelling
   // opened the deck and then broke everything after — the View's dispatches carry no root, so each
@@ -188,6 +190,17 @@ describe("storyWirePath — the workspace subtree", () => {
     expect(storyWirePath("//server/share/myrepo/talk.json", { workspaces: ["//server/share"], roots: [{ id: "abc123", paths: ["//server/share"] }] })).toEqual({
       filePath: "//server/share/myrepo/talk.json",
     });
+    // The same two through the CANONICAL branch, which is what a real server takes. A drive or share
+    // root already ends in a separator, so nothing doubles it.
+    expect(storyWirePath("C:\\myrepo\\decks\\talk.json", { workspaces: ["C:\\"], roots: [{ id: "abc123", paths: ["C:\\"], canonical: "C:\\" }] })).toEqual({
+      filePath: "C:\\myrepo/decks/talk.json",
+    });
+    expect(
+      storyWirePath("//server/share/myrepo/talk.json", {
+        workspaces: ["//server/share"],
+        roots: [{ id: "abc123", paths: ["//server/share"], canonical: "//server/share" }],
+      }),
+    ).toEqual({ filePath: "//server/share/myrepo/talk.json" });
     // Both roots' own stories directories still key rather than pass through.
     expect(storyWirePath("C:\\artifacts\\stories\\x.json", { workspaces: ["C:\\"], roots: [] })).toEqual({ filePath: "stories/x.json" });
   });
@@ -314,7 +327,9 @@ describe("storyWirePath", () => {
 // and the entry can be offered.
 describe("storyWirePath — a deck outside every root", () => {
   const WS = "/work/ws";
-  const ROOTS = { workspaces: [WS], roots: [{ id: "abc123", paths: [WS] }] };
+  // `canonical` is present because a real root always has one — `registeredStoriesRoots()` types it
+  // as required. A fixture without it measures the fallback, not the branch the server takes.
+  const ROOTS = { workspaces: [WS], roots: [{ id: "abc123", paths: [WS], canonical: WS }] };
 
   // The issue's own example: a deck in a directory the user never launched in.
   it("names it by its absolute path, with no root", () => {

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -151,6 +151,10 @@ describe("storyWirePath — the workspace subtree", () => {
   // read back as a UNC share root — so nothing under such a workspace was a story at all
   // (Codex P1 on #1934). The default-root half of that predates the named root.
   it("recognises a workspace that is a filesystem root", () => {
+    expect(storyWirePath("/myrepo/decks/talk.json", { workspaces: ["/"], roots: [{ id: "abc123", paths: ["/"], canonical: "/" }] })).toEqual({
+      filePath: "/myrepo/decks/talk.json",
+    });
+    // Without a canonical, through the pane-spelling fallback: the same answer by a different route.
     expect(storyWirePath("/myrepo/decks/talk.json", { workspaces: ["/"], roots: [{ id: "abc123", paths: ["/"] }] })).toEqual({
       filePath: "/myrepo/decks/talk.json",
     });
@@ -164,6 +168,11 @@ describe("storyWirePath — the workspace subtree", () => {
   // because one rule now answers for both.
   it("recognises a workspace whose last component ends in a space", () => {
     const WS_SPACE = "/work/ws ";
+    expect(storyWirePath("/work/ws /myrepo/deck.json", { workspaces: [WS_SPACE], roots: [{ id: "abc123", paths: [WS_SPACE], canonical: WS_SPACE }] })).toEqual({
+      filePath: "/work/ws /myrepo/deck.json",
+    });
+    // The space survives the CANONICAL branch too, which is the one a real server takes: the tail
+    // is keyed (and so trimmed) but it is joined back onto the root's own untrimmed spelling.
     expect(storyWirePath("/work/ws /myrepo/deck.json", { workspaces: [WS_SPACE], roots: [{ id: "abc123", paths: [WS_SPACE] }] })).toEqual({
       filePath: "/work/ws /myrepo/deck.json",
     });
@@ -181,6 +190,20 @@ describe("storyWirePath — the workspace subtree", () => {
     });
     // Both roots' own stories directories still key rather than pass through.
     expect(storyWirePath("C:\\artifacts\\stories\\x.json", { workspaces: ["C:\\"], roots: [] })).toEqual({ filePath: "stories/x.json" });
+  });
+
+  // On Windows the canonical branch MIXES separators — the root keeps its backslashes and the tail
+  // is rejoined with `/`, because the tail comes from the key and the key joins with `/`. It is
+  // pinned rather than tidied: `dirPathKey` folds both separators, so the mixed spelling keys the
+  // same as the pane's own and the card still collapses; `path.resolve` on the server folds them
+  // too, and `expectPath` travels as the pane spelled it either way. Normalising it here would be a
+  // second spelling rule for one file, which is the thing this whole branch exists to avoid.
+  it("mixes separators under a Windows root, and the card is still one card", () => {
+    const WIN = { workspaces: ["C:\\work\\ws"], roots: [{ id: "abc123", paths: ["C:\\work\\ws"], canonical: "C:\\work\\ws" }] };
+    const dirs = { workspace: "C:\\work\\ws", byId: { abc123: "C:\\work\\ws" } };
+    const wire = storyWirePath("C:\\work\\ws\\myrepo\\deck.json", WIN);
+    expect(wire).toEqual({ filePath: "C:\\work\\ws/myrepo/deck.json" });
+    expect(filePathIdentity({ data: { ...wire } }, dirs)).toBe(filePathIdentity({ data: { filePath: "stories/myrepo/deck.json", root: "abc123" } }, dirs));
   });
 
   // Launched through a symlink, the Files pane can hand either spelling: a cell from the launcher

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -6,6 +6,7 @@
 // wave through.
 import { describe, it, expect, vi, afterEach } from "vitest";
 
+import { filePathIdentity } from "../../../src/utils/canvasIdentity";
 import {
   canvasCardForFile,
   canOpenInCanvas,
@@ -185,9 +186,16 @@ describe("storyWirePath — the workspace subtree", () => {
   // Launched through a symlink, the Files pane can hand either spelling: a cell from the launcher
   // carries the one the user typed, one in a git worktree carries the resolved one. Knowing only
   // the canonical spelling hid the Canvas entry for every deck under the link (Codex P1 iter-5).
-  it("recognises a file under either spelling of the workspace", () => {
-    const BOTH = { workspaces: ["/tmp/ws-link", "/srv/real-ws"], roots: [{ id: "abc123", paths: ["/tmp/ws-link", "/srv/real-ws"] }] };
-    expect(storyWirePath("/tmp/ws-link/decks/talk.json", BOTH)).toEqual({ filePath: "/tmp/ws-link/decks/talk.json" });
+  // BOTH spellings mint the CANONICAL one. Identity is resolved lexically — a browser cannot
+  // realpath — so minting what the pane happened to show would give one deck two identities and
+  // two cards, which is what the rooted spelling this replaced was protecting against (Codex P2,
+  // round 1: measured, `/tmp/ws-link/…` and `/srv/real-ws/…` resolved differently).
+  it("mints the canonical spelling for a file under either spelling of the workspace", () => {
+    const BOTH = {
+      workspaces: ["/tmp/ws-link", "/srv/real-ws"],
+      roots: [{ id: "abc123", paths: ["/tmp/ws-link", "/srv/real-ws"], canonical: "/srv/real-ws" }],
+    };
+    expect(storyWirePath("/tmp/ws-link/decks/talk.json", BOTH)).toEqual({ filePath: "/srv/real-ws/decks/talk.json" });
     expect(storyWirePath("/srv/real-ws/decks/talk.json", BOTH)).toEqual({ filePath: "/srv/real-ws/decks/talk.json" });
     // The default root too — it is the half that worked before the named root existed.
     expect(storyWirePath("/tmp/ws-link/artifacts/stories/x.json", BOTH)).toEqual({ filePath: "stories/x.json" });
@@ -621,5 +629,62 @@ describe("storyWirePath across several roots", () => {
   // resolving to the same identity the root-relative card gets once the config lands.
   it("uses the absolute form before the config arrives", () => {
     expect(storyWirePath("/work/ws/decks/talk.json", { workspaces: [], roots: [] })).toEqual({ filePath: "/work/ws/decks/talk.json" });
+  });
+});
+
+// The property the rooted spelling used to hold, now held by minting canonically. Asserted across
+// the TWO modules that have to agree — `storyWirePath` mints, `filePathIdentity` resolves — because
+// the regression Codex found in round 1 lived exactly in the gap between them: each was
+// self-consistent and together they gave one deck two cards.
+describe("a deck reached two ways is one card", () => {
+  const dirs = { workspace: "/srv/real-ws", byId: { abc123: "/srv/real-ws" } };
+  const ROOTS = {
+    workspaces: ["/tmp/ws-link", "/srv/real-ws"],
+    roots: [{ id: "abc123", paths: ["/tmp/ws-link", "/srv/real-ws"], canonical: "/srv/real-ws" }],
+  };
+  const identityOf = (filePath: string, root?: string) => filePathIdentity({ data: { filePath, ...(root ? { root } : {}) } }, dirs);
+  const mintedIdentity = (panePath: string) => {
+    const wire = storyWirePath(panePath, ROOTS);
+    if (wire === null) throw new Error(`storyWirePath minted nothing for ${panePath}`);
+    return identityOf(wire.filePath);
+  };
+
+  // A card persisted BEFORE this change carries `stories/<tail>` + root. Reopening the same deck
+  // now mints an absolute path, and the two have to collapse or the old card never goes away.
+  it("collapses a pre-change rooted card with a newly minted one", () => {
+    expect(mintedIdentity("/srv/real-ws/decks/talk.json")).toBe(identityOf("stories/decks/talk.json", "abc123"));
+  });
+
+  it("collapses the symlink spelling with the real one", () => {
+    expect(mintedIdentity("/tmp/ws-link/decks/talk.json")).toBe(mintedIdentity("/srv/real-ws/decks/talk.json"));
+  });
+
+  // And with the agent's own card, which is minted root-blind under the default stories directory.
+  it("collapses with an agent-minted default-root card", () => {
+    expect(mintedIdentity("/srv/real-ws/artifacts/stories/tale.json")).toBe(identityOf("stories/tale.json"));
+  });
+});
+
+// The most-specific root wins, and it is only OBSERVABLE when a nested root is itself a symlink:
+// otherwise every root containing the file rebuilds the same absolute path. Here the inner root's
+// real location is outside its parent, so picking the outer one would mint a path that names the
+// deck through the link — a second identity for the file the server writes at `/opt/real-vendor`.
+describe("a root nested inside another", () => {
+  const NESTED = {
+    workspaces: ["/srv/ws"],
+    roots: [
+      { id: "outer", paths: ["/srv/ws"], canonical: "/srv/ws" },
+      { id: "inner", paths: ["/srv/ws/vendor/link"], canonical: "/opt/real-vendor" },
+    ],
+  };
+  const deck = "/srv/ws/vendor/link/decks/talk.json";
+
+  it("mints through the innermost root, not the enclosing one", () => {
+    expect(storyWirePath(deck, NESTED)).toEqual({ filePath: "/opt/real-vendor/decks/talk.json" });
+  });
+
+  // The server lists roots in registration order, which is not a promise about nesting.
+  it("does not depend on the order the roots were listed in", () => {
+    expect(storyWirePath(deck, { ...NESTED, roots: [...NESTED.roots].reverse() })).toEqual(storyWirePath(deck, NESTED));
   });
 });

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -114,12 +114,14 @@ describe("the button's gate and the card's gate agree on the same path", () => {
   });
 });
 
-// mulmoScript, the one tool here that cannot be handed an absolute path — `normalizeStoryPath`
-// refuses those outright. So the question is not "does the extension match" but "is this file in
-// the WORKSPACE's story directory", and the answer is the wire path the plugin wants.
-// A deck kept beside the notes it was written from (#1933). The workspace subtree is registered
-// with the plugin under an id the server mints, and a story anywhere under it is addressable as
-// `(root, stories/<rel>)` — which is what makes "put the deck in the repository" work at all.
+// mulmoScript asks WHERE the file is rather than "does the extension match", and answers with the
+// spelling the plugin wants for that place: the workspace's own `artifacts/stories` stays
+// `stories/<tail>` with no root, and a deck anywhere else — a repository under the workspace
+// included (#1933) — is addressed by its own absolute path, spelled with the root's server-sent
+// `canonical` where there is one.
+//
+// It read `(root, stories/<rel>)` until #1970, and before plugin 4.6.0 an absolute path was refused
+// outright. Both are history: the rooted spelling opened the deck and broke every dispatch after it.
 describe("storyWirePath — the workspace subtree", () => {
   const WS = "/work/ws";
   // `canonical` is present because a real root always has one — `registeredStoriesRoots()` types it

--- a/test/src/composables/canvasOpenFile.spec.ts
+++ b/test/src/composables/canvasOpenFile.spec.ts
@@ -123,8 +123,11 @@ describe("storyWirePath — the workspace subtree", () => {
   const WS = "/work/ws";
   const ROOTS = { workspaces: [WS], roots: [{ id: "abc123", paths: [WS] }] };
 
-  it("names a deck kept anywhere under the workspace", () => {
-    expect(storyWirePath(`${WS}/myrepo/decks/talk.json`, ROOTS)).toEqual({ filePath: "stories/myrepo/decks/talk.json", root: "abc123" });
+  // By its own absolute path, NOT `stories/<tail>` + the root's id. #1970: the rooted spelling
+  // opened the deck and then broke everything after — the View's dispatches carry no root, so each
+  // one resolved the tail against the default stories root and answered `File not found`.
+  it("names a deck kept anywhere under the workspace by its absolute path", () => {
+    expect(storyWirePath(`${WS}/myrepo/decks/talk.json`, ROOTS)).toEqual({ filePath: `${WS}/myrepo/decks/talk.json` });
   });
 
   // The workspace's own stories directory sits INSIDE the subtree, so both could name one file —
@@ -148,9 +151,9 @@ describe("storyWirePath — the workspace subtree", () => {
   // (Codex P1 on #1934). The default-root half of that predates the named root.
   it("recognises a workspace that is a filesystem root", () => {
     expect(storyWirePath("/myrepo/decks/talk.json", { workspaces: ["/"], roots: [{ id: "abc123", paths: ["/"] }] })).toEqual({
-      filePath: "stories/myrepo/decks/talk.json",
-      root: "abc123",
+      filePath: "/myrepo/decks/talk.json",
     });
+    // The half the Codex P1 was about, and the one still keyed rather than passed through.
     expect(storyWirePath("/artifacts/stories/x.json", { workspaces: ["/"], roots: [{ id: "abc123", paths: ["/"] }] })).toEqual({ filePath: "stories/x.json" });
   });
 
@@ -161,8 +164,7 @@ describe("storyWirePath — the workspace subtree", () => {
   it("recognises a workspace whose last component ends in a space", () => {
     const WS_SPACE = "/work/ws ";
     expect(storyWirePath("/work/ws /myrepo/deck.json", { workspaces: [WS_SPACE], roots: [{ id: "abc123", paths: [WS_SPACE] }] })).toEqual({
-      filePath: "stories/myrepo/deck.json",
-      root: "abc123",
+      filePath: "/work/ws /myrepo/deck.json",
     });
     expect(storyWirePath("/work/ws /artifacts/stories/x.json", { workspaces: [WS_SPACE], roots: [{ id: "abc123", paths: [WS_SPACE] }] })).toEqual({
       filePath: "stories/x.json",
@@ -171,13 +173,13 @@ describe("storyWirePath — the workspace subtree", () => {
 
   it("recognises a Windows drive root and a UNC share root", () => {
     expect(storyWirePath("C:\\myrepo\\decks\\talk.json", { workspaces: ["C:\\"], roots: [{ id: "abc123", paths: ["C:\\"] }] })).toEqual({
-      filePath: "stories/myrepo/decks/talk.json",
-      root: "abc123",
+      filePath: "C:\\myrepo\\decks\\talk.json",
     });
     expect(storyWirePath("//server/share/myrepo/talk.json", { workspaces: ["//server/share"], roots: [{ id: "abc123", paths: ["//server/share"] }] })).toEqual({
-      filePath: "stories/myrepo/talk.json",
-      root: "abc123",
+      filePath: "//server/share/myrepo/talk.json",
     });
+    // Both roots' own stories directories still key rather than pass through.
+    expect(storyWirePath("C:\\artifacts\\stories\\x.json", { workspaces: ["C:\\"], roots: [] })).toEqual({ filePath: "stories/x.json" });
   });
 
   // Launched through a symlink, the Files pane can hand either spelling: a cell from the launcher
@@ -185,8 +187,8 @@ describe("storyWirePath — the workspace subtree", () => {
   // the canonical spelling hid the Canvas entry for every deck under the link (Codex P1 iter-5).
   it("recognises a file under either spelling of the workspace", () => {
     const BOTH = { workspaces: ["/tmp/ws-link", "/srv/real-ws"], roots: [{ id: "abc123", paths: ["/tmp/ws-link", "/srv/real-ws"] }] };
-    expect(storyWirePath("/tmp/ws-link/decks/talk.json", BOTH)).toEqual({ filePath: "stories/decks/talk.json", root: "abc123" });
-    expect(storyWirePath("/srv/real-ws/decks/talk.json", BOTH)).toEqual({ filePath: "stories/decks/talk.json", root: "abc123" });
+    expect(storyWirePath("/tmp/ws-link/decks/talk.json", BOTH)).toEqual({ filePath: "/tmp/ws-link/decks/talk.json" });
+    expect(storyWirePath("/srv/real-ws/decks/talk.json", BOTH)).toEqual({ filePath: "/srv/real-ws/decks/talk.json" });
     // The default root too — it is the half that worked before the named root existed.
     expect(storyWirePath("/tmp/ws-link/artifacts/stories/x.json", BOTH)).toEqual({ filePath: "stories/x.json" });
     expect(storyWirePath("/srv/real-ws/artifacts/stories/x.json", BOTH)).toEqual({ filePath: "stories/x.json" });
@@ -313,10 +315,10 @@ describe("storyWirePath — a deck outside every root", () => {
     expect(storyWirePath("C:\\decks\\keynote.json", ROOTS)).toEqual({ filePath: "C:\\decks\\keynote.json" });
   });
 
-  // The root-relative form still wins where there is one: it is the shorter, readable spelling, and
-  // it keeps the root a card names true.
-  it("prefers the root-relative spelling where the file has one", () => {
-    expect(storyWirePath(`${WS}/decks/keynote.json`, ROOTS)).toEqual({ filePath: "stories/decks/keynote.json", root: "abc123" });
+  // Only the DEFAULT stories directory keeps a relative spelling. A registered root does not: that
+  // spelling needs a root to read it against, and the View's dispatches send none (#1970).
+  it("keeps the relative spelling for the default stories directory alone", () => {
+    expect(storyWirePath(`${WS}/decks/keynote.json`, ROOTS)).toEqual({ filePath: `${WS}/decks/keynote.json` });
     expect(storyWirePath(`${WS}/artifacts/stories/keynote.json`, ROOTS)).toEqual({ filePath: "stories/keynote.json" });
   });
 });
@@ -389,20 +391,38 @@ describe("buildCanvasCard", () => {
     });
   });
 
-  // The root travels on the card, because that is what keeps two roots' identically-named decks on
-  // two cards (canvasIdentity.filePathIdentity) rather than folding them into one.
-  it("carries the root onto the card, and asks for it by name", async () => {
-    const fetchMock = mockReopen({ ok: true, script: { title: "Deck" }, filePath: "stories/myrepo/decks/talk.json", root: "abc123" });
+  // #1970. A deck under a registered root is asked for by its own ABSOLUTE path, not by
+  // `stories/<tail>` + the root's id. The rooted spelling opened it and broke everything after: the
+  // View's dispatches pass `filePath` through and send no root, so each resolved the tail against
+  // the default stories root and answered `File not found` — a red error on every beat, and a save
+  // that failed in silence. Measured against a running server: the wire form 404s on
+  // `updateScript` where the absolute form writes the file.
+  //
+  // The root a response still echoes is carried onto the card unchanged (the test below); it is no
+  // longer what identity rests on, because `canonicalCardPath` resolves either spelling to the same
+  // absolute path.
+  it("asks for a deck under a registered root by its absolute path, with no root", async () => {
+    const fetchMock = mockReopen({ ok: true, script: { title: "Deck" }, filePath: `${WS}/myrepo/decks/talk.json` });
     expect(await buildCanvasCard(`${WS}/myrepo/decks/talk.json`, { workspaces: [WS], roots: [{ id: "abc123", paths: [WS] }] })).toEqual({
       kind: "card",
-      card: { toolName: "presentMulmoScript", data: { script: { title: "Deck" }, filePath: "stories/myrepo/decks/talk.json", root: "abc123" } },
+      card: { toolName: "presentMulmoScript", data: { script: { title: "Deck" }, filePath: `${WS}/myrepo/decks/talk.json` } },
     });
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toEqual({
       kind: "save",
-      filePath: "stories/myrepo/decks/talk.json",
-      root: "abc123",
+      filePath: `${WS}/myrepo/decks/talk.json`,
       expectPath: `${WS}/myrepo/decks/talk.json`,
+    });
+  });
+
+  // A root the SERVER echoes still reaches the card. Nothing this file mints asks for one any
+  // more, but the field is the server's to send and dropping it here would lose a card's root for
+  // whatever does.
+  it("still carries a root the server echoes onto the card", async () => {
+    mockReopen({ ok: true, script: { title: "Tale" }, filePath: "stories/tale.json", root: "abc123" });
+    expect(await buildCanvasCard(`${WS}/artifacts/stories/tale.json`, { workspaces: [WS], roots: [] })).toEqual({
+      kind: "card",
+      card: { toolName: "presentMulmoScript", data: { script: { title: "Tale" }, filePath: "stories/tale.json", root: "abc123" } },
     });
   });
 
@@ -565,18 +585,20 @@ describe("storyWirePath across several roots", () => {
 
   it("addresses a deck in a root that is not the workspace", () => {
     expect(storyWirePath("/elsewhere/repo/decks/talk.json", { workspaces: ["/work/ws"], roots: [WS_ROOT, OTHER] })).toEqual({
-      filePath: "stories/decks/talk.json",
-      root: "other-id",
+      filePath: "/elsewhere/repo/decks/talk.json",
     });
   });
 
   // Roots nest: a saved project inside the workspace is under both. The LONGEST match wins, so one
   // file has one identity — and it does not change when the server lists the roots in another
   // order, which would otherwise give the same deck two Canvas cards on two machines.
-  it("takes the most specific root when they nest, whichever order they arrive in", () => {
+  // The determinism this protected is now free: the answer is the file's own path, so no ordering
+  // of the roots can change it. The "most specific root" rule it named is gone with the rooted
+  // spelling (#1970) — this keeps asserting the property, by the mechanism that replaced it.
+  it("answers the same however the roots are ordered", () => {
     const nestedFirst = { workspaces: ["/work/ws"], roots: [NESTED, WS_ROOT] };
     const nestedLast = { workspaces: ["/work/ws"], roots: [WS_ROOT, NESTED] };
-    const expected = { filePath: "stories/decks/talk.json", root: "nested-id" };
+    const expected = { filePath: "/work/ws/inner/decks/talk.json" };
     expect(storyWirePath("/work/ws/inner/decks/talk.json", nestedFirst)).toEqual(expected);
     expect(storyWirePath("/work/ws/inner/decks/talk.json", nestedLast)).toEqual(expected);
   });


### PR DESCRIPTION
## Summary

リポジトリの中に置いたデッキを Canvas で開くと、**開けるのにビート画像も保存も `File not found` になる**
(#1970) を直します。

### 原因

`storyWirePath()` が **登録済み root 配下のデッキだけ** `stories/<tail>` + `root` という綴りを返して
いました。カードは `root` を持ち reopen もそれを受け取るので**開くのは通ります**。

ところがプラグインの View が出す後続の dispatch は `filePath` をそのまま流し、**`root` を送りません**
（`@mulmoclaude/mulmoscript-plugin` **4.6.0**（現 main 同梱）の `dist/vue.js` を読んで確認）:

```
updateScript → { filePath, script, origin }
updateBeat   → { filePath, beatIndex, beat }
beatMovie    → { filePath, beatIndex }
movieStatus / pdfStatus / pendingGenerations / save → { filePath }
```

`root` の無い相対パスをサーバは既定 root（`artifacts/stories/`）として解決するので、実際の置き場所と
食い違います。Media タブの赤字も Edit タブの保存失敗も、原因はこれ 1 つです。

### 直し方

登録済み root の分岐を削除し、既定 stories 配下以外は**そのファイル自身の絶対パス**を返します。
**絶対パスは root を持たないので、root を落とす dispatch でも壊れません。**

新機能ではありません。プラグイン 4.6.0 の `byPath` 形式で、このホストは既に opt-in 済み
（`server/backends/mulmoscript.ts`）、かつ **どの root にも属さないデッキは #1976 で既にこの形**でした。
今回は **登録済み root だけを例外扱いするのをやめた**だけです。

あわせて、冒頭のコメント **「mulmoScript は絶対パスを一切受け付けない」** を直しました。4.5.2 までは真、
4.6.0 で偽になっており、**この前提が残っていたことが上の綴りが残った理由**です。

## 検証 — 実サーバで修正前後を測っています

scratch のワークスペースに `acme-docs/decks/launch.json` を置き、View と同じ形の呼び出しを直接投げました。

**修正前:**

```
相対 + root なし → {"ok":false,"code":"not_found","error":"File not found: stories/acme-docs/decks/launch.json"}
絶対 + root なし → {"ok":true}   ファイルの title が実際に書き変わる
```

**修正後**（ペインが送る綴りを実装から取り出し、その綴りで通す）:

```
ペインが送る形 → {"filePath":"/…/mw/acme-docs/decks/launch.json"}
1) 開く      → ok=True  root=None
2) updateScript（root なし）→ {"ok":true}
3) beatImage → {"ok":true,"image":null}
ファイル      → title = SAVED VIA PANE PATH
```

### symlink 経由の workspace も実サーバで測りました（round 4 checkpoint）

`canonical` で mint する変更は、当初ユニットテストと推論だけで検証していたので、**実機で測り直しました**。
scratch に `real-ws` を作り `ws-link` を張り、**リンクの綴りで** サーバを起動:

```
/api/config の storiesRoots:
  canonical: .../symws/real-ws
  paths:     [.../symws/ws-link, .../symws/real-ws]      ← fixture が模していた形そのもの

ブラウザ側の storyWirePath に実 config を食わせる:
  ペインがリンクの綴り → /…/real-ws/repo/decks/talk.json
  ペインが実体の綴り   → /…/real-ws/repo/decks/talk.json   ← 同じ 1 つ

サーバに投げる:
  1) 開く  filePath=canonical, expectPath=リンクの綴り        → 200 {"ok":true}
  2) updateScript（root 無し）canonical 綴りで書き込む         → 200 {"ok":true}
  3) ディスク上の title                                        → SAVED VIA CANONICAL
  4) 逆向き filePath=リンク, expectPath=canonical              → 200 {"ok":true}
  5) 別ファイルを expectPath に（拒否されるべき）              → 400 "that deck is not the file…"
```

**2 と 3 が #1970 そのもの**（root を運ばない dispatch が実際にファイルを書く）で、symlink 越しでも
通ります。**5 は realpath ガードが緩んでいないことの確認**です。綴りが違っても realpath 照合は両向きに
通るので、canonical 化はサーバから見て無害 — **割れていたのは identity だけ**で、そちらは spec で
固定しています。

`yarn format` → `lint` → `typecheck` → `build` → `test` すべて green（**845 files / 12534 tests**）。

## Items to Confirm / Review

1. **既存 spec を 9 件書き直しました。** いずれも旧規則（root 相対を優先）を固定していたものです。
   機械的に反転させず 1 件ずつ読み、**既定 stories 配下の難所**（ワークスペースが `/`、末尾が空白、
   symlink の両綴り — Codex P1/P2 が過去に見つけた回帰）は**そのまま残す**ようにしています。動くのは
   root 配下の綴りだけです。
2. **カードの同一視 — 当初の主張は過大でした（Codex round 1 P2、修正済み）。**
   「絶対も相対+root も同じ絶対パスに正規化される」は **symlink を数えていませんでした**。ペインは cell を
   起動した綴りを見せ、同一視はブラウザ側で**字句的**に解決される（realpath できない）ので、symlink 経由の
   workspace では 1 つのデッキが 2 枚に割れます。実測:

   ```
   old(rooted): /srv/real-ws/decks/talk.json
   new(link)  : /tmp/ws-link/decks/talk.json   ← old と不一致
   new(real)  : /srv/real-ws/decks/talk.json
   ```

   サーバの `canonical`（realpath 済み綴り）を `StoriesRoot` に通し、**最も内側の root の canonical** で
   組み立てるように直しました。`canonicalCardPath` が `stories/…`+root を解決する先と同じ綴りなので、
   変更前に作られたカードとも畳まれます。**修正後の実測**: 両綴りとも
   `{"filePath":"/srv/real-ws/decks/talk.json"}`。

   **正確な主張はこうです** — 登録済み root 配下なら 1 枚に畳まれる。**どの root にも属さないデッキは
   canonical が無いので別綴りは別カードのまま**で、これは #1976 以前と同じ（この PR は改善も悪化も
   させません）。閉じられるのはサーバが解決済みパスをカードに載せたときだけです。

   これは**ブラウザではなくテストで**押さえています: `storyWirePath` が mint し `filePathIdentity` が
   解決する **2 モジュール越し**に、旧 rooted / symlink 綴り / 既定 stories の 3 経路が 1 つの identity に
   落ちること（round 1 の欠陥はこの 2 つのすき間にありました）。入れ子 root（内側が symlink）で最も内側が
   勝つこと、root の列挙順に依存しないことも追加。**反転 mutation で赤くなることを確認済み**（canonical を
   ペインの綴りに戻すと 2 件、最長 tail 優先に反転すると 1 件）。
3. **開けるファイルの範囲は変えていません。** `canOpenInCanvas` のゲートは `storyWirePath !== null` の
   ままで、任意の `.json` は #1976 以降すでに対象でした。
4. **Windows では canonical 分岐がセパレータを混ぜます**（`C:\work\ws/myrepo/deck.json`）。tail は
   key 由来なので `/` で結合されるためです。`dirPathKey` も `path.resolve` も両方のセパレータを畳むので
   **カードは 1 枚に落ちます**（実測済み・spec で固定）。ここで綴りを整えると 1 ファイルに 2 つ目の
   綴り規則が生まれるので、**正規化せず理由付きで固定**しました。ここは判断が要る箇所です。
5. **ファイル名の末尾が空白のデッキは開けません（この PR 以前からの制約、変えていません）。**
   `dirPathKey` が文字列全体を trim するので tail から空白が落ち、`expectPath`（ペインの綴り）との
   realpath 照合が食い違って拒否されます。変更前も登録済み root 配下は同じく key 由来の tail だったので
   **同じ挙動**です。**どの root にも属さない**デッキだけが綴りをそのまま運ぶので開けます。実測で確認。
6. **到達不能な分岐を 1 つ削除しました。** 当初は「ペインに cwd が無く相対パスで来るとき」用に root 付き
   相対を最後の手段として残したのですが、**実測すると相対入力は全ケースで `null`** でした（root の prefix
   照合が相対キーに一致しない）。起きない場合を説明するコメント付きの死んだコードだったので削っています。

## 範囲外 — 上流に issue を立てます

- **View の dispatch に `root` を載せる**（mulmoclaude#3014）。入れば相対形式でも通りますが、この修正は
  それを待ちません。
- **保存失敗が Edit タブに出ずコンソールだけ**な点。入力欄に値が残るので保存されたように見えます。
  この PR で実害はほぼ消えますが、黙って失敗する設計自体は残ります。

なお **ドキュメントは変更していません。** 「editing it in the Canvas edits that file」は
`docs/guide/en/v4.15.0.md` にありますが日付き snapshot で編集禁止、生きたリファレンスに同じ主張が
無いことは grep で確認済みです。

Closes #1970

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1970 これ原因わかる？複数問題あるなら１つ１つ分割して対応したい
- 1 + 2 を 1 本の PR で進める / 3,4 も向こうで issue(mulmoclaude) たてる

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGUaJzDbjksQeXhnUyZTi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Canvas opening for decks stored under registered workspaces and roots.
  * Decks outside the default stories directory now use reliable absolute paths, allowing them to display, edit, and save correctly.
  * Improved path handling for nested roots, symlinked workspaces, and Windows/UNC paths. A workspace directory whose name ends in a space keeps that space; a deck whose FILE NAME ends in a space still cannot be opened (unchanged by this PR).
  * Reopening files now preserves the correct path and root information.
  * A deck under a registered root reached through two spellings of that root — a symlink and its target — is recognized as the same deck. A deck under NO registered root is unchanged: two spellings are still two cards, as before #1976.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



