### PR TITLE
chore: @mulmoclaude/shapescript-plugin 2.3.0 — every upstream ShapeScript example renders

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,20 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+### Every upstream ShapeScript example renders — `@mulmoclaude/shapescript-plugin@2.3.0`
+
+- **[#PR](https://github.com/receptron/mulmoterminal/pull/PR)** — `presentShapeScript`,
+  `renderShapeScript` and `exportShapeScriptUsdz` take plugin 2.3.0 (2.1.0 to 2.3.0 in one step),
+  so a script written against the upstream docs no longer hits a refused feature: materials
+  (hex and named colours, `opacity`, `metallicity` / `roughness` / `glow`, `material { … }`),
+  `print` output in the tool result, ranges and custom functions, shapes as values with
+  `.polygons` / `.bounds` / `.volume`, `mesh { polygon { … } }`, `minkowski` and `inset` for
+  rounded edges, and `extrude … along` for sweeps. All nine of the upstream project's example
+  scripts render. Toward upstream: `for` / `if` / `switch` no longer reset transforms at their
+  closing brace, a bare `path` draws as a line, `extrude` is centred on its profile plane and
+  does not close an open path for you (an open path extrudes to a wall), and a lone `position`
+  value is X alone. No host code changes.
+
 ## mulmoterminal@4.20.0 — 2026-09-11
 
 > **Setup guide:** [4.20.0 — Your ShapeScript models need converting, and a deck in your repo finally saves](https://receptron.github.io/mulmoterminal/guide/en/v4.20.0.html)

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -10,7 +10,7 @@ Entries here are folded into the next release's heading when it ships.
 
 ### Every upstream ShapeScript example renders — `@mulmoclaude/shapescript-plugin@2.3.0`
 
-- **[#PR](https://github.com/receptron/mulmoterminal/pull/PR)** — `presentShapeScript`,
+- **[#2041](https://github.com/receptron/mulmoterminal/pull/2041)** — `presentShapeScript`,
   `renderShapeScript` and `exportShapeScriptUsdz` take plugin 2.3.0 (2.1.0 to 2.3.0 in one step),
   so a script written against the upstream docs no longer hits a refused feature: materials
   (hex and named colours, `opacity`, `metallicity` / `roughness` / `glow`, `material { … }`),

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^2.0.0",
+    "@mulmoclaude/shapescript-plugin": "^2.3.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,10 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/shapescript-plugin@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-2.0.0.tgz#2c3838d29d35ec734d2c3faf8a46e6357e731259"
-  integrity sha512-5xkhig0S5fXRJB+Gp5rX6SnLKjUn6ydx8gLQtMELt0NgLNyjD2uhjL6UZW6funRxk/gofCUEolDNb47dusasww==
+"@mulmoclaude/shapescript-plugin@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-2.3.0.tgz#e241dafc9a2c1a17544ec023b504a0309862073b"
+  integrity sha512-2OJ3QHeyp0Gb/2iG2f1gSHAogqoQHu/jqGYCSnG2zbU2Bz2sBns6iNzkdlaQHVLCBacSWRRx078G7b3Qrzd9ag==
   dependencies:
     three "^0.185.1"
     three-bvh-csg "^0.0.18"


### PR DESCRIPTION
## Summary

Bumps `@mulmoclaude/shapescript-plugin` from `^2.0.0` to `^2.3.0`, taking three plugin releases (mulmoclaude#3072, #3073, #3074) in one step:

- **2.1.0** — materials (hex and named colours, `opacity`, `metallicity` / `roughness` / `glow`, `material { … }` bundles), `print` output returned with the tool result, `background`, ranges as values, bare calls and custom functions, `icosphere` / `roundrect` / `arc`.
- **2.2.0** — shapes as values (`.polygons` / `.bounds` / `.volume`), `for` / `if` as expressions, shape-building functions, `polygon { point … }` and `mesh { … }`.
- **2.3.0** — `minkowski`, `inset(mesh d)`, `extrude … along`, open paths extruded to walls, `detail` as a value. All nine of the upstream project's example scripts render.

Toward upstream, and worth knowing for saved `.shape` files: `for` / `if` / `switch` no longer reset transforms at their closing brace, a bare `path` draws as a line, `extrude` is centred on its profile plane and does not close an open path for you, and a lone `position` value is X alone.

No host code changes: `presentShapeScript`, `renderShapeScript` and `exportShapeScriptUsdz` consume the same tool contract, renderer and exporter signatures.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`
- [x] `yarn test`: 12537 passed, 50 skipped
- [x] `yarn.lock` resolves the plugin to 2.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - All nine upstream ShapeScript examples now render successfully.
  - Added support for additional ShapeScript language features.
  - Improved behavior alignment with upstream ShapeScript examples.
  - Expanded compatibility with the latest supported ShapeScript functionality.

- **Documentation**
  - Added an unreleased changelog entry documenting ShapeScript compatibility and rendering updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->