### PR TITLE
fix(files): raw ルートが保存名を伝えるようにする (#2040)

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -94,6 +94,25 @@ machine that runs the suite. Not `endsWith` either: `unplaced-sessions.json` end
 `yarn test` on macOS/Linux cannot see any of this — the whole class only appears where the
 separator and the drive letter differ.
 
+**A fixture the filesystem refuses to create takes the WHOLE spec file with it.** Two things
+Windows will not do, and both throw in `beforeAll` — where the failure reports as
+`1 failed` at the FILE level with zero failing tests, so it reads as the feature being broken
+rather than as the fixture being unbuildable:
+
+- **`symlinkSync` needs Developer Mode or an elevated shell.** Guard with
+  `canSymlink` (`test/support/canSymlink.ts`) and mark the spec `it.runIf(canSymlink)`.
+- **`< > : " / \ | ? *` are illegal in a filename.** A spec about quoting or escaping reaches for
+  a name like `weird";name.png` precisely because it is awkward — and that one cannot exist on
+  NTFS. Guard with `canNameFile(name)` (`test/support/canNameFile.ts`).
+
+Both are PROBES rather than `process.platform` checks, for the same reason: the question is what
+the filesystem under this runner accepts, and a Windows box with Developer Mode on should run the
+symlink specs. Non-ASCII names are fine — `月次 レポート.png` writes without complaint.
+
+#2040 paid for both in sequence: the symlink fixture went red first, and fixing it revealed the
+quoted one underneath. Each cost a full Windows round (~15 min), and neither is visible on
+macOS or Linux. Simulate locally before pushing by forcing the probe to `false`.
+
 ## File permissions
 
 **`chmod` moves the read-only attribute and nothing else.** There are no POSIX permission bits

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@xterm/headless": "^6.0.0",
     "@xterm/xterm": "^6.0.0",
     "codemirror": "^6.0.2",
+    "content-disposition": "^3.0.0",
     "dompurify": "^3.4.15",
     "echarts": "^6.0.0",
     "express": "^5.2.1",

--- a/plans/fix-2040-raw-content-disposition.md
+++ b/plans/fix-2040-raw-content-disposition.md
@@ -1,0 +1,62 @@
+# #2040 — raw ルートが保存名を伝えていない
+
+## 症状
+
+ターミナルのパスリンクから PDF を開き、ビューアから保存すると `raw.pdf` になる。
+元の名前（`2026-08-report.pdf` など）が失われる。
+
+## 再現（実ブラウザで測定）
+
+`Content-Disposition` が無いとき、ブラウザは URL の最後のパスセグメント（`raw`）に
+Content-Type から決めた拡張子を足して保存名にする。**Safari 固有ではない**:
+
+| ファイル | Chromium | WebKit（Safari と同エンジン）|
+| --- | --- | --- |
+| `2026-08-report.pdf` | `raw.pdf` | `raw.pdf` |
+| `月次レポート 2026-08.pdf` | `raw.pdf` | `raw.pdf` |
+| `weird";name.pdf` | `raw.pdf` | `raw.pdf` |
+
+稼働中の 4.20.0 のヘッダも確認。200 も 206 も `Content-Disposition` を含まない。
+
+## 直し方
+
+`Accept-Ranges` の直後、**Range 分岐より前**に `Content-Disposition: inline; filename=…` を
+設定する。1 箇所で 200 と 206 の両方に乗る（実測確認済み）。
+
+- **`inline`**: タブ内で表示される今の挙動を変えないため。`res.attachment()` は
+  `attachment` になるので使えない。
+- **ヘッダの組み立ては `content-disposition` パッケージに任せる。** Express 自身が
+  `res.attachment()` で使っているもので、ASCII フォールバック + `filename*=UTF-8''`
+  （RFC 6266）、引用符のエスケープ、改行の除去まで込み。手で組むと issue が挙げていた
+  難所を自前で踏むことになる。推移的依存として既に入っていたものを直接依存に昇格する。
+
+## 名前は「要求された綴り」から採る（規則として切り出す）
+
+`resolveContained` は **realpath する**（`server/files/pathContainment.ts:122`）ので、
+symlink 経由だと `abs` の basename は**リンク先の名前**になる。ユーザーがクリックしたのは
+リンクの名前なので、そちらを出すのが正しく、リンク先の名前を出すのは情報の漏れでもある。
+
+この判断を `server/backends/servedFileName.ts` の純粋関数に切り出し、両方向で網羅的に
+テストする（通常・日本語・引用符・改行・末尾スラッシュ・`.`/`..`・空・Windows 区切り・
+symlink で綴りが食い違うケース）。
+
+## 副作用が無いことの確認（実測）
+
+このルートは画像・テキスト・動画も返す。`inline` を全体に付けて測定:
+
+| 経路 | 結果 |
+| --- | --- |
+| `<img>`（wiki / コレクション画像）| 両エンジンで描画 OK |
+| テキスト（`.md`）| 両エンジンでタブ内表示のまま（ダウンロードにならない）|
+| 未知拡張子（`.bin`）| `raw` → `データ.bin` に改善 |
+
+`rawServingPlan.ts` が意図している「テキストは VIEW させる／未知拡張子は octet-stream で
+ダウンロード」を壊さない。**PDF に限定せず raw ルート全体に付ける。**
+
+## 検証
+
+- `servedFileName` の spec を、正常系と異常系（空・null 相当・区切りだけ・両区切り）で網羅。
+- `files.spec.ts` に 200 / 206 / 日本語名 / 引用符入り / symlink の assertion を追加。
+- 反転 mutation で赤くなることを確認する。
+- `yarn format` → `lint` → `typecheck` → `build` → `test`。
+- 依存を足したので **クリーン install で検証する**（`rm -rf node_modules && yarn install --frozen-lockfile`）。

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -22,7 +22,11 @@ import os from "node:os";
 import type { Express, Request, Response } from "express";
 import { statFileOr404 } from "./statFileOr404.js";
 import { parseByteRange } from "./byte-range.js";
+// Named export: 3.x is ESM and ships its own types. Express uses this same package for
+// `res.attachment()`, so the RFC 6266 escaping is the one the rest of the stack already trusts.
+import { create as contentDisposition } from "content-disposition";
 import { rawServingPlan } from "./rawServingPlan.js";
+import { servedFileName } from "./servedFileName.js";
 import { streamFileToResponse } from "./streamFile.js";
 import { authorizedServingBase, resolveContained } from "../files/pathContainment.js";
 import { rootForProjectId } from "../infra/project-root.js";
@@ -102,6 +106,13 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string; sessio
     // exception (WebKit won't render a sandbox-opaque PDF). See rawServingPlan.
     if (plan.sandbox) res.setHeader("Content-Security-Policy", "sandbox");
     res.setHeader("Accept-Ranges", "bytes");
+    // The name a save from the browser gets. Without it the browser falls back to the URL's last
+    // segment plus an extension guessed from the type, so every file saved as `raw.<ext>` (#2040).
+    // BEFORE the Range branch so the 206 carries it too — a media save takes the partial response.
+    // `inline`, not `attachment`: this route is how the app RENDERS images, PDFs and text, and
+    // `attachment` would turn every one of those into a download.
+    const advertised = servedFileName(rel);
+    if (advertised !== null) res.setHeader("Content-Disposition", contentDisposition(advertised, { type: "inline" }));
 
     // Range support (required for <video>/<audio> seeking in Safari).
     const rangeHeader = req.headers.range;

--- a/server/backends/servedFileName.ts
+++ b/server/backends/servedFileName.ts
@@ -1,0 +1,27 @@
+// The filename `/api/files/raw` advertises for a served file (#2040).
+//
+// From the REQUESTED spelling, not the resolved path: `resolveContained` realpaths
+// (server/files/pathContainment.ts), so a deck reached through a symlink resolves to the
+// target's name — which is not what the user clicked, and names a file they did not ask about.
+import path from "node:path";
+
+/** Both separators, because `path` only splits on the host's own and `rel` arrives off the wire. */
+const SEGMENTS = /[/\\]+/;
+
+/**
+ * The last named segment of `rel`, or null when it has none.
+ *
+ * Null rather than a placeholder: the caller omits the header entirely, which leaves the browser
+ * exactly where it was before this existed. A guessed name would be worse than no name.
+ */
+export function servedFileName(rel: string): string | null {
+  const named = rel
+    .split(SEGMENTS)
+    .map((segment) => segment.trim())
+    // `.` and `..` name a directory rather than a file; the containment gate has already refused
+    // any `..` that escapes, so one reaching here is a spelling to skip, not a path to resolve.
+    .filter((segment) => segment !== "" && segment !== "." && segment !== "..");
+  const last = named.at(-1);
+  // A trailing `~` expansion (`~/x.pdf`) is already a segment by here; a bare `~` is not a name.
+  return last === undefined || last === "~" ? null : path.basename(last);
+}

--- a/server/backends/servedFileName.ts
+++ b/server/backends/servedFileName.ts
@@ -15,12 +15,15 @@ const SEGMENTS = /[/\\]+/;
  * exactly where it was before this existed. A guessed name would be worse than no name.
  */
 export function servedFileName(rel: string): string | null {
-  const named = rel
-    .split(SEGMENTS)
-    .map((segment) => segment.trim())
-    // `.` and `..` name a directory rather than a file; the containment gate has already refused
-    // any `..` that escapes, so one reaching here is a spelling to skip, not a path to resolve.
-    .filter((segment) => segment !== "" && segment !== "." && segment !== "..");
+  // Compared EXACTLY, never trimmed. ` report.pdf` and `report.pdf` are two different files on a
+  // POSIX filesystem, and the served bytes are the untrimmed one — `resolveContained` leaves the
+  // path alone (its `trimTrailingDotsAndSpaces` only classifies Windows device names). Trimming
+  // here advertised a name that did not match the file (CodeRabbit on #2040), which is the same
+  // trap `dirPathKey` set for a workspace whose name ended in a space (#1934).
+  //
+  // `.` and `..` name a directory rather than a file; the containment gate has already refused any
+  // `..` that escapes, so one reaching here is a spelling to skip, not a path to resolve.
+  const named = rel.split(SEGMENTS).filter((segment) => segment !== "" && segment !== "." && segment !== "..");
   const last = named.at(-1);
   // A trailing `~` expansion (`~/x.pdf`) is already a segment by here; a bare `~` is not a name.
   return last === undefined || last === "~" ? null : path.basename(last);

--- a/test/server/backends/files.spec.ts
+++ b/test/server/backends/files.spec.ts
@@ -8,11 +8,14 @@ import { appRequest } from "../../helpers/appRequest.js";
 import { mountFilesRoutes } from "../../../server/backends/files.js";
 import { makeTempDir } from "../../support/tempDir";
 import { canSymlink } from "../../support/canSymlink";
+import { canNameFile } from "../../support/canNameFile";
 import { initProjectRoots, projectId } from "../../../server/infra/project-root.js";
 
 let request: ReturnType<typeof appRequest>;
 // A session project dir OUTSIDE the workspace root (a sibling repo), reachable only via
 // the `?cwd=` scope — mirrors an agent whose cwd is a different repo.
+const QUOTED_NAME = 'weird";name.png';
+const quotedName = canNameFile(QUOTED_NAME);
 let sessionDir: string;
 let projectDir: string;
 
@@ -25,7 +28,8 @@ beforeAll(() => {
   // #2040: the save name. A non-ASCII name needs `filename*`, a quoted one needs escaping, and a
   // symlink is where "the name asked for" and "the name on disk" come apart.
   writeFileSync(path.join(ws, "downloads", "images", "月次 レポート.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-  writeFileSync(path.join(ws, "downloads", "images", 'weird";name.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  // Windows refuses `"` in a filename, so the spec that reads this one is `runIf(quotedName)`.
+  if (quotedName) writeFileSync(path.join(ws, "downloads", "images", QUOTED_NAME), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   // Windows needs Developer Mode or an elevated shell to make one, so the spec that reads it is
   // `runIf(canSymlink)` — a fixture that was never created reads as broken behaviour, not as untested.
   if (canSymlink) symlinkSync(path.join(ws, "downloads", "images", "a.png"), path.join(ws, "downloads", "images", "link.png"));
@@ -152,8 +156,8 @@ describe("GET /api/files/raw — the save name", () => {
     expect(header).toMatch(/^inline; filename="[^"]*"; filename\*=UTF-8''/);
   });
 
-  it("escapes a quote rather than ending the header early", async () => {
-    const res = await request(`/api/files/raw?path=${encodeURIComponent('downloads/images/weird";name.png')}`);
+  it.runIf(quotedName)("escapes a quote rather than ending the header early", async () => {
+    const res = await request(`/api/files/raw?path=${encodeURIComponent("downloads/images/" + QUOTED_NAME)}`);
     expect(res.headers.get("content-disposition")).toBe('inline; filename="weird\\";name.png"');
   });
 

--- a/test/server/backends/files.spec.ts
+++ b/test/server/backends/files.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from "vitest";
 import express from "express";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { appRequest } from "../../helpers/appRequest.js";
@@ -21,6 +21,11 @@ beforeAll(() => {
   // 4-byte PNG signature — enough to assert byte length + Range.
   writeFileSync(path.join(ws, "downloads", "images", "a.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   writeFileSync(path.join(ws, "secret.txt"), "top secret");
+  // #2040: the save name. A non-ASCII name needs `filename*`, a quoted one needs escaping, and a
+  // symlink is where "the name asked for" and "the name on disk" come apart.
+  writeFileSync(path.join(ws, "downloads", "images", "月次 レポート.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  writeFileSync(path.join(ws, "downloads", "images", 'weird";name.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  symlinkSync(path.join(ws, "downloads", "images", "a.png"), path.join(ws, "downloads", "images", "link.png"));
 
   sessionDir = makeTempDir("mt-session-");
   mkdirSync(path.join(sessionDir, "assets", "media"), { recursive: true });
@@ -117,6 +122,51 @@ describe("GET /api/files/raw", () => {
     const res = await request("/api/files/raw?path=downloads/images/a.png", { headers: { Range: "bytes=99-100" } });
     expect(res.status).toBe(416);
     expect(res.headers.get("content-range")).toBe("bytes */4");
+  });
+});
+
+// Without this header the browser names a save after the URL's last segment plus an extension
+// guessed from the type — `raw.png` for every file, whatever it is called on disk (#2040,
+// measured the same way in Chromium and in WebKit).
+describe("GET /api/files/raw — the save name", () => {
+  it("advertises the file's own name, inline so the tab still renders it", async () => {
+    const res = await request("/api/files/raw?path=downloads/images/a.png");
+    expect(res.headers.get("content-disposition")).toBe("inline; filename=a.png");
+  });
+
+  // `attachment` would turn every image, PDF and text file this route serves into a download.
+  it("never says attachment", async () => {
+    const res = await request("/api/files/raw?path=downloads/images/a.png");
+    expect(res.headers.get("content-disposition")).not.toContain("attachment");
+  });
+
+  // RFC 6266: an ASCII fallback for old clients, plus the real name percent-encoded.
+  it("carries a non-ASCII name in both forms", async () => {
+    const res = await request(`/api/files/raw?path=${encodeURIComponent("downloads/images/月次 レポート.png")}`);
+    const header = res.headers.get("content-disposition") ?? "";
+    expect(header).toContain("filename*=UTF-8''");
+    expect(header).toContain("%E6%9C%88%E6%AC%A1%20%E3%83%AC%E3%83%9D%E3%83%BC%E3%83%88.png");
+    expect(header).toMatch(/^inline; filename="[^"]*"; filename\*=UTF-8''/);
+  });
+
+  it("escapes a quote rather than ending the header early", async () => {
+    const res = await request(`/api/files/raw?path=${encodeURIComponent('downloads/images/weird";name.png')}`);
+    expect(res.headers.get("content-disposition")).toBe('inline; filename="weird\\";name.png"');
+  });
+
+  // The 206 is what a media save takes, so the header has to be set before the Range branch.
+  it("carries the name on a partial response too", async () => {
+    const res = await request("/api/files/raw?path=downloads/images/a.png", { headers: { Range: "bytes=0-1" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-disposition")).toBe("inline; filename=a.png");
+  });
+
+  // `resolveContained` realpaths, so the served path is the TARGET. The user clicked the link,
+  // and naming the target would both surprise them and name a file they did not ask about.
+  it("names the link the user asked for, not the file it resolves to", async () => {
+    const res = await request("/api/files/raw?path=downloads/images/link.png");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-disposition")).toBe("inline; filename=link.png");
   });
 });
 

--- a/test/server/backends/files.spec.ts
+++ b/test/server/backends/files.spec.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { appRequest } from "../../helpers/appRequest.js";
 import { mountFilesRoutes } from "../../../server/backends/files.js";
 import { makeTempDir } from "../../support/tempDir";
+import { canSymlink } from "../../support/canSymlink";
 import { initProjectRoots, projectId } from "../../../server/infra/project-root.js";
 
 let request: ReturnType<typeof appRequest>;
@@ -25,7 +26,9 @@ beforeAll(() => {
   // symlink is where "the name asked for" and "the name on disk" come apart.
   writeFileSync(path.join(ws, "downloads", "images", "月次 レポート.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   writeFileSync(path.join(ws, "downloads", "images", 'weird";name.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-  symlinkSync(path.join(ws, "downloads", "images", "a.png"), path.join(ws, "downloads", "images", "link.png"));
+  // Windows needs Developer Mode or an elevated shell to make one, so the spec that reads it is
+  // `runIf(canSymlink)` — a fixture that was never created reads as broken behaviour, not as untested.
+  if (canSymlink) symlinkSync(path.join(ws, "downloads", "images", "a.png"), path.join(ws, "downloads", "images", "link.png"));
 
   sessionDir = makeTempDir("mt-session-");
   mkdirSync(path.join(sessionDir, "assets", "media"), { recursive: true });
@@ -163,7 +166,7 @@ describe("GET /api/files/raw — the save name", () => {
 
   // `resolveContained` realpaths, so the served path is the TARGET. The user clicked the link,
   // and naming the target would both surprise them and name a file they did not ask about.
-  it("names the link the user asked for, not the file it resolves to", async () => {
+  it.runIf(canSymlink)("names the link the user asked for, not the file it resolves to", async () => {
     const res = await request("/api/files/raw?path=downloads/images/link.png");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-disposition")).toBe("inline; filename=link.png");

--- a/test/server/backends/servedFileName.spec.ts
+++ b/test/server/backends/servedFileName.spec.ts
@@ -37,12 +37,24 @@ describe("servedFileName", () => {
 
   // Null is the important answer: the caller omits the header, which leaves the browser exactly
   // where it was before this existed. A placeholder would name a file nobody asked for.
+  // ` report.pdf` and `report.pdf` are two different files on a POSIX filesystem, and the bytes
+  // served are the untrimmed one. Advertising the trimmed name saves the file under a name that
+  // does not match it (CodeRabbit on #2040) — the same trap `dirPathKey` set for a workspace whose
+  // name ended in a space (#1934).
+  it("keeps whitespace that is part of the name", () => {
+    expect(servedFileName("reports/ leading.pdf")).toBe(" leading.pdf");
+    expect(servedFileName("reports/trailing .pdf")).toBe("trailing .pdf");
+    expect(servedFileName("reports/both .pdf ")).toBe("both .pdf ");
+    expect(servedFileName(" spaced dir /file.pdf")).toBe("file.pdf");
+    // A file whose whole name is whitespace is legal on POSIX, so it is a name like any other.
+    expect(servedFileName("reports/  ")).toBe("  ");
+  });
+
   it("answers null when there is no name to give", () => {
     expect(servedFileName("")).toBeNull();
     expect(servedFileName("/")).toBeNull();
     expect(servedFileName("///")).toBeNull();
     expect(servedFileName("\\")).toBeNull();
-    expect(servedFileName("  ")).toBeNull();
     expect(servedFileName(".")).toBeNull();
     expect(servedFileName("..")).toBeNull();
     expect(servedFileName("./../.")).toBeNull();

--- a/test/server/backends/servedFileName.spec.ts
+++ b/test/server/backends/servedFileName.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { servedFileName } from "../../../server/backends/servedFileName.js";
+
+// What the browser is told to call a file saved from /api/files/raw. Without it the save name is
+// the URL's last segment plus an extension guessed from the type — `raw.pdf` for every file
+// (#2040, measured the same way in Chromium and WebKit).
+describe("servedFileName", () => {
+  it("takes the last segment", () => {
+    expect(servedFileName("artifacts/reports/2026-08-report.pdf")).toBe("2026-08-report.pdf");
+  });
+
+  it("keeps a name the header has to escape rather than sanitising it here", () => {
+    // The quoting is `content-disposition`'s job, and doing it twice is how a name ends up
+    // mangled. This function decides WHICH name, never how it is spelled on the wire.
+    expect(servedFileName('a/weird";name.pdf')).toBe('weird";name.pdf');
+    expect(servedFileName("a/月次レポート 2026-08.pdf")).toBe("月次レポート 2026-08.pdf");
+    expect(servedFileName("a/line\nbreak.pdf")).toBe("line\nbreak.pdf");
+  });
+
+  it("splits on both separators, since `rel` arrives off the wire", () => {
+    expect(servedFileName("artifacts\\reports\\note.pdf")).toBe("note.pdf");
+    expect(servedFileName("artifacts/reports\\note.pdf")).toBe("note.pdf");
+  });
+
+  it("ignores segments that name a directory rather than a file", () => {
+    expect(servedFileName("reports/./note.pdf")).toBe("note.pdf");
+    expect(servedFileName("reports/note.pdf/")).toBe("note.pdf");
+    expect(servedFileName("reports//note.pdf")).toBe("note.pdf");
+    expect(servedFileName("reports/sub/..")).toBe("sub");
+  });
+
+  it("expands nothing: a tilde segment is a directory, not a name", () => {
+    expect(servedFileName("~/note.pdf")).toBe("note.pdf");
+    expect(servedFileName("~")).toBeNull();
+  });
+
+  // Null is the important answer: the caller omits the header, which leaves the browser exactly
+  // where it was before this existed. A placeholder would name a file nobody asked for.
+  it("answers null when there is no name to give", () => {
+    expect(servedFileName("")).toBeNull();
+    expect(servedFileName("/")).toBeNull();
+    expect(servedFileName("///")).toBeNull();
+    expect(servedFileName("\\")).toBeNull();
+    expect(servedFileName("  ")).toBeNull();
+    expect(servedFileName(".")).toBeNull();
+    expect(servedFileName("..")).toBeNull();
+    expect(servedFileName("./../.")).toBeNull();
+  });
+});

--- a/test/support/canNameFile.ts
+++ b/test/support/canNameFile.ts
@@ -1,0 +1,22 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Whether this filesystem accepts a given filename. Windows refuses `< > : " / \ | ? *` outright,
+// so a fixture built from one throws in `beforeAll` and takes the WHOLE spec file down — which
+// reads as the feature being broken rather than as the fixture being unbuildable (#2040 cost two
+// Windows CI rounds this way: first the symlink, then the quote).
+//
+// Probed rather than checked against `process.platform`, for `canSymlink`'s reason: the question is
+// what the filesystem under the runner will accept, and a platform check answers a different one.
+export function canNameFile(name: string): boolean {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-name-probe-"));
+  try {
+    writeFileSync(path.join(dir, name), "");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,6 +3758,11 @@ content-disposition@^1.0.0:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.1.0.tgz#f3db789c752d45564cc7e9e1e0b31790d4a38e17"
   integrity sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==
 
+content-disposition@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-3.0.0.tgz#624fe1697b362049d4735368e3fe57138b2c528d"
+  integrity sha512-ZH/0Xs9rMIFWCOmGdmS9eHBTF62qqQYNz4nVjQhkdIO/a0fCP4UIM3mRz/wiqL0L14YgAz/1xio4OaSY4+ON/A==
+
 content-type@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"


### PR DESCRIPTION
## Summary

タブで開いた PDF を保存すると `raw.pdf` になる (#2040) を直します。原因は報告どおりで、
`/api/files/raw` が `Content-Disposition` を返していませんでした。名前の手がかりが無いとき、
ブラウザは URL の最後のセグメント（`raw`）に Content-Type から決めた拡張子を足します。

## 再現 — Safari 固有ではありませんでした

報告は「macOS + Safari で 1 回」でしたが、**Safari と同じ WebKit エンジンと Chromium の両方**で
再現しました。ブラウザが実際に付ける保存名を測定した結果です。

| ファイル | 修正前 | 修正後 (Chromium) | 修正後 (WebKit) |
| --- | --- | --- | --- |
| `2026-08-report.pdf` | `raw.pdf` | **`2026-08-report.pdf`** | **`2026-08-report.pdf`** |
| `月次レポート 2026-08.pdf` | `raw.pdf` | **`月次レポート 2026-08.pdf`** | **`月次レポート 2026-08.pdf`** |
| `weird";name.pdf` | `raw.pdf` | `weird_;name.pdf` | `weird";name.pdf` |

日本語が通っているので **`filename*=UTF-8''` が両エンジンで尊重されています**。引用符入りは
ヘッダ注入にならず、Chromium が `"` を `_` に正規化するだけです。

## 直し方

`Accept-Ranges` の直後、**Range 分岐より前**に 1 行。1 箇所で 200 と 206 の両方に乗ります
（**206 は媒体の保存が取る応答**なので、ここが後ろだと動画・音声の保存名が直りません）。

```ts
const advertised = servedFileName(rel);
if (advertised !== null) res.setHeader("Content-Disposition", contentDisposition(advertised, { type: "inline" }));
```

- **`inline`、`attachment` ではありません。** このルートは画像・PDF・テキストを**描画する**
  経路でもあるので、`attachment` にすると全部ダウンロードになります。
- **ヘッダの組み立ては `content-disposition` に任せました。** Express 自身が `res.attachment()`
  で使っているパッケージで、ASCII フォールバック + `filename*=UTF-8''`（RFC 6266）、引用符の
  エスケープ、改行の除去まで込みです。issue が挙げていた難所を自前で踏まずに済みます。

## 名前は「要求された綴り」から採ります

`resolveContained` は **realpath します**（`server/files/pathContainment.ts:122`）。なので
symlink 経由だと `abs` の basename は**リンク先の名前**です。ユーザーがクリックしたのはリンクの
名前なので、実体の名前を出すのは驚きであると同時に、**要求していないファイルの名前を漏らす**
ことになります。

この判断を `server/backends/servedFileName.ts` の純粋関数に切り出し、両方向で網羅しました
（日本語 / 引用符 / 改行 / 両区切り / 末尾スラッシュ / `.` / `..` / `~` / 空 / 区切りだけ）。
**名前が取れないときは null を返し、呼び出し側はヘッダごと省きます** — 推測した名前は無名より
悪いためです。

## 副作用が無いことを実測しました

PDF に限定せず raw ルート全体に付けたので、他の経路を実ブラウザで確認しています
（issue の「他にも気がついたこと」への回答です）。

| 経路 | 結果 |
| --- | --- |
| `<img>`（wiki / コレクション画像）| **両エンジンで描画 OK** |
| テキスト（`.md`）| **両エンジンでタブ内表示のまま**（ダウンロードにならない）|
| 未知拡張子（`.bin`）| `raw` → **`データ.bin`** に改善 |

`rawServingPlan.ts` が意図している「テキストは VIEW させる／未知拡張子は octet-stream で
ダウンロード」という設計を壊していません。

## Items to Confirm / Review

1. **依存を 1 つ足しました（`content-disposition@^3.0.0`）。** 今まで express の推移的依存として
   入っていたものを直接依存に昇格した形です。**`@types/` は入れていません** — 3.x は ESM で
   自前の型を持ちます。なお 1.x（express 配下の版）は default export の CJS で API が異なるため、
   名前付き export の `create` を使っています。**この違いは vitest で一度 500 になって気づきました**
   （tsx と vitest で CJS interop が食い違い、ローカル緑・CI 赤になる典型でした）。
2. **クリーン install で検証済みです。** 依存を足した PR なので、`rm -rf node_modules` →
   `yarn install --frozen-lockfile` → lint / typecheck / build / test を通しました
   （**847 files / 12549 tests** green）。
3. **反転 mutation 4 種で赤くなることを確認しました**: ヘッダ削除 → 6 件 / Range 分岐の後に
   移動 → 1 件（206 の spec）/ `attachment` 化 → 6 件 / `rel` ではなく `abs` を使う → 1 件
   （symlink の spec）。
4. **Windows CI を一度落としました（修正済み）。** 足した symlink の fixture が `beforeAll` の中で
   無防備に `symlinkSync` を呼んでおり、**spec ファイルごと失敗**していました（個別テストの失敗は
   0 件、ファイル単位で 1 failed = セットアップの例外）。Windows は symlink の作成に Developer Mode
   か昇格したシェルが要ります。リポジトリには既に `test/support/canSymlink.ts` があり、
   `worktrees.spec.ts` / `session-drops.spec.ts` はこれで守っていたので、同じ作法に揃えました
   （fixture を `if (canSymlink)`、読む spec を `it.runIf(canSymlink)`）。ローカルで
   `canSymlink = false` を強制して再現確認済み: **24 passed / 1 skipped**（ファイルごと落ちない）。
5. **実ブラウザでの確認は Chromium と WebKit です。** 報告者の環境（macOS + Safari）そのもので
   はありませんが、WebKit は Safari と同じエンジンです。Firefox は未確認です。
6. **タブ内表示は headless では直接観察していません。** `inline` の定義上そうなるはずで、
   同じルートの画像とテキストがタブ内に留まることは測定しました。実際の PDF ビューア表示は
   報告者の環境での確認が確実です。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/2040 しらべて
- 副作用無くきれいに直して。

Closes #2040

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGUaJzDbjksQeXhnUyZTi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Raw file responses now provide safe, descriptive filenames while preserving inline browser rendering.
  - Filenames are correctly advertised for partial downloads and files containing non-ASCII characters, quotes, or varied path formats.
  - Raw files continue displaying in the browser instead of being forced to download as attachments.

- **Tests**
  - Expanded coverage for filename handling, special characters, path variations, symbolic links, partial responses, and environments without symlink support.

- **Documentation**
  - Added guidance for Windows-specific test fixture limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
