### PR TITLE
chore: @mulmoclaude/shapescript-plugin 2.5.0 — text, one statement per line, USDZ colours

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,6 +8,19 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 Entries here are folded into the next release's heading when it ships.
 
+### `text`, one statement per line, USDZ colours — `@mulmoclaude/shapescript-plugin@2.5.0`
+
+- **[#2043](https://github.com/receptron/mulmoterminal/pull/2043)** — `presentShapeScript`,
+  `renderShapeScript` and `exportShapeScriptUsdz` take plugin 2.5.0 (2.3.0 to 2.5.0 in one step).
+  `text "Hello"` draws glyph outlines laid out as the upstream app does — left margin at x = 0,
+  first baseline at y = 0, one unit per line, `size`, `wrapwidth`, `linespacing`, interpolation —
+  which `fill` and `extrude` turn into letters with their counters, and a text is a value with
+  `.bounds`. **Behaviour change** toward upstream: two statements on one line
+  (`sphere { position 0 1 0 size 2 }`) are now a parse error naming the rule, as the upstream app
+  reads a property's arguments to the end of the line; a saved script in that style fails until
+  reformatted. `tau` is gone (write `2 * pi`). A USDZ export of coloured polygon meshes no longer
+  comes out white or misplaced. No host code changes.
+
 ### Every upstream ShapeScript example renders — `@mulmoclaude/shapescript-plugin@2.3.0`
 
 - **[#2041](https://github.com/receptron/mulmoterminal/pull/2041)** — `presentShapeScript`,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^2.3.0",
+    "@mulmoclaude/shapescript-plugin": "^2.5.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/sharedapp": "^0.35.0",
     "@receptron/task-scheduler": "^1.0.3",

--- a/test/server/infra/shapescriptRenderTool.spec.ts
+++ b/test/server/infra/shapescriptRenderTool.spec.ts
@@ -24,7 +24,7 @@ import { makeTempDir } from "../../support/tempDir";
 const ws = makeTempDir("mt-render-tool-");
 const ARTIFACT = "artifacts/shapes/lamp.shape";
 const REPO_REL = "models/bracket.shape";
-const CUBE = "cube { size 1 color 0.2 0.6 0.9 }";
+const CUBE = "cube {\n size 1\n color 0.2 0.6 0.9\n}";
 
 mkdirSync(path.join(ws, "artifacts", "shapes"), { recursive: true });
 writeFileSync(path.join(ws, ARTIFACT), CUBE);

--- a/test/server/infra/shapescriptUsdzTool.spec.ts
+++ b/test/server/infra/shapescriptUsdzTool.spec.ts
@@ -14,7 +14,7 @@ import { makeTempDir } from "../../support/tempDir";
 const ws = makeTempDir("mt-usdz-tool-");
 const ARTIFACT = "artifacts/shapes/lamp.shape";
 const REPO_REL = "models/bracket.shape";
-const CUBE = "cube { size 1 color 0.2 0.6 0.9 }";
+const CUBE = "cube {\n size 1\n color 0.2 0.6 0.9\n}";
 
 mkdirSync(path.join(ws, "artifacts", "shapes"), { recursive: true });
 writeFileSync(path.join(ws, ARTIFACT), CUBE);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,10 @@
   dependencies:
     "@mulmoclaude/common" "^1.2.0"
 
-"@mulmoclaude/shapescript-plugin@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-2.3.0.tgz#e241dafc9a2c1a17544ec023b504a0309862073b"
-  integrity sha512-2OJ3QHeyp0Gb/2iG2f1gSHAogqoQHu/jqGYCSnG2zbU2Bz2sBns6iNzkdlaQHVLCBacSWRRx078G7b3Qrzd9ag==
+"@mulmoclaude/shapescript-plugin@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/shapescript-plugin/-/shapescript-plugin-2.5.0.tgz#f1d172a70a3e0189f8920842b4a7a6e7ce60e33f"
+  integrity sha512-1Czo79H9Ga6hP+j6U3BkgIC+/97mbjZuU9SnBc/3TF+q/p4UaMMAVNnzvkbMR9ZJqbEPZEOEQ0/aX4XD2/GLww==
   dependencies:
     three "^0.185.1"
     three-bvh-csg "^0.0.18"


### PR DESCRIPTION
## Summary

Takes `@mulmoclaude/shapescript-plugin` from `^2.3.0` to `^2.5.0` (2.4.0 was never bumped here), so `presentShapeScript`, `renderShapeScript` and `exportShapeScriptUsdz` gain:

- **`text`** (2.4.0): glyph outlines laid out as the upstream app does (left margin at x = 0, first baseline at y = 0, one unit per line, `size`, `wrapwidth`, `linespacing`, interpolation), filled and extruded letters with their counters, text as a value with `.bounds`. Built-in Helvetiker face; `font` accepted with a warning.
- **One statement per line is a hard error** (2.5.0), as the upstream app reads a property's arguments to the end of the line — a script that renders here now also renders upstream. `tau` removed (write `2 * pi`). **Behaviour change**: saved scripts in the one-line style fail with a message naming the rule until reformatted.
- **USDZ export keeps colours** (2.5.0): coloured polygon meshes (`mesh { polygon { color … } }`) came out white in Quick Look and, after the first fix, misplaced; each is now split per colour into plain materials with its placement kept.

Host change: the USDZ tool spec's cube fixture rewritten to one statement per line. No host code changes.

## Test plan

- [x] `yarn typecheck`, `yarn lint`, `yarn build`
- [x] `yarn test`: 12534 pass (the 3 USDZ tool failures were the one-line fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated ShapeScript integration to version 2.5.0.
  - Text rendering now draws glyph outlines using improved layout.
  - USDZ exports of colored polygon meshes now preserve color and placement.

- **Bug Fixes**
  - Corrected issues that could cause colored meshes to appear white or incorrectly positioned in USDZ exports.

- **Breaking Changes**
  - Multiple statements on one line now produce a parse error.
  - The `tau` constant is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->