### PR TITLE
feat(files): ツリーの行を右クリックして OS のファイルマネージャで開く (#2039)

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -113,6 +113,26 @@ symlink specs. Non-ASCII names are fine — `月次 レポート.png` writes wit
 quoted one underneath. Each cost a full Windows round (~15 min), and neither is visible on
 macOS or Linux. Simulate locally before pushing by forcing the probe to `false`.
 
+**`..` is folded LEXICALLY by the Win32 path API, before any symlink is followed.** POSIX does the
+opposite: the kernel resolves `link` first and only then applies `..`, so `…/link/../x` can name a
+different file from `path.resolve("…/link/../x")`. On Windows the two always agree, because the
+path is normalised textually before the reparse point is touched.
+
+That difference is a fact about the platform, and a test that asserts one side of it is red on the
+other. #2039 shipped a regression test whose FIRST line was `expect(statSync(asked).isDirectory())
+.toBe(true)` — true on macOS, false on Windows, green locally and red on the runner. The fix is not
+to skip the test: **measure the divergence, then assert the invariant that holds either way.**
+
+```ts
+const diverges = statSync(asked).isDirectory() !== statSync(path.resolve(asked)).isDirectory();
+expect(diverges).toBe(process.platform !== "win32");   // the platform fact, stated
+expect(spawned).toEqual(argvFor(path.resolve(asked))); // the invariant, true on both
+```
+
+This is the one place a `process.platform` check belongs — the thing under test IS the platform's
+own behaviour, so probing for it would be probing for the answer. Everywhere else in this file the
+rule is the opposite: probe the filesystem, do not ask which OS this is.
+
 ## File permissions
 
 **`chmod` moves the read-only attribute and nothing else.** There are no POSIX permission bits

--- a/plans/feat-2039-reveal-in-file-manager.md
+++ b/plans/feat-2039-reveal-in-file-manager.md
@@ -1,0 +1,70 @@
+# #2039 — ツリーの行から OS のファイルマネージャで開く
+
+## 要望
+
+ファイルツリーの行から Finder（等）を開く。**中身を見るためではなく、ファイルを人や
+別のアプリに渡すため** — メールに添付する、提出フォームへドラッグする、エージェントが
+読むフォルダへ大きいファイルを置く。
+
+- ファイルの行 → そのファイルが**選択された状態**で親フォルダが開く
+- フォルダの行 → **そのフォルダが開く**
+
+## MulmoClaude が参照実装（CLAUDE.md の規則）
+
+`../mulmoclaude` に同じ機能がある（issue #1985 → PR #2016）。合わせるもの:
+
+| 合わせる点 | MulmoClaude | 本実装 |
+| --- | --- | --- |
+| ルートパス | `POST /api/files/reveal`（`src/config/apiRoutes.ts:142` が正）| 同じ |
+| 成功 | `200 { ok: true }` | 同じ |
+| 引数不足 | `400` | 同じ |
+| 起動失敗 | `500` | 同じ |
+| 文言 | `"Show in folder"`（`src/lang/en.ts:529`）| ファイル行は同じ |
+| argv | darwin `open -R`、win32 `explorer.exe /select,`、他 `xdg-open <dirname>` | 同じ |
+
+**意図的に違えるところ**（PR に明記する）:
+
+- **WSL を見る。** MulmoClaude の `revealArgv` は `platform` だけで分岐するが、mulmoterminal は
+  既に `openDirCommands()` で WSL を特別扱いしている（distro に `xdg-open` が無い / 見えない
+  Linux アプリが開く、#1447）。同じ候補リストを reveal でも使い、`explorer.exe` →
+  `xdg-open` のフォールバックを保つ。
+- **フォルダの行にも出す。** MulmoClaude の reveal はファイル用。本要望はフォルダも対象で、
+  そのときは「選択」ではなく「そのフォルダを開く」。文言も変える。
+
+## 実装
+
+**サーバ**: 新しいルート `POST /api/files/reveal`。候補リストは `openDirCommands()` を**再利用**
+（プラットフォームごとの opener はフォルダを開くときと同じ）。新しく要るのは argv の組み立てだけ:
+
+```
+revealArgv(cmd, target, isDir)
+  open          → isDir ? [target] : ["-R", target]
+  explorer(.exe)→ isDir ? [target] : [`/select,${target}`]
+  xdg-open      → [isDir ? target : dirname(target)]   // Linux に可搬な「選択」は無い
+```
+
+純粋関数なので単体で網羅できる。**シェルを通さない argv 配列**なので、名前に
+シェルのメタ文字が入っても構文として再解釈されない。
+
+**ガード**: `resolveDirRequest` と同じ門（same-origin → 絶対パス → 存在）を、ディレクトリ限定を
+外した形で通す。**ワークスペースへの封じ込めは既存の `/api/open-dir` にも無い** — ローカルの
+サーバであり、脅威モデルは「他所のサイトに叩かれないこと」で、そこは same-origin が担う。
+reveal だけ厳しくすると一貫性を欠くので、同じ門に揃える。
+
+**UI**: `filesRowActions.ts` の `FilesRowAction` に `reveal` を足す。`FilesRowTarget` に
+`isDir` を足して、文言と挙動を行の種類で変える。**絶対パス**を載せる（ルートが絶対を要求する
+ため）。`FilesPane.vue` が fetch する — emit しないのは、親の関与が無いサーバ副作用だから
+（`writeBuffer` と同じ）。
+
+**失敗は必ず見せる。** #1447 の教訓で、`TerminalCell.vue` の `openDir()` は失敗を
+`showAskMsg` に出している。同じ扱いにする。
+
+## 検証
+
+- `revealArgv` を全プラットフォーム × ファイル/フォルダで網羅（異常系: 未知の cmd、
+  空パス、シェルのメタ文字を含む名前）。
+- ルートの spec: 400 / 404 / 403（origin）/ 200、spawn は注入して argv を assert する。
+- `filesRowActions` の spec: ファイル行とフォルダ行で文言と payload が変わること。
+- 反転 mutation で赤くなることを確認する。
+- **Windows の fixture の罠**（`docs/windows-gotchas.md`）に注意 — symlink と禁止文字。
+- `yarn format` → `lint` → `typecheck` → `build` → `test`。

--- a/server/files/dirRequest.ts
+++ b/server/files/dirRequest.ts
@@ -21,20 +21,35 @@ export interface ResolvedPath {
 // guards is a random website driving the machine — which is what the same-origin check answers.
 // A tree rooted at a session's cwd already shows paths outside the workspace, so containing this
 // alone would refuse rows the pane is displaying.
-export function resolvePathRequest(req: Request, res: Response, isAllowedOrigin: OriginCheck, notFound = "path not found"): ResolvedPath | null {
+export interface ResolveOptions {
+  /** The 404 text, so a caller that has always said "directory" keeps saying it. */
+  notFound?: string;
+  /** Applied BEFORE the stat, so what comes back is exactly what was validated. A caller that
+   *  hands the path to another process needs this: `path.resolve` folds `..` LEXICALLY while the
+   *  kernel folds it through symlinks, so normalising after the stat validates one pathname and
+   *  acts on another (Codex P2 on #2039 — measured: `<root>/link/../adir` stats as a directory
+   *  and its resolved spelling stats as a file). Callers that spawn the string they validated,
+   *  like /api/open-dir, must NOT pass this: for them the two agree already, and resolving would
+   *  open the lexical directory instead of the one the kernel reaches. */
+  normalise?: (path: string) => string;
+}
+
+export function resolvePathRequest(req: Request, res: Response, isAllowedOrigin: OriginCheck, opts: ResolveOptions = {}): ResolvedPath | null {
   if (!requestOriginAllowed(req, isAllowedOrigin)) {
     res.status(403).json({ error: "forbidden origin" });
     return null;
   }
-  const target = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
-  if (!target || !path.isAbsolute(target)) {
+  const asked = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
+  if (!asked || !path.isAbsolute(asked)) {
     res.status(400).json({ error: "absolute path required" });
     return null;
   }
+  // Normalised first, then statted: the pair must describe ONE pathname (see `normalise`).
+  const target = opts.normalise ? opts.normalise(asked) : asked;
   try {
     return { path: target, isDir: statSync(target).isDirectory() };
   } catch {
-    res.status(404).json({ error: notFound });
+    res.status(404).json({ error: opts.notFound ?? "path not found" });
     return null;
   }
 }
@@ -46,7 +61,7 @@ export function resolvePathRequest(req: Request, res: Response, isAllowedOrigin:
 export function resolveDirRequest(req: Request, res: Response, isAllowedOrigin: OriginCheck): string | null {
   // The 404 text is this route's own: its callers have always been told "directory", and the
   // widening below must not change a message they may be showing.
-  const resolved = resolvePathRequest(req, res, isAllowedOrigin, "directory not found");
+  const resolved = resolvePathRequest(req, res, isAllowedOrigin, { notFound: "directory not found" });
   if (!resolved) return null;
   // Kept as its own message: these two routes have always said "directory", and a caller that
   // sent a file gets told which rule it broke rather than a 404 it cannot act on.

--- a/server/files/dirRequest.ts
+++ b/server/files/dirRequest.ts
@@ -4,32 +4,55 @@ import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 
-// Validate a POST { path } request that names a local directory: same-origin,
-// absolute, existing. Returns the directory, or null after sending the matching
-// error response — so the caller just does `const dir = resolveDirRequest(...); if (!dir) return;`.
-// Shared by the local-only /api/open-dir and /api/git-remote routes.
-export function resolveDirRequest(
-  req: Request,
-  res: Response,
-  isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean,
-): string | null {
+type OriginCheck = (origin: string | undefined, remoteAddress: string | undefined) => boolean;
+
+/** The same gate, for a route that accepts a FILE as well (#2039). `isDir` is what the caller
+ *  needs to decide between "open this folder" and "open its folder with this selected". */
+export interface ResolvedPath {
+  path: string;
+  isDir: boolean;
+}
+
+// Validate a POST { path } request that names an existing local path: same-origin, absolute,
+// existing. Returns it with its kind, or null after sending the matching error response.
+//
+// NOT contained to the workspace, deliberately and in line with the two routes that came before:
+// the server is local, the browser tab cannot touch the filesystem at all, and the threat this
+// guards is a random website driving the machine — which is what the same-origin check answers.
+// A tree rooted at a session's cwd already shows paths outside the workspace, so containing this
+// alone would refuse rows the pane is displaying.
+export function resolvePathRequest(req: Request, res: Response, isAllowedOrigin: OriginCheck, notFound = "path not found"): ResolvedPath | null {
   if (!requestOriginAllowed(req, isAllowedOrigin)) {
     res.status(403).json({ error: "forbidden origin" });
     return null;
   }
-  const dir = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
-  if (!dir || !path.isAbsolute(dir)) {
+  const target = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
+  if (!target || !path.isAbsolute(target)) {
     res.status(400).json({ error: "absolute path required" });
     return null;
   }
   try {
-    if (!statSync(dir).isDirectory()) {
-      res.status(400).json({ error: "not a directory" });
-      return null;
-    }
+    return { path: target, isDir: statSync(target).isDirectory() };
   } catch {
-    res.status(404).json({ error: "directory not found" });
+    res.status(404).json({ error: notFound });
     return null;
   }
-  return dir;
+}
+
+// Validate a POST { path } request that names a local directory: same-origin,
+// absolute, existing. Returns the directory, or null after sending the matching
+// error response — so the caller just does `const dir = resolveDirRequest(...); if (!dir) return;`.
+// Shared by the local-only /api/open-dir and /api/git-remote routes.
+export function resolveDirRequest(req: Request, res: Response, isAllowedOrigin: OriginCheck): string | null {
+  // The 404 text is this route's own: its callers have always been told "directory", and the
+  // widening below must not change a message they may be showing.
+  const resolved = resolvePathRequest(req, res, isAllowedOrigin, "directory not found");
+  if (!resolved) return null;
+  // Kept as its own message: these two routes have always said "directory", and a caller that
+  // sent a file gets told which rule it broke rather than a 404 it cannot act on.
+  if (!resolved.isDir) {
+    res.status(400).json({ error: "not a directory" });
+    return null;
+  }
+  return resolved.path;
 }

--- a/server/files/reveal-argv.ts
+++ b/server/files/reveal-argv.ts
@@ -1,0 +1,31 @@
+// The argv that shows a path in the OS file manager (#2039).
+//
+// Separate from the opener LIST, which is `openDirCommands()`'s: the same commands open a folder
+// on each platform, and only what they are handed differs. Pure so every platform can be asserted
+// on one machine — the branch that matters most is the one this machine cannot run.
+import path from "node:path";
+
+/** Windows has two spellings: `explorer` on win32, `explorer.exe` under WSL interop. */
+const isExplorer = (cmd: string): boolean => cmd === "explorer" || cmd === "explorer.exe";
+
+/**
+ * How `cmd` should be asked to show `target`.
+ *
+ * A FILE is revealed with its folder open and the file selected, which is what makes it draggable
+ * into a mail composer or an upload form. A DIRECTORY is opened, not selected in its parent —
+ * the row the user right-clicked is the folder they want in front of them.
+ *
+ * An argv ARRAY, never a command line: a filename carrying a quote, a space or a `;` is one
+ * argument here and cannot be reinterpreted as syntax. `/select,` is prefixed to the path rather
+ * than passed separately because that is the form Explorer parses — it is one token to it.
+ *
+ * `xdg-open` gets the containing directory instead: no Linux file manager has a portable "select
+ * this item", and landing next to the file is enough to drag it (the same call MulmoClaude makes,
+ * server/api/routes/files.ts `revealArgv`).
+ */
+export function revealArgv(cmd: string, target: string, isDir: boolean): string[] {
+  if (isDir) return [target];
+  if (cmd === "open") return ["-R", target];
+  if (isExplorer(cmd)) return [`/select,${target}`];
+  return [path.dirname(target)];
+}

--- a/server/files/reveal.ts
+++ b/server/files/reveal.ts
@@ -45,12 +45,15 @@ interface RevealOptions {
 
 export function mountRevealRoute(app: Express, { isAllowedOrigin, spawner = spawn }: RevealOptions): void {
   app.post("/api/files/reveal", async (req: Request, res) => {
-    const target = resolvePathRequest(req, res, isAllowedOrigin);
+    // `path.resolve` BEFORE the stat, not after. The browser joins a row onto the tree's root with
+    // `/` whatever the root looks like, so a Windows path arrives as `C:\\proj/reports/a.pdf` and
+    // `explorer /select,` is particular about separators — but resolving AFTERWARDS would validate
+    // one pathname and hand the OS another, because `path.resolve` folds `..` lexically while the
+    // kernel folds it through symlinks (Codex P2: `<root>/link/../adir` stats as a directory while
+    // its resolved spelling stats as a file). One string, validated and spawned.
+    const target = resolvePathRequest(req, res, isAllowedOrigin, { normalise: path.resolve });
     if (!target) return;
-    // The browser joins a row onto the tree's root with `/` whatever the root looks like, so a
-    // Windows path arrives as `C:\\proj/reports/a.pdf`. `explorer /select,` is particular about
-    // separators, and this is the side that knows which ones the host uses.
-    const native = path.resolve(target.path);
+    const native = target.path;
     const attempts: string[] = [];
     for (const candidate of openDirCommands(process.platform, isWsl(process.platform, process.env))) {
       // Translated BEFORE the argv is built: `/select,<path>` is one token, so a Windows opener

--- a/server/files/reveal.ts
+++ b/server/files/reveal.ts
@@ -1,0 +1,72 @@
+// POST /api/files/reveal { path } — show a file or folder in the OS file manager (#2039).
+//
+// Not for LOOKING at the file: it is how something the agent produced gets handed to another
+// app — dragged into a mail composer or an upload form — and how a file too big to paste gets
+// dropped into a folder the agent reads. A file lands selected; a folder simply opens.
+//
+// The route path, the `{ ok: true }` body and the 400/500 split are MulmoClaude's, whose
+// `/api/files/reveal` does the same job (src/config/apiRoutes.ts is its naming authority, and
+// server/api/routes/files.ts its implementation). Two divergences, both deliberate:
+//
+//   - WSL. MulmoClaude branches on `platform` alone; this host already knows that a WSL distro
+//     has no desktop of its own, so the opener list comes from `openDirCommands()` — the same
+//     `explorer.exe` → `xdg-open` fallback that stopped a silent no-op there (#1447).
+//   - Folders. MulmoClaude reveals files; a row here can be either, and a folder is OPENED
+//     rather than selected in its parent.
+import type { Express, Request } from "express";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { openDirCommands } from "./open-dir.js";
+import { resolvePathRequest } from "./dirRequest.js";
+import { revealArgv } from "./reveal-argv.js";
+import { isWsl, toWindowsPath } from "./wsl.js";
+
+/** Injected so a spec can assert the argv without a file manager appearing on the machine. */
+export type Spawner = typeof spawn;
+
+// Resolves null once the child is RUNNING, or the reason it could not start. The exit code is
+// deliberately not awaited — `explorer.exe` returns 1 on a perfectly successful open, and the
+// user is done with us the moment the window appears. Same reasoning as open-dir.ts.
+function spawnReveal(cmd: string, args: string[], spawner: Spawner): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawner(cmd, args, { detached: true, stdio: "ignore" });
+    child.on("error", (e) => resolve(e.message));
+    child.on("spawn", () => {
+      child.unref();
+      resolve(null);
+    });
+  });
+}
+
+interface RevealOptions {
+  isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
+  spawner?: Spawner;
+}
+
+export function mountRevealRoute(app: Express, { isAllowedOrigin, spawner = spawn }: RevealOptions): void {
+  app.post("/api/files/reveal", async (req: Request, res) => {
+    const target = resolvePathRequest(req, res, isAllowedOrigin);
+    if (!target) return;
+    // The browser joins a row onto the tree's root with `/` whatever the root looks like, so a
+    // Windows path arrives as `C:\\proj/reports/a.pdf`. `explorer /select,` is particular about
+    // separators, and this is the side that knows which ones the host uses.
+    const native = path.resolve(target.path);
+    const attempts: string[] = [];
+    for (const candidate of openDirCommands(process.platform, isWsl(process.platform, process.env))) {
+      // Translated BEFORE the argv is built: `/select,<path>` is one token, so a Windows opener
+      // has to be handed the Windows spelling inside it rather than beside it.
+      const asked = candidate.windowsPath ? await toWindowsPath(native) : native;
+      if (asked === null) {
+        attempts.push(`${candidate.cmd}: wslpath could not translate ${native}`);
+        continue;
+      }
+      const failure = await spawnReveal(candidate.cmd, revealArgv(candidate.cmd, asked, target.isDir), spawner);
+      if (failure === null) return res.json({ ok: true });
+      attempts.push(`${candidate.cmd}: ${failure}`);
+    }
+    // Answered only once an opener has actually STARTED. Saying ok first and logging the failure
+    // to a console nobody reads is what made a host without `xdg-open` report a reveal that never
+    // happened (#1447).
+    res.status(500).json({ error: `could not show ${target.path} [${attempts.join("; ")}]` });
+  });
+}

--- a/server/files/wsl.ts
+++ b/server/files/wsl.ts
@@ -38,8 +38,15 @@ const runWslpath: WslpathRunner = (args) => spawnCaptureAsync("wslpath", args, {
 async function convert(flag: string, value: string, run: WslpathRunner): Promise<string | null> {
   const { status, stdout } = await run([flag, value]);
   if (status !== 0) return null;
-  const converted = stdout.trim();
-  return converted.length > 0 ? converted : null;
+  // Exactly the line terminator `wslpath` writes, never `trim()`. A trailing space is a legal
+  // character in a filename on both sides, and trimming it translates one path and hands back
+  // another — the same trap `dirPathKey` set for a workspace whose name ended in a space (#1934)
+  // and `servedFileName` for a saved file (#2040). Reached here from every caller of
+  // toWindowsPath / toLinuxPath: reveal, open-dir and the file picker (Codex P3 on #2039).
+  const converted = stdout.replace(/\r?\n$/, "");
+  // Whitespace-only output is still no answer: `wslpath` printing blanks has told us nothing,
+  // and the callers take null as "this opener cannot express the path" rather than as a path.
+  return converted.trim().length > 0 ? converted : null;
 }
 
 /** `C:\proj` / `\\wsl.localhost\Ubuntu\home\me` → the path this process can open, or null. */

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -31,6 +31,7 @@ import { mountDirRoutes } from "../routes/dir-routes.js";
 import { mountGuiMcpRoutes } from "../routes/gui-mcp-routes.js";
 import { mountDropRoutes } from "../routes/drop-routes.js";
 import { mountOpenDirRoute } from "../files/open-dir.js";
+import { mountRevealRoute } from "../files/reveal.js";
 import { mountGitRemoteRoute } from "../git/gitRemote.js";
 import { mountWorktreeRoutes } from "../git/worktree-routes.js";
 import { mountPickFileRoute } from "../files/pick-file.js";
@@ -378,6 +379,9 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   // GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
   // OS file manager (a browser tab can't, but this local server can).
   mountOpenDirRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
+  // POST /api/files/reveal shows a file or folder in the OS file manager, so something the agent
+  // produced can be dragged into another app (#2039). Same local-only guard as the route above.
+  mountRevealRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
 
   // GRID-ONLY (dev_tool): POST /api/git-remote reports a cell dir's GitHub repository
   // URL (null if it isn't a GitHub repo), so the header can offer an "open on GitHub" link.

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -190,6 +190,9 @@ function menuPosition(actions: FilesRowAction[], x: number, y: number): { top: n
 function openRowMenu(node: Node, event: MouseEvent | KeyboardEvent): void {
   const actions = filesRowActions({
     pathRel: node.path,
+    // Decides the wording and what the file manager is asked to do: a folder is opened, a file
+    // is selected inside its own (#2039).
+    isDir: node.dir,
     cwd: props.cwd,
     terminal: insertTerminal.value,
     // The same pair the header's Canvas button is drawn from, so a row can never offer what that
@@ -272,8 +275,32 @@ function runRowAction(action: FilesRowAction): void {
   // The Canvas entry carries the row's path, not text for the terminal — and it goes out on the
   // SAME emit as the header button, relative to the tree's root, so the receiver resolves it once.
   if (action.id === "open-canvas") emit("open-in-canvas", action.pathRel);
+  // Not an emit: nothing above this pane takes part. The browser cannot open a file manager, so
+  // the local server does it (#2039) — the same shape as `writeBuffer` below.
+  else if (action.id === "reveal") void revealInFileManager(action.pathAbs);
   else emit("insert-text", action.text);
   closeRowMenu();
+}
+
+/** Show a path in the OS file manager (#2039).
+ *
+ *  Failures are SHOWN, not logged: a host with no file manager to call — a bare Linux box, WSL
+ *  with interop off — used to look exactly like a successful reveal, and nothing appeared (#1447).
+ *  Into `fileError` because that is this pane's own alert line (`role="alert"`); the message names
+ *  what failed, so it does not read as the open file's problem. */
+async function revealInFileManager(pathAbs: string): Promise<void> {
+  try {
+    const res = await fetchWithTimeout("/api/files/reveal", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: pathAbs }),
+    });
+    if (res.ok) return;
+    const body = await jsonBody(res);
+    fileError.value = typeof body.error === "string" && body.error.length > 0 ? body.error : `could not show ${pathAbs} (HTTP ${res.status})`;
+  } catch (e) {
+    fileError.value = `could not show ${pathAbs}: ${e instanceof Error ? e.message : String(e)}`;
+  }
 }
 
 onBeforeUnmount(() => closeRowMenu());

--- a/src/components/filesRowActions.ts
+++ b/src/components/filesRowActions.ts
@@ -23,6 +23,12 @@ export type FilesRowAction =
       text: string;
     })
   | (RowActionChrome & {
+      id: "reveal";
+      /** ABSOLUTE, because the route spawns an OS command and takes nothing else — unlike the
+       *  Canvas entry, whose receiver resolves against the pane's cwd. */
+      pathAbs: string;
+    })
+  | (RowActionChrome & {
       id: "open-canvas";
       /** RELATIVE to the tree's root, which is what `open-in-canvas` already carries from the
        *  pane's own button — the receiver resolves it against the pane's cwd, so an absolute one
@@ -33,6 +39,9 @@ export type FilesRowAction =
 export interface FilesRowTarget {
   /** The row's path, relative to the tree's root. */
   pathRel: string;
+  /** Whether the row is a directory. Decides both the wording and what the file manager is asked
+   *  to do — a folder is opened, a file is selected inside its own. */
+  isDir: boolean;
   /** The tree's root. */
   cwd: string | null;
   /** The terminal an insert goes to, or null where there is none — the full-screen Files view. */
@@ -53,6 +62,9 @@ const ICON = "attach_file";
 // the tree. The Canvas panel's own icon.
 const CANVAS_ICON = "space_dashboard";
 
+// The OS's own window, not ours — the same glyph the header uses for a cell's working directory.
+const REVEAL_ICON = "folder_open";
+
 // Compared without a trailing separator, because `absoluteUnder` JOINS without doubling one: a
 // root spelled `/proj/` builds the same absolute path as `/proj`, so it has to answer the same
 // here too. The two roots reach this function from different cells, so nothing guarantees one
@@ -66,7 +78,7 @@ const withoutTrailingSeparator = (dir: string): string => (dir.endsWith("/") || 
  * A LIST rather than two booleans so a later action (a text file's contents, say) is an entry
  * here and nothing else.
  */
-export function filesRowActions({ pathRel, cwd, terminal, canvas }: FilesRowTarget): FilesRowAction[] {
+export function filesRowActions({ pathRel, isDir, cwd, terminal, canvas }: FilesRowTarget): FilesRowAction[] {
   // No root means no path worth offering: the tree is on the server's default and its rows cannot
   // be resolved against anything the terminal — or the plugins' file layer — knows.
   if (pathRel === "" || cwd === null) return [];
@@ -81,6 +93,16 @@ export function filesRowActions({ pathRel, cwd, terminal, canvas }: FilesRowTarg
   if (canvas && canOpenInCanvas(absoluteUnder(cwd, pathRel), canvas.roots)) {
     actions.push({ id: "open-canvas", label: "Open in the Canvas", icon: CANVAS_ICON, pathRel });
   }
+  // Second: this is how a file LEAVES the app. Not for reading it — for dragging it into a mail
+  // composer or an upload form, or for dropping a file too big to paste into a folder the agent
+  // reads (#2039). Offered on every row, including in the full-screen view that has no terminal,
+  // because neither use needs one.
+  actions.push({
+    id: "reveal",
+    label: isDir ? "Open this folder" : "Show in folder",
+    icon: REVEAL_ICON,
+    pathAbs: absoluteUnder(cwd, pathRel),
+  });
   if (terminal === null) return actions;
   // Only when a relative path means the same thing at the other end. The pane keeps the cell it
   // is on when a re-root could not be saved out of, so the tree and the terminal on screen can

--- a/test/server/files/reveal-argv.spec.ts
+++ b/test/server/files/reveal-argv.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { revealArgv } from "../../../server/files/reveal-argv.js";
+
+// The point of the feature is DRAG AND DROP: the file has to end up selected in a window the user
+// can drag out of (#2039). Every platform is asserted here because the interesting branch is
+// always the one the developer's machine cannot run.
+describe("revealArgv", () => {
+  const FILE = "/work/ws/reports/2026-08.pdf";
+
+  it("selects the file on macOS", () => {
+    expect(revealArgv("open", FILE, false)).toEqual(["-R", FILE]);
+  });
+
+  // Explorer parses `/select,<path>` as ONE token; passing the flag separately opens the user's
+  // home folder instead of selecting anything.
+  it("selects the file on Windows, under both spellings of Explorer", () => {
+    expect(revealArgv("explorer", "C:\\work\\a.pdf", false)).toEqual(["/select,C:\\work\\a.pdf"]);
+    expect(revealArgv("explorer.exe", "C:\\work\\a.pdf", false)).toEqual(["/select,C:\\work\\a.pdf"]);
+  });
+
+  // No Linux file manager has a portable "select this item", so the folder is as close as it gets.
+  it("opens the containing folder on Linux, since it cannot select", () => {
+    expect(revealArgv("xdg-open", FILE, false)).toEqual(["/work/ws/reports"]);
+  });
+
+  // The row the user right-clicked IS the folder they want in front of them — revealing it would
+  // open its PARENT with the folder merely highlighted.
+  it("opens a directory itself on every platform, rather than selecting it in its parent", () => {
+    for (const cmd of ["open", "explorer", "explorer.exe", "xdg-open"]) {
+      expect(revealArgv(cmd, "/work/ws/reports", true)).toEqual(["/work/ws/reports"]);
+    }
+  });
+
+  // An argv array, never a command line: these are one argument each and reach the file manager
+  // intact. A shell would have read the first as two words and the second as a statement end.
+  it.each(['/work/a file with "quotes".pdf', "/work/a;rm -rf x.pdf", "/work/$(whoami).pdf", "/work/a\nb.pdf"])(
+    "passes %j through as a single argument",
+    (name) => {
+      expect(revealArgv("open", name, false)).toEqual(["-R", name]);
+      expect(revealArgv("explorer", name, false)).toEqual([`/select,${name}`]);
+      expect(revealArgv("xdg-open", name, false)).toEqual([path.dirname(name)]);
+    },
+  );
+
+  // An opener this module has not heard of is treated as "cannot select" rather than handed a
+  // flag it would print usage for. The list comes from `openDirCommands`, so this is the two
+  // halves of the pair disagreeing — which is exactly when a silent wrong answer is worst.
+  it("falls back to the containing folder for an opener it does not know", () => {
+    expect(revealArgv("nautilus", FILE, false)).toEqual(["/work/ws/reports"]);
+  });
+});

--- a/test/server/files/reveal.spec.ts
+++ b/test/server/files/reveal.spec.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import { EventEmitter } from "node:events";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { appRequest } from "../../helpers/appRequest.js";
+import { mountRevealRoute, type Spawner } from "../../../server/files/reveal.js";
+import { makeTempDir } from "../../support/tempDir";
+import { isRecord } from "../../../common/isRecord.js";
+
+// The route that hands a produced file to another app (#2039): it opens the OS file manager, so
+// the spawn is INJECTED — a real one would put a Finder window on the machine running the suite,
+// and the thing worth asserting is the argv, not that a window appeared.
+let dir: string;
+let file: string;
+
+/** A child that reports a successful start, like a file manager that came up. */
+function fakeChild(event: "spawn" | "error", message = ""): EventEmitter & { unref: () => void } {
+  const child = Object.assign(new EventEmitter(), { unref: () => {} });
+  // After the listeners are attached, which happens synchronously in the route.
+  setImmediate(() => child.emit(event, event === "error" ? new Error(message) : undefined));
+  return child;
+}
+
+interface Call {
+  cmd: string;
+  args: string[];
+}
+
+function mount(outcome: (call: Call) => "spawn" | "error"): { request: ReturnType<typeof appRequest>; calls: Call[] } {
+  const calls: Call[] = [];
+  const spawner = ((cmd: string, args: string[]) => {
+    calls.push({ cmd, args });
+    return fakeChild(outcome({ cmd, args }), "no such file or directory");
+  }) as unknown as Spawner;
+  const app = express();
+  app.use(express.json());
+  mountRevealRoute(app, { isAllowedOrigin: () => true, spawner });
+  return { request: appRequest(app), calls };
+}
+
+beforeAll(() => {
+  dir = makeTempDir("mt-reveal-");
+  mkdirSync(path.join(dir, "reports"), { recursive: true });
+  file = path.join(dir, "reports", "2026-08.pdf");
+  writeFileSync(file, "%PDF-1.4\n");
+});
+
+const post = (request: ReturnType<typeof appRequest>, body: unknown) =>
+  request("/api/files/reveal", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+describe("POST /api/files/reveal", () => {
+  it("spawns the platform opener and answers ok", async () => {
+    const { request, calls } = mount(() => "spawn");
+    const res = await post(request, { path: file });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    // The argv itself is `revealArgv`'s contract, pinned per platform in its own spec. What this
+    // asserts is that the route asked for the FILE's form rather than the directory's.
+    expect(calls[0]?.args).not.toEqual([file]);
+    expect(calls[0]?.args.join(" ")).toContain(file);
+  });
+
+  it("opens a directory as itself", async () => {
+    const { request, calls } = mount(() => "spawn");
+    expect((await post(request, { path: path.join(dir, "reports") })).status).toBe(200);
+    expect(calls[0]?.args).toEqual([path.join(dir, "reports")]);
+  });
+
+  it("400s without a path", async () => {
+    const { request } = mount(() => "spawn");
+    expect((await post(request, {})).status).toBe(400);
+  });
+
+  it("400s on a relative path", async () => {
+    const { request } = mount(() => "spawn");
+    expect((await post(request, { path: "reports/2026-08.pdf" })).status).toBe(400);
+  });
+
+  it("404s on a path that is not there", async () => {
+    const { request } = mount(() => "spawn");
+    const res = await post(request, { path: path.join(dir, "nope.pdf") });
+    expect(res.status).toBe(404);
+  });
+
+  // The gate that stops a random website driving the machine — the same one /api/open-dir uses.
+  it("403s a disallowed origin, before spawning anything", async () => {
+    const calls: Call[] = [];
+    const app = express();
+    app.use(express.json());
+    mountRevealRoute(app, {
+      isAllowedOrigin: () => false,
+      spawner: ((cmd: string, args: string[]) => {
+        calls.push({ cmd, args });
+        return fakeChild("spawn");
+      }) as unknown as Spawner,
+    });
+    const res = await post(appRequest(app), { path: file });
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  // #1447: a host with no file manager used to look exactly like a successful reveal — the route
+  // said ok and nothing appeared. The answer has to wait for an opener to actually start.
+  it("reports 500 when no opener starts, naming what it tried", async () => {
+    const { request, calls } = mount(() => "error");
+    const res = await post(request, { path: file });
+    expect(res.status).toBe(500);
+    const body: unknown = await res.json();
+    expect(String(isRecord(body) ? body.error : "")).toContain(calls[0]?.cmd ?? "");
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // The browser joins a row onto the tree's root with `/` whatever the root looks like, so the
+  // path arrives with the separators of neither side in particular. `explorer /select,` is
+  // particular about them, and this is the side that knows which the host uses.
+  it("straightens the separators before handing the path to the file manager", async () => {
+    const { request, calls } = mount(() => "spawn");
+    const messy = path.join(dir, "reports") + "/./2026-08.pdf";
+    expect((await post(request, { path: messy })).status).toBe(200);
+    expect(calls[0]?.args.join(" ")).toContain(path.resolve(messy));
+    expect(calls[0]?.args.join(" ")).not.toContain("/./");
+  });
+});

--- a/test/server/files/reveal.spec.ts
+++ b/test/server/files/reveal.spec.ts
@@ -2,11 +2,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import express from "express";
 import { EventEmitter } from "node:events";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { appRequest } from "../../helpers/appRequest.js";
 import { mountRevealRoute, type Spawner } from "../../../server/files/reveal.js";
+import { revealArgv } from "../../../server/files/reveal-argv.js";
 import { makeTempDir } from "../../support/tempDir";
+import { canSymlink } from "../../support/canSymlink";
 import { isRecord } from "../../../common/isRecord.js";
 
 // The route that hands a produced file to another app (#2039): it opens the OS file manager, so
@@ -57,10 +59,12 @@ describe("POST /api/files/reveal", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
     expect(calls).toHaveLength(1);
-    // The argv itself is `revealArgv`'s contract, pinned per platform in its own spec. What this
-    // asserts is that the route asked for the FILE's form rather than the directory's.
-    expect(calls[0]?.args).not.toEqual([file]);
-    expect(calls[0]?.args.join(" ")).toContain(file);
+    // Composed against `revealArgv` rather than spelled out: WHICH argv each platform wants is
+    // that function's contract, pinned per platform in its own spec, and on Linux the file is
+    // deliberately reduced to its folder (there is no portable "select this item"). Asserting a
+    // literal here passed on macOS and Windows and went red on Linux — the route's own job is to
+    // pass the RESOLVED path and the right `isDir`, which is what this now checks.
+    expect(calls[0]?.args).toEqual(revealArgv(calls[0]?.cmd ?? "", file, false));
   });
 
   it("opens a directory as itself", async () => {
@@ -120,7 +124,53 @@ describe("POST /api/files/reveal", () => {
     const { request, calls } = mount(() => "spawn");
     const messy = path.join(dir, "reports") + "/./2026-08.pdf";
     expect((await post(request, { path: messy })).status).toBe(200);
-    expect(calls[0]?.args.join(" ")).toContain(path.resolve(messy));
+    expect(calls[0]?.args).toEqual(revealArgv(calls[0]?.cmd ?? "", path.resolve(messy), false));
     expect(calls[0]?.args.join(" ")).not.toContain("/./");
+  });
+
+  // The security property this route rests on, stated where both halves meet: the guard requires
+  // an ABSOLUTE path, and every absolute spelling on every platform begins with `/`, `\\` or a
+  // drive letter — so the argument DERIVED from the path can never begin with `-`. `open -R -foo`
+  // reading its own target as a flag is therefore not reachable, and it stays that way only while
+  // the absolute-path check does. (Observed during Claude review, not flagged by Codex.)
+  it("can never hand the opener an argument that looks like a flag", async () => {
+    const { request, calls } = mount(() => "spawn");
+    const dashed = path.join(dir, "reports", "-R.pdf");
+    writeFileSync(dashed, "%PDF-1.4\n");
+    expect((await post(request, { path: dashed })).status).toBe(200);
+    // The LAST argument is the one derived from the path, in all three shapes (`["-R", p]`,
+    // [`/select,${p}`], `[dirname]`). Any earlier one is a flag WE chose, fixed in the source.
+    expect(calls[0]?.args.at(-1)?.startsWith("-")).toBe(false);
+    // And the relative spelling that COULD produce one is refused before any spawn.
+    const before = calls.length;
+    expect((await post(request, { path: "-R.pdf" })).status).toBe(400);
+    expect(calls).toHaveLength(before);
+  });
+
+  // `path.resolve` folds `..` LEXICALLY; the kernel folds it through symlinks. So a path carrying
+  // a literal `..` after a symlinked directory names one file to `statSync` and a different one to
+  // `path.resolve` — measured on this fixture: `<root>/link/../adir` stats as a DIRECTORY and its
+  // resolved spelling stats as a FILE. Validating one and spawning the other is what this pins
+  // shut: the route normalises BEFORE the guard stats, so both are the same string (Codex P2).
+  //
+  // `runIf(canSymlink)`: Windows needs Developer Mode to make one, and a fixture that was never
+  // created reads as broken behaviour rather than as untestable (docs/windows-gotchas.md).
+  it.runIf(canSymlink)("validates the same pathname it hands to the file manager", async () => {
+    const { request, calls } = mount(() => "spawn");
+    const root = makeTempDir("mt-reveal-sym-");
+    mkdirSync(path.join(root, "deep", "sub"), { recursive: true });
+    mkdirSync(path.join(root, "deep", "adir"));
+    writeFileSync(path.join(root, "adir"), "a FILE where the lexical fold lands");
+    symlinkSync(path.join(root, "deep", "sub"), path.join(root, "link"));
+
+    // Built by concatenation: `path.join` would fold the `..` before the route ever saw it.
+    const asked = root + "/link/../adir";
+    expect(statSync(asked).isDirectory()).toBe(true); // what the kernel reaches
+    expect(statSync(path.resolve(asked)).isDirectory()).toBe(false); // what `path.resolve` names
+
+    expect((await post(request, { path: asked })).status).toBe(200);
+    // The spawned path is the resolved one, and it was treated as the FILE it actually is there —
+    // not as the directory the unresolved spelling would have claimed.
+    expect(calls[0]?.args).toEqual(revealArgv(calls[0]?.cmd ?? "", path.resolve(asked), false));
   });
 });

--- a/test/server/files/reveal.spec.ts
+++ b/test/server/files/reveal.spec.ts
@@ -165,12 +165,18 @@ describe("POST /api/files/reveal", () => {
 
     // Built by concatenation: `path.join` would fold the `..` before the route ever saw it.
     const asked = root + "/link/../adir";
-    expect(statSync(asked).isDirectory()).toBe(true); // what the kernel reaches
-    expect(statSync(path.resolve(asked)).isDirectory()).toBe(false); // what `path.resolve` names
+    const lexical = path.resolve(asked);
+    // MEASURED, not assumed. On POSIX the kernel follows `link` and only then folds `..`, so this
+    // names a DIRECTORY while `path.resolve` names the FILE beside it — the mismatch Codex found.
+    // Win32 folds `..` lexically in the path API itself, before the reparse point, so the two
+    // agree there and the mismatch cannot arise at all. Asserting the divergence unconditionally
+    // is what turned this test red on Windows CI while passing on macOS.
+    const diverges = statSync(asked).isDirectory() !== statSync(lexical).isDirectory();
+    expect(diverges).toBe(process.platform !== "win32");
 
     expect((await post(request, { path: asked })).status).toBe(200);
-    // The spawned path is the resolved one, and it was treated as the FILE it actually is there —
-    // not as the directory the unresolved spelling would have claimed.
-    expect(calls[0]?.args).toEqual(revealArgv(calls[0]?.cmd ?? "", path.resolve(asked), false));
+    // The invariant, which holds on both: whatever the guard statted is what gets spawned. The
+    // route normalises BEFORE the stat, so `isDir` describes `lexical` and not the other one.
+    expect(calls[0]?.args).toEqual(revealArgv(calls[0]?.cmd ?? "", lexical, statSync(lexical).isDirectory()));
   });
 });

--- a/test/server/files/wsl.spec.ts
+++ b/test/server/files/wsl.spec.ts
@@ -83,4 +83,19 @@ describe("isWsl with an empty variable", () => {
   it("is still false when both are empty on an ordinary kernel", () => {
     expect(isWsl("linux", { WSL_DISTRO_NAME: "", WSL_INTEROP: "" }, "6.8.0-45-generic")).toBe(false);
   });
+
+  // A trailing space is a legal filename character on both sides of the translation, and `trim()`
+  // took it — so a file named `a ` was revealed as `a`, a different path (Codex P3 on #2039).
+  // The same class as #1934 and #2040: whitespace at the edge of a name is part of the name.
+  it("keeps a trailing space in the name, dropping only wslpath's own line terminator", async () => {
+    await expect(toWindowsPath("/home/me/a ", answers(0, "C:\\x\\a \n"))).resolves.toBe("C:\\x\\a ");
+    await expect(toWindowsPath("/home/me/a ", answers(0, "C:\\x\\a \r\n"))).resolves.toBe("C:\\x\\a ");
+    await expect(toLinuxPath("C:\\x\\a ", answers(0, "/mnt/c/x/a \n"))).resolves.toBe("/mnt/c/x/a ");
+  });
+
+  // Only ONE terminator: a blank line after the path is content, not punctuation, and guessing
+  // which trailing newlines are ours is how the first version lost a space.
+  it("drops one line terminator, not every trailing blank line", async () => {
+    await expect(toWindowsPath("/x", answers(0, "C:\\x\n\n"))).resolves.toBe("C:\\x\n");
+  });
 });

--- a/test/src/components/filesRowActions.spec.ts
+++ b/test/src/components/filesRowActions.spec.ts
@@ -5,11 +5,15 @@ import { filesRowActions, menuFocusMove } from "../../../src/components/filesRow
 // meaning something DIFFERENT at the other end than it does in the tree, which is why it is a
 // pure function rather than an assertion about a menu.
 
-const ids = (...args: Parameters<typeof filesRowActions>) => filesRowActions(...args).map((a) => a.id);
+// `isDir: false` by default: every case written before #2039 is a file row, and spelling it at
+// each call would say nothing. The folder rows have their own describe below.
+type Target = Omit<Parameters<typeof filesRowActions>[0], "isDir"> & { isDir?: boolean };
+const call = (t: Target) => filesRowActions({ isDir: false, ...t });
+const ids = (t: Target) => call(t).map((a) => a.id);
 // Narrowed rather than asserted: only the insert entries carry text, which is the whole point of
 // the union — the Canvas one has a path instead.
-const textOf = (id: string, ...args: Parameters<typeof filesRowActions>) => {
-  const action = filesRowActions(...args).find((a) => a.id === id);
+const textOf = (id: string, t: Target) => {
+  const action = call(t).find((a) => a.id === id);
   return action && "text" in action ? action.text : undefined;
 };
 
@@ -21,19 +25,19 @@ describe("filesRowActions — the Canvas entry", () => {
   const inProject = { cwd: "/proj", terminal: { cwd: "/proj" }, canvas: { roots: { workspaces: [WORKSPACE], roots: [] } } };
 
   it("offers it on a file a plugin can render, before the inserts", () => {
-    expect(ids({ ...inProject, pathRel: "notes/talk.md" })).toEqual(["open-canvas", "insert-relative", "insert-absolute"]);
+    expect(ids({ ...inProject, pathRel: "notes/talk.md" })).toEqual(["open-canvas", "reveal", "insert-relative", "insert-absolute"]);
     expect(ids({ ...inProject, pathRel: "site/page.html" })[0]).toBe("open-canvas");
   });
 
   // RELATIVE, because `open-in-canvas` already carries that from the pane's own button and the
   // receiver resolves it against the pane's cwd — an absolute one would be resolved twice.
   it("carries the row's path relative to the tree root", () => {
-    const action = filesRowActions({ ...inProject, pathRel: "notes/talk.md" }).find((a) => a.id === "open-canvas");
+    const action = call({ ...inProject, pathRel: "notes/talk.md" }).find((a) => a.id === "open-canvas");
     expect(action).toEqual({ id: "open-canvas", label: "Open in the Canvas", icon: "space_dashboard", pathRel: "notes/talk.md" });
   });
 
   it("offers nothing extra on a file no plugin renders", () => {
-    expect(ids({ ...inProject, pathRel: "src/index.ts" })).toEqual(["insert-relative", "insert-absolute"]);
+    expect(ids({ ...inProject, pathRel: "src/index.ts" })).toEqual(["reveal", "insert-relative", "insert-absolute"]);
   });
 
   // A story in the WORKSPACE's own stories directory travels as `stories/…`; a project's own copy
@@ -60,13 +64,13 @@ describe("filesRowActions — the Canvas entry", () => {
 
   // The full-screen Files view mounts the same pane with no cell to put a Canvas beside.
   it("offers nothing where there is no cell to draw beside", () => {
-    expect(ids({ ...inProject, pathRel: "notes/talk.md", canvas: null })).toEqual(["insert-relative", "insert-absolute"]);
+    expect(ids({ ...inProject, pathRel: "notes/talk.md", canvas: null })).toEqual(["reveal", "insert-relative", "insert-absolute"]);
   });
 
   // The two halves are independent: the pane can trail a cell after a declined re-root, which is
   // why the pane keeps `canvasTarget` and `insertTarget` as separate props.
   it("stands alone when there is no terminal to insert into", () => {
-    expect(ids({ ...inProject, pathRel: "notes/talk.md", terminal: null })).toEqual(["open-canvas"]);
+    expect(ids({ ...inProject, pathRel: "notes/talk.md", terminal: null })).toEqual(["open-canvas", "reveal"]);
   });
 });
 
@@ -74,7 +78,7 @@ describe("filesRowActions", () => {
   const here = { pathRel: "src/index.ts", cwd: "/proj", terminal: { cwd: "/proj" }, canvas: null };
 
   it("offers both paths when the tree and the terminal are the same directory", () => {
-    expect(ids(here)).toEqual(["insert-relative", "insert-absolute"]);
+    expect(ids(here)).toEqual(["reveal", "insert-relative", "insert-absolute"]);
     expect(textOf("insert-relative", here)).toBe("src/index.ts ");
     expect(textOf("insert-absolute", here)).toBe("/proj/src/index.ts ");
   });
@@ -84,12 +88,12 @@ describe("filesRowActions", () => {
   // in the wrong one — and it would exist, which is what makes this worth withholding.
   it("withholds the relative path when the terminal is in another directory", () => {
     const elsewhere = { ...here, terminal: { cwd: "/other" } };
-    expect(ids(elsewhere)).toEqual(["insert-absolute"]);
+    expect(ids(elsewhere)).toEqual(["reveal", "insert-absolute"]);
     expect(textOf("insert-absolute", elsewhere)).toBe("/proj/src/index.ts ");
   });
 
   it("offers nothing where there is no terminal to insert into", () => {
-    expect(ids({ ...here, terminal: null })).toEqual([]);
+    expect(ids({ ...here, terminal: null })).toEqual(["reveal"]);
   });
 
   // Both are unreachable from the grid, which always has a root — but the pane takes `cwd: null`
@@ -128,14 +132,14 @@ describe("filesRowActions", () => {
   // `absoluteUnder` already builds the SAME absolute path from either, so the equality test has
   // to agree with it. Both asymmetries, since only one of them is the obvious way round.
   it("reads a root with and without a trailing separator as the same directory", () => {
-    expect(ids({ ...here, cwd: "/proj/", terminal: { cwd: "/proj" } })).toEqual(["insert-relative", "insert-absolute"]);
-    expect(ids({ ...here, cwd: "/proj", terminal: { cwd: "/proj/" } })).toEqual(["insert-relative", "insert-absolute"]);
-    expect(ids({ ...here, cwd: "C:\\proj\\", terminal: { cwd: "C:\\proj" } })).toEqual(["insert-relative", "insert-absolute"]);
+    expect(ids({ ...here, cwd: "/proj/", terminal: { cwd: "/proj" } })).toEqual(["reveal", "insert-relative", "insert-absolute"]);
+    expect(ids({ ...here, cwd: "/proj", terminal: { cwd: "/proj/" } })).toEqual(["reveal", "insert-relative", "insert-absolute"]);
+    expect(ids({ ...here, cwd: "C:\\proj\\", terminal: { cwd: "C:\\proj" } })).toEqual(["reveal", "insert-relative", "insert-absolute"]);
   });
 
   // ...without collapsing two directories that only LOOK alike after the trim.
   it("still tells two different directories apart", () => {
-    expect(ids({ ...here, cwd: "/proj/", terminal: { cwd: "/project" } })).toEqual(["insert-absolute"]);
+    expect(ids({ ...here, cwd: "/proj/", terminal: { cwd: "/project" } })).toEqual(["reveal", "insert-absolute"]);
   });
 });
 
@@ -167,5 +171,56 @@ describe("menuFocusMove", () => {
   it("stays put in a one-item menu", () => {
     expect(menuFocusMove("ArrowDown", 0, 1)).toBe(0);
     expect(menuFocusMove("ArrowUp", 0, 1)).toBe(0);
+  });
+});
+
+// The entry that hands a file to ANOTHER app (#2039): dragged into a mail composer or an upload
+// form, or a file too big to paste dropped into a folder the agent reads. Not for reading it —
+// which is why it is offered where the Canvas entry is not, and where there is no terminal.
+describe("filesRowActions — showing a row in the OS file manager", () => {
+  const here = { cwd: "/proj", terminal: { cwd: "/proj" }, canvas: null };
+  const reveal = (t: Parameters<typeof ids>[0]) => call(t).find((a) => a.id === "reveal");
+
+  // ABSOLUTE: the route spawns an OS command and takes nothing else. The Canvas entry is relative
+  // for the opposite reason — its receiver resolves against the pane's cwd.
+  it("carries the row's absolute path", () => {
+    expect(reveal({ ...here, pathRel: "reports/2026-08.pdf" })).toEqual({
+      id: "reveal",
+      label: "Show in folder",
+      icon: "folder_open",
+      pathAbs: "/proj/reports/2026-08.pdf",
+    });
+  });
+
+  // The row the user right-clicked IS the folder they want in front of them, so the wording says
+  // so — "Show in folder" would promise its parent.
+  it("says something different on a folder row", () => {
+    const action = reveal({ ...here, pathRel: "reports", isDir: true });
+    expect(action?.label).toBe("Open this folder");
+    expect(action).toMatchObject({ pathAbs: "/proj/reports" });
+  });
+
+  // Both uses — sending a file on, and dropping one where the agent will read it — work in the
+  // full-screen view, which has no terminal to insert into.
+  it("is offered where there is no terminal, unlike the inserts", () => {
+    expect(ids({ ...here, pathRel: "reports/2026-08.pdf", terminal: null })).toEqual(["reveal"]);
+  });
+
+  // The early return still governs: without a root the row's path resolves to nothing, and an
+  // absolute path is exactly what this entry needs.
+  it("is withheld when the tree has no root", () => {
+    expect(ids({ ...here, pathRel: "reports/2026-08.pdf", cwd: null })).toEqual([]);
+  });
+
+  it("joins a root that already ends in a separator without doubling it", () => {
+    expect(reveal({ ...here, cwd: "/proj/", pathRel: "a.pdf" })?.pathAbs).toBe("/proj/a.pdf");
+  });
+
+  // `absoluteUnder` joins with `/` whatever the root looks like, so a Windows root comes out with
+  // MIXED separators — pinned here because it is what the route receives, and `explorer /select,`
+  // is particular about them. Straightening it is the SERVER's job (it is the side that knows the
+  // platform); see `server/files/reveal.ts`.
+  it("hands a Windows root over with mixed separators, for the server to straighten", () => {
+    expect(reveal({ ...here, cwd: "C:\\proj", pathRel: "reports/a.pdf" })?.pathAbs).toBe("C:\\proj/reports/a.pdf");
   });
 });

--- a/test/src/components/filesRowMenu.spec.ts
+++ b/test/src/components/filesRowMenu.spec.ts
@@ -65,7 +65,7 @@ describe("the files tree's row menu", () => {
     rightClick(w.findAll('[data-testid="files-row"]')[0].element);
     await flushPromises();
 
-    expect(labels()).toEqual(["Insert relative path", "Insert absolute path"]);
+    expect(labels()).toEqual(["Show in folder", "Insert relative path", "Insert absolute path"]);
     item("insert-relative")?.click();
     await flushPromises();
     expect(w.emitted("insert-text")).toEqual([["README.md "]]);
@@ -89,7 +89,7 @@ describe("the files tree's row menu", () => {
     rightClick(w.findAll('[data-testid="files-row"]')[0].element); // README.md
     await flushPromises();
 
-    expect(labels()).toEqual(["Open in the Canvas", "Insert relative path", "Insert absolute path"]);
+    expect(labels()).toEqual(["Open in the Canvas", "Show in folder", "Insert relative path", "Insert absolute path"]);
     item("open-canvas")?.click();
     await flushPromises();
     expect(w.emitted("open-in-canvas")).toEqual([["README.md"]]);
@@ -97,23 +97,26 @@ describe("the files tree's row menu", () => {
     expect(menu()).toBeNull();
   });
 
-  // A directory is not something a plugin renders, so the row keeps the two inserts it had.
+  // A directory is not something a plugin renders, so the row keeps the two inserts it had. Its
+  // file-manager entry words itself for a folder — "Show in folder" would promise its parent.
   it("does not offer the Canvas on a row nothing can render", async () => {
     const w = await mountPane({ canvasTarget: true, workspace: "/ws" });
     rightClick(w.findAll('[data-testid="files-row"]')[1].element); // src/
     await flushPromises();
-    expect(labels()).toEqual(["Insert relative path", "Insert absolute path"]);
+    expect(labels()).toEqual(["Open this folder", "Insert relative path", "Insert absolute path"]);
   });
 
-  // The full-screen view mounts the same pane with no terminal beside it. Swallowing the
-  // right-click there would cost the user the browser's own menu for nothing.
-  it("leaves the browser's menu alone where there is no terminal to insert into", async () => {
+  // The full-screen view mounts the same pane with no terminal beside it, and until #2039 the
+  // menu was empty there — so the right-click was left to the browser rather than swallowed for
+  // nothing. Showing a row in the file manager needs no terminal, and is most useful exactly
+  // there: it is how a produced file is handed to another app.
+  it("still opens where there is no terminal, now that one entry needs none", async () => {
     const w = await mountPane({ insertTarget: false });
     const event = rightClick(w.findAll('[data-testid="files-row"]')[0].element);
     await flushPromises();
 
-    expect(menu()).toBeNull();
-    expect(event.defaultPrevented).toBe(false);
+    expect(labels()).toEqual(["Show in folder"]);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("drops the relative path when the terminal is in another directory", async () => {
@@ -121,7 +124,7 @@ describe("the files tree's row menu", () => {
     rightClick(w.findAll('[data-testid="files-row"]')[0].element);
     await flushPromises();
 
-    expect(labels()).toEqual(["Insert absolute path"]);
+    expect(labels()).toEqual(["Show in folder", "Insert absolute path"]);
   });
 
   it("opens from the keyboard, on both spellings of the menu key", async () => {
@@ -146,12 +149,18 @@ describe("the files tree's row menu", () => {
     const row = w.findAll('[data-testid="files-row"]')[0];
     await row.trigger("keydown", { key: "F10", shiftKey: true });
     await flushPromises();
-    expect(document.activeElement).toBe(item("insert-relative"));
+    // The first item, which since #2039 is the file-manager entry rather than an insert.
+    expect(document.activeElement).toBe(item("reveal"));
 
+    menu()?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(document.activeElement).toBe(item("insert-relative"));
     menu()?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(document.activeElement).toBe(item("insert-absolute"));
     menu()?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
-    expect(document.activeElement).toBe(item("insert-relative")); // wraps
+    expect(document.activeElement).toBe(item("reveal")); // wraps
+
+    menu()?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(document.activeElement).toBe(item("insert-relative"));
 
     (document.activeElement as HTMLElement).click(); // what Enter does on a button
     await flushPromises();


### PR DESCRIPTION
## Summary

ファイルツリーの行を右クリックして、OS のファイルマネージャで開けるようにします (#2039)。
**中身を見るためではなく、ファイルを人や別のアプリに渡すため**の導線です。

- **ファイルの行** → `Show in folder` — 選択された状態で親フォルダが開く（そのままドラッグできる）
- **フォルダの行** → `Open this folder` — そのフォルダが開く

## MulmoClaude を参照実装にしました

CLAUDE.md の規則どおり `../mulmoclaude` の同機能（#1985 → PR #2016）に合わせています。

| | MulmoClaude | 本 PR |
| --- | --- | --- |
| ルートパス | `/api/files/reveal`（`src/config/apiRoutes.ts:142` が命名の正）| 同じ |
| 成功 / 引数不足 / 起動失敗 | `200 {ok:true}` / `400` / `500` | 同じ |
| 文言 | `"Show in folder"`（`src/lang/en.ts:529`）| ファイル行は同じ |
| argv | darwin `open -R` / win32 `explorer.exe /select,` / 他 `xdg-open <dirname>` | 同じ |

**意図的に違えた 2 点**:

1. **WSL を見ます。** MulmoClaude の `revealArgv` は `platform` だけで分岐しますが、この host は
   既に `openDirCommands()` で WSL を特別扱いしています（distro に `xdg-open` が無い / 見えない
   Linux アプリが開く、#1447）。**候補リストをそのまま再利用**して `explorer.exe` → `xdg-open`
   のフォールバックを保ちました。
2. **フォルダの行にも出します。** MulmoClaude の reveal はファイル用です。ツリーの行はどちらにも
   なり得るので、フォルダは「選択」ではなく「開く」にし、文言も変えました（`Show in folder` は
   フォルダ行だと親フォルダを約束してしまいます）。

## 検証 — 実ブラウザで端から端まで

Chromium で実際に右クリックし、`open` を差し替えて**実 argv を記録**しました。

```
フォルダ行を右クリック → ["folder_open Open this folder"] → クリック
ファイル行を右クリック → ["folder_open Show in folder"]   → クリック

実際に走った argv:
  open -R /…/revws/reports/2026-08.pdf     ← ファイル（選択される）
  open    /…/revws/reports                 ← フォルダ（開く）
```

反転 mutation がそれぞれ赤くなります。当初の 5 種: ファイルも選択しない（9 件）/ フォルダも
選択する（2 件）/ `/select,` を別引数に（5 件）/ サーバの正規化を外す（1 件）/ 行の種類を
無視（1 件）。レビュー後に足した 4 種: 正規化を stat の後ろに戻す（1 件）/ WSL を `trim()` に
戻す（2 件）/ 空白だけの出力を通す（1 件）/ 既存ルートの 404 文言を変える（1 件）。

## codex-cross-review で変わったところ

tier C で 2 ラウンド。round 1 が `CHANGES REQUESTED`（P2 × 1・P3 × 1）、round 2 が
**全 11 軸 "none" の `LGTM`**。詳細は下のレビューコメントに全文があります。

- **P2 — 検証したパスと OS に渡すパスが別物になり得た。** 正規化を stat の**前**へ移動。
  実測: `<root>/link/../adir` は stat では directory、`path.resolve` 先では file。
- **P3 — WSL のパス変換が名前末尾の空白を落としていた。** `stdout.trim()` → 改行だけを落とす形へ。
  **#1934・#2040 と同じクラス**で、このリポジトリが 3 回目に踏んだもの。Codex が挙げた 4 サイト
  全部に効きます。
- **CI が 1 件** — ルートの spec がプラットフォーム依存で ubuntu だけ赤。**Linux は `xdg-open` に
  親ディレクトリを渡すのが正しい**（可搬な「選択」が無い）。`revealArgv` との合成を assert する
  形に書き直しました。macOS と Windows では緑だったので、ローカルでは見えない類です。
- **自分で 1 件** — 入力由来の引数が `-` で始まり得ないことを spec で固定（絶対パス必須なので
  構造的に不可能）。

## Items to Confirm / Review

1. **サーバで `path.resolve` してから、その結果を stat します（順序が肝心です）。** ブラウザは行を
   ツリーの root に `/` で繋ぐので、Windows では `C:\proj/reports/a.pdf` のように**区切りが
   混ざって**届きます。`explorer /select,` は区切りにうるさく、どちらを使うかを知っているのは
   サーバ側です。**これは自分で書いたテストが `C:\proj/a.pdf` を出したことで気づきました。**

   最初は **stat の後**に正規化していて、Codex の P2 で直しました（`path.resolve` は `..` を
   字句的に、カーネルは symlink を辿って畳むので、**検証したパスと OS に渡すパスが別物**に
   なり得た）。**共有ガードには resolve を足していません** — `/api/open-dir` と
   `/api/git-remote` は検証した文字列をそのまま spawn していて既に整合しており、resolve すると
   カーネルが到達する側ではなく字句的な側を開いてしまいます。Codex もこの据え置きを
   round 2 で支持しています。
2. **ワークスペースへの封じ込めはしていません。** 既存の `/api/open-dir` にも無く、脅威モデルは
   「他所のサイトに叩かれないこと」で same-origin が担っています。セッションの cwd を root に
   したツリーは既にワークスペース外を表示しているので、ここだけ厳しくすると**表示中の行を拒む**
   ことになります。判断が要るところなので明示します。
3. **挙動が変わるところが 1 つあります。** ターミナルが無いフルスクリーンの Files ビューでは、
   これまでメニューが空だったので右クリックはブラウザに任せていました。この項目はターミナルを
   必要とせず、**むしろそこが一番効く**（大きいファイルをエージェント用フォルダに置く導線）ので、
   メニューが開くようになります。該当 spec は文言も理由ごと書き換えました。
4. **`resolveDirRequest` を広げました。** ファイルも受ける `resolvePathRequest` を土台にし、
   **既存の 404 文言は呼び出し側ごとに保って**います（`/api/open-dir` は今も
   `"directory not found"`）。最初に文言を変えてしまい、既存 spec が捕まえました。
5. **文言は i18n を通していません。** `FilesPane.vue` は i18n を 1 箇所も使っておらず、行メニューの
   既存 3 項目もハードコードの英語です。4 項目のうち 1 つだけ i18n にするのは不整合なので、
   局所の慣習に合わせました。ここは方針の判断が要ります。
6. **実機確認は macOS のみです。** Windows / WSL / Linux は手元で確認できていません。argv は
   純粋関数として全プラットフォームを spec で固定していますが、**実際のファイルマネージャの
   挙動は未確認**です。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/2039 右クリックでひらけるようにして

Closes #2039

work in mulmoterminal3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGUaJzDbjksQeXhnUyZTi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Show in folder” for files and “Open this folder” for directories in the file-tree context menu.
  - Opens selected items in the system file manager across supported platforms.
  - Displays an error message when the file manager cannot be opened.

- **Bug Fixes**
  - Improved handling of filenames with spaces in WSL environments.

- **Tests**
  - Added coverage for platform-specific behavior, path validation, permissions, failures, and menu actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
