### PR TITLE
fix(canvas): 拡大済みセルに seed したカードが "not enabled" に隠れる (#1965)

### DIFF
--- a/plans/fix-1965-canvas-has-card-probe.md
+++ b/plans/fix-1965-canvas-has-card-probe.md
@@ -1,0 +1,50 @@
+# #1965 — `[Mulmo]` から選んだデッキが "Canvas is not enabled for this session" に隠れる
+
+## 症状
+
+render MCP を持たないセル（`/api/tools` の `groups` が `[]`）を拡大した状態で、ヘッダーの
+`[Mulmo]` メニューからデッキを選ぶと、Canvas ペインが "Canvas is not enabled for this session"
+を出してデッキが表示されない。カード自体はサーバに保存されており、縮小→再拡大すると出る。
+
+## 原因
+
+`canvasHasCard`（`src/components/TerminalGrid.vue`）は **キャッシュ**で、
+`[expandedSessionId, expandedUid]` の watch が拡大のたびに `hasStoredCard()` で取り直す。
+
+- Files ペイン経路（`openFileInCanvas`）は seed の直後に自分で `canvasHasCard.value = true` を立てる
+- `[Mulmo]` メニュー経路は `Terminal.vue` の `onDeck` が seed してから `emit("canvas")` を出し、
+  grid 側は `openCanvasFor(cell.uid)` を呼ぶだけ。**フラグに触れない**
+
+セルが既に拡大済みだと `expandedUid` も `expandedSessionId` も変わらないので watch も走らず、
+`canvasHasCard` は seed より前に取った `false` のまま残る。`canvasUnavailable` は
+`canvasChecked && !(canvasAvailable || canvasHasCard)` なので "no-canvas-mcp" を出す。
+
+## 直し方 — 経路ごとにフラグを立てるのではなく、`openCanvasFor` が取り直す
+
+issue が挙げた 2 案のうち後者。**クラスを直す**形にする:
+
+- 立て忘れの余地が無くなる。同じ形の経路は `[Mulmo]` だけではなく、GridView が
+  `defineExpose({ openCanvasFor })` 越しに呼ぶ「seed 済みの chat を置く」経路もある
+- ストアが権威。seed の POST は `storeToolResult` を await してから 200 を返すので、
+  直後の GET は必ずそのカードを見る（`server/routes/tool-routes.ts:102-127`）。
+  しかも POST は **落とされたカード**（`stored === false`）でも 200 を返すので、
+  手で立てるフラグは「あるはずのカード」を主張し得る
+
+取り直しは **ペインが "no-canvas-mcp" を出す条件のときだけ**走らせる:
+`expandedUid === uid && session あり && !canvasAvailable && !canvasHasCard`。
+render MCP を持つ通常のセルでは 1 往復も増えない。
+
+`openFileInCanvas` の `canvasHasCard.value = true` は**残す**。あちらは「いま自分が書いた」と
+知っている側で、往復が要らないうえ、probe が失敗（ネットワーク）しても正しい。二重ではなく、
+「知っている側は言う / 知らない側は訊く」の 2 つ。
+
+## テスト
+
+`test/src/components/TerminalGrid.spec.ts` の `describe("open-in-canvas")` に、
+`TerminalCell` の `canvas` イベント経由の同型ケースを足す:
+
+- `/api/tools` は `groups: []`（render MCP 無し）
+- ストアは seed の**後**にだけカードを返す
+- 拡大済みのセルで `canvas` を emit → `GuiPanel` の `unavailable` prop が `null` になる
+
+壊して確認: probe を外すと `unavailable === "no-canvas-mcp"` で赤になる。

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -397,10 +397,32 @@ async function openCanvasFor(uid: number, enlarge = true, stillWanted?: () => bo
   if (props.expandedUid !== uid) {
     if (!enlarge) return;
     emit("toggle-expand", uid);
-  }
+    // Nothing to re-ask: the enlargement re-runs the watch that takes `canvasHasCard` in the
+    // first place.
+  } else if (mayHaveGainedACard()) await adoptStoredCard();
   // Named rather than left to default: the enlargement above is the PARENT's to apply, so
   // `expandedUid` is still the previous cell when this runs.
   setRightPane("canvas", uid);
+}
+
+// `canvasHasCard` is a CACHE, taken when the enlargement last changed. Seeding a card for the cell
+// that is ALREADY enlarged leaves it stale, and the pane then says "not enabled for this session"
+// over a card sitting in the store — #1965, which reached the deck menu because only the files
+// pane's route remembered to set the flag by hand.
+//
+// Asked here instead, so a route that seeds and then opens cannot forget to. The store is the
+// authority anyway: the seed's POST awaits the write before answering, so the GET below sees the
+// card — and it answers 200 for a card it DROPPED as well, which a hand-set flag would report as
+// something to render.
+const mayHaveGainedACard = (): boolean => expandedSessionId.value !== null && !canvasAvailable.value && !canvasHasCard.value;
+
+async function adoptStoredCard(): Promise<void> {
+  const sessionId = expandedSessionId.value;
+  if (!sessionId) return;
+  const has = await hasStoredCard(sessionId);
+  // The zoom can walk while the ask is in flight; `canvasHasCard` is one flag for whichever cell
+  // is enlarged, so a late answer must not speak for the cell that replaced it.
+  if (sessionId === expandedSessionId.value) canvasHasCard.value = has;
 }
 
 // The same gesture for the files pane: the path menu's "Browse files in the app", which is on
@@ -472,6 +494,10 @@ async function openFileInCanvas(path: string): Promise<void> {
   if (sessionId !== expandedSessionId.value) return;
   // The pane this came from is about to be replaced by the Canvas, so its buffer has to flush —
   // openCanvasFor does that. Already enlarged, hence `false`.
+  //
+  // Said rather than asked: this route just wrote the card and the write came back, so it needs no
+  // round trip — and `adoptStoredCard`'s probe answers "no" when it cannot reach the server, which
+  // over a card that IS there would put the pane's "not enabled" message back.
   canvasHasCard.value = true;
   await openCanvasFor(uid, false);
 }

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -30,7 +30,7 @@ vi.mock("../../../src/components/TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
     props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "openSessionIds", "reorderable", "canvasAvailable"],
-    emits: ["toggle-expand", "toggle-files", "toggle-prompts", "session", "cwd", "run", "close", "move", "status"],
+    emits: ["toggle-expand", "toggle-files", "toggle-prompts", "session", "cwd", "run", "close", "move", "status", "canvas"],
     template: '<div class="stub-cell" />',
   },
 }));
@@ -964,6 +964,39 @@ describe("open-in-canvas", () => {
     release();
     await flushPromises();
     expect(w.find(".stub-gui-panel").exists()).toBe(true);
+  });
+
+  // The OTHER route that seeds a card and then asks for the Canvas: the header's `[Mulmo]` menu
+  // (#1948), which seeds in Terminal.vue and emits `canvas`. On a cell that is ALREADY enlarged
+  // nothing re-runs the watch that takes `canvasHasCard`, so the pane said "not enabled for this
+  // session" over the card just written, and collapsing the cell and re-enlarging it was what
+  // appeared to fix it (#1965).
+  //
+  // Asserted on the pane's own `unavailable` prop rather than on the panel existing: the panel
+  // opens either way — carrying the message is the bug.
+  it("shows a card seeded for the cell that is already enlarged, with no render MCP", async () => {
+    let stored: unknown[] = [];
+    globalThis.fetch = vi.fn((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/agent/toolResults/")) return Promise.resolve(ok({ toolResults: stored }));
+      if (u.includes("/api/tools")) return Promise.resolve(ok({ groups: [] }));
+      return Promise.resolve(ok({}));
+    }) as unknown as typeof fetch;
+
+    const w = mountGrid([cell(1, "s-one", "/work/a")], 1);
+    await flushPromises();
+    // The premise, both halves. The session has no canvas group AND the grid has been told so —
+    // an unanswered `/api/tools` leaves `canvasChecked` false, and then the pane carries no
+    // message whatever this flag says, which is a test that cannot fail.
+    expect(w.findComponent({ name: "TerminalCell" }).props("canvasAvailable")).toBe(false);
+    expect(w.findComponent({ name: "GuiPanel" }).exists()).toBe(false);
+
+    // What the deck route has already done by the time it emits: the card is in the store.
+    stored = [{ uuid: "u-1", toolName: "presentMulmoScript" }];
+    w.findComponent({ name: "TerminalCell" }).vm.$emit("canvas");
+    await flushPromises();
+
+    expect(w.findComponent({ name: "GuiPanel" }).props("unavailable")).toBeNull();
   });
 
   // The cell moved on while the write was in flight. `canvasHasCard` is one flag for whichever


### PR DESCRIPTION
## Summary

`[Mulmo]` メニューから選んだデッキが、render MCP を持たない**拡大済み**セルで
"Canvas is not enabled for this session" に隠れる件 (#1965) を直します。

`canvasHasCard` は「このセッションにカードが保存されているか」の**キャッシュ**で、
取り直すのは `[expandedSessionId, expandedUid]` の watch だけです。更新する経路は
これまで 1 つしかありませんでした —— Files ペインの `openFileInCanvas` が seed の直後に
`canvasHasCard.value = true` を手で立てる形。`[Mulmo]` メニュー経路は `Terminal.vue` の
`onDeck` が seed してから `emit("canvas")` を出し、grid 側は `openCanvasFor()` を呼ぶだけで
フラグに触れません。セルが既に拡大済みだと `expandedUid` も `expandedSessionId` も
変わらないので watch も走らず、フラグは seed より前に取った `false` のまま残ります。
`canvasUnavailable` は `canvasChecked && !(canvasAvailable || canvasHasCard)` なので
"no-canvas-mcp" を出し、縮小→再拡大でしか表示されませんでした。

**経路ごとにフラグを立てるのではなく、`openCanvasFor` が訊き直す形**にしました
（issue が挙げた 2 案のうち後者）。クラスとして塞ぐ選択です:

- 立て忘れの余地が無くなる。同型の経路は `[Mulmo]` だけではなく、GridView が
  `defineExpose({ openCanvasFor })` 越しに呼ぶ「seed 済みの chat を置く」経路もあります
- **ストアが権威**。seed の POST は `storeToolResult` を await してから 200 を返すので
  （`server/routes/tool-routes.ts:102-127`）、直後の GET は必ずそのカードを見ます。
  しかも POST は**落とされたカード**（`stored === false`）でも 200 を返すので、手で立てる
  フラグは「あるはずのカード」を主張し得ます

取り直しは**ペインがそのメッセージを出す条件のときだけ**走ります
（`expandedUid === uid && セッションあり && !canvasAvailable && !canvasHasCard`）。
render MCP を持つ通常のセルでは 1 往復も増えません。

`openFileInCanvas` の直接代入は**残しました**。あちらは「いま自分が書いた」と知っている側で、
往復が要らないうえ、probe がネットワーク失敗で "no" を返したときにもメッセージを戻しません。
二重ではなく「知っている側は言う / 知らない側は訊く」の 2 つです。この判断は実測でも裏が
取れていて、`gridOpenFiles.spec.ts` の strict なリクエスト数検査（1 拡大につき各ルート
ちょうど 1 回）がそのまま通ります —— 直接代入を外すと、あの経路にも往復が 1 本増えます。

## Items to Confirm / Review

- **実機確認をしていません。** render MCP を持たないセル（`/api/tools` の `groups` が `[]`）に
  実際のデッキを `[Mulmo]` から入れる操作は、報告者の環境の再現条件です。ここで確認したのは
  spec（下記）と、seed の POST が書き込みを await してから応答することのコード確認までです
- **`openFileInCanvas` の直接代入を残す判断**。「どちらか一方に寄せる」なら消す選択もあり得ますが、
  probe の失敗時に "not enabled" が戻る劣化と、strict spec の往復 1 本増を避けて残しました
- **`canvasChecked` が false の窓では probe が watch の分と重複**します（`/api/agent/toolResults/`
  が 2 回）。メッセージが出ない窓なので実害はありませんが、意図した割り切りです

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green
- `yarn test` —— **852 files / 12,615 passed**（3 files / 50 skipped）
- **壊して確認**: `openCanvasFor` の probe を無効化すると、新しい spec が
  `AssertionError: expected 'no-canvas-mcp' to be null` で赤になります。同ファイル 69 件中
  **赤は 1 件だけ**で、既存 68 件は緑のまま —— 新しい spec が拾っているのは issue の症状そのもの

## User Prompt

- 「https://github.com/receptron/mulmoclaude/issues/3014 mulmoterminalの残課題ある？」
- 「mainとりこんだら1はfixかな。」
- 「mainをとりこんで。で、他に必要なものあれば順次すすめて」

（#3014 の MulmoTerminal 側残課題を洗い、main を取り込んで残り 1 本目（プラグイン 4.8.0）が
解決済みであることを確認したうえで、残っていた 2 本目・3 本目を順に進めた —— その 3 本目。
2 本目「成果物の置き場所」は receptron/mulmoclaude#3014 に実測コメントとして残しました。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mGUaJzDbjksQeXhnUyZTi

work in mulmoterminal3
